### PR TITLE
Fix immich-server service name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ docker-compose -f ./docker/docker-compose.yml up
 If you have a few thousand photos/videos, I suggest running docker-compose with scaling option for the `immich_server` container to handle high I/O load when using fast scrolling.
 
 ```bash
-docker-compose -f ./docker/docker-compose.yml up --scale immich_server=5 
+docker-compose -f ./docker/docker-compose.yml up --scale immich-server=5 
 ```
 
 


### PR DESCRIPTION
The current documentation has a typo (at least to my understanding) when using the `docker-compose --scale` argument. 

The command in question is:
```docker-compose -f ./docker/docker-compose.yml up --scale immich_server=5 ```
but running it results in an error
```unknown service "immich_server"```

Therefore I fixed the above command in `README.md` to:
```docker-compose -f ./docker/docker-compose.yml up --scale immich-server=5```
