### PR TITLE
improve docker experience

### DIFF
--- a/server/apps/immich/src/main.ts
+++ b/server/apps/immich/src/main.ts
@@ -46,12 +46,12 @@ async function bootstrap() {
     customSiteTitle: 'Immich API Documentation',
   });
 
-  // Generate API Documentation
-  const outputPath = path.resolve(process.cwd(), 'immich-openapi-specs.json');
-  writeFileSync(outputPath, JSON.stringify(apiDocument), { encoding: 'utf8' });
-
+  
   await app.listen(3001, () => {
     if (process.env.NODE_ENV == 'development') {
+      // Generate API Documentation only in development mode
+      const outputPath = path.resolve(process.cwd(), 'immich-openapi-specs.json');
+      writeFileSync(outputPath, JSON.stringify(apiDocument), { encoding: 'utf8' });
       Logger.log('Running Immich Server in DEVELOPMENT environment', 'ImmichServer');
     }
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "nest build",
+    "build": "nest build immich && nest build microservices",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/server/start-microservices.sh
+++ b/server/start-microservices.sh
@@ -1,1 +1,1 @@
-npm start microservices
+node dist/apps/microservices/apps/microservices/src/main

--- a/server/start-server.sh
+++ b/server/start-server.sh
@@ -1,1 +1,1 @@
-npm start immich
+node dist/apps/immich/apps/immich/src/main

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,35 +5,23 @@ WORKDIR /usr/src/app
 
 RUN chown node:node /usr/src/app
 
-COPY --chown=node:node package*.json ./
+RUN apk add --no-cache setpriv
 
-RUN apk add --update-cache build-base python3
+COPY --chown=node:node package*.json ./
 
 RUN npm ci
 
 COPY --chown=node:node . .
 
 EXPOSE 3000
-EXPOSE 24678
 
 FROM base AS dev
 ENV CHOKIDAR_USEPOLLING=true
+EXPOSE 24678
 CMD ["npm", "run", "dev"]
 
-FROM node:16-alpine3.14 as prod
-
-WORKDIR /usr/src/app
-
-RUN chown node:node /usr/src/app
-
-COPY --chown=node:node package*.json ./
-COPY --chown=node:node . .
-
-RUN apk add --update-cache build-base python3
-
-RUN npm ci
-
-EXPOSE 3000
+FROM base as prod
+ENV NODE_ENV=production
 
 
 # Issue build command in entrypoint.sh to capture user .env file instead of the builder .env file.

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,1 +1,6 @@
-npm run build && node /usr/src/app/build/index.js
+npm run build
+if [ `id -u` -eq 0 ] && [ -n "$PUID" ] && [ -n "$PGID" ]; then
+    exec setpriv --reuid $PUID --regid $PGID --clear-groups node /usr/src/app/build/index.js
+else
+    node /usr/src/app/build/index.js
+fi

--- a/web/src/hooks.ts
+++ b/web/src/hooks.ts
@@ -1,7 +1,7 @@
 import type { GetSession, Handle } from '@sveltejs/kit';
 import * as cookie from 'cookie';
 import { api } from '@api';
-import { AxiosError } from 'axios';
+import AxiosError from 'axios';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const cookies = cookie.parse(event.request.headers.get('cookie') || '');


### PR DESCRIPTION
This proposed change has the following benefits:

1. Significantly faster startup of containers (immich-server & immich-microservices)
2. Reduced memory usage of containers (immich-server & immich-microservices) by a factor of 4 (from ~ 577mb to 133mb)
3. Allow to run containers (immich-server, immich-microservices & immich-web) with non-root user to enhance security: Simply add `user: <UID>:<GID>` to docker-compose.yml for server/microservices, immich-web instead needs env variables `PUID`and `PGID` (see notes below why this is the case)
4. Decrease image size and build time of immich-web + simplify Dockerfile


Implementation notes:

1. Actually use the transpiled files from the dist folder. Currently, they are ignored and rebuild on-the-fly by `npm start`
2. Follows from 1. and directly calling `node` on the dist files instead of `npm start` spawns fewer processes
3. This is made possible by no longer writing to the containers. For server/microservice, the change in `main.ts` skips writing the API docs. As the svelte build (with files writes) currently needs to be performed during container start (to use the users env variables), one cannot directly start the container without root. Thus, `web/entrypoint.sh` changes the user (if `PUID`and `PGID` are specified) after building.
4. Removed packages/dependencies not needed & use base image for prod as well

Regarding the change in `hooks.ts`: I could not build the immich-web Dockerfile due to `SyntaxError: Named export 'AxiosError' not found. The requested module 'axios' is a CommonJS module, which may not support all module.exports as named exports.`. This change works for me..