### PR TITLE
Log a warning if JWT_SECRET key does not have enough bits

### DIFF
--- a/server/libs/common/src/config/app.config.ts
+++ b/server/libs/common/src/config/app.config.ts
@@ -1,5 +1,20 @@
+import { Logger } from '@nestjs/common';
 import { ConfigModuleOptions } from '@nestjs/config';
 import Joi from 'joi';
+import { createSecretKey, generateKeySync } from 'node:crypto'
+
+const jwtSecretValidator: Joi.CustomValidator<string> = (value, _) => {
+  const key = createSecretKey(value, "base64")
+  const keySizeBits = (key.symmetricKeySize ?? 0) * 8
+
+  if (keySizeBits < 128) {
+    const newKey = generateKeySync('hmac', { length: 256 }).export().toString('base64')
+    Logger.warn("The current JWT_SECRET key is insecure. It should be at least 128 bits long!")
+    Logger.warn(`Here is a new, securely generated key that you can use instead: ${newKey}`)
+  }
+
+  return value;
+}
 
 export const immichAppConfig: ConfigModuleOptions = {
   envFilePath: '.env',
@@ -9,7 +24,7 @@ export const immichAppConfig: ConfigModuleOptions = {
     DB_USERNAME: Joi.string().required(),
     DB_PASSWORD: Joi.string().required(),
     DB_DATABASE_NAME: Joi.string().required(),
-    JWT_SECRET: Joi.string().required(),
+    JWT_SECRET: Joi.string().required().custom(jwtSecretValidator),
     DISABLE_REVERSE_GEOCODING: Joi.boolean().optional().valid(true, false).default(false),
     REVERSE_GEOCODING_PRECISION: Joi.number().optional().valid(0,1,2,3).default(3),
     LOG_LEVEL: Joi.string().optional().valid('simple', 'verbose').default('simple'),

--- a/server/libs/common/src/config/app.config.ts
+++ b/server/libs/common/src/config/app.config.ts
@@ -3,7 +3,7 @@ import { ConfigModuleOptions } from '@nestjs/config';
 import Joi from 'joi';
 import { createSecretKey, generateKeySync } from 'node:crypto'
 
-const jwtSecretValidator: Joi.CustomValidator<string> = (value, _) => {
+const jwtSecretValidator: Joi.CustomValidator<string> = (value, ) => {
   const key = createSecretKey(value, "base64")
   const keySizeBits = (key.symmetricKeySize ?? 0) * 8
 


### PR DESCRIPTION
The JWT_SECRET key is used to sign and validate authentication tokens for Immich. As such, it should be set to a sufficiently large value. For the signing algorithm we're using (default, HS256), that means ideally the key should be 256 bits in length. 

This PR adds a logged warning when the JWT_SECRET used is less than 128 bits in length (for some leniency) and generates a new, cryptographically sound key value that the user is presented with to use instead. 