### PR TITLE
feat(mobile): Responsive layout improvements with a navigation rail and album grid

### DIFF
--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -1,10 +1,8 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:immich_mobile/constants/hive_box.dart';
-import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:openapi/api.dart';

--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -10,9 +10,12 @@ import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:openapi/api.dart';
 
 class AlbumThumbnailCard extends StatelessWidget {
+  final Function()? onTap;
+
   const AlbumThumbnailCard({
     Key? key,
     required this.album,
+    this.onTap,
   }) : super(key: key);
 
   final Album album;
@@ -23,18 +26,19 @@ class AlbumThumbnailCard extends StatelessWidget {
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
     return LayoutBuilder(
       builder: (context, constraints) {
-      var cardSize = constraints.maxWidth / 2 - 18;
+      var cardSize = constraints.maxWidth;
 
       buildEmptyThumbnail() {
         return Container(
+          height: cardSize,
+          width: cardSize,
           decoration: BoxDecoration(
             color: isDarkMode ? Colors.grey[800] : Colors.grey[200],
           ),
-          child: SizedBox(
-            height: cardSize,
-            width: cardSize,
-            child: const Center(
-              child: Icon(Icons.no_photography),
+          child: Center(
+            child: Icon(
+              Icons.no_photography,
+              size: cardSize * .15,
             ),
           ),
         );
@@ -56,19 +60,19 @@ class AlbumThumbnailCard extends StatelessWidget {
       }
 
       return GestureDetector(
-        onTap: () {
-          AutoRouter.of(context).push(AlbumViewerRoute(albumId: album.id));
-        },
+        onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.only(bottom: 32.0),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: album.albumThumbnailAssetId == null
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: album.albumThumbnailAssetId == null
                     ? buildEmptyThumbnail()
                     : buildAlbumThumbnail(),
+                ),
               ),
               Padding(
                 padding: const EdgeInsets.only(top: 8.0),

--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -20,89 +20,93 @@ class AlbumThumbnailCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var box = Hive.box(userInfoBox);
-    var cardSize = MediaQuery.of(context).size.width / 2 - 18;
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+      var cardSize = constraints.maxWidth / 2 - 18;
 
-    buildEmptyThumbnail() {
-      return Container(
-        decoration: BoxDecoration(
-          color: isDarkMode ? Colors.grey[800] : Colors.grey[200],
-        ),
-        child: SizedBox(
-          height: cardSize,
-          width: cardSize,
-          child: const Center(
-            child: Icon(Icons.no_photography),
+      buildEmptyThumbnail() {
+        return Container(
+          decoration: BoxDecoration(
+            color: isDarkMode ? Colors.grey[800] : Colors.grey[200],
           ),
-        ),
-      );
-    }
-
-    buildAlbumThumbnail() {
-      return CachedNetworkImage(
-        width: cardSize,
-        height: cardSize,
-        fit: BoxFit.cover,
-        fadeInDuration: const Duration(milliseconds: 200),
-        imageUrl: getAlbumThumbnailUrl(
-          album,
-          type: ThumbnailFormat.JPEG,
-        ),
-        httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
-        cacheKey: getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.JPEG),
-      );
-    }
-
-    return GestureDetector(
-      onTap: () {
-        AutoRouter.of(context).push(AlbumViewerRoute(albumId: album.id));
-      },
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 32.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: album.albumThumbnailAssetId == null
-                  ? buildEmptyThumbnail()
-                  : buildAlbumThumbnail(),
+          child: SizedBox(
+            height: cardSize,
+            width: cardSize,
+            child: const Center(
+              child: Icon(Icons.no_photography),
             ),
-            Padding(
-              padding: const EdgeInsets.only(top: 8.0),
-              child: SizedBox(
-                width: cardSize,
-                child: Text(
-                  album.name,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
+          ),
+        );
+      }
+
+      buildAlbumThumbnail() {
+        return CachedNetworkImage(
+          width: cardSize,
+          height: cardSize,
+          fit: BoxFit.cover,
+          fadeInDuration: const Duration(milliseconds: 200),
+          imageUrl: getAlbumThumbnailUrl(
+            album,
+            type: ThumbnailFormat.JPEG,
+          ),
+          httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
+          cacheKey: getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.JPEG),
+        );
+      }
+
+      return GestureDetector(
+        onTap: () {
+          AutoRouter.of(context).push(AlbumViewerRoute(albumId: album.id));
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 32.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: album.albumThumbnailAssetId == null
+                    ? buildEmptyThumbnail()
+                    : buildAlbumThumbnail(),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: SizedBox(
+                  width: cardSize,
+                  child: Text(
+                    album.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
               ),
-            ),
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  album.assetCount == 1
-                      ? 'album_thumbnail_card_item'
-                      : 'album_thumbnail_card_items',
-                  style: const TextStyle(
-                    fontSize: 12,
-                  ),
-                ).tr(args: ['${album.assetCount}']),
-                if (album.shared)
-                  const Text(
-                    'album_thumbnail_card_shared',
-                    style: TextStyle(
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    album.assetCount == 1
+                        ? 'album_thumbnail_card_item'
+                        : 'album_thumbnail_card_items',
+                    style: const TextStyle(
                       fontSize: 12,
                     ),
-                  ).tr()
-              ],
-            )
-          ],
+                  ).tr(args: ['${album.assetCount}']),
+                  if (album.shared)
+                    const Text(
+                      'album_thumbnail_card_shared',
+                      style: TextStyle(
+                        fontSize: 12,
+                      ),
+                    ).tr()
+                ],
+              )
+            ],
+          ),
         ),
-      ),
+      );
+      },
     );
   }
 }

--- a/mobile/lib/modules/album/views/library_page.dart
+++ b/mobile/lib/modules/album/views/library_page.dart
@@ -112,15 +112,14 @@ class LibraryPage extends HookConsumerWidget {
         onTap: () {
           AutoRouter.of(context).push(CreateAlbumRoute(isSharedAlbum: false));
         },
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            LayoutBuilder(
-              builder: (context, constraints) {
-                return Container(
-                  width: constraints.maxWidth / 2 - 18,
-                  height: constraints.maxWidth / 2 - 18,
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Container(
                   decoration: BoxDecoration(
                     border: Border.all(
                       color: Colors.grey,
@@ -134,19 +133,22 @@ class LibraryPage extends HookConsumerWidget {
                       color: Theme.of(context).primaryColor,
                     ),
                   ),
-                );
-              }
-            ),
-            Padding(
-              padding: const EdgeInsets.only(top: 8.0),
-              child: const Text(
-                'library_page_new_album',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
                 ),
-              ).tr(),
-            )
-          ],
+              ),
+              Padding(
+                padding: const EdgeInsets.only(
+                  top: 8.0,
+                  bottom: 16,
+                ),
+                child: const Text(
+                  'library_page_new_album',
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ).tr(),
+              ),
+            ],
+          ),
         ),
       );
     }
@@ -188,6 +190,8 @@ class LibraryPage extends HookConsumerWidget {
         ),
       );
     }
+
+    final sorted = sortedAlbums();
 
     return Scaffold(
       appBar: buildAppBar(),
@@ -238,20 +242,33 @@ class LibraryPage extends HookConsumerWidget {
             ),
           ),
           SliverPadding(
-            padding: const EdgeInsets.only(left: 12.0, right: 12, bottom: 50),
-            sliver: SliverToBoxAdapter(
-              child: Wrap(
-                spacing: 12,
-                children: [
-                  buildCreateAlbumButton(),
-                  for (var album in sortedAlbums())
-                    AlbumThumbnailCard(
-                      album: album,
+            padding: const EdgeInsets.all(12.0),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 250,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: .7,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                childCount: sorted.length + 1,
+                (context, index) {
+                  if (index  == 0) {
+                    return buildCreateAlbumButton();
+                  }
+
+                  return AlbumThumbnailCard(
+                    album: sorted[index - 1],
+                    onTap: () => AutoRouter.of(context).push(
+                      AlbumViewerRoute(
+                        albumId: sorted[index - 1].id,
+                      ),
                     ),
-                ],
+                  );
+                },
               ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/mobile/lib/modules/album/views/library_page.dart
+++ b/mobile/lib/modules/album/views/library_page.dart
@@ -116,22 +116,26 @@ class LibraryPage extends HookConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Container(
-              width: MediaQuery.of(context).size.width / 2 - 18,
-              height: MediaQuery.of(context).size.width / 2 - 18,
-              decoration: BoxDecoration(
-                border: Border.all(
-                  color: Colors.grey,
-                ),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Center(
-                child: Icon(
-                  Icons.add_rounded,
-                  size: 28,
-                  color: Theme.of(context).primaryColor,
-                ),
-              ),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                return Container(
+                  width: constraints.maxWidth / 2 - 18,
+                  height: constraints.maxWidth / 2 - 18,
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: Colors.grey,
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Center(
+                    child: Icon(
+                      Icons.add_rounded,
+                      size: 28,
+                      color: Theme.of(context).primaryColor,
+                    ),
+                  ),
+                );
+              }
             ),
             Padding(
               padding: const EdgeInsets.only(top: 8.0),

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -97,24 +97,29 @@ class ImmichAssetGridState extends State<ImmichAssetGrid> {
     RenderAssetGridRow row,
     bool scrolling,
   ) {
-    double size = _getItemSize(context);
 
-    return Row(
-      key: Key("asset-row-${row.assets.first.id}"),
-      children: row.assets.map((Asset asset) {
-        bool last = asset.id == row.assets.last.id;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.maxWidth / widget.assetsPerRow -
+          widget.margin * (widget.assetsPerRow - 1) / widget.assetsPerRow;
+        return Row(
+          key: Key("asset-row-${row.assets.first.id}"),
+          children: row.assets.map((Asset asset) {
+            bool last = asset.id == row.assets.last.id;
 
-        return Container(
-          key: Key("asset-${asset.id}"),
-          width: size,
-          height: size,
-          margin: EdgeInsets.only(
-            top: widget.margin,
-            right: last ? 0.0 : widget.margin,
-          ),
-          child: _buildThumbnailOrPlaceholder(asset, scrolling),
+            return Container(
+              key: Key("asset-${asset.id}"),
+              width: size,
+              height: size,
+              margin: EdgeInsets.only(
+                top: widget.margin,
+                right: last ? 0.0 : widget.margin,
+              ),
+              child: _buildThumbnailOrPlaceholder(asset, scrolling),
+            );
+          }).toList(),
         );
-      }).toList(),
+      }
     );
   }
 

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -66,11 +66,6 @@ class ImmichAssetGridState extends State<ImmichAssetGrid> {
         assets.firstWhereOrNull((e) => !_selectedAssets.contains(e.id)) == null;
   }
 
-  double _getItemSize(BuildContext context) {
-    return MediaQuery.of(context).size.width / widget.assetsPerRow -
-        widget.margin * (widget.assetsPerRow - 1) / widget.assetsPerRow;
-  }
-
   Widget _buildThumbnailOrPlaceholder(
     Asset asset,
     bool placeholder,
@@ -119,7 +114,7 @@ class ImmichAssetGridState extends State<ImmichAssetGrid> {
             );
           }).toList(),
         );
-      }
+      },
     );
   }
 

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -14,7 +14,6 @@ class TabControllerPage extends ConsumerWidget {
 
     navigationRail(TabsRouter tabsRouter) {
       return NavigationRail(
-        leading: Padding(padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top)),
         labelType: NavigationRailLabelType.all,
         selectedIndex: tabsRouter.activeIndex,
         onDestinationSelected: (index) {
@@ -23,7 +22,12 @@ class TabControllerPage extends ConsumerWidget {
         },
         destinations: [
           NavigationRailDestination(
-            padding: const EdgeInsets.all(4),
+            padding: EdgeInsets.only(
+              top: MediaQuery.of(context).padding.top + 4,
+              left: 4,
+              right: 4,
+              bottom: 4,
+            ),
             icon: const Icon(Icons.photo_outlined), 
             label: const Text('tab_controller_nav_photos').tr(),
           ),

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -11,6 +11,81 @@ class TabControllerPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+
+    navigationRail(TabsRouter tabsRouter) {
+      return NavigationRail(
+        leading: Padding(padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top)),
+        labelType: NavigationRailLabelType.all,
+        selectedIndex: tabsRouter.activeIndex,
+        onDestinationSelected: (index) {
+          HapticFeedback.selectionClick();
+          tabsRouter.setActiveIndex(index);
+        },
+        destinations: [
+          NavigationRailDestination(
+            padding: const EdgeInsets.all(4),
+            icon: const Icon(Icons.photo_outlined), 
+            label: const Text('tab_controller_nav_photos').tr(),
+          ),
+          NavigationRailDestination(
+            padding: const EdgeInsets.all(4),
+            icon: const Icon(Icons.search_rounded), 
+            label: const Text('tab_controller_nav_search').tr(),
+          ),
+          NavigationRailDestination(
+            padding: const EdgeInsets.all(4),
+            icon: const Icon(Icons.share_rounded), 
+            label: const Text('tab_controller_nav_sharing').tr(),
+          ),
+          NavigationRailDestination(
+            padding: const EdgeInsets.all(4),
+            icon: const Icon(Icons.photo_album_outlined), 
+            label: const Text('tab_controller_nav_library').tr(),
+          ),
+        ],
+      );
+    }
+
+    bottomNavigationBar(TabsRouter tabsRouter) {
+      return BottomNavigationBar(
+        selectedLabelStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedLabelStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+        currentIndex: tabsRouter.activeIndex,
+        onTap: (index) {
+          HapticFeedback.selectionClick();
+          tabsRouter.setActiveIndex(index);
+        },
+        items: [
+          BottomNavigationBarItem(
+            label: 'tab_controller_nav_photos'.tr(),
+            icon: const Icon(Icons.photo_outlined),
+            activeIcon: const Icon(Icons.photo),
+          ),
+          BottomNavigationBarItem(
+            label: 'tab_controller_nav_search'.tr(),
+            icon: const Icon(Icons.search_rounded),
+            activeIcon: const Icon(Icons.search),
+          ),
+          BottomNavigationBarItem(
+            label: 'tab_controller_nav_sharing'.tr(),
+            icon: const Icon(Icons.group_outlined),
+            activeIcon: const Icon(Icons.group),
+          ),
+          BottomNavigationBarItem(
+            label: 'tab_controller_nav_library'.tr(),
+            icon: const Icon(Icons.photo_album_outlined),
+            activeIcon: const Icon(Icons.photo_album_rounded),
+          )
+        ],
+      );
+    }
+
     final multiselectEnabled = ref.watch(multiselectProvider);
     return AutoTabsRouter(
       routes: [
@@ -32,51 +107,39 @@ class TabControllerPage extends ConsumerWidget {
             }
             return atHomeTab;
           },
-          child: Scaffold(
-            body: FadeTransition(
-              opacity: animation,
-              child: child,
-            ),
-            bottomNavigationBar: multiselectEnabled
-                ? null
-                : BottomNavigationBar(
-                    selectedLabelStyle: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              const medium = 600;
+              final Widget? bottom;
+              final Widget body;
+              if (constraints.maxWidth < medium) {
+                // Normal phone width
+                bottom = bottomNavigationBar(tabsRouter);
+                body = FadeTransition(
+                  opacity: animation,
+                  child: child,
+                );
+              } else {
+                // Medium tablet width
+                bottom = null;
+                body = Row(
+                  children: [
+                    navigationRail(tabsRouter),
+                    Expanded(
+                      child: FadeTransition(
+                        opacity: animation,
+                        child: child,
+                      ),
                     ),
-                    unselectedLabelStyle: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    currentIndex: tabsRouter.activeIndex,
-                    onTap: (index) {
-                      HapticFeedback.selectionClick();
-                      tabsRouter.setActiveIndex(index);
-                    },
-                    items: [
-                      BottomNavigationBarItem(
-                        label: 'tab_controller_nav_photos'.tr(),
-                        icon: const Icon(Icons.photo_outlined),
-                        activeIcon: const Icon(Icons.photo),
-                      ),
-                      BottomNavigationBarItem(
-                        label: 'tab_controller_nav_search'.tr(),
-                        icon: const Icon(Icons.search_rounded),
-                        activeIcon: const Icon(Icons.search),
-                      ),
-                      BottomNavigationBarItem(
-                        label: 'tab_controller_nav_sharing'.tr(),
-                        icon: const Icon(Icons.group_outlined),
-                        activeIcon: const Icon(Icons.group),
-                      ),
-                      BottomNavigationBarItem(
-                        label: 'tab_controller_nav_library'.tr(),
-                        icon: const Icon(Icons.photo_album_outlined),
-                        activeIcon: const Icon(Icons.photo_album_rounded),
-                      )
-                    ],
-                  ),
-          ),
+                  ],
+                );
+              }              return Scaffold(
+               body: body,
+               bottomNavigationBar: multiselectEnabled
+                  ? null
+                  : bottom,
+            );
+          },),
         );
       },
     );

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -20,6 +20,13 @@ class TabControllerPage extends ConsumerWidget {
           HapticFeedback.selectionClick();
           tabsRouter.setActiveIndex(index);
         },
+        selectedIconTheme: IconThemeData(
+          color: Theme.of(context).primaryColor,
+        ),
+        selectedLabelTextStyle: TextStyle(
+          color: Theme.of(context).primaryColor,
+        ),
+        useIndicator: false,
         destinations: [
           NavigationRailDestination(
             padding: EdgeInsets.only(
@@ -29,21 +36,25 @@ class TabControllerPage extends ConsumerWidget {
               bottom: 4,
             ),
             icon: const Icon(Icons.photo_outlined), 
+            selectedIcon: const Icon(Icons.photo),
             label: const Text('tab_controller_nav_photos').tr(),
           ),
           NavigationRailDestination(
             padding: const EdgeInsets.all(4),
             icon: const Icon(Icons.search_rounded), 
+            selectedIcon: const Icon(Icons.search), 
             label: const Text('tab_controller_nav_search').tr(),
           ),
           NavigationRailDestination(
             padding: const EdgeInsets.all(4),
             icon: const Icon(Icons.share_rounded), 
+            selectedIcon: const Icon(Icons.share), 
             label: const Text('tab_controller_nav_sharing').tr(),
           ),
           NavigationRailDestination(
             padding: const EdgeInsets.all(4),
             icon: const Icon(Icons.photo_album_outlined), 
+            selectedIcon: const Icon(Icons.photo_album), 
             label: const Text('tab_controller_nav_library').tr(),
           ),
         ],


### PR DESCRIPTION
- Uses [NavigationRail](https://api.flutter.dev/flutter/material/NavigationRail-class.html) for wide layouts instead of the bottom tab controller
- Uses GridView with max extents to dynamically lay out the album grid

## Navigation Rail

![image](https://user-images.githubusercontent.com/100457/217530237-053c3f7c-6dbf-4117-94a8-9d64489ae2c8.png)

On wide layouts (greater than 600dp), we use this navigation rail instead of the bottom tab controller. 

Thin layouts continue using the bottom navigation bar:
![image](https://user-images.githubusercontent.com/100457/217429968-8f6cd298-8c7a-4527-9707-9d30131a8d2b.png)


[See scaling and adaptation here](https://www.material.io/components/bottom-navigation#behavior) on the Material guidelines. This improves over the existing way to lay out the bottom navigation on tablets, which is spread too wide:

![image](https://user-images.githubusercontent.com/100457/217428792-dff4a2e9-b996-4f57-826c-f9c275c6e96b.png)
(Thanks to tbleiker in Discord for the above image and helpful discussion!)

## Album GridView
![image](https://user-images.githubusercontent.com/100457/217546129-5082bde1-ade0-43f5-a938-8808e597faa0.png)
![image](https://user-images.githubusercontent.com/100457/217546203-f3c02d62-b428-4e7d-af21-48e9482fdef1.png)
