### PR TITLE
Web: Disallow all robots

### DIFF
--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Currently, `robots.txt` does not restrict access for any robots, as a blank `Disallow` disallows nothing.

This reverses that and disallows all paths for all robots.