### PR TITLE
Rebind PUBLIC_* env vars inside web container entrypoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,10 +51,6 @@ services:
     entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:
       - .env
-    environment:
-      # Rename these values for svelte public interface
-      - PUBLIC_IMMICH_SERVER_URL=${IMMICH_SERVER_URL}
-      - PUBLIC_IMMICH_API_URL_EXTERNAL=${IMMICH_API_URL_EXTERNAL}
     restart: always
 
   redis:

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,4 +1,9 @@
 #! /bin/sh
+
+# Rebind env vars to PUBLIC_ for svelte
+export PUBLIC_IMMICH_SERVER_URL=$IMMICH_SERVER_URL
+export PUBLIC_IMMICH_API_URL_EXTERNAL=$IMMICH_API_URL_EXTERNAL
+
 if [ "$(id -u)" -eq 0 ] && [ -n "$PUID" ] && [ -n "$PGID" ]; then
     exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups node /usr/src/app/build/index.js
 else


### PR DESCRIPTION
This PR moves the rebinding of the `PUBLIC_IMMICH_SERVER_URL` and `PUBLIC_IMMICH_API_URL_EXTERNAL` environment variables from the `docker-compose.yml` to inside of the web container's `entrypoint.sh`. This cleans up the user-facing configurations (a little) and prevents confusion when deploying in non-default setups.