### PR TITLE
fix(web): remove link header causing 502 errors

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -2,7 +2,13 @@ import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { AxiosError } from 'axios';
 
 export const handle: Handle = async ({ event, resolve }) => {
-	return await resolve(event);
+	const res = await resolve(event);
+
+	// The link header can grow quite big and has caused issues with our nginx
+	// proxy returning a 502 Bad Gateway error. Therefore the header gets deleted.
+	res.headers.delete('Link');
+
+	return res;
 };
 
 export const handleError: HandleServerError = async ({ error }) => {


### PR DESCRIPTION
Remove the Link header returned by SvelteKit that causes the response header to grow too large for the nginx buffers, leading to 502 Bad Gateway errors. Fixes #1753