### PR TITLE
fix(nginx): define stopsignal

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,4 +6,6 @@ COPY LICENSE /LICENSE
 COPY nginx.conf "/etc/nginx/nginx.conf.template"
 COPY start.sh /start.sh
 
+STOPSIGNAL SIGQUIT
+
 CMD /start.sh


### PR DESCRIPTION
Uses the correct signal for nginx. This should trigger a graceful shutdown if the container is stopped/restarted.

Source: https://github.com/nginxinc/docker-nginx/blob/5ce65c3efd395ee2d82d32670f233140e92dba99/mainline/debian/Dockerfile#L112