### PR TITLE
Fix error with geocodingClient being null

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -65,7 +65,7 @@ export class MetadataExtractionProcessor {
       newExif.longitude = exifData['longitude'] || null;
 
       // Reverse GeoCoding
-      if (process.env.ENABLE_MAPBOX && exifData['longitude'] && exifData['latitude']) {
+      if (this.geocodingClient && exifData['longitude'] && exifData['latitude']) {
         const geoCodeInfo: MapiResponse = await this.geocodingClient
           .reverseGeocode({
             query: [exifData['longitude'], exifData['latitude']],


### PR DESCRIPTION
Instead of checking the environment variable again, just check whether `this.geocodingClient` has been defined.
This way it can never be null here, no matter the value of the environment variable.