### PR TITLE
fix: increase oauth timeout

### DIFF
--- a/server/apps/immich/src/api-v1/oauth/oauth.service.ts
+++ b/server/apps/immich/src/api-v1/oauth/oauth.service.ts
@@ -1,6 +1,6 @@
 import { ImmichConfigService } from '@app/immich-config';
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
-import { ClientMetadata, generators, Issuer, UserinfoResponse } from 'openid-client';
+import { ClientMetadata, custom, generators, Issuer, UserinfoResponse } from 'openid-client';
 import { ImmichJwtService } from '../../modules/immich-jwt/immich-jwt.service';
 import { LoginResponseDto } from '../auth/response-dto/login-response.dto';
 import { IUserRepository, USER_REPOSITORY } from '../user/user-repository';
@@ -20,7 +20,11 @@ export class OAuthService {
     private immichJwtService: ImmichJwtService,
     private immichConfigService: ImmichConfigService,
     @Inject(USER_REPOSITORY) private userRepository: IUserRepository,
-  ) {}
+  ) {
+    custom.setHttpOptionsDefaults({
+      timeout: 30000,
+    });
+  }
 
   public async generateConfig(dto: OAuthConfigDto): Promise<OAuthConfigResponseDto> {
     const config = await this.immichConfigService.getConfig();


### PR DESCRIPTION
This PR increases the request timeout used in http requests in the `openid-client` library from 3.5 seconds to 30 seconds.