### PR TITLE
Select album to backup

### DIFF
--- a/mobile/lib/constants/hive_box.dart
+++ b/mobile/lib/constants/hive_box.dart
@@ -9,3 +9,7 @@ const String serverEndpointKey = 'immichBoxServerEndpoint';
 // Login Info
 const String hiveLoginInfoBox = "immichLoginInfoBox";
 const String savedLoginInfoKey = "immichSavedLoginInfoKey";
+
+// Backup Info
+const String hiveBackupInfoBox = "immichBackupInfoBox";
+const String savedBackupInfoKey = "immichSavedLoginInfoKey";

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/immich_colors.dart';
 import 'package:immich_mobile/modules/login/models/hive_saved_login_info.model.dart';
+import 'package:immich_mobile/shared/models/hive_saved_backup_info.model.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/routing/tab_navigation_observer.dart';
@@ -17,8 +18,10 @@ import 'constants/hive_box.dart';
 void main() async {
   await Hive.initFlutter();
   Hive.registerAdapter(HiveSavedLoginInfoAdapter());
+  Hive.registerAdapter(HiveSavedBackupInfoAdapter());
   await Hive.openBox(userInfoBox);
   await Hive.openBox<HiveSavedLoginInfo>(hiveLoginInfoBox);
+  await Hive.openBox<HiveSavedBackupInfo>(hiveBackupInfoBox);
 
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(

--- a/mobile/lib/modules/home/ui/immich_sliver_appbar.dart
+++ b/mobile/lib/modules/home/ui/immich_sliver_appbar.dart
@@ -131,7 +131,7 @@ class ImmichSliverAppBar extends ConsumerWidget {
                 ? Positioned(
                     bottom: 5,
                     child: Text(
-                      _backupState.backingUpAssetCount.toString(),
+                      _backupState.remainderAssetCount.toString(),
                       style: const TextStyle(fontSize: 9, fontWeight: FontWeight.bold),
                     ),
                   )

--- a/mobile/lib/shared/models/backup_state.model.dart
+++ b/mobile/lib/shared/models/backup_state.model.dart
@@ -9,8 +9,8 @@ enum BackUpProgressEnum { idle, inProgress, done }
 class BackUpState {
   final BackUpProgressEnum backupProgress;
   final int totalAssetCount;
+  final int remainderAssetCount;
   final int assetOnDatabase;
-  final int backingUpAssetCount;
   final double progressInPercentage;
   final CancelToken cancelToken;
   final ServerInfo serverInfo;
@@ -18,8 +18,8 @@ class BackUpState {
   BackUpState({
     required this.backupProgress,
     required this.totalAssetCount,
+    required this.remainderAssetCount,
     required this.assetOnDatabase,
-    required this.backingUpAssetCount,
     required this.progressInPercentage,
     required this.cancelToken,
     required this.serverInfo,
@@ -28,8 +28,8 @@ class BackUpState {
   BackUpState copyWith({
     BackUpProgressEnum? backupProgress,
     int? totalAssetCount,
+    int? remainderAssetCount,
     int? assetOnDatabase,
-    int? backingUpAssetCount,
     double? progressInPercentage,
     CancelToken? cancelToken,
     ServerInfo? serverInfo,
@@ -37,8 +37,8 @@ class BackUpState {
     return BackUpState(
       backupProgress: backupProgress ?? this.backupProgress,
       totalAssetCount: totalAssetCount ?? this.totalAssetCount,
+      remainderAssetCount: remainderAssetCount ?? this.remainderAssetCount,
       assetOnDatabase: assetOnDatabase ?? this.assetOnDatabase,
-      backingUpAssetCount: backingUpAssetCount ?? this.backingUpAssetCount,
       progressInPercentage: progressInPercentage ?? this.progressInPercentage,
       cancelToken: cancelToken ?? this.cancelToken,
       serverInfo: serverInfo ?? this.serverInfo,
@@ -47,7 +47,7 @@ class BackUpState {
 
   @override
   String toString() {
-    return 'BackUpState(backupProgress: $backupProgress, totalAssetCount: $totalAssetCount, assetOnDatabase: $assetOnDatabase, backingUpAssetCount: $backingUpAssetCount, progressInPercentage: $progressInPercentage, cancelToken: $cancelToken, serverInfo: $serverInfo)';
+    return 'BackUpState(backupProgress: $backupProgress, totalAssetCount: $totalAssetCount, remainderAssetCount: $remainderAssetCount, assetOnDatabase: $assetOnDatabase, progressInPercentage: $progressInPercentage, cancelToken: $cancelToken, serverInfo: $serverInfo)';
   }
 
   @override
@@ -57,8 +57,8 @@ class BackUpState {
     return other is BackUpState &&
         other.backupProgress == backupProgress &&
         other.totalAssetCount == totalAssetCount &&
+        other.remainderAssetCount == remainderAssetCount &&
         other.assetOnDatabase == assetOnDatabase &&
-        other.backingUpAssetCount == backingUpAssetCount &&
         other.progressInPercentage == progressInPercentage &&
         other.cancelToken == cancelToken &&
         other.serverInfo == serverInfo;
@@ -68,8 +68,8 @@ class BackUpState {
   int get hashCode {
     return backupProgress.hashCode ^
         totalAssetCount.hashCode ^
+        remainderAssetCount.hashCode ^
         assetOnDatabase.hashCode ^
-        backingUpAssetCount.hashCode ^
         progressInPercentage.hashCode ^
         cancelToken.hashCode ^
         serverInfo.hashCode;

--- a/mobile/lib/shared/models/hive_saved_backup_info.model.dart
+++ b/mobile/lib/shared/models/hive_saved_backup_info.model.dart
@@ -1,0 +1,11 @@
+import 'package:hive/hive.dart';
+
+part 'hive_saved_backup_info.model.g.dart';
+
+@HiveType(typeId: 1)
+class HiveSavedBackupInfo {
+  @HiveField(0)
+  String assetEntityId;
+
+  HiveSavedBackupInfo({required this.assetEntityId});
+}

--- a/mobile/lib/shared/models/hive_saved_backup_info.model.g.dart
+++ b/mobile/lib/shared/models/hive_saved_backup_info.model.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'hive_saved_backup_info.model.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class HiveSavedBackupInfoAdapter extends TypeAdapter<HiveSavedBackupInfo> {
+  @override
+  final int typeId = 1;
+
+  @override
+  HiveSavedBackupInfo read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return HiveSavedBackupInfo(
+      assetEntityId: fields[0] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, HiveSavedBackupInfo obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.assetEntityId);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is HiveSavedBackupInfoAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/mobile/lib/shared/providers/backup.provider.dart
+++ b/mobile/lib/shared/providers/backup.provider.dart
@@ -73,7 +73,14 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       // await PhotoManager.presentLimited();
       // Gather assets info
       List<AssetPathEntity> list = await PhotoManager.getAssetPathList(
-          hasAll: true, onlyAll: true, type: RequestType.common);
+          hasAll: true, type: RequestType.common);
+
+      // debugPrint("ASDASD");
+      //
+      // list.forEach((element) {
+      //   debugPrint(element.name);
+      //   debugPrint(element.id);
+      // });
 
       // Get device assets info from database
       // Compare and find different assets that has not been backing up

--- a/mobile/lib/shared/providers/backup.provider.dart
+++ b/mobile/lib/shared/providers/backup.provider.dart
@@ -75,13 +75,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       List<AssetPathEntity> list = await PhotoManager.getAssetPathList(
           hasAll: true, type: RequestType.common);
 
-      // debugPrint("ASDASD");
-      //
-      // list.forEach((element) {
-      //   debugPrint(element.name);
-      //   debugPrint(element.id);
-      // });
-
       // Get device assets info from database
       // Compare and find different assets that has not been backing up
       // Backup those assets

--- a/mobile/lib/shared/providers/backup.provider.dart
+++ b/mobile/lib/shared/providers/backup.provider.dart
@@ -88,6 +88,26 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         assetOnDatabase: didBackupAsset.length);
   }
 
+  void updateBackupState() async {
+    List<String> didBackupAsset = await _backupService.getDeviceBackupAsset();
+
+    // Gather assets info
+    var backupAlbum = await _getBackupAlbum();
+    if (backupAlbum == null) {
+      state = state.copyWith(
+          backupProgress: BackUpProgressEnum.idle,
+          totalAssetCount: 0,
+          assetOnDatabase: didBackupAsset.length);
+      return;
+    }
+
+    state = state.copyWith(
+        totalAssetCount: backupAlbum.assetCount,
+        assetOnDatabase: didBackupAsset.length
+    );
+
+  }
+
   void startBackupProcess() async {
     _updateServerInfo();
 
@@ -107,8 +127,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         return;
       }
 
-      state = state.copyWith(backupProgress: BackUpProgressEnum.inProgress);
-
       // Get device assets info from database
       // Compare and find different assets that has not been backing up
       // Backup those assets
@@ -117,7 +135,10 @@ class BackupNotifier extends StateNotifier<BackUpState> {
           await backupAlbum.getAssetListRange(start: 0, end: totalAsset);
 
       state = state.copyWith(
-          totalAssetCount: totalAsset, assetOnDatabase: didBackupAsset.length);
+          backupProgress: BackUpProgressEnum.inProgress,
+          totalAssetCount: totalAsset,
+          assetOnDatabase: didBackupAsset.length
+      );
 
       // Remove item that has already been backed up
       currentAssets.removeWhere((e) => didBackupAsset.contains(e.id));

--- a/mobile/lib/shared/views/backup_controller_page.dart
+++ b/mobile/lib/shared/views/backup_controller_page.dart
@@ -38,10 +38,6 @@ class BackupControllerPage extends HookConsumerWidget {
     AsyncSnapshot<List<AssetPathEntity>> assetEntities = useFuture(PhotoManager.getAssetPathList());
 
     saveAlbumId(String albumId) {
-      debugPrint("Saving");
-      if (backupAlbumId == "LOADING") {
-        debugPrint("AAA");
-      }
       backupAlbumId = albumId;
       Hive.box<HiveSavedBackupInfo>(hiveBackupInfoBox).put(
           savedBackupInfoKey,
@@ -130,6 +126,7 @@ class BackupControllerPage extends HookConsumerWidget {
                   children: [
                     DropdownButton<String>(
                       hint: const Text("Select album to backup"),
+                      icon: const Icon(Icons.photo),
                       isExpanded: true,
                       items: assetEntities.hasData ?
                       ((assetEntities.data as List<AssetPathEntity>)

--- a/mobile/lib/shared/views/backup_controller_page.dart
+++ b/mobile/lib/shared/views/backup_controller_page.dart
@@ -35,7 +35,7 @@ class BackupControllerPage extends HookConsumerWidget {
 
     String backupAlbumId = Hive.box<HiveSavedBackupInfo>(hiveBackupInfoBox).get(savedBackupInfoKey)?.assetEntityId ?? "";
 
-    AsyncSnapshot<List<AssetPathEntity>> assetEntities = useFuture(PhotoManager.getAssetPathList());
+    AsyncSnapshot<List<AssetPathEntity>> assetEntities = useFuture(useMemoized(PhotoManager.getAssetPathList, const []));
 
     saveAlbumId(String albumId) {
       backupAlbumId = albumId;
@@ -58,8 +58,6 @@ class BackupControllerPage extends HookConsumerWidget {
       ref.watch(websocketProvider.notifier).stopListenToEvent('on_upload_success');
       return null;
     }, []);
-
-
 
     Widget _buildStorageInformation() {
       return ListTile(
@@ -132,11 +130,11 @@ class BackupControllerPage extends HookConsumerWidget {
                       items: assetEntities.hasData ?
                       ((assetEntities.data as List<AssetPathEntity>)
                           .map((AssetPathEntity element) => {
-                        DropdownMenuItem(
-                          value: element.id,
-                          child: Text(element.name),
-                        )
-                      }.first).toList())
+                            DropdownMenuItem(
+                              value: element.id,
+                              child: Text(element.name),
+                            )
+                          }.first).toList())
                           : null,
                       value: assetEntities.hasData ? backupAlbumId : null,
                       onChanged: (albumId) {

--- a/mobile/lib/shared/views/backup_controller_page.dart
+++ b/mobile/lib/shared/views/backup_controller_page.dart
@@ -185,7 +185,7 @@ class BackupControllerPage extends HookConsumerWidget {
             ),
             BackupInfoCard(
               title: "Total",
-              subtitle: "All images and videos on the device",
+              subtitle: "All images and videos in the album to backup",
               info: "${_backupState.totalAssetCount}",
             ),
             BackupInfoCard(
@@ -195,8 +195,8 @@ class BackupControllerPage extends HookConsumerWidget {
             ),
             BackupInfoCard(
               title: "Remainder",
-              subtitle: "Images and videos that has not been backing up",
-              info: "${_backupState.totalAssetCount - _backupState.assetOnDatabase}", // todo this value is not correct
+              subtitle: "Images and videos of the album that has not been backed up",
+              info: "${_backupState.remainderAssetCount}",
             ),
             const Divider(),
             _buildBackupController(),
@@ -206,7 +206,7 @@ class BackupControllerPage extends HookConsumerWidget {
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: Text(
-                  "Asset that were being backup: ${_backupState.backingUpAssetCount} [${_backupState.progressInPercentage.toStringAsFixed(0)}%]"),
+                  "Asset that were being backup: ${_backupState.remainderAssetCount} [${_backupState.progressInPercentage.toStringAsFixed(0)}%]"),
             ),
             Padding(
               padding: const EdgeInsets.only(left: 8.0),

--- a/mobile/lib/shared/views/backup_controller_page.dart
+++ b/mobile/lib/shared/views/backup_controller_page.dart
@@ -45,6 +45,7 @@ class BackupControllerPage extends HookConsumerWidget {
             assetEntityId: albumId,
           )
       );
+      ref.read(backupProvider.notifier).updateBackupState();
     }
 
     bool shouldBackup = _backupState.totalAssetCount - _backupState.assetOnDatabase == 0 ? false : true;
@@ -197,7 +198,7 @@ class BackupControllerPage extends HookConsumerWidget {
             BackupInfoCard(
               title: "Remainder",
               subtitle: "Images and videos that has not been backing up",
-              info: "${_backupState.totalAssetCount - _backupState.assetOnDatabase}",
+              info: "${_backupState.totalAssetCount - _backupState.assetOnDatabase}", // todo this value is not correct
             ),
             const Divider(),
             _buildBackupController(),


### PR DESCRIPTION
Hi!
I've been watching this repo for some time and I find it awesome, I've never been able to contribute since I didn't know anything about Flutter until yesterday.

I really wanted to use this app to backup my photo from the camera, but a feature I really needed was the possibility to pick a folder to backup on Android (see #120 and #89). So I decided to give a try, and here is the result.

The photo_manager library doesn't offer any way to read photos directly from folders, for this reason, to reuse the actual code as much as possible, the user will only be able to pick an album (among which there is "Recent" which is the one currently used).
The album picker is a dropdown menu in the Backup settings page for now, it's very easy to move it somewhere else tho.

I tried to use the pattern that were already implemented as much as possible, but since I've no experience in Flutter I may have made some mistakes or followed some bad practice. I'd like to get some feedback about my code to improve.

I'll leave this a draft for now, since it needs to be tested on iOS as I don't have an iPhone.