### PR TITLE
fix(server): fix resolution in thumbnail generation

### DIFF
--- a/server/apps/microservices/src/processors/thumbnail.processor.ts
+++ b/server/apps/microservices/src/processors/thumbnail.processor.ts
@@ -50,7 +50,7 @@ export class ThumbnailGeneratorProcessor {
     if (asset.type == AssetType.IMAGE) {
       try {
         await sharp(asset.originalPath, { failOnError: false })
-          .resize(1440, 1440, { fit: 'outside' })
+          .resize(1440, 1440, { fit: 'outside', withoutEnlargement: true })
           .jpeg()
           .rotate()
           .toFile(jpegThumbnailPath);

--- a/server/apps/microservices/src/processors/thumbnail.processor.ts
+++ b/server/apps/microservices/src/processors/thumbnail.processor.ts
@@ -50,7 +50,7 @@ export class ThumbnailGeneratorProcessor {
     if (asset.type == AssetType.IMAGE) {
       try {
         await sharp(asset.originalPath, { failOnError: false })
-          .resize(1440, 2560, { fit: 'inside' })
+          .resize(1440, 1440, { fit: 'outside' })
           .jpeg()
           .rotate()
           .toFile(jpegThumbnailPath);


### PR DESCRIPTION
Hey there, thanks for this awesome project!

This fixes #1510 by applying equal scaling to portrait and landscape images. (And switches the `fit` parameter from `inside` to `outside` which ensures that for example panorama images still maintain a proper height)

Furthermore it adds the `withoutEnlargement` option so that smaller images do not get upscaled to 1440p without any benefit.