### PR TITLE
Delete assets from server if local deletion fails

### DIFF
--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/home/models/delete_asset_response.model.dart';
 import 'package:immich_mobile/modules/home/services/asset.service.dart';
@@ -47,7 +48,11 @@ class AssetNotifier extends StateNotifier<List<ImmichAsset>> {
     }
 
     // final List<String> result = await PhotoManager.editor.deleteWithIds(deleteIdList);
-    await PhotoManager.editor.deleteWithIds(deleteIdList);
+    try {
+      await PhotoManager.editor.deleteWithIds(deleteIdList);
+    } catch (e) {
+      debugPrint("Delete asset from device failed: $e");
+    }
 
     // Delete asset on server
     List<DeleteAssetResponse>? deleteAssetResult =

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -46,8 +46,7 @@ class AssetNotifier extends StateNotifier<List<ImmichAsset>> {
         }
       }
     }
-
-    // final List<String> result = await PhotoManager.editor.deleteWithIds(deleteIdList);
+    
     try {
       await PhotoManager.editor.deleteWithIds(deleteIdList);
     } catch (e) {


### PR DESCRIPTION
Just a little edge-case that I stumbled across. If an asset was deleted locally but still exists on the server, the deletion fails beacause `deleteWithIds` throws an uncaught exception.