### PR TITLE
fix(web): hide deleted users

### DIFF
--- a/web/src/lib/components/album-page/user-selection-modal.svelte
+++ b/web/src/lib/components/album-page/user-selection-modal.svelte
@@ -13,7 +13,8 @@
 	onMount(async () => {
 		const { data } = await api.userApi.getAllUsers(false);
 
-		users = data;
+		// remove soft deleted users
+		users = data.filter((user) => !user.deletedAt);
 
 		// Remove the existed shared users from the album
 		sharedUsersInAlbum.forEach((sharedUser) => {


### PR DESCRIPTION
Hide deleted users from the list.

The repository implementation has `withDelete: true`, presumably for admin features. We should probably have an admin/non-admin endpoint or another easy way to filter them out at the server level.