### PR TITLE
feat: remove webp on asset deleted as well

### DIFF
--- a/server/apps/immich/src/modules/background-task/background-task.processor.ts
+++ b/server/apps/immich/src/modules/background-task/background-task.processor.ts
@@ -33,7 +33,15 @@ export class BackgroundTaskProcessor {
       if (asset.resizePath) {
         fs.unlink(asset.resizePath, (err) => {
           if (err) {
-            console.log('error deleting ', asset.originalPath);
+            console.log('error deleting ', asset.resizePath);
+          }
+        });
+      }
+
+      if (asset.webpPath) {
+        fs.unlink(asset.webpPath, (err) => {
+          if (err) {
+            console.log('error deleting ', asset.webpPath);
           }
         });
       }

--- a/server/apps/immich/src/modules/background-task/background-task.processor.ts
+++ b/server/apps/immich/src/modules/background-task/background-task.processor.ts
@@ -30,6 +30,7 @@ export class BackgroundTaskProcessor {
       });
 
       // TODO: what if there is no asset.resizePath. Should fail the Job?
+      // => panoti report: Job not fail
       if (asset.resizePath) {
         fs.unlink(asset.resizePath, (err) => {
           if (err) {


### PR DESCRIPTION
Current webp file still keep on thumbnail folder when asset has been already deleted.

- [x]: remove webp file when asset was deleted.
