### PR TITLE
feat(mobile): Background app refresh status

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -229,5 +229,5 @@
   "version_announcement_overlay_title": "New Server Version Available \uD83C\uDF89",
   "backup_controller_page_background_app_refresh_disabled_title": "Background app refresh disabled",
   "backup_controller_page_background_app_refresh_disabled_content": "Enable background app refresh in settings in order to use background sync.",
-  "backup_controller_page_background_app_refresh_enable_button_text": "Go To Settings"
+  "backup_controller_page_background_app_refresh_enable_button_text": "Go to settings"
 }

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -226,5 +226,8 @@
   "version_announcement_overlay_text_1": "Hi friend, there is a new release of",
   "version_announcement_overlay_text_2": "please take your time to visit the ",
   "version_announcement_overlay_text_3": " and ensure your docker-compose and .env setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your server application automatically.",
-  "version_announcement_overlay_title": "New Server Version Available \uD83C\uDF89"
+  "version_announcement_overlay_title": "New Server Version Available \uD83C\uDF89",
+  "backup_controller_page_background_app_refresh_disabled_title": "Background app refresh disabled",
+  "backup_controller_page_background_app_refresh_disabled_content": "Enable background app refresh in settings in order to use background sync.",
+  "backup_controller_page_background_app_refresh_enable_button_text": "Go To Settings"
 }

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -228,6 +228,6 @@
   "version_announcement_overlay_text_3": " and ensure your docker-compose and .env setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your server application automatically.",
   "version_announcement_overlay_title": "New Server Version Available \uD83C\uDF89",
   "backup_controller_page_background_app_refresh_disabled_title": "Background app refresh disabled",
-  "backup_controller_page_background_app_refresh_disabled_content": "Enable background app refresh in settings in order to use background sync.",
+  "backup_controller_page_background_app_refresh_disabled_content": "Enable background app refresh in Settings > General > Background App Refresh in order to use background backup.",
   "backup_controller_page_background_app_refresh_enable_button_text": "Go to settings"
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/modules/backup/background_service/background.servi
 import 'package:immich_mobile/modules/backup/models/hive_backup_albums.model.dart';
 import 'package:immich_mobile/modules/backup/models/hive_duplicated_assets.model.dart';
 import 'package:immich_mobile/modules/backup/providers/backup.provider.dart';
+import 'package:immich_mobile/modules/backup/providers/ios_background_settings.provider.dart';
 import 'package:immich_mobile/modules/login/models/hive_saved_login_info.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 import 'package:immich_mobile/modules/settings/providers/permission.provider.dart';
@@ -129,6 +130,8 @@ class ImmichAppState extends ConsumerState<ImmichApp>
 
         ref.watch(notificationPermissionProvider.notifier)
           .getNotificationPermission();
+
+        ref.read(iOSBackgroundSettingsProvider).refresh();
 
         break;
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -131,7 +131,7 @@ class ImmichAppState extends ConsumerState<ImmichApp>
         ref.watch(notificationPermissionProvider.notifier)
           .getNotificationPermission();
 
-        ref.read(iOSBackgroundSettingsProvider).refresh();
+        ref.read(iOSBackgroundSettingsProvider.notifier).refresh();
 
         break;
 

--- a/mobile/lib/modules/backup/background_service/background.service.dart
+++ b/mobile/lib/modules/backup/background_service/background.service.dart
@@ -574,6 +574,10 @@ class BackgroundService {
   Future<int> getIOSBackupNumberOfProcesses() async {
     return await _foregroundChannel.invokeMethod('numberOfBackgroundProcesses');
   }
+
+  Future<bool> getIOSBackgroundAppRefreshEnabled() async {
+    return await _foregroundChannel.invokeMethod('backgroundAppRefreshEnabled');
+  }
 }
 
 enum IosBackgroundTask { fetch, processing }

--- a/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
+++ b/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
@@ -15,9 +15,9 @@ class IOSBackgroundSettings {
   });
 }
 
-class IOSBackgroundSettingsState extends StateNotifier<IOSBackgroundSettings?> {
+class IOSBackgroundSettingsNotifier extends StateNotifier<IOSBackgroundSettings?> {
   final BackgroundService _service;
-  IOSBackgroundSettingsState(this._service) : super(null);
+  IOSBackgroundSettingsNotifier(this._service) : super(null);
 
   IOSBackgroundSettings? get settings => state;
 
@@ -51,7 +51,7 @@ class IOSBackgroundSettingsState extends StateNotifier<IOSBackgroundSettings?> {
 
 }
 
-final iOSBackgroundSettingsProvider = StateProvider<IOSBackgroundSettingsState>(
-  (ref) => IOSBackgroundSettingsState(ref.watch(backgroundServiceProvider)),
+final iOSBackgroundSettingsProvider = StateNotifierProvider<IOSBackgroundSettingsNotifier, IOSBackgroundSettings?>(
+  (ref) => IOSBackgroundSettingsNotifier(ref.watch(backgroundServiceProvider)),
 );
 

--- a/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
+++ b/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
@@ -52,6 +52,6 @@ class IOSBackgroundSettingsState extends StateNotifier<IOSBackgroundSettings?> {
 }
 
 final iOSBackgroundSettingsProvider = StateProvider<IOSBackgroundSettingsState>(
-  (ref) => IOSBackgroundSettingsState(ref.read(backgroundServiceProvider)),
+  (ref) => IOSBackgroundSettingsState(ref.watch(backgroundServiceProvider)),
 );
 

--- a/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
+++ b/mobile/lib/modules/backup/providers/ios_background_settings.provider.dart
@@ -1,0 +1,57 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
+
+class IOSBackgroundSettings {
+  final bool appRefreshEnabled;
+  final int numberOfBackgroundTasksQueued;
+  final DateTime? timeOfLastFetch;
+  final DateTime? timeOfLastProcessing;
+
+  IOSBackgroundSettings({
+    required this.appRefreshEnabled,
+    required this.numberOfBackgroundTasksQueued,
+    this.timeOfLastFetch,
+    this.timeOfLastProcessing,
+  });
+}
+
+class IOSBackgroundSettingsState extends StateNotifier<IOSBackgroundSettings?> {
+  final BackgroundService _service;
+  IOSBackgroundSettingsState(this._service) : super(null);
+
+  IOSBackgroundSettings? get settings => state;
+
+  Future<IOSBackgroundSettings> refresh() async {
+    final lastFetchTime = await _service.getIOSBackupLastRun(IosBackgroundTask.fetch);
+    final lastProcessingTime = await _service.getIOSBackupLastRun(IosBackgroundTask.processing);
+    int numberOfProcesses = await _service.getIOSBackupNumberOfProcesses();
+    final appRefreshEnabled = await _service.getIOSBackgroundAppRefreshEnabled();
+
+    // If this is enabled and there are no background processes,
+    // the user just enabled app refresh in Settings.
+    // But we don't have any background services running, since it was disabled
+    // before.
+    if (await _service.isBackgroundBackupEnabled() &&
+        numberOfProcesses == 0) {
+      // We need to restart the background service
+      await _service.enableService();
+      numberOfProcesses = await _service.getIOSBackupNumberOfProcesses();
+    }
+
+    final settings = IOSBackgroundSettings(
+      appRefreshEnabled: appRefreshEnabled,
+      numberOfBackgroundTasksQueued: numberOfProcesses,
+      timeOfLastFetch: lastFetchTime,
+      timeOfLastProcessing: lastProcessingTime,
+    );
+
+    state = settings;
+    return settings;
+  }
+
+}
+
+final iOSBackgroundSettingsProvider = StateProvider<IOSBackgroundSettingsState>(
+  (ref) => IOSBackgroundSettingsState(ref.read(backgroundServiceProvider)),
+);
+

--- a/mobile/lib/modules/backup/ui/ios_debug_info_tile.dart
+++ b/mobile/lib/modules/backup/ui/ios_debug_info_tile.dart
@@ -1,78 +1,61 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
+import 'package:immich_mobile/modules/backup/providers/ios_background_settings.provider.dart';
 import 'package:intl/intl.dart';
 
 /// This is a simple debug widget which should be removed later on when we are
 /// more confident about background sync
 class IosDebugInfoTile extends HookConsumerWidget {
-  const IosDebugInfoTile({super.key});
+  final IOSBackgroundSettings settings;
+  const IosDebugInfoTile({
+    super.key,
+    required this.settings,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final futures = [
-      ref
-          .read(backgroundServiceProvider)
-          .getIOSBackupLastRun(IosBackgroundTask.fetch),
-      ref
-          .read(backgroundServiceProvider)
-          .getIOSBackupLastRun(IosBackgroundTask.processing),
-      ref.read(backgroundServiceProvider).getIOSBackupNumberOfProcesses(),
-    ];
-    return FutureBuilder<List<dynamic>>(
-      future: Future.wait(futures),
-      builder: (context, snapshot) {
-        String? title;
-        String? subtitle;
-        if (snapshot.hasData) {
-          final results = snapshot.data as List<dynamic>;
-          final fetch = results[0] as DateTime?;
-          final processing = results[1] as DateTime?;
-          final processes = results[2] as int;
+    final fetch = settings.timeOfLastFetch;
+    final processing = settings.timeOfLastProcessing;
+    final processes = settings.numberOfBackgroundTasksQueued;
 
-          final processOrProcesses = processes == 1 ? 'process' : 'processes';
-          final numberOrZero = processes == 0 ? 'No' : processes.toString();
-          title = '$numberOrZero background $processOrProcesses queued';
+    final processOrProcesses = processes == 1 ? 'process' : 'processes';
+    final numberOrZero = processes == 0 ? 'No' : processes.toString();
+    final title = '$numberOrZero background $processOrProcesses queued';
 
-          final df = DateFormat.yMd().add_jm();
-          if (fetch == null && processing == null) {
-            subtitle = 'No background sync job has run yet';
-          } else if (fetch != null && processing == null) {
-            subtitle = 'Fetch ran ${df.format(fetch)}';
-          } else if (processing != null && fetch == null) {
-            subtitle = 'Processing ran ${df.format(processing)}';
-          } else {
-            final fetchOrProcessing =
-                fetch!.isAfter(processing!) ? fetch : processing;
-            subtitle = 'Last sync ${df.format(fetchOrProcessing)}';
-          }
-        }
+    final df = DateFormat.yMd().add_jm();
+    final String subtitle;
+    if (fetch == null && processing == null) {
+      subtitle = 'No background sync job has run yet';
+    } else if (fetch != null && processing == null) {
+      subtitle = 'Fetch ran ${df.format(fetch)}';
+    } else if (processing != null && fetch == null) {
+      subtitle = 'Processing ran ${df.format(processing)}';
+    } else {
+      final fetchOrProcessing =
+          fetch!.isAfter(processing!) ? fetch : processing;
+      subtitle = 'Last sync ${df.format(fetchOrProcessing)}';
+    }
 
-        return AnimatedSwitcher(
-          duration: const Duration(milliseconds: 200),
-          child: ListTile(
-            key: ValueKey(title),
-            title: Text(
-              title ?? '',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 14,
-                color: Theme.of(context).primaryColor,
-              ),
-            ),
-            subtitle: Text(
-              subtitle ?? '',
-              style: const TextStyle(
-                fontSize: 14,
-              ),
-            ),
-            leading: Icon(
-              Icons.bug_report,
-              color: Theme.of(context).primaryColor,
-            ),
-          ),
-        );
-      },
+    return ListTile(
+      key: ValueKey(title),
+      title: Text(
+        title,
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 14,
+          color: Theme.of(context).primaryColor,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: const TextStyle(
+          fontSize: 14,
+        ),
+      ),
+      leading: Icon(
+        Icons.bug_report,
+        color: Theme.of(context).primaryColor,
+      ),
     );
   }
 }

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -27,10 +27,10 @@ class BackupControllerPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     BackUpState backupState = ref.watch(backupProvider);
     AuthenticationState authenticationState = ref.watch(authenticationProvider);
-    final IOSBackgroundSettingsNotifier settings = ref.watch(iOSBackgroundSettingsProvider);
+    final settings = ref.watch(iOSBackgroundSettingsProvider.notifier).settings;
 
     final appRefreshDisabled = Platform.isIOS &&
-      settings.settings?.appRefreshEnabled != true;
+      settings?.appRefreshEnabled != true;
     bool hasExclusiveAccess =
         backupState.backupProgress != BackUpProgressEnum.inBackground;
     bool shouldBackup = backupState.allUniqueAssets.length -
@@ -48,7 +48,7 @@ class BackupControllerPage extends HookConsumerWidget {
         }
 
         if (Platform.isIOS) {
-          ref.read(iOSBackgroundSettingsProvider).refresh();
+          ref.read(iOSBackgroundSettingsProvider.notifier).refresh();
         }
 
         ref
@@ -389,9 +389,9 @@ class BackupControllerPage extends HookConsumerWidget {
                 return Container();
               },
             ),
-          if (isBackgroundEnabled && settings.settings != null)
+          if (isBackgroundEnabled && settings != null)
             IosDebugInfoTile(
-              settings: settings.settings!,
+              settings: settings,
           ),
         ],
       );

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -27,7 +27,7 @@ class BackupControllerPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     BackUpState backupState = ref.watch(backupProvider);
     AuthenticationState authenticationState = ref.watch(authenticationProvider);
-    final IOSBackgroundSettingsState settings = ref.watch(iOSBackgroundSettingsProvider);
+    final IOSBackgroundSettingsNotifier settings = ref.watch(iOSBackgroundSettingsProvider);
 
     final appRefreshDisabled = Platform.isIOS &&
       settings.settings?.appRefreshEnabled != true;

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -5,7 +5,9 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/modules/backup/background_service/background.service.dart';
 import 'package:immich_mobile/modules/backup/providers/error_backup_list.provider.dart';
+import 'package:immich_mobile/modules/backup/providers/ios_background_settings.provider.dart';
 import 'package:immich_mobile/modules/backup/ui/current_backup_asset_info_box.dart';
 import 'package:immich_mobile/modules/backup/ui/ios_debug_info_tile.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
@@ -15,6 +17,7 @@ import 'package:immich_mobile/modules/backup/providers/backup.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/providers/websocket.provider.dart';
 import 'package:immich_mobile/modules/backup/ui/backup_info_card.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class BackupControllerPage extends HookConsumerWidget {
@@ -24,6 +27,10 @@ class BackupControllerPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     BackUpState backupState = ref.watch(backupProvider);
     AuthenticationState authenticationState = ref.watch(authenticationProvider);
+    final IOSBackgroundSettingsState settings = ref.watch(iOSBackgroundSettingsProvider);
+    final appRefreshDisabled = Platform.isIOS &&
+      (!(settings.settings?.appRefreshEnabled ?? false));
+    ref.read(backgroundServiceProvider).getIOSBackgroundAppRefreshEnabled();
     bool hasExclusiveAccess =
         backupState.backupProgress != BackUpProgressEnum.inBackground;
     bool shouldBackup = backupState.allUniqueAssets.length -
@@ -362,11 +369,44 @@ class BackupControllerPage extends HookConsumerWidget {
               ],
             ),
           ),
-          if (isBackgroundEnabled)
-            IosDebugInfoTile(
-              key: ValueKey(isChargingRequired),
+          if (isBackgroundEnabled && Platform.isIOS)
+            FutureBuilder(
+              future: ref
+                .read(backgroundServiceProvider)
+                .getIOSBackgroundAppRefreshEnabled(),
+              builder: (context, snapshot) {
+                final enabled = snapshot.data as bool?;
+                // If it's not enabled, show them some kind of alert that says
+                // background refresh is not enabled
+                if (enabled != null && !enabled) {
+
+                }
+                // If it's enabled, no need to bother them
+                return Container();
+              },
             ),
+          if (isBackgroundEnabled && settings.settings != null)
+            IosDebugInfoTile(
+              settings: settings.settings!,
+          ),
         ],
+      );
+    }
+
+    Widget buildBackgroundAppRefreshWarning() {
+      return ListTile(
+        leading: const Icon(Icons.task_outlined,),
+        title: const Text('backup_controller_page_background_app_refresh_disabled_title').tr(),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('backup_controller_page_background_app_refresh_disabled_content').tr(),
+            ElevatedButton(
+              onPressed: () => openAppSettings(),
+              child: const Text('backup_controller_page_background_app_refresh_enable_button_text').tr(),
+            ),
+          ],
+        ),
       );
     }
 
@@ -613,7 +653,15 @@ class BackupControllerPage extends HookConsumerWidget {
             const Divider(),
             buildAutoBackupController(),
             const Divider(),
-            buildBackgroundBackupController(),
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 500),
+              child: Platform.isIOS
+              ? (
+                appRefreshDisabled
+                  ? buildBackgroundAppRefreshWarning()
+                  : buildBackgroundBackupController()
+              ) : buildBackgroundBackupController(),
+            ),
             const Divider(),
             buildStorageInformation(),
             const Divider(),
@@ -624,4 +672,6 @@ class BackupControllerPage extends HookConsumerWidget {
       ),
     );
   }
+
+
 }

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -399,17 +399,25 @@ class BackupControllerPage extends HookConsumerWidget {
 
     Widget buildBackgroundAppRefreshWarning() {
       return ListTile(
+        isThreeLine: true,
         leading: const Icon(Icons.task_outlined,),
         title: const Text(
           'backup_controller_page_background_app_refresh_disabled_title',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 14,
+          ),
         ).tr(),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'backup_controller_page_background_app_refresh_disabled_content',
-            ).tr(),
-            ElevatedButton(
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: const Text(
+                'backup_controller_page_background_app_refresh_disabled_content',
+              ).tr(),
+            ),
+          ElevatedButton(
               onPressed: () => openAppSettings(),
               child: const Text(
                 'backup_controller_page_background_app_refresh_enable_button_text',

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -28,9 +28,9 @@ class BackupControllerPage extends HookConsumerWidget {
     BackUpState backupState = ref.watch(backupProvider);
     AuthenticationState authenticationState = ref.watch(authenticationProvider);
     final IOSBackgroundSettingsState settings = ref.watch(iOSBackgroundSettingsProvider);
+
     final appRefreshDisabled = Platform.isIOS &&
-      (!(settings.settings?.appRefreshEnabled ?? false));
-    ref.read(backgroundServiceProvider).getIOSBackgroundAppRefreshEnabled();
+      settings.settings?.appRefreshEnabled != true;
     bool hasExclusiveAccess =
         backupState.backupProgress != BackUpProgressEnum.inBackground;
     bool shouldBackup = backupState.allUniqueAssets.length -
@@ -45,6 +45,10 @@ class BackupControllerPage extends HookConsumerWidget {
       () {
         if (backupState.backupProgress != BackUpProgressEnum.inProgress) {
           ref.watch(backupProvider.notifier).getBackupInfo();
+        }
+
+        if (Platform.isIOS) {
+          ref.read(iOSBackgroundSettingsProvider).refresh();
         }
 
         ref
@@ -396,14 +400,24 @@ class BackupControllerPage extends HookConsumerWidget {
     Widget buildBackgroundAppRefreshWarning() {
       return ListTile(
         leading: const Icon(Icons.task_outlined,),
-        title: const Text('backup_controller_page_background_app_refresh_disabled_title').tr(),
+        title: const Text(
+          'backup_controller_page_background_app_refresh_disabled_title',
+        ).tr(),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('backup_controller_page_background_app_refresh_disabled_content').tr(),
+            const Text(
+              'backup_controller_page_background_app_refresh_disabled_content',
+            ).tr(),
             ElevatedButton(
               onPressed: () => openAppSettings(),
-              child: const Text('backup_controller_page_background_app_refresh_enable_button_text').tr(),
+              child: const Text(
+                'backup_controller_page_background_app_refresh_enable_button_text',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                ),
+              ).tr(),
             ),
           ],
         ),

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -47,8 +47,11 @@ class BackupControllerPage extends HookConsumerWidget {
           ref.watch(backupProvider.notifier).getBackupInfo();
         }
 
+        // Update the background settings information just to make sure we
+        // have the latest, since the platform channel will not update
+        // automatically
         if (Platform.isIOS) {
-          ref.read(iOSBackgroundSettingsProvider.notifier).refresh();
+          ref.watch(iOSBackgroundSettingsProvider.notifier).refresh();
         }
 
         ref


### PR DESCRIPTION
Adds a message that App Refresh is currently disabled and a settings button to navigate to app settings.

Unfortunately, the Go To Settings takes you to  Settings > Immich instead of Settings > General > Background App Refresh.

- There is not a safe way to navigate to the latter. Maybe the message should say that's where they need to go?
- If Background App Refresh is on globally, but off for Immich, the system still reports that it's "available". This will be obvious for folks with 0 processes queued, though.
- App Refresh tasks can now be scheduled even when connected power is required; they will check to see if they have power and if so, run, otherwise immediately complete.
- Fixes an issue where turning off and on background app refresh would clear all Immich tasks until a full app restart. Now you just need to reopen the Immich app to bring it back to foreground to reschedule the background tasks.

![image](https://user-images.githubusercontent.com/100457/220751367-cac5e54b-3e03-474b-a648-4373d891266c.png)
