### PR TITLE
fix(mobile): top padding missing from drag handle in add to album bottom sheet

### DIFF
--- a/mobile/lib/modules/album/ui/add_to_album_bottom_sheet.dart
+++ b/mobile/lib/modules/album/ui/add_to_album_bottom_sheet.dart
@@ -80,6 +80,7 @@ class AddToAlbumBottomSheet extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  const SizedBox(height: 12),
                   const Align(
                     alignment: Alignment.center,
                     child: CustomDraggingHandle(),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/100457/215273285-edd3dd0e-7da6-4c6b-a50c-0cac111c2ef2.png)

![image](https://user-images.githubusercontent.com/100457/215273300-918f32d6-5278-457b-85ed-eed0ba32ef02.png)

I made the issue, so it's only fair I fix it...