### PR TITLE
fix(mobile): Fix endless 'Building timeline' loop after changing the number of assets per row

### DIFF
--- a/mobile/lib/modules/settings/ui/asset_list_settings/asset_list_tiles_per_row.dart
+++ b/mobile/lib/modules/settings/ui/asset_list_settings/asset_list_tiles_per_row.dart
@@ -24,6 +24,7 @@ class TilesPerRow extends HookConsumerWidget {
 
     void sliderChangedEnd(double _) {
       ref.invalidate(assetProvider);
+      ref.watch(assetProvider.notifier).getAllAsset();
     }
 
     useEffect(


### PR DESCRIPTION
Spotted during testing. Probably missed after changing the assetProvider from Value- to StateNotifierProvider.