### PR TITLE
feat(web): only show copy image when supported

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,14 +11,12 @@
 				"axios": "^0.27.2",
 				"cookie": "^0.4.2",
 				"copy-image-clipboard": "^2.1.2",
-				"exifr": "^7.1.3",
 				"handlebars": "^4.7.7",
 				"leaflet": "^1.8.0",
 				"lodash-es": "^4.17.21",
 				"luxon": "^3.1.1",
 				"rxjs": "^7.8.0",
 				"socket.io-client": "^4.5.1",
-				"svelte-keydown": "^0.5.0",
 				"svelte-material-icons": "^2.0.2"
 			},
 			"devDependencies": {
@@ -55,7 +53,6 @@
 				"svelte": "^3.44.0",
 				"svelte-check": "^2.7.1",
 				"svelte-jester": "^2.3.2",
-				"svelte-keydown": "^0.5.0",
 				"svelte-preprocess": "^4.10.7",
 				"tailwindcss": "^3.0.24",
 				"tslib": "^2.3.1",
@@ -5762,11 +5759,6 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
-		"node_modules/exifr": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-			"integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
-		},
 		"node_modules/exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -10600,12 +10592,6 @@
 				"jest": ">= 27",
 				"svelte": ">= 3"
 			}
-		},
-		"node_modules/svelte-keydown": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/svelte-keydown/-/svelte-keydown-0.5.0.tgz",
-			"integrity": "sha512-DgY6AYlKbBocSvjC3kUeNPcStJQOTOCxAGG9ymVHzJdsQ1hRJuB8pcnB4UFH8uH3bAPdYyXXa3LwenLDL41eqQ==",
-			"dev": true
 		},
 		"node_modules/svelte-material-icons": {
 			"version": "2.0.4",
@@ -15514,11 +15500,6 @@
 				"strip-final-newline": "^2.0.0"
 			}
 		},
-		"exifr": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-			"integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
-		},
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -19046,12 +19027,6 @@
 			"integrity": "sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==",
 			"dev": true,
 			"requires": {}
-		},
-		"svelte-keydown": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/svelte-keydown/-/svelte-keydown-0.5.0.tgz",
-			"integrity": "sha512-DgY6AYlKbBocSvjC3kUeNPcStJQOTOCxAGG9ymVHzJdsQ1hRJuB8pcnB4UFH8uH3bAPdYyXXa3LwenLDL41eqQ==",
-			"dev": true
 		},
 		"svelte-material-icons": {
 			"version": "2.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,6 @@
 		"svelte": "^3.44.0",
 		"svelte-check": "^2.7.1",
 		"svelte-jester": "^2.3.2",
-		"svelte-keydown": "^0.5.0",
 		"svelte-preprocess": "^4.10.7",
 		"tailwindcss": "^3.0.24",
 		"tslib": "^2.3.1",
@@ -70,7 +69,6 @@
 		"luxon": "^3.1.1",
 		"rxjs": "^7.8.0",
 		"socket.io-client": "^4.5.1",
-		"svelte-keydown": "^0.5.0",
 		"svelte-material-icons": "^2.0.2"
 	}
 }

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -39,12 +39,18 @@
 	let addToSharedAlbum = true;
 	let shouldPlayMotionPhoto = false;
 	let shouldShowDownloadButton = sharedLink ? sharedLink.allowDownload : true;
+	let canCopyImagesToClipboard: boolean;
 	const onKeyboardPress = (keyInfo: KeyboardEvent) => handleKeyboardPress(keyInfo.key);
 
 	onMount(async () => {
 		document.addEventListener('keydown', onKeyboardPress);
 
 		getAllAlbums();
+
+		// Import hack :( see https://github.com/vadimkorr/svelte-carousel/issues/27#issuecomment-851022295
+		// TODO: Move to regular import once the package correctly supports ESM.
+		const module = await import('copy-image-clipboard');
+		canCopyImagesToClipboard = module.canCopyImagesToClipboard();
 	});
 
 	onDestroy(() => {
@@ -253,7 +259,7 @@
 		<AssetViewerNavBar
 			{asset}
 			isMotionPhotoPlaying={shouldPlayMotionPhoto}
-			showCopyButton={asset.type === AssetTypeEnum.Image}
+			showCopyButton={canCopyImagesToClipboard && asset.type === AssetTypeEnum.Image}
 			showMotionPlayButton={!!asset.livePhotoVideoId}
 			showDownloadButton={shouldShowDownloadButton}
 			on:goBack={closeViewer}


### PR DESCRIPTION
Only enable the copy image functionality when the browser supports it. When there is no support, the keyboard shortcut is disabled and the copy image icon is hidden. Also I've added an error message when copying an image fails. Previously it was suggested to add a link to the [documentation](https://github.com/LuanEdCosta/copy-image-clipboard#enable-clipboard-api-features-in-firefox) of `copy-image-clipboard`, but I feel like that isn't really user friendly and it's better to disable the function entirely.