### PR TITLE
Optimization/fix slow backup when asset list is long.

### DIFF
--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -21,9 +21,9 @@ platform :ios do
     increment_version_number(
       version_number: "1.5.0"
     )
-    increment_build_number({
-      build_number: 0
-    })
+    increment_build_number(
+      build_number: latest_testflight_build_number + 1,
+    )
     build_app(scheme: "Runner",
               workspace: "Runner.xcworkspace",
               xcargs: "-allowProvisioningUpdates")

--- a/mobile/lib/modules/home/ui/immich_sliver_appbar.dart
+++ b/mobile/lib/modules/home/ui/immich_sliver_appbar.dart
@@ -121,8 +121,12 @@ class ImmichSliverAppBar extends ConsumerWidget {
                       ),
                       child: const Icon(Icons.backup_rounded)),
               tooltip: 'Backup Controller',
-              onPressed: () {
-                AutoRouter.of(context).push(const BackupControllerRoute());
+              onPressed: () async {
+                var onPop = await AutoRouter.of(context).push(const BackupControllerRoute());
+
+                if (onPop != null && onPop == true) {
+                  onPopBack!();
+                }
               },
             ),
             _backupState.backupProgress == BackUpProgressEnum.inProgress

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -34,7 +34,6 @@ class HomePage extends HookConsumerWidget {
     }, []);
 
     void reloadAllAsset() {
-      print("reload all asset");
       ref.read(assetProvider.notifier).getAllAsset();
     }
 

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -33,6 +33,11 @@ class HomePage extends HookConsumerWidget {
       return null;
     }, []);
 
+    void reloadAllAsset() {
+      print("reload all asset");
+      ref.read(assetProvider.notifier).getAllAsset();
+    }
+
     Widget _buildBody() {
       if (assetGroupByDateTime.isNotEmpty) {
         int? lastMonth;
@@ -86,7 +91,9 @@ class HomePage extends HookConsumerWidget {
                               child: null,
                             ),
                           )
-                        : const ImmichSliverAppBar(),
+                        : ImmichSliverAppBar(
+                            onPopBack: reloadAllAsset,
+                          ),
                     duration: const Duration(milliseconds: 350),
                   ),
                   ..._imageGridGroup

--- a/mobile/lib/shared/providers/websocket.provider.dart
+++ b/mobile/lib/shared/providers/websocket.provider.dart
@@ -108,12 +108,12 @@ class WebsocketNotifier extends StateNotifier<WebscoketState> {
   }
 
   stopListenToEvent(String eventName) {
-    debugPrint("Websocket stop listening to event $eventName");
+    debugPrint("[Websocket] Stop listening to event $eventName");
     state.socket?.off(eventName);
   }
 
   listenUploadEvent() {
-    debugPrint("listening to event onuploadsuccess");
+    debugPrint("[Websocket] Start listening to event on_upload_success");
     state.socket?.on('on_upload_success', (data) {
       var jsonString = jsonDecode(data.toString());
       ImmichAsset newAsset = ImmichAsset.fromMap(jsonString);

--- a/mobile/lib/shared/providers/websocket.provider.dart
+++ b/mobile/lib/shared/providers/websocket.provider.dart
@@ -106,6 +106,20 @@ class WebsocketNotifier extends StateNotifier<WebscoketState> {
       }
     }
   }
+
+  stopListenToEvent(String eventName) {
+    debugPrint("Websocket stop listening to event $eventName");
+    state.socket?.off(eventName);
+  }
+
+  listenUploadEvent() {
+    debugPrint("listening to event onuploadsuccess");
+    state.socket?.on('on_upload_success', (data) {
+      var jsonString = jsonDecode(data.toString());
+      ImmichAsset newAsset = ImmichAsset.fromMap(jsonString);
+      ref.watch(assetProvider.notifier).onNewAssetUploaded(newAsset);
+    });
+  }
 }
 
 final websocketProvider = StateNotifierProvider<WebsocketNotifier, WebscoketState>((ref) {

--- a/mobile/lib/shared/views/backup_controller_page.dart
+++ b/mobile/lib/shared/views/backup_controller_page.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/modules/login/models/authentication_state.model.da
 import 'package:immich_mobile/shared/models/backup_state.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 import 'package:immich_mobile/shared/providers/backup.provider.dart';
+import 'package:immich_mobile/shared/providers/websocket.provider.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
 
 class BackupControllerPage extends HookConsumerWidget {
@@ -23,6 +24,7 @@ class BackupControllerPage extends HookConsumerWidget {
         ref.read(backupProvider.notifier).getBackupInfo();
       }
 
+      ref.watch(websocketProvider.notifier).stopListenToEvent('on_upload_success');
       return null;
     }, []);
 
@@ -107,6 +109,7 @@ class BackupControllerPage extends HookConsumerWidget {
         ),
         leading: IconButton(
             onPressed: () {
+              ref.watch(websocketProvider.notifier).listenUploadEvent();
               AutoRouter.of(context).pop(true);
             },
             icon: const Icon(Icons.arrow_back_ios_rounded)),

--- a/server/src/api-v1/asset/asset.controller.ts
+++ b/server/src/api-v1/asset/asset.controller.ts
@@ -115,18 +115,8 @@ export class AssetController {
     return this.assetService.searchAsset(authUser, searchAssetDto);
   }
 
-  @Get('/new')
-  async getNewAssets(@GetAuthUser() authUser: AuthUserDto, @Query(ValidationPipe) query: GetNewAssetQueryDto) {
-    return await this.assetService.getNewAssets(authUser, query.latestDate);
-  }
-
-  @Get('/all')
-  async getAllAssets(@GetAuthUser() authUser: AuthUserDto, @Query(ValidationPipe) query: GetAllAssetQueryDto) {
-    return await this.assetService.getAllAssets(authUser, query);
-  }
-
   @Get('/')
-  async getAllAssetsNoPagination(@GetAuthUser() authUser: AuthUserDto) {
+  async getAllAssets(@GetAuthUser() authUser: AuthUserDto) {
     return await this.assetService.getAllAssetsNoPagination(authUser);
   }
 
@@ -137,7 +127,7 @@ export class AssetController {
 
   @Get('/assetById/:assetId')
   async getAssetById(@GetAuthUser() authUser: AuthUserDto, @Param('assetId') assetId) {
-    return this.assetService.getAssetById(authUser, assetId);
+    return await this.assetService.getAssetById(authUser, assetId);
   }
 
   @Delete('/')


### PR DESCRIPTION
This PR removed the WebSocket listener `on_upload_success` to avoid updating the main asset list on the main page.

The app will listen to the event after navigating back from the backup page.