### PR TITLE
Add extended redis & DB port configuration via environment variables

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,7 +7,8 @@ DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE_NAME=immich
 
-
+# Optional Database settings:
+DB_PORT=5432
 
 
 
@@ -16,7 +17,6 @@ DB_DATABASE_NAME=immich
 ###################################################################################
 
 REDIS_HOSTNAME=immich_redis
-
 
 
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -8,7 +8,8 @@ DB_PASSWORD=postgres
 DB_DATABASE_NAME=immich
 
 # Optional Database settings:
-DB_PORT=5432
+# DB_PORT=5432
+
 
 
 
@@ -17,6 +18,13 @@ DB_PORT=5432
 ###################################################################################
 
 REDIS_HOSTNAME=immich_redis
+
+# Optional Redis settings:
+# REDIS_PORT=6379
+# REDIS_DBINDEX=0
+# REDIS_PASSWORD=
+# REDIS_SOCKET=
+
 
 
 

--- a/machine-learning/src/config/database.config.ts
+++ b/machine-learning/src/config/database.config.ts
@@ -3,7 +3,7 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 export const databaseConfig: TypeOrmModuleOptions = {
   type: 'postgres',
   host: process.env.DB_HOSTNAME || 'immich_postgres',
-  port: 5432,
+  port: parseInt(process.env.DB_PORT || '5432'),
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE_NAME,

--- a/server/apps/immich/src/app.module.ts
+++ b/server/apps/immich/src/app.module.ts
@@ -36,7 +36,10 @@ import { AppLoggerMiddleware } from './middlewares/app-logger.middleware';
       useFactory: async () => ({
         redis: {
           host: process.env.REDIS_HOSTNAME || 'immich_redis',
-          port: 6379,
+          port: parseInt(process.env.REDIS_PORT || '6379'),
+          db: parseInt(process.env.REDIS_DBINDEX || '0'),
+          password: process.env.REDIS_PASSWORD || undefined,
+          path: process.env.REDIS_SOCKET || undefined,
         },
       }),
     }),

--- a/server/apps/immich/src/middlewares/redis-io.adapter.middleware.ts
+++ b/server/apps/immich/src/middlewares/redis-io.adapter.middleware.ts
@@ -3,13 +3,20 @@ import { RedisClient } from 'redis';
 import { ServerOptions } from 'socket.io';
 import { createAdapter } from 'socket.io-redis';
 
-const redis_host = process.env.REDIS_HOSTNAME || 'immich_redis';
+const redisHost = process.env.REDIS_HOSTNAME || 'immich_redis';
+const redisPort = parseInt(process.env.REDIS_PORT || '6379');
+const redisDb = parseInt(process.env.REDIS_DBINDEX || '0');
+const redisPassword = process.env.REDIS_PASSWORD || undefined;
+const redisSocket = process.env.REDIS_SOCKET || undefined;
 // const pubClient = createClient({ url: `redis://${redis_host}:6379` });
 // const subClient = pubClient.duplicate();
 
 const pubClient = new RedisClient({
-  host: redis_host,
-  port: 6379,
+  host: redisHost,
+  port: redisPort,
+  db: redisDb,
+  password: redisPassword,
+  path: redisSocket,
 });
 
 const subClient = pubClient.duplicate();

--- a/server/apps/microservices/src/microservices.module.ts
+++ b/server/apps/microservices/src/microservices.module.ts
@@ -27,7 +27,10 @@ import {
       useFactory: async () => ({
         redis: {
           host: process.env.REDIS_HOSTNAME || 'immich_redis',
-          port: 6379,
+          port: parseInt(process.env.REDIS_PORT || '6379'),
+          db: parseInt(process.env.REDIS_DBINDEX || '0'),
+          password: process.env.REDIS_PASSWORD || undefined,
+          path: process.env.REDIS_SOCKET || undefined,
         },
       }),
     }),

--- a/server/libs/database/src/config/database.config.ts
+++ b/server/libs/database/src/config/database.config.ts
@@ -4,7 +4,7 @@ import {DataSource} from "typeorm";
 export const databaseConfig: PostgresConnectionOptions = {
   type: 'postgres',
   host: process.env.DB_HOSTNAME || 'immich_postgres',
-  port: 5432,
+  port: parseInt(process.env.DB_PORT || '5432'),
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE_NAME,


### PR DESCRIPTION
Add env variables to better support shared redis & db running on the host system or in other containers:

1. Add env variable `DB_PORT` to change the database port.
2. Add env variables `REDIS_PORT`, `REDIS_DBINDEX`, `REDIS_PASSWORD` and `REDIS_SOCKET` to configure connections to use a shared redis instance (optionally via unix sockets)