### PR TITLE
feat(web): redirect to login from getting started

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 		</h1>
 		<button
 			class="border px-4 py-4 rounded-md bg-immich-primary dark:bg-immich-dark-primary dark:text-immich-dark-gray dark:border-immich-dark-gray hover:bg-immich-primary/75 text-white font-bold w-[200px]"
-			on:click={() => goto('/auth/login')}
+			on:click={() => goto('/auth/register')}
 			>Getting Started
 		</button>
 	</div>

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,4 +1,5 @@
 export const prerender = false;
+import { serverApi } from '@api';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
@@ -6,6 +7,12 @@ export const load: PageLoad = async ({ parent }) => {
 	const { user } = await parent();
 	if (user) {
 		throw redirect(302, '/photos');
+	}
+
+	const { data } = await serverApi.userApi.getUserCount(true);
+	if (data.userCount > 0) {
+		// Redirect to login page if an admin is already registered.
+		throw redirect(302, '/auth/login');
 	}
 
 	return {


### PR DESCRIPTION
Show the 'Getting Started' page only when no admin account is set up. Fixes #1552 