### PR TITLE
typo(android-feature-note): Reserve geocoding -> Reverse geocoding 

### DIFF
--- a/mobile/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/mobile/android/fastlane/metadata/android/en-US/full_description.txt
@@ -15,7 +15,7 @@ Once set up, this app can be used as photo and video backup solution directly fr
 * Object detection based on COCO SSD.
 * Search assets based on tags and exif data (lens, make, model, orientation)
 * Upload assets from your local computer/server using <a href='https://www.npmjs.com/package/immich' target='_blank' rel='nofollow'>immich cli tools</a>
-* [Optional] Reverse geocoding using Mapbox (Generous free-tier of 100,000 search/month)
+* Reverse geocoding from image exif data
 * Show asset's location information on map (OpenStreetMap).
 * Show curated places on the search page
 * Show curated objects on the search page

--- a/mobile/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/mobile/android/fastlane/metadata/android/en-US/full_description.txt
@@ -15,7 +15,7 @@ Once set up, this app can be used as photo and video backup solution directly fr
 * Object detection based on COCO SSD.
 * Search assets based on tags and exif data (lens, make, model, orientation)
 * Upload assets from your local computer/server using <a href='https://www.npmjs.com/package/immich' target='_blank' rel='nofollow'>immich cli tools</a>
-* [Optional] Reserve geocoding using Mapbox (Generous free-tier of 100,000 search/month)
+* [Optional] Reverse geocoding using Mapbox (Generous free-tier of 100,000 search/month)
 * Show asset's location information on map (OpenStreetMap).
 * Show curated places on the search page
 * Show curated objects on the search page


### PR DESCRIPTION
The term should be reverse geocoding ("address <- geo coordinates" instead of "address -> geo coordinates").

There is no "reserve geocoding".

https://en.wikipedia.org/wiki/Reverse_geocoding