### PR TITLE
Only run scheduled geocoding task once per day

### DIFF
--- a/server/apps/immich/src/modules/schedule-tasks/schedule-tasks.service.ts
+++ b/server/apps/immich/src/modules/schedule-tasks/schedule-tasks.service.ts
@@ -80,7 +80,7 @@ export class ScheduleTasksService {
     }
   }
 
-  @Cron(CronExpression.EVERY_5_SECONDS)
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async reverseGeocoding() {
     const isMapboxEnable = this.configService.get('ENABLE_MAPBOX');
 


### PR DESCRIPTION
This prevents queuing the same asset for multiple tasks at the same time, which would result in duplicated mapbox requests.