### PR TITLE
[Mobile]: 830: make sure upload re-uses http client

### DIFF
--- a/mobile/lib/modules/backup/models/current_upload_asset.model.dart
+++ b/mobile/lib/modules/backup/models/current_upload_asset.model.dart
@@ -2,12 +2,14 @@ import 'dart:convert';
 
 class CurrentUploadAsset {
   final String id;
+  final String deviceId;
   final DateTime createdAt;
   final String fileName;
   final String fileType;
 
   CurrentUploadAsset({
     required this.id,
+    required this.deviceId,
     required this.createdAt,
     required this.fileName,
     required this.fileType,
@@ -15,12 +17,14 @@ class CurrentUploadAsset {
 
   CurrentUploadAsset copyWith({
     String? id,
+    String? deviceId,
     DateTime? createdAt,
     String? fileName,
     String? fileType,
   }) {
     return CurrentUploadAsset(
       id: id ?? this.id,
+      deviceId: deviceId ?? this.deviceId,
       createdAt: createdAt ?? this.createdAt,
       fileName: fileName ?? this.fileName,
       fileType: fileType ?? this.fileType,
@@ -31,6 +35,7 @@ class CurrentUploadAsset {
     final result = <String, dynamic>{};
 
     result.addAll({'id': id});
+    result.addAll({'deviceId': deviceId});
     result.addAll({'createdAt': createdAt.millisecondsSinceEpoch});
     result.addAll({'fileName': fileName});
     result.addAll({'fileType': fileType});
@@ -41,6 +46,7 @@ class CurrentUploadAsset {
   factory CurrentUploadAsset.fromMap(Map<String, dynamic> map) {
     return CurrentUploadAsset(
       id: map['id'] ?? '',
+      deviceId: map['deviceId'] ?? '',
       createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt']),
       fileName: map['fileName'] ?? '',
       fileType: map['fileType'] ?? '',
@@ -54,7 +60,7 @@ class CurrentUploadAsset {
 
   @override
   String toString() {
-    return 'CurrentUploadAsset(id: $id, createdAt: $createdAt, fileName: $fileName, fileType: $fileType)';
+    return 'CurrentUploadAsset(id: $id, deviceId: $deviceId, createdAt: $createdAt, fileName: $fileName, fileType: $fileType)';
   }
 
   @override
@@ -63,6 +69,7 @@ class CurrentUploadAsset {
 
     return other is CurrentUploadAsset &&
         other.id == id &&
+        other.deviceId == deviceId &&
         other.createdAt == createdAt &&
         other.fileName == fileName &&
         other.fileType == fileType;
@@ -71,6 +78,7 @@ class CurrentUploadAsset {
   @override
   int get hashCode {
     return id.hashCode ^
+        deviceId.hashCode ^
         createdAt.hashCode ^
         fileName.hashCode ^
         fileType.hashCode;

--- a/mobile/lib/modules/backup/models/error_upload_asset.model.dart
+++ b/mobile/lib/modules/backup/models/error_upload_asset.model.dart
@@ -1,9 +1,12 @@
 import 'package:equatable/equatable.dart';
 import 'package:photo_manager/photo_manager.dart';
 
+import 'current_upload_asset.model.dart';
+
 class ErrorUploadAsset extends Equatable {
   final String id;
   final DateTime createdAt;
+  final CurrentUploadAsset uploadAsset;
   final String fileName;
   final String fileType;
   final AssetEntity asset;
@@ -12,6 +15,7 @@ class ErrorUploadAsset extends Equatable {
   const ErrorUploadAsset({
     required this.id,
     required this.createdAt,
+    required this.uploadAsset,
     required this.fileName,
     required this.fileType,
     required this.asset,
@@ -21,6 +25,7 @@ class ErrorUploadAsset extends Equatable {
   ErrorUploadAsset copyWith({
     String? id,
     DateTime? createdAt,
+    CurrentUploadAsset? uploadAsset,
     String? fileName,
     String? fileType,
     AssetEntity? asset,
@@ -29,6 +34,7 @@ class ErrorUploadAsset extends Equatable {
     return ErrorUploadAsset(
       id: id ?? this.id,
       createdAt: createdAt ?? this.createdAt,
+      uploadAsset: uploadAsset ?? this.uploadAsset,
       fileName: fileName ?? this.fileName,
       fileType: fileType ?? this.fileType,
       asset: asset ?? this.asset,
@@ -38,7 +44,7 @@ class ErrorUploadAsset extends Equatable {
 
   @override
   String toString() {
-    return 'ErrorUploadAsset(id: $id, createdAt: $createdAt, fileName: $fileName, fileType: $fileType, asset: $asset, errorMessage: $errorMessage)';
+    return 'ErrorUploadAsset(id: $id, createdAt: $createdAt, uploadAsset: $uploadAsset, fileName: $fileName, fileType: $fileType, asset: $asset, errorMessage: $errorMessage)';
   }
 
   @override

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -5,13 +5,13 @@ import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
 import 'package:immich_mobile/modules/backup/models/available_album.model.dart';
 import 'package:immich_mobile/modules/backup/models/backup_state.model.dart';
 import 'package:immich_mobile/modules/backup/models/current_upload_asset.model.dart';
 import 'package:immich_mobile/modules/backup/models/error_upload_asset.model.dart';
 import 'package:immich_mobile/modules/backup/models/hive_backup_albums.model.dart';
 import 'package:immich_mobile/modules/backup/providers/error_backup_list.provider.dart';
-import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
 import 'package:immich_mobile/modules/backup/services/backup.service.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
@@ -52,6 +52,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
             selectedAlbumsBackupAssetsIds: const {},
             currentUploadAsset: CurrentUploadAsset(
               id: '...',
+              deviceId: '...',
               createdAt: DateTime.parse('2020-10-04'),
               fileName: '...',
               fileType: '...',
@@ -455,7 +456,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     );
   }
 
-  void _onAssetUploaded(String deviceAssetId, String deviceId) {
+  void _onAssetUploaded(CurrentUploadAsset asset) {
+    final deviceAssetId = asset.id;
     state = state.copyWith(
       selectedAlbumsBackupAssetsIds: {
         ...state.selectedAlbumsBackupAssetsIds,
@@ -487,7 +489,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     _updateServerInfo();
   }
 
-  void _onUploadProgress(int sent, int total) {
+  void _onUploadProgress(CurrentUploadAsset asset, int sent, int total) {
     state = state.copyWith(
       progressInPercentage: (sent.toDouble() / total.toDouble() * 100),
     );

--- a/mobile/lib/modules/backup/services/uploader.service.dart
+++ b/mobile/lib/modules/backup/services/uploader.service.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cancellation_token_http/http.dart' as http;
+import 'package:flutter/cupertino.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:immich_mobile/modules/backup/services/backup.service.dart';
+
+class UploadJob {
+  final String assetId;
+  final String serverEndpoint;
+  final String originalFileName;
+  final String fileNameWithoutPath;
+  final File src;
+  final String mediaType;
+  final Map<String, String> headers;
+  final Map<String, String> formFields;
+
+  const UploadJob({
+    required this.assetId,
+    required this.serverEndpoint,
+    required this.originalFileName,
+    required this.fileNameWithoutPath,
+    required this.src,
+    required this.mediaType,
+    required this.headers,
+    required this.formFields,
+  });
+}
+
+class UploadResult {
+  final bool success;
+  final bool isCancelled;
+
+  UploadResult({required this.success, required this.isCancelled});
+}
+
+class UploadService {
+  final _httpClient = http.Client();
+
+  UploadService();
+
+  Future<UploadResult> run(
+    UploadJob job, {
+    required Function(String, int, int) onProgress,
+    required Function(String) onCompleted,
+    required Function(String assetId, Object error) onError,
+    http.CancellationToken? cancelToken,
+  }) async {
+    var mediaType = MediaType.parse(job.mediaType);
+    var assetId = job.assetId;
+    var originalFileName = job.originalFileName;
+    var fileNameWithoutPath = job.fileNameWithoutPath;
+
+    var file = job.src;
+    var fileSize = await file.length();
+    var fileStream = file.openRead();
+
+    var assetRawUploadData = http.MultipartFile(
+      "assetData",
+      fileStream,
+      fileSize,
+      filename: fileNameWithoutPath,
+      contentType: mediaType,
+    );
+
+    var uploadTarget = Uri.parse("${job.serverEndpoint}/asset/upload");
+    var req = MultipartRequest(
+      'POST',
+      uploadTarget,
+      onProgress: (bytes, totalBytes) => onProgress(assetId, bytes, totalBytes),
+    );
+    var formFields = job.formFields;
+    req.fields.addAll(formFields);
+    req.files.add(assetRawUploadData);
+    var headers = job.headers;
+    // TODO: leave authorization header up to caller?
+    //req.headers["Authorization"] = "Bearer $accessToken";
+    req.headers.addAll(headers);
+
+    bool success = false;
+    try {
+      var response = await _httpClient.send(
+        req,
+        cancellationToken: cancelToken,
+      );
+      if (response.statusCode == 201) {
+        success = true;
+        onCompleted(assetId);
+      } else {
+        var data = await response.stream.bytesToString();
+        var error = jsonDecode(data);
+
+        final errorMsg =
+            "Error(${response.statusCode}) body='$data' uploading $fileNameWithoutPath | $originalFileName | ${error['error']}";
+        debugPrint(errorMsg);
+        onError(assetId, errorMsg);
+      }
+    } on http.CancelledException {
+      debugPrint("Backup was cancelled by the user");
+      return UploadResult(success: false, isCancelled: true);
+    } catch (e) {
+      debugPrint("ERROR backupAsset: ${e.toString()}");
+      onError(assetId, e);
+    }
+
+    return UploadResult(success: success, isCancelled: false);
+  }
+}


### PR DESCRIPTION
Initial upload on a large timeline is slow. My 8000 photos takes at least 3 hours even when on the same local network.

I noticed that the http client is created new for every single file in the upload. This breaks connection pooling/caching, making each upload setup a new connection.

This also moves the upload process towards centering around the CurrentUploadAsset object.

I created a issue here:
https://github.com/immich-app/immich/issues/830