### PR TITLE
fix(nginx): Switch to sh

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -8,4 +8,4 @@ COPY start.sh /start.sh
 
 STOPSIGNAL SIGQUIT
 
-CMD /start.sh
+ENTRYPOINT ["start.sh"]

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -1,12 +1,12 @@
-#! /bin/bash
+#! /bin/sh
 set -e
 
-export IMMICH_WEB_URL=${IMMICH_WEB_URL:-http://immich-web:3000}
+export IMMICH_WEB_URL="${IMMICH_WEB_URL:-http://immich-web:3000}"
 IMMICH_WEB_SCHEME=$(echo "$IMMICH_WEB_URL" | grep -Eo '^https?://' || echo "http://")
 export IMMICH_WEB_SCHEME
 IMMICH_WEB_HOST=$(echo "$IMMICH_WEB_URL" | cut -d '/' -f 3)
 export IMMICH_WEB_HOST
-export IMMICH_SERVER_URL=${IMMICH_SERVER_URL:-http://immich-server:3001}
+export IMMICH_SERVER_URL="${IMMICH_SERVER_URL:-http://immich-server:3001}"
 IMMICH_SERVER_SCHEME=$(echo "$IMMICH_WEB_URL" | grep -Eo '^https?://' || echo "http://")
 export IMMICH_SERVER_SCHEME
 IMMICH_SERVER_HOST=$(echo "$IMMICH_SERVER_URL" | cut -d '/' -f 3)


### PR DESCRIPTION
Sadly theirs still an sh process left after #1210 

```
docker top immich_proxy 
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
systemd+            2274224             2274202             0                   07:18               ?                   00:00:00            /bin/sh -c /start.sh
systemd+            2274272             2274224             0                   07:18               ?                   00:00:00            nginx: master process nginx -g daemon off;
systemd+            2274286             2274272             0                   07:18               ?                   00:00:00            nginx: worker process
systemd+            2274287             2274272             0                   07:18               ?                   00:00:00            nginx: worker process
```

I *think* this is caused by the shebang mismatch and `sh` spawning a `bash` process for the script.