### PR TITLE
Update local-reverse-geocoder to 0.12.5

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -20,7 +20,7 @@ import ffmpeg from 'fluent-ffmpeg';
 import path from 'path';
 import sharp from 'sharp';
 import { Repository } from 'typeorm/repository/Repository';
-import geocoder, { AddressObject, InitOptions } from 'local-reverse-geocoder';
+import geocoder, { InitOptions } from 'local-reverse-geocoder';
 import { getName } from 'i18n-iso-countries';
 import { find } from 'geo-tz';
 import * as luxon from 'luxon';

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -36,7 +36,7 @@
         "geo-tz": "^7.0.2",
         "i18n-iso-countries": "^7.5.0",
         "joi": "^17.5.0",
-        "local-reverse-geocoder": "^0.12.2",
+        "local-reverse-geocoder": "^0.12.5",
         "lodash": "^4.17.21",
         "luxon": "^3.0.3",
         "passport": "^0.6.0",
@@ -7661,12 +7661,11 @@
       }
     },
     "node_modules/local-reverse-geocoder": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.2.tgz",
-      "integrity": "sha512-kTSvDxGTuJoqx619jmHFoGCqFpBi0PPwyd7PDOLZCyo8mMEwJSMx713+ksOCihGpzUfO3hcclE7z/T43sY/IaA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.5.tgz",
+      "integrity": "sha512-FaH8+T29K9PQRiiqYlt+M9Qvq9GlSnWEnX0FTDXgPrNzQ9SWWYGEvO5uODwAD6sep9z19u/K/+Z3cw4AGVW97Q==",
       "dependencies": {
         "async": "^3.2.4",
-        "cors": "^2.8.5",
         "csv-parse": "^5.3.0",
         "debug": "^4.3.4",
         "kdt": "^0.1.0",
@@ -17109,12 +17108,11 @@
       "dev": true
     },
     "local-reverse-geocoder": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.2.tgz",
-      "integrity": "sha512-kTSvDxGTuJoqx619jmHFoGCqFpBi0PPwyd7PDOLZCyo8mMEwJSMx713+ksOCihGpzUfO3hcclE7z/T43sY/IaA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.5.tgz",
+      "integrity": "sha512-FaH8+T29K9PQRiiqYlt+M9Qvq9GlSnWEnX0FTDXgPrNzQ9SWWYGEvO5uODwAD6sep9z19u/K/+Z3cw4AGVW97Q==",
       "requires": {
         "async": "^3.2.4",
-        "cors": "^2.8.5",
         "csv-parse": "^5.3.0",
         "debug": "^4.3.4",
         "kdt": "^0.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -55,7 +55,7 @@
     "geo-tz": "^7.0.2",
     "i18n-iso-countries": "^7.5.0",
     "joi": "^17.5.0",
-    "local-reverse-geocoder": "^0.12.2",
+    "local-reverse-geocoder": "^0.12.5",
     "lodash": "^4.17.21",
     "luxon": "^3.0.3",
     "passport": "^0.6.0",


### PR DESCRIPTION
This version includes a fix to the error handling in that library, which was causing our code to silently fail and loop.
See https://github.com/tomayac/local-reverse-geocoder/issues/58 for more detail.