### PR TITLE
fix(mobile): fix cache invalidation on logout

### DIFF
--- a/mobile/lib/modules/home/services/asset.service.dart
+++ b/mobile/lib/modules/home/services/asset.service.dart
@@ -30,11 +30,11 @@ class AssetService {
   AssetService(this._apiService, this._backupService, this._backgroundService);
 
   /// Returns `null` if the server state did not change, else list of assets
-  Future<List<Asset>?> getRemoteAssets() async {
+  Future<List<Asset>?> getRemoteAssets({required bool hasCache}) async {
     final Box box = Hive.box(userInfoBox);
     final Pair<List<AssetResponseDto>, String?>? remote = await _apiService
         .assetApi
-        .getAllAssetsWithETag(eTag: box.get(assetEtagKey));
+        .getAllAssetsWithETag(eTag: hasCache ? box.get(assetEtagKey) : null);
     if (remote == null) {
       return null;
     }

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -38,7 +38,7 @@ class AssetNotifier extends StateNotifier<List<Asset>> {
       final bool isCacheValid = await _assetCacheService.isValid();
       stopwatch.start();
       final localTask = _assetService.getLocalAssets(urgent: !isCacheValid);
-      final remoteTask = _assetService.getRemoteAssets();
+      final remoteTask = _assetService.getRemoteAssets(hasCache: isCacheValid);
       if (isCacheValid && state.isEmpty) {
         state = await _assetCacheService.get();
         log.info(

--- a/mobile/lib/shared/services/json_cache.dart
+++ b/mobile/lib/shared/services/json_cache.dart
@@ -23,8 +23,12 @@ abstract class JsonCache<T> {
   }
 
   Future<void> invalidate() async {
-    final file = await _getCacheFile();
-    await file.delete();
+    try {
+      final file = await _getCacheFile();
+      await file.delete();
+    } on FileSystemException {
+      // file is already deleted
+    }
   }
 
   Future<void> putRawData(dynamic data) async {


### PR DESCRIPTION
await all the cache-invalidation operations during logout and catch errors to actually perform all operations.