### PR TITLE
feat(immich-server) use ubuntu base-image

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,4 +1,5 @@
 node_modules/
 upload/
 dist/
+coverage/
 .reverse-geocoding-dump

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,28 +1,41 @@
 # Build stage
-FROM node:16-alpine3.14 as builder
+FROM node:16-slim as builder
 
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
 
-RUN apk add --update-cache build-base python3 libheif vips-dev ffmpeg
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      python3 \
+      libheif-dev \
+      libvips-dev \
+      ffmpeg && \
+    apt-get -y clean && apt-get autoremove -y && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+
 RUN npm ci
 
 COPY . .
 
 RUN npm run build
 
-
 # Prod stage
-FROM node:16-alpine3.14
+FROM node:16-slim
 
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
 COPY start-server.sh start-microservices.sh ./
 
-RUN mkdir -p /usr/src/app/dist \
-  && apk add --no-cache libheif vips ffmpeg
+RUN mkdir -p /usr/src/app/dist
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      libheif-dev \
+      libvips-dev \
+      ffmpeg && \
+    apt-get -y clean && apt-get autoremove -y && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist


### PR DESCRIPTION
this changes the base-image for immich-server from `node:16-alpine3.14`
to
`node:16-slim`

There is an open issue with alpine DNS resolving which breaks immich-microservice when deployed on
kubernetes.

This fixes https://github.com/immich-app/immich-charts/issues/4

Signed-off-by: PixelJonas <5434875+PixelJonas@users.noreply.github.com>