### PR TITLE
fix: out of memory error when uploading large assets on slow internet

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -23,6 +23,8 @@ PODS:
     - Flutter
     - FMDB (>= 2.7.5)
   - Toast (4.0.0)
+  - url_launcher_ios (0.0.1):
+    - Flutter
   - video_player_avfoundation (0.0.1):
     - Flutter
   - wakelock (0.0.1):
@@ -37,6 +39,7 @@ DEPENDENCIES:
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - photo_manager (from `.symlinks/plugins/photo_manager/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/ios`)
   - wakelock (from `.symlinks/plugins/wakelock/ios`)
 
@@ -63,6 +66,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/photo_manager/ios"
   sqflite:
     :path: ".symlinks/plugins/sqflite/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
   video_player_avfoundation:
     :path: ".symlinks/plugins/video_player_avfoundation/ios"
   wakelock:
@@ -80,6 +85,7 @@ SPEC CHECKSUMS:
   SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
+  url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
   video_player_avfoundation: e489aac24ef5cf7af82702979ed16f2a5ef84cff
   wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
 

--- a/mobile/lib/modules/backup/models/backup_state.model.dart
+++ b/mobile/lib/modules/backup/models/backup_state.model.dart
@@ -1,4 +1,4 @@
-import 'package:dio/dio.dart';
+import 'package:cancellation_token_http/http.dart';
 import 'package:equatable/equatable.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -12,7 +12,7 @@ class BackUpState extends Equatable {
   final BackUpProgressEnum backupProgress;
   final List<String> allAssetOnDatabase;
   final double progressInPercentage;
-  final CancelToken cancelToken;
+  final CancellationToken cancelToken;
   final ServerInfo serverInfo;
 
   /// All available albums on the device
@@ -43,7 +43,7 @@ class BackUpState extends Equatable {
     BackUpProgressEnum? backupProgress,
     List<String>? allAssetOnDatabase,
     double? progressInPercentage,
-    CancelToken? cancelToken,
+    CancellationToken? cancelToken,
     ServerInfo? serverInfo,
     List<AvailableAlbum>? availableAlbums,
     Set<AssetPathEntity>? selectedBackupAlbums,

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -1,3 +1,4 @@
+import 'package:cancellation_token_http/http.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -19,7 +20,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
             backupProgress: BackUpProgressEnum.idle,
             allAssetOnDatabase: const [],
             progressInPercentage: 0,
-            cancelToken: CancelToken(),
+            cancelToken: CancellationToken(),
             serverInfo: ServerInfo(
               diskAvailable: "0",
               diskAvailableRaw: 0,
@@ -266,7 +267,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       }
 
       // Perform Backup
-      state = state.copyWith(cancelToken: CancelToken());
+      state = state.copyWith(cancelToken: CancellationToken());
       _backupService.backupAsset(assetsWillBeBackup, state.cancelToken, _onAssetUploaded, _onUploadProgress);
     } else {
       PhotoManager.openSetting();
@@ -274,7 +275,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   }
 
   void cancelBackup() {
-    state.cancelToken.cancel('Cancel Backup');
+    state.cancelToken.cancel();
     state = state.copyWith(backupProgress: BackUpProgressEnum.idle, progressInPercentage: 0.0);
   }
 

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -28,8 +28,6 @@ class BackupService {
 
   backupAsset(Set<AssetEntity> assetList, http.CancellationToken cancelToken, Function(String, String) singleAssetDoneCb,
       Function(int, int) uploadProgress) async {
-    var dio = Dio();
-    dio.interceptors.add(AuthenticatedRequestInterceptor());
 
     String deviceId = Hive.box(userInfoBox).get(deviceIdKey);
     String savedEndpoint = Hive.box(userInfoBox).get(serverEndpointKey);

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -26,9 +26,8 @@ class BackupService {
     return result.cast<String>();
   }
 
-  backupAsset(Set<AssetEntity> assetList, http.CancellationToken cancelToken, Function(String, String) singleAssetDoneCb,
-      Function(int, int) uploadProgress) async {
-
+  backupAsset(Set<AssetEntity> assetList, http.CancellationToken cancelToken,
+      Function(String, String) singleAssetDoneCb, Function(int, int) uploadProgress) async {
     String deviceId = Hive.box(userInfoBox).get(deviceIdKey);
     String savedEndpoint = Hive.box(userInfoBox).get(serverEndpointKey);
     File? file;
@@ -76,7 +75,8 @@ class BackupService {
 
           var box = Hive.box(userInfoBox);
 
-          var req = MultipartRequest('POST', Uri.parse('$savedEndpoint/asset/upload'), onProgress: ((bytes, totalBytes) => uploadProgress(bytes, totalBytes)));
+          var req = MultipartRequest('POST', Uri.parse('$savedEndpoint/asset/upload'),
+              onProgress: ((bytes, totalBytes) => uploadProgress(bytes, totalBytes)));
           req.headers["Authorization"] = "Bearer ${box.get(accessTokenKey)}";
 
           req.fields['deviceAssetId'] = entity.id;
@@ -88,7 +88,7 @@ class BackupService {
           req.fields['fileExtension'] = fileExtension;
           req.fields['duration'] = entity.videoDuration.toString();
 
-          if(thumbnailUploadData != null) {
+          if (thumbnailUploadData != null) {
             req.files.add(thumbnailUploadData);
           }
           req.files.add(assetRawUploadData);
@@ -101,6 +101,7 @@ class BackupService {
         }
       } on http.CancelledException {
         debugPrint("Backup was cancelled by the user");
+        return;
       } catch (e) {
         debugPrint("ERROR backupAsset: ${e.toString()}");
         continue;
@@ -135,7 +136,6 @@ class BackupService {
     return DeviceInfoRemote.fromJson(res.toString());
   }
 }
-
 
 class MultipartRequest extends http.MultipartRequest {
   /// Creates a new [MultipartRequest].

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -141,6 +141,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  cancellation_token:
+    dependency: transitive
+    description:
+      name: cancellation_token
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
+  cancellation_token_http:
+    dependency: "direct main"
+    description:
+      name: cancellation_token_http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   characters:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -437,7 +437,7 @@ packages:
     source: hosted
     version: "0.15.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   equatable: ^2.0.3
   image_picker: ^0.8.5+3
   url_launcher: ^6.1.3
+  http: 0.13.4
 
 dev_dependencies:
   flutter_test:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   image_picker: ^0.8.5+3
   url_launcher: ^6.1.3
   http: 0.13.4
+  cancellation_token_http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This is a fix for an out of memory exception caused by uploading large assets on slow internet. Size of asset that would cause this varies based on the device.
This should should fix #54 and fix #190 