### PR TITLE
feat(deployment): Consistent container names

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   immich-server:
+    container_name: immich_server
     image: immich-server-dev:latest
     build:
       context: ../server
@@ -23,6 +24,7 @@ services:
       - database
 
   immich-machine-learning:
+    container_name: immich_machine_learning
     image: immich-machine-learning-dev:latest
     build:
       context: ../machine-learning
@@ -41,6 +43,7 @@ services:
       - database
 
   immich-microservices:
+    container_name: immich_microservices
     image: immich-microservices:latest
     build:
       context: ../server
@@ -60,6 +63,7 @@ services:
       - immich-server
 
   immich-web:
+    container_name: immich_web
     image: immich-web-dev:1.9.0
     build:
       context: ../web

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -46,7 +46,7 @@ services:
     restart: always
 
   immich-web:
-    container_name: immich_we
+    container_name: immich_web
     image: altran1502/immich-web:staging
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
   immich-server:
+    container_name: immich_server
     image: altran1502/immich-server:staging
     entrypoint: ["/bin/sh", "./start-server.sh"]
     volumes:
@@ -16,6 +17,7 @@ services:
     restart: always
 
   immich-microservices:
+    container_name: immich_microservices
     image: altran1502/immich-server:staging
     entrypoint: ["/bin/sh", "./start-microservices.sh"]
     volumes:
@@ -30,6 +32,7 @@ services:
     restart: always
 
   immich-machine-learning:
+    container_name: immich_machine_learning
     image: altran1502/immich-machine-learning:staging
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     volumes:
@@ -43,6 +46,7 @@ services:
     restart: always
 
   immich-web:
+    container_name: immich_we
     image: altran1502/immich-web:staging
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
   immich-server:
+    container_name: immich_server
     image: altran1502/immich-server:release
     entrypoint: ["/bin/sh", "./start-server.sh"]
     volumes:
@@ -16,6 +17,7 @@ services:
     restart: always
 
   immich-microservices:
+    container_name: immich_microservices
     image: altran1502/immich-server:release
     entrypoint: ["/bin/sh", "./start-microservices.sh"]
     volumes:
@@ -30,6 +32,7 @@ services:
     restart: always
 
   immich-machine-learning:
+    container_name: immich_machine_learning
     image: altran1502/immich-machine-learning:release
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     volumes:
@@ -43,6 +46,7 @@ services:
     restart: always
 
   immich-web:
+    container_name: immich_web
     image: altran1502/immich-web:release
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:


### PR DESCRIPTION
Enforces the `immich_<service>` naming schema for all containers.

e.g `<project>-immich-web-1` -> `immich_web`

Since container networking and dependency resolution is based on the service name, this is a purely cosmetic change.