### PR TITLE
feat(deployment): Geocoding volume

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -52,6 +52,7 @@ services:
     command: npm run start:dev microservices
     volumes:
       - ../server:/usr/src/app
+      - /usr/src/app/.reverse-geocoding-dump
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /usr/src/app/node_modules
     env_file:

--- a/docker/docker-compose.staging.yml
+++ b/docker/docker-compose.staging.yml
@@ -21,6 +21,7 @@ services:
     image: altran1502/immich-server:staging
     entrypoint: ["/bin/sh", "./start-microservices.sh"]
     volumes:
+      - /usr/src/app/.reverse-geocoding-dump
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
       - .env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     image: altran1502/immich-server:release
     entrypoint: ["/bin/sh", "./start-microservices.sh"]
     volumes:
+      - /usr/src/app/.reverse-geocoding-dump
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
       - .env

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -34,6 +34,8 @@ COPY start-server.sh start-microservices.sh ./
 
 RUN npm link
 
+RUN mkdir /usr/src/app/upload && chmod 777 /usr/src/app/upload && \
+    mkdir /usr/src/app/.reverse-geocoding-dump && chmod 777 /usr/src/app/.reverse-geocoding-dump
 VOLUME /usr/src/app/upload
 
 EXPOSE 3001


### PR DESCRIPTION
This defines an anonymous volume to store the reverse geocoding files. Additionally, mount points are created as part of the Dockerfile. As a side effect, we could now run the containers with a read-only file system.

Without these changes, Docker will detect the changes to the container's file system:

```
docker diff immich_microservices
C /usr
C /usr/src
C /usr/src/app
A /usr/src/app/.reverse-geocoding-dump
A /usr/src/app/upload
```