### PR TITLE
chore(mobile): Improve reliability of asset loading and indexing

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -47,9 +47,6 @@ Future<void> openBoxes() async {
     Hive.openBox<HiveSavedLoginInfo>(hiveLoginInfoBox),
     Hive.openBox(hiveGithubReleaseInfoBox),
     Hive.openBox(userSettingInfoBox),
-    Hive.openBox<HiveBackupAlbums>(hiveBackupInfoBox),
-    Hive.openBox<HiveDuplicatedAssets>(duplicatedAssetsBox),
-    Hive.openBox(backgroundBackupInfoBox),
     EasyLocalization.ensureInitialized(),
   ]);
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -47,6 +47,9 @@ Future<void> openBoxes() async {
     Hive.openBox<HiveSavedLoginInfo>(hiveLoginInfoBox),
     Hive.openBox(hiveGithubReleaseInfoBox),
     Hive.openBox(userSettingInfoBox),
+    Hive.openBox<HiveBackupAlbums>(hiveBackupInfoBox),
+    Hive.openBox<HiveDuplicatedAssets>(duplicatedAssetsBox),
+    Hive.openBox(backgroundBackupInfoBox),
     EasyLocalization.ensureInitialized(),
   ]);
 }

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -577,7 +577,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   }
 
   Future<void> resumeBackup() async {
-    print("Resuming backup get called");
     // assumes the background service is currently running
     // if true, waits until it has stopped to update the app state from HiveDB
     // before actually resuming backup by calling the internal `_resumeBackup`

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -588,6 +588,11 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       return;
     }
 
+    await Future.wait([
+      Hive.openBox<HiveBackupAlbums>(hiveBackupInfoBox),
+      Hive.openBox<HiveDuplicatedAssets>(duplicatedAssetsBox),
+      Hive.openBox(backgroundBackupInfoBox),
+    ]);
     final HiveBackupAlbums? albums =
         Hive.box<HiveBackupAlbums>(hiveBackupInfoBox).get(backupInfoKey);
     Set<AvailableAlbum> selectedAlbums = state.selectedBackupAlbums;

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -67,7 +67,7 @@ class HomePage extends HookConsumerWidget {
     );
 
     void reloadAllAsset() {
-      ref.read(assetProvider.notifier).getAllAsset();
+      ref.watch(assetProvider.notifier).getAllAsset();
     }
 
     Widget buildBody() {

--- a/mobile/lib/routing/auth_guard.dart
+++ b/mobile/lib/routing/auth_guard.dart
@@ -11,6 +11,8 @@ class AuthGuard extends AutoRouteGuard {
   @override
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
     try {
+      // temporary fix for race condition that the _apiService
+      // get called before accessToken is set
       var userInfoHiveBox = await Hive.openBox(userInfoBox);
       var accessToken = userInfoHiveBox.get(accessTokenKey);
       _apiService.setAccessToken(accessToken);

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -35,6 +35,10 @@ class AssetService {
   /// Returns `null` if the server state did not change, else list of assets
   Future<Pair<List<Asset>?, String?>> getRemoteAssets({String? etag}) async {
     try {
+      var userInfoHiveBox = await Hive.openBox(userInfoBox);
+      var accessToken = userInfoHiveBox.get(accessTokenKey);
+      _apiService.setAccessToken(accessToken);
+
       final Pair<List<AssetResponseDto>, String?>? remote =
           await _apiService.assetApi.getAllAssetsWithETag(eTag: etag);
       if (remote == null) {

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -35,6 +35,8 @@ class AssetService {
   /// Returns `null` if the server state did not change, else list of assets
   Future<Pair<List<Asset>?, String?>> getRemoteAssets({String? etag}) async {
     try {
+      // temporary fix for race condition that the _apiService
+      // get called before accessToken is set
       var userInfoHiveBox = await Hive.openBox(userInfoBox);
       var accessToken = userInfoHiveBox.get(accessTokenKey);
       _apiService.setAccessToken(accessToken);


### PR DESCRIPTION
* Resolved issue with remote assets cannot be loaded occasionally.
* Resolved issue with the error message `[_updateAlbumBackupTime] failed to find album in state` get logged when there is no excludedAlbum selected
* Add additional comments on previous fixes
* Resolved issue with the album selection page does not update state after finishing scanning for albums