### PR TITLE
fix(server): correct media info

### DIFF
--- a/server/apps/microservices/src/processors/asset-uploaded.processor.ts
+++ b/server/apps/microservices/src/processors/asset-uploaded.processor.ts
@@ -64,7 +64,11 @@ export class AssetUploadedProcessor {
 
     // Extract video duration if uploaded from the web & CLI
     if (asset.type == AssetType.VIDEO) {
-      await this.metadataExtractionQueue.add(videoMetadataExtractionProcessorName, { asset }, { jobId: randomUUID() });
+      await this.metadataExtractionQueue.add(
+        videoMetadataExtractionProcessorName,
+        { asset, fileName, fileSize },
+        { jobId: randomUUID() }
+      );
     }
   }
 }

--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -239,13 +239,14 @@ export class MetadataExtractionProcessor {
         const match = location.match(locationRegex);
 
         if (match?.length === 3) {
-          newExif.longitude = parseFloat(match[0]);
           newExif.latitude = parseFloat(match[1]);
+          newExif.longitude = parseFloat(match[2]);
         }
       } else if (videoTags && videoTags['com.apple.quicktime.location.ISO6709']) {
         const location = videoTags['com.apple.quicktime.location.ISO6709'] as string;
         const locationRegex = /([+-][0-9]+\.[0-9]+)([+-][0-9]+\.[0-9]+)([+-][0-9]+\.[0-9]+)\/$/;
         const match = location.match(locationRegex);
+
         if (match?.length === 4) {
           newExif.latitude = parseFloat(match[1]);
           newExif.longitude = parseFloat(match[2]);

--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -190,7 +190,7 @@ export class MetadataExtractionProcessor {
 
   @Process({ name: videoMetadataExtractionProcessorName, concurrency: 2 })
   async extractVideoMetadata(job: Job<IVideoLengthExtractionProcessor>) {
-    const { asset } = job.data;
+    const { asset, fileName } = job.data;
 
     try {
       const data = await new Promise<ffmpeg.FfprobeData>((resolve, reject) =>
@@ -222,6 +222,7 @@ export class MetadataExtractionProcessor {
       const newExif = new ExifEntity();
       newExif.assetId = asset.id;
       newExif.description = '';
+      newExif.imageName = path.parse(fileName).name || null;
       newExif.fileSizeInByte = data.format.size || null;
       newExif.dateTimeOriginal = createdAt ? new Date(createdAt) : null;
       newExif.modifyDate = null;
@@ -238,8 +239,8 @@ export class MetadataExtractionProcessor {
         const match = location.match(locationRegex);
 
         if (match?.length === 3) {
-          newExif.latitude = parseFloat(match[0]);
-          newExif.longitude = parseFloat(match[1]);
+          newExif.longitude = parseFloat(match[0]);
+          newExif.latitude = parseFloat(match[1]);
         }
       } else if (videoTags && videoTags['com.apple.quicktime.location.ISO6709']) {
         const location = videoTags['com.apple.quicktime.location.ISO6709'] as string;

--- a/server/libs/job/src/interfaces/metadata-extraction.interface.ts
+++ b/server/libs/job/src/interfaces/metadata-extraction.interface.ts
@@ -23,6 +23,16 @@ export interface IVideoLengthExtractionProcessor {
    * The Asset entity that was saved in the database
    */
   asset: AssetEntity;
+
+  /**
+   * Original file name
+   */
+  fileName: string;
+
+  /**
+   * File size in byte
+   */
+  fileSize: number;
 }
 
 export interface IReverseGeocodingProcessor {


### PR DESCRIPTION
We've used wrong index in rex match to get location. I also make use of `imageName` to store video filename, so we can avoid `null` in UI.