### PR TITLE
feat(docker) revert ubuntu base image

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
 
-RUN apt-get update
-RUN apt-get install gcc g++ make cmake python3 python3-pip ffmpeg -y
+RUN   apt-get update > /dev/null \
+  &&  apt-get install --no-install-recommends -y gcc g++ make cmake python3 python3-pip ffmpeg > /dev/null \
+  &&  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN npm ci
 RUN npm rebuild @tensorflow/tfjs-node --build-from-source
@@ -23,6 +24,9 @@ FROM node:16-bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+COPY LICENSE /licenses/LICENSE.txt
+COPY LICENSE /LICENSE
+
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
@@ -30,13 +34,18 @@ COPY entrypoint.sh ./
 
 RUN mkdir -p /usr/src/app/dist \
   && mkdir -p /usr/src/app/node_modules \
-  && apt-get update \
-  && apt-get install -y ffmpeg \
-  && rm -rf /var/cache/apt/lists
+  && mkdir -p /usr/src/app/.reverse-geocoding-dump \
+  && apt-get update > /dev/null \
+  && apt-get install --no-install-recommends -y ffmpeg > /dev/null \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/lists/*
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 
 RUN npm prune --production
 
-# CMD [ "node", "dist/main" ]
+RUN   chown -R node:0 /usr/src/app \
+  &&  chmod -R g=u /usr/src/app
+
+RUN addgroup node root

--- a/machine-learning/LICENSE
+++ b/machine-learning/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hau Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker.io/nginxinc/nginx-unprivileged:latest
 
+COPY LICENSE /licenses/LICENSE.txt
+COPY LICENSE /LICENSE
+
 COPY nginx.conf "/etc/nginx/nginx.conf"
 
 CMD nginx -g "daemon off;"

--- a/nginx/LICENSE
+++ b/nginx/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hau Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,19 +1,10 @@
-# Build stage
-FROM node:16-slim as builder
+FROM node:16-alpine3.14 as builder
 
 WORKDIR /usr/src/app
 
 COPY package.json package-lock.json ./
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      build-essential \
-      python3 \
-      libheif-dev \
-      libvips-dev \
-      ffmpeg && \
-    apt-get -y clean && apt-get autoremove -y && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
-
+RUN apk add --update-cache build-base python3 libheif vips-dev ffmpeg
 RUN npm ci
 
 COPY . .
@@ -21,26 +12,28 @@ COPY . .
 RUN npm run build
 
 # Prod stage
-FROM node:16-slim
+FROM node:16-alpine3.14
 
 WORKDIR /usr/src/app
+COPY LICENSE /licenses/LICENSE.txt
+COPY LICENSE /LICENSE
 
 COPY package.json package-lock.json ./
 COPY start-server.sh start-microservices.sh ./
 
-RUN mkdir -p /usr/src/app/dist
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      libheif-dev \
-      libvips-dev \
-      ffmpeg && \
-    apt-get -y clean && apt-get autoremove -y && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /usr/src/app/dist \
+  && mkdir /usr/src/app/.reverse-geocoding-dump \
+  && apk add --no-cache libheif vips ffmpeg
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 
 RUN npm prune --production
+
+RUN   chown -R node:0 /usr/src/app \
+  &&  chmod -R g=u /usr/src/app
+
+RUN addgroup node root
 
 VOLUME /usr/src/app/upload
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,45 @@
+# FROM node:16-alpine3.14 as builder
+
+# WORKDIR /usr/src/app
+
+# COPY package.json package-lock.json ./
+
+# RUN apk add --update-cache build-base python3 libheif vips-dev ffmpeg
+# RUN npm ci
+
+# COPY . .
+
+# RUN npm run build
+
+# # Prod stage
+# FROM node:16-alpine3.14
+
+# WORKDIR /usr/src/app
+# COPY LICENSE /licenses/LICENSE.txt
+# COPY LICENSE /LICENSE
+
+# COPY package.json package-lock.json ./
+# COPY start-server.sh start-microservices.sh ./
+
+# RUN mkdir -p /usr/src/app/dist \
+#   && mkdir /usr/src/app/.reverse-geocoding-dump \
+#   && apk add --no-cache libheif vips ffmpeg
+
+# COPY --from=builder /usr/src/app/node_modules ./node_modules
+# COPY --from=builder /usr/src/app/dist ./dist
+
+# RUN npm prune --production
+
+# RUN   chown -R node:0 /usr/src/app \
+#   &&  chmod -R g=u /usr/src/app
+
+# RUN addgroup node root
+
+# VOLUME /usr/src/app/upload
+
+# EXPOSE 3001
+
+# Build stage
 FROM node:16-alpine3.14 as builder
 
 WORKDIR /usr/src/app
@@ -11,29 +53,22 @@ COPY . .
 
 RUN npm run build
 
+
 # Prod stage
 FROM node:16-alpine3.14
 
 WORKDIR /usr/src/app
-COPY LICENSE /licenses/LICENSE.txt
-COPY LICENSE /LICENSE
 
 COPY package.json package-lock.json ./
 COPY start-server.sh start-microservices.sh ./
 
 RUN mkdir -p /usr/src/app/dist \
-  && mkdir /usr/src/app/.reverse-geocoding-dump \
   && apk add --no-cache libheif vips ffmpeg
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 
 RUN npm prune --production
-
-RUN   chown -R node:0 /usr/src/app \
-  &&  chmod -R g=u /usr/src/app
-
-RUN addgroup node root
 
 VOLUME /usr/src/app/upload
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,45 +1,3 @@
-# FROM node:16-alpine3.14 as builder
-
-# WORKDIR /usr/src/app
-
-# COPY package.json package-lock.json ./
-
-# RUN apk add --update-cache build-base python3 libheif vips-dev ffmpeg
-# RUN npm ci
-
-# COPY . .
-
-# RUN npm run build
-
-# # Prod stage
-# FROM node:16-alpine3.14
-
-# WORKDIR /usr/src/app
-# COPY LICENSE /licenses/LICENSE.txt
-# COPY LICENSE /LICENSE
-
-# COPY package.json package-lock.json ./
-# COPY start-server.sh start-microservices.sh ./
-
-# RUN mkdir -p /usr/src/app/dist \
-#   && mkdir /usr/src/app/.reverse-geocoding-dump \
-#   && apk add --no-cache libheif vips ffmpeg
-
-# COPY --from=builder /usr/src/app/node_modules ./node_modules
-# COPY --from=builder /usr/src/app/dist ./dist
-
-# RUN npm prune --production
-
-# RUN   chown -R node:0 /usr/src/app \
-#   &&  chmod -R g=u /usr/src/app
-
-# RUN addgroup node root
-
-# VOLUME /usr/src/app/upload
-
-# EXPOSE 3001
-
-# Build stage
 FROM node:16-alpine3.14 as builder
 
 WORKDIR /usr/src/app
@@ -53,22 +11,29 @@ COPY . .
 
 RUN npm run build
 
-
 # Prod stage
 FROM node:16-alpine3.14
 
 WORKDIR /usr/src/app
+COPY LICENSE /licenses/LICENSE.txt
+COPY LICENSE /LICENSE
 
 COPY package.json package-lock.json ./
 COPY start-server.sh start-microservices.sh ./
 
 RUN mkdir -p /usr/src/app/dist \
+  && mkdir /usr/src/app/.reverse-geocoding-dump \
   && apk add --no-cache libheif vips ffmpeg
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 
 RUN npm prune --production
+
+RUN   chown -R node:0 /usr/src/app \
+  &&  chmod -R g=u /usr/src/app
+
+RUN addgroup node root
 
 VOLUME /usr/src/app/upload
 

--- a/server/LICENSE
+++ b/server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hau Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,11 +1,13 @@
 # Our Node base image
 FROM node:16-alpine3.14 as base
 
+COPY LICENSE /licenses/LICENSE.txt
+COPY LICENSE /LICENSE
+
 WORKDIR /usr/src/app
 
-RUN chown node:node /usr/src/app
-
-RUN apk add --no-cache setpriv
+RUN chown node:node /usr/src/app && \
+    apk add --no-cache setpriv
 
 COPY --chown=node:node package*.json ./
 
@@ -13,7 +15,11 @@ RUN npm ci
 
 COPY --chown=node:node . .
 
-RUN npm run build
+RUN   npm run build \
+  &&  chown -R node:0 /usr/src/app \
+  &&  chmod -R g=u /usr/src/app
+
+RUN addgroup node root
 
 EXPOSE 3000
 

--- a/web/LICENSE
+++ b/web/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hau Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR reverts the base image for immich-server back to alpine

Adds LICENSE to all Images
Quiets apt-get commands when building
ensures write-permission for root group on app folders

Signed-off-by: PixelJonas <5434875+PixelJonas@users.noreply.github.com>