### PR TITLE
Input validation for email and server endpoint in mobile app

### DIFF
--- a/mobile/lib/modules/login/ui/login_form.dart
+++ b/mobile/lib/modules/login/ui/login_form.dart
@@ -96,12 +96,20 @@ class ServerEndpointInput extends StatelessWidget {
 
   const ServerEndpointInput({Key? key, required this.controller}) : super(key: key);
 
+  String? _validateInput(String? url) {
+    if (url == null) return null;
+    if (!url.startsWith(RegExp(r'https?://'))) return 'Please specify http:// or https://';
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
       decoration: const InputDecoration(
           labelText: 'Server Endpoint URL', border: OutlineInputBorder(), hintText: 'http://your-server-ip:port'),
+      validator: _validateInput,
+      autovalidateMode: AutovalidateMode.always,
     );
   }
 }
@@ -111,12 +119,22 @@ class EmailInput extends StatelessWidget {
 
   const EmailInput({Key? key, required this.controller}) : super(key: key);
 
+  String? _validateInput(String? email) {
+    if (email == null || email == '') return null;
+    if (email.endsWith(' ')) return 'Trailing whitespace';
+    if (email.startsWith(' ')) return 'Leading whitespace';
+    if (email.contains(' ') || !email.contains('@')) return 'Invalid Email';
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
       decoration:
           const InputDecoration(labelText: 'Email', border: OutlineInputBorder(), hintText: 'youremail@email.com'),
+      validator: _validateInput,
+      autovalidateMode: AutovalidateMode.always,
     );
   }
 }


### PR DESCRIPTION
Hi,

I installed Immich on a Samsung phone yesterday and realized that the E-Mail completion of this phone adds trailing whitespaces which is hard to spot and causes the login to fail. So I added an input validator that warns about such malformed emails.

I also added a check whether the server endpoint starts with http:// or https:// as this might not be obvious to less-technical users.

Is there any reason why the server-endpoint field is pre-filled with an url?
I think this is confusing as all other fields just show hints.

```dart
final serverEndpointController = useTextEditingController(text: 'http://your-server-ip:2283');
```