### PR TITLE
Fix test instance cannot clear database after each test"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Immich Server 2E2 Test
-        run: docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test up --abort-on-container-exit --exit-code-from immich_server_test
+        run: docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test up --abort-on-container-exit --exit-code-from immich-server-test

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ stage:
 	docker-compose -f ./docker/docker-compose.staging.yml up --build -V --remove-orphans
 
 test-e2e:
-	docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test -p immich-test-e2e up  --renew-anon-volumes --abort-on-container-exit --exit-code-from immich-server-test --remove-orphans
+	docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test -p immich-test-e2e up  --renew-anon-volumes --abort-on-container-exit --exit-code-from immich-server-test --remove-orphans --build
 
 prod:
 	docker-compose -f ./docker/docker-compose.yml up --build -V --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ stage:
 	docker-compose -f ./docker/docker-compose.staging.yml up --build -V --remove-orphans
 
 test-e2e:
-	docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test up --renew-anon-volumes --abort-on-container-exit --exit-code-from immich_server_test --remove-orphans
+	docker-compose -f ./docker/docker-compose.test.yml --env-file ./docker/.env.test -p immich-test-e2e up  --renew-anon-volumes --abort-on-container-exit --exit-code-from immich-server-test --remove-orphans
 
 prod:
 	docker-compose -f ./docker/docker-compose.yml up --build -V --remove-orphans

--- a/docker/.env.test
+++ b/docker/.env.test
@@ -1,5 +1,5 @@
 # Database
-DB_HOSTNAME=immich_postgres_test
+DB_HOSTNAME=immich-database-test
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE_NAME=e2e_test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,8 +1,8 @@
 version: "3.8"
 
 services:
-  immich_server_test:
-    image: immich-server-dev:latest
+  immich-server-test:
+    image: immich-server-test
     build:
       context: ../server
       dockerfile: Dockerfile
@@ -17,15 +17,15 @@ services:
     environment:
       - NODE_ENV=development
     depends_on:
-      - redis
-      - database
+      - immich-redis-test
+      - immich-database-test
 
-  redis:
-    container_name: immich_redis_test
+  immich-redis-test:
+    container_name: immich-redis-test
     image: redis:6.2
 
-  database:
-    container_name: immich_postgres_test
+  immich-database-test:
+    container_name: immich-database-test
     image: postgres:14
     env_file:
       - .env.test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -19,11 +19,13 @@ services:
     depends_on:
       - immich-redis-test
       - immich-database-test
-
+    networks:
+      - immich-test-network
   immich-redis-test:
     container_name: immich-redis-test
     image: redis:6.2
-
+    networks:
+      - immich-test-network
   immich-database-test:
     container_name: immich-database-test
     image: postgres:14
@@ -36,5 +38,8 @@ services:
       PG_DATA: /var/lib/postgresql/data
     volumes:
       - /var/lib/postgresql/data
-    ports:
-      - 5432:5432
+    networks:
+      - immich-test-network
+
+networks:
+  immich-test-network:

--- a/server/apps/immich/test/album.e2e-spec.ts
+++ b/server/apps/immich/test/album.e2e-spec.ts
@@ -91,13 +91,13 @@ describe('Album', () => {
         // setup users
         const result = await Promise.all([
           userService.createUser({
-            email: 'one1@test.com',
+            email: 'one@test.com',
             password: '1234',
             firstName: 'one',
             lastName: 'test',
           }),
           userService.createUser({
-            email: 'two2@test.com',
+            email: 'two@test.com',
             password: '1234',
             firstName: 'two',
             lastName: 'test',

--- a/server/apps/immich/test/album.e2e-spec.ts
+++ b/server/apps/immich/test/album.e2e-spec.ts
@@ -10,6 +10,7 @@ import { ImmichJwtModule } from '../src/modules/immich-jwt/immich-jwt.module';
 import { AuthUserDto } from '../src/decorators/auth-user.decorator';
 import { UserService } from '../src/api-v1/user/user.service';
 import { UserModule } from '../src/api-v1/user/user.module';
+import { DataSource } from 'typeorm';
 
 function _createAlbum(app: INestApplication, data: CreateAlbumDto) {
   return request(app.getHttpServer()).post('/album').send(data);
@@ -17,9 +18,10 @@ function _createAlbum(app: INestApplication, data: CreateAlbumDto) {
 
 describe('Album', () => {
   let app: INestApplication;
+  let database: DataSource;
 
   afterAll(async () => {
-    await clearDb();
+    await clearDb(database);
     await app.close();
   });
 
@@ -30,6 +32,7 @@ describe('Album', () => {
       }).compile();
 
       app = moduleFixture.createNestApplication();
+      database = app.get(DataSource);
       await app.init();
     });
 
@@ -56,12 +59,14 @@ describe('Album', () => {
 
       app = moduleFixture.createNestApplication();
       userService = app.get(UserService);
+      database = app.get(DataSource);
+
       await app.init();
     });
 
     describe('with empty DB', () => {
       afterEach(async () => {
-        await clearDb();
+        await clearDb(database);
       });
 
       it('creates an album', async () => {

--- a/server/apps/immich/test/test-utils.ts
+++ b/server/apps/immich/test/test-utils.ts
@@ -3,13 +3,10 @@ import { CanActivate, ExecutionContext } from '@nestjs/common';
 import { TestingModuleBuilder } from '@nestjs/testing';
 import { AuthUserDto } from '../src/decorators/auth-user.decorator';
 import { JwtAuthGuard } from '../src/modules/immich-jwt/guards/jwt-auth.guard';
-import { databaseConfig } from '@app/database/config/database.config';
 
 type CustomAuthCallback = () => AuthUserDto;
 
-export async function clearDb() {
-  const db = new DataSource(databaseConfig);
-
+export async function clearDb(db: DataSource) {
   const entities = db.entityMetadatas;
   for (const entity of entities) {
     const repository = db.getRepository(entity.name);

--- a/server/apps/immich/test/user.e2e-spec.ts
+++ b/server/apps/immich/test/user.e2e-spec.ts
@@ -9,6 +9,7 @@ import { ImmichJwtModule } from '../src/modules/immich-jwt/immich-jwt.module';
 import { UserService } from '../src/api-v1/user/user.service';
 import { CreateUserDto } from '../src/api-v1/user/dto/create-user.dto';
 import { UserResponseDto } from '../src/api-v1/user/response-dto/user-response.dto';
+import { DataSource } from 'typeorm';
 
 function _createUser(userService: UserService, data: CreateUserDto) {
   return userService.createUser(data);
@@ -16,9 +17,10 @@ function _createUser(userService: UserService, data: CreateUserDto) {
 
 describe('User', () => {
   let app: INestApplication;
+  let database: DataSource;
 
   afterAll(async () => {
-    await clearDb();
+    await clearDb(database);
     await app.close();
   });
 
@@ -29,6 +31,7 @@ describe('User', () => {
       }).compile();
 
       app = moduleFixture.createNestApplication();
+      database = app.get(DataSource);
       await app.init();
     });
 
@@ -54,6 +57,7 @@ describe('User', () => {
 
       app = moduleFixture.createNestApplication();
       userService = app.get(UserService);
+      database = app.get(DataSource);
       await app.init();
     });
 


### PR DESCRIPTION
Fixed issue with test instance cannot clear database due to using an uninitialized database connection. 

The test docker-compose is now grouped with the name `immich-test-e2e` from flag `-p` in the Makefile command. 
