### PR TITLE
Fix Dev web container port mapping

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -68,7 +68,7 @@ services:
     env_file:
       - .env
     ports:
-      - 3002:3000
+      - 3000:3000
       - 24678:24678
     volumes:
       - ../web:/usr/src/app


### PR DESCRIPTION
Vite uses port 3000 to do Websocket connection. If it doesn't mange to
connect it enters in an endless loop refreshing the page.