### PR TITLE
Fix(web)  navbar color overlap and scroll bar incorrect z index

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -46,7 +46,7 @@
 </script>
 
 <div
-	class="h-16 bg-black/5 flex justify-between place-items-center px-3 transition-transform duration-200 z-[9999]"
+	class="h-16 flex justify-between place-items-center px-3 transition-transform duration-200 z-[9999]"
 >
 	<div>
 		<CircleIconButton logo={ArrowLeft} on:click={() => dispatch('goBack')} />

--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -94,7 +94,7 @@
 
 <div
 	id="immich-scrubbable-scrollbar"
-	class="fixed right-0 bg-immich-bg z-[50] hover:cursor-row-resize select-none "
+	class="fixed right-0 bg-immich-bg z-[100] hover:cursor-row-resize select-none "
 	style:width={isDragging ? '100vw' : '60px'}
 	style:background-color={isDragging ? 'transparent' : 'transparent'}
 	on:mouseenter={() => (isHover = true)}
@@ -109,7 +109,7 @@
 >
 	{#if isHover}
 		<div
-			class="border-b-2 border-immich-primary dark:border-immich-dark-primary w-[100px] right-0 pr-6 py-1 text-sm pl-1 font-medium absolute bg-immich-bg dark:bg-immich-dark-gray z-50 pointer-events-none rounded-tl-md shadow-lg dark:text-immich-dark-fg"
+			class="border-b-2 border-immich-primary dark:border-immich-dark-primary w-[100px] right-0 pr-6 py-1 text-sm pl-1 font-medium absolute bg-immich-bg dark:bg-immich-dark-gray z-[100] pointer-events-none rounded-tl-md shadow-lg dark:text-immich-dark-fg"
 			style:top={currentMouseYLocation + 'px'}
 		>
 			{hoveredDate?.toLocaleString('default', { month: 'short' })}


### PR DESCRIPTION
* Change z-index of scroll bar so that when scrubbing through dates the hover date is on top of the nav bar. This should resolve issue #757  
![image](https://user-images.githubusercontent.com/5291295/204029003-6857b984-dc19-4d7f-9bb0-3f1362ee0162.png)

* When viewing images that are the full browser height, the navbar overlays a light gray bar across the top of the image 
Old appearance:
![image](https://user-images.githubusercontent.com/5291295/204028636-ce0b3558-51d4-4c1e-819a-efcac498b472.png)
New appearance:
![image](https://user-images.githubusercontent.com/5291295/204028730-c2d18490-e504-4825-91cb-a00e573b9d29.png)
