### PR TITLE
fix(mobile): fixes dark mode color for invite to album app bar

### DIFF
--- a/mobile/lib/modules/album/views/select_additional_user_for_sharing_page.dart
+++ b/mobile/lib/modules/album/views/select_additional_user_for_sharing_page.dart
@@ -118,7 +118,6 @@ class SelectAdditionalUserForSharingPage extends HookConsumerWidget {
       appBar: AppBar(
         title: const Text(
           'share_invite',
-          style: TextStyle(color: Colors.black),
         ).tr(),
         elevation: 0,
         centerTitle: false,


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/100457/216402116-a8c973c9-1cfd-4ea2-8ac0-f0c52d78bcf7.png)

After
![image](https://user-images.githubusercontent.com/100457/216402220-bf4f869b-cb8b-4334-84f6-8f6628103b60.png)
