### PR TITLE
Update localizely.yml to include danish locale

### DIFF
--- a/localizely.yml
+++ b/localizely.yml
@@ -15,6 +15,8 @@ upload:
       locale_code: nl-NL
     - file: mobile/assets/i18n/ko-KR.json
       locale_code: ko-KR
+    - file: mobile/assets/i18n/da-DK.json
+      locale_code: da-DK
 download:
   files:
     - file: mobile/assets/i18n/en-US.json
@@ -29,3 +31,5 @@ download:
       locale_code: nl-NL
     - file: mobile/assets/i18n/ko-KR.json
       locale_code: ko-KR
+    - file: mobile/assets/i18n/da-DK.json
+      locale_code: da-DK


### PR DESCRIPTION
Updated the localizely.yaml file. It might be an idea to include the rest of the languages found in /mobile/assets/i18n if we have maintainers for those.