### PR TITLE
fix(mobile): Adds overscroll at end of timeline to select images on the bottom

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -189,6 +189,9 @@ class ImmichAssetGridState extends State<ImmichAssetGrid> {
     }
 
     final listWidget = ScrollablePositionedList.builder(
+      padding: const EdgeInsets.only(
+        bottom: 220,
+      ),
       itemBuilder: _itemBuilder,
       itemPositionsListener: _itemPositionsListener,
       itemScrollController: _itemScrollController,

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -216,7 +216,6 @@ class HomePage extends HookConsumerWidget {
       }
 
       return SafeArea(
-        bottom: !multiselectEnabled.state,
         top: true,
         child: Stack(
           children: [
@@ -234,14 +233,17 @@ class HomePage extends HookConsumerWidget {
                     selectionActive: selectionEnabledHook.value,
                   ),
             if (selectionEnabledHook.value)
-              ControlBottomAppBar(
-                onShare: onShareAssets,
-                onFavorite: onFavoriteAssets,
-                onDelete: onDelete,
-                onAddToAlbum: onAddToAlbum,
-                albums: albums,
-                sharedAlbums: sharedAlbums,
-                onCreateNewAlbum: onCreateNewAlbum,
+              SafeArea(
+                bottom: true,
+                child: ControlBottomAppBar(
+                  onShare: onShareAssets,
+                  onFavorite: onFavoriteAssets,
+                  onDelete: onDelete,
+                  onAddToAlbum: onAddToAlbum,
+                  albums: albums,
+                  sharedAlbums: sharedAlbums,
+                  onCreateNewAlbum: onCreateNewAlbum,
+                ),
               ),
           ],
         ),
@@ -249,11 +251,9 @@ class HomePage extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: multiselectEnabled.state
-          ? null
-          : HomePageAppBar(
-              onPopBack: reloadAllAsset,
-            ),
+      appBar: HomePageAppBar(
+        onPopBack: reloadAllAsset,
+      ),
       drawer: const ProfileDrawer(),
       body: buildBody(),
     );


### PR DESCRIPTION
- Adds some extra padding on the bottom of the timeline so you can overscroll to select images there
- Fixes a bug with `SafeArea` on the bottom of the timeline while multiselect is enabled
- Closes #1717 

![image](https://user-images.githubusercontent.com/100457/217998301-0af971ca-9e1d-4f12-8ebd-64928ea18b05.png)
