### PR TITLE
fix(nginx): revert nginx image to support arm/v7

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry.access.redhat.com/ubi9/nginx-120:latest
+FROM docker.io/nginxinc/nginx-unprivileged:latest
 
-COPY nginx.conf "${NGINX_CONF_PATH}"
+COPY nginx.conf "/etc/nginx/nginx.conf"
 
 CMD nginx -g "daemon off;"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,7 +2,7 @@
 
 worker_processes auto;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+pid /tmp/nginx.pid;
 
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
@@ -16,6 +16,12 @@ http {
     default upgrade;
     '' close;
   }
+
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path       /tmp/proxy_temp_path;
+  fastcgi_temp_path     /tmp/fastcgi_temp;
+  uwsgi_temp_path       /tmp/uwsgi_temp;
+  scgi_temp_path        /tmp/scgi_temp;
 
   # events {
   #   worker_connections 1000;


### PR DESCRIPTION
This PR fixes the nginx image not supporting arm/v7 when using ubi9-nginx as base image.

I changed the base-image to the official [unprivileged version of the default nginx image](https://hub.docker.com/r/nginxinc/nginx-unprivileged)