### PR TITLE
refactor(web): theme switch button

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
 				"luxon": "^3.1.1",
 				"rxjs": "^7.8.0",
 				"socket.io-client": "^4.5.1",
+				"svelte-local-storage-store": "^0.4.0",
 				"svelte-material-icons": "^2.0.2"
 			},
 			"devDependencies": {
@@ -10584,6 +10585,17 @@
 				"svelte": ">= 3"
 			}
 		},
+		"node_modules/svelte-local-storage-store": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-local-storage-store/-/svelte-local-storage-store-0.4.0.tgz",
+			"integrity": "sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==",
+			"engines": {
+				"node": ">=0.14"
+			},
+			"peerDependencies": {
+				"svelte": "^3.48.0"
+			}
+		},
 		"node_modules/svelte-material-icons": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/svelte-material-icons/-/svelte-material-icons-2.0.4.tgz",
@@ -19012,6 +19024,12 @@
 			"resolved": "https://registry.npmjs.org/svelte-jester/-/svelte-jester-2.3.2.tgz",
 			"integrity": "sha512-JtxSz4FWAaCRBXbPsh4LcDs4Ua7zdXgLC0TZvT1R56hRV0dymmNP+abw67DTPF7sQPyNxWsOKd0Sl7Q8SnP8kg==",
 			"dev": true,
+			"requires": {}
+		},
+		"svelte-local-storage-store": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/svelte-local-storage-store/-/svelte-local-storage-store-0.4.0.tgz",
+			"integrity": "sha512-ctPykTt4S3BE5bF0mfV0jKiUR1qlmqLvnAkQvYHLeb9wRyO1MdIFDVI23X+TZEFleATHkTaOpYZswIvf3b2tWA==",
 			"requires": {}
 		},
 		"svelte-material-icons": {

--- a/web/package.json
+++ b/web/package.json
@@ -68,6 +68,7 @@
 		"luxon": "^3.1.1",
 		"rxjs": "^7.8.0",
 		"socket.io-client": "^4.5.1",
+		"svelte-local-storage-store": "^0.4.0",
 		"svelte-material-icons": "^2.0.2"
 	}
 }

--- a/web/src/lib/components/shared-components/theme-button.svelte
+++ b/web/src/lib/components/shared-components/theme-button.svelte
@@ -1,74 +1,35 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-
-	onMount(() => {
-		var themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
-		var themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
-
-		// Change the icons inside the button based on previous settings
-		if (
-			localStorage.getItem('color-theme') === 'dark' ||
-			(!('color-theme' in localStorage) &&
-				window.matchMedia('(prefers-color-scheme: dark)').matches)
-		) {
-			themeToggleLightIcon?.classList.remove('hidden');
-		} else {
-			themeToggleDarkIcon?.classList.remove('hidden');
-		}
-	});
+	import { preferences } from '$lib/stores/preferences.store';
 
 	const toggleTheme = () => {
-		var themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
-		var themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
-		// toggle icons inside button
-		themeToggleDarkIcon?.classList.toggle('hidden');
-		themeToggleLightIcon?.classList.toggle('hidden');
-
-		// if set via local storage previously
-		if (localStorage.getItem('color-theme')) {
-			if (localStorage.getItem('color-theme') === 'light') {
-				document.documentElement.classList.add('dark');
-				localStorage.setItem('color-theme', 'dark');
-			} else {
-				document.documentElement.classList.remove('dark');
-				localStorage.setItem('color-theme', 'light');
-			}
-		} else {
-			if (document.documentElement.classList.contains('dark')) {
-				document.documentElement.classList.remove('dark');
-				localStorage.setItem('color-theme', 'light');
-			} else {
-				document.documentElement.classList.add('dark');
-				localStorage.setItem('color-theme', 'dark');
-			}
-		}
+		$preferences.theme = $preferences.theme === 'dark' ? 'light' : 'dark';
 	};
+
+	$: {
+		if ($preferences.theme === 'light') {
+			document.documentElement.classList.remove('dark');
+		} else {
+			document.documentElement.classList.add('dark');
+		}
+	}
 </script>
 
 <button
 	on:click={toggleTheme}
-	id="theme-toggle"
 	type="button"
-	class="text-gray-500 dark:text-immich-dark-primary hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none  rounded-full text-sm p-2.5"
+	class="text-gray-500 dark:text-immich-dark-primary hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none rounded-full p-2.5"
 >
-	<svg
-		id="theme-toggle-dark-icon"
-		class="hidden w-6 h-6"
-		fill="currentColor"
-		viewBox="0 0 20 20"
-		xmlns="http://www.w3.org/2000/svg"
-		><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" /></svg
-	>
-	<svg
-		id="theme-toggle-light-icon"
-		class="hidden w-6 h-6"
-		fill="currentColor"
-		viewBox="0 0 20 20"
-		xmlns="http://www.w3.org/2000/svg"
-		><path
-			d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-			fill-rule="evenodd"
-			clip-rule="evenodd"
-		/></svg
-	>
+	{#if $preferences.theme === 'light'}
+		<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
+			><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" /></svg
+		>
+	{:else}
+		<svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"
+			><path
+				d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+			/></svg
+		>
+	{/if}
 </button>

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -1,0 +1,10 @@
+import { browser } from '$app/environment';
+import { persisted } from 'svelte-local-storage-store';
+
+export type Preferences = {
+	theme: 'dark' | 'light';
+};
+
+export const preferences = persisted<Preferences>('preferences', {
+	theme: browser && !window.matchMedia('(prefers-color-scheme: dark)').matches ? 'light' : 'dark'
+});


### PR DESCRIPTION
Recently I ran into an issue where the theme switch button would disappear when navigating Photos > Sharing > Photos. When clicking the now empty button, both icons would appear. This PR fixes that issue, but given the way it was implemented the component has been refactored completely.

Using the new `svelte-local-storage-store` package, a preferences store is added that is persisted to localStorage. This store can also be used for managing future preferences.

The old theme preference of users will be lost when merging this PR.