### PR TITLE
web(feat): Add support for actions when clicking notifications

### DIFF
--- a/web/src/lib/components/shared-components/notification/__tests__/notification-card.spec.ts
+++ b/web/src/lib/components/shared-components/notification/__tests__/notification-card.spec.ts
@@ -16,7 +16,7 @@ describe('NotificationCard component', () => {
 				message: 'Notification message',
 				timeout: 1000,
 				type: NotificationType.Info,
-				action: { type: "discard" }
+				action: { type: 'discard' }
 			}
 		});
 
@@ -31,7 +31,7 @@ describe('NotificationCard component', () => {
 				message: 'Notification message',
 				timeout: 1000,
 				type: NotificationType.Info,
-				action: { type: "discard" }
+				action: { type: 'discard' }
 			}
 		});
 

--- a/web/src/lib/components/shared-components/notification/__tests__/notification-card.spec.ts
+++ b/web/src/lib/components/shared-components/notification/__tests__/notification-card.spec.ts
@@ -15,7 +15,8 @@ describe('NotificationCard component', () => {
 				id: 1234,
 				message: 'Notification message',
 				timeout: 1000,
-				type: NotificationType.Info
+				type: NotificationType.Info,
+				action: { type: "discard" }
 			}
 		});
 
@@ -29,7 +30,8 @@ describe('NotificationCard component', () => {
 				id: 1234,
 				message: 'Notification message',
 				timeout: 1000,
-				type: NotificationType.Info
+				type: NotificationType.Info,
+				action: { type: "discard" }
 			}
 		});
 

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -2,6 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import CloseCircleOutline from 'svelte-material-icons/CloseCircleOutline.svelte';
 	import InformationOutline from 'svelte-material-icons/InformationOutline.svelte';
+	import WindowClose from 'svelte-material-icons/WindowClose.svelte'
 
 	import {
 		ImmichNotification,
@@ -51,12 +52,13 @@
 	let removeNotificationTimeout: NodeJS.Timeout | undefined = undefined;
 
 	onMount(() => {
-		removeNotificationTimeout = setTimeout(() => {
-			notificationController.removeNotificationById(notificationInfo.id);
-		}, notificationInfo.timeout);
-
+		removeNotificationTimeout = setTimeout(discard, notificationInfo.timeout);
 		return () => clearTimeout(removeNotificationTimeout);
 	});
+
+	const discard = () => {
+		notificationController.removeNotificationById(notificationInfo.id);
+	}
 </script>
 
 <div
@@ -65,11 +67,17 @@
 	style:border={borderStyle()}
 	class="min-h-[80px] w-[300px] rounded-2xl z-[999999] shadow-md p-4 mb-4"
 >
-	<div class="flex gap-2 place-items-center">
-		<svelte:component this={icon} color={primaryColor()} size="20" />
-		<h2 style:color={primaryColor()} class="font-medium" data-testid="title">
-			{notificationInfo.type.toString()}
-		</h2>
+
+	<div class="flex justify-between">
+		<div class="flex gap-2 place-items-center">
+			<svelte:component this={icon} color={primaryColor()} size="20" />
+			<h2 style:color={primaryColor()} class="font-medium" data-testid="title">
+				{notificationInfo.type.toString()}
+			</h2>
+		</div>
+		<button on:click={discard}>
+			<svelte:component this={WindowClose} size="20"/>
+		</button>
 	</div>
 
 	<p class="text-sm pl-[28px] pr-[16px]" data-testid="message">{notificationInfo.message}</p>

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -84,7 +84,7 @@
 				{notificationInfo.type.toString()}
 			</h2>
 		</div>
-		<button on:click={discard}>
+		<button on:click|stopPropagation={discard}>
 			<svelte:component this={WindowClose} size="20" />
 		</button>
 	</div>

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -59,13 +59,23 @@
 	const discard = () => {
 		notificationController.removeNotificationById(notificationInfo.id);
 	}
+
+	const handleClick = () => {
+		const action = notificationInfo.action;
+		if (action.type == "discard") {
+			discard();
+		} else if (action.type == "link") {
+			window.open(action.target)
+		}
+	}
 </script>
 
 <div
 	transition:fade={{ duration: 250 }}
 	style:background-color={backgroundColor()}
 	style:border={borderStyle()}
-	class="min-h-[80px] w-[300px] rounded-2xl z-[999999] shadow-md p-4 mb-4"
+	class="min-h-[80px] w-[300px] rounded-2xl z-[999999] shadow-md p-4 mb-4 hover:cursor-pointer"
+	on:click={handleClick}
 >
 
 	<div class="flex justify-between">

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -66,7 +66,6 @@
 			discard();
 		} else if (action.type == 'link') {
 			window.open(action.target);
-			event.preventDefault();
 		}
 	};
 </script>

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import CloseCircleOutline from 'svelte-material-icons/CloseCircleOutline.svelte';
 	import InformationOutline from 'svelte-material-icons/InformationOutline.svelte';
-	import WindowClose from 'svelte-material-icons/WindowClose.svelte'
+	import WindowClose from 'svelte-material-icons/WindowClose.svelte';
 
 	import {
 		ImmichNotification,
@@ -58,16 +58,16 @@
 
 	const discard = () => {
 		notificationController.removeNotificationById(notificationInfo.id);
-	}
+	};
 
 	const handleClick = () => {
 		const action = notificationInfo.action;
-		if (action.type == "discard") {
+		if (action.type == 'discard') {
 			discard();
-		} else if (action.type == "link") {
-			window.open(action.target)
+		} else if (action.type == 'link') {
+			window.open(action.target);
 		}
-	}
+	};
 </script>
 
 <div
@@ -77,7 +77,6 @@
 	class="min-h-[80px] w-[300px] rounded-2xl z-[999999] shadow-md p-4 mb-4 hover:cursor-pointer"
 	on:click={handleClick}
 >
-
 	<div class="flex justify-between">
 		<div class="flex gap-2 place-items-center">
 			<svelte:component this={icon} color={primaryColor()} size="20" />
@@ -86,7 +85,7 @@
 			</h2>
 		</div>
 		<button on:click={discard}>
-			<svelte:component this={WindowClose} size="20"/>
+			<svelte:component this={WindowClose} size="20" />
 		</button>
 	</div>
 

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -60,12 +60,13 @@
 		notificationController.removeNotificationById(notificationInfo.id);
 	};
 
-	const handleClick = () => {
+	const handleClick = (event: MouseEvent) => {
 		const action = notificationInfo.action;
 		if (action.type == 'discard') {
 			discard();
 		} else if (action.type == 'link') {
 			window.open(action.target);
+			event.preventDefault();
 		}
 	};
 </script>
@@ -89,5 +90,5 @@
 		</button>
 	</div>
 
-	<p class="text-sm pl-[28px] pr-[16px]" data-testid="message">{notificationInfo.message}</p>
+	<p class="text-sm pl-[28px] pr-[16px]" data-testid="message">{@html notificationInfo.message}</p>
 </div>

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -60,7 +60,7 @@
 		notificationController.removeNotificationById(notificationInfo.id);
 	};
 
-	const handleClick = (event: MouseEvent) => {
+	const handleClick = () => {
 		const action = notificationInfo.action;
 		if (action.type == 'discard') {
 			discard();

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -9,8 +9,13 @@ export class ImmichNotification {
 	id = new Date().getTime();
 	type!: NotificationType;
 	message!: string;
+	action!: NotificationAction;
 	timeout = 3000;
 }
+
+type DiscardAction = {type: "discard"};
+type LinkAction = {type: "link", target: string};
+export type NotificationAction = DiscardAction | LinkAction;
 
 export class ImmichNotificationDto {
 	/**
@@ -28,7 +33,13 @@ export class ImmichNotificationDto {
 	 * Timeout in miliseconds
 	 */
 	timeout?: number;
+
+	/**
+	 * The action to take when the notification is clicked
+	 */
+	action?: NotificationAction;
 }
+
 function createNotificationList() {
 	const notificationList = writable<ImmichNotification[]>([]);
 
@@ -37,6 +48,7 @@ function createNotificationList() {
 		newNotification.message = notificationInfo.message;
 		newNotification.type = notificationInfo.type;
 		newNotification.timeout = notificationInfo.timeout || 3000;
+		newNotification.action = notificationInfo.action || {type: "discard"};
 
 		notificationList.update((currentList) => [...currentList, newNotification]);
 	};

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -14,8 +14,9 @@ export class ImmichNotification {
 }
 
 type DiscardAction = { type: 'discard' };
+type NoopAction = { type: 'noop' };
 type LinkAction = { type: 'link'; target: string };
-export type NotificationAction = DiscardAction | LinkAction;
+export type NotificationAction = DiscardAction | NoopAction | LinkAction;
 
 export class ImmichNotificationDto {
 	/**

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -13,8 +13,8 @@ export class ImmichNotification {
 	timeout = 3000;
 }
 
-type DiscardAction = {type: "discard"};
-type LinkAction = {type: "link", target: string};
+type DiscardAction = { type: 'discard' };
+type LinkAction = { type: 'link'; target: string };
 export type NotificationAction = DiscardAction | LinkAction;
 
 export class ImmichNotificationDto {
@@ -48,7 +48,7 @@ function createNotificationList() {
 		newNotification.message = notificationInfo.message;
 		newNotification.type = notificationInfo.type;
 		newNotification.timeout = notificationInfo.timeout || 3000;
-		newNotification.action = notificationInfo.action || {type: "discard"};
+		newNotification.action = notificationInfo.action || { type: 'discard' };
 
 		notificationList.update((currentList) => [...currentList, newNotification]);
 	};

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -44,7 +44,7 @@ export const openFileUploadDialog = (uploadType: UploadType) => {
 				notificationController.show({
 					type: NotificationType.Error,
 					message: `Cannot upload more than 50 files at a time - you are uploading ${files.length} files. 
-          Please check out <a href="https://immich.app/docs/usage/bulk-upload" class="underline" target="_blank">the bulk upload documentation</a> if you need to upload more than 50 files.`,
+          Please check out <u>the bulk upload documentation</u> if you need to upload more than 50 files.`,
 					timeout: 10000,
 					action: { type: 'link', target: 'https://immich.app/docs/usage/bulk-upload' }
 				});

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -46,7 +46,7 @@ export const openFileUploadDialog = (uploadType: UploadType) => {
 					message: `Cannot upload more than 50 files at a time - you are uploading ${files.length} files. 
           Please use the CLI tool if you need to upload more than 50 files. (Click this message to see a guide).`,
 					timeout: 10000,
-					action: {type: "link", target: "https://immich.app/docs/usage/bulk-upload"}
+					action: { type: 'link', target: 'https://immich.app/docs/usage/bulk-upload' }
 				});
 
 				return;

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -44,7 +44,7 @@ export const openFileUploadDialog = (uploadType: UploadType) => {
 				notificationController.show({
 					type: NotificationType.Error,
 					message: `Cannot upload more than 50 files at a time - you are uploading ${files.length} files. 
-          Please use the CLI tool if you need to upload more than 50 files. (Click this message to see a guide).`,
+          Please check out <a href="https://immich.app/docs/usage/bulk-upload" class="underline" target="_blank">the bulk upload documentation</a> if you need to upload more than 50 files.`,
 					timeout: 10000,
 					action: { type: 'link', target: 'https://immich.app/docs/usage/bulk-upload' }
 				});

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -44,8 +44,9 @@ export const openFileUploadDialog = (uploadType: UploadType) => {
 				notificationController.show({
 					type: NotificationType.Error,
 					message: `Cannot upload more than 50 files at a time - you are uploading ${files.length} files. 
-          Please use the CLI tool if you need to upload more than 50 files.`,
-					timeout: 5000
+          Please use the CLI tool if you need to upload more than 50 files. (Click this message to see a guide).`,
+					timeout: 10000,
+					action: {type: "link", target: "https://immich.app/docs/usage/bulk-upload"}
 				});
 
 				return;


### PR DESCRIPTION
This PR adds a `NotificationAction` to be taken when a notification popup card is clicked. The two currently implemented actions are discard (remove the card, default) and link (open a link in a new tab). The error notification that is displayed when trying to upload more than 50 assets at once now links to the CLI guide when clicked.

There's probably a nicer way to structure the `NotificationAction` type, but I don't know my way around typescript well enough to come up with it. Any suggestions for improvements there are welcome. If not, this PR is ready to merge from my end :)