### PR TITLE
fix(server, web): harden auto pick album thumbnails (#918)

### DIFF
--- a/server/apps/immich/src/api-v1/album/album.service.ts
+++ b/server/apps/immich/src/api-v1/album/album.service.ts
@@ -64,11 +64,13 @@ export class AlbumService {
    * @returns All Shared Album And Its Members
    */
   async getAllAlbums(authUser: AuthUserDto, getAlbumsDto: GetAlbumsDto): Promise<AlbumResponseDto[]> {
+    let albums: AlbumEntity[];
+
     if (typeof getAlbumsDto.assetId === 'string') {
-      const albums = await this._albumRepository.getListByAssetId(authUser.id, getAlbumsDto.assetId);
-      return albums.map(mapAlbumExcludeAssetInfo);
+      albums = await this._albumRepository.getListByAssetId(authUser.id, getAlbumsDto.assetId);
+    } else {
+      albums = await this._albumRepository.getList(authUser.id, getAlbumsDto);
     }
-    const albums = await this._albumRepository.getList(authUser.id, getAlbumsDto);
 
     for (const album of albums) {
       await this._checkValidThumbnail(album);

--- a/web/src/lib/components/album-page/__tests__/album-card.spec.ts
+++ b/web/src/lib/components/album-page/__tests__/album-card.spec.ts
@@ -43,8 +43,8 @@ describe('AlbumCard component', () => {
 			const albumNameElement = sut.getByTestId('album-name');
 			const albumDetailsElement = sut.getByTestId('album-details');
 			const detailsText = `${count} items` + (shared ? ' . Shared' : '');
-			// TODO: is this a bug?
-			expect(albumImgElement).toHaveAttribute('src', '/api/asset/thumbnail/null?format=WEBP');
+
+			expect(albumImgElement).toHaveAttribute('src', 'no-thumbnail.png');
 			expect(albumImgElement).toHaveAttribute('alt', album.id);
 
 			await waitFor(() => expect(albumImgElement).toHaveAttribute('src', 'no-thumbnail.png'));

--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -19,7 +19,13 @@
 
 	export let album: AlbumResponseDto;
 
+	const NO_THUMBNAIL = 'no-thumbnail.png';
+
 	let imageData = `/api/asset/thumbnail/${album.albumThumbnailAssetId}?format=${ThumbnailFormat.Webp}`;
+	if (!album.albumThumbnailAssetId) {
+		imageData = NO_THUMBNAIL;
+	}
+
 	const dispatchClick = createEventDispatcher<OnClick>();
 	const dispatchShowContextMenu = createEventDispatcher<OnShowContextMenu>();
 
@@ -45,7 +51,7 @@
 	};
 
 	onMount(async () => {
-		imageData = (await loadHighQualityThumbnail(album.albumThumbnailAssetId)) || 'no-thumbnail.png';
+		imageData = (await loadHighQualityThumbnail(album.albumThumbnailAssetId)) || NO_THUMBNAIL;
 	});
 </script>
 


### PR DESCRIPTION
The PR fixes a few things related to album thumbnails. Specifically it will auto-fix albums where the asset thumbnail has been deleted from the library or removed from the album.

- Fix web client - prevent it from making a request to a null thumbnail on first load
- Move bad request logic from the album repository to the album service
- Check for valid thumbnails on all code paths
- Auto-pick a new thumbnail from the existing album assets.