### PR TITLE
Allow zooming in image viewer

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -11,15 +11,11 @@ enum _RemoteImageStatus {
 }
 
 class _RemotePhotoViewState extends State<RemotePhotoView> {
-  CachedNetworkImageProvider? _imageProvider;
+  late CachedNetworkImageProvider _imageProvider;
   _RemoteImageStatus _status = _RemoteImageStatus.empty;
 
   @override
   Widget build(BuildContext context) {
-    if (_status == _RemoteImageStatus.empty || _imageProvider == null) {
-      return const CircularProgressIndicator();
-    }
-
     bool allowMoving = _status == _RemoteImageStatus.full;
 
     return PhotoView(
@@ -53,6 +49,8 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
 
   void _loadImages() {
     CachedNetworkImageProvider thumbnailProvider = _authorizedImageProvider(widget.thumbnailUrl);
+    _imageProvider = thumbnailProvider;
+
     thumbnailProvider.resolve(const ImageConfiguration()).addListener(ImageStreamListener((ImageInfo imageInfo, _) {
       _performStateTransition(_RemoteImageStatus.thumbnail, thumbnailProvider);
     }));

--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -9,6 +9,7 @@ enum _RemoteImageStatus { empty, thumbnail, full }
 class _RemotePhotoViewState extends State<RemotePhotoView> {
   late CachedNetworkImageProvider _imageProvider;
   _RemoteImageStatus _status = _RemoteImageStatus.empty;
+  bool _zoomedIn = false;
 
   static const int swipeThreshold = 100;
 
@@ -21,16 +22,24 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
         minScale: PhotoViewComputedScale.contained,
         maxScale: allowMoving ? 1.0 : PhotoViewComputedScale.contained,
         enablePanAlways: true,
+        scaleStateChangedCallback: _scaleStateChanged,
         onScaleEnd: _onScaleListener);
   }
 
   void _onScaleListener(BuildContext context, ScaleEndDetails details,
       PhotoViewControllerValue controllerValue) {
+    // Disable swipe events when zoomed in
+    if (_zoomedIn) return;
+
     if (controllerValue.position.dy > swipeThreshold) {
       widget.onSwipeDown();
     } else if (controllerValue.position.dy < -swipeThreshold) {
       widget.onSwipeUp();
     }
+  }
+
+  void _scaleStateChanged(PhotoViewScaleState state) {
+    _zoomedIn = state == PhotoViewScaleState.zoomedIn;
   }
 
   CachedNetworkImageProvider _authorizedImageProvider(String url) {

--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -1,0 +1,84 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:photo_view/photo_view.dart';
+
+enum _RemoteImageStatus {
+  empty,
+  thumbnail,
+  full
+}
+
+class _RemotePhotoViewState extends State<RemotePhotoView> {
+  CachedNetworkImageProvider? _imageProvider;
+  _RemoteImageStatus _status = _RemoteImageStatus.empty;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_status == _RemoteImageStatus.empty || _imageProvider == null) {
+      return const CircularProgressIndicator();
+    }
+
+    bool allowMoving = _status == _RemoteImageStatus.full;
+
+    return PhotoView(
+        imageProvider: _imageProvider,
+        minScale: PhotoViewComputedScale.contained,
+        maxScale: allowMoving ? null : PhotoViewComputedScale.contained,
+    );
+  }
+
+  CachedNetworkImageProvider _authorizedImageProvider(String url) {
+    return CachedNetworkImageProvider(
+        url,
+        headers: { "Authorization": widget.authToken },
+        cacheKey: url
+    );
+  }
+
+  void _performStateTransition(_RemoteImageStatus newStatus, CachedNetworkImageProvider provider) {
+    // Transition to same status is forbidden
+    if (_status == newStatus) return;
+    // Transition full -> thumbnail is forbidden
+    if (_status == _RemoteImageStatus.full && newStatus == _RemoteImageStatus.thumbnail) return;
+
+    if (!mounted) return;
+
+    setState(() {
+      _status = newStatus;
+      _imageProvider = provider;
+    });
+  }
+
+  void _loadImages() {
+    CachedNetworkImageProvider thumbnailProvider = _authorizedImageProvider(widget.thumbnailUrl);
+    thumbnailProvider.resolve(const ImageConfiguration()).addListener(ImageStreamListener((ImageInfo imageInfo, _) {
+      _performStateTransition(_RemoteImageStatus.thumbnail, thumbnailProvider);
+    }));
+
+    CachedNetworkImageProvider fullProvider = _authorizedImageProvider(widget.imageUrl);
+    fullProvider.resolve(const ImageConfiguration()).addListener(ImageStreamListener((ImageInfo imageInfo, _) {
+      _performStateTransition(_RemoteImageStatus.full, fullProvider);
+    }));
+  }
+
+  @override
+  void initState() {
+    _loadImages();
+    super.initState();
+  }
+}
+
+class RemotePhotoView extends StatefulWidget {
+  const RemotePhotoView({ Key? key, required this.thumbnailUrl, required this.imageUrl, required this.authToken }) : super(key: key);
+
+  final String thumbnailUrl;
+  final String imageUrl;
+  final String authToken;
+
+  @override
+  State<StatefulWidget> createState() {
+    return _RemotePhotoViewState();
+  }
+}

--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -21,7 +21,7 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
     return PhotoView(
         imageProvider: _imageProvider,
         minScale: PhotoViewComputedScale.contained,
-        maxScale: allowMoving ? null : PhotoViewComputedScale.contained,
+        maxScale: allowMoving ? 1.0 : PhotoViewComputedScale.contained,
     );
   }
 

--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -4,11 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:photo_view/photo_view.dart';
 
-enum _RemoteImageStatus {
-  empty,
-  thumbnail,
-  full
-}
+enum _RemoteImageStatus { empty, thumbnail, full }
 
 class _RemotePhotoViewState extends State<RemotePhotoView> {
   late CachedNetworkImageProvider _imageProvider;
@@ -25,11 +21,11 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
         minScale: PhotoViewComputedScale.contained,
         maxScale: allowMoving ? 1.0 : PhotoViewComputedScale.contained,
         enablePanAlways: true,
-        onScaleEnd: _onScaleListener
-    );
+        onScaleEnd: _onScaleListener);
   }
 
-  void _onScaleListener(BuildContext context, ScaleEndDetails details, PhotoViewControllerValue controllerValue) {
+  void _onScaleListener(BuildContext context, ScaleEndDetails details,
+      PhotoViewControllerValue controllerValue) {
     if (controllerValue.position.dy > swipeThreshold) {
       widget.onSwipeDown();
     } else if (controllerValue.position.dy < -swipeThreshold) {
@@ -38,18 +34,17 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
   }
 
   CachedNetworkImageProvider _authorizedImageProvider(String url) {
-    return CachedNetworkImageProvider(
-        url,
-        headers: { "Authorization": widget.authToken },
-        cacheKey: url
-    );
+    return CachedNetworkImageProvider(url,
+        headers: {"Authorization": widget.authToken}, cacheKey: url);
   }
 
-  void _performStateTransition(_RemoteImageStatus newStatus, CachedNetworkImageProvider provider) {
+  void _performStateTransition(
+      _RemoteImageStatus newStatus, CachedNetworkImageProvider provider) {
     // Transition to same status is forbidden
     if (_status == newStatus) return;
     // Transition full -> thumbnail is forbidden
-    if (_status == _RemoteImageStatus.full && newStatus == _RemoteImageStatus.thumbnail) return;
+    if (_status == _RemoteImageStatus.full &&
+        newStatus == _RemoteImageStatus.thumbnail) return;
 
     if (!mounted) return;
 
@@ -60,15 +55,21 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
   }
 
   void _loadImages() {
-    CachedNetworkImageProvider thumbnailProvider = _authorizedImageProvider(widget.thumbnailUrl);
+    CachedNetworkImageProvider thumbnailProvider =
+        _authorizedImageProvider(widget.thumbnailUrl);
     _imageProvider = thumbnailProvider;
 
-    thumbnailProvider.resolve(const ImageConfiguration()).addListener(ImageStreamListener((ImageInfo imageInfo, _) {
+    thumbnailProvider
+        .resolve(const ImageConfiguration())
+        .addListener(ImageStreamListener((ImageInfo imageInfo, _) {
       _performStateTransition(_RemoteImageStatus.thumbnail, thumbnailProvider);
     }));
 
-    CachedNetworkImageProvider fullProvider = _authorizedImageProvider(widget.imageUrl);
-    fullProvider.resolve(const ImageConfiguration()).addListener(ImageStreamListener((ImageInfo imageInfo, _) {
+    CachedNetworkImageProvider fullProvider =
+        _authorizedImageProvider(widget.imageUrl);
+    fullProvider
+        .resolve(const ImageConfiguration())
+        .addListener(ImageStreamListener((ImageInfo imageInfo, _) {
       _performStateTransition(_RemoteImageStatus.full, fullProvider);
     }));
   }
@@ -81,14 +82,14 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
 }
 
 class RemotePhotoView extends StatefulWidget {
-  const RemotePhotoView({
-    Key? key,
-    required this.thumbnailUrl,
-    required this.imageUrl,
-    required this.authToken,
-    required this.onSwipeDown,
-    required this.onSwipeUp
-  }) : super(key: key);
+  const RemotePhotoView(
+      {Key? key,
+      required this.thumbnailUrl,
+      required this.imageUrl,
+      required this.authToken,
+      required this.onSwipeDown,
+      required this.onSwipeUp})
+      : super(key: key);
 
   final String thumbnailUrl;
   final String imageUrl;

--- a/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
+++ b/mobile/lib/modules/asset_viewer/ui/remote_photo_view.dart
@@ -14,6 +14,8 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
   late CachedNetworkImageProvider _imageProvider;
   _RemoteImageStatus _status = _RemoteImageStatus.empty;
 
+  static const int swipeThreshold = 100;
+
   @override
   Widget build(BuildContext context) {
     bool allowMoving = _status == _RemoteImageStatus.full;
@@ -22,7 +24,17 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
         imageProvider: _imageProvider,
         minScale: PhotoViewComputedScale.contained,
         maxScale: allowMoving ? 1.0 : PhotoViewComputedScale.contained,
+        enablePanAlways: true,
+        onScaleEnd: _onScaleListener
     );
+  }
+
+  void _onScaleListener(BuildContext context, ScaleEndDetails details, PhotoViewControllerValue controllerValue) {
+    if (controllerValue.position.dy > swipeThreshold) {
+      widget.onSwipeDown();
+    } else if (controllerValue.position.dy < -swipeThreshold) {
+      widget.onSwipeUp();
+    }
   }
 
   CachedNetworkImageProvider _authorizedImageProvider(String url) {
@@ -69,11 +81,21 @@ class _RemotePhotoViewState extends State<RemotePhotoView> {
 }
 
 class RemotePhotoView extends StatefulWidget {
-  const RemotePhotoView({ Key? key, required this.thumbnailUrl, required this.imageUrl, required this.authToken }) : super(key: key);
+  const RemotePhotoView({
+    Key? key,
+    required this.thumbnailUrl,
+    required this.imageUrl,
+    required this.authToken,
+    required this.onSwipeDown,
+    required this.onSwipeUp
+  }) : super(key: key);
 
   final String thumbnailUrl;
   final String imageUrl;
   final String authToken;
+
+  final void Function() onSwipeDown;
+  final void Function() onSwipeUp;
 
   @override
   State<StatefulWidget> createState() {

--- a/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
@@ -64,11 +64,7 @@ class ImageViewerPage extends HookConsumerWidget {
           ref.watch(imageViewerStateProvider.notifier).downloadAsset(asset, context);
         },
       ),
-      body: GestureDetector(
-        onLongPress: () {
-          showInfo();
-        },
-        child: SafeArea(
+      body: SafeArea(
           child: Stack(
             children: [
               Center(
@@ -78,6 +74,8 @@ class ImageViewerPage extends HookConsumerWidget {
                       thumbnailUrl: thumbnailUrl,
                       imageUrl: imageUrl,
                       authToken: "Bearer ${box.get(accessTokenKey)}",
+                      onSwipeDown: () => AutoRouter.of(context).pop(),
+                      onSwipeUp: () => showInfo(),
                   )
                 ),
               ),
@@ -88,7 +86,6 @@ class ImageViewerPage extends HookConsumerWidget {
             ],
           ),
         ),
-      ),
     );
   }
 }

--- a/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
@@ -1,8 +1,6 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_swipe_detector/flutter_swipe_detector.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/hive_box.dart';

--- a/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/image_viewer_page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/modules/asset_viewer/models/image_viewer_page_stat
 import 'package:immich_mobile/modules/asset_viewer/providers/image_viewer_page_state.provider.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/download_loading_indicator.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/exif_bottom_sheet.dart';
+import 'package:immich_mobile/modules/asset_viewer/ui/remote_photo_view.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/top_control_app_bar.dart';
 import 'package:immich_mobile/modules/home/services/asset.service.dart';
 import 'package:immich_mobile/shared/models/immich_asset.model.dart';
@@ -63,11 +64,8 @@ class ImageViewerPage extends HookConsumerWidget {
           ref.watch(imageViewerStateProvider.notifier).downloadAsset(asset, context);
         },
       ),
-      body: SwipeDetector(
-        onSwipeDown: (_) {
-          AutoRouter.of(context).pop();
-        },
-        onSwipeUp: (_) {
+      body: GestureDetector(
+        onLongPress: () {
           showInfo();
         },
         child: SafeArea(
@@ -76,51 +74,11 @@ class ImageViewerPage extends HookConsumerWidget {
               Center(
                 child: Hero(
                   tag: heroTag,
-                  child: CachedNetworkImage(
-                    fit: BoxFit.cover,
-                    imageUrl: imageUrl,
-                    httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
-                    fadeInDuration: const Duration(milliseconds: 250),
-                    errorWidget: (context, url, error) => ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 300),
-                      child: Wrap(
-                        spacing: 32,
-                        runSpacing: 32,
-                        alignment: WrapAlignment.center,
-                        children: [
-                          const Text(
-                            "Failed To Render Image - Possibly Corrupted Data",
-                            textAlign: TextAlign.center,
-                            style: TextStyle(fontSize: 16, color: Colors.white),
-                          ),
-                          SingleChildScrollView(
-                            child: Text(
-                              error.toString(),
-                              textAlign: TextAlign.center,
-                              style: TextStyle(fontSize: 12, color: Colors.grey[400]),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    placeholder: (context, url) {
-                      return CachedNetworkImage(
-                        cacheKey: thumbnailUrl,
-                        fit: BoxFit.cover,
-                        imageUrl: thumbnailUrl,
-                        httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
-                        placeholderFadeInDuration: const Duration(milliseconds: 0),
-                        progressIndicatorBuilder: (context, url, downloadProgress) => Transform.scale(
-                          scale: 0.2,
-                          child: CircularProgressIndicator(value: downloadProgress.progress),
-                        ),
-                        errorWidget: (context, url, error) => Icon(
-                          Icons.error,
-                          color: Colors.grey[300],
-                        ),
-                      );
-                    },
-                  ),
+                  child: RemotePhotoView(
+                      thumbnailUrl: thumbnailUrl,
+                      imageUrl: imageUrl,
+                      authToken: "Bearer ${box.get(accessTokenKey)}",
+                  )
                 ),
               ),
               if (downloadAssetStatus == DownloadAssetStatus.loading)

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -743,7 +743,7 @@ packages:
       name: photo_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.0"
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   chewie: ^1.2.2
   sliver_tools: ^0.2.5
   badges: ^2.0.2
-  photo_view: ^0.13.0
+  photo_view: ^0.14.0
   socket_io_client: ^2.0.0-beta.4-nullsafety.0
   flutter_map: ^0.14.0
   flutter_udid: ^2.0.0


### PR DESCRIPTION
As discussed [here](https://github.com/alextran1502/immich/discussions/226) I'm working on some improvements for the image viewer page.
photo_view 0.14 seems to resolve the issues of the previous versions for the newest flutter version.

By using the `CachedNetworkImageProvider` directly, we have more control over the loading behavior.

I decided to use the state-machine pattern for the thumbnail / full image loading process:

![state_machine](https://user-images.githubusercontent.com/6898797/174073800-8ab350ee-a9a2-431d-990a-e80f03539bb4.png)

That way we can avoid nasty race-conditions.

This PR contains a first (working) state. I will do the refactoring / testing next week.
