### PR TITLE
feat(mobile): Favorites staggered gridview

### DIFF
--- a/mobile/lib/modules/favorite/ui/favorite_image.dart
+++ b/mobile/lib/modules/favorite/ui/favorite_image.dart
@@ -1,34 +1,29 @@
-
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/ui/immich_image.dart';
 
 class FavoriteImage extends HookConsumerWidget {
   final Asset asset;
-  final List<Asset> assets;
+  final Function()? onTap;
 
-  const FavoriteImage(this.asset, this.assets, {super.key});
+  const FavoriteImage({
+    super.key,
+    required this.asset,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    void viewAsset() {
-      AutoRouter.of(context).push(
-        GalleryViewerRoute(
-          asset: asset,
-          assetList: assets,
-        ),
-      );
-    }
-
     return GestureDetector(
-      onTap: viewAsset,
-      child: ImmichImage(
-        asset,
-        width: 300,
-        height: 300,
+      onTap: onTap,
+      child: Hero(
+        tag: asset.id,
+        child: ImmichImage(
+          asset,
+          width: 300,
+          height: 300,
+        ),
       ),
     );
   }

--- a/mobile/lib/modules/favorite/views/favorites_page.dart
+++ b/mobile/lib/modules/favorite/views/favorites_page.dart
@@ -5,8 +5,6 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/favorite/providers/favorite_provider.dart';
 import 'package:immich_mobile/modules/favorite/ui/favorite_image.dart';
-import 'package:immich_mobile/modules/settings/providers/app_settings.provider.dart';
-import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 

--- a/mobile/lib/modules/favorite/views/favorites_page.dart
+++ b/mobile/lib/modules/favorite/views/favorites_page.dart
@@ -1,11 +1,14 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/favorite/providers/favorite_provider.dart';
 import 'package:immich_mobile/modules/favorite/ui/favorite_image.dart';
 import 'package:immich_mobile/modules/settings/providers/app_settings.provider.dart';
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
+import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
 
 class FavoritesPage extends HookConsumerWidget {
   const FavoritesPage({Key? key}) : super(key: key);
@@ -28,41 +31,44 @@ class FavoritesPage extends HookConsumerWidget {
     }
 
     Widget buildImageGrid() {
-      final appSettingService = ref.watch(appSettingsServiceProvider);
+      final favorites = ref.watch(favoriteAssetProvider);
 
-      if (ref.watch(favoriteAssetProvider).isNotEmpty) {
-        return SliverPadding(
-          padding: const EdgeInsets.only(top: 10.0),
-          sliver: SliverGrid(
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount:
-                  appSettingService.getSetting(AppSettingsEnum.tilesPerRow),
-              crossAxisSpacing: 5.0,
-              mainAxisSpacing: 5,
-            ),
-            delegate: SliverChildBuilderDelegate(
-              (
-                BuildContext context,
-                int index,
-              ) {
-                return FavoriteImage(
-                  ref.watch(favoriteAssetProvider)[index],
-                  ref.watch(favoriteAssetProvider),
-                );
-              },
-              childCount: ref.watch(favoriteAssetProvider).length,
-            ),
+      void viewAsset(Asset asset) {
+        AutoRouter.of(context).push(
+          GalleryViewerRoute(
+            asset: asset,
+            assetList: favorites,
           ),
         );
       }
-      return const SliverToBoxAdapter();
+
+      return GridView.builder(
+        itemCount: favorites.length,
+        gridDelegate: SliverQuiltedGridDelegate(
+          crossAxisCount: 4,
+          mainAxisSpacing: 5,
+          crossAxisSpacing: 5,
+          repeatPattern: QuiltedGridRepeatPattern.inverted,
+          pattern: [
+            const QuiltedGridTile(2, 2),
+            const QuiltedGridTile(1, 1),
+            const QuiltedGridTile(1, 1),
+            const QuiltedGridTile(1, 2),
+          ],
+        ),
+        itemBuilder: (
+                BuildContext context,
+                int index,
+              ) => FavoriteImage(
+                  asset: favorites[index],
+                  onTap: () => viewAsset(favorites[index]),
+                ),
+      );
     }
 
     return Scaffold(
       appBar: buildAppBar(),
-      body: CustomScrollView(
-        slivers: [buildImageGrid()],
-      ),
+      body:  buildImageGrid(),
     );
   }
 }

--- a/mobile/lib/modules/favorite/views/favorites_page.dart
+++ b/mobile/lib/modules/favorite/views/favorites_page.dart
@@ -42,27 +42,33 @@ class FavoritesPage extends HookConsumerWidget {
         );
       }
 
-      return GridView.builder(
-        itemCount: favorites.length,
-        gridDelegate: SliverQuiltedGridDelegate(
-          crossAxisCount: 4,
-          mainAxisSpacing: 5,
-          crossAxisSpacing: 5,
-          repeatPattern: QuiltedGridRepeatPattern.inverted,
-          pattern: [
-            const QuiltedGridTile(2, 2),
-            const QuiltedGridTile(1, 1),
-            const QuiltedGridTile(1, 1),
-            const QuiltedGridTile(1, 2),
-          ],
-        ),
-        itemBuilder: (
-                BuildContext context,
-                int index,
-              ) => FavoriteImage(
-                  asset: favorites[index],
-                  onTap: () => viewAsset(favorites[index]),
-                ),
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final crossAxisCount = constraints.maxWidth > 500 ? 4 : 2;
+          return  GridView.builder(
+            itemCount: favorites.length,
+            gridDelegate: SliverQuiltedGridDelegate(
+              crossAxisCount: crossAxisCount,
+              mainAxisSpacing: 5,
+              crossAxisSpacing: 5,
+              repeatPattern: QuiltedGridRepeatPattern.inverted,
+              pattern: [
+                const QuiltedGridTile(2, 2),
+                const QuiltedGridTile(1, 1),
+                const QuiltedGridTile(1, 1),
+                const QuiltedGridTile(1, 2),
+                const QuiltedGridTile(1, 1),
+              ],
+            ),
+            itemBuilder: (
+                    BuildContext context,
+                    int index,
+                  ) => FavoriteImage(
+                      asset: favorites[index],
+                      onTap: () => viewAsset(favorites[index]),
+                    ),
+          );
+        },
       );
     }
 

--- a/mobile/lib/modules/favorite/views/favorites_page.dart
+++ b/mobile/lib/modules/favorite/views/favorites_page.dart
@@ -57,7 +57,6 @@ class FavoritesPage extends HookConsumerWidget {
                 const QuiltedGridTile(1, 1),
                 const QuiltedGridTile(1, 1),
                 const QuiltedGridTile(1, 2),
-                const QuiltedGridTile(1, 1),
               ],
             ),
             itemBuilder: (

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -366,6 +366,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0-dev.7"
+  flutter_staggered_grid_view:
+    dependency: "direct main"
+    description:
+      name: flutter_staggered_grid_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_udid: ^2.0.0
   package_info_plus: ^1.4.0
   url_launcher: ^6.1.3
+  flutter_staggered_grid_view: ^0.6.2
   http: 0.13.4
   cancellation_token_http: ^1.1.0
   easy_localization: ^3.0.1


### PR DESCRIPTION
Changed the favorites GridView to use [`'flutter_staggered_grid_view`](https://pub.dev/documentation/flutter_staggered_grid_view/latest/)

In particular, I changed it to use a "2" unit wide Quilted layout. 

![image](https://user-images.githubusercontent.com/100457/216815586-ffe4bffc-385c-4067-86b8-fb41c090c241.png)

On wider layouts, we use a "4" unit wide Quilted layout.

![image](https://user-images.githubusercontent.com/100457/216815651-e76d4911-9a74-4600-bbbe-6774142241a3.png)


![image](https://user-images.githubusercontent.com/100457/216815660-c61c55c8-19f3-40a2-8c9b-a1aa10861aec.png)

**Current Behavior**
![image](https://user-images.githubusercontent.com/100457/216815746-44b3a4d0-77ef-41f0-8bb7-09a51c5c98f4.png)

**Notes**
- Also adds hero animations to animate the image selection
- The QuiltedLayout is sort of static, having to declare the size of the squares before laying out. Due to the complexity, this PR no longer supports the user-defined number of columns to show.
- This customization option could be added back in for this PR (if desired) or added later (if requested).
