### PR TITLE
Up minor v1.6.0

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server-dev:1.5.2
+    image: immich-server-dev:1.6.0
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -24,7 +24,7 @@ services:
       - immich_network
 
   immich_microservices:
-    image: immich-microservices-dev:1.5.2
+    image: immich-microservices-dev:1.6.0
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server-dev:1.5.0
+    image: immich-server-dev:1.5.2
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -24,7 +24,7 @@ services:
       - immich_network
 
   immich_microservices:
-    image: immich-microservices-dev:1.5.0
+    image: immich-microservices-dev:1.5.2
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server-dev:1.5.2
+    image: immich-server-dev:1.6.0
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -22,7 +22,7 @@ services:
       - immich_network
 
   immich_microservices:
-    image: immich-microservices-dev:1.5.2
+    image: immich-microservices-dev:1.6.0
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server-dev:1.5.0
+    image: immich-server-dev:1.5.2
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -22,7 +22,7 @@ services:
       - immich_network
 
   immich_microservices:
-    image: immich-microservices-dev:1.5.0
+    image: immich-microservices-dev:1.5.2
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server:1.5.0
+    image: immich-server:1.5.2
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
 
   immich_microservices:
-    image: immich-microservices:1.5.0
+    image: immich-microservices:1.5.2
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   immich_server:
-    image: immich-server:1.5.2
+    image: immich-server:1.6.0
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
 
   immich_microservices:
-    image: immich-microservices:1.5.2
+    image: immich-microservices:1.6.0
     build:
       context: ../microservices
       dockerfile: Dockerfile

--- a/mobile/android/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/mobile/android/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,2 @@
+* Accepting webp file format
+* Fixed backup stop when an asset is of wrong file type. The app will now skip that asset and try its best to perform the backup operation on the rest of the assets.

--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
   desc "iOS Beta"
   lane :beta do
     increment_version_number(
-      version_number: "1.5.2"
+      version_number: "1.6.0"
     )
     increment_build_number(
       build_number: latest_testflight_build_number + 1,

--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
   desc "iOS Beta"
   lane :beta do
     increment_version_number(
-      version_number: "1.5.1"
+      version_number: "1.5.2"
     )
     increment_build_number(
       build_number: latest_testflight_build_number + 1,

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: immich_mobile
 description: Immich - selfhosted backup media file on mobile phone
 
 publish_to: "none"
-version: 1.5.1+9
+version: 1.5.2+10
 
 environment:
   sdk: ">=2.15.1 <3.0.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: immich_mobile
 description: Immich - selfhosted backup media file on mobile phone
 
 publish_to: "none"
-version: 1.5.2+10
+version: 1.6.0+10
 
 environment:
   sdk: ">=2.15.1 <3.0.0"

--- a/server/src/constants/server_version.constant.ts
+++ b/server/src/constants/server_version.constant.ts
@@ -4,6 +4,6 @@
 export const serverVersion = {
   major: 1,
   minor: 5,
-  patch: 1,
-  build: 9,
+  patch: 2,
+  build: 10,
 };

--- a/server/src/constants/server_version.constant.ts
+++ b/server/src/constants/server_version.constant.ts
@@ -3,7 +3,7 @@
 
 export const serverVersion = {
   major: 1,
-  minor: 5,
-  patch: 2,
+  minor: 6,
+  patch: 0,
   build: 10,
 };


### PR DESCRIPTION
* Accepting webp file format
* Fixed backup stop when an asset is of the wrong file type. The app will now skip that asset and try its best to perform the backup operation on the rest of the assets.