### PR TITLE
feat(web) Make "no albums" card clickable (#888)

### DIFF
--- a/web/src/routes/albums/+page.svelte
+++ b/web/src/routes/albums/+page.svelte
@@ -93,7 +93,8 @@
 			<!-- Empty Message -->
 			{#if $albums.length === 0}
 				<div
-					class="border dark:border-immich-dark-gray p-5 w-[50%] m-auto mt-10 bg-gray-50 dark:bg-immich-dark-gray rounded-3xl flex flex-col place-content-center place-items-center"
+					on:click={handleCreateAlbum}
+					class="border dark:border-immich-dark-gray hover:bg-immich-primary/5 dark:hover:bg-immich-dark-primary/25 p-5 w-[50%] m-auto mt-10 bg-gray-50 dark:bg-immich-dark-gray rounded-3xl flex flex-col place-content-center place-items-center"
 				>
 					<img src="/empty-1.svg" alt="Empty shared album" width="500" />
 

--- a/web/src/routes/albums/+page.svelte
+++ b/web/src/routes/albums/+page.svelte
@@ -94,7 +94,7 @@
 			{#if $albums.length === 0}
 				<div
 					on:click={handleCreateAlbum}
-					class="border dark:border-immich-dark-gray hover:bg-immich-primary/5 dark:hover:bg-immich-dark-primary/25 p-5 w-[50%] m-auto mt-10 bg-gray-50 dark:bg-immich-dark-gray rounded-3xl flex flex-col place-content-center place-items-center"
+					class="border dark:border-immich-dark-gray hover:bg-immich-primary/5 dark:hover:bg-immich-dark-primary/25 hover:cursor-pointer p-5 w-[50%] m-auto mt-10 bg-gray-50 dark:bg-immich-dark-gray rounded-3xl flex flex-col place-content-center place-items-center"
 				>
 					<img src="/empty-1.svg" alt="Empty shared album" width="500" />
 


### PR DESCRIPTION
On the albums page, if no albums exist, there is a card saying so and inviting you to create a new album. That card looks very clickable, but isn't. This change fixes that.