### PR TITLE
feat(server): auto-link live photos

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -19,11 +19,10 @@ import geocoder, { InitOptions } from 'local-reverse-geocoder';
 import { getName } from 'i18n-iso-countries';
 import fs from 'node:fs';
 import { ExifDateTime, exiftool, Tags } from 'exiftool-vendored';
-import { Not } from 'typeorm';
+import { IsNull, Not } from 'typeorm';
 
 interface ImmichTags extends Tags {
   ContentIdentifier?: string;
-  Apple_0x0011?: string;
 }
 
 function geocoderInit(init: InitOptions) {
@@ -164,8 +163,6 @@ export class MetadataExtractionProcessor {
       const modifyDate = exifToDate(exifData?.ModifyDate ?? asset.modifiedAt);
       const fileStats = fs.statSync(asset.originalPath);
       const fileSizeInBytes = fileStats.size;
-      const livePhotoCID =
-        (asset.type === AssetType.VIDEO ? exifData?.ContentIdentifier : exifData?.Apple_0x0011) || null;
 
       const newExif = new ExifEntity();
       newExif.assetId = asset.id;
@@ -185,22 +182,20 @@ export class MetadataExtractionProcessor {
       newExif.iso = exifData?.ISO || null;
       newExif.latitude = exifData?.GPSLatitude || null;
       newExif.longitude = exifData?.GPSLongitude || null;
-      newExif.livePhotoCID = livePhotoCID;
+      newExif.livePhotoCID = exifData?.MediaGroupUUID || null;
 
       await this.assetRepository.save({
         id: asset.id,
         createdAt: createdAt?.toISOString(),
       });
 
-      if (livePhotoCID) {
-        const oppositeType = asset.type === AssetType.VIDEO ? AssetType.IMAGE : AssetType.VIDEO;
-
-        const match = await this.assetRepository.findOne({
+      if (newExif.livePhotoCID && !asset.livePhotoVideoId) {
+        const motionAsset = await this.assetRepository.findOne({
           where: {
             id: Not(asset.id),
-            type: oppositeType,
+            type: AssetType.VIDEO,
             exifInfo: {
-              livePhotoCID,
+              livePhotoCID: newExif.livePhotoCID,
             },
           },
           relations: {
@@ -208,14 +203,9 @@ export class MetadataExtractionProcessor {
           },
         });
 
-        if (match) {
-          const [photoAsset, motionAsset] = asset.type === AssetType.IMAGE ? [asset, match] : [match, asset];
-          if (!photoAsset.livePhotoVideoId) {
-            await this.assetRepository.save({
-              id: photoAsset.id,
-              livePhotoVideoId: motionAsset.id,
-            });
-          }
+        if (motionAsset) {
+          await this.assetRepository.update(asset.id, { livePhotoVideoId: motionAsset.id });
+          await this.assetRepository.update(motionAsset.id, { isVisible: false });
         }
       }
 
@@ -302,6 +292,11 @@ export class MetadataExtractionProcessor {
         createdAt = asset.createdAt;
       }
 
+      const exifData = await exiftool.read<ImmichTags>(asset.originalPath).catch((e) => {
+        this.logger.warn(`The exifData parsing failed due to: ${e} on file ${asset.originalPath}`);
+        return null;
+      });
+
       const newExif = new ExifEntity();
       newExif.assetId = asset.id;
       newExif.description = '';
@@ -315,6 +310,25 @@ export class MetadataExtractionProcessor {
       newExif.state = null;
       newExif.country = null;
       newExif.fps = null;
+      newExif.livePhotoCID = exifData?.ContentIdentifier || null;
+
+      if (newExif.livePhotoCID) {
+        const photoAsset = await this.assetRepository.findOne({
+          where: {
+            id: Not(asset.id),
+            type: AssetType.IMAGE,
+            livePhotoVideoId: IsNull(),
+            exifInfo: {
+              livePhotoCID: newExif.livePhotoCID,
+            },
+          },
+        });
+
+        if (photoAsset) {
+          await this.assetRepository.update(photoAsset.id, { livePhotoVideoId: asset.id });
+          await this.assetRepository.update(asset.id, { isVisible: false });
+        }
+      }
 
       if (videoTags && videoTags['location']) {
         const location = videoTags['location'] as string;

--- a/server/libs/domain/test/fixtures.ts
+++ b/server/libs/domain/test/fixtures.ts
@@ -378,6 +378,7 @@ export const sharedLinkStub = {
             isVisible: true,
             livePhotoVideoId: null,
             exifInfo: {
+              livePhotoCID: null,
               id: 1,
               assetId: 'id_1',
               description: 'description',

--- a/server/libs/infra/src/db/entities/exif.entity.ts
+++ b/server/libs/infra/src/db/entities/exif.entity.ts
@@ -44,6 +44,10 @@ export class ExifEntity {
   @Column({ type: 'varchar', nullable: true })
   city!: string | null;
 
+  @Index('IDX_live_photo_cid')
+  @Column({ type: 'varchar', nullable: true })
+  livePhotoCID!: string | null;
+
   @Column({ type: 'varchar', nullable: true })
   state!: string | null;
 

--- a/server/libs/infra/src/db/migrations/1676437878377-AppleContentIdentifier.ts
+++ b/server/libs/infra/src/db/migrations/1676437878377-AppleContentIdentifier.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AppleContentIdentifier1676437878377 implements MigrationInterface {
+  name = 'AppleContentIdentifier1676437878377';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "exif" ADD "livePhotoCID" character varying`);
+    await queryRunner.query(`CREATE INDEX "IDX_live_photo_cid" ON "exif" ("livePhotoCID") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_live_photo_cid"`);
+    await queryRunner.query(`ALTER TABLE "exif" DROP COLUMN "livePhotoCID"`);
+  }
+}


### PR DESCRIPTION
This PR makes it possible to upload the photo and motion portions of a live photo independently, but still have them displayed together as a live photo.

[Screencast from 02-15-2023 04:05:48 PM.webm](https://user-images.githubusercontent.com/4334196/219273105-5b7e3e9b-f1ee-4d7e-b887-44b022284e69.webm)
