### PR TITLE
Fix z-index ordering of Account Info Box and date-sidebar on web

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar.svelte
@@ -119,7 +119,7 @@
 			in:fade={{ duration: 100 }}
 			out:fade={{ duration: 100 }}
 			id="account-info-panel"
-			class="absolute right-[25px] top-[75px] bg-white shadow-lg rounded-2xl w-[360px] text-center"
+			class="absolute right-[25px] top-[75px] bg-white shadow-lg rounded-2xl w-[360px] text-center z-[100]"
 			use:clickOutside
 			on:out-click={() => (shouldShowAccountInfoPanel = false)}
 		>

--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -94,7 +94,7 @@
 
 <div
 	id="immich-scrubbable-scrollbar"
-	class="fixed right-0 bg-immich-bg z-[999] hover:cursor-row-resize select-none "
+	class="fixed right-0 bg-immich-bg z-[50] hover:cursor-row-resize select-none "
 	style:width={isDragging ? '100vw' : '60px'}
 	style:background-color={isDragging ? 'transparent' : 'transparent'}
 	on:mouseenter={() => (isHover = true)}


### PR DESCRIPTION
Hi there!
This is a small PR to fix a tiny UI issue with the date-sidebar overlapping the Account info box on the web-version of Immich.
Screenshots:
- **Before:**

![Screenshot BEFORE](https://user-images.githubusercontent.com/18481195/194763816-f04285f7-c0f4-482a-930a-2c12c01a0591.png)

- **After:**

![Screenshot AFTER](https://user-images.githubusercontent.com/18481195/194763790-bfaf8047-45ed-4a79-b418-8ccd77a8e580.png)


Great project btw - keep up the great work!
_An_