### PR TITLE
refactor(web): use cookies interface

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,9 +9,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"axios": "^0.27.2",
-				"cookie": "^0.4.2",
 				"copy-image-clipboard": "^2.1.2",
-				"exifr": "^7.1.3",
 				"handlebars": "^4.7.7",
 				"leaflet": "^1.8.0",
 				"lodash-es": "^4.17.21",
@@ -4766,14 +4764,6 @@
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
 			"dev": true
 		},
-		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/copy-image-clipboard": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/copy-image-clipboard/-/copy-image-clipboard-2.1.2.tgz",
@@ -5761,11 +5751,6 @@
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
-		},
-		"node_modules/exifr": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-			"integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
 		},
 		"node_modules/exit": {
 			"version": "0.1.2",
@@ -14783,11 +14768,6 @@
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
 			"dev": true
 		},
-		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-		},
 		"copy-image-clipboard": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/copy-image-clipboard/-/copy-image-clipboard-2.1.2.tgz",
@@ -15513,11 +15493,6 @@
 				"signal-exit": "^3.0.3",
 				"strip-final-newline": "^2.0.0"
 			}
-		},
-		"exifr": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
-			"integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
 		},
 		"exit": {
 			"version": "0.1.2",

--- a/web/package.json
+++ b/web/package.json
@@ -62,7 +62,6 @@
 	"type": "module",
 	"dependencies": {
 		"axios": "^0.27.2",
-		"cookie": "^0.4.2",
 		"copy-image-clipboard": "^2.1.2",
 		"handlebars": "^4.7.7",
 		"leaflet": "^1.8.0",

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,29 +1,19 @@
 import { serverApi } from '@api';
-import * as cookieParser from 'cookie';
-
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ request }) => {
+export const load = (async ({ cookies }) => {
 	try {
-		const cookies = cookieParser.parse(request.headers.get('cookie') || '');
-		const accessToken = cookies['immich_access_token'];
-
+		const accessToken = cookies.get('immich_access_token');
 		if (!accessToken) {
-			return {
-				user: undefined
-			};
+			return { user: undefined };
 		}
 
 		serverApi.setAccessToken(accessToken);
-		const { data: userInfo } = await serverApi.userApi.getMyUserInfo();
+		const { data: user } = await serverApi.userApi.getMyUserInfo();
 
-		return {
-			user: userInfo
-		};
+		return { user };
 	} catch (e) {
 		console.error('[ERROR] layout.server.ts [LayoutServerLoad]: ');
-		return {
-			user: undefined
-		};
+		return { user: undefined };
 	}
-};
+}) satisfies LayoutServerLoad;

--- a/web/src/routes/auth/logout/+server.ts
+++ b/web/src/routes/auth/logout/+server.ts
@@ -2,26 +2,12 @@ import { json } from '@sveltejs/kit';
 import { api, serverApi } from '@api';
 import type { RequestHandler } from '@sveltejs/kit';
 
-export const POST: RequestHandler = async () => {
+export const POST = (async ({ cookies }) => {
 	api.removeAccessToken();
 	serverApi.removeAccessToken();
 
-	const headers = new Headers();
+	cookies.delete('immich_auth_type', { path: '/' });
+	cookies.delete('immich_access_token', { path: '/' });
 
-	headers.append(
-		'set-cookie',
-		'immich_auth_type=deleted; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;'
-	);
-	headers.append(
-		'set-cookie',
-		'immich_access_token=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-	);
-	return json(
-		{
-			ok: true
-		},
-		{
-			headers
-		}
-	);
-};
+	return json({ ok: true });
+}) satisfies RequestHandler;


### PR DESCRIPTION
Refactored to use SvelteKit's [cookies interface](https://kit.svelte.dev/docs/load#cookies-and-headers) introduced in september last year.