### PR TITLE
feat(deployment) Allow overriding service host and ports with env variable

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -75,9 +75,6 @@ PUBLIC_LOGIN_PAGE_MESSAGE=
 # This is an advanced feature for users who may be running their immich services on different hosts. It will not change which address or port that services bind to within their containers, but it will change where other services look for their peers.
 # Note: immich-microservices is bound to 3002, but no references are made
 
-# IMMICH_WEB_HOST=immich-web
-# IMMICH_WEB_PORT=3000
-# IMMICH_SERVER_HOST=immich-server
-# IMMICH_SERVER_PORT=3001
-# IMMICH_MACHINE_LEARNING_HOST=immich-machine-learning
-# IMMICH_MACHINE_LEARNING_PORT=3003
+# IMMICH_WEB_URL=http://immich-web:3000
+# IMMICH_SERVER_URL=http://immich-server:3001
+# IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -67,3 +67,17 @@ JWT_SECRET=
 # For example PUBLIC_LOGIN_PAGE_MESSAGE="This is a demo instance of Immich.<br><br>Email: <i>demo@demo.de</i><br>Password: <i>demo</i>"
 
 PUBLIC_LOGIN_PAGE_MESSAGE=
+
+####################################################################################
+# Alternative Service Addresses - Optional
+####################################################################################
+
+# This is an advanced feature for users who may be running their immich services on different hosts. It will not change which address or port that services bind to within their containers, but it will change where other services look for their peers.
+# Note: immich-microservices is bound to 3002, but no references are made
+
+# IMMICH_WEB_HOST=immich-web
+# IMMICH_WEB_PORT=3000
+# IMMICH_SERVER_HOST=immich-server
+# IMMICH_SERVER_PORT=3001
+# IMMICH_MACHINE_LEARNING_HOST=immich-machine-learning
+# IMMICH_MACHINE_LEARNING_PORT=3003

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -68,6 +68,10 @@ services:
     command: npm run dev --host
     env_file:
       - .env
+    environment:
+      # Rename these values for svelte public interface
+      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
+      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
     ports:
       - 3000:3000
       - 24678:24678

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -100,6 +100,12 @@ services:
   immich-proxy:
     container_name: immich_proxy
     image: immich-proxy-dev:latest
+    environment:
+      # Make sure these values get passed through from the env file
+      - IMMICH_SERVER_HOST
+      - IMMICH_SERVER_PORT
+      - IMMICH_WEB_HOST
+      - IMMICH_WEB_PORT
     build:
       context: ../nginx
       dockerfile: Dockerfile

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -70,8 +70,7 @@ services:
       - .env
     environment:
       # Rename these values for svelte public interface
-      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
-      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
+      - PUBLIC_IMMICH_SERVER_URL=${IMMICH_SERVER_URL}
     ports:
       - 3000:3000
       - 24678:24678
@@ -106,10 +105,8 @@ services:
     image: immich-proxy-dev:latest
     environment:
       # Make sure these values get passed through from the env file
-      - IMMICH_SERVER_HOST
-      - IMMICH_SERVER_PORT
-      - IMMICH_WEB_HOST
-      - IMMICH_WEB_PORT
+      - IMMICH_SERVER_URL
+      - IMMICH_WEB_URL
     build:
       context: ../nginx
       dockerfile: Dockerfile

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -71,6 +71,12 @@ services:
   immich-proxy:
     container_name: immich_proxy
     image: altran1502/immich-proxy:staging
+    environment:
+      # Make sure these values get passed through from the env file
+      - IMMICH_SERVER_HOST
+      - IMMICH_SERVER_PORT
+      - IMMICH_WEB_HOST
+      - IMMICH_WEB_PORT
     ports:
       - 2283:8080
     logging:

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -47,6 +47,10 @@ services:
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:
       - .env
+    environment:
+      # Rename these values for svelte public interface
+      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
+      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
     restart: always
 
   redis:

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -49,8 +49,7 @@ services:
       - .env
     environment:
       # Rename these values for svelte public interface
-      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
-      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
+      - PUBLIC_IMMICH_SERVER_URL=${IMMICH_SERVER_URL}
     restart: always
 
   redis:
@@ -77,10 +76,8 @@ services:
     image: altran1502/immich-proxy:staging
     environment:
       # Make sure these values get passed through from the env file
-      - IMMICH_SERVER_HOST
-      - IMMICH_SERVER_PORT
-      - IMMICH_WEB_HOST
-      - IMMICH_WEB_PORT
+      - IMMICH_SERVER_URL
+      - IMMICH_WEB_URL
     ports:
       - 2283:8080
     logging:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,12 @@ services:
   immich-proxy:
     container_name: immich_proxy
     image: altran1502/immich-proxy:release
+    environment:
+      # Make sure these values get passed through from the env file
+      - IMMICH_SERVER_HOST
+      - IMMICH_SERVER_PORT
+      - IMMICH_WEB_HOST
+      - IMMICH_WEB_PORT
     ports:
       - 2283:8080
     logging:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,10 @@ services:
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:
       - .env
+    environment:
+      # Rename these values for svelte public interface
+      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
+      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
     restart: always
 
   redis:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,8 +49,7 @@ services:
       - .env
     environment:
       # Rename these values for svelte public interface
-      - PUBLIC_IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST}
-      - PUBLIC_IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT}
+      - PUBLIC_IMMICH_SERVER_URL=${IMMICH_SERVER_URL}
     restart: always
 
   redis:
@@ -77,10 +76,8 @@ services:
     image: altran1502/immich-proxy:release
     environment:
       # Make sure these values get passed through from the env file
-      - IMMICH_SERVER_HOST
-      - IMMICH_SERVER_PORT
-      - IMMICH_WEB_HOST
-      - IMMICH_WEB_PORT
+      - IMMICH_SERVER_URL
+      - IMMICH_WEB_URL
     ports:
       - 2283:8080
     logging:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/nginxinc/nginx-unprivileged:latest
 COPY LICENSE /licenses/LICENSE.txt
 COPY LICENSE /LICENSE
 
-COPY nginx.conf "/etc/nginx/nginx.conf"
+COPY nginx.conf "/etc/nginx/nginx.conf.template"
+COPY start.sh /start.sh
 
-CMD nginx -g "daemon off;"
+CMD /start.sh

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,7 +61,7 @@ http {
 
       rewrite /api/(.*) /$1 break;
 
-      proxy_pass http://$IMMICH_SERVER_HOST:$IMMICH_SERVER_PORT;
+      proxy_pass $IMMICH_SERVER_URL;
     }
 
     location / {
@@ -86,7 +86,7 @@ http {
       proxy_set_header Connection "upgrade";
       proxy_set_header Host $host;
 
-      proxy_pass http://$IMMICH_WEB_HOST:$IMMICH_WEB_PORT;
+      proxy_pass $IMMICH_WEB_URL;
     }
   }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,3 @@
-
-
 worker_processes auto;
 error_log /var/log/nginx/error.log;
 pid /tmp/nginx.pid;
@@ -62,7 +60,7 @@ http {
 
       rewrite /api/(.*) /$1 break;
 
-      proxy_pass http://immich-server:3001;
+      proxy_pass http://$IMMICH_SERVER_HOST:$IMMICH_SERVER_PORT;
     }
 
     location / {
@@ -87,7 +85,7 @@ http {
       proxy_set_header Connection "upgrade";
       proxy_set_header Host $host;
 
-      proxy_pass http://immich-web:3000;
+      proxy_pass http://$IMMICH_WEB_HOST:$IMMICH_WEB_PORT;
     }
   }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,4 @@
+# NOTE: This file is generated on startup. See /start.sh
 worker_processes auto;
 error_log /var/log/nginx/error.log;
 pid /tmp/nginx.pid;

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -1,11 +1,9 @@
 #! /bin/bash
 set -e
 
-export IMMICH_WEB_HOST=${IMMICH_WEB_HOST:-immich-web}
-export IMMICH_WEB_PORT=${IMMICH_WEB_PORT:-3000}
-export IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST:-immich-server}
-export IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT:-3001}
+export IMMICH_WEB_URL=${IMMICH_WEB_URL:-http://immich-web:3000}
+export IMMICH_SERVER_URL=${IMMICH_SERVER_URL:-http://immich-server:3001}
 
-envsubst '$IMMICH_WEB_HOST $IMMICH_WEB_PORT $IMMICH_SERVER_HOST $IMMICH_SERVER_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '$IMMICH_WEB_URL $IMMICH_SERVER_URL' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+set -e
+
+export IMMICH_WEB_HOST=${IMMICH_WEB_HOST:-immich-web}
+export IMMICH_WEB_PORT=${IMMICH_WEB_PORT:-3000}
+export IMMICH_SERVER_HOST=${IMMICH_SERVER_HOST:-immich-server}
+export IMMICH_SERVER_PORT=${IMMICH_SERVER_PORT:-3001}
+
+envsubst '$IMMICH_WEB_HOST $IMMICH_WEB_PORT $IMMICH_SERVER_HOST $IMMICH_SERVER_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec nginx -g 'daemon off;'

--- a/server/apps/microservices/src/processors/machine-learning.processor.ts
+++ b/server/apps/microservices/src/processors/machine-learning.processor.ts
@@ -9,6 +9,9 @@ import axios from 'axios';
 import { Job } from 'bull';
 import { Repository } from 'typeorm';
 
+const immich_machine_learning_host = process.env.IMMICH_MACHINE_LEARNING_HOST || 'immich-machine-learning';
+const immich_machine_learning_port = process.env.IMMICH_MACHINE_LEARNING_PORT || '3003';
+
 @Processor(QueueNameEnum.MACHINE_LEARNING)
 export class MachineLearningProcessor {
   constructor(
@@ -20,9 +23,12 @@ export class MachineLearningProcessor {
   async tagImage(job: Job<IMachineLearningJob>) {
     const { asset } = job.data;
 
-    const res = await axios.post('http://immich-machine-learning:3003/image-classifier/tag-image', {
-      thumbnailPath: asset.resizePath,
-    });
+    const res = await axios.post(
+      'http://' + immich_machine_learning_host + ':' + immich_machine_learning_port + '/image-classifier/tag-image',
+      {
+        thumbnailPath: asset.resizePath,
+      },
+    );
 
     if (res.status == 201 && res.data.length > 0) {
       const smartInfo = new SmartInfoEntity();
@@ -40,9 +46,12 @@ export class MachineLearningProcessor {
     try {
       const { asset }: { asset: AssetEntity } = job.data;
 
-      const res = await axios.post('http://immich-machine-learning:3003/object-detection/detect-object', {
-        thumbnailPath: asset.resizePath,
-      });
+      const res = await axios.post(
+        'http://' + immich_machine_learning_host + ':' + immich_machine_learning_port + '/object-detection/detect-object',
+        {
+          thumbnailPath: asset.resizePath,
+        },
+      );
 
       if (res.status == 201 && res.data.length > 0) {
         const smartInfo = new SmartInfoEntity();

--- a/server/apps/microservices/src/processors/machine-learning.processor.ts
+++ b/server/apps/microservices/src/processors/machine-learning.processor.ts
@@ -9,8 +9,7 @@ import axios from 'axios';
 import { Job } from 'bull';
 import { Repository } from 'typeorm';
 
-const immich_machine_learning_host = process.env.IMMICH_MACHINE_LEARNING_HOST || 'immich-machine-learning';
-const immich_machine_learning_port = process.env.IMMICH_MACHINE_LEARNING_PORT || '3003';
+const immich_machine_learning_url = process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003';
 
 @Processor(QueueNameEnum.MACHINE_LEARNING)
 export class MachineLearningProcessor {
@@ -24,7 +23,7 @@ export class MachineLearningProcessor {
     const { asset } = job.data;
 
     const res = await axios.post(
-      'http://' + immich_machine_learning_host + ':' + immich_machine_learning_port + '/image-classifier/tag-image',
+      immich_machine_learning_url + '/image-classifier/tag-image',
       {
         thumbnailPath: asset.resizePath,
       },
@@ -47,7 +46,7 @@ export class MachineLearningProcessor {
       const { asset }: { asset: AssetEntity } = job.data;
 
       const res = await axios.post(
-        'http://' + immich_machine_learning_host + ':' + immich_machine_learning_port + '/object-detection/detect-object',
+        immich_machine_learning_url + '/object-detection/detect-object',
         {
           thumbnailPath: asset.resizePath,
         },

--- a/web/src/api/api.ts
+++ b/web/src/api/api.ts
@@ -46,7 +46,5 @@ class ImmichApi {
 
 export const api = new ImmichApi();
 export const serverApi = new ImmichApi();
-const immich_server_host = env.PUBLIC_IMMICH_SERVER_HOST || 'immich-server';
-const immich_server_port = env.PUBLIC_IMMICH_SERVER_PORT || 3001;
-const immich_server_url = 'http://' + immich_server_host + ':' + immich_server_port;
+const immich_server_url = env.PUBLIC_IMMICH_SERVER_URL || 'http://immich-server:3001';
 serverApi.setBaseUrl(immich_server_url);

--- a/web/src/api/api.ts
+++ b/web/src/api/api.ts
@@ -1,3 +1,4 @@
+import { env } from '$env/dynamic/public';
 import {
 	AlbumApi,
 	AssetApi,
@@ -45,4 +46,7 @@ class ImmichApi {
 
 export const api = new ImmichApi();
 export const serverApi = new ImmichApi();
-serverApi.setBaseUrl('http://immich-server:3001');
+const immich_server_host = env.PUBLIC_IMMICH_SERVER_HOST || 'immich-server';
+const immich_server_port = env.PUBLIC_IMMICH_SERVER_PORT || 3001;
+const immich_server_url = 'http://' + immich_server_host + ':' + immich_server_port;
+serverApi.setBaseUrl(immich_server_url);


### PR DESCRIPTION
This won't change what host and port the service binds to, but changes the host and port used by other services to reach each other. This should allow running on systems like Kubernetes and Nomad.

This should address #647

A question for the maintainers, I can see that `immich-microservices` binds to port `3002`, however it doesn't look like any of the other services call that port. Is there somewhere I should be updating this as well?

I've been unable to verify this works yet because when I run `make dev` on the `main` branch I get this error:

```
immich-web_1               | Error: EACCES: permission denied, mkdir '/usr/src/app/node_modules/.vite/deps_temp'
immich-web_1               |     at Object.mkdirSync (node:fs:1349:3)
immich-web_1               |     at runOptimizeDeps (file:///usr/src/app/node_modules/vite/dist/node/chunks/dep-a713b95d.js:42258:14)
immich-web_1               |     at Timeout._onTimeout (file:///usr/src/app/node_modules/vite/dist/node/chunks/dep-a713b95d.js:41675:54)
immich-web_1               |     at processTicksAndRejections (node:internal/process/task_queues:96:5) {
immich-web_1               |   errno: -13,
immich-web_1               |   syscall: 'mkdir',
immich-web_1               |   code: 'EACCES',
immich-web_1               |   path: '/usr/src/app/node_modules/.vite/deps_temp'
immich-web_1               | }
```

So I'll be debugging that.

