### PR TITLE
feat(ci): Update the sdk_update workflow to not run on forks

### DIFF
--- a/.github/workflows/dispatch_sdk_update.yml
+++ b/.github/workflows/dispatch_sdk_update.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-sdk-repos:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
I think this shouldn't be ran on forks.