### PR TITLE
feat(server) Add original file name to the `originalPath` generated UUID file name

### DIFF
--- a/server/apps/immich/src/config/asset-upload.config.ts
+++ b/server/apps/immich/src/config/asset-upload.config.ts
@@ -3,7 +3,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer-options.interface';
 import { existsSync, mkdirSync } from 'fs';
 import { diskStorage } from 'multer';
-import { extname, join } from 'path';
+import { extname, join, basename } from 'path';
 import { Request } from 'express';
 import { randomUUID } from 'crypto';
 import sanitize from 'sanitize-filename';
@@ -39,8 +39,9 @@ export const assetUploadOption: MulterOptions = {
     },
 
     filename: (req: Request, file: Express.Multer.File, cb: any) => {
+      const originalFileName = sanitize(basename(file.originalname, extname(file.originalname)));
       const fileNameUUID = randomUUID();
-      const fileName = `${fileNameUUID}${req.body['fileExtension'].toLowerCase()}`;
+      const fileName = `${originalFileName}-${fileNameUUID}${req.body['fileExtension'].toLowerCase()}`;
       const sanitizedFileName = sanitize(fileName);
       cb(null, sanitizedFileName);
     },


### PR DESCRIPTION
As mentioned in https://github.com/immich-app/immich/issues/38#issuecomment-1274383789

This PR adds the original file name along with generated UUID for the raw uploaded file.

File from phone: `IMG_4852.heic`

Before
```
originalPath: upload/c78b139b-4c1e-490a-9895-ad288461d391/original/device-id/75bcb8b4-1b81-40a1-97a4-7109689d41d4.heic
```

After
```
originalPath: upload/c78b139b-4c1e-490a-9895-ad288461d391/original/device-id/IMG_4852-75bcb8b4-1b81-40a1-97a4-7109689d41d4.heic
```