### PR TITLE
fix(server): link 'immich'

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,6 +32,8 @@ COPY LICENSE /LICENSE
 COPY package.json package-lock.json ./
 COPY start-server.sh start-microservices.sh ./
 
+RUN npm link
+
 VOLUME /usr/src/app/upload
 
 EXPOSE 3001


### PR DESCRIPTION
This PR (hopefully) fixes the `immich` command availability in the `immich-server` docker image.