### PR TITLE
Allow the use of SSL connections to the postgres database.

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,6 +7,9 @@ DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE_NAME=immich
 
+# Optional Database settings:
+# DB_PORT=5432
+
 ###################################################################################
 # Redis
 ###################################################################################

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,13 +7,6 @@ DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE_NAME=immich
 
-# Remember you need to URL encode your password.
-# When you set DB_URL it overrides ALL the other DB ENV variables.
-# They are currently still used by the docker database container.
-# They should NOT be commented out as the validation still checks for them even if not used.
-
-# DB_URL=postgres://postgres:postgres@immich_postgres:5432/immich?sslmode=disable
-
 ###################################################################################
 # Redis
 ###################################################################################

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,9 +7,12 @@ DB_USERNAME=postgres
 DB_PASSWORD=postgres
 DB_DATABASE_NAME=immich
 
-# Optional Database settings:
-# DB_PORT=5432
-# DB_SSL=True
+# Remember you need to URL encode your password.
+# When you set DB_URL it overrides ALL the other DB ENV variables.
+# They are currently still used by the docker database container.
+# They should NOT be commented out as the validation still checks for them even if not used.
+
+# DB_URL=postgres://postgres:postgres@immich_postgres:5432/immich?sslmode=disable
 
 ###################################################################################
 # Redis

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,6 +9,7 @@ DB_DATABASE_NAME=immich
 
 # Optional Database settings:
 # DB_PORT=5432
+# DB_SSL=True
 
 ###################################################################################
 # Redis

--- a/server/libs/common/src/config/app.config.ts
+++ b/server/libs/common/src/config/app.config.ts
@@ -16,14 +16,21 @@ const jwtSecretValidator: Joi.CustomValidator<string> = (value) => {
   return value;
 };
 
+const WHEN_DB_URL_SET = Joi.when('DB_URL', {
+  is: Joi.exist(),
+  then: Joi.string().optional(),
+  otherwise: Joi.string().required(),
+});
+
 export const immichAppConfig: ConfigModuleOptions = {
   envFilePath: '.env',
   isGlobal: true,
   validationSchema: Joi.object({
     NODE_ENV: Joi.string().required().valid('development', 'production', 'staging').default('development'),
-    DB_USERNAME: Joi.string().required(),
-    DB_PASSWORD: Joi.string().required(),
-    DB_DATABASE_NAME: Joi.string().required(),
+    DB_USERNAME: WHEN_DB_URL_SET,
+    DB_PASSWORD: WHEN_DB_URL_SET,
+    DB_DATABASE_NAME: WHEN_DB_URL_SET,
+    DB_URL: Joi.string().optional(),
     JWT_SECRET: Joi.string().required().custom(jwtSecretValidator),
     DISABLE_REVERSE_GEOCODING: Joi.boolean().optional().valid(true, false).default(false),
     REVERSE_GEOCODING_PRECISION: Joi.number().optional().valid(0, 1, 2, 3).default(3),

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -25,6 +25,7 @@ if(process.env.DB_SSL) {
 }
 else {
     additionalSSLDatabaseConfig = {
+        ssl: false,
     };
 }
 

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -1,7 +1,8 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { DataSource } from 'typeorm';
 
-export const databaseConfig: PostgresConnectionOptions = {
+let additionalSSLDatabaseConfig;
+let baseDatabaseConfig: PostgresConnectionOptions = {
   type: 'postgres',
   host: process.env.DB_HOSTNAME || 'immich_postgres',
   port: parseInt(process.env.DB_PORT || '5432'),
@@ -15,4 +16,17 @@ export const databaseConfig: PostgresConnectionOptions = {
   connectTimeoutMS: 10000, // 10 seconds
 };
 
+if(process.env.DB_SSL) {
+    additionalSSLDatabaseConfig = {
+      ssl: {
+        rejectUnauthorized : false,
+      },
+    };
+}
+else {
+    additionalSSLDatabaseConfig = {
+    };
+}
+
+export const databaseConfig: PostgresConnectionOptions = {...baseDatabaseConfig, ...additionalSSLDatabaseConfig};
 export const dataSource = new DataSource(databaseConfig);

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -10,13 +10,7 @@ let baseDatabaseConfig: PostgresConnectionOptions = {
   migrationsRun: true,
 };
 
-let urlBasedDatabaseConfig: PostgresConnectionOptions = {
-  type: 'postgres',
-  url: process.env.DB_URL || 'postgres://postgres:postgres@immich_postgres:5432/immich?sslmode=disable',
-};
-
-let envBasedDatabaseConfig: PostgresConnectionOptions = {
-  type: 'postgres',
+let envBasedDatabaseConfig = {
   host: process.env.DB_HOSTNAME || 'immich_postgres',
   port: parseInt(process.env.DB_PORT || '5432'),
   username: process.env.DB_USERNAME,
@@ -32,12 +26,8 @@ let envBasedDatabaseConfig: PostgresConnectionOptions = {
   connectTimeoutMS: 10000, // 10 seconds
 };
 
-if(process.env.DB_URL) {
-    additionalSSLDatabaseConfig = urlBasedDatabaseConfig;
-}
-else {
-    additionalSSLDatabaseConfig = envBasedDatabaseConfig;
-}
+const url = process.env.DB_URL;
+additionalSSLDatabaseConfig = url ? ({ url }) : (envBasedDatabaseConfig)
 
 export const databaseConfig: PostgresConnectionOptions = {...baseDatabaseConfig, ...additionalSSLDatabaseConfig};
 

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -16,13 +16,6 @@ let envBasedDatabaseConfig = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE_NAME,
-  entities: [__dirname + '/../**/*.entity.{js,ts}'],
-  synchronize: false,
-  migrations: [__dirname + '/../migrations/*.{js,ts}'],
-  migrationsRun: true,
-  ssl:  process.env.DB_SSL === 'True'
-    ? { rejectUnauthorized: false }
-    : false,
   connectTimeoutMS: 10000, // 10 seconds
 };
 

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -8,6 +8,7 @@ let baseDatabaseConfig: PostgresConnectionOptions = {
   synchronize: false,
   migrations: [__dirname + '/../migrations/*.{js,ts}'],
   migrationsRun: true,
+  connectTimeoutMS: 10000, // 10 seconds
 };
 
 let envBasedDatabaseConfig = {
@@ -16,12 +17,11 @@ let envBasedDatabaseConfig = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_DATABASE_NAME,
-  connectTimeoutMS: 10000, // 10 seconds
 };
 
 const url = process.env.DB_URL;
-additionalSSLDatabaseConfig = url ? ({ url }) : (envBasedDatabaseConfig)
+additionalSSLDatabaseConfig = url ? { url } : envBasedDatabaseConfig;
 
-export const databaseConfig: PostgresConnectionOptions = {...baseDatabaseConfig, ...additionalSSLDatabaseConfig};
+export const databaseConfig: PostgresConnectionOptions = { ...baseDatabaseConfig, ...additionalSSLDatabaseConfig };
 
 export const dataSource = new DataSource(databaseConfig);

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -1,7 +1,21 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { DataSource } from 'typeorm';
 
-export const databaseConfig: PostgresConnectionOptions = {
+let additionalSSLDatabaseConfig;
+let baseDatabaseConfig: PostgresConnectionOptions = {
+  type: 'postgres',
+  entities: [__dirname + '/../**/*.entity.{js,ts}'],
+  synchronize: false,
+  migrations: [__dirname + '/../migrations/*.{js,ts}'],
+  migrationsRun: true,
+};
+
+let urlBasedDatabaseConfig: PostgresConnectionOptions = {
+  type: 'postgres',
+  url: process.env.DB_URL || 'postgres://postgres:postgres@immich_postgres:5432/immich?sslmode=disable',
+};
+
+let envBasedDatabaseConfig: PostgresConnectionOptions = {
   type: 'postgres',
   host: process.env.DB_HOSTNAME || 'immich_postgres',
   port: parseInt(process.env.DB_PORT || '5432'),
@@ -17,5 +31,14 @@ export const databaseConfig: PostgresConnectionOptions = {
     : false,
   connectTimeoutMS: 10000, // 10 seconds
 };
+
+if(process.env.DB_URL) {
+    additionalSSLDatabaseConfig = urlBasedDatabaseConfig;
+}
+else {
+    additionalSSLDatabaseConfig = envBasedDatabaseConfig;
+}
+
+export const databaseConfig: PostgresConnectionOptions = {...baseDatabaseConfig, ...additionalSSLDatabaseConfig};
 
 export const dataSource = new DataSource(databaseConfig);

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -1,8 +1,7 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { DataSource } from 'typeorm';
 
-let additionalSSLDatabaseConfig;
-let baseDatabaseConfig: PostgresConnectionOptions = {
+const baseDatabaseConfig: PostgresConnectionOptions = {
   type: 'postgres',
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
   synchronize: false,
@@ -11,7 +10,7 @@ let baseDatabaseConfig: PostgresConnectionOptions = {
   connectTimeoutMS: 10000, // 10 seconds
 };
 
-let envBasedDatabaseConfig = {
+const envBasedDatabaseConfig = {
   host: process.env.DB_HOSTNAME || 'immich_postgres',
   port: parseInt(process.env.DB_PORT || '5432'),
   username: process.env.DB_USERNAME,
@@ -20,7 +19,7 @@ let envBasedDatabaseConfig = {
 };
 
 const url = process.env.DB_URL;
-additionalSSLDatabaseConfig = url ? { url } : envBasedDatabaseConfig;
+const additionalSSLDatabaseConfig = url ? { url } : envBasedDatabaseConfig;
 
 export const databaseConfig: PostgresConnectionOptions = { ...baseDatabaseConfig, ...additionalSSLDatabaseConfig };
 

--- a/server/libs/infra/src/db/config/database.config.ts
+++ b/server/libs/infra/src/db/config/database.config.ts
@@ -1,8 +1,7 @@
 import { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
 import { DataSource } from 'typeorm';
 
-let additionalSSLDatabaseConfig;
-let baseDatabaseConfig: PostgresConnectionOptions = {
+export const databaseConfig: PostgresConnectionOptions = {
   type: 'postgres',
   host: process.env.DB_HOSTNAME || 'immich_postgres',
   port: parseInt(process.env.DB_PORT || '5432'),
@@ -13,21 +12,10 @@ let baseDatabaseConfig: PostgresConnectionOptions = {
   synchronize: false,
   migrations: [__dirname + '/../migrations/*.{js,ts}'],
   migrationsRun: true,
+  ssl:  process.env.DB_SSL === 'True'
+    ? { rejectUnauthorized: false }
+    : false,
   connectTimeoutMS: 10000, // 10 seconds
 };
 
-if(process.env.DB_SSL) {
-    additionalSSLDatabaseConfig = {
-      ssl: {
-        rejectUnauthorized : false,
-      },
-    };
-}
-else {
-    additionalSSLDatabaseConfig = {
-        ssl: false,
-    };
-}
-
-export const databaseConfig: PostgresConnectionOptions = {...baseDatabaseConfig, ...additionalSSLDatabaseConfig};
 export const dataSource = new DataSource(databaseConfig);


### PR DESCRIPTION
Hello,

fixes #902 

Just throwing it out there, I have never coded in typescript before so wasn't exactly sure what I was doing as I code mainly in python/C.

I tweaked the code slightly so allow untrusted SSL connections or no SSL. I tested it with the docker-compose-dev deployment and also changing the environment parameters to point to my crunchydata postgres instance within K8s (which requires SSL). It all seemed to work.

I have made this a draft as I am not sure if this is a good way of doing it and I haven't changed/written any tests for it.

PS. I haven't tested immich yet as I am migrating stuff to K8s and want to deploy it there but it looks very promising; exactly what I have been looking for! Thank you for creating this.