### PR TITLE
fix(server): download album error handling

### DIFF
--- a/server/apps/immich/src/api-v1/album/album.controller.ts
+++ b/server/apps/immich/src/api-v1/album/album.controller.ts
@@ -25,7 +25,7 @@ import { GetAlbumsDto } from './dto/get-albums.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AlbumResponseDto } from './response-dto/album-response.dto';
 import { AlbumCountResponseDto } from './response-dto/album-count-response.dto';
-import {AddAssetsResponseDto} from "./response-dto/add-assets-response.dto";
+import { AddAssetsResponseDto } from './response-dto/add-assets-response.dto';
 import { Response as Res } from 'express';
 
 // TODO might be worth creating a AlbumParamsDto that validates `albumId` instead of using the pipe.
@@ -60,7 +60,7 @@ export class AlbumController {
     @GetAuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) addAssetsDto: AddAssetsDto,
     @Param('albumId', new ParseUUIDPipe({ version: '4' })) albumId: string,
-  ) : Promise<AddAssetsResponseDto> {
+  ): Promise<AddAssetsResponseDto> {
     return this.albumService.addAssetsToAlbum(authUser, addAssetsDto, albumId);
   }
 
@@ -121,6 +121,8 @@ export class AlbumController {
     @Param('albumId', new ParseUUIDPipe({ version: '4' })) albumId: string,
     @Response({ passthrough: true }) res: Res,
   ): Promise<any> {
-    return this.albumService.downloadArchive(authUser, albumId, res);
+    const { stream, filename } = await this.albumService.downloadArchive(authUser, albumId);
+    res.attachment(filename);
+    return stream;
   }
 }


### PR DESCRIPTION
This PR fixes a bug in the error handling of the download album feature. Specifically, unauthorized access to an album incorrectly throws an internal server error.

It was also refactored to:
- Use `path.extname` instead of string splitting
- Use `StreamableFile` instead of `Response` (easier to test)
- Throw `BadRequestException` when trying to download an empty album
- Fix linting in album controller.