### PR TITLE
feat(web) add handler for ctrl-c copying images from viewer (#881)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,12 +10,14 @@
 			"dependencies": {
 				"axios": "^0.27.2",
 				"cookie": "^0.4.2",
+				"copy-image-clipboard": "^2.1.2",
 				"exifr": "^7.1.3",
 				"leaflet": "^1.8.0",
 				"lodash": "^4.17.21",
 				"lodash-es": "^4.17.21",
 				"moment": "^2.29.3",
 				"socket.io-client": "^4.5.1",
+				"svelte-keydown": "^0.5.0",
 				"svelte-material-icons": "^2.0.2"
 			},
 			"devDependencies": {
@@ -4454,6 +4456,11 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/copy-image-clipboard": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/copy-image-clipboard/-/copy-image-clipboard-2.1.2.tgz",
+			"integrity": "sha512-3VCXVl2IpFfOyD8drv9DozcNlwmqBqxOlsgkEGyVAzadjlPk1go8YNZyy8QmTnwHPxSFpeCR9OdsStEdVK7qDA=="
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.25.1",
@@ -10334,6 +10341,11 @@
 				"svelte": ">= 3"
 			}
 		},
+		"node_modules/svelte-keydown": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/svelte-keydown/-/svelte-keydown-0.5.0.tgz",
+			"integrity": "sha512-DgY6AYlKbBocSvjC3kUeNPcStJQOTOCxAGG9ymVHzJdsQ1hRJuB8pcnB4UFH8uH3bAPdYyXXa3LwenLDL41eqQ=="
+		},
 		"node_modules/svelte-material-icons": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/svelte-material-icons/-/svelte-material-icons-2.0.4.tgz",
@@ -14400,6 +14412,11 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+		},
+		"copy-image-clipboard": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/copy-image-clipboard/-/copy-image-clipboard-2.1.2.tgz",
+			"integrity": "sha512-3VCXVl2IpFfOyD8drv9DozcNlwmqBqxOlsgkEGyVAzadjlPk1go8YNZyy8QmTnwHPxSFpeCR9OdsStEdVK7qDA=="
 		},
 		"core-js-compat": {
 			"version": "3.25.1",
@@ -18618,6 +18635,11 @@
 			"integrity": "sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==",
 			"dev": true,
 			"requires": {}
+		},
+		"svelte-keydown": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/svelte-keydown/-/svelte-keydown-0.5.0.tgz",
+			"integrity": "sha512-DgY6AYlKbBocSvjC3kUeNPcStJQOTOCxAGG9ymVHzJdsQ1hRJuB8pcnB4UFH8uH3bAPdYyXXa3LwenLDL41eqQ=="
 		},
 		"svelte-material-icons": {
 			"version": "2.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -59,12 +59,14 @@
 	"dependencies": {
 		"axios": "^0.27.2",
 		"cookie": "^0.4.2",
+		"copy-image-clipboard": "^2.1.2",
 		"exifr": "^7.1.3",
 		"leaflet": "^1.8.0",
 		"lodash": "^4.17.21",
 		"lodash-es": "^4.17.21",
 		"moment": "^2.29.3",
 		"socket.io-client": "^4.5.1",
+		"svelte-keydown": "^0.5.0",
 		"svelte-material-icons": "^2.0.2"
 	}
 }


### PR DESCRIPTION
This adds a handler for copying an image from the web asset viewer with Control-c. Nice for sharing quickly to messaging programs and such :)

The import for copy-image-clipboard is a bit hacky. Unfortunately I couldn't get it to work any other way - everything I tired resulted in this error:
```
immich-web_1               | copy-image-clipboard doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
immich-web_1               | (node:17) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
immich-web_1               | (Use `node --trace-warnings ...` to show where the warning was created)
immich-web_1               | Unexpected token 'export'
immich-web_1               | /usr/src/app/node_modules/copy-image-clipboard/dist/index.js:175
immich-web_1               | export { canCopyImagesToClipboard, convertBlobToPng, copyBlobToClipboard, copyImageToClipboard, createImageElement, getBlobFromImageElement, getBlobFromImageSource, isJpegBlob, isPngBlob, requestClipboardWritePermission };
immich-web_1               | ^^^^^^
immich-web_1               | 
immich-web_1               | SyntaxError: Unexpected token 'export'
immich-web_1               |     at compileFunction (<anonymous>)
immich-web_1               |     at Object.compileFunction (node:vm:352:18)
immich-web_1               |     at wrapSafe (node:internal/modules/cjs/loader:1033:15)
immich-web_1               |     at Module._compile (node:internal/modules/cjs/loader:1069:27)
immich-web_1               |     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
immich-web_1               |     at Module.load (node:internal/modules/cjs/loader:981:32)
immich-web_1               |     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
immich-web_1               |     at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:170:29)
immich-web_1               |     at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
immich-web_1               |     at async Promise.all (index 0)
```
If anybody knows how to fix that, that'd be welcome :)