### PR TITLE
fix(ci): Mobile build should not run on fork PRs

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -7,6 +7,7 @@ on:
       ref:
         required: false
         type: string
+  pull_request:
   push:
     branches: [main]
 
@@ -17,6 +18,8 @@ concurrency:
 jobs:
   build-sign-android:
     name: Build and sign Android
+    # Skip when PR from a fork
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: macos-12
 
     steps:

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -7,7 +7,6 @@ on:
       ref:
         required: false
         type: string
-  pull_request:
   push:
     branches: [main]
 


### PR DESCRIPTION
It doesn't have the necessary secrets exposed for it succeed in PR context.