### PR TITLE
fix(server): avoid loading all file content on memory

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -50,10 +50,11 @@ export class MetadataExtractionProcessor {
   async extractExifInfo(job: Job<IExifExtractionProcessor>) {
     try {
       const { asset, fileName, fileSize }: { asset: AssetEntity; fileName: string; fileSize: number } = job.data;
+      const exifData = await exifr.parse(asset.originalPath);
 
-      const fileBuffer = await readFile(asset.originalPath);
-
-      const exifData = await exifr.parse(fileBuffer);
+      if (!exifData) {
+        throw new Error(`can not fetch exif data from file ${asset.originalPath}`);
+      }
 
       const newExif = new ExifEntity();
       newExif.assetId = asset.id;


### PR DESCRIPTION
- [x] fix undefined exif data error from user `ibra`
- [x] pass directly file path into `exifr.parse` function because `exifr` has file parser with the best performance as they said *exifr reads the file from disk, only a few hundred bytes.* 