### PR TITLE
Use runtime env var for login page message to lower web container startup time

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -61,6 +61,6 @@ MAPBOX_KEY=
 ####################################################################################
 
 # Custom message on the login page, should be written in HTML form.
-# For example VITE_LOGIN_PAGE_MESSAGE="This is a demo instance of Immich.<br><br>Email: <i>demo@demo.de</i><br>Password: <i>demo</i>"
+# For example PUBLIC_LOGIN_PAGE_MESSAGE="This is a demo instance of Immich.<br><br>Email: <i>demo@demo.de</i><br>Password: <i>demo</i>"
 
-VITE_LOGIN_PAGE_MESSAGE=
+PUBLIC_LOGIN_PAGE_MESSAGE=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,6 +13,8 @@ RUN npm ci
 
 COPY --chown=node:node . .
 
+RUN npm run build
+
 EXPOSE 3000
 
 FROM base AS dev

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,6 +24,3 @@ CMD ["npm", "run", "dev"]
 
 FROM base as prod
 ENV NODE_ENV=production
-
-
-# Issue build command in entrypoint.sh to capture user .env file instead of the builder .env file.

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,4 +1,3 @@
-npm run build
 if [ `id -u` -eq 0 ] && [ -n "$PUID" ] && [ -n "$PGID" ]; then
     exec setpriv --reuid $PUID --regid $PGID --clear-groups node /usr/src/app/build/index.js
 else

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,1 +1,2 @@
-export const loginPageMessage: string = import.meta.env.VITE_LOGIN_PAGE_MESSAGE;
+import { env } from '$env/dynamic/public';
+export const loginPageMessage: string = env.PUBLIC_LOGIN_PAGE_MESSAGE;


### PR DESCRIPTION
With the new sveltekit version, we can use [runtime environment variables](https://kit.svelte.dev/docs/modules#$env-dynamic-private). This PR changes the VITE_LOGIN_PAGE_MESSAGE to use those runtime env vars, allowing us to run the vite build when building the Docker image rather than at startup time. 

This does require renaming the env var to PUBLIC_LOGIN_PAGE_MESSAGE.

~~The runtime env var change works, but the change to the docker build is currently resulting in a runtime error. It would be nice to get a second pair of eyes on that.~~