### PR TITLE
feature(mobile): sync assets, albums & users to local database on device

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -142,6 +142,7 @@
   "library_page_sharing": "Sharing",
   "library_page_sort_created": "Most recently created",
   "library_page_sort_title": "Album title",
+  "library_page_device_albums": "Albums on Device",
   "login_form_button_text": "Login",
   "login_form_email_hint": "youremail@email.com",
   "login_form_endpoint_hint": "http://your-server-ip:port/api",

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -19,8 +19,12 @@ import 'package:immich_mobile/modules/onboarding/providers/gallery_permission.pr
 import 'package:immich_mobile/modules/settings/providers/notification_permission.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/routing/tab_navigation_observer.dart';
+import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/immich_logger_message.model.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/app_state.provider.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
@@ -42,6 +46,7 @@ void main() async {
   await initApp();
   final db = await loadDb();
   await migrateHiveToStoreIfNecessary();
+  await migrateJsonCacheIfNecessary();
   runApp(getMainWidget(db));
 }
 
@@ -93,7 +98,13 @@ Future<void> initApp() async {
 Future<Isar> loadDb() async {
   final dir = await getApplicationDocumentsDirectory();
   Isar db = await Isar.open(
-    [StoreValueSchema],
+    [
+      StoreValueSchema,
+      ExifInfoSchema,
+      AssetSchema,
+      AlbumSchema,
+      UserSchema,
+    ],
     directory: dir.path,
     maxSizeMiB: 256,
   );

--- a/mobile/lib/modules/album/providers/album.provider.dart
+++ b/mobile/lib/modules/album/providers/album.provider.dart
@@ -35,9 +35,9 @@ class AlbumNotifier extends StateNotifier<List<Album>> {
     }
   }
 
-  Future<void> deleteAlbum(Album album) async {
-    _albumService.deleteAlbum(album);
-    state = state.where((album) => album.id != album.id).toList();
+  Future<bool> deleteAlbum(Album album) async {
+    state = state.where((a) => a.id != album.id).toList();
+    return _albumService.deleteAlbum(album);
   }
 
   Future<Album?> createAlbum(

--- a/mobile/lib/modules/album/providers/asset_selection.provider.dart
+++ b/mobile/lib/modules/album/providers/asset_selection.provider.dart
@@ -58,7 +58,7 @@ class AssetSelectionNotifier extends StateNotifier<AssetSelectionState> {
     );
   }
 
-  void addNewAssets(List<Asset> assets) {
+  void addNewAssets(Iterable<Asset> assets) {
     state = state.copyWith(
       selectedNewAssetsForAlbum: {
         ...state.selectedNewAssetsForAlbum,

--- a/mobile/lib/modules/album/providers/shared_album.provider.dart
+++ b/mobile/lib/modules/album/providers/shared_album.provider.dart
@@ -1,21 +1,18 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/album/services/album.service.dart';
-import 'package:immich_mobile/modules/album/services/album_cache.service.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
+import 'package:isar/isar.dart';
 
 class SharedAlbumNotifier extends StateNotifier<List<Album>> {
-  SharedAlbumNotifier(this._albumService, this._sharedAlbumCacheService)
-      : super([]);
+  SharedAlbumNotifier(this._albumService, this._db) : super([]);
 
   final AlbumService _albumService;
-  final SharedAlbumCacheService _sharedAlbumCacheService;
-
-  void _cacheState() {
-    _sharedAlbumCacheService.put(state);
-  }
+  final Isar _db;
 
   Future<Album?> createSharedAlbum(
     String albumName,
@@ -23,7 +20,7 @@ class SharedAlbumNotifier extends StateNotifier<List<Album>> {
     Iterable<User> sharedUsers,
   ) async {
     try {
-      var newAlbum = await _albumService.createAlbum(
+      final Album? newAlbum = await _albumService.createAlbum(
         albumName,
         assets,
         sharedUsers,
@@ -31,61 +28,45 @@ class SharedAlbumNotifier extends StateNotifier<List<Album>> {
 
       if (newAlbum != null) {
         state = [...state, newAlbum];
-        _cacheState();
+        return newAlbum;
       }
-
-      return newAlbum;
     } catch (e) {
       debugPrint("Error createSharedAlbum  ${e.toString()}");
-
-      return null;
     }
+    return null;
   }
 
   Future<void> getAllSharedAlbums() async {
-    if (await _sharedAlbumCacheService.isValid() && state.isEmpty) {
-      final albums = await _sharedAlbumCacheService.get();
-      if (albums != null) {
-        state = albums;
-      }
+    if (state.isEmpty &&
+        0 < await _db.albums.filter().sharedEqualTo(true).count()) {
+      state = await _db.albums.filter().sharedEqualTo(true).findAll();
     }
+    await _albumService.refreshRemoteAlbums(isShared: true);
 
-    List<Album>? sharedAlbums = await _albumService.getAlbums(isShared: true);
-
-    if (sharedAlbums != null) {
-      state = sharedAlbums;
-      _cacheState();
+    final albums = await _db.albums.filter().sharedEqualTo(true).findAll();
+    if (!const ListEquality().equals(albums, state)) {
+      state = albums;
     }
   }
 
-  void deleteAlbum(Album album) {
+  Future<bool> deleteAlbum(Album album) {
     state = state.where((a) => a.id != album.id).toList();
-    _cacheState();
+    return _albumService.deleteAlbum(album);
   }
 
   Future<bool> leaveAlbum(Album album) async {
     var res = await _albumService.leaveAlbum(album);
 
     if (res) {
-      state = state.where((a) => a.id != album.id).toList();
-      _cacheState();
+      await deleteAlbum(album);
       return true;
     } else {
       return false;
     }
   }
 
-  Future<bool> removeAssetFromAlbum(
-    Album album,
-    Iterable<Asset> assets,
-  ) async {
-    var res = await _albumService.removeAssetFromAlbum(album, assets);
-
-    if (res) {
-      return true;
-    } else {
-      return false;
-    }
+  Future<bool> removeAssetFromAlbum(Album album, Iterable<Asset> assets) {
+    return _albumService.removeAssetFromAlbum(album, assets);
   }
 }
 
@@ -93,12 +74,12 @@ final sharedAlbumProvider =
     StateNotifierProvider<SharedAlbumNotifier, List<Album>>((ref) {
   return SharedAlbumNotifier(
     ref.watch(albumServiceProvider),
-    ref.watch(sharedAlbumCacheServiceProvider),
+    ref.watch(dbProvider),
   );
 });
 
 final sharedAlbumDetailProvider =
-    FutureProvider.autoDispose.family<Album?, String>((ref, albumId) async {
+    FutureProvider.autoDispose.family<Album?, int>((ref, albumId) async {
   final AlbumService sharedAlbumService = ref.watch(albumServiceProvider);
 
   return await sharedAlbumService.getAlbumDetail(albumId);

--- a/mobile/lib/modules/album/providers/shared_album.provider.dart
+++ b/mobile/lib/modules/album/providers/shared_album.provider.dart
@@ -81,5 +81,7 @@ final sharedAlbumDetailProvider =
     FutureProvider.autoDispose.family<Album?, int>((ref, albumId) async {
   final AlbumService sharedAlbumService = ref.watch(albumServiceProvider);
 
-  return await sharedAlbumService.getAlbumDetail(albumId);
+  final Album? a = await sharedAlbumService.getAlbumDetail(albumId);
+  await a?.loadSortedAssets();
+  return a;
 });

--- a/mobile/lib/modules/album/providers/shared_album.provider.dart
+++ b/mobile/lib/modules/album/providers/shared_album.provider.dart
@@ -37,13 +37,12 @@ class SharedAlbumNotifier extends StateNotifier<List<Album>> {
   }
 
   Future<void> getAllSharedAlbums() async {
-    if (state.isEmpty &&
-        0 < await _db.albums.filter().sharedEqualTo(true).count()) {
-      state = await _db.albums.filter().sharedEqualTo(true).findAll();
+    var albums = await _db.albums.filter().sharedEqualTo(true).findAll();
+    if (!const ListEquality().equals(albums, state)) {
+      state = albums;
     }
     await _albumService.refreshRemoteAlbums(isShared: true);
-
-    final albums = await _db.albums.filter().sharedEqualTo(true).findAll();
+    albums = await _db.albums.filter().sharedEqualTo(true).findAll();
     if (!const ListEquality().equals(albums, state)) {
       state = albums;
     }

--- a/mobile/lib/modules/album/providers/suggested_shared_users.provider.dart
+++ b/mobile/lib/modules/album/providers/suggested_shared_users.provider.dart
@@ -3,8 +3,8 @@ import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/services/user.service.dart';
 
 final suggestedSharedUsersProvider =
-    FutureProvider.autoDispose<List<User>>((ref) async {
+    FutureProvider.autoDispose<List<User>>((ref) {
   UserService userService = ref.watch(userServiceProvider);
 
-  return await userService.getAllUsers(isAll: false) ?? [];
+  return userService.getUsersInDb();
 });

--- a/mobile/lib/modules/album/services/album.service.dart
+++ b/mobile/lib/modules/album/services/album.service.dart
@@ -42,6 +42,8 @@ class AlbumService {
     this._db,
   );
 
+  /// Checks all selected device albums for changes of albums and their assets
+  /// Updates the local database and returns `true` if there were any changes
   Future<bool> refreshDeviceAlbums() async {
     if (!_localCompleter.isCompleted) {
       // guard against concurrent calls
@@ -75,6 +77,8 @@ class AlbumService {
     return changes;
   }
 
+  /// Checks remote albums (owned if `isShared` is false) for changes,
+  /// updates the local database and returns `true` if there were any changes
   Future<bool> refreshRemoteAlbums({required bool isShared}) async {
     if (!_remoteCompleter.isCompleted) {
       // guard against concurrent calls

--- a/mobile/lib/modules/album/services/album.service.dart
+++ b/mobile/lib/modules/album/services/album.service.dart
@@ -12,9 +12,8 @@ import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
-import 'package:immich_mobile/shared/services/asset.service.dart';
+import 'package:immich_mobile/shared/services/sync.service.dart';
 import 'package:immich_mobile/shared/services/user.service.dart';
-import 'package:immich_mobile/utils/diff.dart';
 import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -22,25 +21,24 @@ import 'package:photo_manager/photo_manager.dart';
 final albumServiceProvider = Provider(
   (ref) => AlbumService(
     ref.watch(apiServiceProvider),
-    ref.watch(assetServiceProvider),
     ref.watch(userServiceProvider),
+    ref.watch(syncServiceProvider),
     ref.watch(dbProvider),
   ),
 );
 
 class AlbumService {
   final ApiService _apiService;
-  final AssetService _assetService;
   final UserService _userService;
+  final SyncService _syncService;
   final Isar _db;
   Completer<bool> _localCompleter = Completer()..complete(false);
   Completer<bool> _remoteCompleter = Completer()..complete(false);
-  int? userId;
 
   AlbumService(
     this._apiService,
-    this._assetService,
     this._userService,
+    this._syncService,
     this._db,
   );
 
@@ -50,13 +48,26 @@ class AlbumService {
       return _localCompleter.future;
     }
     _localCompleter = Completer();
-    // wait until remote assets are fetched
-    await _assetService.assetRefreshComplete;
-    _assetService.albumLocalComplete = _localCompleter.future;
     final Stopwatch sw = Stopwatch()..start();
     bool changes = false;
     try {
-      changes = await _refreshDeviceAlbums();
+      final List<AssetPathEntity> onDevice =
+          await PhotoManager.getAssetPathList(
+        hasAll: false,
+        filterOption: FilterOptionGroup(containsPathModified: true),
+      );
+      HiveBackupAlbums? infos =
+          Hive.box<HiveBackupAlbums>(hiveBackupInfoBox).get(backupInfoKey);
+      if (infos == null) {
+        return false;
+      }
+      if (infos.excludedAlbumsIds.isNotEmpty) {
+        onDevice.removeWhere((e) => infos.excludedAlbumsIds.contains(e.id));
+      }
+      if (infos.selectedAlbumIds.isNotEmpty) {
+        onDevice.removeWhere((e) => !infos.selectedAlbumIds.contains(e.id));
+      }
+      changes = await _syncService.syncLocalAlbumAssetsToDb(onDevice);
     } finally {
       _localCompleter.complete(changes);
     }
@@ -70,369 +81,27 @@ class AlbumService {
       return _remoteCompleter.future;
     }
     _remoteCompleter = Completer();
-    // wait until remote assets are fetched
-    await _assetService.assetRefreshComplete;
-    _assetService.albumRemoteComplete = _remoteCompleter.future;
     final Stopwatch sw = Stopwatch()..start();
     bool changes = false;
     try {
-      changes = await _refreshRemoteAlbums(isShared: isShared);
+      await _userService.refreshUsers();
+      final List<AlbumResponseDto>? serverAlbums = await _apiService.albumApi
+          .getAllAlbums(shared: isShared ? true : null);
+      if (serverAlbums == null) {
+        return false;
+      }
+      changes = await _syncService.syncRemoteAlbumsToDb(
+        serverAlbums,
+        isShared: isShared,
+        loadDetails: (dto) async => dto.assetCount == dto.assets.length
+            ? dto
+            : (await _apiService.albumApi.getAlbumInfo(dto.id)) ?? dto,
+      );
     } finally {
       _remoteCompleter.complete(changes);
     }
     debugPrint("refreshRemoteAlbums took ${sw.elapsedMilliseconds}ms");
     return changes;
-  }
-
-  Future<bool> _refreshDeviceAlbums() async {
-    final List<AssetPathEntity> onDevice = await PhotoManager.getAssetPathList(
-      hasAll: false,
-      filterOption: FilterOptionGroup(containsPathModified: true),
-    );
-    HiveBackupAlbums? infos =
-        Hive.box<HiveBackupAlbums>(hiveBackupInfoBox).get(backupInfoKey);
-    if (infos == null) {
-      return false;
-    }
-    if (infos.excludedAlbumsIds.isNotEmpty) {
-      onDevice.removeWhere((e) => infos.excludedAlbumsIds.contains(e.id));
-    }
-    if (infos.selectedAlbumIds.isNotEmpty) {
-      onDevice.removeWhere((e) => !infos.selectedAlbumIds.contains(e.id));
-    }
-    onDevice.sort((a, b) => a.id.compareTo(b.id));
-
-    final List<Album> inDb =
-        await _db.albums.where().localIdIsNotNull().sortByLocalId().findAll();
-    final List<Asset> deleteCandidates = [];
-    final List<Asset> existing = [];
-
-    final bool anyChanges = await diffSortedLists(
-      onDevice,
-      inDb,
-      compare: (AssetPathEntity a, Album b) => a.id.compareTo(b.localId!),
-      both: (AssetPathEntity ape, Album album) => _syncAlbumInDbAndOnDevice(
-        ape,
-        album,
-        deleteCandidates,
-        existing,
-      ),
-      onlyFirst: (AssetPathEntity ape) => _addAlbumFromDevice(ape, existing),
-      onlySecond: (Album a) => _removeAlbumFromDb(a, deleteCandidates),
-    );
-
-    await _assetService.handleLocalAssetRemoval(deleteCandidates, existing);
-
-    return anyChanges;
-  }
-
-  Future<bool> _syncAlbumInDbAndOnDevice(
-    AssetPathEntity ape,
-    Album album,
-    List<Asset> deleteCandidates,
-    List<Asset> existing, [
-    bool forceRefresh = false,
-  ]) async {
-    if (!forceRefresh && !await _hasAssetPathEntityChanged(ape, album)) {
-      return false;
-    }
-    if (!forceRefresh && await _tryDeviceAlbumFastSync(ape, album)) {
-      return true;
-    }
-
-    // general case, e.g. some assets have been deleted
-    await album.assets.load();
-    final List<Asset> inDb = album.assets.toList(growable: false);
-    inDb.sort((a, b) => a.localId.compareTo(b.localId));
-    List<AssetEntity> onDevice =
-        await ape.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
-    onDevice.sort((a, b) => a.id.compareTo(b.id));
-    final List<AssetEntity> assetEntitiesToAdd = [];
-    final List<Asset> toDelete = [];
-    final List<Asset> toUpdate = [];
-    await diffSortedLists(
-      onDevice,
-      inDb,
-      compare: (AssetEntity a, Asset b) => a.id.compareTo(b.localId),
-      both: (AssetEntity a, Asset b) {
-        final bool hasChanged = b.updateFromAssetEntity(a);
-        if (hasChanged) {
-          toUpdate.add(b);
-        }
-        return hasChanged;
-      },
-      onlyFirst: (AssetEntity a) => assetEntitiesToAdd.add(a),
-      onlySecond: (Asset b) => toDelete.add(b),
-    );
-
-    final result = await _assetService.linkExistingToLocal(assetEntitiesToAdd);
-
-    deleteCandidates.addAll(toDelete);
-    existing.addAll(result.first);
-    album.name = ape.name;
-    album.modifiedAt = ape.lastModified!;
-    try {
-      await _db.writeTxn(() async {
-        await _db.assets.putAll(result.second);
-        await album.assets
-            .update(link: result.first + result.second, unlink: toDelete);
-        await _db.albums.put(album);
-        await _db.assets.putAll(toUpdate);
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
-    }
-
-    return true;
-  }
-
-  /// fast path for common case: add new assets to album
-  Future<bool> _tryDeviceAlbumFastSync(AssetPathEntity ape, Album album) async {
-    final int totalOnDevice = await ape.assetCountAsync;
-    final AssetPathEntity? modified = totalOnDevice > album.assetCount
-        ? await ape.fetchPathProperties(
-            filterOptionGroup: FilterOptionGroup(
-              updateTimeCond: DateTimeCond(
-                min: album.modifiedAt.add(const Duration(seconds: 1)),
-                max: ape.lastModified!,
-              ),
-            ),
-          )
-        : null;
-    if (modified == null) {
-      return false;
-    }
-    final List<AssetEntity> newAssets = (await modified.getAssetListRange(
-      start: 0,
-      end: 0x7fffffffffffffff,
-    ));
-    if (totalOnDevice != album.assets.length + newAssets.length) {
-      return false;
-    }
-    album.modifiedAt = ape.lastModified!;
-    final result = await _assetService.linkExistingToLocal(newAssets);
-    try {
-      await _db.writeTxn(() async {
-        await _db.assets.putAll(result.second);
-        await album.assets.update(link: result.first + result.second);
-        await _db.albums.put(album);
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
-    }
-
-    return true;
-  }
-
-  Future<void> _addAlbumFromDevice(
-    AssetPathEntity ape,
-    List<Asset> existing,
-  ) async {
-    final Album newAlbum = Album.local(ape);
-    final List<AssetEntity> deviceAssets =
-        await ape.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
-    final result = await _assetService.linkExistingToLocal(deviceAssets);
-    existing.addAll(result.first);
-    newAlbum.assets.addAll(result.first);
-    newAlbum.assets.addAll(result.second);
-    try {
-      await _db.writeTxn(() async {
-        await _db.assets.putAll(result.second);
-        await _db.albums.store(newAlbum);
-        if (newAlbum.assets.isNotEmpty) {
-          newAlbum.thumbnail.value = newAlbum.assets.first;
-          await newAlbum.thumbnail.save();
-        }
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
-    }
-  }
-
-  Future<void> _removeAlbumFromDb(
-    Album album,
-    List<Asset> deleteCandidates,
-  ) async {
-    final bool ok = await _db.writeTxn(() => _db.albums.delete(album.id));
-    assert(ok);
-    if (album.isLocal) {
-      // delete assets in DB unless they are remote or part of some other album
-      deleteCandidates.addAll(album.assets.where((a) => !a.isRemote));
-    } else if (album.shared) {
-      // delete assets in DB unless they belong to this user or part of some other shared album
-      deleteCandidates.addAll(album.assets.where((a) => a.ownerId != userId));
-    }
-  }
-
-  /// Fetches the remote albums and updates the local DB if needed.
-  /// Return `true` if there were any changes
-  Future<bool> _refreshRemoteAlbums({required bool isShared}) async {
-    await _userService.fetchAllUsers();
-    final List<AlbumResponseDto>? serverAlbums =
-        await _getRemoteAlbums(isShared: isShared ? true : null);
-    if (serverAlbums == null) {
-      return false;
-    }
-    serverAlbums.sort((a, b) => a.id.compareTo(b.id));
-    final baseQuery = _db.albums.where().remoteIdIsNotNull().filter();
-    final QueryBuilder<Album, Album, QAfterFilterCondition> query;
-    final User me = Store.get(StoreKey.currentUser);
-    userId = me.isarId;
-    if (isShared) {
-      query = baseQuery.sharedEqualTo(true);
-    } else {
-      query = baseQuery.owner((q) => q.isarIdEqualTo(me.isarId));
-    }
-    final List<Album> dbAlbums = await query.sortByRemoteId().findAll();
-    final List<Asset> deleteCandidates = [];
-    final List<Asset> existing = [];
-    final bool changes = await diffSortedLists(
-      serverAlbums,
-      dbAlbums,
-      compare: (AlbumResponseDto a, Album b) => a.id.compareTo(b.remoteId!),
-      both: (AlbumResponseDto a, Album b) =>
-          _syncAlbumInDbAndOnServer(a, b, deleteCandidates, existing),
-      onlyFirst: (AlbumResponseDto a) => _addAlbumFromServer(a, existing),
-      onlySecond: (Album a) => _removeAlbumFromDb(a, deleteCandidates),
-    );
-    if (isShared && deleteCandidates.isNotEmpty) {
-      await _assetService.handleSharedAssetRemoval(deleteCandidates, existing);
-    } else {
-      assert(deleteCandidates.isEmpty);
-    }
-
-    return changes;
-  }
-
-  /// syncs data from server to local DB (does not support syncing changes from local to server)
-  Future<bool> _syncAlbumInDbAndOnServer(
-    AlbumResponseDto dto,
-    Album album,
-    List<Asset> deleteCandidates,
-    List<Asset> existing,
-  ) async {
-    if (!_hasAlbumResponseDtoChanged(dto, album)) {
-      return false;
-    }
-    if (dto.assetCount != dto.assets.length) {
-      // load details (assets)
-      final withDetails = await _apiService.albumApi.getAlbumInfo(dto.id);
-      if (withDetails == null) {
-        return false;
-      }
-      dto = withDetails;
-    }
-    dto.assets.sort((a, b) => a.id.compareTo(b.id));
-    await album.assets.load();
-    final assetsInDb =
-        album.assets.where((e) => e.isRemote).toList(growable: false);
-    assetsInDb.sort((a, b) => a.remoteId!.compareTo(b.remoteId!));
-    final List<AssetResponseDto> dtosToAdd = [];
-    final List<Asset> toUnlink = [];
-    final List<Asset> toUpdate = [];
-    await diffSortedLists(
-      dto.assets,
-      assetsInDb,
-      compare: (AssetResponseDto a, Asset b) => a.id.compareTo(b.remoteId!),
-      both: (AssetResponseDto a, Asset b) {
-        if (DateTime.parse(a.updatedAt).toUtc().isAfter(b.updatedAt)) {
-          toUpdate.add(b.withUpdatesFromDto(a));
-          return true;
-        }
-        return false;
-      },
-      onlyFirst: (AssetResponseDto a) => dtosToAdd.add(a),
-      onlySecond: (Asset a) => toUnlink.add(a),
-    );
-
-    // update shared users
-    final List<User> sharedUsers = album.sharedUsers.toList(growable: false);
-    sharedUsers.sort((a, b) => a.id.compareTo(b.id));
-    dto.sharedUsers.sort((a, b) => a.id.compareTo(b.id));
-    final List<String> userIdsToAdd = [];
-    final List<User> usersToUnlink = [];
-    await diffSortedLists(
-      dto.sharedUsers,
-      sharedUsers,
-      compare: (UserResponseDto a, User b) => a.id.compareTo(b.id),
-      both: (a, b) => false,
-      onlyFirst: (UserResponseDto a) => userIdsToAdd.add(a.id),
-      onlySecond: (User a) => usersToUnlink.add(a),
-    );
-
-    album.name = dto.albumName;
-    album.shared = dto.shared;
-    album.modifiedAt = DateTime.parse(dto.updatedAt).toUtc();
-    if (album.thumbnail.value?.remoteId != dto.albumThumbnailAssetId) {
-      album.thumbnail.value = await _db.assets
-          .where()
-          .remoteIdEqualTo(dto.albumThumbnailAssetId)
-          .findFirst();
-    }
-    if (album.shared || dto.shared) {
-      // shared album: put missing album assets into local DB
-      _assetService.addMissingRemoteAssetsToDb(dtosToAdd);
-    }
-    final assetsToLink =
-        await _db.assets.getAllByRemoteId(dtosToAdd.map((e) => e.id));
-    final usersToLink = (await _db.users.getAllById(userIdsToAdd)).cast<User>();
-
-    // write & commit all changes to DB
-    try {
-      await _db.writeTxn(() async {
-        await _db.assets.putAll(toUpdate);
-        await album.thumbnail.save();
-        await album.sharedUsers
-            .update(link: usersToLink, unlink: usersToUnlink);
-        await album.assets.update(link: assetsToLink, unlink: toUnlink.cast());
-        await _db.albums.put(album);
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
-    }
-
-    if (album.shared || dto.shared) {
-      final foreign =
-          await album.assets.filter().not().ownerIdEqualTo(userId!).findAll();
-      existing.addAll(foreign);
-
-      // delete assets in DB unless they belong to this user or part of some other shared album
-      deleteCandidates.addAll(toUnlink.where((a) => a.ownerId != userId));
-    }
-
-    return true;
-  }
-
-  Future<void> _addAlbumFromServer(
-    AlbumResponseDto dto,
-    List<Asset> existing,
-  ) async {
-    if (dto.assetCount != dto.assets.length) {
-      // load details (assets)
-      final withDetails = await _apiService.albumApi.getAlbumInfo(dto.id);
-      if (withDetails == null) {
-        return;
-      }
-      dto = withDetails;
-    }
-    if (dto.shared) {
-      // shared album: put missing album assets into local DB
-      await _assetService.addMissingRemoteAssetsToDb(dto.assets);
-    }
-    final Album a = await Album.remote(dto);
-    await _db.writeTxn(() => _db.albums.store(a));
-    if (dto.shared) {
-      existing.addAll(a.assets.where((e) => e.ownerId != userId));
-    }
-  }
-
-  Future<List<AlbumResponseDto>?> _getRemoteAlbums({bool? isShared}) async {
-    try {
-      return await _apiService.albumApi.getAllAlbums(shared: isShared);
-    } catch (e) {
-      debugPrint("Error getAllSharedAlbum  ${e.toString()}");
-      return null;
-    }
   }
 
   Future<Album?> createAlbum(
@@ -531,22 +200,27 @@ class AlbumService {
 
   Future<bool> deleteAlbum(Album album) async {
     try {
+      final userId = Store.get<User>(StoreKey.currentUser)!.isarId;
       if (album.owner.value?.isarId == userId) {
         await _apiService.albumApi.deleteAlbum(album.remoteId!);
       }
       if (album.shared) {
         final foreignAssets =
-            await album.assets.filter().not().ownerIdEqualTo(userId!).findAll();
+            await album.assets.filter().not().ownerIdEqualTo(userId).findAll();
         await _db.writeTxn(() => _db.albums.delete(album.id));
         final List<Album> albums =
             await _db.albums.filter().sharedEqualTo(true).findAll();
         final List<Asset> existing = [];
         for (Album a in albums) {
           existing.addAll(
-            await a.assets.filter().not().ownerIdEqualTo(userId!).findAll(),
+            await a.assets.filter().not().ownerIdEqualTo(userId).findAll(),
           );
         }
-        _assetService.handleSharedAssetRemoval(foreignAssets, existing);
+        final List<int> idsToRemove =
+            _syncService.sharedAssetsToRemove(foreignAssets, existing);
+        if (idsToRemove.isNotEmpty) {
+          await _db.writeTxn(() => _db.assets.deleteAll(idsToRemove));
+        }
       } else {
         await _db.writeTxn(() => _db.albums.delete(album.id));
       }
@@ -608,18 +282,4 @@ class AlbumService {
       return false;
     }
   }
-}
-
-Future<bool> _hasAssetPathEntityChanged(AssetPathEntity a, Album b) async {
-  return a.name != b.name ||
-      a.lastModified != b.modifiedAt ||
-      await a.assetCountAsync != b.assets.length;
-}
-
-bool _hasAlbumResponseDtoChanged(AlbumResponseDto dto, Album a) {
-  return dto.assetCount != a.assetCount ||
-      dto.albumName != a.name ||
-      dto.albumThumbnailAssetId != a.thumbnail.value?.remoteId ||
-      dto.shared != a.shared ||
-      DateTime.parse(dto.updatedAt).toUtc() != a.modifiedAt.toUtc();
 }

--- a/mobile/lib/modules/album/services/album.service.dart
+++ b/mobile/lib/modules/album/services/album.service.dart
@@ -74,7 +74,8 @@ class AlbumService {
       if (infos.excludedAlbumsIds.isNotEmpty) {
         onDevice.removeWhere((e) => infos.excludedAlbumsIds.contains(e.id));
       }
-      if (infos.selectedAlbumIds.isNotEmpty) {
+      if (infos.selectedAlbumIds.isNotEmpty &&
+          !infos.selectedAlbumIds.contains("isAll")) {
         onDevice.removeWhere((e) => !infos.selectedAlbumIds.contains(e.id));
       }
       changes = await _syncService.syncLocalAlbumAssetsToDb(onDevice);

--- a/mobile/lib/modules/album/services/album.service.dart
+++ b/mobile/lib/modules/album/services/album.service.dart
@@ -1,30 +1,434 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/modules/backup/models/hive_backup_albums.model.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:immich_mobile/shared/services/asset.service.dart';
+import 'package:immich_mobile/shared/services/user.service.dart';
+import 'package:immich_mobile/utils/diff.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 final albumServiceProvider = Provider(
   (ref) => AlbumService(
     ref.watch(apiServiceProvider),
+    ref.watch(assetServiceProvider),
+    ref.watch(userServiceProvider),
+    ref.watch(dbProvider),
   ),
 );
 
 class AlbumService {
   final ApiService _apiService;
+  final AssetService _assetService;
+  final UserService _userService;
+  final Isar _db;
+  Completer<bool> _localCompleter = Completer()..complete(false);
+  Completer<bool> _remoteCompleter = Completer()..complete(false);
+  int? userId;
 
-  AlbumService(this._apiService);
+  AlbumService(
+    this._apiService,
+    this._assetService,
+    this._userService,
+    this._db,
+  );
 
-  Future<List<Album>?> getAlbums({required bool isShared}) async {
+  Future<bool> refreshDeviceAlbums() async {
+    if (!_localCompleter.isCompleted) {
+      // guard against concurrent calls
+      return _localCompleter.future;
+    }
+    _localCompleter = Completer();
+    // wait until remote assets are fetched
+    await _assetService.assetRefreshComplete;
+    _assetService.albumLocalComplete = _localCompleter.future;
+    final Stopwatch sw = Stopwatch()..start();
+    bool changes = false;
     try {
-      final dto = await _apiService.albumApi
-          .getAllAlbums(shared: isShared ? isShared : null);
-      return dto?.map(Album.remote).toList();
+      changes = await _refreshDeviceAlbums();
+    } finally {
+      _localCompleter.complete(changes);
+    }
+    debugPrint("refreshDeviceAlbums took ${sw.elapsedMilliseconds}ms");
+    return changes;
+  }
+
+  Future<bool> refreshRemoteAlbums({required bool isShared}) async {
+    if (!_remoteCompleter.isCompleted) {
+      // guard against concurrent calls
+      return _remoteCompleter.future;
+    }
+    _remoteCompleter = Completer();
+    // wait until remote assets are fetched
+    await _assetService.assetRefreshComplete;
+    _assetService.albumRemoteComplete = _remoteCompleter.future;
+    final Stopwatch sw = Stopwatch()..start();
+    bool changes = false;
+    try {
+      changes = await _refreshRemoteAlbums(isShared: isShared);
+    } finally {
+      _remoteCompleter.complete(changes);
+    }
+    debugPrint("refreshRemoteAlbums took ${sw.elapsedMilliseconds}ms");
+    return changes;
+  }
+
+  Future<bool> _refreshDeviceAlbums() async {
+    final List<AssetPathEntity> onDevice = await PhotoManager.getAssetPathList(
+      hasAll: false,
+      filterOption: FilterOptionGroup(containsPathModified: true),
+    );
+    HiveBackupAlbums? infos =
+        Hive.box<HiveBackupAlbums>(hiveBackupInfoBox).get(backupInfoKey);
+    if (infos == null) {
+      return false;
+    }
+    if (infos.excludedAlbumsIds.isNotEmpty) {
+      onDevice.removeWhere((e) => infos.excludedAlbumsIds.contains(e.id));
+    }
+    if (infos.selectedAlbumIds.isNotEmpty) {
+      onDevice.removeWhere((e) => !infos.selectedAlbumIds.contains(e.id));
+    }
+    onDevice.sort((a, b) => a.id.compareTo(b.id));
+
+    final List<Album> inDb =
+        await _db.albums.where().localIdIsNotNull().sortByLocalId().findAll();
+    final List<Asset> deleteCandidates = [];
+    final List<Asset> existing = [];
+
+    final bool anyChanges = await diffSortedLists(
+      onDevice,
+      inDb,
+      compare: (AssetPathEntity a, Album b) => a.id.compareTo(b.localId!),
+      both: (AssetPathEntity ape, Album album) => _syncAlbumInDbAndOnDevice(
+        ape,
+        album,
+        deleteCandidates,
+        existing,
+      ),
+      onlyFirst: (AssetPathEntity ape) => _addAlbumFromDevice(ape, existing),
+      onlySecond: (Album a) => _removeAlbumFromDb(a, deleteCandidates),
+    );
+
+    await _assetService.handleLocalAssetRemoval(deleteCandidates, existing);
+
+    return anyChanges;
+  }
+
+  Future<bool> _syncAlbumInDbAndOnDevice(
+    AssetPathEntity ape,
+    Album album,
+    List<Asset> deleteCandidates,
+    List<Asset> existing, [
+    bool forceRefresh = false,
+  ]) async {
+    if (!forceRefresh && !await _hasAssetPathEntityChanged(ape, album)) {
+      return false;
+    }
+    if (!forceRefresh && await _tryDeviceAlbumFastSync(ape, album)) {
+      return true;
+    }
+
+    // general case, e.g. some assets have been deleted
+    await album.assets.load();
+    final List<Asset> inDb = album.assets.toList(growable: false);
+    inDb.sort((a, b) => a.localId.compareTo(b.localId));
+    List<AssetEntity> onDevice =
+        await ape.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
+    onDevice.sort((a, b) => a.id.compareTo(b.id));
+    final List<AssetEntity> assetEntitiesToAdd = [];
+    final List<Asset> toDelete = [];
+    final List<Asset> toUpdate = [];
+    await diffSortedLists(
+      onDevice,
+      inDb,
+      compare: (AssetEntity a, Asset b) => a.id.compareTo(b.localId),
+      both: (AssetEntity a, Asset b) {
+        final bool hasChanged = b.updateFromAssetEntity(a);
+        if (hasChanged) {
+          toUpdate.add(b);
+        }
+        return hasChanged;
+      },
+      onlyFirst: (AssetEntity a) => assetEntitiesToAdd.add(a),
+      onlySecond: (Asset b) => toDelete.add(b),
+    );
+
+    final result = await _assetService.linkExistingToLocal(assetEntitiesToAdd);
+
+    deleteCandidates.addAll(toDelete);
+    existing.addAll(result.first);
+    album.name = ape.name;
+    album.modifiedAt = ape.lastModified!;
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(result.second);
+        await album.assets
+            .update(link: result.first + result.second, unlink: toDelete);
+        await _db.albums.put(album);
+        await _db.assets.putAll(toUpdate);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return true;
+  }
+
+  /// fast path for common case: add new assets to album
+  Future<bool> _tryDeviceAlbumFastSync(AssetPathEntity ape, Album album) async {
+    final int totalOnDevice = await ape.assetCountAsync;
+    final AssetPathEntity? modified = totalOnDevice > album.assetCount
+        ? await ape.fetchPathProperties(
+            filterOptionGroup: FilterOptionGroup(
+              updateTimeCond: DateTimeCond(
+                min: album.modifiedAt.add(const Duration(seconds: 1)),
+                max: ape.lastModified!,
+              ),
+            ),
+          )
+        : null;
+    if (modified == null) {
+      return false;
+    }
+    final List<AssetEntity> newAssets = (await modified.getAssetListRange(
+      start: 0,
+      end: 0x7fffffffffffffff,
+    ));
+    if (totalOnDevice != album.assets.length + newAssets.length) {
+      return false;
+    }
+    album.modifiedAt = ape.lastModified!;
+    final result = await _assetService.linkExistingToLocal(newAssets);
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(result.second);
+        await album.assets.update(link: result.first + result.second);
+        await _db.albums.put(album);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return true;
+  }
+
+  Future<void> _addAlbumFromDevice(
+    AssetPathEntity ape,
+    List<Asset> existing,
+  ) async {
+    final Album newAlbum = Album.local(ape);
+    final List<AssetEntity> deviceAssets =
+        await ape.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
+    final result = await _assetService.linkExistingToLocal(deviceAssets);
+    existing.addAll(result.first);
+    newAlbum.assets.addAll(result.first);
+    newAlbum.assets.addAll(result.second);
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(result.second);
+        await _db.albums.store(newAlbum);
+        if (newAlbum.assets.isNotEmpty) {
+          newAlbum.thumbnail.value = newAlbum.assets.first;
+          await newAlbum.thumbnail.save();
+        }
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+
+  Future<void> _removeAlbumFromDb(
+    Album album,
+    List<Asset> deleteCandidates,
+  ) async {
+    final bool ok = await _db.writeTxn(() => _db.albums.delete(album.id));
+    assert(ok);
+    if (album.isLocal) {
+      // delete assets in DB unless they are remote or part of some other album
+      deleteCandidates.addAll(album.assets.where((a) => !a.isRemote));
+    } else if (album.shared) {
+      // delete assets in DB unless they belong to this user or part of some other shared album
+      deleteCandidates.addAll(album.assets.where((a) => a.ownerId != userId));
+    }
+  }
+
+  /// Fetches the remote albums and updates the local DB if needed.
+  /// Return `true` if there were any changes
+  Future<bool> _refreshRemoteAlbums({required bool isShared}) async {
+    await _userService.fetchAllUsers();
+    final List<AlbumResponseDto>? serverAlbums =
+        await _getRemoteAlbums(isShared: isShared ? true : null);
+    if (serverAlbums == null) {
+      return false;
+    }
+    serverAlbums.sort((a, b) => a.id.compareTo(b.id));
+    final baseQuery = _db.albums.where().remoteIdIsNotNull().filter();
+    final QueryBuilder<Album, Album, QAfterFilterCondition> query;
+    final User me = Store.get(StoreKey.currentUser);
+    userId = me.isarId;
+    if (isShared) {
+      query = baseQuery.sharedEqualTo(true);
+    } else {
+      query = baseQuery.owner((q) => q.isarIdEqualTo(me.isarId));
+    }
+    final List<Album> dbAlbums = await query.sortByRemoteId().findAll();
+    final List<Asset> deleteCandidates = [];
+    final List<Asset> existing = [];
+    final bool changes = await diffSortedLists(
+      serverAlbums,
+      dbAlbums,
+      compare: (AlbumResponseDto a, Album b) => a.id.compareTo(b.remoteId!),
+      both: (AlbumResponseDto a, Album b) =>
+          _syncAlbumInDbAndOnServer(a, b, deleteCandidates, existing),
+      onlyFirst: (AlbumResponseDto a) => _addAlbumFromServer(a, existing),
+      onlySecond: (Album a) => _removeAlbumFromDb(a, deleteCandidates),
+    );
+    if (isShared && deleteCandidates.isNotEmpty) {
+      await _assetService.handleSharedAssetRemoval(deleteCandidates, existing);
+    } else {
+      assert(deleteCandidates.isEmpty);
+    }
+
+    return changes;
+  }
+
+  /// syncs data from server to local DB (does not support syncing changes from local to server)
+  Future<bool> _syncAlbumInDbAndOnServer(
+    AlbumResponseDto dto,
+    Album album,
+    List<Asset> deleteCandidates,
+    List<Asset> existing,
+  ) async {
+    if (!_hasAlbumResponseDtoChanged(dto, album)) {
+      return false;
+    }
+    if (dto.assetCount != dto.assets.length) {
+      // load details (assets)
+      final withDetails = await _apiService.albumApi.getAlbumInfo(dto.id);
+      if (withDetails == null) {
+        return false;
+      }
+      dto = withDetails;
+    }
+    dto.assets.sort((a, b) => a.id.compareTo(b.id));
+    await album.assets.load();
+    final assetsInDb =
+        album.assets.where((e) => e.isRemote).toList(growable: false);
+    assetsInDb.sort((a, b) => a.remoteId!.compareTo(b.remoteId!));
+    final List<AssetResponseDto> dtosToAdd = [];
+    final List<Asset> toUnlink = [];
+    final List<Asset> toUpdate = [];
+    await diffSortedLists(
+      dto.assets,
+      assetsInDb,
+      compare: (AssetResponseDto a, Asset b) => a.id.compareTo(b.remoteId!),
+      both: (AssetResponseDto a, Asset b) {
+        if (DateTime.parse(a.updatedAt).toUtc().isAfter(b.updatedAt)) {
+          toUpdate.add(b.withUpdatesFromDto(a));
+          return true;
+        }
+        return false;
+      },
+      onlyFirst: (AssetResponseDto a) => dtosToAdd.add(a),
+      onlySecond: (Asset a) => toUnlink.add(a),
+    );
+
+    // update shared users
+    final List<User> sharedUsers = album.sharedUsers.toList(growable: false);
+    sharedUsers.sort((a, b) => a.id.compareTo(b.id));
+    dto.sharedUsers.sort((a, b) => a.id.compareTo(b.id));
+    final List<String> userIdsToAdd = [];
+    final List<User> usersToUnlink = [];
+    await diffSortedLists(
+      dto.sharedUsers,
+      sharedUsers,
+      compare: (UserResponseDto a, User b) => a.id.compareTo(b.id),
+      both: (a, b) => false,
+      onlyFirst: (UserResponseDto a) => userIdsToAdd.add(a.id),
+      onlySecond: (User a) => usersToUnlink.add(a),
+    );
+
+    album.name = dto.albumName;
+    album.shared = dto.shared;
+    album.modifiedAt = DateTime.parse(dto.updatedAt).toUtc();
+    if (album.thumbnail.value?.remoteId != dto.albumThumbnailAssetId) {
+      album.thumbnail.value = await _db.assets
+          .where()
+          .remoteIdEqualTo(dto.albumThumbnailAssetId)
+          .findFirst();
+    }
+    if (album.shared || dto.shared) {
+      // shared album: put missing album assets into local DB
+      _assetService.addMissingRemoteAssetsToDb(dtosToAdd);
+    }
+    final assetsToLink =
+        await _db.assets.getAllByRemoteId(dtosToAdd.map((e) => e.id));
+    final usersToLink = (await _db.users.getAllById(userIdsToAdd)).cast<User>();
+
+    // write & commit all changes to DB
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(toUpdate);
+        await album.thumbnail.save();
+        await album.sharedUsers
+            .update(link: usersToLink, unlink: usersToUnlink);
+        await album.assets.update(link: assetsToLink, unlink: toUnlink.cast());
+        await _db.albums.put(album);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    if (album.shared || dto.shared) {
+      final foreign =
+          await album.assets.filter().not().ownerIdEqualTo(userId!).findAll();
+      existing.addAll(foreign);
+
+      // delete assets in DB unless they belong to this user or part of some other shared album
+      deleteCandidates.addAll(toUnlink.where((a) => a.ownerId != userId));
+    }
+
+    return true;
+  }
+
+  Future<void> _addAlbumFromServer(
+    AlbumResponseDto dto,
+    List<Asset> existing,
+  ) async {
+    if (dto.assetCount != dto.assets.length) {
+      // load details (assets)
+      final withDetails = await _apiService.albumApi.getAlbumInfo(dto.id);
+      if (withDetails == null) {
+        return;
+      }
+      dto = withDetails;
+    }
+    if (dto.shared) {
+      // shared album: put missing album assets into local DB
+      await _assetService.addMissingRemoteAssetsToDb(dto.assets);
+    }
+    final Album a = await Album.remote(dto);
+    await _db.writeTxn(() => _db.albums.store(a));
+    if (dto.shared) {
+      existing.addAll(a.assets.where((e) => e.ownerId != userId));
+    }
+  }
+
+  Future<List<AlbumResponseDto>?> _getRemoteAlbums({bool? isShared}) async {
+    try {
+      return await _apiService.albumApi.getAllAlbums(shared: isShared);
     } catch (e) {
       debugPrint("Error getAllSharedAlbum  ${e.toString()}");
       return null;
@@ -37,56 +441,51 @@ class AlbumService {
     Iterable<User> sharedUsers = const [],
   ]) async {
     try {
-      final dto = await _apiService.albumApi.createAlbum(
+      AlbumResponseDto? remote = await _apiService.albumApi.createAlbum(
         CreateAlbumDto(
           albumName: albumName,
           assetIds: assets.map((asset) => asset.remoteId!).toList(),
           sharedWithUserIds: sharedUsers.map((e) => e.id).toList(),
         ),
       );
-      return dto != null ? Album.remote(dto) : null;
+      if (remote != null) {
+        Album album = await Album.remote(remote);
+        await _db.writeTxn(() => _db.albums.store(album));
+        return album;
+      }
     } catch (e) {
       debugPrint("Error createSharedAlbum  ${e.toString()}");
-      return null;
     }
+    return null;
   }
 
   /*
    * Creates names like Untitled, Untitled (1), Untitled (2), ...
    */
-  String _getNextAlbumName(List<Album>? albums) {
+  Future<String> _getNextAlbumName() async {
     const baseName = "Untitled";
+    for (int round = 0;; round++) {
+      final proposedName = "$baseName${round == 0 ? "" : " ($round)"}";
 
-    if (albums != null) {
-      for (int round = 0; round < albums.length; round++) {
-        final proposedName = "$baseName${round == 0 ? "" : " ($round)"}";
-
-        if (albums.where((a) => a.name == proposedName).isEmpty) {
-          return proposedName;
-        }
+      if (null ==
+          await _db.albums.filter().nameEqualTo(proposedName).findFirst()) {
+        return proposedName;
       }
     }
-    return baseName;
   }
 
   Future<Album?> createAlbumWithGeneratedName(
     Iterable<Asset> assets,
   ) async {
     return createAlbum(
-      _getNextAlbumName(await getAlbums(isShared: false)),
+      await _getNextAlbumName(),
       assets,
       [],
     );
   }
 
-  Future<Album?> getAlbumDetail(String albumId) async {
-    try {
-      final dto = await _apiService.albumApi.getAlbumInfo(albumId);
-      return dto != null ? Album.remote(dto) : null;
-    } catch (e) {
-      debugPrint('Error [getAlbumDetail] ${e.toString()}');
-      return null;
-    }
+  Future<Album?> getAlbumDetail(int albumId) {
+    return _db.albums.get(albumId);
   }
 
   Future<AddAssetsResponseDto?> addAdditionalAssetToAlbum(
@@ -98,6 +497,10 @@ class AlbumService {
         album.remoteId!,
         AddAssetsDto(assetIds: assets.map((asset) => asset.remoteId!).toList()),
       );
+      if (result != null && result.successfullyAdded > 0) {
+        album.assets.addAll(assets);
+        await _db.writeTxn(() => album.assets.save());
+      }
       return result;
     } catch (e) {
       debugPrint("Error addAdditionalAssetToAlbum  ${e.toString()}");
@@ -110,26 +513,48 @@ class AlbumService {
     Album album,
   ) async {
     try {
-      var result = await _apiService.albumApi.addUsersToAlbum(
+      final result = await _apiService.albumApi.addUsersToAlbum(
         album.remoteId!,
         AddUsersDto(sharedUserIds: sharedUserIds),
       );
-
-      return result != null;
+      if (result != null) {
+        album.sharedUsers
+            .addAll((await _db.users.getAllById(sharedUserIds)).cast());
+        await _db.writeTxn(() => album.sharedUsers.save());
+        return true;
+      }
     } catch (e) {
       debugPrint("Error addAdditionalUserToAlbum  ${e.toString()}");
-      return false;
     }
+    return false;
   }
 
   Future<bool> deleteAlbum(Album album) async {
     try {
-      await _apiService.albumApi.deleteAlbum(album.remoteId!);
+      if (album.owner.value?.isarId == userId) {
+        await _apiService.albumApi.deleteAlbum(album.remoteId!);
+      }
+      if (album.shared) {
+        final foreignAssets =
+            await album.assets.filter().not().ownerIdEqualTo(userId!).findAll();
+        await _db.writeTxn(() => _db.albums.delete(album.id));
+        final List<Album> albums =
+            await _db.albums.filter().sharedEqualTo(true).findAll();
+        final List<Asset> existing = [];
+        for (Album a in albums) {
+          existing.addAll(
+            await a.assets.filter().not().ownerIdEqualTo(userId!).findAll(),
+          );
+        }
+        _assetService.handleSharedAssetRemoval(foreignAssets, existing);
+      } else {
+        await _db.writeTxn(() => _db.albums.delete(album.id));
+      }
       return true;
     } catch (e) {
       debugPrint("Error deleteAlbum  ${e.toString()}");
-      return false;
     }
+    return false;
   }
 
   Future<bool> leaveAlbum(Album album) async {
@@ -153,6 +578,8 @@ class AlbumService {
           assetIds: assets.map((e) => e.remoteId!).toList(growable: false),
         ),
       );
+      album.assets.removeAll(assets);
+      await _db.writeTxn(() => album.assets.update(unlink: assets));
 
       return true;
     } catch (e) {
@@ -173,6 +600,7 @@ class AlbumService {
         ),
       );
       album.name = newAlbumTitle;
+      await _db.writeTxn(() => _db.albums.put(album));
 
       return true;
     } catch (e) {
@@ -180,4 +608,18 @@ class AlbumService {
       return false;
     }
   }
+}
+
+Future<bool> _hasAssetPathEntityChanged(AssetPathEntity a, Album b) async {
+  return a.name != b.name ||
+      a.lastModified != b.modifiedAt ||
+      await a.assetCountAsync != b.assets.length;
+}
+
+bool _hasAlbumResponseDtoChanged(AlbumResponseDto dto, Album a) {
+  return dto.assetCount != a.assetCount ||
+      dto.albumName != a.name ||
+      dto.albumThumbnailAssetId != a.thumbnail.value?.remoteId ||
+      dto.shared != a.shared ||
+      DateTime.parse(dto.updatedAt).toUtc() != a.modifiedAt.toUtc();
 }

--- a/mobile/lib/modules/album/services/album_cache.service.dart
+++ b/mobile/lib/modules/album/services/album_cache.service.dart
@@ -1,46 +1,23 @@
-import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/services/json_cache.dart';
 
-class BaseAlbumCacheService extends JsonCache<List<Album>> {
-  BaseAlbumCacheService(super.cacheFileName);
+@Deprecated("only kept to remove its files after migration")
+class _BaseAlbumCacheService extends JsonCache<List<Album>> {
+  _BaseAlbumCacheService(super.cacheFileName);
 
   @override
-  void put(List<Album> data) {
-    putRawData(data.map((e) => e.toJson()).toList());
-  }
+  void put(List<Album> data) {}
 
   @override
-  Future<List<Album>?> get() async {
-    try {
-      final mapList = await readRawData() as List<dynamic>;
-
-      final responseData =
-          mapList.map((e) => Album.fromJson(e)).whereNotNull().toList();
-
-      return responseData;
-    } catch (e) {
-      await invalidate();
-      debugPrint(e.toString());
-      return null;
-    }
-  }
+  Future<List<Album>?> get() => Future.value(null);
 }
 
-class AlbumCacheService extends BaseAlbumCacheService {
+@Deprecated("only kept to remove its files after migration")
+class AlbumCacheService extends _BaseAlbumCacheService {
   AlbumCacheService() : super("album_cache");
 }
 
-class SharedAlbumCacheService extends BaseAlbumCacheService {
+@Deprecated("only kept to remove its files after migration")
+class SharedAlbumCacheService extends _BaseAlbumCacheService {
   SharedAlbumCacheService() : super("shared_album_cache");
 }
-
-final albumCacheServiceProvider = Provider(
-  (ref) => AlbumCacheService(),
-);
-
-final sharedAlbumCacheServiceProvider = Provider(
-  (ref) => SharedAlbumCacheService(),
-);

--- a/mobile/lib/modules/album/ui/add_to_album_bottom_sheet.dart
+++ b/mobile/lib/modules/album/ui/add_to_album_bottom_sheet.dart
@@ -25,7 +25,7 @@ class AddToAlbumBottomSheet extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final albums = ref.watch(albumProvider);
+    final albums = ref.watch(albumProvider).where((a) => a.isRemote).toList();
     final albumService = ref.watch(albumServiceProvider);
     final sharedAlbums = ref.watch(sharedAlbumProvider);
 

--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -1,11 +1,7 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/shared/models/album.dart';
-import 'package:immich_mobile/utils/image_url_builder.dart';
-import 'package:openapi/api.dart';
+import 'package:immich_mobile/shared/ui/immich_image.dart';
 
 class AlbumThumbnailCard extends StatelessWidget {
   final Function()? onTap;
@@ -20,7 +16,6 @@ class AlbumThumbnailCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var box = Hive.box(userInfoBox);
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -42,21 +37,11 @@ class AlbumThumbnailCard extends StatelessWidget {
           );
         }
 
-        buildAlbumThumbnail() {
-          return CachedNetworkImage(
-            width: cardSize,
-            height: cardSize,
-            fit: BoxFit.cover,
-            fadeInDuration: const Duration(milliseconds: 200),
-            imageUrl: getAlbumThumbnailUrl(
-              album,
-              type: ThumbnailFormat.JPEG,
-            ),
-            httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
-            cacheKey:
-                getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.JPEG),
-          );
-        }
+        buildAlbumThumbnail() => ImmichImage(
+              album.thumbnail.value,
+              width: cardSize,
+              height: cardSize,
+            );
 
         return GestureDetector(
           onTap: onTap,
@@ -72,7 +57,7 @@ class AlbumThumbnailCard extends StatelessWidget {
                       height: cardSize,
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(20),
-                        child: album.albumThumbnailAssetId == null
+                        child: album.thumbnail.value == null
                             ? buildEmptyThumbnail()
                             : buildAlbumThumbnail(),
                       ),

--- a/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
@@ -68,7 +68,7 @@ class AlbumThumbnailListTile extends StatelessWidget {
           children: [
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
-              child: album.albumThumbnailAssetId == null
+              child: album.thumbnail.value == null
                   ? buildEmptyThumbnail()
                   : buildAlbumThumbnail(),
             ),

--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -208,11 +208,12 @@ class AlbumViewerAppbar extends HookConsumerWidget with PreferredSizeWidget {
           : null,
       centerTitle: false,
       actions: [
-        IconButton(
-          splashRadius: 25,
-          onPressed: buildBottomSheet,
-          icon: const Icon(Icons.more_horiz_rounded),
-        ),
+        if (album.isRemote)
+          IconButton(
+            splashRadius: 25,
+            onPressed: buildBottomSheet,
+            icon: const Icon(Icons.more_horiz_rounded),
+          ),
       ],
     );
   }

--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -7,7 +7,6 @@ import 'package:immich_mobile/modules/album/providers/album.provider.dart';
 import 'package:immich_mobile/modules/album/providers/album_viewer.provider.dart';
 import 'package:immich_mobile/modules/album/providers/asset_selection.provider.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
-import 'package:immich_mobile/modules/album/services/album.service.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/ui/immich_toast.dart';
@@ -35,19 +34,18 @@ class AlbumViewerAppbar extends HookConsumerWidget with PreferredSizeWidget {
     void onDeleteAlbumPressed() async {
       ImmichLoadingOverlayController.appLoader.show();
 
-      bool isSuccess = await ref.watch(albumServiceProvider).deleteAlbum(album);
-
-      if (isSuccess) {
-        if (album.shared) {
-          ref.watch(sharedAlbumProvider.notifier).deleteAlbum(album);
-          AutoRouter.of(context)
-              .navigate(const TabControllerRoute(children: [SharingRoute()]));
-        } else {
-          ref.watch(albumProvider.notifier).deleteAlbum(album);
-          AutoRouter.of(context)
-              .navigate(const TabControllerRoute(children: [LibraryRoute()]));
-        }
+      final bool success;
+      if (album.shared) {
+        success =
+            await ref.watch(sharedAlbumProvider.notifier).deleteAlbum(album);
+        AutoRouter.of(context)
+            .navigate(const TabControllerRoute(children: [SharingRoute()]));
       } else {
+        success = await ref.watch(albumProvider.notifier).deleteAlbum(album);
+        AutoRouter.of(context)
+            .navigate(const TabControllerRoute(children: [LibraryRoute()]));
+      }
+      if (!success) {
         ImmichToast.show(
           context: context,
           msg: "album_viewer_appbar_share_err_delete".tr(),

--- a/mobile/lib/modules/album/ui/album_viewer_thumbnail.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_thumbnail.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/favorite/providers/favorite_provider.dart';
-import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 import 'package:immich_mobile/modules/album/providers/asset_selection.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
@@ -22,7 +21,6 @@ class AlbumViewerThumbnail extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var deviceId = ref.watch(authenticationProvider).deviceId;
     final selectedAssetsInAlbumViewer =
         ref.watch(assetSelectionProvider).selectedAssetsInAlbumViewer;
     final isMultiSelectionEnable =
@@ -88,7 +86,7 @@ class AlbumViewerThumbnail extends HookConsumerWidget {
         bottom: 5,
         child: Icon(
           asset.isRemote
-              ? (deviceId == asset.deviceId
+              ? (asset.isLocal
                   ? Icons.cloud_done_outlined
                   : Icons.cloud_outlined)
               : Icons.cloud_off_outlined,

--- a/mobile/lib/modules/album/views/album_viewer_page.dart
+++ b/mobile/lib/modules/album/views/album_viewer_page.dart
@@ -20,12 +20,13 @@ import 'package:immich_mobile/modules/settings/providers/app_settings.provider.d
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:immich_mobile/shared/ui/immich_sliver_persistent_app_bar_delegate.dart';
 import 'package:immich_mobile/shared/views/immich_loading_overlay.dart';
 
 class AlbumViewerPage extends HookConsumerWidget {
-  final String albumId;
+  final int albumId;
 
   const AlbumViewerPage({Key? key, required this.albumId}) : super(key: key);
 
@@ -101,7 +102,7 @@ class AlbumViewerPage extends HookConsumerWidget {
     Widget buildTitle(Album album) {
       return Padding(
         padding: const EdgeInsets.only(left: 8, right: 8, top: 16),
-        child: userId == album.ownerId
+        child: userId == album.ownerId && album.isRemote
             ? AlbumViewerEditableTitle(
                 album: album,
                 titleFocusNode: titleFocusNode,
@@ -122,9 +123,10 @@ class AlbumViewerPage extends HookConsumerWidget {
     Widget buildAlbumDateRange(Album album) {
       final DateTime startDate = album.assets.first.fileCreatedAt;
       final DateTime endDate = album.assets.last.fileCreatedAt; //Need default.
-      final String startDateText =
-          (startDate.year == endDate.year ? DateFormat.MMMd() : DateFormat.yMMMd())
-              .format(startDate);
+      final String startDateText = (startDate.year == endDate.year
+              ? DateFormat.MMMd()
+              : DateFormat.yMMMd())
+          .format(startDate);
       final String endDateText = DateFormat.yMMMd().format(endDate);
 
       return Padding(
@@ -189,6 +191,7 @@ class AlbumViewerPage extends HookConsumerWidget {
           appSettingService.getSetting(AppSettingsEnum.storageIndicator);
 
       if (album.assets.isNotEmpty) {
+        final List<Asset> assets = album.assets.toList(growable: false);
         return SliverPadding(
           padding: const EdgeInsets.only(top: 10.0),
           sliver: SliverGrid(
@@ -201,8 +204,8 @@ class AlbumViewerPage extends HookConsumerWidget {
             delegate: SliverChildBuilderDelegate(
               (BuildContext context, int index) {
                 return AlbumViewerThumbnail(
-                  asset: album.assets[index],
-                  assetList: album.assets,
+                  asset: assets[index],
+                  assetList: assets,
                   showStorageIndicator: showStorageIndicator,
                 );
               },
@@ -267,17 +270,18 @@ class AlbumViewerPage extends HookConsumerWidget {
               controller: scrollController,
               slivers: [
                 buildHeader(album),
-                SliverPersistentHeader(
-                  pinned: true,
-                  delegate: ImmichSliverPersistentAppBarDelegate(
-                    minHeight: 50,
-                    maxHeight: 50,
-                    child: Container(
-                      color: Theme.of(context).scaffoldBackgroundColor,
-                      child: buildControlButton(album),
+                if (album.isRemote)
+                  SliverPersistentHeader(
+                    pinned: true,
+                    delegate: ImmichSliverPersistentAppBarDelegate(
+                      minHeight: 50,
+                      maxHeight: 50,
+                      child: Container(
+                        color: Theme.of(context).scaffoldBackgroundColor,
+                        child: buildControlButton(album),
+                      ),
                     ),
                   ),
-                ),
                 SliverSafeArea(
                   sliver: buildImageGrid(album),
                 ),

--- a/mobile/lib/modules/album/views/album_viewer_page.dart
+++ b/mobile/lib/modules/album/views/album_viewer_page.dart
@@ -20,7 +20,6 @@ import 'package:immich_mobile/modules/settings/providers/app_settings.provider.d
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
-import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:immich_mobile/shared/ui/immich_sliver_persistent_app_bar_delegate.dart';
 import 'package:immich_mobile/shared/views/immich_loading_overlay.dart';
@@ -190,8 +189,7 @@ class AlbumViewerPage extends HookConsumerWidget {
       final bool showStorageIndicator =
           appSettingService.getSetting(AppSettingsEnum.storageIndicator);
 
-      if (album.assets.isNotEmpty) {
-        final List<Asset> assets = album.assets.toList(growable: false);
+      if (album.sortedAssets.isNotEmpty) {
         return SliverPadding(
           padding: const EdgeInsets.only(top: 10.0),
           sliver: SliverGrid(
@@ -204,8 +202,8 @@ class AlbumViewerPage extends HookConsumerWidget {
             delegate: SliverChildBuilderDelegate(
               (BuildContext context, int index) {
                 return AlbumViewerThumbnail(
-                  asset: assets[index],
-                  assetList: assets,
+                  asset: album.sortedAssets[index],
+                  assetList: album.sortedAssets,
                   showStorageIndicator: showStorageIndicator,
                 );
               },

--- a/mobile/lib/modules/album/views/library_page.dart
+++ b/mobile/lib/modules/album/views/library_page.dart
@@ -44,9 +44,13 @@ class LibraryPage extends HookConsumerWidget {
 
     List<Album> sortedAlbums() {
       if (selectedAlbumSortOrder.value == 0) {
-        return albums.sortedBy((album) => album.createdAt).reversed.toList();
+        return albums
+            .where((a) => a.isRemote)
+            .sortedBy((album) => album.createdAt)
+            .reversed
+            .toList();
       }
-      return albums.sortedBy((album) => album.name);
+      return albums.where((a) => a.isRemote).sortedBy((album) => album.name);
     }
 
     Widget buildSortButton() {
@@ -194,6 +198,8 @@ class LibraryPage extends HookConsumerWidget {
 
     final sorted = sortedAlbums();
 
+    final local = albums.where((a) => a.isLocal).toList();
+
     return Scaffold(
       appBar: buildAppBar(),
       body: CustomScrollView(
@@ -267,6 +273,47 @@ class LibraryPage extends HookConsumerWidget {
                     ),
                   );
                 },
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(
+                top: 12.0,
+                left: 12.0,
+                right: 12.0,
+                bottom: 20.0,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    'library_page_device_albums',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ).tr(),
+                ],
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.all(12.0),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 250,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: .7,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                childCount: local.length,
+                (context, index) => AlbumThumbnailCard(
+                  album: local[index],
+                  onTap: () => AutoRouter.of(context).push(
+                    AlbumViewerRoute(
+                      albumId: local[index].id,
+                    ),
+                  ),
+                ),
               ),
             ),
           ),

--- a/mobile/lib/modules/album/views/sharing_page.dart
+++ b/mobile/lib/modules/album/views/sharing_page.dart
@@ -1,23 +1,19 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
 import 'package:immich_mobile/modules/album/ui/sharing_sliver_appbar.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
-import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:immich_mobile/shared/ui/immich_image.dart';
 
 class SharingPage extends HookConsumerWidget {
   const SharingPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var box = Hive.box(userInfoBox);
     final List<Album> sharedAlbums = ref.watch(sharedAlbumProvider);
 
     useEffect(
@@ -39,16 +35,10 @@ class SharingPage extends HookConsumerWidget {
                   const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
               leading: ClipRRect(
                 borderRadius: BorderRadius.circular(8),
-                child: CachedNetworkImage(
+                child: ImmichImage(
+                  album.thumbnail.value,
                   width: 60,
                   height: 60,
-                  fit: BoxFit.cover,
-                  imageUrl: getAlbumThumbnailUrl(album),
-                  cacheKey: getAlbumThumbNailCacheKey(album),
-                  httpHeaders: {
-                    "Authorization": "Bearer ${box.get(accessTokenKey)}"
-                  },
-                  fadeInDuration: const Duration(milliseconds: 200),
                 ),
               ),
               title: Text(

--- a/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
@@ -14,10 +14,14 @@ class ExifBottomSheet extends HookConsumerWidget {
   const ExifBottomSheet({Key? key, required this.assetDetail})
       : super(key: key);
 
-  bool get showMap => assetDetail.latitude != null && assetDetail.longitude != null;
+  bool get showMap =>
+      assetDetail.exifInfo?.latitude != null &&
+      assetDetail.exifInfo?.longitude != null;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final ExifInfo? exifInfo = assetDetail.exifInfo;
+
     buildMap() {
       return Padding(
         padding: const EdgeInsets.symmetric(vertical: 16.0),
@@ -33,8 +37,8 @@ class ExifBottomSheet extends HookConsumerWidget {
                 options: MapOptions(
                   interactiveFlags: InteractiveFlag.none,
                   center: LatLng(
-                    assetDetail.latitude ?? 0,
-                    assetDetail.longitude ?? 0,
+                    exifInfo?.latitude ?? 0,
+                    exifInfo?.longitude ?? 0,
                   ),
                   zoom: 16.0,
                 ),
@@ -55,8 +59,8 @@ class ExifBottomSheet extends HookConsumerWidget {
                       Marker(
                         anchorPos: AnchorPos.align(AnchorAlign.top),
                         point: LatLng(
-                          assetDetail.latitude ?? 0,
-                          assetDetail.longitude ?? 0,
+                          exifInfo?.latitude ?? 0,
+                          exifInfo?.longitude ?? 0,
                         ),
                         builder: (ctx) => const Image(
                           image: AssetImage('assets/location-pin.png'),
@@ -73,8 +77,6 @@ class ExifBottomSheet extends HookConsumerWidget {
     }
 
     final textColor = Theme.of(context).primaryColor;
-
-    ExifInfo? exifInfo = assetDetail.exifInfo;
 
     buildLocationText() {
       return Text(
@@ -134,7 +136,7 @@ class ExifBottomSheet extends HookConsumerWidget {
                   exifInfo.state != null)
                 buildLocationText(),
               Text(
-                "${assetDetail.latitude!.toStringAsFixed(4)}, ${assetDetail.longitude!.toStringAsFixed(4)}",
+                "${exifInfo!.latitude!.toStringAsFixed(4)}, ${exifInfo.longitude!.toStringAsFixed(4)}",
                 style: const TextStyle(fontSize: 12),
               )
             ],

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -75,15 +75,11 @@ class GalleryViewerPage extends HookConsumerWidget {
       ref.watch(favoriteProvider.notifier).toggleFavorite(asset);
     }
 
-    getAssetExif() async {
-      if (assetList[indexOfAsset.value].isRemote) {
-        assetDetail = await ref
-            .watch(assetServiceProvider)
-            .getAssetById(assetList[indexOfAsset.value].id);
-      } else {
-        // TODO local exif parsing?
-        assetDetail = assetList[indexOfAsset.value];
-      }
+    void getAssetExif() async {
+      assetDetail = assetList[indexOfAsset.value];
+      assetDetail = await ref
+          .watch(assetServiceProvider)
+          .loadExif(assetList[indexOfAsset.value]);
     }
 
     /// Thumbnail image of a remote asset. Required asset.isRemote

--- a/mobile/lib/modules/favorite/providers/favorite_provider.dart
+++ b/mobile/lib/modules/favorite/providers/favorite_provider.dart
@@ -2,7 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 
-class FavoriteSelectionNotifier extends StateNotifier<Set<String>> {
+class FavoriteSelectionNotifier extends StateNotifier<Set<int>> {
   FavoriteSelectionNotifier(this.assetsState, this.assetNotifier) : super({}) {
     state = assetsState.allAssets
         .where((asset) => asset.isFavorite)
@@ -13,7 +13,7 @@ class FavoriteSelectionNotifier extends StateNotifier<Set<String>> {
   final AssetsState assetsState;
   final AssetNotifier assetNotifier;
 
-  void _setFavoriteForAssetId(String id, bool favorite) {
+  void _setFavoriteForAssetId(int id, bool favorite) {
     if (!favorite) {
       state = state.difference({id});
     } else {
@@ -21,7 +21,7 @@ class FavoriteSelectionNotifier extends StateNotifier<Set<String>> {
     }
   }
 
-  bool _isFavorite(String id) {
+  bool _isFavorite(int id) {
     return state.contains(id);
   }
 
@@ -38,22 +38,22 @@ class FavoriteSelectionNotifier extends StateNotifier<Set<String>> {
 
   Future<void> addToFavorites(Iterable<Asset> assets) {
     state = state.union(assets.map((a) => a.id).toSet());
-    final futures = assets.map((a) =>
-        assetNotifier.toggleFavorite(
-          a,
-          true,
-        ),
-      );
+    final futures = assets.map(
+      (a) => assetNotifier.toggleFavorite(
+        a,
+        true,
+      ),
+    );
 
     return Future.wait(futures);
   }
 }
 
 final favoriteProvider =
-    StateNotifierProvider<FavoriteSelectionNotifier, Set<String>>((ref) {
+    StateNotifierProvider<FavoriteSelectionNotifier, Set<int>>((ref) {
   return FavoriteSelectionNotifier(
-      ref.watch(assetProvider),
-      ref.watch(assetProvider.notifier),
+    ref.watch(assetProvider),
+    ref.watch(assetProvider.notifier),
   );
 });
 

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -23,7 +23,7 @@ class ImmichAssetGridState extends State<ImmichAssetGrid> {
       ItemPositionsListener.create();
 
   bool _scrolling = false;
-  final Set<String> _selectedAssets = HashSet();
+  final Set<int> _selectedAssets = HashSet();
 
   Set<Asset> _getSelectedAssets() {
     return _selectedAssets

--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/favorite/providers/favorite_provider.dart';
-import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/ui/immich_image.dart';
@@ -32,8 +31,6 @@ class ThumbnailImage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var deviceId = ref.watch(authenticationProvider).deviceId;
-
     Widget buildSelectionIcon(Asset asset) {
       if (isSelected) {
         return Icon(
@@ -103,7 +100,7 @@ class ThumbnailImage extends HookConsumerWidget {
                 bottom: 5,
                 child: Icon(
                   asset.isRemote
-                      ? (deviceId == asset.deviceId
+                      ? (asset.isLocal
                           ? Icons.cloud_done_outlined
                           : Icons.cloud_outlined)
                       : Icons.cloud_off_outlined,

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -38,7 +38,7 @@ class HomePage extends HookConsumerWidget {
     final selectionEnabledHook = useState(false);
 
     final selection = useState(<Asset>{});
-    final albums = ref.watch(albumProvider);
+    final albums = ref.watch(albumProvider).where((a) => a.isRemote).toList();
     final sharedAlbums = ref.watch(sharedAlbumProvider);
     final albumService = ref.watch(albumServiceProvider);
 

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -3,15 +3,15 @@ import 'package:flutter/services.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/hive_box.dart';
-import 'package:immich_mobile/modules/album/services/album_cache.service.dart';
 import 'package:immich_mobile/shared/models/store.dart';
-import 'package:immich_mobile/shared/services/asset_cache.service.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/modules/login/models/hive_saved_login_info.model.dart';
 import 'package:immich_mobile/modules/backup/services/backup.service.dart';
+import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
 import 'package:immich_mobile/shared/services/device_info.service.dart';
+import 'package:immich_mobile/utils/hash.dart';
 import 'package:openapi/api.dart';
 
 class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
@@ -19,9 +19,6 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
     this._deviceInfoService,
     this._backupService,
     this._apiService,
-    this._assetCacheService,
-    this._albumCacheService,
-    this._sharedAlbumCacheService,
   ) : super(
           AuthenticationState(
             deviceId: "",
@@ -48,9 +45,6 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
   final DeviceInfoService _deviceInfoService;
   final BackupService _backupService;
   final ApiService _apiService;
-  final AssetCacheService _assetCacheService;
-  final AlbumCacheService _albumCacheService;
-  final SharedAlbumCacheService _sharedAlbumCacheService;
 
   Future<bool> login(
     String email,
@@ -98,9 +92,6 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         Hive.box(userInfoBox).delete(accessTokenKey),
         Store.delete(StoreKey.assetETag),
         Store.delete(StoreKey.userRemoteId),
-        _assetCacheService.invalidate(),
-        _albumCacheService.invalidate(),
-        _sharedAlbumCacheService.invalidate(),
         Hive.box<HiveSavedLoginInfo>(hiveLoginInfoBox).delete(savedLoginInfoKey)
       ]);
 
@@ -160,7 +151,9 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       var deviceInfo = await _deviceInfoService.getDeviceInfo();
       userInfoHiveBox.put(deviceIdKey, deviceInfo["deviceId"]);
       userInfoHiveBox.put(accessTokenKey, accessToken);
+      Store.put(StoreKey.deviceIdHash, fastHash(deviceInfo["deviceId"]));
       Store.put(StoreKey.userRemoteId, userResponseDto.id);
+      Store.put(StoreKey.currentUser, User.fromDto(userResponseDto));
 
       state = state.copyWith(
         isAuthenticated: true,
@@ -218,8 +211,5 @@ final authenticationProvider =
     ref.watch(deviceInfoServiceProvider),
     ref.watch(backupServiceProvider),
     ref.watch(apiServiceProvider),
-    ref.watch(assetCacheServiceProvider),
-    ref.watch(albumCacheServiceProvider),
-    ref.watch(sharedAlbumCacheServiceProvider),
   );
 });

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -151,6 +151,7 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       var deviceInfo = await _deviceInfoService.getDeviceInfo();
       userInfoHiveBox.put(deviceIdKey, deviceInfo["deviceId"]);
       userInfoHiveBox.put(accessTokenKey, accessToken);
+      Store.put(StoreKey.deviceId, deviceInfo["deviceId"]);
       Store.put(StoreKey.deviceIdHash, fastHash(deviceInfo["deviceId"]));
       Store.put(StoreKey.userRemoteId, userResponseDto.id);
       Store.put(StoreKey.currentUser, User.fromDto(userResponseDto));

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -92,6 +92,7 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         Hive.box(userInfoBox).delete(accessTokenKey),
         Store.delete(StoreKey.assetETag),
         Store.delete(StoreKey.userRemoteId),
+        Store.delete(StoreKey.currentUser),
         Hive.box<HiveSavedLoginInfo>(hiveLoginInfoBox).delete(savedLoginInfoKey)
       ]);
 

--- a/mobile/lib/modules/search/models/search_result_page_state.model.dart
+++ b/mobile/lib/modules/search/models/search_result_page_state.model.dart
@@ -1,8 +1,5 @@
-import 'dart:convert';
-
 import 'package:collection/collection.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:openapi/api.dart';
 
 class SearchResultPageState {
   final bool isLoading;
@@ -30,34 +27,6 @@ class SearchResultPageState {
       searchResult: searchResult ?? this.searchResult,
     );
   }
-
-  Map<String, dynamic> toMap() {
-    return {
-      'isLoading': isLoading,
-      'isSuccess': isSuccess,
-      'isError': isError,
-      'searchResult': searchResult.map((x) => x.toJson()).toList(),
-    };
-  }
-
-  factory SearchResultPageState.fromMap(Map<String, dynamic> map) {
-    return SearchResultPageState(
-      isLoading: map['isLoading'] ?? false,
-      isSuccess: map['isSuccess'] ?? false,
-      isError: map['isError'] ?? false,
-      searchResult: List.from(
-        map['searchResult']
-            .map(AssetResponseDto.fromJson)
-            .where((e) => e != null)
-            .map(Asset.remote),
-      ),
-    );
-  }
-
-  String toJson() => json.encode(toMap());
-
-  factory SearchResultPageState.fromJson(String source) =>
-      SearchResultPageState.fromMap(json.decode(source));
 
   @override
   String toString() {

--- a/mobile/lib/modules/search/services/search.service.dart
+++ b/mobile/lib/modules/search/services/search.service.dart
@@ -2,19 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 
 final searchServiceProvider = Provider(
   (ref) => SearchService(
     ref.watch(apiServiceProvider),
+    ref.watch(dbProvider),
   ),
 );
 
 class SearchService {
   final ApiService _apiService;
+  final Isar _db;
 
-  SearchService(this._apiService);
+  SearchService(this._apiService, this._db);
 
   Future<List<String>?> getUserSuggestedSearchTerms() async {
     try {
@@ -26,13 +30,15 @@ class SearchService {
   }
 
   Future<List<Asset>?> searchAsset(String searchTerm) async {
+    // TODO search in local DB: 1. when offline, 2. to find local assets
     try {
       final List<AssetResponseDto>? results = await _apiService.assetApi
           .searchAsset(SearchAssetDto(searchTerm: searchTerm));
       if (results == null) {
         return null;
       }
-      return results.map((e) => Asset.remote(e)).toList();
+      // TODO local DB might be out of date; add assets not yet in DB?
+      return _db.assets.getAllByRemoteId(results.map((e) => e.id));
     } catch (e) {
       debugPrint("[ERROR] [searchAsset] ${e.toString()}");
       return null;

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -698,7 +698,7 @@ class SelectUserForSharingRoute extends PageRouteInfo<void> {
 class AlbumViewerRoute extends PageRouteInfo<AlbumViewerRouteArgs> {
   AlbumViewerRoute({
     Key? key,
-    required String albumId,
+    required int albumId,
   }) : super(
           AlbumViewerRoute.name,
           path: '/album-viewer-page',

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -719,7 +719,7 @@ class AlbumViewerRouteArgs {
 
   final Key? key;
 
-  final String albumId;
+  final int albumId;
 
   @override
   String toString() {

--- a/mobile/lib/shared/models/album.dart
+++ b/mobile/lib/shared/models/album.dart
@@ -1,132 +1,122 @@
+import 'package:flutter/cupertino.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
+import 'package:photo_manager/photo_manager.dart';
 
+part 'album.g.dart';
+
+@Collection(inheritance: false)
 class Album {
-  Album.remote(AlbumResponseDto dto)
-      : remoteId = dto.id,
-        name = dto.albumName,
-        createdAt = DateTime.parse(dto.createdAt),
-        // TODO add modifiedAt to server
-        modifiedAt = DateTime.parse(dto.createdAt),
-        shared = dto.shared,
-        ownerId = dto.ownerId,
-        albumThumbnailAssetId = dto.albumThumbnailAssetId,
-        assetCount = dto.assetCount,
-        sharedUsers = dto.sharedUsers.map((e) => User.fromDto(e)).toList(),
-        assets = dto.assets.map(Asset.remote).toList();
-
+  @protected
   Album({
     this.remoteId,
     this.localId,
     required this.name,
-    required this.ownerId,
     required this.createdAt,
     required this.modifiedAt,
     required this.shared,
-    required this.assetCount,
-    this.albumThumbnailAssetId,
-    this.sharedUsers = const [],
-    this.assets = const [],
   });
 
+  Id id = Isar.autoIncrement;
+  @Index(unique: false, replace: false, type: IndexType.hash)
   String? remoteId;
+  @Index(unique: false, replace: false, type: IndexType.hash)
   String? localId;
   String name;
-  String ownerId;
   DateTime createdAt;
   DateTime modifiedAt;
   bool shared;
-  String? albumThumbnailAssetId;
-  int assetCount;
-  List<User> sharedUsers = const [];
-  List<Asset> assets = const [];
+  final IsarLink<User> owner = IsarLink<User>();
+  final IsarLink<Asset> thumbnail = IsarLink<Asset>();
+  final IsarLinks<User> sharedUsers = IsarLinks<User>();
+  final IsarLinks<Asset> assets = IsarLinks<Asset>();
 
+  @ignore
   bool get isRemote => remoteId != null;
 
+  @ignore
   bool get isLocal => localId != null;
 
-  String get id => isRemote ? remoteId! : localId!;
+  @ignore
+  int get assetCount => assets.length;
+
+  @ignore
+  String? get ownerId => owner.value?.id;
 
   @override
   bool operator ==(other) {
     if (other is! Album) return false;
-    return remoteId == other.remoteId &&
+    return id == other.id &&
+        remoteId == other.remoteId &&
         localId == other.localId &&
         name == other.name &&
         createdAt == other.createdAt &&
         modifiedAt == other.modifiedAt &&
-        shared == other.shared &&
-        ownerId == other.ownerId &&
-        albumThumbnailAssetId == other.albumThumbnailAssetId;
+        shared == other.shared;
   }
 
   @override
+  @ignore
   int get hashCode =>
+      id.hashCode ^
       remoteId.hashCode ^
       localId.hashCode ^
       name.hashCode ^
       createdAt.hashCode ^
       modifiedAt.hashCode ^
-      shared.hashCode ^
-      ownerId.hashCode ^
-      albumThumbnailAssetId.hashCode;
+      shared.hashCode;
 
-  Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-    json["remoteId"] = remoteId;
-    json["localId"] = localId;
-    json["name"] = name;
-    json["ownerId"] = ownerId;
-    json["createdAt"] = createdAt.millisecondsSinceEpoch;
-    json["modifiedAt"] = modifiedAt.millisecondsSinceEpoch;
-    json["shared"] = shared;
-    json["albumThumbnailAssetId"] = albumThumbnailAssetId;
-    json["assetCount"] = assetCount;
-    json["sharedUsers"] = sharedUsers;
-    json["assets"] = assets;
-    return json;
+  static Album local(AssetPathEntity ape) {
+    final Album a = Album(
+      name: ape.name,
+      createdAt: ape.lastModified?.toUtc() ?? DateTime.now().toUtc(),
+      modifiedAt: ape.lastModified?.toUtc() ?? DateTime.now().toUtc(),
+      shared: false,
+    );
+    a.owner.value = Store.get(StoreKey.currentUser);
+    a.localId = ape.id;
+    return a;
   }
 
-  static Album? fromJson(dynamic value) {
-    if (value is Map) {
-      final json = value.cast<String, dynamic>();
-      return Album(
-        remoteId: json["remoteId"],
-        localId: json["localId"],
-        name: json["name"],
-        ownerId: json["ownerId"],
-        createdAt: DateTime.fromMillisecondsSinceEpoch(
-          json["createdAt"],
-          isUtc: true,
-        ),
-        modifiedAt: DateTime.fromMillisecondsSinceEpoch(
-          json["modifiedAt"],
-          isUtc: true,
-        ),
-        shared: json["shared"],
-        albumThumbnailAssetId: json["albumThumbnailAssetId"],
-        assetCount: json["assetCount"],
-        sharedUsers: _listFromJson<User>(json["sharedUsers"], User.fromJson),
-        assets: _listFromJson<Asset>(json["assets"], Asset.fromJson),
-      );
+  static Future<Album> remote(AlbumResponseDto dto) async {
+    final Isar db = Isar.getInstance()!;
+    final Album a = Album(
+      remoteId: dto.id,
+      name: dto.albumName,
+      createdAt: DateTime.parse(dto.createdAt),
+      modifiedAt: DateTime.parse(dto.updatedAt),
+      shared: dto.shared,
+    );
+    a.owner.value = await db.users.getById(dto.ownerId);
+    if (dto.albumThumbnailAssetId != null) {
+      a.thumbnail.value = await db.assets
+          .where()
+          .remoteIdEqualTo(dto.albumThumbnailAssetId)
+          .findFirst();
     }
-    return null;
+    if (dto.sharedUsers.isNotEmpty) {
+      final users = await db.users
+          .getAllById(dto.sharedUsers.map((e) => e.id).toList(growable: false));
+      a.sharedUsers.addAll(users.cast());
+    }
+    if (dto.assets.isNotEmpty) {
+      final assets =
+          await db.assets.getAllByRemoteId(dto.assets.map((e) => e.id));
+      a.assets.addAll(assets);
+    }
+    return a;
   }
 }
 
-List<T> _listFromJson<T>(
-  dynamic json,
-  T? Function(dynamic) fromJson,
-) {
-  final result = <T>[];
-  if (json is List && json.isNotEmpty) {
-    for (final entry in json) {
-      final value = fromJson(entry);
-      if (value != null) {
-        result.add(value);
-      }
-    }
+extension AssetsHelper on IsarCollection<Album> {
+  Future<void> store(Album a) async {
+    await put(a);
+    await a.owner.save();
+    await a.thumbnail.save();
+    await a.sharedUsers.save();
+    await a.assets.save();
   }
-  return result;
 }

--- a/mobile/lib/shared/models/album.dart
+++ b/mobile/lib/shared/models/album.dart
@@ -55,7 +55,11 @@ class Album {
         name == other.name &&
         createdAt == other.createdAt &&
         modifiedAt == other.modifiedAt &&
-        shared == other.shared;
+        shared == other.shared &&
+        owner.value == other.owner.value &&
+        thumbnail.value == other.thumbnail.value &&
+        sharedUsers.length == other.sharedUsers.length &&
+        assets.length == other.assets.length;
   }
 
   @override
@@ -67,7 +71,11 @@ class Album {
       name.hashCode ^
       createdAt.hashCode ^
       modifiedAt.hashCode ^
-      shared.hashCode;
+      shared.hashCode ^
+      owner.value.hashCode ^
+      thumbnail.value.hashCode ^
+      sharedUsers.length.hashCode ^
+      assets.length.hashCode;
 
   static Album local(AssetPathEntity ape) {
     final Album a = Album(
@@ -119,4 +127,18 @@ extension AssetsHelper on IsarCollection<Album> {
     await a.sharedUsers.save();
     await a.assets.save();
   }
+}
+
+extension AssetPathEntityHelper on AssetPathEntity {
+  Future<List<Asset>> getAssets({
+    int start = 0,
+    int end = 0x7fffffffffffffff,
+  }) async {
+    final assetEntities = await getAssetListRange(start: start, end: end);
+    return assetEntities.map(Asset.local).toList();
+  }
+}
+
+extension AlbumResponseDtoHelper on AlbumResponseDto {
+  List<Asset> getAssets() => assets.map(Asset.remote).toList();
 }

--- a/mobile/lib/shared/models/album.dart
+++ b/mobile/lib/shared/models/album.dart
@@ -34,6 +34,11 @@ class Album {
   final IsarLinks<User> sharedUsers = IsarLinks<User>();
   final IsarLinks<Asset> assets = IsarLinks<Asset>();
 
+  List<Asset> _sortedAssets = [];
+
+  @ignore
+  List<Asset> get sortedAssets => _sortedAssets;
+
   @ignore
   bool get isRemote => remoteId != null;
 
@@ -45,6 +50,10 @@ class Album {
 
   @ignore
   String? get ownerId => owner.value?.id;
+
+  Future<void> loadSortedAssets() async {
+    _sortedAssets = await assets.filter().sortByFileCreatedAt().findAll();
+  }
 
   @override
   bool operator ==(other) {

--- a/mobile/lib/shared/models/album.g.dart
+++ b/mobile/lib/shared/models/album.g.dart
@@ -1,0 +1,1391 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'album.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+extension GetAlbumCollection on Isar {
+  IsarCollection<Album> get albums => this.collection();
+}
+
+const AlbumSchema = CollectionSchema(
+  name: r'Album',
+  id: -1355968412107120937,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'localId': PropertySchema(
+      id: 1,
+      name: r'localId',
+      type: IsarType.string,
+    ),
+    r'modifiedAt': PropertySchema(
+      id: 2,
+      name: r'modifiedAt',
+      type: IsarType.dateTime,
+    ),
+    r'name': PropertySchema(
+      id: 3,
+      name: r'name',
+      type: IsarType.string,
+    ),
+    r'remoteId': PropertySchema(
+      id: 4,
+      name: r'remoteId',
+      type: IsarType.string,
+    ),
+    r'shared': PropertySchema(
+      id: 5,
+      name: r'shared',
+      type: IsarType.bool,
+    )
+  },
+  estimateSize: _albumEstimateSize,
+  serialize: _albumSerialize,
+  deserialize: _albumDeserialize,
+  deserializeProp: _albumDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'remoteId': IndexSchema(
+      id: 6301175856541681032,
+      name: r'remoteId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'remoteId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    ),
+    r'localId': IndexSchema(
+      id: 1199848425898359622,
+      name: r'localId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'localId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {
+    r'owner': LinkSchema(
+      id: 8272576585804958029,
+      name: r'owner',
+      target: r'User',
+      single: true,
+    ),
+    r'thumbnail': LinkSchema(
+      id: 4055421409629988258,
+      name: r'thumbnail',
+      target: r'Asset',
+      single: true,
+    ),
+    r'sharedUsers': LinkSchema(
+      id: 8972835302564625434,
+      name: r'sharedUsers',
+      target: r'User',
+      single: false,
+    ),
+    r'assets': LinkSchema(
+      id: 1059358332698388152,
+      name: r'assets',
+      target: r'Asset',
+      single: false,
+    )
+  },
+  embeddedSchemas: {},
+  getId: _albumGetId,
+  getLinks: _albumGetLinks,
+  attach: _albumAttach,
+  version: '3.0.5',
+);
+
+int _albumEstimateSize(
+  Album object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.localId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.name.length * 3;
+  {
+    final value = object.remoteId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _albumSerialize(
+  Album object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeString(offsets[1], object.localId);
+  writer.writeDateTime(offsets[2], object.modifiedAt);
+  writer.writeString(offsets[3], object.name);
+  writer.writeString(offsets[4], object.remoteId);
+  writer.writeBool(offsets[5], object.shared);
+}
+
+Album _albumDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = Album(
+    createdAt: reader.readDateTime(offsets[0]),
+    localId: reader.readStringOrNull(offsets[1]),
+    modifiedAt: reader.readDateTime(offsets[2]),
+    name: reader.readString(offsets[3]),
+    remoteId: reader.readStringOrNull(offsets[4]),
+    shared: reader.readBool(offsets[5]),
+  );
+  object.id = id;
+  return object;
+}
+
+P _albumDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    case 2:
+      return (reader.readDateTime(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (reader.readBool(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _albumGetId(Album object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _albumGetLinks(Album object) {
+  return [object.owner, object.thumbnail, object.sharedUsers, object.assets];
+}
+
+void _albumAttach(IsarCollection<dynamic> col, Id id, Album object) {
+  object.id = id;
+  object.owner.attach(col, col.isar.collection<User>(), r'owner', id);
+  object.thumbnail.attach(col, col.isar.collection<Asset>(), r'thumbnail', id);
+  object.sharedUsers
+      .attach(col, col.isar.collection<User>(), r'sharedUsers', id);
+  object.assets.attach(col, col.isar.collection<Asset>(), r'assets', id);
+}
+
+extension AlbumQueryWhereSort on QueryBuilder<Album, Album, QWhere> {
+  QueryBuilder<Album, Album, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension AlbumQueryWhere on QueryBuilder<Album, Album, QWhereClause> {
+  QueryBuilder<Album, Album, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'remoteId',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'remoteId',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> remoteIdEqualTo(
+      String? remoteId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'remoteId',
+        value: [remoteId],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> remoteIdNotEqualTo(
+      String? remoteId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [],
+              upper: [remoteId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [remoteId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [remoteId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [],
+              upper: [remoteId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> localIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'localId',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> localIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'localId',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> localIdEqualTo(
+      String? localId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'localId',
+        value: [localId],
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterWhereClause> localIdNotEqualTo(
+      String? localId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId',
+              lower: [],
+              upper: [localId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId',
+              lower: [localId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId',
+              lower: [localId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId',
+              lower: [],
+              upper: [localId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension AlbumQueryFilter on QueryBuilder<Album, Album, QFilterCondition> {
+  QueryBuilder<Album, Album, QAfterFilterCondition> createdAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'localId',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'localId',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'localId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'localId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> localIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'localId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> modifiedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> modifiedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> modifiedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> modifiedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'modifiedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'name',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameContains(String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'name',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameMatches(String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'name',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'name',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'remoteId',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'remoteId',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'remoteId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'remoteId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> remoteIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'remoteId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'shared',
+        value: value,
+      ));
+    });
+  }
+}
+
+extension AlbumQueryObject on QueryBuilder<Album, Album, QFilterCondition> {}
+
+extension AlbumQueryLinks on QueryBuilder<Album, Album, QFilterCondition> {
+  QueryBuilder<Album, Album, QAfterFilterCondition> owner(FilterQuery<User> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'owner');
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> ownerIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'owner', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> thumbnail(
+      FilterQuery<Asset> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'thumbnail');
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> thumbnailIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'thumbnail', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsers(
+      FilterQuery<User> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'sharedUsers');
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsersLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedUsers', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsersIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedUsers', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsersIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedUsers', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsersLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedUsers', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition>
+      sharedUsersLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedUsers', length, include, 999999, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> sharedUsersLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(
+          r'sharedUsers', lower, includeLower, upper, includeUpper);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assets(
+      FilterQuery<Asset> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'assets');
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'assets', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'assets', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'assets', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'assets', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'assets', length, include, 999999, true);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterFilterCondition> assetsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(
+          r'assets', lower, includeLower, upper, includeUpper);
+    });
+  }
+}
+
+extension AlbumQuerySortBy on QueryBuilder<Album, Album, QSortBy> {
+  QueryBuilder<Album, Album, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByLocalId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByLocalIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortByShared() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shared', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> sortBySharedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shared', Sort.desc);
+    });
+  }
+}
+
+extension AlbumQuerySortThenBy on QueryBuilder<Album, Album, QSortThenBy> {
+  QueryBuilder<Album, Album, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByLocalId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByLocalIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenByShared() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shared', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Album, Album, QAfterSortBy> thenBySharedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shared', Sort.desc);
+    });
+  }
+}
+
+extension AlbumQueryWhereDistinct on QueryBuilder<Album, Album, QDistinct> {
+  QueryBuilder<Album, Album, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Album, Album, QDistinct> distinctByLocalId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'localId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Album, Album, QDistinct> distinctByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<Album, Album, QDistinct> distinctByName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'name', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Album, Album, QDistinct> distinctByRemoteId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'remoteId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Album, Album, QDistinct> distinctByShared() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'shared');
+    });
+  }
+}
+
+extension AlbumQueryProperty on QueryBuilder<Album, Album, QQueryProperty> {
+  QueryBuilder<Album, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<Album, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Album, String?, QQueryOperations> localIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'localId');
+    });
+  }
+
+  QueryBuilder<Album, DateTime, QQueryOperations> modifiedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<Album, String, QQueryOperations> nameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'name');
+    });
+  }
+
+  QueryBuilder<Album, String?, QQueryOperations> remoteIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'remoteId');
+    });
+  }
+
+  QueryBuilder<Album, bool, QQueryOperations> sharedProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'shared');
+    });
+  }
+}

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -1,60 +1,65 @@
-import 'package:hive/hive.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
+import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/utils/hash.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:immich_mobile/utils/builtin_extensions.dart';
 import 'package:path/path.dart' as p;
 
+part 'asset.g.dart';
+
 /// Asset (online or local)
+@Collection(inheritance: false)
 class Asset {
   Asset.remote(AssetResponseDto remote)
       : remoteId = remote.id,
-        fileCreatedAt = DateTime.parse(remote.fileCreatedAt),
-        fileModifiedAt = DateTime.parse(remote.fileModifiedAt),
+        isLocal = false,
+        fileCreatedAt = DateTime.parse(remote.fileCreatedAt).toUtc(),
+        fileModifiedAt = DateTime.parse(remote.fileModifiedAt).toUtc(),
+        updatedAt = DateTime.parse(remote.updatedAt).toUtc(),
         durationInSeconds = remote.duration.toDuration().inSeconds,
         fileName = p.basename(remote.originalPath),
         height = remote.exifInfo?.exifImageHeight?.toInt(),
         width = remote.exifInfo?.exifImageWidth?.toInt(),
         livePhotoVideoId = remote.livePhotoVideoId,
-        deviceAssetId = remote.deviceAssetId,
-        deviceId = remote.deviceId,
-        ownerId = remote.ownerId,
-        latitude = remote.exifInfo?.latitude?.toDouble(),
-        longitude = remote.exifInfo?.longitude?.toDouble(),
+        localId = remote.deviceAssetId,
+        deviceId = fastHash(remote.deviceId),
+        ownerId = fastHash(remote.ownerId),
         exifInfo =
             remote.exifInfo != null ? ExifInfo.fromDto(remote.exifInfo!) : null,
         isFavorite = remote.isFavorite;
 
-  Asset.local(AssetEntity local, String owner)
+  Asset.local(AssetEntity local)
       : localId = local.id,
-        latitude = local.latitude,
-        longitude = local.longitude,
+        isLocal = true,
         durationInSeconds = local.duration,
         height = local.height,
         width = local.width,
         fileName = local.title!,
-        deviceAssetId = local.id,
-        deviceId = Hive.box(userInfoBox).get(deviceIdKey),
-        ownerId = owner,
+        deviceId = Store.get(StoreKey.deviceIdHash),
+        ownerId = Store.get<User>(StoreKey.currentUser)!.isarId,
         fileModifiedAt = local.modifiedDateTime.toUtc(),
+        updatedAt = local.modifiedDateTime.toUtc(),
         isFavorite = local.isFavorite,
         fileCreatedAt = local.createDateTime.toUtc() {
     if (fileCreatedAt.year == 1970) {
       fileCreatedAt = fileModifiedAt;
     }
+    if (local.latitude != null) {
+      exifInfo = ExifInfo(lat: local.latitude, long: local.longitude);
+    }
   }
 
   Asset({
-    this.localId,
     this.remoteId,
-    required this.deviceAssetId,
+    required this.localId,
     required this.deviceId,
     required this.ownerId,
     required this.fileCreatedAt,
     required this.fileModifiedAt,
-    this.latitude,
-    this.longitude,
+    required this.updatedAt,
     required this.durationInSeconds,
     this.width,
     this.height,
@@ -62,21 +67,22 @@ class Asset {
     this.livePhotoVideoId,
     this.exifInfo,
     required this.isFavorite,
+    required this.isLocal,
   });
 
+  @ignore
   AssetEntity? _local;
 
+  @ignore
   AssetEntity? get local {
     if (isLocal && _local == null) {
       _local = AssetEntity(
-        id: localId!.toString(),
+        id: localId.toString(),
         typeInt: isImage ? 1 : 2,
         width: width!,
         height: height!,
         duration: durationInSeconds,
         createDateSecond: fileCreatedAt.millisecondsSinceEpoch ~/ 1000,
-        latitude: latitude,
-        longitude: longitude,
         modifiedDateSecond: fileModifiedAt.millisecondsSinceEpoch ~/ 1000,
         title: fileName,
       );
@@ -84,110 +90,122 @@ class Asset {
     return _local;
   }
 
-  String? localId;
+  Id id = Isar.autoIncrement;
 
+  @Index(unique: false, replace: false, type: IndexType.hash)
   String? remoteId;
 
-  String deviceAssetId;
+  @Index(
+    unique: true,
+    replace: false,
+    type: IndexType.hash,
+    composite: [CompositeIndex('deviceId')],
+  )
+  String localId;
 
-  String deviceId;
+  int deviceId;
 
-  String ownerId;
+  int ownerId;
 
   DateTime fileCreatedAt;
 
   DateTime fileModifiedAt;
 
-  double? latitude;
-
-  double? longitude;
+  DateTime updatedAt;
 
   int durationInSeconds;
 
-  int? width;
+  short? width;
 
-  int? height;
+  short? height;
 
   String fileName;
 
   String? livePhotoVideoId;
 
-  ExifInfo? exifInfo;
-
   bool isFavorite;
 
-  String get id => isLocal ? localId.toString() : remoteId!;
+  bool isLocal;
 
+  @ignore
+  ExifInfo? exifInfo;
+
+  @ignore
+  bool get isInDb => id != Isar.autoIncrement;
+
+  @ignore
   String get name => p.withoutExtension(fileName);
 
+  @ignore
   bool get isRemote => remoteId != null;
 
-  bool get isLocal => localId != null;
-
+  @ignore
   bool get isImage => durationInSeconds == 0;
 
+  @ignore
   Duration get duration => Duration(seconds: durationInSeconds);
 
   @override
   bool operator ==(other) {
     if (other is! Asset) return false;
-    return id == other.id && isLocal == other.isLocal;
+    return id == other.id;
   }
 
   @override
+  @ignore
   int get hashCode => id.hashCode;
 
-  // methods below are only required for caching as JSON
-
-  Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-    json["localId"] = localId;
-    json["remoteId"] = remoteId;
-    json["deviceAssetId"] = deviceAssetId;
-    json["deviceId"] = deviceId;
-    json["ownerId"] = ownerId;
-    json["fileCreatedAt"] = fileCreatedAt.millisecondsSinceEpoch;
-    json["fileModifiedAt"] = fileModifiedAt.millisecondsSinceEpoch;
-    json["latitude"] = latitude;
-    json["longitude"] = longitude;
-    json["durationInSeconds"] = durationInSeconds;
-    json["width"] = width;
-    json["height"] = height;
-    json["fileName"] = fileName;
-    json["livePhotoVideoId"] = livePhotoVideoId;
-    json["isFavorite"] = isFavorite;
-    if (exifInfo != null) {
-      json["exifInfo"] = exifInfo!.toJson();
+  bool updateFromAssetEntity(AssetEntity ae) {
+    // TODO check more fields;
+    // width and height are most important because local assets require these
+    final bool hasChanges =
+        isLocal == false || width != ae.width || height != ae.height;
+    if (hasChanges) {
+      isLocal = true;
+      width = ae.width;
+      height = ae.height;
     }
-    return json;
+    return hasChanges;
   }
 
-  static Asset? fromJson(dynamic value) {
-    if (value is Map) {
-      final json = value.cast<String, dynamic>();
-      return Asset(
-        localId: json["localId"],
-        remoteId: json["remoteId"],
-        deviceAssetId: json["deviceAssetId"],
-        deviceId: json["deviceId"],
-        ownerId: json["ownerId"],
-        fileCreatedAt:
-            DateTime.fromMillisecondsSinceEpoch(json["fileCreatedAt"], isUtc: true),
-        fileModifiedAt: DateTime.fromMillisecondsSinceEpoch(
-          json["fileModifiedAt"],
-          isUtc: true,
-        ),
-        latitude: json["latitude"],
-        longitude: json["longitude"],
-        durationInSeconds: json["durationInSeconds"],
-        width: json["width"],
-        height: json["height"],
-        fileName: json["fileName"],
-        livePhotoVideoId: json["livePhotoVideoId"],
-        exifInfo: ExifInfo.fromJson(json["exifInfo"]),
-        isFavorite: json["isFavorite"],
-      );
+  Asset withUpdatesFromDto(AssetResponseDto dto) {
+    Asset a = Asset.remote(dto);
+    a.id = id;
+    a.localId = localId;
+    a.isLocal = isLocal;
+    a.width ??= width;
+    a.height ??= height;
+    a.exifInfo ??= exifInfo;
+    a.exifInfo?.id = id;
+    return a;
+  }
+
+  Future<void> put(Isar db) async {
+    await db.assets.put(this);
+    if (exifInfo != null) {
+      exifInfo!.id = id;
+      await db.exifInfos.put(exifInfo!);
     }
-    return null;
+  }
+}
+
+extension AssetsHelper on IsarCollection<Asset> {
+  Future<int> deleteAllByRemoteId(Iterable<String> ids) =>
+      ids.isEmpty ? Future.value(0) : _remote(ids).deleteAll();
+  Future<int> deleteAllByLocalId(Iterable<String> ids) =>
+      ids.isEmpty ? Future.value(0) : _local(ids).deleteAll();
+  Future<List<Asset>> getAllByRemoteId(Iterable<String> ids) =>
+      ids.isEmpty ? Future.value([]) : _remote(ids).findAll();
+  Future<List<Asset>> getAllByLocalId(Iterable<String> ids) =>
+      ids.isEmpty ? Future.value([]) : _local(ids).findAll();
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> _remote(Iterable<String> ids) =>
+      where().anyOf(ids, (q, String e) => q.remoteIdEqualTo(e));
+  QueryBuilder<Asset, Asset, QAfterWhereClause> _local(Iterable<String> ids) {
+    return where().anyOf(
+      ids,
+      (q, String e) =>
+          q.localIdDeviceIdEqualTo(e, Store.get(StoreKey.deviceIdHash)),
+    );
   }
 }

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -168,16 +168,20 @@ class Asset {
     return hasChanges;
   }
 
-  Asset withUpdatesFromDto(AssetResponseDto dto) {
-    Asset a = Asset.remote(dto);
-    a.id = id;
-    a.localId = localId;
-    a.isLocal = isLocal;
-    a.width ??= width;
-    a.height ??= height;
-    a.exifInfo ??= exifInfo;
-    a.exifInfo?.id = id;
-    return a;
+  Asset withUpdatesFromDto(AssetResponseDto dto) =>
+      Asset.remote(dto).updateFromDb(this);
+
+  Asset updateFromDb(Asset a) {
+    assert(localId == a.localId);
+    assert(deviceId == a.deviceId);
+    id = a.id;
+    isLocal |= a.isLocal;
+    remoteId ??= a.remoteId;
+    width ??= a.width;
+    height ??= a.height;
+    exifInfo ??= a.exifInfo;
+    exifInfo?.id = id;
+    return this;
   }
 
   Future<void> put(Isar db) async {
@@ -187,6 +191,16 @@ class Asset {
       await db.exifInfos.put(exifInfo!);
     }
   }
+
+  static int compareByDeviceIdLocalId(Asset a, Asset b) {
+    final int order = a.deviceId.compareTo(b.deviceId);
+    return order == 0 ? a.localId.compareTo(b.localId) : order;
+  }
+
+  static int compareById(Asset a, Asset b) => a.id.compareTo(b.id);
+
+  static int compareByLocalId(Asset a, Asset b) =>
+      a.localId.compareTo(b.localId);
 }
 
 extension AssetsHelper on IsarCollection<Asset> {

--- a/mobile/lib/shared/models/asset.g.dart
+++ b/mobile/lib/shared/models/asset.g.dart
@@ -1,0 +1,2244 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'asset.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+extension GetAssetCollection on Isar {
+  IsarCollection<Asset> get assets => this.collection();
+}
+
+const AssetSchema = CollectionSchema(
+  name: r'Asset',
+  id: -2933289051367723566,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'deviceId': PropertySchema(
+      id: 1,
+      name: r'deviceId',
+      type: IsarType.long,
+    ),
+    r'durationInSeconds': PropertySchema(
+      id: 2,
+      name: r'durationInSeconds',
+      type: IsarType.long,
+    ),
+    r'fileName': PropertySchema(
+      id: 3,
+      name: r'fileName',
+      type: IsarType.string,
+    ),
+    r'height': PropertySchema(
+      id: 4,
+      name: r'height',
+      type: IsarType.int,
+    ),
+    r'isFavorite': PropertySchema(
+      id: 5,
+      name: r'isFavorite',
+      type: IsarType.bool,
+    ),
+    r'isLocal': PropertySchema(
+      id: 6,
+      name: r'isLocal',
+      type: IsarType.bool,
+    ),
+    r'livePhotoVideoId': PropertySchema(
+      id: 7,
+      name: r'livePhotoVideoId',
+      type: IsarType.string,
+    ),
+    r'localId': PropertySchema(
+      id: 8,
+      name: r'localId',
+      type: IsarType.string,
+    ),
+    r'modifiedAt': PropertySchema(
+      id: 9,
+      name: r'modifiedAt',
+      type: IsarType.dateTime,
+    ),
+    r'ownerId': PropertySchema(
+      id: 10,
+      name: r'ownerId',
+      type: IsarType.long,
+    ),
+    r'remoteId': PropertySchema(
+      id: 11,
+      name: r'remoteId',
+      type: IsarType.string,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 12,
+      name: r'updatedAt',
+      type: IsarType.dateTime,
+    ),
+    r'width': PropertySchema(
+      id: 13,
+      name: r'width',
+      type: IsarType.int,
+    )
+  },
+  estimateSize: _assetEstimateSize,
+  serialize: _assetSerialize,
+  deserialize: _assetDeserialize,
+  deserializeProp: _assetDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'remoteId': IndexSchema(
+      id: 6301175856541681032,
+      name: r'remoteId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'remoteId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    ),
+    r'localId_deviceId': IndexSchema(
+      id: 7649417350086526165,
+      name: r'localId_deviceId',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'localId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        ),
+        IndexPropertySchema(
+          name: r'deviceId',
+          type: IndexType.value,
+          caseSensitive: false,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _assetGetId,
+  getLinks: _assetGetLinks,
+  attach: _assetAttach,
+  version: '3.0.5',
+);
+
+int _assetEstimateSize(
+  Asset object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.fileName.length * 3;
+  {
+    final value = object.livePhotoVideoId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.localId.length * 3;
+  {
+    final value = object.remoteId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _assetSerialize(
+  Asset object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeLong(offsets[1], object.deviceId);
+  writer.writeLong(offsets[2], object.durationInSeconds);
+  writer.writeString(offsets[3], object.fileName);
+  writer.writeInt(offsets[4], object.height);
+  writer.writeBool(offsets[5], object.isFavorite);
+  writer.writeBool(offsets[6], object.isLocal);
+  writer.writeString(offsets[7], object.livePhotoVideoId);
+  writer.writeString(offsets[8], object.localId);
+  writer.writeDateTime(offsets[9], object.modifiedAt);
+  writer.writeLong(offsets[10], object.ownerId);
+  writer.writeString(offsets[11], object.remoteId);
+  writer.writeDateTime(offsets[12], object.updatedAt);
+  writer.writeInt(offsets[13], object.width);
+}
+
+Asset _assetDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = Asset(
+    createdAt: reader.readDateTime(offsets[0]),
+    deviceId: reader.readLong(offsets[1]),
+    durationInSeconds: reader.readLong(offsets[2]),
+    fileName: reader.readString(offsets[3]),
+    height: reader.readIntOrNull(offsets[4]),
+    isFavorite: reader.readBool(offsets[5]),
+    isLocal: reader.readBool(offsets[6]),
+    livePhotoVideoId: reader.readStringOrNull(offsets[7]),
+    localId: reader.readString(offsets[8]),
+    modifiedAt: reader.readDateTime(offsets[9]),
+    ownerId: reader.readLong(offsets[10]),
+    remoteId: reader.readStringOrNull(offsets[11]),
+    updatedAt: reader.readDateTime(offsets[12]),
+    width: reader.readIntOrNull(offsets[13]),
+  );
+  object.id = id;
+  return object;
+}
+
+P _assetDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readLong(offset)) as P;
+    case 2:
+      return (reader.readLong(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
+      return (reader.readIntOrNull(offset)) as P;
+    case 5:
+      return (reader.readBool(offset)) as P;
+    case 6:
+      return (reader.readBool(offset)) as P;
+    case 7:
+      return (reader.readStringOrNull(offset)) as P;
+    case 8:
+      return (reader.readString(offset)) as P;
+    case 9:
+      return (reader.readDateTime(offset)) as P;
+    case 10:
+      return (reader.readLong(offset)) as P;
+    case 11:
+      return (reader.readStringOrNull(offset)) as P;
+    case 12:
+      return (reader.readDateTime(offset)) as P;
+    case 13:
+      return (reader.readIntOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _assetGetId(Asset object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _assetGetLinks(Asset object) {
+  return [];
+}
+
+void _assetAttach(IsarCollection<dynamic> col, Id id, Asset object) {
+  object.id = id;
+}
+
+extension AssetByIndex on IsarCollection<Asset> {
+  Future<Asset?> getByLocalIdDeviceId(String localId, int deviceId) {
+    return getByIndex(r'localId_deviceId', [localId, deviceId]);
+  }
+
+  Asset? getByLocalIdDeviceIdSync(String localId, int deviceId) {
+    return getByIndexSync(r'localId_deviceId', [localId, deviceId]);
+  }
+
+  Future<bool> deleteByLocalIdDeviceId(String localId, int deviceId) {
+    return deleteByIndex(r'localId_deviceId', [localId, deviceId]);
+  }
+
+  bool deleteByLocalIdDeviceIdSync(String localId, int deviceId) {
+    return deleteByIndexSync(r'localId_deviceId', [localId, deviceId]);
+  }
+
+  Future<List<Asset?>> getAllByLocalIdDeviceId(
+      List<String> localIdValues, List<int> deviceIdValues) {
+    final len = localIdValues.length;
+    assert(deviceIdValues.length == len,
+        'All index values must have the same length');
+    final values = <List<dynamic>>[];
+    for (var i = 0; i < len; i++) {
+      values.add([localIdValues[i], deviceIdValues[i]]);
+    }
+
+    return getAllByIndex(r'localId_deviceId', values);
+  }
+
+  List<Asset?> getAllByLocalIdDeviceIdSync(
+      List<String> localIdValues, List<int> deviceIdValues) {
+    final len = localIdValues.length;
+    assert(deviceIdValues.length == len,
+        'All index values must have the same length');
+    final values = <List<dynamic>>[];
+    for (var i = 0; i < len; i++) {
+      values.add([localIdValues[i], deviceIdValues[i]]);
+    }
+
+    return getAllByIndexSync(r'localId_deviceId', values);
+  }
+
+  Future<int> deleteAllByLocalIdDeviceId(
+      List<String> localIdValues, List<int> deviceIdValues) {
+    final len = localIdValues.length;
+    assert(deviceIdValues.length == len,
+        'All index values must have the same length');
+    final values = <List<dynamic>>[];
+    for (var i = 0; i < len; i++) {
+      values.add([localIdValues[i], deviceIdValues[i]]);
+    }
+
+    return deleteAllByIndex(r'localId_deviceId', values);
+  }
+
+  int deleteAllByLocalIdDeviceIdSync(
+      List<String> localIdValues, List<int> deviceIdValues) {
+    final len = localIdValues.length;
+    assert(deviceIdValues.length == len,
+        'All index values must have the same length');
+    final values = <List<dynamic>>[];
+    for (var i = 0; i < len; i++) {
+      values.add([localIdValues[i], deviceIdValues[i]]);
+    }
+
+    return deleteAllByIndexSync(r'localId_deviceId', values);
+  }
+
+  Future<Id> putByLocalIdDeviceId(Asset object) {
+    return putByIndex(r'localId_deviceId', object);
+  }
+
+  Id putByLocalIdDeviceIdSync(Asset object, {bool saveLinks = true}) {
+    return putByIndexSync(r'localId_deviceId', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByLocalIdDeviceId(List<Asset> objects) {
+    return putAllByIndex(r'localId_deviceId', objects);
+  }
+
+  List<Id> putAllByLocalIdDeviceIdSync(List<Asset> objects,
+      {bool saveLinks = true}) {
+    return putAllByIndexSync(r'localId_deviceId', objects,
+        saveLinks: saveLinks);
+  }
+}
+
+extension AssetQueryWhereSort on QueryBuilder<Asset, Asset, QWhere> {
+  QueryBuilder<Asset, Asset, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension AssetQueryWhere on QueryBuilder<Asset, Asset, QWhereClause> {
+  QueryBuilder<Asset, Asset, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'remoteId',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'remoteId',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> remoteIdEqualTo(
+      String? remoteId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'remoteId',
+        value: [remoteId],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> remoteIdNotEqualTo(
+      String? remoteId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [],
+              upper: [remoteId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [remoteId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [remoteId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'remoteId',
+              lower: [],
+              upper: [remoteId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> localIdEqualToAnyDeviceId(
+      String localId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'localId_deviceId',
+        value: [localId],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> localIdNotEqualToAnyDeviceId(
+      String localId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [],
+              upper: [localId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [],
+              upper: [localId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> localIdDeviceIdEqualTo(
+      String localId, int deviceId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'localId_deviceId',
+        value: [localId, deviceId],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause>
+      localIdEqualToDeviceIdNotEqualTo(String localId, int deviceId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId],
+              upper: [localId, deviceId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId, deviceId],
+              includeLower: false,
+              upper: [localId],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId, deviceId],
+              includeLower: false,
+              upper: [localId],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localId_deviceId',
+              lower: [localId],
+              upper: [localId, deviceId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause>
+      localIdEqualToDeviceIdGreaterThan(
+    String localId,
+    int deviceId, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'localId_deviceId',
+        lower: [localId, deviceId],
+        includeLower: include,
+        upper: [localId],
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> localIdEqualToDeviceIdLessThan(
+    String localId,
+    int deviceId, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'localId_deviceId',
+        lower: [localId],
+        upper: [localId, deviceId],
+        includeUpper: include,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterWhereClause> localIdEqualToDeviceIdBetween(
+    String localId,
+    int lowerDeviceId,
+    int upperDeviceId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'localId_deviceId',
+        lower: [localId, lowerDeviceId],
+        includeLower: includeLower,
+        upper: [localId, upperDeviceId],
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> deviceIdEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'deviceId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> deviceIdGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> deviceIdLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> deviceIdBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'deviceId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> durationInSecondsEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'durationInSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition>
+      durationInSecondsGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'durationInSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> durationInSecondsLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'durationInSeconds',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> durationInSecondsBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'durationInSeconds',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'fileName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'fileName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'fileName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fileName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'fileName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'height',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'height',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'height',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'height',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'height',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> heightBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'height',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> isFavoriteEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isFavorite',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> isLocalEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isLocal',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'livePhotoVideoId',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition>
+      livePhotoVideoIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'livePhotoVideoId',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'livePhotoVideoId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'livePhotoVideoId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'livePhotoVideoId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> livePhotoVideoIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'livePhotoVideoId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition>
+      livePhotoVideoIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'livePhotoVideoId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'localId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'localId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'localId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> localIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'localId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'modifiedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> ownerIdEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'ownerId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> ownerIdGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'ownerId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> ownerIdLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'ownerId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> ownerIdBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'ownerId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'remoteId',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'remoteId',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'remoteId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'remoteId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'remoteId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> remoteIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'remoteId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> updatedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> updatedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> updatedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> updatedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'updatedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'width',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'width',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'width',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'width',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'width',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> widthBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'width',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension AssetQueryObject on QueryBuilder<Asset, Asset, QFilterCondition> {}
+
+extension AssetQueryLinks on QueryBuilder<Asset, Asset, QFilterCondition> {}
+
+extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByDurationInSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByDurationInSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByHeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'height', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByHeightDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'height', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByIsFavoriteDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByIsLocal() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isLocal', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByIsLocalDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isLocal', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByLivePhotoVideoId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'livePhotoVideoId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByLivePhotoVideoIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'livePhotoVideoId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByLocalId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByLocalIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByOwnerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'ownerId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByOwnerIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'ownerId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByWidth() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'width', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByWidthDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'width', Sort.desc);
+    });
+  }
+}
+
+extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByDurationInSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByDurationInSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByHeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'height', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByHeightDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'height', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByIsFavoriteDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isFavorite', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByIsLocal() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isLocal', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByIsLocalDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isLocal', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByLivePhotoVideoId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'livePhotoVideoId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByLivePhotoVideoIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'livePhotoVideoId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByLocalId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByLocalIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByOwnerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'ownerId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByOwnerIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'ownerId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByWidth() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'width', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByWidthDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'width', Sort.desc);
+    });
+  }
+}
+
+extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
+  QueryBuilder<Asset, Asset, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'deviceId');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByDurationInSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'durationInSeconds');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByFileName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'fileName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByHeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'height');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByIsFavorite() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isFavorite');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByIsLocal() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isLocal');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByLivePhotoVideoId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'livePhotoVideoId',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByLocalId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'localId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByOwnerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'ownerId');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByRemoteId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'remoteId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'updatedAt');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByWidth() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'width');
+    });
+  }
+}
+
+extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
+  QueryBuilder<Asset, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<Asset, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<Asset, int, QQueryOperations> deviceIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'deviceId');
+    });
+  }
+
+  QueryBuilder<Asset, int, QQueryOperations> durationInSecondsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'durationInSeconds');
+    });
+  }
+
+  QueryBuilder<Asset, String, QQueryOperations> fileNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'fileName');
+    });
+  }
+
+  QueryBuilder<Asset, int?, QQueryOperations> heightProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'height');
+    });
+  }
+
+  QueryBuilder<Asset, bool, QQueryOperations> isFavoriteProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isFavorite');
+    });
+  }
+
+  QueryBuilder<Asset, bool, QQueryOperations> isLocalProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isLocal');
+    });
+  }
+
+  QueryBuilder<Asset, String?, QQueryOperations> livePhotoVideoIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'livePhotoVideoId');
+    });
+  }
+
+  QueryBuilder<Asset, String, QQueryOperations> localIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'localId');
+    });
+  }
+
+  QueryBuilder<Asset, DateTime, QQueryOperations> modifiedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<Asset, int, QQueryOperations> ownerIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'ownerId');
+    });
+  }
+
+  QueryBuilder<Asset, String?, QQueryOperations> remoteIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'remoteId');
+    });
+  }
+
+  QueryBuilder<Asset, DateTime, QQueryOperations> updatedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'updatedAt');
+    });
+  }
+
+  QueryBuilder<Asset, int?, QQueryOperations> widthProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'width');
+    });
+  }
+}

--- a/mobile/lib/shared/models/asset.g.dart
+++ b/mobile/lib/shared/models/asset.g.dart
@@ -17,55 +17,55 @@ const AssetSchema = CollectionSchema(
   name: r'Asset',
   id: -2933289051367723566,
   properties: {
-    r'createdAt': PropertySchema(
-      id: 0,
-      name: r'createdAt',
-      type: IsarType.dateTime,
-    ),
     r'deviceId': PropertySchema(
-      id: 1,
+      id: 0,
       name: r'deviceId',
       type: IsarType.long,
     ),
     r'durationInSeconds': PropertySchema(
-      id: 2,
+      id: 1,
       name: r'durationInSeconds',
       type: IsarType.long,
     ),
-    r'fileName': PropertySchema(
+    r'fileCreatedAt': PropertySchema(
+      id: 2,
+      name: r'fileCreatedAt',
+      type: IsarType.dateTime,
+    ),
+    r'fileModifiedAt': PropertySchema(
       id: 3,
+      name: r'fileModifiedAt',
+      type: IsarType.dateTime,
+    ),
+    r'fileName': PropertySchema(
+      id: 4,
       name: r'fileName',
       type: IsarType.string,
     ),
     r'height': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'height',
       type: IsarType.int,
     ),
     r'isFavorite': PropertySchema(
-      id: 5,
+      id: 6,
       name: r'isFavorite',
       type: IsarType.bool,
     ),
     r'isLocal': PropertySchema(
-      id: 6,
+      id: 7,
       name: r'isLocal',
       type: IsarType.bool,
     ),
     r'livePhotoVideoId': PropertySchema(
-      id: 7,
+      id: 8,
       name: r'livePhotoVideoId',
       type: IsarType.string,
     ),
     r'localId': PropertySchema(
-      id: 8,
+      id: 9,
       name: r'localId',
       type: IsarType.string,
-    ),
-    r'modifiedAt': PropertySchema(
-      id: 9,
-      name: r'modifiedAt',
-      type: IsarType.dateTime,
     ),
     r'ownerId': PropertySchema(
       id: 10,
@@ -163,16 +163,16 @@ void _assetSerialize(
   List<int> offsets,
   Map<Type, List<int>> allOffsets,
 ) {
-  writer.writeDateTime(offsets[0], object.createdAt);
-  writer.writeLong(offsets[1], object.deviceId);
-  writer.writeLong(offsets[2], object.durationInSeconds);
-  writer.writeString(offsets[3], object.fileName);
-  writer.writeInt(offsets[4], object.height);
-  writer.writeBool(offsets[5], object.isFavorite);
-  writer.writeBool(offsets[6], object.isLocal);
-  writer.writeString(offsets[7], object.livePhotoVideoId);
-  writer.writeString(offsets[8], object.localId);
-  writer.writeDateTime(offsets[9], object.modifiedAt);
+  writer.writeLong(offsets[0], object.deviceId);
+  writer.writeLong(offsets[1], object.durationInSeconds);
+  writer.writeDateTime(offsets[2], object.fileCreatedAt);
+  writer.writeDateTime(offsets[3], object.fileModifiedAt);
+  writer.writeString(offsets[4], object.fileName);
+  writer.writeInt(offsets[5], object.height);
+  writer.writeBool(offsets[6], object.isFavorite);
+  writer.writeBool(offsets[7], object.isLocal);
+  writer.writeString(offsets[8], object.livePhotoVideoId);
+  writer.writeString(offsets[9], object.localId);
   writer.writeLong(offsets[10], object.ownerId);
   writer.writeString(offsets[11], object.remoteId);
   writer.writeDateTime(offsets[12], object.updatedAt);
@@ -186,16 +186,16 @@ Asset _assetDeserialize(
   Map<Type, List<int>> allOffsets,
 ) {
   final object = Asset(
-    createdAt: reader.readDateTime(offsets[0]),
-    deviceId: reader.readLong(offsets[1]),
-    durationInSeconds: reader.readLong(offsets[2]),
-    fileName: reader.readString(offsets[3]),
-    height: reader.readIntOrNull(offsets[4]),
-    isFavorite: reader.readBool(offsets[5]),
-    isLocal: reader.readBool(offsets[6]),
-    livePhotoVideoId: reader.readStringOrNull(offsets[7]),
-    localId: reader.readString(offsets[8]),
-    modifiedAt: reader.readDateTime(offsets[9]),
+    deviceId: reader.readLong(offsets[0]),
+    durationInSeconds: reader.readLong(offsets[1]),
+    fileCreatedAt: reader.readDateTime(offsets[2]),
+    fileModifiedAt: reader.readDateTime(offsets[3]),
+    fileName: reader.readString(offsets[4]),
+    height: reader.readIntOrNull(offsets[5]),
+    isFavorite: reader.readBool(offsets[6]),
+    isLocal: reader.readBool(offsets[7]),
+    livePhotoVideoId: reader.readStringOrNull(offsets[8]),
+    localId: reader.readString(offsets[9]),
     ownerId: reader.readLong(offsets[10]),
     remoteId: reader.readStringOrNull(offsets[11]),
     updatedAt: reader.readDateTime(offsets[12]),
@@ -213,25 +213,25 @@ P _assetDeserializeProp<P>(
 ) {
   switch (propertyId) {
     case 0:
-      return (reader.readDateTime(offset)) as P;
+      return (reader.readLong(offset)) as P;
     case 1:
       return (reader.readLong(offset)) as P;
     case 2:
-      return (reader.readLong(offset)) as P;
+      return (reader.readDateTime(offset)) as P;
     case 3:
-      return (reader.readString(offset)) as P;
+      return (reader.readDateTime(offset)) as P;
     case 4:
-      return (reader.readIntOrNull(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 5:
-      return (reader.readBool(offset)) as P;
+      return (reader.readIntOrNull(offset)) as P;
     case 6:
       return (reader.readBool(offset)) as P;
     case 7:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 8:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 9:
-      return (reader.readDateTime(offset)) as P;
+      return (reader.readString(offset)) as P;
     case 10:
       return (reader.readLong(offset)) as P;
     case 11:
@@ -625,59 +625,6 @@ extension AssetQueryWhere on QueryBuilder<Asset, Asset, QWhereClause> {
 }
 
 extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtEqualTo(
-      DateTime value) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'createdAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtGreaterThan(
-    DateTime value, {
-    bool include = false,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'createdAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtLessThan(
-    DateTime value, {
-    bool include = false,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'createdAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> createdAtBetween(
-    DateTime lower,
-    DateTime upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'createdAt',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-      ));
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterFilterCondition> deviceIdEqualTo(int value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
@@ -776,6 +723,112 @@ extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.between(
         property: r'durationInSeconds',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileCreatedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fileCreatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileCreatedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'fileCreatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileCreatedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'fileCreatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileCreatedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'fileCreatedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileModifiedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fileModifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileModifiedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'fileModifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileModifiedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'fileModifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> fileModifiedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'fileModifiedAt',
         lower: lower,
         includeLower: includeLower,
         upper: upper,
@@ -1331,59 +1384,6 @@ extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
     });
   }
 
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtEqualTo(
-      DateTime value) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.equalTo(
-        property: r'modifiedAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtGreaterThan(
-    DateTime value, {
-    bool include = false,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.greaterThan(
-        include: include,
-        property: r'modifiedAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtLessThan(
-    DateTime value, {
-    bool include = false,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.lessThan(
-        include: include,
-        property: r'modifiedAt',
-        value: value,
-      ));
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterFilterCondition> modifiedAtBetween(
-    DateTime lower,
-    DateTime upper, {
-    bool includeLower = true,
-    bool includeUpper = true,
-  }) {
-    return QueryBuilder.apply(this, (query) {
-      return query.addFilterCondition(FilterCondition.between(
-        property: r'modifiedAt',
-        lower: lower,
-        includeLower: includeLower,
-        upper: upper,
-        includeUpper: includeUpper,
-      ));
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterFilterCondition> ownerIdEqualTo(int value) {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.equalTo(
@@ -1709,18 +1709,6 @@ extension AssetQueryObject on QueryBuilder<Asset, Asset, QFilterCondition> {}
 extension AssetQueryLinks on QueryBuilder<Asset, Asset, QFilterCondition> {}
 
 extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
-  QueryBuilder<Asset, Asset, QAfterSortBy> sortByCreatedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'createdAt', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterSortBy> sortByCreatedAtDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'createdAt', Sort.desc);
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterSortBy> sortByDeviceId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'deviceId', Sort.asc);
@@ -1742,6 +1730,30 @@ extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
   QueryBuilder<Asset, Asset, QAfterSortBy> sortByDurationInSecondsDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'durationInSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileCreatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileCreatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileModifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByFileModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileModifiedAt', Sort.desc);
     });
   }
 
@@ -1817,18 +1829,6 @@ extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
     });
   }
 
-  QueryBuilder<Asset, Asset, QAfterSortBy> sortByModifiedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'modifiedAt', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterSortBy> sortByModifiedAtDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'modifiedAt', Sort.desc);
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterSortBy> sortByOwnerId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'ownerId', Sort.asc);
@@ -1879,18 +1879,6 @@ extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
 }
 
 extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
-  QueryBuilder<Asset, Asset, QAfterSortBy> thenByCreatedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'createdAt', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterSortBy> thenByCreatedAtDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'createdAt', Sort.desc);
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterSortBy> thenByDeviceId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'deviceId', Sort.asc);
@@ -1912,6 +1900,30 @@ extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
   QueryBuilder<Asset, Asset, QAfterSortBy> thenByDurationInSecondsDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'durationInSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileCreatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileCreatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileModifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByFileModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileModifiedAt', Sort.desc);
     });
   }
 
@@ -1999,18 +2011,6 @@ extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
     });
   }
 
-  QueryBuilder<Asset, Asset, QAfterSortBy> thenByModifiedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'modifiedAt', Sort.asc);
-    });
-  }
-
-  QueryBuilder<Asset, Asset, QAfterSortBy> thenByModifiedAtDesc() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addSortBy(r'modifiedAt', Sort.desc);
-    });
-  }
-
   QueryBuilder<Asset, Asset, QAfterSortBy> thenByOwnerId() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'ownerId', Sort.asc);
@@ -2061,12 +2061,6 @@ extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
 }
 
 extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
-  QueryBuilder<Asset, Asset, QDistinct> distinctByCreatedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'createdAt');
-    });
-  }
-
   QueryBuilder<Asset, Asset, QDistinct> distinctByDeviceId() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'deviceId');
@@ -2076,6 +2070,18 @@ extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
   QueryBuilder<Asset, Asset, QDistinct> distinctByDurationInSeconds() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'durationInSeconds');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByFileCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'fileCreatedAt');
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QDistinct> distinctByFileModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'fileModifiedAt');
     });
   }
 
@@ -2119,12 +2125,6 @@ extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
     });
   }
 
-  QueryBuilder<Asset, Asset, QDistinct> distinctByModifiedAt() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addDistinctBy(r'modifiedAt');
-    });
-  }
-
   QueryBuilder<Asset, Asset, QDistinct> distinctByOwnerId() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'ownerId');
@@ -2158,12 +2158,6 @@ extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
     });
   }
 
-  QueryBuilder<Asset, DateTime, QQueryOperations> createdAtProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'createdAt');
-    });
-  }
-
   QueryBuilder<Asset, int, QQueryOperations> deviceIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'deviceId');
@@ -2173,6 +2167,18 @@ extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
   QueryBuilder<Asset, int, QQueryOperations> durationInSecondsProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'durationInSeconds');
+    });
+  }
+
+  QueryBuilder<Asset, DateTime, QQueryOperations> fileCreatedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'fileCreatedAt');
+    });
+  }
+
+  QueryBuilder<Asset, DateTime, QQueryOperations> fileModifiedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'fileModifiedAt');
     });
   }
 
@@ -2209,12 +2215,6 @@ extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
   QueryBuilder<Asset, String, QQueryOperations> localIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'localId');
-    });
-  }
-
-  QueryBuilder<Asset, DateTime, QQueryOperations> modifiedAtProperty() {
-    return QueryBuilder.apply(this, (query) {
-      return query.addPropertyName(r'modifiedAt');
     });
   }
 

--- a/mobile/lib/shared/models/exif_info.g.dart
+++ b/mobile/lib/shared/models/exif_info.g.dart
@@ -1,0 +1,2304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'exif_info.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+extension GetExifInfoCollection on Isar {
+  IsarCollection<ExifInfo> get exifInfos => this.collection();
+}
+
+const ExifInfoSchema = CollectionSchema(
+  name: r'ExifInfo',
+  id: -2409260054350835217,
+  properties: {
+    r'city': PropertySchema(
+      id: 0,
+      name: r'city',
+      type: IsarType.string,
+    ),
+    r'country': PropertySchema(
+      id: 1,
+      name: r'country',
+      type: IsarType.string,
+    ),
+    r'exposureSeconds': PropertySchema(
+      id: 2,
+      name: r'exposureSeconds',
+      type: IsarType.float,
+    ),
+    r'f': PropertySchema(
+      id: 3,
+      name: r'f',
+      type: IsarType.float,
+    ),
+    r'fileSize': PropertySchema(
+      id: 4,
+      name: r'fileSize',
+      type: IsarType.long,
+    ),
+    r'iso': PropertySchema(
+      id: 5,
+      name: r'iso',
+      type: IsarType.int,
+    ),
+    r'lat': PropertySchema(
+      id: 6,
+      name: r'lat',
+      type: IsarType.float,
+    ),
+    r'lens': PropertySchema(
+      id: 7,
+      name: r'lens',
+      type: IsarType.string,
+    ),
+    r'long': PropertySchema(
+      id: 8,
+      name: r'long',
+      type: IsarType.float,
+    ),
+    r'make': PropertySchema(
+      id: 9,
+      name: r'make',
+      type: IsarType.string,
+    ),
+    r'mm': PropertySchema(
+      id: 10,
+      name: r'mm',
+      type: IsarType.float,
+    ),
+    r'model': PropertySchema(
+      id: 11,
+      name: r'model',
+      type: IsarType.string,
+    ),
+    r'state': PropertySchema(
+      id: 12,
+      name: r'state',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _exifInfoEstimateSize,
+  serialize: _exifInfoSerialize,
+  deserialize: _exifInfoDeserialize,
+  deserializeProp: _exifInfoDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _exifInfoGetId,
+  getLinks: _exifInfoGetLinks,
+  attach: _exifInfoAttach,
+  version: '3.0.5',
+);
+
+int _exifInfoEstimateSize(
+  ExifInfo object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.city;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.country;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.lens;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.make;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.model;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.state;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _exifInfoSerialize(
+  ExifInfo object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.city);
+  writer.writeString(offsets[1], object.country);
+  writer.writeFloat(offsets[2], object.exposureSeconds);
+  writer.writeFloat(offsets[3], object.f);
+  writer.writeLong(offsets[4], object.fileSize);
+  writer.writeInt(offsets[5], object.iso);
+  writer.writeFloat(offsets[6], object.lat);
+  writer.writeString(offsets[7], object.lens);
+  writer.writeFloat(offsets[8], object.long);
+  writer.writeString(offsets[9], object.make);
+  writer.writeFloat(offsets[10], object.mm);
+  writer.writeString(offsets[11], object.model);
+  writer.writeString(offsets[12], object.state);
+}
+
+ExifInfo _exifInfoDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = ExifInfo(
+    city: reader.readStringOrNull(offsets[0]),
+    country: reader.readStringOrNull(offsets[1]),
+    exposureSeconds: reader.readFloatOrNull(offsets[2]),
+    f: reader.readFloatOrNull(offsets[3]),
+    fileSize: reader.readLongOrNull(offsets[4]),
+    iso: reader.readIntOrNull(offsets[5]),
+    lat: reader.readFloatOrNull(offsets[6]),
+    lens: reader.readStringOrNull(offsets[7]),
+    long: reader.readFloatOrNull(offsets[8]),
+    make: reader.readStringOrNull(offsets[9]),
+    mm: reader.readFloatOrNull(offsets[10]),
+    model: reader.readStringOrNull(offsets[11]),
+    state: reader.readStringOrNull(offsets[12]),
+  );
+  object.id = id;
+  return object;
+}
+
+P _exifInfoDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    case 2:
+      return (reader.readFloatOrNull(offset)) as P;
+    case 3:
+      return (reader.readFloatOrNull(offset)) as P;
+    case 4:
+      return (reader.readLongOrNull(offset)) as P;
+    case 5:
+      return (reader.readIntOrNull(offset)) as P;
+    case 6:
+      return (reader.readFloatOrNull(offset)) as P;
+    case 7:
+      return (reader.readStringOrNull(offset)) as P;
+    case 8:
+      return (reader.readFloatOrNull(offset)) as P;
+    case 9:
+      return (reader.readStringOrNull(offset)) as P;
+    case 10:
+      return (reader.readFloatOrNull(offset)) as P;
+    case 11:
+      return (reader.readStringOrNull(offset)) as P;
+    case 12:
+      return (reader.readStringOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _exifInfoGetId(ExifInfo object) {
+  return object.id ?? Isar.autoIncrement;
+}
+
+List<IsarLinkBase<dynamic>> _exifInfoGetLinks(ExifInfo object) {
+  return [];
+}
+
+void _exifInfoAttach(IsarCollection<dynamic> col, Id id, ExifInfo object) {
+  object.id = id;
+}
+
+extension ExifInfoQueryWhereSort on QueryBuilder<ExifInfo, ExifInfo, QWhere> {
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension ExifInfoQueryWhere on QueryBuilder<ExifInfo, ExifInfo, QWhereClause> {
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension ExifInfoQueryFilter
+    on QueryBuilder<ExifInfo, ExifInfo, QFilterCondition> {
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'city',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'city',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'city',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'city',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'city',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'city',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> cityIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'city',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'country',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'country',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'country',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'country',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'country',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'country',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> countryIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'country',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'exposureSeconds',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'exposureSeconds',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'exposureSeconds',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'exposureSeconds',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'exposureSeconds',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition>
+      exposureSecondsBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'exposureSeconds',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'f',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'f',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'f',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'f',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'f',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'f',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'fileSize',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'fileSize',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fileSize',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'fileSize',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'fileSize',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> fileSizeBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'fileSize',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'id',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'id',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idEqualTo(Id? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idGreaterThan(
+    Id? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idLessThan(
+    Id? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> idBetween(
+    Id? lower,
+    Id? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'iso',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'iso',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoEqualTo(
+      int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'iso',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'iso',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'iso',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> isoBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'iso',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'lat',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'lat',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lat',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lat',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lat',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> latBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lat',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'lens',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'lens',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lens',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'lens',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'lens',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lens',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> lensIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'lens',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'long',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'long',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'long',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'long',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'long',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> longBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'long',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'make',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'make',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'make',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'make',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'make',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'make',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> makeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'make',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'mm',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'mm',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'mm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'mm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'mm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> mmBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'mm',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'model',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'model',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'model',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'model',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'model',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'model',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> modelIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'model',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'state',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'state',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'state',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'state',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'state',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'state',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterFilterCondition> stateIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'state',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension ExifInfoQueryObject
+    on QueryBuilder<ExifInfo, ExifInfo, QFilterCondition> {}
+
+extension ExifInfoQueryLinks
+    on QueryBuilder<ExifInfo, ExifInfo, QFilterCondition> {}
+
+extension ExifInfoQuerySortBy on QueryBuilder<ExifInfo, ExifInfo, QSortBy> {
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByCity() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'city', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByCityDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'city', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByCountry() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'country', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByCountryDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'country', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByExposureSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'exposureSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByExposureSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'exposureSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByF() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'f', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByFDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'f', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByFileSize() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileSize', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByFileSizeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileSize', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByIso() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'iso', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByIsoDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'iso', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLat() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lat', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLatDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lat', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLens() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lens', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLensDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lens', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLong() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'long', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByLongDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'long', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByMake() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'make', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByMakeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'make', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByMm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'mm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByMmDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'mm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByState() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'state', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> sortByStateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'state', Sort.desc);
+    });
+  }
+}
+
+extension ExifInfoQuerySortThenBy
+    on QueryBuilder<ExifInfo, ExifInfo, QSortThenBy> {
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByCity() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'city', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByCityDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'city', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByCountry() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'country', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByCountryDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'country', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByExposureSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'exposureSeconds', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByExposureSecondsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'exposureSeconds', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByF() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'f', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByFDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'f', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByFileSize() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileSize', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByFileSizeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fileSize', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByIso() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'iso', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByIsoDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'iso', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLat() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lat', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLatDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lat', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLens() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lens', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLensDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lens', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLong() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'long', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByLongDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'long', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByMake() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'make', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByMakeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'make', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByMm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'mm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByMmDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'mm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'model', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByState() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'state', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QAfterSortBy> thenByStateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'state', Sort.desc);
+    });
+  }
+}
+
+extension ExifInfoQueryWhereDistinct
+    on QueryBuilder<ExifInfo, ExifInfo, QDistinct> {
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByCity(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'city', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByCountry(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'country', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByExposureSeconds() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'exposureSeconds');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByF() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'f');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByFileSize() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'fileSize');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByIso() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'iso');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByLat() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lat');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByLens(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lens', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByLong() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'long');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByMake(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'make', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByMm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'mm');
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByModel(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'model', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ExifInfo, ExifInfo, QDistinct> distinctByState(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'state', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension ExifInfoQueryProperty
+    on QueryBuilder<ExifInfo, ExifInfo, QQueryProperty> {
+  QueryBuilder<ExifInfo, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> cityProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'city');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> countryProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'country');
+    });
+  }
+
+  QueryBuilder<ExifInfo, double?, QQueryOperations> exposureSecondsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'exposureSeconds');
+    });
+  }
+
+  QueryBuilder<ExifInfo, double?, QQueryOperations> fProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'f');
+    });
+  }
+
+  QueryBuilder<ExifInfo, int?, QQueryOperations> fileSizeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'fileSize');
+    });
+  }
+
+  QueryBuilder<ExifInfo, int?, QQueryOperations> isoProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'iso');
+    });
+  }
+
+  QueryBuilder<ExifInfo, double?, QQueryOperations> latProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lat');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> lensProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lens');
+    });
+  }
+
+  QueryBuilder<ExifInfo, double?, QQueryOperations> longProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'long');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> makeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'make');
+    });
+  }
+
+  QueryBuilder<ExifInfo, double?, QQueryOperations> mmProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'mm');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> modelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'model');
+    });
+  }
+
+  QueryBuilder<ExifInfo, String?, QQueryOperations> stateProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'state');
+    });
+  }
+}

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -96,6 +96,7 @@ enum StoreKey {
   assetETag(1),
   currentUser(2, isInt: true, fromDb: _getUser, toDb: _toUser),
   deviceIdHash(3, isInt: true),
+  deviceId(4),
   ;
 
   const StoreKey(

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -1,3 +1,4 @@
+import 'package:immich_mobile/shared/models/user.dart';
 import 'package:isar/isar.dart';
 import 'dart:convert';
 
@@ -25,26 +26,28 @@ class Store {
 
   /// Returns the stored value for the given key, or the default value if null
   static T? get<T>(StoreKey key, [T? defaultValue]) =>
-      _cache[key._id] ?? defaultValue;
+      _cache[key.id] ?? defaultValue;
 
   /// Stores the value synchronously in the cache and asynchronously in the DB
   static Future<void> put<T>(StoreKey key, T value) {
-    _cache[key._id] = value;
-    return _db.writeTxn(() => _db.storeValues.put(StoreValue._of(value, key)));
+    _cache[key.id] = value;
+    return _db.writeTxn(
+      () async => _db.storeValues.put(await StoreValue._of(value, key)),
+    );
   }
 
   /// Removes the value synchronously from the cache and asynchronously from the DB
   static Future<void> delete(StoreKey key) {
-    _cache[key._id] = null;
-    return _db.writeTxn(() => _db.storeValues.delete(key._id));
+    _cache[key.id] = null;
+    return _db.writeTxn(() => _db.storeValues.delete(key.id));
   }
 
   /// Fills the cache with the values from the DB
   static _populateCache() {
     for (StoreKey key in StoreKey.values) {
-      final StoreValue? value = _db.storeValues.getSync(key._id);
+      final StoreValue? value = _db.storeValues.getSync(key.id);
       if (value != null) {
-        _cache[key._id] = value._extract(key);
+        _cache[key.id] = value._extract(key);
       }
     }
   }
@@ -67,17 +70,22 @@ class StoreValue {
   int? intValue;
   String? strValue;
 
-  T? _extract<T>(StoreKey key) => key._isInt
-      ? intValue
-      : (key._fromJson != null
-          ? key._fromJson!(json.decode(strValue!))
+  T? _extract<T>(StoreKey key) => key.isInt
+      ? (key.fromDb == null ? intValue : key.fromDb!.call(Store._db, intValue!))
+      : (key.fromJson != null
+          ? key.fromJson!(json.decode(strValue!))
           : strValue);
-  static StoreValue _of(dynamic value, StoreKey key) => StoreValue(
-        key._id,
-        intValue: key._isInt ? value : null,
-        strValue: key._isInt
+  static Future<StoreValue> _of(dynamic value, StoreKey key) async =>
+      StoreValue(
+        key.id,
+        intValue: key.isInt
+            ? (key.toDb == null
+                ? value
+                : await key.toDb!.call(Store._db, value))
+            : null,
+        strValue: key.isInt
             ? null
-            : (key._fromJson == null ? value : json.encode(value.toJson())),
+            : (key.fromJson == null ? value : json.encode(value.toJson())),
       );
 }
 
@@ -86,11 +94,27 @@ class StoreValue {
 enum StoreKey {
   userRemoteId(0),
   assetETag(1),
+  currentUser(2, isInt: true, fromDb: _getUser, toDb: _toUser),
+  deviceIdHash(3, isInt: true),
   ;
 
-  // ignore: unused_element
-  const StoreKey(this._id, [this._isInt = false, this._fromJson]);
-  final int _id;
-  final bool _isInt;
-  final Function(dynamic)? _fromJson;
+  const StoreKey(
+    this.id, {
+    this.isInt = false,
+    this.fromDb,
+    this.toDb,
+    // ignore: unused_element
+    this.fromJson,
+  });
+  final int id;
+  final bool isInt;
+  final dynamic Function(Isar, int)? fromDb;
+  final Future<int> Function(Isar, dynamic)? toDb;
+  final Function(dynamic)? fromJson;
+}
+
+User? _getUser(Isar db, int i) => db.users.getSync(i);
+Future<int> _toUser(Isar db, dynamic u) {
+  User user = (u as User);
+  return db.users.put(user);
 }

--- a/mobile/lib/shared/models/user.g.dart
+++ b/mobile/lib/shared/models/user.g.dart
@@ -1,0 +1,1338 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+extension GetUserCollection on Isar {
+  IsarCollection<User> get users => this.collection();
+}
+
+const UserSchema = CollectionSchema(
+  name: r'User',
+  id: -7838171048429979076,
+  properties: {
+    r'email': PropertySchema(
+      id: 0,
+      name: r'email',
+      type: IsarType.string,
+    ),
+    r'firstName': PropertySchema(
+      id: 1,
+      name: r'firstName',
+      type: IsarType.string,
+    ),
+    r'id': PropertySchema(
+      id: 2,
+      name: r'id',
+      type: IsarType.string,
+    ),
+    r'isAdmin': PropertySchema(
+      id: 3,
+      name: r'isAdmin',
+      type: IsarType.bool,
+    ),
+    r'lastName': PropertySchema(
+      id: 4,
+      name: r'lastName',
+      type: IsarType.string,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 5,
+      name: r'updatedAt',
+      type: IsarType.dateTime,
+    )
+  },
+  estimateSize: _userEstimateSize,
+  serialize: _userSerialize,
+  deserialize: _userDeserialize,
+  deserializeProp: _userDeserializeProp,
+  idName: r'isarId',
+  indexes: {
+    r'id': IndexSchema(
+      id: -3268401673993471357,
+      name: r'id',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'id',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {
+    r'albums': LinkSchema(
+      id: -8764917375410137318,
+      name: r'albums',
+      target: r'Album',
+      single: false,
+      linkName: r'owner',
+    ),
+    r'sharedAlbums': LinkSchema(
+      id: -7037628715076287024,
+      name: r'sharedAlbums',
+      target: r'Album',
+      single: false,
+      linkName: r'sharedUsers',
+    )
+  },
+  embeddedSchemas: {},
+  getId: _userGetId,
+  getLinks: _userGetLinks,
+  attach: _userAttach,
+  version: '3.0.5',
+);
+
+int _userEstimateSize(
+  User object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.email.length * 3;
+  bytesCount += 3 + object.firstName.length * 3;
+  bytesCount += 3 + object.id.length * 3;
+  bytesCount += 3 + object.lastName.length * 3;
+  return bytesCount;
+}
+
+void _userSerialize(
+  User object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.email);
+  writer.writeString(offsets[1], object.firstName);
+  writer.writeString(offsets[2], object.id);
+  writer.writeBool(offsets[3], object.isAdmin);
+  writer.writeString(offsets[4], object.lastName);
+  writer.writeDateTime(offsets[5], object.updatedAt);
+}
+
+User _userDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = User(
+    email: reader.readString(offsets[0]),
+    firstName: reader.readString(offsets[1]),
+    id: reader.readString(offsets[2]),
+    isAdmin: reader.readBool(offsets[3]),
+    lastName: reader.readString(offsets[4]),
+    updatedAt: reader.readDateTime(offsets[5]),
+  );
+  return object;
+}
+
+P _userDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readString(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readString(offset)) as P;
+    case 3:
+      return (reader.readBool(offset)) as P;
+    case 4:
+      return (reader.readString(offset)) as P;
+    case 5:
+      return (reader.readDateTime(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _userGetId(User object) {
+  return object.isarId;
+}
+
+List<IsarLinkBase<dynamic>> _userGetLinks(User object) {
+  return [object.albums, object.sharedAlbums];
+}
+
+void _userAttach(IsarCollection<dynamic> col, Id id, User object) {
+  object.albums.attach(col, col.isar.collection<Album>(), r'albums', id);
+  object.sharedAlbums
+      .attach(col, col.isar.collection<Album>(), r'sharedAlbums', id);
+}
+
+extension UserByIndex on IsarCollection<User> {
+  Future<User?> getById(String id) {
+    return getByIndex(r'id', [id]);
+  }
+
+  User? getByIdSync(String id) {
+    return getByIndexSync(r'id', [id]);
+  }
+
+  Future<bool> deleteById(String id) {
+    return deleteByIndex(r'id', [id]);
+  }
+
+  bool deleteByIdSync(String id) {
+    return deleteByIndexSync(r'id', [id]);
+  }
+
+  Future<List<User?>> getAllById(List<String> idValues) {
+    final values = idValues.map((e) => [e]).toList();
+    return getAllByIndex(r'id', values);
+  }
+
+  List<User?> getAllByIdSync(List<String> idValues) {
+    final values = idValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'id', values);
+  }
+
+  Future<int> deleteAllById(List<String> idValues) {
+    final values = idValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'id', values);
+  }
+
+  int deleteAllByIdSync(List<String> idValues) {
+    final values = idValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'id', values);
+  }
+
+  Future<Id> putById(User object) {
+    return putByIndex(r'id', object);
+  }
+
+  Id putByIdSync(User object, {bool saveLinks = true}) {
+    return putByIndexSync(r'id', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllById(List<User> objects) {
+    return putAllByIndex(r'id', objects);
+  }
+
+  List<Id> putAllByIdSync(List<User> objects, {bool saveLinks = true}) {
+    return putAllByIndexSync(r'id', objects, saveLinks: saveLinks);
+  }
+}
+
+extension UserQueryWhereSort on QueryBuilder<User, User, QWhere> {
+  QueryBuilder<User, User, QAfterWhere> anyIsarId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension UserQueryWhere on QueryBuilder<User, User, QWhereClause> {
+  QueryBuilder<User, User, QAfterWhereClause> isarIdEqualTo(Id isarId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: isarId,
+        upper: isarId,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> isarIdNotEqualTo(Id isarId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: isarId, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: isarId, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: isarId, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: isarId, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> isarIdGreaterThan(Id isarId,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: isarId, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> isarIdLessThan(Id isarId,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: isarId, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> isarIdBetween(
+    Id lowerIsarId,
+    Id upperIsarId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerIsarId,
+        includeLower: includeLower,
+        upper: upperIsarId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> idEqualTo(String id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'id',
+        value: [id],
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterWhereClause> idNotEqualTo(String id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'id',
+              lower: [],
+              upper: [id],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'id',
+              lower: [id],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'id',
+              lower: [id],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'id',
+              lower: [],
+              upper: [id],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension UserQueryFilter on QueryBuilder<User, User, QFilterCondition> {
+  QueryBuilder<User, User, QAfterFilterCondition> emailEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'email',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailContains(String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'email',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailMatches(String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'email',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'email',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> emailIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'email',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'firstName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'firstName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'firstName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'firstName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> firstNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'firstName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idContains(String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'id',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idMatches(String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'id',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> idIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'id',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> isAdminEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isAdmin',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> isarIdEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isarId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> isarIdGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'isarId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> isarIdLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'isarId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> isarIdBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'isarId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lastName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameContains(String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'lastName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'lastName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> lastNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'lastName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> updatedAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> updatedAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> updatedAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> updatedAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'updatedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension UserQueryObject on QueryBuilder<User, User, QFilterCondition> {}
+
+extension UserQueryLinks on QueryBuilder<User, User, QFilterCondition> {
+  QueryBuilder<User, User, QAfterFilterCondition> albums(FilterQuery<Album> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'albums');
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'albums', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'albums', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'albums', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'albums', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'albums', length, include, 999999, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> albumsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(
+          r'albums', lower, includeLower, upper, includeUpper);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbums(
+      FilterQuery<Album> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.link(q, r'sharedAlbums');
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedAlbums', length, true, length, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedAlbums', 0, true, 0, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedAlbums', 0, false, 999999, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedAlbums', 0, true, length, include);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(r'sharedAlbums', length, include, 999999, true);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterFilterCondition> sharedAlbumsLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.linkLength(
+          r'sharedAlbums', lower, includeLower, upper, includeUpper);
+    });
+  }
+}
+
+extension UserQuerySortBy on QueryBuilder<User, User, QSortBy> {
+  QueryBuilder<User, User, QAfterSortBy> sortByEmail() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'email', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByEmailDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'email', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByFirstName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'firstName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByFirstNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'firstName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByIsAdmin() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAdmin', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByIsAdminDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAdmin', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByLastName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByLastNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> sortByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+}
+
+extension UserQuerySortThenBy on QueryBuilder<User, User, QSortThenBy> {
+  QueryBuilder<User, User, QAfterSortBy> thenByEmail() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'email', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByEmailDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'email', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByFirstName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'firstName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByFirstNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'firstName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByIsAdmin() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAdmin', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByIsAdminDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAdmin', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByIsarId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isarId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByIsarIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isarId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByLastName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByLastNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<User, User, QAfterSortBy> thenByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+}
+
+extension UserQueryWhereDistinct on QueryBuilder<User, User, QDistinct> {
+  QueryBuilder<User, User, QDistinct> distinctByEmail(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'email', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<User, User, QDistinct> distinctByFirstName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'firstName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<User, User, QDistinct> distinctById(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'id', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<User, User, QDistinct> distinctByIsAdmin() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isAdmin');
+    });
+  }
+
+  QueryBuilder<User, User, QDistinct> distinctByLastName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lastName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<User, User, QDistinct> distinctByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'updatedAt');
+    });
+  }
+}
+
+extension UserQueryProperty on QueryBuilder<User, User, QQueryProperty> {
+  QueryBuilder<User, int, QQueryOperations> isarIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isarId');
+    });
+  }
+
+  QueryBuilder<User, String, QQueryOperations> emailProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'email');
+    });
+  }
+
+  QueryBuilder<User, String, QQueryOperations> firstNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'firstName');
+    });
+  }
+
+  QueryBuilder<User, String, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<User, bool, QQueryOperations> isAdminProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isAdmin');
+    });
+  }
+
+  QueryBuilder<User, String, QQueryOperations> lastNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lastName');
+    });
+  }
+
+  QueryBuilder<User, DateTime, QQueryOperations> updatedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'updatedAt');
+    });
+  }
+}

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -92,8 +92,7 @@ class AssetNotifier extends StateNotifier<AssetsState> {
       final int cachedCount =
           await _db.assets.filter().ownerIdEqualTo(me.isarId).count();
       stopwatch.start();
-      if (cachedCount > 0 && state.allAssets.isEmpty ||
-          cachedCount != state.allAssets.length) {
+      if (cachedCount > 0 && cachedCount != state.allAssets.length) {
         await _updateAssetsState(
           await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll(),
         );
@@ -113,8 +112,10 @@ class AssetNotifier extends StateNotifier<AssetsState> {
       stopwatch.reset();
       final assets =
           await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll();
-      log.info("setting new asset state");
-      await _updateAssetsState(assets);
+      if (!const ListEquality().equals(assets, state.allAssets)) {
+        log.info("setting new asset state");
+        await _updateAssetsState(assets);
+      }
     } finally {
       _getAllAssetInProgress = false;
     }

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/album/services/album.service.dart';
+import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
@@ -123,7 +124,11 @@ class AssetNotifier extends StateNotifier<AssetsState> {
 
   Future<void> clearAllAsset() {
     state = AssetsState.empty();
-    return _db.writeTxn(() async => _db.assets.clear());
+    return _db.writeTxn(() async {
+      await _db.assets.clear();
+      await _db.exifInfos.clear();
+      await _db.albums.clear();
+    });
   }
 
   Future<void> onNewAssetUploaded(Asset newAsset) async {

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -94,9 +94,7 @@ class AssetNotifier extends StateNotifier<AssetsState> {
           await _db.assets.filter().ownerIdEqualTo(me.isarId).count();
       stopwatch.start();
       if (cachedCount > 0 && cachedCount != state.allAssets.length) {
-        await _updateAssetsState(
-          await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll(),
-        );
+        await _updateAssetsState(await _getUserAssets(me.isarId));
         log.info(
           "Reading assets ${state.allAssets.length} from DB: ${stopwatch.elapsedMilliseconds}ms",
         );
@@ -111,8 +109,7 @@ class AssetNotifier extends StateNotifier<AssetsState> {
         return;
       }
       stopwatch.reset();
-      final assets =
-          await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll();
+      final assets = await _getUserAssets(me.isarId);
       if (!const ListEquality().equals(assets, state.allAssets)) {
         log.info("setting new asset state");
         await _updateAssetsState(assets);
@@ -121,6 +118,12 @@ class AssetNotifier extends StateNotifier<AssetsState> {
       _getAllAssetInProgress = false;
     }
   }
+
+  Future<List<Asset>> _getUserAssets(int userId) => _db.assets
+      .filter()
+      .ownerIdEqualTo(userId)
+      .sortByFileCreatedAtDesc()
+      .findAll();
 
   Future<void> clearAllAsset() {
     state = AssetsState.empty();

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -1,20 +1,18 @@
-import 'dart:collection';
-
 import 'package:flutter/foundation.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/modules/album/services/album.service.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/asset.service.dart';
-import 'package:immich_mobile/shared/services/asset_cache.service.dart';
 import 'package:immich_mobile/modules/home/ui/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/modules/settings/providers/app_settings.provider.dart';
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:immich_mobile/shared/services/device_info.service.dart';
 import 'package:collection/collection.dart';
-import 'package:immich_mobile/utils/tuple.dart';
 import 'package:intl/intl.dart';
+import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -50,50 +48,36 @@ class AssetsState {
   }
 }
 
-class _CombineAssetsComputeParameters {
-  final Iterable<Asset> local;
-  final Iterable<Asset> remote;
-  final String deviceId;
-
-  _CombineAssetsComputeParameters(this.local, this.remote, this.deviceId);
-}
-
 class AssetNotifier extends StateNotifier<AssetsState> {
   final AssetService _assetService;
-  final AssetCacheService _assetCacheService;
   final AppSettingsService _settingsService;
+  final AlbumService _albumService;
+  final Isar _db;
   final log = Logger('AssetNotifier');
-  final DeviceInfoService _deviceInfoService = DeviceInfoService();
   bool _getAllAssetInProgress = false;
   bool _deleteInProgress = false;
 
   AssetNotifier(
     this._assetService,
-    this._assetCacheService,
     this._settingsService,
+    this._albumService,
+    this._db,
   ) : super(AssetsState.fromAssetList([]));
 
-  Future<void> _updateAssetsState(
-    List<Asset> newAssetList, {
-    bool cache = true,
-  }) async {
-    if (cache) {
-      _assetCacheService.put(newAssetList);
-    }
-
+  Future<void> _updateAssetsState(List<Asset> newAssetList) async {
     final layout = AssetGridLayoutParameters(
       _settingsService.getSetting(AppSettingsEnum.tilesPerRow),
       _settingsService.getSetting(AppSettingsEnum.dynamicLayout),
-      GroupAssetsBy.values[_settingsService.getSetting(AppSettingsEnum.groupAssetsBy)],
+      GroupAssetsBy
+          .values[_settingsService.getSetting(AppSettingsEnum.groupAssetsBy)],
     );
-
     state = await AssetsState.fromAssetList(newAssetList)
         .withRenderDataStructure(layout);
   }
 
   // Just a little helper to trigger a rebuild of the state object
   Future<void> rebuildAssetGridDataStructure() async {
-    await _updateAssetsState(state.allAssets, cache: false);
+    await _updateAssetsState(state.allAssets);
   }
 
   getAllAsset() async {
@@ -104,127 +88,94 @@ class AssetNotifier extends StateNotifier<AssetsState> {
     final stopwatch = Stopwatch();
     try {
       _getAllAssetInProgress = true;
-      bool isCacheValid = await _assetCacheService.isValid();
+      final User me = Store.get(StoreKey.currentUser);
+      final int cachedCount =
+          await _db.assets.filter().ownerIdEqualTo(me.isarId).count();
       stopwatch.start();
-      if (isCacheValid && state.allAssets.isEmpty) {
-        final List<Asset>? cachedData = await _assetCacheService.get();
-        if (cachedData == null) {
-          isCacheValid = false;
-          log.warning("Cached asset data is invalid, fetching new data");
-        } else {
-          await _updateAssetsState(cachedData, cache: false);
-          log.info(
-            "Reading assets ${state.allAssets.length} from cache: ${stopwatch.elapsedMilliseconds}ms",
-          );
-        }
+      if (cachedCount > 0 && state.allAssets.isEmpty ||
+          cachedCount != state.allAssets.length) {
+        await _updateAssetsState(
+          await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll(),
+        );
+        log.info(
+          "Reading assets ${state.allAssets.length} from DB: ${stopwatch.elapsedMilliseconds}ms",
+        );
         stopwatch.reset();
       }
-      final localTask = _assetService.getLocalAssets(urgent: !isCacheValid);
-      final remoteTask = _assetService.getRemoteAssets(
-        etag: isCacheValid ? Store.get(StoreKey.assetETag) : null,
-      );
-
-      int remoteBegin = state.allAssets.indexWhere((a) => a.isRemote);
-      remoteBegin = remoteBegin == -1 ? state.allAssets.length : remoteBegin;
-
-      final List<Asset> currentLocal = state.allAssets.slice(0, remoteBegin);
-
-      final Pair<List<Asset>?, String?> remoteResult = await remoteTask;
-      List<Asset>? newRemote = remoteResult.first;
-      List<Asset>? newLocal = await localTask;
+      final bool newRemote = await _assetService.refreshRemoteAssets();
+      final bool newLocal = await _albumService.refreshDeviceAlbums();
       log.info("Load assets: ${stopwatch.elapsedMilliseconds}ms");
       stopwatch.reset();
-      if (newRemote == null &&
-          (newLocal == null || currentLocal.equals(newLocal))) {
+      if (!newRemote && !newLocal) {
         log.info("state is already up-to-date");
         return;
       }
-      newRemote ??= state.allAssets.slice(remoteBegin);
-      newLocal ??= [];
-
-      final combinedAssets = await _combineLocalAndRemoteAssets(
-        local: newLocal,
-        remote: newRemote,
-      );
-      await _updateAssetsState(combinedAssets);
-
-      log.info("Combining assets: ${stopwatch.elapsedMilliseconds}ms");
-
-      Store.put(StoreKey.assetETag, remoteResult.second);
+      stopwatch.reset();
+      final assets =
+          await _db.assets.filter().ownerIdEqualTo(me.isarId).findAll();
+      log.info("setting new asset state");
+      await _updateAssetsState(assets);
     } finally {
       _getAllAssetInProgress = false;
     }
   }
 
-  static Future<List<Asset>> _computeCombine(
-    _CombineAssetsComputeParameters data,
-  ) async {
-    var local = data.local;
-    var remote = data.remote;
-    final deviceId = data.deviceId;
-
-    final List<Asset> assets = [];
-    if (remote.isNotEmpty && local.isNotEmpty) {
-      final Set<String> existingIds = remote
-          .where((e) => e.deviceId == deviceId)
-          .map((e) => e.deviceAssetId)
-          .toSet();
-      local = local.where((e) => !existingIds.contains(e.id));
-    }
-    assets.addAll(local);
-    // the order (first all local, then remote assets) is important!
-    assets.addAll(remote);
-    return assets;
+  Future<void> clearAllAsset() {
+    state = AssetsState.empty();
+    return _db.writeTxn(() async => _db.assets.clear());
   }
 
-  Future<List<Asset>> _combineLocalAndRemoteAssets({
-    required Iterable<Asset> local,
-    required List<Asset> remote,
-  }) async {
-    final String deviceId = Hive.box(userInfoBox).get(deviceIdKey);
-    return await compute(
-      _computeCombine,
-      _CombineAssetsComputeParameters(local, remote, deviceId),
-    );
-  }
-
-  clearAllAsset() {
-    _updateAssetsState([]);
-  }
-
-  void onNewAssetUploaded(Asset newAsset) {
+  Future<void> onNewAssetUploaded(Asset newAsset) async {
     final int i = state.allAssets.indexWhere(
       (a) =>
           a.isRemote ||
-          (a.id == newAsset.deviceAssetId && a.deviceId == newAsset.deviceId),
+          (a.localId == newAsset.localId && a.deviceId == newAsset.deviceId),
     );
 
-    if (i == -1 || state.allAssets[i].deviceAssetId != newAsset.deviceAssetId) {
-      _updateAssetsState([...state.allAssets, newAsset]);
+    if (i == -1 ||
+        state.allAssets[i].localId != newAsset.localId ||
+        state.allAssets[i].deviceId != newAsset.deviceId) {
+      await _updateAssetsState([...state.allAssets, newAsset]);
     } else {
+      // unify local/remote assets by replacing the
+      // local-only asset in the DB with a local&remote asset
+      final Asset? inDb = await _db.assets
+          .where()
+          .localIdDeviceIdEqualTo(newAsset.localId, newAsset.deviceId)
+          .findFirst();
+      if (inDb != null) {
+        newAsset.id = inDb.id;
+        newAsset.isLocal = inDb.isLocal;
+      }
+
       // order is important to keep all local-only assets at the beginning!
-      _updateAssetsState([
+      await _updateAssetsState([
         ...state.allAssets.slice(0, i),
         ...state.allAssets.slice(i + 1),
         newAsset,
       ]);
-      // TODO here is a place to unify local/remote assets by replacing the
-      // local-only asset in the state with a local&remote asset
+    }
+    try {
+      await _db.writeTxn(() => newAsset.put(_db));
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
     }
   }
 
-  deleteAssets(Set<Asset> deleteAssets) async {
+  Future<void> deleteAssets(Set<Asset> deleteAssets) async {
     _deleteInProgress = true;
     try {
+      _updateAssetsState(
+        state.allAssets.whereNot(deleteAssets.contains).toList(),
+      );
       final localDeleted = await _deleteLocalAssets(deleteAssets);
       final remoteDeleted = await _deleteRemoteAssets(deleteAssets);
-      final Set<String> deleted = HashSet();
-      deleted.addAll(localDeleted);
-      deleted.addAll(remoteDeleted);
-      if (deleted.isNotEmpty) {
-        _updateAssetsState(
-          state.allAssets.where((a) => !deleted.contains(a.id)).toList(),
-        );
+      if (localDeleted.isNotEmpty || remoteDeleted.isNotEmpty) {
+        final dbIds = deleteAssets.map((e) => e.id).toList();
+        await _db.writeTxn(() async {
+          await _db.exifInfos.deleteAll(dbIds);
+          await _db.assets.deleteAll(dbIds);
+        });
       }
     } finally {
       _deleteInProgress = false;
@@ -232,16 +183,15 @@ class AssetNotifier extends StateNotifier<AssetsState> {
   }
 
   Future<List<String>> _deleteLocalAssets(Set<Asset> assetsToDelete) async {
-    var deviceInfo = await _deviceInfoService.getDeviceInfo();
-    var deviceId = deviceInfo["deviceId"];
+    final int deviceId = Store.get(StoreKey.deviceIdHash);
     final List<String> local = [];
     // Delete asset from device
     for (final Asset asset in assetsToDelete) {
       if (asset.isLocal) {
-        local.add(asset.localId!);
+        local.add(asset.localId);
       } else if (asset.deviceId == deviceId) {
         // Delete asset on device if it is still present
-        var localAsset = await AssetEntity.fromId(asset.deviceAssetId);
+        var localAsset = await AssetEntity.fromId(asset.localId);
         if (localAsset != null) {
           local.add(localAsset.id);
         }
@@ -249,7 +199,7 @@ class AssetNotifier extends StateNotifier<AssetsState> {
     }
     if (local.isNotEmpty) {
       try {
-        return await PhotoManager.editor.deleteWithIds(local);
+        await PhotoManager.editor.deleteWithIds(local);
       } catch (e, stack) {
         log.severe("Failed to delete asset from device", e, stack);
       }
@@ -289,8 +239,9 @@ class AssetNotifier extends StateNotifier<AssetsState> {
 final assetProvider = StateNotifierProvider<AssetNotifier, AssetsState>((ref) {
   return AssetNotifier(
     ref.watch(assetServiceProvider),
-    ref.watch(assetCacheServiceProvider),
     ref.watch(appSettingsServiceProvider),
+    ref.watch(albumServiceProvider),
+    ref.watch(dbProvider),
   );
 });
 

--- a/mobile/lib/shared/services/api.service.dart
+++ b/mobile/lib/shared/services/api.service.dart
@@ -28,9 +28,13 @@ class ApiService {
       debugPrint("Cannot init ApiServer endpoint, userInfoBox not open yet.");
     }
   }
+  String? _authToken;
 
   setEndpoint(String endpoint) {
     _apiClient = ApiClient(basePath: endpoint);
+    if (_authToken != null) {
+      setAccessToken(_authToken!);
+    }
     userApi = UserApi(_apiClient);
     authenticationApi = AuthenticationApi(_apiClient);
     oAuthApi = OAuthApi(_apiClient);
@@ -94,6 +98,9 @@ class ApiService {
   }
 
   setAccessToken(String accessToken) {
+    _authToken = accessToken;
     _apiClient.addDefaultHeader('Authorization', 'Bearer $accessToken');
   }
+
+  ApiClient get apiClient => _apiClient;
 }

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -1,99 +1,196 @@
 import 'dart:async';
+import 'dart:collection';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/hive_box.dart';
-import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
-import 'package:immich_mobile/modules/backup/models/hive_backup_albums.model.dart';
-import 'package:immich_mobile/modules/backup/services/backup.service.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:immich_mobile/utils/diff.dart';
+import 'package:immich_mobile/utils/hash.dart';
 import 'package:immich_mobile/utils/openapi_extensions.dart';
 import 'package:immich_mobile/utils/tuple.dart';
+import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
+import 'package:photo_manager/photo_manager.dart';
 
 final assetServiceProvider = Provider(
   (ref) => AssetService(
     ref.watch(apiServiceProvider),
-    ref.watch(backupServiceProvider),
-    ref.watch(backgroundServiceProvider),
+    ref.watch(dbProvider),
   ),
 );
 
 class AssetService {
   final ApiService _apiService;
-  final BackupService _backupService;
-  final BackgroundService _backgroundService;
   final log = Logger('AssetService');
+  final Isar _db;
+  Completer<bool> _completer = Completer()..complete(false);
+  Future<void> _albumRemoteComplete = Future.value();
+  Future<void> _albumLocalComplete = Future.value();
 
-  AssetService(this._apiService, this._backupService, this._backgroundService);
+  AssetService(
+    this._apiService,
+    this._db,
+  );
+
+  Future<bool> refreshRemoteAssets() async {
+    if (!_completer.isCompleted) {
+      // guard against concurrent calls
+      return _completer.future;
+    }
+    _completer = Completer();
+    // guard against concurrent calls:
+    // AlbumService fetches remote assets from shared albums
+    await _albumRemoteComplete;
+    // AlbumServices reads local assets
+    await _albumLocalComplete;
+    final Stopwatch sw = Stopwatch()..start();
+    bool changes = false;
+    try {
+      changes = await _refreshRemoteAssets();
+    } finally {
+      _completer.complete(changes);
+    }
+    debugPrint("refreshRemoteAssets took ${sw.elapsedMilliseconds}ms");
+    return changes;
+  }
+
+  Future<bool> get assetRefreshComplete => _completer.future;
+
+  set albumRemoteComplete(Future<void> f) => _albumRemoteComplete = f;
+  set albumLocalComplete(Future<void> f) => _albumLocalComplete = f;
 
   /// Returns `null` if the server state did not change, else list of assets
-  Future<Pair<List<Asset>?, String?>> getRemoteAssets({String? etag}) async {
+  Future<List<AssetResponseDto>?> _getRemoteAssets({
+    required bool hasCache,
+  }) async {
     try {
-      // temporary fix for race condition that the _apiService
-      // get called before accessToken is set
-      var userInfoHiveBox = await Hive.openBox(userInfoBox);
-      var accessToken = userInfoHiveBox.get(accessTokenKey);
-      _apiService.setAccessToken(accessToken);
-
+      final etag = hasCache ? Store.get(StoreKey.assetETag) : null;
       final Pair<List<AssetResponseDto>, String?>? remote =
           await _apiService.assetApi.getAllAssetsWithETag(eTag: etag);
       if (remote == null) {
-        return Pair(null, etag);
+        return null;
       }
-      return Pair(
-        remote.first.map(Asset.remote).toList(growable: false),
-        remote.second,
-      );
+      if (remote.second != null && remote.second != etag) {
+        Store.put(StoreKey.assetETag, remote.second);
+      }
+      return remote.first;
     } catch (e, stack) {
       log.severe('Error while getting remote assets', e, stack);
-      debugPrint("[ERROR] [getRemoteAssets] $e");
-      return Pair(null, etag);
+      return null;
     }
   }
 
-  /// if [urgent] is `true`, do not block by waiting on the background service
-  /// to finish running. Returns `null` instead after a timeout.
-  Future<List<Asset>?> getLocalAssets({bool urgent = false}) async {
-    try {
-      final Future<bool> hasAccess = urgent
-          ? _backgroundService.hasAccess
-              .timeout(const Duration(milliseconds: 250))
-          : _backgroundService.hasAccess;
-      if (!await hasAccess) {
-        throw Exception("Error [getAllAsset] failed to gain access");
-      }
-      final box = await Hive.openBox<HiveBackupAlbums>(hiveBackupInfoBox);
-      final HiveBackupAlbums? backupAlbumInfo = box.get(backupInfoKey);
-      final String userId = Store.get(StoreKey.userRemoteId);
-      if (backupAlbumInfo != null) {
-        return (await _backupService
-                .buildUploadCandidates(backupAlbumInfo.deepCopy()))
-            .map((e) => Asset.local(e, userId))
-            .toList(growable: false);
-      }
-    } catch (e, stackTrace) {
-      log.severe('Error while getting local assets', e, stackTrace);
-      debugPrint("Error [_getLocalAssets] ${e.toString()}");
+  Future<bool> _refreshRemoteAssets() async {
+    final Stopwatch sw = Stopwatch()..start();
+    final int c = await _db.assets.where().remoteIdIsNotNull().count();
+    final List<AssetResponseDto>? dtos =
+        await _getRemoteAssets(hasCache: c > 0);
+    if (dtos == null) {
+      debugPrint("fetchRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
+      return false;
     }
-    return null;
+    final HashSet<String> existingRemoteIds = HashSet.from(
+      await _db.assets.where().remoteIdIsNotNull().remoteIdProperty().findAll(),
+    );
+    final String deviceId = Hive.box(userInfoBox).get(deviceIdKey);
+    final HashSet<String> existingLocalIds = HashSet.from(
+      await _db.assets
+          .filter()
+          .isLocalEqualTo(true)
+          .localIdProperty()
+          .findAll(),
+    );
+    final HashSet<String> allRemoteIds = HashSet.from(dtos.map((e) => e.id));
+
+    final List<Asset> assets = [];
+
+    for (AssetResponseDto dto in dtos) {
+      if (!existingRemoteIds.contains(dto.id)) {
+        if (dto.deviceId == deviceId &&
+            existingLocalIds.contains(dto.deviceAssetId)) {
+          // link to existing asset
+          Asset? a = await _db.assets
+              .where()
+              .localIdDeviceIdEqualTo(dto.deviceAssetId, fastHash(dto.deviceId))
+              .findFirst();
+          if (a != null) {
+            assets.add(a.withUpdatesFromDto(dto));
+            continue;
+          }
+        }
+        assets.add(Asset.remote(dto));
+      }
+    }
+
+    final deletedAssetIds = existingRemoteIds.difference(allRemoteIds);
+
+    if (assets.isEmpty && deletedAssetIds.isEmpty) {
+      debugPrint("fetchRemoteAssets medium took ${sw.elapsedMilliseconds}ms");
+      return false;
+    }
+    final exifInfos = assets.map((e) => e.exifInfo).whereNotNull().toList();
+    try {
+      await _db.writeTxn(() async {
+        if (deletedAssetIds.isNotEmpty) {
+          await _db.assets.deleteAllByRemoteId(deletedAssetIds);
+        }
+        if (assets.isNotEmpty) {
+          await _db.assets.putAll(assets);
+          for (final Asset added in assets) {
+            added.exifInfo?.id = added.id;
+          }
+          await _db.exifInfos.putAll(exifInfos);
+        }
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    debugPrint("fetchRemoteAssets full took ${sw.elapsedMilliseconds}ms");
+    return true;
   }
 
-  Future<Asset?> getAssetById(String assetId) async {
+  Future<void> addMissingRemoteAssetsToDb(
+    List<AssetResponseDto> remotes,
+  ) async {
+    final List<Asset> toAdd = [];
+    final List<String> inDb = (await _db.assets
+            .where()
+            .remoteIdIsNotNull()
+            .sortByRemoteId()
+            .remoteIdProperty()
+            .findAll())
+        .cast();
+    remotes.sort((a, b) => a.id.compareTo(b.id));
+    await diffSortedLists(
+      inDb,
+      remotes,
+      compare: (String a, AssetResponseDto b) => a.compareTo(b.id),
+      both: (a, b) => false,
+      onlyFirst: (a) {},
+      onlySecond: (AssetResponseDto b) => toAdd.add(Asset.remote(b)),
+    );
+    final exifInfos = toAdd.map((e) => e.exifInfo).whereNotNull().toList();
     try {
-      final dto = await _apiService.assetApi.getAssetById(assetId);
-      if (dto != null) {
-        return Asset.remote(dto);
-      }
-    } catch (e) {
-      debugPrint("Error [getAssetById]  ${e.toString()}");
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(toAdd);
+        for (final Asset added in toAdd) {
+          added.exifInfo?.id = added.id;
+        }
+        await _db.exifInfos.putAll(exifInfos);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
     }
-    return null;
   }
 
   Future<List<DeleteAssetResponseDto>?> deleteAssets(
@@ -111,6 +208,128 @@ class AssetService {
     } catch (e) {
       debugPrint("Error getAllAsset  ${e.toString()}");
       return null;
+    }
+  }
+
+  Future<Asset> loadExif(Asset a) async {
+    a.exifInfo ??= await _db.exifInfos.get(a.id);
+    if (a.exifInfo?.iso == null) {
+      if (a.isRemote) {
+        final dto = await _apiService.assetApi.getAssetById(a.remoteId!);
+        if (dto != null && dto.exifInfo != null) {
+          a = a.withUpdatesFromDto(dto);
+          if (a.isInDb) {
+            _db.writeTxn(() => a.put(_db));
+          } else {
+            debugPrint("[loadExif] parameter Asset is not from DB!");
+          }
+        }
+      } else {
+        // TODO implement local exif info parsing
+      }
+    }
+    return a;
+  }
+
+  /// Returns a tuple (toLink, toUpsert)
+  Future<Pair<List<Asset>, List<Asset>>> linkExistingToLocal(
+    List<AssetEntity> assets,
+  ) async {
+    if (assets.isEmpty) {
+      return const Pair([], []);
+    }
+    final int deviceId = Store.get(StoreKey.deviceIdHash);
+    final List<Asset> inDb = await _db.assets
+        .where()
+        .anyOf(
+          assets,
+          (q, AssetEntity a) => q.localIdDeviceIdEqualTo(a.id, deviceId),
+        )
+        .sortByLocalId()
+        .findAll();
+
+    assets.sort((a, b) => a.id.compareTo(b.id));
+
+    final List<Asset> existing = [];
+    final List<Asset> toUpsert = [];
+    await diffSortedLists(
+      inDb,
+      assets,
+      compare: (Asset a, AssetEntity b) => a.localId.compareTo(b.id),
+      both: (Asset a, AssetEntity b) {
+        if (a.isLocal) {
+          existing.add(a);
+        } else {
+          if (a.updateFromAssetEntity(b)) {
+            toUpsert.add(a);
+            return true;
+          }
+        }
+        return false;
+      },
+      onlyFirst: (Asset a) {},
+      onlySecond: (AssetEntity a) => toUpsert.add(Asset.local(a)),
+    );
+
+    return Pair(existing, toUpsert);
+  }
+
+  /// removes local assets from DB only if they are neither remote nor in another album
+  Future<void> handleLocalAssetRemoval(
+    List<Asset> deleteCandidates,
+    List<Asset> existing,
+  ) async {
+    if (deleteCandidates.isEmpty) {
+      return;
+    }
+    deleteCandidates.sort((a, b) => a.id.compareTo(b.id));
+    existing.sort((a, b) => a.id.compareTo(b.id));
+    final List<int> idsToDelete = [];
+    final List<Asset> toUpdate = [];
+    await diffSortedLists(
+      existing,
+      deleteCandidates,
+      compare: (Asset a, Asset b) => a.id.compareTo(b.id),
+      both: (Asset a, Asset b) => false,
+      onlyFirst: (Asset a) {},
+      onlySecond: (Asset b) {
+        if (b.isRemote) {
+          b.isLocal = false;
+          toUpdate.add(b);
+        } else {
+          idsToDelete.add(b.id);
+        }
+      },
+    );
+    if (idsToDelete.isNotEmpty || toUpdate.isNotEmpty) {
+      await _db.writeTxn(() async {
+        await _db.assets.deleteAll(idsToDelete);
+        await _db.assets.putAll(toUpdate);
+      });
+    }
+  }
+
+  /// removes remote shared assets from DB unless they exist in another shared album
+  Future<void> handleSharedAssetRemoval(
+    List<Asset> deleteCandidates,
+    List<Asset> existing,
+  ) async {
+    if (deleteCandidates.isEmpty) {
+      return;
+    }
+    deleteCandidates.sort((a, b) => a.id.compareTo(b.id));
+    existing.sort((a, b) => a.id.compareTo(b.id));
+    final List<int> idsToDelete = [];
+    await diffSortedLists(
+      existing,
+      deleteCandidates,
+      compare: (Asset a, Asset b) => a.id.compareTo(b.id),
+      both: (Asset a, Asset b) => false,
+      onlyFirst: (Asset a) {},
+      onlySecond: (Asset b) => idsToDelete.add(b.id),
+    );
+    if (idsToDelete.isNotEmpty) {
+      return _db.writeTxn(() => _db.assets.deleteAll(idsToDelete));
     }
   }
 

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -36,6 +36,8 @@ class AssetService {
     this._db,
   );
 
+  /// Checks the server for updated assets and updates the local database if
+  /// required. Returns `true` if there were any changes.
   Future<bool> refreshRemoteAssets() async {
     final Stopwatch sw = Stopwatch()..start();
     final int numOwnedRemoteAssets = await _db.assets
@@ -95,6 +97,8 @@ class AssetService {
     }
   }
 
+  /// Loads the exif information from the database. If there is none, loads
+  /// the exif info from the server (remote assets only)
   Future<Asset> loadExif(Asset a) async {
     a.exifInfo ??= await _db.exifInfos.get(a.id);
     if (a.exifInfo?.iso == null) {

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -1,72 +1,60 @@
 import 'dart:async';
-import 'dart:collection';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
-import 'package:immich_mobile/utils/diff.dart';
-import 'package:immich_mobile/utils/hash.dart';
+import 'package:immich_mobile/shared/services/sync.service.dart';
 import 'package:immich_mobile/utils/openapi_extensions.dart';
 import 'package:immich_mobile/utils/tuple.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
-import 'package:photo_manager/photo_manager.dart';
 
 final assetServiceProvider = Provider(
   (ref) => AssetService(
     ref.watch(apiServiceProvider),
+    ref.watch(syncServiceProvider),
     ref.watch(dbProvider),
   ),
 );
 
 class AssetService {
   final ApiService _apiService;
+  final SyncService _syncService;
   final log = Logger('AssetService');
   final Isar _db;
-  Completer<bool> _completer = Completer()..complete(false);
-  Future<void> _albumRemoteComplete = Future.value();
-  Future<void> _albumLocalComplete = Future.value();
 
   AssetService(
     this._apiService,
+    this._syncService,
     this._db,
   );
 
   Future<bool> refreshRemoteAssets() async {
-    if (!_completer.isCompleted) {
-      // guard against concurrent calls
-      return _completer.future;
-    }
-    _completer = Completer();
-    // guard against concurrent calls:
-    // AlbumService fetches remote assets from shared albums
-    await _albumRemoteComplete;
-    // AlbumServices reads local assets
-    await _albumLocalComplete;
     final Stopwatch sw = Stopwatch()..start();
-    bool changes = false;
-    try {
-      changes = await _refreshRemoteAssets();
-    } finally {
-      _completer.complete(changes);
+    final int numOwnedRemoteAssets = await _db.assets
+        .where()
+        .remoteIdIsNotNull()
+        .filter()
+        .ownerIdEqualTo(Store.get<User>(StoreKey.currentUser)!.isarId)
+        .count();
+    final List<AssetResponseDto>? dtos =
+        await _getRemoteAssets(hasCache: numOwnedRemoteAssets > 0);
+    if (dtos == null) {
+      debugPrint("fetchRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
+      return false;
     }
-    debugPrint("refreshRemoteAssets took ${sw.elapsedMilliseconds}ms");
+    final bool changes = await _syncService
+        .syncRemoteAssetsToDb(dtos.map(Asset.remote).toList());
+    debugPrint("fetchRemoteAssets full took ${sw.elapsedMilliseconds}ms");
     return changes;
   }
-
-  Future<bool> get assetRefreshComplete => _completer.future;
-
-  set albumRemoteComplete(Future<void> f) => _albumRemoteComplete = f;
-  set albumLocalComplete(Future<void> f) => _albumLocalComplete = f;
 
   /// Returns `null` if the server state did not change, else list of assets
   Future<List<AssetResponseDto>?> _getRemoteAssets({
@@ -86,110 +74,6 @@ class AssetService {
     } catch (e, stack) {
       log.severe('Error while getting remote assets', e, stack);
       return null;
-    }
-  }
-
-  Future<bool> _refreshRemoteAssets() async {
-    final Stopwatch sw = Stopwatch()..start();
-    final int c = await _db.assets.where().remoteIdIsNotNull().count();
-    final List<AssetResponseDto>? dtos =
-        await _getRemoteAssets(hasCache: c > 0);
-    if (dtos == null) {
-      debugPrint("fetchRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
-      return false;
-    }
-    final HashSet<String> existingRemoteIds = HashSet.from(
-      await _db.assets.where().remoteIdIsNotNull().remoteIdProperty().findAll(),
-    );
-    final String deviceId = Hive.box(userInfoBox).get(deviceIdKey);
-    final HashSet<String> existingLocalIds = HashSet.from(
-      await _db.assets
-          .filter()
-          .isLocalEqualTo(true)
-          .localIdProperty()
-          .findAll(),
-    );
-    final HashSet<String> allRemoteIds = HashSet.from(dtos.map((e) => e.id));
-
-    final List<Asset> assets = [];
-
-    for (AssetResponseDto dto in dtos) {
-      if (!existingRemoteIds.contains(dto.id)) {
-        if (dto.deviceId == deviceId &&
-            existingLocalIds.contains(dto.deviceAssetId)) {
-          // link to existing asset
-          Asset? a = await _db.assets
-              .where()
-              .localIdDeviceIdEqualTo(dto.deviceAssetId, fastHash(dto.deviceId))
-              .findFirst();
-          if (a != null) {
-            assets.add(a.withUpdatesFromDto(dto));
-            continue;
-          }
-        }
-        assets.add(Asset.remote(dto));
-      }
-    }
-
-    final deletedAssetIds = existingRemoteIds.difference(allRemoteIds);
-
-    if (assets.isEmpty && deletedAssetIds.isEmpty) {
-      debugPrint("fetchRemoteAssets medium took ${sw.elapsedMilliseconds}ms");
-      return false;
-    }
-    final exifInfos = assets.map((e) => e.exifInfo).whereNotNull().toList();
-    try {
-      await _db.writeTxn(() async {
-        if (deletedAssetIds.isNotEmpty) {
-          await _db.assets.deleteAllByRemoteId(deletedAssetIds);
-        }
-        if (assets.isNotEmpty) {
-          await _db.assets.putAll(assets);
-          for (final Asset added in assets) {
-            added.exifInfo?.id = added.id;
-          }
-          await _db.exifInfos.putAll(exifInfos);
-        }
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
-    }
-
-    debugPrint("fetchRemoteAssets full took ${sw.elapsedMilliseconds}ms");
-    return true;
-  }
-
-  Future<void> addMissingRemoteAssetsToDb(
-    List<AssetResponseDto> remotes,
-  ) async {
-    final List<Asset> toAdd = [];
-    final List<String> inDb = (await _db.assets
-            .where()
-            .remoteIdIsNotNull()
-            .sortByRemoteId()
-            .remoteIdProperty()
-            .findAll())
-        .cast();
-    remotes.sort((a, b) => a.id.compareTo(b.id));
-    await diffSortedLists(
-      inDb,
-      remotes,
-      compare: (String a, AssetResponseDto b) => a.compareTo(b.id),
-      both: (a, b) => false,
-      onlyFirst: (a) {},
-      onlySecond: (AssetResponseDto b) => toAdd.add(Asset.remote(b)),
-    );
-    final exifInfos = toAdd.map((e) => e.exifInfo).whereNotNull().toList();
-    try {
-      await _db.writeTxn(() async {
-        await _db.assets.putAll(toAdd);
-        for (final Asset added in toAdd) {
-          added.exifInfo?.id = added.id;
-        }
-        await _db.exifInfos.putAll(exifInfos);
-      });
-    } on IsarError catch (e) {
-      debugPrint(e.toString());
     }
   }
 
@@ -229,108 +113,6 @@ class AssetService {
       }
     }
     return a;
-  }
-
-  /// Returns a tuple (toLink, toUpsert)
-  Future<Pair<List<Asset>, List<Asset>>> linkExistingToLocal(
-    List<AssetEntity> assets,
-  ) async {
-    if (assets.isEmpty) {
-      return const Pair([], []);
-    }
-    final int deviceId = Store.get(StoreKey.deviceIdHash);
-    final List<Asset> inDb = await _db.assets
-        .where()
-        .anyOf(
-          assets,
-          (q, AssetEntity a) => q.localIdDeviceIdEqualTo(a.id, deviceId),
-        )
-        .sortByLocalId()
-        .findAll();
-
-    assets.sort((a, b) => a.id.compareTo(b.id));
-
-    final List<Asset> existing = [];
-    final List<Asset> toUpsert = [];
-    await diffSortedLists(
-      inDb,
-      assets,
-      compare: (Asset a, AssetEntity b) => a.localId.compareTo(b.id),
-      both: (Asset a, AssetEntity b) {
-        if (a.isLocal) {
-          existing.add(a);
-        } else {
-          if (a.updateFromAssetEntity(b)) {
-            toUpsert.add(a);
-            return true;
-          }
-        }
-        return false;
-      },
-      onlyFirst: (Asset a) {},
-      onlySecond: (AssetEntity a) => toUpsert.add(Asset.local(a)),
-    );
-
-    return Pair(existing, toUpsert);
-  }
-
-  /// removes local assets from DB only if they are neither remote nor in another album
-  Future<void> handleLocalAssetRemoval(
-    List<Asset> deleteCandidates,
-    List<Asset> existing,
-  ) async {
-    if (deleteCandidates.isEmpty) {
-      return;
-    }
-    deleteCandidates.sort((a, b) => a.id.compareTo(b.id));
-    existing.sort((a, b) => a.id.compareTo(b.id));
-    final List<int> idsToDelete = [];
-    final List<Asset> toUpdate = [];
-    await diffSortedLists(
-      existing,
-      deleteCandidates,
-      compare: (Asset a, Asset b) => a.id.compareTo(b.id),
-      both: (Asset a, Asset b) => false,
-      onlyFirst: (Asset a) {},
-      onlySecond: (Asset b) {
-        if (b.isRemote) {
-          b.isLocal = false;
-          toUpdate.add(b);
-        } else {
-          idsToDelete.add(b.id);
-        }
-      },
-    );
-    if (idsToDelete.isNotEmpty || toUpdate.isNotEmpty) {
-      await _db.writeTxn(() async {
-        await _db.assets.deleteAll(idsToDelete);
-        await _db.assets.putAll(toUpdate);
-      });
-    }
-  }
-
-  /// removes remote shared assets from DB unless they exist in another shared album
-  Future<void> handleSharedAssetRemoval(
-    List<Asset> deleteCandidates,
-    List<Asset> existing,
-  ) async {
-    if (deleteCandidates.isEmpty) {
-      return;
-    }
-    deleteCandidates.sort((a, b) => a.id.compareTo(b.id));
-    existing.sort((a, b) => a.id.compareTo(b.id));
-    final List<int> idsToDelete = [];
-    await diffSortedLists(
-      existing,
-      deleteCandidates,
-      compare: (Asset a, Asset b) => a.id.compareTo(b.id),
-      both: (Asset a, Asset b) => false,
-      onlyFirst: (Asset a) {},
-      onlySecond: (Asset b) => idsToDelete.add(b.id),
-    );
-    if (idsToDelete.isNotEmpty) {
-      return _db.writeTxn(() => _db.assets.deleteAll(idsToDelete));
-    }
   }
 
   Future<Asset?> updateAsset(

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -49,12 +49,12 @@ class AssetService {
     final List<AssetResponseDto>? dtos =
         await _getRemoteAssets(hasCache: numOwnedRemoteAssets > 0);
     if (dtos == null) {
-      debugPrint("fetchRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
+      debugPrint("refreshRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
       return false;
     }
     final bool changes = await _syncService
         .syncRemoteAssetsToDb(dtos.map(Asset.remote).toList());
-    debugPrint("fetchRemoteAssets full took ${sw.elapsedMilliseconds}ms");
+    debugPrint("refreshRemoteAssets full took ${sw.elapsedMilliseconds}ms");
     return changes;
   }
 

--- a/mobile/lib/shared/services/asset_cache.service.dart
+++ b/mobile/lib/shared/services/asset_cache.service.dart
@@ -1,41 +1,13 @@
-import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/services/json_cache.dart';
 
+@Deprecated("only kept to remove its files after migration")
 class AssetCacheService extends JsonCache<List<Asset>> {
   AssetCacheService() : super("asset_cache");
 
-  static Future<List<Map<String, dynamic>>> _computeSerialize(
-    List<Asset> assets,
-  ) async {
-    return assets.map((e) => e.toJson()).toList();
-  }
+  @override
+  void put(List<Asset> data) {}
 
   @override
-  void put(List<Asset> data) async {
-    putRawData(await compute(_computeSerialize, data));
-  }
-
-  static Future<List<Asset>> _computeEncode(List<dynamic> data) async {
-    return data.map((e) => Asset.fromJson(e)).whereNotNull().toList();
-  }
-
-  @override
-  Future<List<Asset>?> get() async {
-    try {
-      final mapList = await readRawData() as List<dynamic>;
-      final responseData = await compute(_computeEncode, mapList);
-      return responseData;
-    } catch (e) {
-      debugPrint(e.toString());
-      await invalidate();
-      return null;
-    }
-  }
+  Future<List<Asset>?> get() => Future.value(null);
 }
-
-final assetCacheServiceProvider = Provider(
-  (ref) => AssetCacheService(),
-);

--- a/mobile/lib/shared/services/json_cache.dart
+++ b/mobile/lib/shared/services/json_cache.dart
@@ -1,9 +1,8 @@
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
+@Deprecated("only kept to remove its files after migration")
 abstract class JsonCache<T> {
   final String cacheFileName;
 
@@ -30,33 +29,6 @@ abstract class JsonCache<T> {
     } on FileSystemException {
       // file is already deleted
     }
-  }
-
-  static Future<String> _computeEncodeJson(dynamic toEncode) async {
-    return json.encode(toEncode);
-  }
-
-  Future<void> putRawData(dynamic data) async {
-    final jsonString = await compute(_computeEncodeJson, data);
-
-    final file = await _getCacheFile();
-
-    if (!await file.exists()) {
-      await file.create();
-    }
-
-    await file.writeAsString(jsonString);
-  }
-
-  static Future<dynamic> _computeDecodeJson(String jsonString) async {
-    return json.decode(jsonString);
-  }
-
-  Future<dynamic> readRawData() async {
-    final file = await _getCacheFile();
-    final data = await file.readAsString();
-
-    return await compute(_computeDecodeJson, data);
   }
 
   void put(T data);

--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -1,0 +1,587 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
+import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
+import 'package:immich_mobile/utils/diff.dart';
+import 'package:immich_mobile/utils/tuple.dart';
+import 'package:isar/isar.dart';
+import 'package:openapi/api.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+final syncServiceProvider =
+    Provider((ref) => SyncService(ref.watch(dbProvider)));
+
+class SyncService {
+  final Isar _db;
+  Completer<bool> _remoteAlbumCompleter = Completer()..complete(false);
+  Completer<bool> _remoteAssetCompleter = Completer()..complete(false);
+  Completer<bool> _deviceCompleter = Completer()..complete(false);
+
+  SyncService(this._db);
+
+  // public methods:
+
+  /// Syncs users from the server to the local database
+  /// Returns `true`if there were any changes
+  Future<bool> syncUsersFromServer(List<User> users) async {
+    users.sortBy((u) => u.id);
+    final dbUsers = await _db.users.where().sortById().findAll();
+    final List<int> toDelete = [];
+    final List<User> toUpsert = [];
+    final changes = diffSortedListsSync(
+      users,
+      dbUsers,
+      compare: (User a, User b) => a.id.compareTo(b.id),
+      both: (User a, User b) {
+        if (a.updatedAt != b.updatedAt) {
+          toUpsert.add(a);
+          return true;
+        }
+        return false;
+      },
+      onlyFirst: (User a) => toUpsert.add(a),
+      onlySecond: (User b) => toDelete.add(b.isarId),
+    );
+    if (changes) {
+      await _db.writeTxn(() async {
+        await _db.users.deleteAll(toDelete);
+        await _db.users.putAll(toUpsert);
+      });
+    }
+    return changes;
+  }
+
+  /// Syncs remote assets owned by the logged-in user to the DB
+  /// Returns `true` if there were any changes
+  Future<bool> syncRemoteAssetsToDb(List<Asset> remote) async {
+    if (!_remoteAssetCompleter.isCompleted) {
+      return _remoteAssetCompleter.future;
+    }
+    _remoteAssetCompleter = Completer();
+    bool changes = false;
+    try {
+      changes = await _syncRemoteAssetsToDb(remote);
+    } finally {
+      _remoteAssetCompleter.complete(changes);
+    }
+    return changes;
+  }
+
+  /// Syncs remote albums to the database
+  /// returns `true` if there were any changes
+  Future<bool> syncRemoteAlbumsToDb(
+    List<AlbumResponseDto> remote, {
+    required bool isShared,
+    required FutureOr<AlbumResponseDto> Function(AlbumResponseDto) loadDetails,
+  }) async {
+    if (!_remoteAlbumCompleter.isCompleted) {
+      return _remoteAlbumCompleter.future;
+    }
+    _remoteAlbumCompleter = Completer();
+    bool changes = false;
+    try {
+      changes = await _syncRemoteAlbumsToDb(
+        remote,
+        isShared: isShared,
+        loadDetails: loadDetails,
+      );
+    } finally {
+      _remoteAlbumCompleter.complete(changes);
+    }
+    return changes;
+  }
+
+  /// Syncs all device albums and their assets to the database
+  /// Returns `true` if there were any changes
+  Future<bool> syncLocalAlbumAssetsToDb(List<AssetPathEntity> onDevice) async {
+    if (!_deviceCompleter.isCompleted) {
+      return _deviceCompleter.future;
+    }
+    _deviceCompleter = Completer();
+    bool changes = false;
+    try {
+      changes = await _syncLocalAlbumAssetsToDb(onDevice);
+    } finally {
+      _deviceCompleter.complete(changes);
+    }
+    return changes;
+  }
+
+  /// returns all Asset IDs that are not contained in the existing list
+  List<int> sharedAssetsToRemove(
+    List<Asset> deleteCandidates,
+    List<Asset> existing,
+  ) {
+    if (deleteCandidates.isEmpty) {
+      return [];
+    }
+    deleteCandidates.sort(Asset.compareById);
+    existing.sort(Asset.compareById);
+    return _diffAssets(existing, deleteCandidates, compare: Asset.compareById)
+        .third
+        .map((e) => e.id)
+        .toList();
+  }
+
+  // private methods:
+
+  /// Syncs remote assets to the databas
+  /// returns `true` if there were any changes
+  Future<bool> _syncRemoteAssetsToDb(List<Asset> remote) async {
+    final User user = Store.get(StoreKey.currentUser);
+    final List<Asset> inDb = await _db.assets
+        .filter()
+        .ownerIdEqualTo(user.isarId)
+        .sortByDeviceId()
+        .thenByLocalId()
+        .findAll();
+    remote.sort(Asset.compareByDeviceIdLocalId);
+    final diff = _diffAssets(remote, inDb, remote: true);
+    if (diff.first.isEmpty && diff.second.isEmpty && diff.third.isEmpty) {
+      return false;
+    }
+    final idsToDelete = diff.third.map((e) => e.id).toList();
+    try {
+      await _db.writeTxn(() => _db.assets.deleteAll(idsToDelete));
+      await _upsertAssetsWithExif(diff.first + diff.second);
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+    return true;
+  }
+
+  /// Syncs remote albums to the database
+  /// returns `true` if there were any changes
+  Future<bool> _syncRemoteAlbumsToDb(
+    List<AlbumResponseDto> remote, {
+    required bool isShared,
+    required FutureOr<AlbumResponseDto> Function(AlbumResponseDto) loadDetails,
+  }) async {
+    remote.sortBy((e) => e.id);
+
+    final baseQuery = _db.albums.where().remoteIdIsNotNull().filter();
+    final QueryBuilder<Album, Album, QAfterFilterCondition> query;
+    if (isShared) {
+      query = baseQuery.sharedEqualTo(true);
+    } else {
+      final User me = Store.get(StoreKey.currentUser);
+      query = baseQuery.owner((q) => q.isarIdEqualTo(me.isarId));
+    }
+    final List<Album> dbAlbums = await query.sortByRemoteId().findAll();
+
+    final List<Asset> toDelete = [];
+    final List<Asset> existing = [];
+
+    final bool changes = await diffSortedLists(
+      remote,
+      dbAlbums,
+      compare: (AlbumResponseDto a, Album b) => a.id.compareTo(b.remoteId!),
+      both: (AlbumResponseDto a, Album b) =>
+          _syncRemoteAlbum(a, b, toDelete, existing, loadDetails),
+      onlyFirst: (AlbumResponseDto a) async =>
+          _addAlbumFromServer(await loadDetails(a), existing),
+      onlySecond: (Album a) => _removeAlbumFromDb(a, toDelete),
+    );
+
+    if (isShared && toDelete.isNotEmpty) {
+      final List<int> idsToRemove = sharedAssetsToRemove(toDelete, existing);
+      if (idsToRemove.isNotEmpty) {
+        await _db.writeTxn(() => _db.assets.deleteAll(idsToRemove));
+      }
+    } else {
+      assert(toDelete.isEmpty);
+    }
+    return changes;
+  }
+
+  /// syncs albums from the server to the local database (does not support
+  /// syncing changes from local back to server)
+  /// accumulates
+  Future<bool> _syncRemoteAlbum(
+    AlbumResponseDto dto,
+    Album album,
+    List<Asset> deleteCandidates,
+    List<Asset> existing,
+    FutureOr<AlbumResponseDto> Function(AlbumResponseDto) loadDetails,
+  ) async {
+    if (!_hasAlbumResponseDtoChanged(dto, album)) {
+      return false;
+    }
+    dto = await loadDetails(dto);
+    if (dto.assetCount != dto.assets.length) {
+      return false;
+    }
+    final assetsInDb =
+        await album.assets.filter().sortByDeviceId().thenByLocalId().findAll();
+    final List<Asset> assetsOnRemote = dto.getAssets();
+    assetsOnRemote.sort(Asset.compareByDeviceIdLocalId);
+    final d = _diffAssets(assetsOnRemote, assetsInDb);
+    final List<Asset> toAdd = d.first, toUpdate = d.second, toUnlink = d.third;
+
+    // update shared users
+    final List<User> sharedUsers = album.sharedUsers.toList(growable: false);
+    sharedUsers.sort((a, b) => a.id.compareTo(b.id));
+    dto.sharedUsers.sort((a, b) => a.id.compareTo(b.id));
+    final List<String> userIdsToAdd = [];
+    final List<User> usersToUnlink = [];
+    diffSortedListsSync(
+      dto.sharedUsers,
+      sharedUsers,
+      compare: (UserResponseDto a, User b) => a.id.compareTo(b.id),
+      both: (a, b) => false,
+      onlyFirst: (UserResponseDto a) => userIdsToAdd.add(a.id),
+      onlySecond: (User a) => usersToUnlink.add(a),
+    );
+
+    // for shared album: put missing album assets into local DB
+    final resultPair = await _linkWithExistingFromDb(toAdd);
+    await _upsertAssetsWithExif(resultPair.second);
+    final assetsToLink = resultPair.first + resultPair.second;
+    final usersToLink = (await _db.users.getAllById(userIdsToAdd)).cast<User>();
+
+    album.name = dto.albumName;
+    album.shared = dto.shared;
+    album.modifiedAt = DateTime.parse(dto.updatedAt).toUtc();
+    if (album.thumbnail.value?.remoteId != dto.albumThumbnailAssetId) {
+      album.thumbnail.value = await _db.assets
+          .where()
+          .remoteIdEqualTo(dto.albumThumbnailAssetId)
+          .findFirst();
+    }
+
+    // write & commit all changes to DB
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(toUpdate);
+        await album.thumbnail.save();
+        await album.sharedUsers
+            .update(link: usersToLink, unlink: usersToUnlink);
+        await album.assets.update(link: assetsToLink, unlink: toUnlink.cast());
+        await _db.albums.put(album);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    if (album.shared || dto.shared) {
+      final userId = Store.get<User>(StoreKey.currentUser)!.isarId;
+      final foreign =
+          await album.assets.filter().not().ownerIdEqualTo(userId).findAll();
+      existing.addAll(foreign);
+
+      // delete assets in DB unless they belong to this user or part of some other shared album
+      deleteCandidates.addAll(toUnlink.where((a) => a.ownerId != userId));
+    }
+
+    return true;
+  }
+
+  /// Adds a remote album to the database while making sure to add any foreign
+  /// (shared) assets to the database beforehand
+  /// accumulates assets already existing in the database
+  Future<void> _addAlbumFromServer(
+    AlbumResponseDto dto,
+    List<Asset> existing,
+  ) async {
+    if (dto.assetCount == dto.assets.length) {
+      if (dto.shared) {
+        // shared album: put missing album assets into local DB
+        final result = await _linkWithExistingFromDb(dto.getAssets());
+        existing.addAll(result.first);
+        await _upsertAssetsWithExif(result.second);
+      }
+      final Album a = await Album.remote(dto);
+      await _db.writeTxn(() => _db.albums.store(a));
+    }
+  }
+
+  /// Accumulates all suitable album assets to the `deleteCandidates` and
+  /// removes the album from the database.
+  Future<void> _removeAlbumFromDb(
+    Album album,
+    List<Asset> deleteCandidates,
+  ) async {
+    if (album.isLocal) {
+      // delete assets in DB unless they are remote or part of some other album
+      deleteCandidates.addAll(
+        await album.assets.filter().remoteIdIsNull().findAll(),
+      );
+    } else if (album.shared) {
+      final User user = Store.get(StoreKey.currentUser);
+      // delete assets in DB unless they belong to this user or are part of some other shared album
+      deleteCandidates.addAll(
+        await album.assets.filter().not().ownerIdEqualTo(user.isarId).findAll(),
+      );
+    }
+    final bool ok = await _db.writeTxn(() => _db.albums.delete(album.id));
+    assert(ok);
+  }
+
+  /// Syncs all device albums and their assets to the database
+  /// Returns `true` if there were any changes
+  Future<bool> _syncLocalAlbumAssetsToDb(List<AssetPathEntity> onDevice) async {
+    onDevice.sort((a, b) => a.id.compareTo(b.id));
+    final List<Album> inDb =
+        await _db.albums.where().localIdIsNotNull().sortByLocalId().findAll();
+    final List<Asset> deleteCandidates = [];
+    final List<Asset> existing = [];
+    final bool anyChanges = await diffSortedLists(
+      onDevice,
+      inDb,
+      compare: (AssetPathEntity a, Album b) => a.id.compareTo(b.localId!),
+      both: (AssetPathEntity ape, Album album) =>
+          _syncAlbumInDbAndOnDevice(ape, album, deleteCandidates, existing),
+      onlyFirst: (AssetPathEntity ape) => _addAlbumFromDevice(ape, existing),
+      onlySecond: (Album a) => _removeAlbumFromDb(a, deleteCandidates),
+    );
+    final pair = _handleAssetRemoval(deleteCandidates, existing);
+    if (pair.first.isNotEmpty || pair.second.isNotEmpty) {
+      await _db.writeTxn(() async {
+        await _db.assets.deleteAll(pair.first);
+        await _db.assets.putAll(pair.second);
+      });
+    }
+    return anyChanges;
+  }
+
+  /// Syncs the device album to the album in the database
+  /// returns `true` if there were any changes
+  /// Accumulates asset candidates to delete and those already existing in DB
+  Future<bool> _syncAlbumInDbAndOnDevice(
+    AssetPathEntity ape,
+    Album album,
+    List<Asset> deleteCandidates,
+    List<Asset> existing, [
+    bool forceRefresh = false,
+  ]) async {
+    if (!forceRefresh && !await _hasAssetPathEntityChanged(ape, album)) {
+      return false;
+    }
+    if (!forceRefresh && await _syncDeviceAlbumFast(ape, album)) {
+      return true;
+    }
+
+    // general case, e.g. some assets have been deleted
+    final inDb = await album.assets.filter().sortByLocalId().findAll();
+    final List<Asset> onDevice = await ape.getAssets();
+    onDevice.sort(Asset.compareByLocalId);
+    final d = _diffAssets(onDevice, inDb, compare: Asset.compareByLocalId);
+    final List<Asset> toAdd = d.first, toUpdate = d.second, toDelete = d.third;
+    final result = await _linkWithExistingFromDb(toAdd);
+    deleteCandidates.addAll(toDelete);
+    existing.addAll(result.first);
+    album.name = ape.name;
+    album.modifiedAt = ape.lastModified!;
+    album.thumbnail.value ??= album.assets.firstOrNull;
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(result.second);
+        await _db.assets.putAll(toUpdate);
+        await album.assets
+            .update(link: result.first + result.second, unlink: toDelete);
+        await _db.albums.put(album);
+        await album.thumbnail.save();
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return true;
+  }
+
+  /// fast path for common case: only new assets were added to device album
+  /// returns `true` if successfull, else `false`
+  Future<bool> _syncDeviceAlbumFast(AssetPathEntity ape, Album album) async {
+    final int totalOnDevice = await ape.assetCountAsync;
+    final AssetPathEntity? modified = totalOnDevice > album.assetCount
+        ? await ape.fetchPathProperties(
+            filterOptionGroup: FilterOptionGroup(
+              updateTimeCond: DateTimeCond(
+                min: album.modifiedAt.add(const Duration(seconds: 1)),
+                max: ape.lastModified!,
+              ),
+            ),
+          )
+        : null;
+    if (modified == null) {
+      return false;
+    }
+    final List<Asset> newAssets = await modified.getAssets();
+    if (totalOnDevice != album.assets.length + newAssets.length) {
+      return false;
+    }
+    album.modifiedAt = ape.lastModified!.toUtc();
+    final result = await _linkWithExistingFromDb(newAssets);
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(result.second);
+        await album.assets.update(link: result.first + result.second);
+        await _db.albums.put(album);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+
+    return true;
+  }
+
+  /// Adds a new album from the device to the database and Accumulates all
+  /// assets already existing in the database to the list of `existing` assets
+  Future<void> _addAlbumFromDevice(
+    AssetPathEntity ape,
+    List<Asset> existing,
+  ) async {
+    final Album a = Album.local(ape);
+    final result = await _linkWithExistingFromDb(await ape.getAssets());
+    await _upsertAssetsWithExif(result.second);
+    existing.addAll(result.first);
+    a.assets.addAll(result.first);
+    a.assets.addAll(result.second);
+    a.thumbnail.value = a.assets.firstOrNull;
+    try {
+      await _db.writeTxn(() => _db.albums.store(a));
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+
+  /// Returns a tuple (existing, updated)
+  Future<Pair<List<Asset>, List<Asset>>> _linkWithExistingFromDb(
+    List<Asset> assets,
+  ) async {
+    if (assets.isEmpty) {
+      return const Pair([], []);
+    }
+    final List<Asset> inDb = await _db.assets
+        .where()
+        .anyOf(
+          assets,
+          (q, Asset e) => q.localIdDeviceIdEqualTo(e.localId, e.deviceId),
+        )
+        .sortByDeviceId()
+        .thenByLocalId()
+        .findAll();
+    assets.sort(Asset.compareByDeviceIdLocalId);
+    final List<Asset> existing = [], toUpsert = [];
+    diffSortedListsSync(
+      inDb,
+      assets,
+      compare: Asset.compareByDeviceIdLocalId,
+      both: (Asset a, Asset b) {
+        if ((a.isLocal || !b.isLocal) &&
+            (a.isRemote || !b.isRemote) &&
+            a.updatedAt == b.updatedAt) {
+          existing.add(a);
+          return false;
+        } else {
+          toUpsert.add(b.updateFromDb(a));
+          return true;
+        }
+      },
+      onlyFirst: (Asset a) => throw Exception("programming error"),
+      onlySecond: (Asset b) => toUpsert.add(b),
+    );
+    return Pair(existing, toUpsert);
+  }
+
+  /// Inserts or updates the assets in the database with their ExifInfo (if any)
+  Future<void> _upsertAssetsWithExif(List<Asset> assets) async {
+    if (assets.isEmpty) {
+      return;
+    }
+    final exifInfos = assets.map((e) => e.exifInfo).whereNotNull().toList();
+    try {
+      await _db.writeTxn(() async {
+        await _db.assets.putAll(assets);
+        for (final Asset added in assets) {
+          added.exifInfo?.id = added.id;
+        }
+        await _db.exifInfos.putAll(exifInfos);
+      });
+    } on IsarError catch (e) {
+      debugPrint(e.toString());
+    }
+  }
+}
+
+/// Returns a triple(toAdd, toUpdate, toRemove)
+Triple<List<Asset>, List<Asset>, List<Asset>> _diffAssets(
+  List<Asset> assets,
+  List<Asset> inDb, {
+  bool? remote,
+  int Function(Asset, Asset) compare = Asset.compareByDeviceIdLocalId,
+}) {
+  final List<Asset> toAdd = [];
+  final List<Asset> toUpdate = [];
+  final List<Asset> toRemove = [];
+  diffSortedListsSync(
+    inDb,
+    assets,
+    compare: compare,
+    both: (Asset a, Asset b) {
+      if (a.updatedAt.isBefore(b.updatedAt) ||
+          (!a.isLocal && b.isLocal) ||
+          (!a.isRemote && b.isRemote)) {
+        toUpdate.add(b.updateFromDb(a));
+        debugPrint("both");
+        return true;
+      }
+      return false;
+    },
+    onlyFirst: (Asset a) {
+      if (remote == true && a.isLocal) {
+        if (a.remoteId != null) {
+          a.remoteId = null;
+          toUpdate.add(a);
+        }
+      } else if (remote == false && a.isRemote) {
+        if (a.isLocal) {
+          a.isLocal = false;
+          toUpdate.add(a);
+        }
+      } else {
+        toRemove.add(a);
+      }
+    },
+    onlySecond: (Asset b) => toAdd.add(b),
+  );
+  return Triple(toAdd, toUpdate, toRemove);
+}
+
+/// returns a tuple (toDelete toUpdate) when assets are to be deleted
+Pair<List<int>, List<Asset>> _handleAssetRemoval(
+  List<Asset> deleteCandidates,
+  List<Asset> existing,
+) {
+  if (deleteCandidates.isEmpty) {
+    return const Pair([], []);
+  }
+  deleteCandidates.sort(Asset.compareById);
+  existing.sort(Asset.compareById);
+  final triple =
+      _diffAssets(existing, deleteCandidates, compare: Asset.compareById);
+  return Pair(triple.third.map((e) => e.id).toList(), triple.second);
+}
+
+/// returns `true` if the albums differ on the surface
+Future<bool> _hasAssetPathEntityChanged(AssetPathEntity a, Album b) async {
+  return a.name != b.name ||
+      a.lastModified != b.modifiedAt ||
+      await a.assetCountAsync != b.assetCount;
+}
+
+/// returns `true` if the albums differ on the surface
+bool _hasAlbumResponseDtoChanged(AlbumResponseDto dto, Album a) {
+  return dto.assetCount != a.assetCount ||
+      dto.albumName != a.name ||
+      dto.albumThumbnailAssetId != a.thumbnail.value?.remoteId ||
+      dto.shared != a.shared ||
+      DateTime.parse(dto.updatedAt).toUtc() != a.modifiedAt.toUtc();
+}

--- a/mobile/lib/shared/services/user.service.dart
+++ b/mobile/lib/shared/services/user.service.dart
@@ -1,26 +1,33 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:immich_mobile/utils/diff.dart';
 import 'package:immich_mobile/utils/files_helper.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 
 final userServiceProvider = Provider(
   (ref) => UserService(
     ref.watch(apiServiceProvider),
+    ref.watch(dbProvider),
   ),
 );
 
 class UserService {
   final ApiService _apiService;
+  final Isar _db;
 
-  UserService(this._apiService);
+  UserService(this._apiService, this._db);
 
-  Future<List<User>?> getAllUsers({required bool isAll}) async {
+  Future<List<User>?> _getAllUsers({required bool isAll}) async {
     try {
       final dto = await _apiService.userApi.getAllUsers(isAll);
       return dto?.map(User.fromDto).toList();
@@ -28,6 +35,14 @@ class UserService {
       debugPrint("Error [getAllUsersInfo]  ${e.toString()}");
       return null;
     }
+  }
+
+  Future<List<User>> getUsersInDb({bool self = false}) async {
+    if (self) {
+      return _db.users.where().findAll();
+    }
+    final int userId = Store.get<User>(StoreKey.currentUser)!.isarId;
+    return _db.users.where().isarIdNotEqualTo(userId).findAll();
   }
 
   Future<CreateProfileImageResponseDto?> uploadProfileImage(XFile image) async {
@@ -48,6 +63,37 @@ class UserService {
     } catch (e) {
       debugPrint("Error [uploadProfileImage] ${e.toString()}");
       return null;
+    }
+  }
+
+  Future<void> fetchAllUsers() async {
+    final users = await _getAllUsers(isAll: true);
+    if (users == null) {
+      return;
+    }
+    users.sortBy((u) => u.id);
+    final dbUsers = await _db.users.where().sortById().findAll();
+    List<int> toDelete = [];
+    List<User> toUpsert = [];
+    final changes = await diffSortedLists(
+      users,
+      dbUsers,
+      compare: (a, b) => a.id.compareTo(b.id),
+      both: (a, b) {
+        if (a.updatedAt != b.updatedAt) {
+          toUpsert.add(a);
+          return true;
+        }
+        return false;
+      },
+      onlyFirst: (a) => toUpsert.add(a),
+      onlySecond: (b) => toDelete.add(b.isarId),
+    );
+    if (changes) {
+      await _db.writeTxn(() async {
+        await _db.users.deleteAll(toDelete);
+        await _db.users.putAll(toUpsert);
+      });
     }
   }
 }

--- a/mobile/lib/shared/services/user.service.dart
+++ b/mobile/lib/shared/services/user.service.dart
@@ -73,21 +73,21 @@ class UserService {
     }
     users.sortBy((u) => u.id);
     final dbUsers = await _db.users.where().sortById().findAll();
-    List<int> toDelete = [];
-    List<User> toUpsert = [];
+    final List<int> toDelete = [];
+    final List<User> toUpsert = [];
     final changes = await diffSortedLists(
       users,
       dbUsers,
-      compare: (a, b) => a.id.compareTo(b.id),
-      both: (a, b) {
+      compare: (User a, User b) => a.id.compareTo(b.id),
+      both: (User a, User b) {
         if (a.updatedAt != b.updatedAt) {
           toUpsert.add(a);
           return true;
         }
         return false;
       },
-      onlyFirst: (a) => toUpsert.add(a),
-      onlySecond: (b) => toDelete.add(b.isarId),
+      onlyFirst: (User a) => toUpsert.add(a),
+      onlySecond: (User b) => toDelete.add(b.isarId),
     );
     if (changes) {
       await _db.writeTxn(() async {

--- a/mobile/lib/utils/async_mutex.dart
+++ b/mobile/lib/utils/async_mutex.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+/// Async mutex to guarantee actions are performed sequentially and do not interleave
+class AsyncMutex {
+  Future _running = Future.value(null);
+
+  /// Execute [operation] exclusively, after any currently running operations.
+  /// Returns a [Future] with the result of the [operation].
+  Future<T> run<T>(Future<T> Function() operation) {
+    final completer = Completer<T>();
+    _running.whenComplete(() {
+      completer.complete(Future<T>.sync(operation));
+    });
+    return _running = completer.future;
+  }
+}

--- a/mobile/lib/utils/builtin_extensions.dart
+++ b/mobile/lib/utils/builtin_extensions.dart
@@ -5,7 +5,11 @@ extension DurationExtension on String {
     return Duration(hours: parts[0], minutes: parts[1], seconds: parts[2]);
   }
 
-  double? toDouble() {
-    return double.tryParse(this);
+  double toDouble() {
+    return double.parse(this);
+  }
+
+  int toInt() {
+    return int.parse(this);
   }
 }

--- a/mobile/lib/utils/diff.dart
+++ b/mobile/lib/utils/diff.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+/// Efficiently compares two sorted lists in O(n), calling the given callback
+/// for each item.
+/// Return `true` if there are any differences found, else `false`
+Future<bool> diffSortedLists<A, B>(
+  List<A> la,
+  List<B> lb, {
+  required int Function(A a, B b) compare,
+  required FutureOr<bool> Function(A a, B b) both,
+  required FutureOr<void> Function(A a) onlyFirst,
+  required FutureOr<void> Function(B b) onlySecond,
+}) async {
+  bool diff = false;
+  int i = 0, j = 0;
+  for (; i < la.length && j < lb.length;) {
+    final int order = compare(la[i], lb[j]);
+    if (order == 0) {
+      diff |= await both(la[i++], lb[j++]);
+    } else if (order < 0) {
+      await onlyFirst(la[i++]);
+      diff = true;
+    } else if (order > 0) {
+      await onlySecond(lb[j++]);
+      diff = true;
+    }
+  }
+  diff |= i < la.length || j < lb.length;
+  for (; i < la.length; i++) {
+    await onlyFirst(la[i]);
+  }
+  for (; j < lb.length; j++) {
+    await onlySecond(lb[j]);
+  }
+  return diff;
+}

--- a/mobile/lib/utils/diff.dart
+++ b/mobile/lib/utils/diff.dart
@@ -34,3 +34,38 @@ Future<bool> diffSortedLists<A, B>(
   }
   return diff;
 }
+
+/// Efficiently compares two sorted lists in O(n), calling the given callback
+/// for each item.
+/// Return `true` if there are any differences found, else `false`
+bool diffSortedListsSync<A, B>(
+  List<A> la,
+  List<B> lb, {
+  required int Function(A a, B b) compare,
+  required bool Function(A a, B b) both,
+  required void Function(A a) onlyFirst,
+  required void Function(B b) onlySecond,
+}) {
+  bool diff = false;
+  int i = 0, j = 0;
+  for (; i < la.length && j < lb.length;) {
+    final int order = compare(la[i], lb[j]);
+    if (order == 0) {
+      diff |= both(la[i++], lb[j++]);
+    } else if (order < 0) {
+      onlyFirst(la[i++]);
+      diff = true;
+    } else if (order > 0) {
+      onlySecond(lb[j++]);
+      diff = true;
+    }
+  }
+  diff |= i < la.length || j < lb.length;
+  for (; i < la.length; i++) {
+    onlyFirst(la[i]);
+  }
+  for (; j < lb.length; j++) {
+    onlySecond(lb[j]);
+  }
+  return diff;
+}

--- a/mobile/lib/utils/hash.dart
+++ b/mobile/lib/utils/hash.dart
@@ -1,0 +1,15 @@
+/// FNV-1a 64bit hash algorithm optimized for Dart Strings
+int fastHash(String string) {
+  var hash = 0xcbf29ce484222325;
+
+  var i = 0;
+  while (i < string.length) {
+    final codeUnit = string.codeUnitAt(i++);
+    hash ^= codeUnit >> 8;
+    hash *= 0x100000001b3;
+    hash ^= codeUnit & 0xFF;
+    hash *= 0x100000001b3;
+  }
+
+  return hash;
+}

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -31,20 +31,20 @@ String getAlbumThumbnailUrl(
   final Album album, {
   ThumbnailFormat type = ThumbnailFormat.WEBP,
 }) {
-  if (album.albumThumbnailAssetId == null) {
+  if (album.thumbnail.value?.remoteId == null) {
     return '';
   }
-  return _getThumbnailUrl(album.albumThumbnailAssetId!, type: type);
+  return _getThumbnailUrl(album.thumbnail.value!.remoteId!, type: type);
 }
 
 String getAlbumThumbNailCacheKey(
   final Album album, {
   ThumbnailFormat type = ThumbnailFormat.WEBP,
 }) {
-  if (album.albumThumbnailAssetId == null) {
+  if (album.thumbnail.value?.remoteId == null) {
     return '';
   }
-  return _getThumbnailCacheKey(album.albumThumbnailAssetId!, type);
+  return _getThumbnailCacheKey(album.thumbnail.value!.remoteId!, type);
 }
 
 String getImageUrl(final Asset asset) {

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -1,7 +1,11 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/cupertino.dart';
 import 'package:hive/hive.dart';
 import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/modules/album/services/album_cache.service.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/services/asset_cache.service.dart';
 
 Future<void> migrateHiveToStoreIfNecessary() async {
   try {
@@ -21,4 +25,10 @@ _migrateSingleKey(Box box, String hiveKey, StoreKey key) async {
     await Store.put(key, value);
     await box.delete(hiveKey);
   }
+}
+
+Future<void> migrateJsonCacheIfNecessary() async {
+  await AlbumCacheService().invalidate();
+  await SharedAlbumCacheService().invalidate();
+  await AssetCacheService().invalidate();
 }

--- a/mobile/lib/utils/tuple.dart
+++ b/mobile/lib/utils/tuple.dart
@@ -6,3 +6,13 @@ class Pair<T1, T2> {
 
   const Pair(this.first, this.second);
 }
+
+/// An immutable triple or 3-tuple
+/// TODO replace with Record once Dart 2.19 is available
+class Triple<T1, T2, T3> {
+  final T1 first;
+  final T2 second;
+  final T3 third;
+
+  const Triple(this.first, this.second, this.third);
+}

--- a/mobile/openapi/doc/UserResponseDto.md
+++ b/mobile/openapi/doc/UserResponseDto.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **shouldChangePassword** | **bool** |  | 
 **isAdmin** | **bool** |  | 
 **deletedAt** | [**DateTime**](DateTime.md) |  | [optional] 
+**updatedAt** | **String** |  | [optional] 
 **oauthId** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/mobile/openapi/lib/model/user_response_dto.dart
+++ b/mobile/openapi/lib/model/user_response_dto.dart
@@ -22,6 +22,7 @@ class UserResponseDto {
     required this.shouldChangePassword,
     required this.isAdmin,
     this.deletedAt,
+    this.updatedAt,
     required this.oauthId,
   });
 
@@ -49,6 +50,14 @@ class UserResponseDto {
   ///
   DateTime? deletedAt;
 
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? updatedAt;
+
   String oauthId;
 
   @override
@@ -62,6 +71,7 @@ class UserResponseDto {
      other.shouldChangePassword == shouldChangePassword &&
      other.isAdmin == isAdmin &&
      other.deletedAt == deletedAt &&
+     other.updatedAt == updatedAt &&
      other.oauthId == oauthId;
 
   @override
@@ -76,10 +86,11 @@ class UserResponseDto {
     (shouldChangePassword.hashCode) +
     (isAdmin.hashCode) +
     (deletedAt == null ? 0 : deletedAt!.hashCode) +
+    (updatedAt == null ? 0 : updatedAt!.hashCode) +
     (oauthId.hashCode);
 
   @override
-  String toString() => 'UserResponseDto[id=$id, email=$email, firstName=$firstName, lastName=$lastName, createdAt=$createdAt, profileImagePath=$profileImagePath, shouldChangePassword=$shouldChangePassword, isAdmin=$isAdmin, deletedAt=$deletedAt, oauthId=$oauthId]';
+  String toString() => 'UserResponseDto[id=$id, email=$email, firstName=$firstName, lastName=$lastName, createdAt=$createdAt, profileImagePath=$profileImagePath, shouldChangePassword=$shouldChangePassword, isAdmin=$isAdmin, deletedAt=$deletedAt, updatedAt=$updatedAt, oauthId=$oauthId]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -95,6 +106,11 @@ class UserResponseDto {
       json[r'deletedAt'] = this.deletedAt!.toUtc().toIso8601String();
     } else {
       // json[r'deletedAt'] = null;
+    }
+    if (this.updatedAt != null) {
+      json[r'updatedAt'] = this.updatedAt;
+    } else {
+      // json[r'updatedAt'] = null;
     }
       json[r'oauthId'] = this.oauthId;
     return json;
@@ -128,6 +144,7 @@ class UserResponseDto {
         shouldChangePassword: mapValueOfType<bool>(json, r'shouldChangePassword')!,
         isAdmin: mapValueOfType<bool>(json, r'isAdmin')!,
         deletedAt: mapDateTime(json, r'deletedAt', ''),
+        updatedAt: mapValueOfType<String>(json, r'updatedAt'),
         oauthId: mapValueOfType<String>(json, r'oauthId')!,
       );
     }

--- a/mobile/openapi/test/user_response_dto_test.dart
+++ b/mobile/openapi/test/user_response_dto_test.dart
@@ -61,6 +61,11 @@ void main() {
       // TODO
     });
 
+    // String updatedAt
+    test('to test the property `updatedAt`', () async {
+      // TODO
+    });
+
     // String oauthId
     test('to test the property `oauthId`', () async {
       // TODO

--- a/mobile/test/asset_grid_data_structure_test.dart
+++ b/mobile/test/asset_grid_data_structure_test.dart
@@ -13,14 +13,16 @@ void main() {
 
     testAssets.add(
       Asset(
-        deviceAssetId: '$i',
-        deviceId: '',
-        ownerId: '',
+        localId: '$i',
+        deviceId: 1,
+        ownerId: 1,
         fileCreatedAt: date,
         fileModifiedAt: date,
+        updatedAt: date,
         durationInSeconds: 0,
         fileName: '',
         isFavorite: false,
+        isLocal: false,
       ),
     );
   }

--- a/mobile/test/diff_test.dart
+++ b/mobile/test/diff_test.dart
@@ -13,13 +13,13 @@ void main() {
       final changes = await diffSortedLists(
         listA,
         listB,
-        compare: (a, b) => a.compareTo(b),
-        both: (a, b) {
+        compare: (int a, int b) => a.compareTo(b),
+        both: (int a, int b) {
           inBoth.add(b);
           return false;
         },
-        onlyFirst: (a) => onlyInA.add(a),
-        onlySecond: (b) => onlyInB.add(b),
+        onlyFirst: (int a) => onlyInA.add(a),
+        onlySecond: (int b) => onlyInB.add(b),
       );
       expect(changes, true);
       expect(onlyInA, [2, 4, 6]);

--- a/mobile/test/diff_test.dart
+++ b/mobile/test/diff_test.dart
@@ -26,5 +26,25 @@ void main() {
       expect(onlyInB, [5, 7]);
       expect(inBoth, [1, 3]);
     });
+    test('test partial overlap sync', () {
+      final List<int> onlyInA = [];
+      final List<int> onlyInB = [];
+      final List<int> inBoth = [];
+      final changes = diffSortedListsSync(
+        listA,
+        listB,
+        compare: (int a, int b) => a.compareTo(b),
+        both: (int a, int b) {
+          inBoth.add(b);
+          return false;
+        },
+        onlyFirst: (int a) => onlyInA.add(a),
+        onlySecond: (int b) => onlyInB.add(b),
+      );
+      expect(changes, true);
+      expect(onlyInA, [2, 4, 6]);
+      expect(onlyInB, [5, 7]);
+      expect(inBoth, [1, 3]);
+    });
   });
 }

--- a/mobile/test/diff_test.dart
+++ b/mobile/test/diff_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/diff.dart';
+
+void main() {
+  final List<int> listA = [1, 2, 3, 4, 6];
+  final List<int> listB = [1, 3, 5, 7];
+
+  group('Test grouped', () {
+    test('test partial overlap', () async {
+      final List<int> onlyInA = [];
+      final List<int> onlyInB = [];
+      final List<int> inBoth = [];
+      final changes = await diffSortedLists(
+        listA,
+        listB,
+        compare: (a, b) => a.compareTo(b),
+        both: (a, b) {
+          inBoth.add(b);
+          return false;
+        },
+        onlyFirst: (a) => onlyInA.add(a),
+        onlySecond: (b) => onlyInB.add(b),
+      );
+      expect(changes, true);
+      expect(onlyInA, [2, 4, 6]);
+      expect(onlyInB, [5, 7]);
+      expect(inBoth, [1, 3]);
+    });
+  });
+}

--- a/mobile/test/favorite_provider_test.dart
+++ b/mobile/test/favorite_provider_test.dart
@@ -12,75 +12,81 @@ import 'package:mockito/mockito.dart';
 ])
 import 'favorite_provider_test.mocks.dart';
 
-Asset _getTestAsset(String id, bool favorite) {
-  return Asset(
-    remoteId: id,
-    deviceAssetId: '',
-    deviceId: '',
-    ownerId: '',
+Asset _getTestAsset(int id, bool favorite) {
+  final Asset a = Asset(
+    remoteId: id.toString(),
+    localId: id.toString(),
+    deviceId: 1,
+    ownerId: 1,
     fileCreatedAt: DateTime.now(),
     fileModifiedAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+    isLocal: false,
     durationInSeconds: 0,
     fileName: '',
     isFavorite: favorite,
   );
+  a.id = id;
+  return a;
 }
 
 void main() {
   group("Test favoriteProvider", () {
-
     late MockAssetsState assetsState;
     late MockAssetNotifier assetNotifier;
     late ProviderContainer container;
-    late StateNotifierProvider<FavoriteSelectionNotifier, Set<String>> testFavoritesProvider;
+    late StateNotifierProvider<FavoriteSelectionNotifier, Set<int>>
+        testFavoritesProvider;
 
-    setUp(() {
-      assetsState = MockAssetsState();
-      assetNotifier = MockAssetNotifier();
-      container = ProviderContainer();
+    setUp(
+      () {
+        assetsState = MockAssetsState();
+        assetNotifier = MockAssetNotifier();
+        container = ProviderContainer();
 
-      testFavoritesProvider =
-          StateNotifierProvider<FavoriteSelectionNotifier, Set<String>>((ref) {
-            return FavoriteSelectionNotifier(
-              assetsState,
-              assetNotifier,
-            );
-          });
-    },);
+        testFavoritesProvider =
+            StateNotifierProvider<FavoriteSelectionNotifier, Set<int>>((ref) {
+          return FavoriteSelectionNotifier(
+            assetsState,
+            assetNotifier,
+          );
+        });
+      },
+    );
 
     test("Empty favorites provider", () {
       when(assetsState.allAssets).thenReturn([]);
-      expect(<String>{}, container.read(testFavoritesProvider));
+      expect(<int>{}, container.read(testFavoritesProvider));
     });
 
     test("Non-empty favorites provider", () {
       when(assetsState.allAssets).thenReturn([
-        _getTestAsset("001", false),
-        _getTestAsset("002", true),
-        _getTestAsset("003", false),
-        _getTestAsset("004", false),
-        _getTestAsset("005", true),
+        _getTestAsset(1, false),
+        _getTestAsset(2, true),
+        _getTestAsset(3, false),
+        _getTestAsset(4, false),
+        _getTestAsset(5, true),
       ]);
 
-      expect(<String>{"002", "005"}, container.read(testFavoritesProvider));
+      expect(<int>{2, 5}, container.read(testFavoritesProvider));
     });
 
     test("Toggle favorite", () {
       when(assetNotifier.toggleFavorite(null, false))
           .thenAnswer((_) async => false);
 
-      final testAsset1 = _getTestAsset("001", false);
-      final testAsset2 = _getTestAsset("002", true);
+      final testAsset1 = _getTestAsset(1, false);
+      final testAsset2 = _getTestAsset(2, true);
 
       when(assetsState.allAssets).thenReturn([testAsset1, testAsset2]);
 
-      expect(<String>{"002"}, container.read(testFavoritesProvider));
+      expect(<int>{2}, container.read(testFavoritesProvider));
 
       container.read(testFavoritesProvider.notifier).toggleFavorite(testAsset2);
-      expect(<String>{}, container.read(testFavoritesProvider));
+      expect(<int>{}, container.read(testFavoritesProvider));
 
       container.read(testFavoritesProvider.notifier).toggleFavorite(testAsset1);
-      expect(<String>{"001"}, container.read(testFavoritesProvider));
+      expect(<int>{1}, container.read(testFavoritesProvider));
     });
 
     test("Add favorites", () {
@@ -89,16 +95,16 @@ void main() {
 
       when(assetsState.allAssets).thenReturn([]);
 
-      expect(<String>{}, container.read(testFavoritesProvider));
+      expect(<int>{}, container.read(testFavoritesProvider));
 
       container.read(testFavoritesProvider.notifier).addToFavorites(
         [
-          _getTestAsset("001", false),
-          _getTestAsset("002", false),
+          _getTestAsset(1, false),
+          _getTestAsset(2, false),
         ],
       );
 
-      expect(<String>{"001", "002"}, container.read(testFavoritesProvider));
+      expect(<int>{1, 2}, container.read(testFavoritesProvider));
     });
   });
 }

--- a/mobile/test/favorite_provider_test.mocks.dart
+++ b/mobile/test/favorite_provider_test.mocks.dart
@@ -187,7 +187,7 @@ class MockAssetNotifier extends _i1.Mock implements _i2.AssetNotifier {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
-  void onNewAssetUploaded(_i4.Asset? newAsset) => super.noSuchMethod(
+  Future<void> onNewAssetUploaded(_i4.Asset? newAsset) => super.noSuchMethod(
         Invocation.method(
           #onNewAssetUploaded,
           [newAsset],
@@ -195,7 +195,7 @@ class MockAssetNotifier extends _i1.Mock implements _i2.AssetNotifier {
         returnValueForMissingStub: null,
       );
   @override
-  dynamic deleteAssets(Set<_i4.Asset>? deleteAssets) => super.noSuchMethod(
+  Future<void> deleteAssets(Set<_i4.Asset> deleteAssets) => super.noSuchMethod(
         Invocation.method(
           #deleteAssets,
           [deleteAssets],

--- a/server/apps/immich/test/user.e2e-spec.ts
+++ b/server/apps/immich/test/user.e2e-spec.ts
@@ -101,6 +101,7 @@ describe('User', () => {
               shouldChangePassword: true,
               profileImagePath: '',
               deletedAt: null,
+              updatedAt: expect.anything(),
               oauthId: '',
             },
             {
@@ -113,6 +114,7 @@ describe('User', () => {
               shouldChangePassword: true,
               profileImagePath: '',
               deletedAt: null,
+              updatedAt: expect.anything(),
               oauthId: '',
             },
           ]),

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -3418,6 +3418,9 @@
             "format": "date-time",
             "type": "string"
           },
+          "updatedAt": {
+            "type": "string"
+          },
           "oauthId": {
             "type": "string"
           }

--- a/server/libs/domain/src/user/response-dto/user-response.dto.ts
+++ b/server/libs/domain/src/user/response-dto/user-response.dto.ts
@@ -10,6 +10,7 @@ export class UserResponseDto {
   shouldChangePassword!: boolean;
   isAdmin!: boolean;
   deletedAt?: Date;
+  updatedAt?: string;
   oauthId!: string;
 }
 
@@ -24,6 +25,7 @@ export function mapUser(entity: UserEntity): UserResponseDto {
     shouldChangePassword: entity.shouldChangePassword,
     isAdmin: entity.isAdmin,
     deletedAt: entity.deletedAt,
+    updatedAt: entity.updatedAt,
     oauthId: entity.oauthId,
   };
 }

--- a/server/libs/domain/src/user/user.service.spec.ts
+++ b/server/libs/domain/src/user/user.service.spec.ts
@@ -100,6 +100,7 @@ const adminUserResponse = Object.freeze({
   shouldChangePassword: false,
   profileImagePath: '',
   createdAt: '2021-01-01',
+  updatedAt: '2021-01-01',
 });
 
 describe(UserService.name, () => {
@@ -162,6 +163,7 @@ describe(UserService.name, () => {
           shouldChangePassword: false,
           profileImagePath: '',
           createdAt: '2021-01-01',
+          updatedAt: '2021-01-01',
         },
       ]);
     });

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -2279,6 +2279,12 @@ export interface UserResponseDto {
      * @type {string}
      * @memberof UserResponseDto
      */
+    'updatedAt'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserResponseDto
+     */
     'oauthId': string;
 }
 /**


### PR DESCRIPTION
This PR adds functionality to sync assets, albums & users from the server (remote) to the local (device) Isar database.

General principle: Server changes are synced to the local DB (never the other way around!) Syncing works by comparing ordered lists of items (assets, albums, users) where one list is the latest result from the server and the other list is the state in the local database.

- If items only exist on the server, they are added to the local db
- If items only exist in the local DB, they are staged for removal
- If items exist in both lists, they are checked whether there have been changes. If yes, in case of album the assets and users are compared using the same principle

Items staged for removal are only removed if they are no longer found/referenced elsewhere (e.g. by moving them from one local album/folder to another, or by deleting an asset from your account while the asset is still present in a album shared by someone else).

The sync operations are triggered whenever the server was previously asked to get some data, e.g. in `main.dart`  `getAllAsset` (whenever the app is opened) or when viewing the library/shared album page (`getAllAlbums`).

This does not yet enable offline usage (i.e. without network connection, you are still sent back to the login screen)

Modifies the library page to also show device-local albums (folders).

As part of the migration, it clears the JSON cache (code to be removed after a few versions).

Adds `updatedAt` to the `UserResponseDto`.

### EDIT:

Reworked this PR; the DB syncing operations are now all consolidated in a new service `SyncService`.  Further, I've rebased my work to latest main and fixed the inevitable conflicts...

Fixed the reason for the endless timeline loading bug: ApiClient authToken was overwritten when setting a new endpoint

In my testing it works quite well now and is ready for another review!
