### PR TITLE
Legacy CPUs architecture alternative tip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,19 @@ This is also a meaningful way to give me motivation and encounragment to continu
 Cheer! 🎉
 
 # Known Issue
-
-TensorFlow doesn't run with older CPU architecture, it requires CPU with AVX and AVX2 instruction set. If you encounter the error `illegal instruction core dump` when running the docker-compose command above, check for your CPU flags with the command and make sure you see `AVX` and `AVX2`. Otherwise, switch to a different VM/desktop with different architecture.
-
+ 
+TensorFlow doesn't run with older CPU architecture, it requires CPU with AVX and AVX2 instruction set. If you encounter the error `illegal instruction core dump` when running the docker-compose command above, check for your CPU flags with the command and make sure you see `AVX` and `AVX2`:
+ 
 ```bash
 more /proc/cpuinfo | grep flags
-```
-
+``` 
+  
 If you are running virtualization in Promox, the VM doesn't have the flag enable.
-
+  
 You need to change the CPU type from `kvm64` to `host` under VMs hardware tab.
-
+  
 `Hardware > Processors > Edit > Advanced > Type (dropdown menu) > host`
+ 
+Otherwise you can:
+- edit `docker-compose.yml` file and comment the whole `immich_microservices` service **which will disable Search feature**
+- switch to a different VM/desktop with different architecture.


### PR DESCRIPTION
As already mentioned, TensorFlow uses next-gen architecture instructions
which are not supported by legacy CPU architectures.

I've added a tip for the legacy CPU: commenting `immich-microservices` service from the `docker-compose.yml` allows us to run Immich.
However, this makes the Search feature unusable since TensorFlow does not give data anymore.