### PR TITLE
build(docker): Use ghcr.io as build cache instead of gha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,6 @@ jobs:
           platforms: linux/arm/v7,linux/amd64,linux/arm64
           # Skip pushing when PR from a fork
           push: ${{ !github.event.pull_request.head.repo.fork }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{matrix.image}}
+          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{matrix.image}}
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,16 @@ jobs:
             type=ref,event=tag
             type=raw,value=release,enable=${{ github.event_name == 'release' }}
 
+      - name: Determine build cache output
+        id: cache-target
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Essentially just ignore the cache output (PR can't write to registry cache)
+            echo "cache-to=type=local,dest=/tmp/discard,ignore-error=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-to=type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{ matrix.image }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push image
         uses: docker/build-push-action@v3.3.0
         with:
@@ -86,5 +96,5 @@ jobs:
           # Skip pushing when PR from a fork
           push: ${{ !github.event.pull_request.head.repo.fork }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{matrix.image}}
-          cache-to: type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{matrix.image}}
+          cache-to: ${{ steps.cache-target.outputs.cache-to }}
           tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
This pr replaces the gha-internal layer caching with an image pushed to ghcr.io. This works more reliably than the gha cache (which I'm pretty sure is bugged), with the added benefit that there is no 10GB cache limit. One caveat is that pull requests cannot -write- cache entries, because the push fails with a permission error. This is somewhat odd, because normal images can be pushed no problem, but I can't figure it out and it doesn't seem a big issue anyways :P 

I'm not 100% confident about this caching approach (it feels a little gross), so I'd like to hear others' opinions on it before this is merged.