### PR TITLE
fix(mobile) back button navigation Android

### DIFF
--- a/mobile/lib/modules/login/ui/login_form.dart
+++ b/mobile/lib/modules/login/ui/login_form.dart
@@ -228,7 +228,7 @@ class LoginButton extends ConsumerWidget {
             AutoRouter.of(context).push(const ChangePasswordRoute());
           } else {
             ref.watch(backupProvider.notifier).resumeBackup();
-            AutoRouter.of(context).pushNamed("/tab-controller-page");
+            AutoRouter.of(context).replace(const TabControllerRoute());
           }
         } else {
           ImmichToast.show(

--- a/mobile/lib/shared/views/splash_screen.dart
+++ b/mobile/lib/shared/views/splash_screen.dart
@@ -29,9 +29,9 @@ class SplashScreenPage extends HookConsumerWidget {
       if (isAuthenticated) {
         // Resume backup (if enable) then navigate
         ref.watch(backupProvider.notifier).resumeBackup();
-        AutoRouter.of(context).pushNamed("/tab-controller-page");
+        AutoRouter.of(context).replace(const TabControllerRoute());
       } else {
-        AutoRouter.of(context).push(const LoginRoute());
+        AutoRouter.of(context).replace(const LoginRoute());
       }
     }
 
@@ -40,7 +40,7 @@ class SplashScreenPage extends HookConsumerWidget {
         if (loginInfo?.isSaveLogin == true) {
           performLoggingIn();
         } else {
-          AutoRouter.of(context).push(const LoginRoute());
+          AutoRouter.of(context).replace(const LoginRoute());
         }
         return null;
       },

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -12,7 +12,6 @@ class TabControllerPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final multiselectEnabled = ref.watch(multiselectProvider);
-
     return AutoTabsRouter(
       routes: [
         const HomeRoute(),
@@ -22,9 +21,17 @@ class TabControllerPage extends ConsumerWidget {
       ],
       builder: (context, child, animation) {
         final tabsRouter = AutoTabsRouter.of(context);
+        final appRouter = AutoRouter.of(context);
         return WillPopScope(
           onWillPop: () async {
-            tabsRouter.setActiveIndex(0);
+            if (tabsRouter.activeIndex == 0) {
+              if (!appRouter.canNavigateBack) {
+                appRouter.navigateBack();
+              }
+              return appRouter.canNavigateBack;
+            } else {
+              tabsRouter.setActiveIndex(0);
+            }
             return false;
           },
           child: Scaffold(


### PR DESCRIPTION
this PR is to fix a bug reported by issue #310,
 
additionally there are screens (e.g. Splash Screen) which should not be visited again when back button is pressed,
to handle such cases I have replaced some `router.push` calls with `router.replace` calls.
