### PR TITLE
feat(nginx): Compress more types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,8 +28,19 @@ http {
 
   server {
 
+    # Compression
     gzip on;
+    gzip_comp_level 2;
     gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types
+       application/javascript
+       application/json
+       font/truetype
+       image/svg+xml
+       text/css
+       text/html;
+    gzip_vary on;
     gunzip on;
 
     client_max_body_size 50000M;
@@ -38,11 +49,6 @@ http {
     access_log off;
 
     location /api {
-
-      # Compression
-      gzip_static on;
-      gzip_min_length 1000;
-      gzip_comp_level 2;
 
       proxy_buffering off;
       proxy_buffer_size 16k;
@@ -65,11 +71,6 @@ http {
     }
 
     location / {
-
-      # Compression
-      gzip_static on;
-      gzip_min_length 1000;
-      gzip_comp_level 2;
 
       proxy_buffering off;
       proxy_buffer_size 16k;


### PR DESCRIPTION
Enables compression for css, js, json, svg and ttf

I also noticed that the root path `/` has no `content-type` header but declares `x-content-type-options: nosniff`.