### PR TITLE
Minor improvements to the detail-panel component

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -15,35 +15,43 @@
 	let marker: any;
 
 	export let asset: ImmichAsset;
-	$: {
-		// Redraw map
-		if (map && leaflet) {
-			map.removeLayer(marker);
-			map.setView([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0], 17);
-			marker = leaflet.marker([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0]);
-			marker.bindPopup(`${asset.exifInfo?.latitude || 0},${asset.exifInfo?.longitude || 0}`);
-			map.addLayer(marker);
-		}
+	$: if (asset.exifInfo) {
+		drawMap(asset.exifInfo.latitude, asset.exifInfo.longitude);
 	}
 
 	onMount(async () => {
 		if (browser) {
+			if (asset.exifInfo) {
+				await drawMap(asset.exifInfo.latitude, asset.exifInfo.longitude);
+			}
+		}
+	});
+
+	async function drawMap(lat: number, lon: number) {
+		if (!leaflet) {
 			// @ts-ignore
 			leaflet = await import('leaflet');
-			map = leaflet.map('map').setView([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0], 17);
+		}
 
+		if (!map) {
+			map = leaflet.map('map');
 			leaflet
 				.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 				})
 				.addTo(map);
-
-			marker = leaflet.marker([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0]);
-			marker.bindPopup(`${asset.exifInfo?.latitude || 0},${asset.exifInfo?.longitude || 0}`);
-
-			map.addLayer(marker);
 		}
-	});
+
+		if (marker) {
+			map.removeLayer(marker);
+		}
+
+		map.setView([lat || 0, lon || 0], 17);
+
+		marker = leaflet.marker([lat || 0, lon || 0]);
+		marker.bindPopup(`${(lat || 0).toFixed(7)},${(lon || 0).toFixed(7)}`);
+		map.addLayer(marker);
+	}
 
 	const dispatch = createEventDispatcher();
 	const getHumanReadableString = (sizeInByte: number) => {

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -21,6 +21,7 @@
 			map.removeLayer(marker);
 			map.setView([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0], 17);
 			marker = leaflet.marker([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0]);
+			marker.bindPopup(`${asset.exifInfo?.latitude || 0},${asset.exifInfo?.longitude || 0}`);
 			map.addLayer(marker);
 		}
 	}
@@ -38,6 +39,7 @@
 				.addTo(map);
 
 			marker = leaflet.marker([asset.exifInfo?.latitude || 0, asset.exifInfo?.longitude || 0]);
+			marker.bindPopup(`${asset.exifInfo?.latitude || 0},${asset.exifInfo?.longitude || 0}`);
 
 			map.addLayer(marker);
 		}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -131,7 +131,7 @@
 					<p>{asset.exifInfo.make || ''} {asset.exifInfo.model || ''}</p>
 					<div class="flex text-sm gap-2">
 						<p>{`f/${asset.exifInfo.fNumber}` || ''}</p>
-						<p>{`1/${1 / asset.exifInfo.exposureTime}` || ''}</p>
+						<p>{`1/${Math.floor(1 / asset.exifInfo.exposureTime)}` || ''}</p>
 						<p>{`${asset.exifInfo.focalLength}mm` || ''}</p>
 						<p>{`ISO${asset.exifInfo.iso}` || ''}</p>
 					</div>


### PR DESCRIPTION
This PR contains three improvements of the details-panel component:

- Floor the exposure time as the current implementation can result in very long numbers (see attached image)
- Add a popup to the map-marker that shows the location in the lat,lon format (useful e.g. to copy the location to google maps)
- Refactor some duplicated map-related code to a separate function

![immich01](https://user-images.githubusercontent.com/6898797/172235195-838ceb4b-3883-44e0-856d-324dd149f8ae.png)

