### PR TITLE
fix(mobile): Fixes back navigation with tab controller

### DIFF
--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -111,15 +111,13 @@ class TabControllerPage extends ConsumerWidget {
       ],
       builder: (context, child, animation) {
         final tabsRouter = AutoTabsRouter.of(context);
-        final appRouter = AutoRouter.of(context);
         return WillPopScope(
           onWillPop: () async {
             bool atHomeTab = tabsRouter.activeIndex == 0;
             if (!atHomeTab) {
               tabsRouter.setActiveIndex(0);
-            } else {
-              appRouter.navigateBack();
-            }
+            } 
+
             return atHomeTab;
           },
           child: LayoutBuilder(


### PR DESCRIPTION
Back button didn't close the drawer properly in Android and back navigation from the main timeline would sometimes take you back to settings.

- Open Drawer
- Tap Settings
- Go Back (either with the back button or tapping back icon in App Bar)
- Hit Back Button

This would take you back to Settings, because of the superfluous `appRouter.navigateBack()` command in the top level `TabControllerPage`.

I removed it and tested the behavior, and everything works as expected. Was there some reason it was there to begin with that I have neglected to consider?
