### PR TITLE
fix(ci): Shake up prepare-release concurrency group

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-root
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
[The latest prepare-release run](https://github.com/immich-app/immich/actions/runs/4235198153) got automatically cancelled because of the concurrency groups:
```
Canceling since a deadlock for concurrency group 'Prepare new release-refs/heads/main' was detected between 'top level workflow' and 'build_mobile'
```

I think this happened because both the parent `prepare-release.yml` and the `build-mobile.yml` that it calls use `${{ github.workflow }}-${{ github.ref }}` for the concurrency group, and build-mobile inherits the `github.workflow` from the caller. With this change, those groups should be different. I haven't tested this 👀