### PR TITLE
feat(ci): Push images to GitHub Container Registry

### DIFF
--- a/.github/workflows/build_push_docker_latest.yml
+++ b/.github/workflows/build_push_docker_latest.yml
@@ -43,7 +43,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-server:latest
-            ghcr.io/immich-app/immich-server:latest
+            ghcr.io/${{ github.repository_owner }}/immich-server:latest
 
   build_and_push_machine_learning_latest:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-machine-learning:latest
-            ghcr.io/immich-app/immich-machine-learning:latest
+            ghcr.io/${{ github.repository_owner }}/immich-machine-learning:latest
 
   build_and_push_web_latest:
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
           push: true
           tags: |
             altran1502/immich-web:latest
-            ghcr.io/immich-app/immich-web:latest
+            ghcr.io/${{ github.repository_owner }}/immich-web:latest
 
   build_and_push_nginx_latest:
     runs-on: ubuntu-latest
@@ -149,4 +149,4 @@ jobs:
           push: true
           tags: |
             altran1502/immich-proxy:latest
-            ghcr.io/immich-app/immich-proxy:latest
+            ghcr.io/${{ github.repository_owner }}/immich-proxy:latest

--- a/.github/workflows/build_push_docker_latest.yml
+++ b/.github/workflows/build_push_docker_latest.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Immich Mono Repo
         uses: docker/build-push-action@v3.2.0
         with:
@@ -37,6 +43,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-server:latest
+            ghcr.io/immch-app/immich-server:latest
 
   build_and_push_machine_learning_latest:
     runs-on: ubuntu-latest
@@ -56,6 +63,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Machine Learning
         uses: docker/build-push-action@v3.2.0
         with:
@@ -67,6 +80,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-machine-learning:latest
+            ghcr.io/immch-app/immich-machine-learning:latest
 
   build_and_push_web_latest:
     runs-on: ubuntu-latest
@@ -85,6 +99,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Web
         uses: docker/build-push-action@v3.2.0
         with:
@@ -95,6 +115,7 @@ jobs:
           push: true
           tags: |
             altran1502/immich-web:latest
+            ghcr.io/immch-app/immich-web:latest
 
   build_and_push_nginx_latest:
     runs-on: ubuntu-latest
@@ -113,6 +134,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Proxy
         uses: docker/build-push-action@v3.2.0
         with:
@@ -122,3 +149,4 @@ jobs:
           push: true
           tags: |
             altran1502/immich-proxy:latest
+            ghcr.io/immch-app/immich-proxy:latest

--- a/.github/workflows/build_push_docker_latest.yml
+++ b/.github/workflows/build_push_docker_latest.yml
@@ -43,7 +43,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-server:latest
-            ghcr.io/immch-app/immich-server:latest
+            ghcr.io/immich-app/immich-server:latest
 
   build_and_push_machine_learning_latest:
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             altran1502/immich-machine-learning:latest
-            ghcr.io/immch-app/immich-machine-learning:latest
+            ghcr.io/immich-app/immich-machine-learning:latest
 
   build_and_push_web_latest:
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
           push: true
           tags: |
             altran1502/immich-web:latest
-            ghcr.io/immch-app/immich-web:latest
+            ghcr.io/immich-app/immich-web:latest
 
   build_and_push_nginx_latest:
     runs-on: ubuntu-latest
@@ -149,4 +149,4 @@ jobs:
           push: true
           tags: |
             altran1502/immich-proxy:latest
-            ghcr.io/immch-app/immich-proxy:latest
+            ghcr.io/immich-app/immich-proxy:latest

--- a/.github/workflows/build_push_docker_staging.yml
+++ b/.github/workflows/build_push_docker_staging.yml
@@ -46,8 +46,8 @@ jobs:
           tags: |
             altran1502/immich-server:staging
             altran1502/immich-server:${{ github.event.pull_request.number }}
-            ghcr.io/immch-app/immich-server:staging
-            ghcr.io/immch-app/immich-server:${{ github.event.pull_request.number }}
+            ghcr.io/immich-app/immich-server:staging
+            ghcr.io/immich-app/immich-server:${{ github.event.pull_request.number }}
 
   build_and_push_machine_learning_staging:
     runs-on: ubuntu-latest
@@ -87,8 +87,8 @@ jobs:
           tags: |
             altran1502/immich-machine-learning:staging
             altran1502/immich-machine-learning:${{ github.event.pull_request.number }}
-            ghcr.io/immch-app/immich-machine-learning:staging
-            ghcr.io/immch-app/immich-machine-learning:${{ github.event.pull_request.number }}
+            ghcr.io/immich-app/immich-machine-learning:staging
+            ghcr.io/immich-app/immich-machine-learning:${{ github.event.pull_request.number }}
 
   build_and_push_web_staging:
     runs-on: ubuntu-latest
@@ -126,8 +126,8 @@ jobs:
           tags: |
             altran1502/immich-web:staging
             altran1502/immich-web:${{ github.event.pull_request.number }}
-            ghcr.io/immch-app/immich-web:staging
-            ghcr.io/immch-app/immich-web:${{ github.event.pull_request.number }}
+            ghcr.io/immich-app/immich-web:staging
+            ghcr.io/immich-app/immich-web:${{ github.event.pull_request.number }}
 
   build_and_push_nginx_staging:
     runs-on: ubuntu-latest
@@ -164,5 +164,5 @@ jobs:
           tags: |
             altran1502/immich-proxy:staging
             altran1502/immich-proxy:${{ github.event.pull_request.number }}
-            ghcr.io/immch-app/immich-proxy:staging
-            ghcr.io/immch-app/immich-proxy:${{ github.event.pull_request.number }}
+            ghcr.io/immich-app/immich-proxy:staging
+            ghcr.io/immich-app/immich-proxy:${{ github.event.pull_request.number }}

--- a/.github/workflows/build_push_docker_staging.yml
+++ b/.github/workflows/build_push_docker_staging.yml
@@ -46,8 +46,8 @@ jobs:
           tags: |
             altran1502/immich-server:staging
             altran1502/immich-server:${{ github.event.pull_request.number }}
-            ghcr.io/immich-app/immich-server:staging
-            ghcr.io/immich-app/immich-server:${{ github.event.pull_request.number }}
+            ghcr.io/${{ github.repository_owner }}/immich-server:staging
+            ghcr.io/${{ github.repository_owner }}/immich-server:${{ github.event.pull_request.number }}
 
   build_and_push_machine_learning_staging:
     runs-on: ubuntu-latest
@@ -87,8 +87,8 @@ jobs:
           tags: |
             altran1502/immich-machine-learning:staging
             altran1502/immich-machine-learning:${{ github.event.pull_request.number }}
-            ghcr.io/immich-app/immich-machine-learning:staging
-            ghcr.io/immich-app/immich-machine-learning:${{ github.event.pull_request.number }}
+            ghcr.io/${{ github.repository_owner }}/immich-machine-learning:staging
+            ghcr.io/${{ github.repository_owner }}/immich-machine-learning:${{ github.event.pull_request.number }}
 
   build_and_push_web_staging:
     runs-on: ubuntu-latest
@@ -126,8 +126,8 @@ jobs:
           tags: |
             altran1502/immich-web:staging
             altran1502/immich-web:${{ github.event.pull_request.number }}
-            ghcr.io/immich-app/immich-web:staging
-            ghcr.io/immich-app/immich-web:${{ github.event.pull_request.number }}
+            ghcr.io/${{ github.repository_owner }}/immich-web:staging
+            ghcr.io/${{ github.repository_owner }}/immich-web:${{ github.event.pull_request.number }}
 
   build_and_push_nginx_staging:
     runs-on: ubuntu-latest
@@ -164,5 +164,5 @@ jobs:
           tags: |
             altran1502/immich-proxy:staging
             altran1502/immich-proxy:${{ github.event.pull_request.number }}
-            ghcr.io/immich-app/immich-proxy:staging
-            ghcr.io/immich-app/immich-proxy:${{ github.event.pull_request.number }}
+            ghcr.io/${{ github.repository_owner }}/immich-proxy:staging
+            ghcr.io/${{ github.repository_owner }}/immich-proxy:${{ github.event.pull_request.number }}

--- a/.github/workflows/build_push_docker_staging.yml
+++ b/.github/workflows/build_push_docker_staging.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository == 'immich-app/immich' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Immich Mono Repo
         uses: docker/build-push-action@v3.2.0
         with:
@@ -39,6 +46,8 @@ jobs:
           tags: |
             altran1502/immich-server:staging
             altran1502/immich-server:${{ github.event.pull_request.number }}
+            ghcr.io/immch-app/immich-server:staging
+            ghcr.io/immch-app/immich-server:${{ github.event.pull_request.number }}
 
   build_and_push_machine_learning_staging:
     runs-on: ubuntu-latest
@@ -59,6 +68,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository == 'immich-app/immich' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Machine Learning
         uses: docker/build-push-action@v3.2.0
         with:
@@ -71,6 +87,8 @@ jobs:
           tags: |
             altran1502/immich-machine-learning:staging
             altran1502/immich-machine-learning:${{ github.event.pull_request.number }}
+            ghcr.io/immch-app/immich-machine-learning:staging
+            ghcr.io/immch-app/immich-machine-learning:${{ github.event.pull_request.number }}
 
   build_and_push_web_staging:
     runs-on: ubuntu-latest
@@ -90,6 +108,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository == 'immich-app/immich' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Web
         uses: docker/build-push-action@v3.2.0
         with:
@@ -101,6 +126,8 @@ jobs:
           tags: |
             altran1502/immich-web:staging
             altran1502/immich-web:${{ github.event.pull_request.number }}
+            ghcr.io/immch-app/immich-web:staging
+            ghcr.io/immch-app/immich-web:${{ github.event.pull_request.number }}
 
   build_and_push_nginx_staging:
     runs-on: ubuntu-latest
@@ -120,6 +147,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository == 'immich-app/immich' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Proxy
         uses: docker/build-push-action@v3.2.0
         with:
@@ -130,3 +164,5 @@ jobs:
           tags: |
             altran1502/immich-proxy:staging
             altran1502/immich-proxy:${{ github.event.pull_request.number }}
+            ghcr.io/immch-app/immich-proxy:staging
+            ghcr.io/immch-app/immich-proxy:${{ github.event.pull_request.number }}

--- a/.github/workflows/build_push_server_release.yml
+++ b/.github/workflows/build_push_server_release.yml
@@ -34,6 +34,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push immich-server release
         uses: docker/build-push-action@v3.2.0
         with:
@@ -46,6 +53,8 @@ jobs:
           tags: |
             altran1502/immich-server:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-server:release
+            ghcr.io/immich-app/immich-server:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/immich-app/immich-server:release
 
   build_and_push_machine_learning_release:
     runs-on: ubuntu-latest
@@ -69,6 +78,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Machine Learning
         uses: docker/build-push-action@v3.2.0
         with:
@@ -81,6 +96,8 @@ jobs:
           tags: |
             altran1502/immich-machine-learning:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-machine-learning:release
+            ghcr.io/immich-app/immich-machine-learning:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/immich-app/immich-machine-learning:release
 
   build_and_push_web_release:
     runs-on: ubuntu-latest
@@ -110,6 +127,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push immich-web release
         uses: docker/build-push-action@v3.2.0
         with:
@@ -121,6 +145,8 @@ jobs:
           tags: |
             altran1502/immich-web:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-web:release
+            ghcr.io/immich-app/immich-web:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/immich-app/immich-web:release
 
   build_and_push_nginx_release:
     runs-on: ubuntu-latest
@@ -150,6 +176,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push immich-proxy release
         uses: docker/build-push-action@v3.2.0
         with:
@@ -160,3 +193,5 @@ jobs:
           tags: |
             altran1502/immich-proxy:release
             altran1502/immich-proxy:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/immich-app/immich-proxy:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/immich-app/immich-proxy:release

--- a/.github/workflows/build_push_server_release.yml
+++ b/.github/workflows/build_push_server_release.yml
@@ -53,8 +53,8 @@ jobs:
           tags: |
             altran1502/immich-server:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-server:release
-            ghcr.io/immich-app/immich-server:${{ steps.previoustag.outputs.tag }}
-            ghcr.io/immich-app/immich-server:release
+            ghcr.io/${{ github.repository_owner }}/immich-server:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/immich-server:release
 
   build_and_push_machine_learning_release:
     runs-on: ubuntu-latest
@@ -96,8 +96,8 @@ jobs:
           tags: |
             altran1502/immich-machine-learning:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-machine-learning:release
-            ghcr.io/immich-app/immich-machine-learning:${{ steps.previoustag.outputs.tag }}
-            ghcr.io/immich-app/immich-machine-learning:release
+            ghcr.io/${{ github.repository_owner }}/immich-machine-learning:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/immich-machine-learning:release
 
   build_and_push_web_release:
     runs-on: ubuntu-latest
@@ -145,8 +145,8 @@ jobs:
           tags: |
             altran1502/immich-web:${{ steps.previoustag.outputs.tag }}
             altran1502/immich-web:release
-            ghcr.io/immich-app/immich-web:${{ steps.previoustag.outputs.tag }}
-            ghcr.io/immich-app/immich-web:release
+            ghcr.io/${{ github.repository_owner }}/immich-web:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/immich-web:release
 
   build_and_push_nginx_release:
     runs-on: ubuntu-latest
@@ -193,5 +193,5 @@ jobs:
           tags: |
             altran1502/immich-proxy:release
             altran1502/immich-proxy:${{ steps.previoustag.outputs.tag }}
-            ghcr.io/immich-app/immich-proxy:${{ steps.previoustag.outputs.tag }}
-            ghcr.io/immich-app/immich-proxy:release
+            ghcr.io/${{ github.repository_owner }}/immich-proxy:${{ steps.previoustag.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/immich-proxy:release


### PR DESCRIPTION
DockerHub has a very aggressive pull limit policy, this gives users a choice to use Docker images published to GHCR instead.

After merged and images set to public, they can be pulled:

```
docker pull ghcr.io/immich-app/immich-server:${TAG}
docker pull ghcr.io/immich-app/immich-machine-learning:${TAG}
docker pull ghcr.io/immich-app/immich-proxy:${TAG}
docker pull ghcr.io/immich-app/immich-web:${TAG}
```