### PR TITLE
fix(web) long album name break styling for shared album card

### DIFF
--- a/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
+++ b/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <div
-	class="flex min-w-[550px] border-b border-gray-300 dark:border-immich-dark-gray place-items-center py-4  gap-6 transition-all hover:border-immich-primary dark:hover:border-immich-dark-primary"
+	class="grid grid-cols-[75px_1fr] w-[550px] border-b border-gray-300 dark:border-immich-dark-gray place-items-center py-4  gap-6 transition-all hover:border-immich-primary dark:hover:border-immich-dark-primary"
 >
 	<div>
 		{#await loadImageData(album.albumThumbnailAssetId)}
@@ -46,8 +46,10 @@
 		{/await}
 	</div>
 
-	<div>
-		<p class="font-medium text-gray-800 dark:text-immich-dark-primary">{album.albumName}</p>
+	<div class="justify-self-start">
+		<p class="font-medium text-gray-800 dark:text-immich-dark-primary">
+			{album.albumName}
+		</p>
 
 		{#await getAlbumOwnerInfo() then albumOwner}
 			{#if user.email == albumOwner.email}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27055614/215301462-a3df47a6-f118-4544-b3f2-5433ea60fe61.png)
