### PR TITLE
feat(server): turn off machine learning endpoint

### DIFF
--- a/server/apps/immich/src/api-v1/job/job.service.ts
+++ b/server/apps/immich/src/api-v1/job/job.service.ts
@@ -9,6 +9,7 @@ import { GetJobDto, JobId } from './dto/get-job.dto';
 import { JobStatusResponseDto } from './response-dto/job-status-response.dto';
 import { IMachineLearningJob } from '@app/job/interfaces/machine-learning.interface';
 import { StorageService } from '@app/storage';
+import { MACHINE_LEARNING_ENABLED } from '@app/common';
 
 @Injectable()
 export class JobService {
@@ -161,6 +162,10 @@ export class JobService {
   }
 
   private async runMachineLearningPipeline(): Promise<number> {
+    if (!MACHINE_LEARNING_ENABLED) {
+      throw new BadRequestException('Machine learning is not enabled.');
+    }
+
     const jobCount = await this.machineLearningQueue.getJobCounts();
 
     if (jobCount.waiting > 0) {

--- a/server/apps/immich/src/main.ts
+++ b/server/apps/immich/src/main.ts
@@ -10,7 +10,7 @@ import { SERVER_VERSION } from './constants/server_version.constant';
 import { RedisIoAdapter } from './middlewares/redis-io.adapter.middleware';
 import { json } from 'body-parser';
 import { patchOpenAPI } from './utils/patch-open-api.util';
-import { getLogLevels } from '@app/common';
+import { getLogLevels, MACHINE_LEARNING_ENABLED } from '@app/common';
 
 const logger = new Logger('ImmichServer');
 
@@ -69,5 +69,7 @@ async function bootstrap() {
     const envName = (process.env.NODE_ENV || 'development').toUpperCase();
     logger.log(`Running Immich Server in ${envName} environment - version ${SERVER_VERSION}`);
   });
+
+  logger.warn(`Machine learning is ${MACHINE_LEARNING_ENABLED ? 'enabled' : 'disabled'}`);
 }
 bootstrap();

--- a/server/libs/common/src/constants/index.ts
+++ b/server/libs/common/src/constants/index.ts
@@ -1,1 +1,4 @@
 export * from './upload_location.constant';
+
+export const MACHINE_LEARNING_URL = process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003';
+export const MACHINE_LEARNING_ENABLED = MACHINE_LEARNING_URL !== 'false';

--- a/web/src/lib/components/admin-page/jobs/jobs-panel.svelte
+++ b/web/src/lib/components/admin-page/jobs/jobs-panel.svelte
@@ -3,6 +3,7 @@
 		notificationController,
 		NotificationType
 	} from '$lib/components/shared-components/notification/notification';
+	import { handleError } from '$lib/utils/handle-error';
 	import { AllJobStatusResponseDto, api, JobCommand, JobId } from '@api';
 	import { onDestroy, onMount } from 'svelte';
 	import JobTile from './job-tile.svelte';
@@ -95,13 +96,8 @@
 					type: NotificationType.Info
 				});
 			}
-		} catch (e) {
-			console.log('[ERROR] runMachineLearning', e);
-
-			notificationController.show({
-				message: `Error running machine learning job, check console for more detail`,
-				type: NotificationType.Error
-			});
+		} catch (error) {
+			handleError(error, `Error running machine learning job, check console for more detail`);
 		}
 	};
 


### PR DESCRIPTION
This PR allows turning off machine learning with a env variable. I plan to document this option when there's a dedicated page on the docs site for env variables.

Setting `IMMICH_MACHINE_LEARNING_URL=false` will disable ML on start up, preventing the job from being queued and tasks from being processed related to ML.

![image](https://user-images.githubusercontent.com/4334196/213528211-adb58243-7d25-49d6-9855-efefab1c558a.png)
