### PR TITLE
fix(mobile): fixed local asset thumbnail size and eliminated fade in

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -108,7 +108,10 @@ class GalleryViewerPage extends HookConsumerWidget {
       return AssetEntityImageProvider(
         asset.local!,
         isOriginal: false,
-        thumbnailSize: const ThumbnailSize.square(250),
+        thumbnailSize: ThumbnailSize(
+          MediaQuery.of(context).size.width.floor(),
+          MediaQuery.of(context).size.height.floor(),
+        ),
       );
 
     }
@@ -285,6 +288,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                 cacheKey: getThumbnailCacheKey(asset.remote!, type: api.ThumbnailFormat.WEBP),
                 httpHeaders: { 'Authorization': authToken },
                 progressIndicatorBuilder: (_, __, ___) => const Center(child: ImmichLoadingIndicator(),),
+                fadeInDuration: const Duration(milliseconds: 0),
                 fit: BoxFit.contain,
               );
 
@@ -293,6 +297,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                 cacheKey: getThumbnailCacheKey(asset.remote!, type: api.ThumbnailFormat.JPEG),
                 httpHeaders: { 'Authorization': authToken },
                 fit: BoxFit.contain,
+                fadeInDuration: const Duration(milliseconds: 0),
                 placeholder: (_, __) => webPThumbnail,
               );
             } else {


### PR DESCRIPTION
The local asset thumbnail should be generated to size the screen and there was a fade in duration by default of the `CachedNetworkImage` which made the loading thumbnails appear dark as you paged through your images.