### PR TITLE
feat(server): improve API specification

### DIFF
--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -39,6 +39,16 @@ Please follow the [installation procedure](#installation--usage) and then run th
 ```dart
 import 'package:openapi/api.dart';
 
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 final aPIKeyCreateDto = APIKeyCreateDto(); // APIKeyCreateDto | 
@@ -230,6 +240,12 @@ Class | Method | HTTP request | Description
 ## bearer
 
 - **Type**: HTTP Bearer authentication
+
+## cookie
+
+- **Type**: API key
+- **API key parameter name**: immich_access_token
+- **Location**: 
 
 
 ## Author

--- a/mobile/openapi/doc/APIKeyApi.md
+++ b/mobile/openapi/doc/APIKeyApi.md
@@ -26,6 +26,16 @@ Method | HTTP request | Description
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 final aPIKeyCreateDto = APIKeyCreateDto(); // APIKeyCreateDto | 
@@ -50,7 +60,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -69,6 +79,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 final id = id_example; // String | 
@@ -92,7 +112,7 @@ void (empty response body)
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -111,6 +131,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 final id = id_example; // String | 
@@ -135,7 +165,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -154,6 +184,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 
@@ -174,7 +214,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -193,6 +233,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = APIKeyApi();
 final id = id_example; // String | 
@@ -219,7 +269,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/AlbumApi.md
+++ b/mobile/openapi/doc/AlbumApi.md
@@ -24,7 +24,7 @@ Method | HTTP request | Description
 
 
 # **addAssetsToAlbum**
-> AddAssetsResponseDto addAssetsToAlbum(albumId, addAssetsDto)
+> AddAssetsResponseDto addAssetsToAlbum(albumId, addAssetsDto, key)
 
 
 
@@ -39,13 +39,18 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
 final addAssetsDto = AddAssetsDto(); // AddAssetsDto | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.addAssetsToAlbum(albumId, addAssetsDto);
+    final result = api_instance.addAssetsToAlbum(albumId, addAssetsDto, key);
     print(result);
 } catch (e) {
     print('Exception when calling AlbumApi->addAssetsToAlbum: $e\n');
@@ -58,6 +63,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **albumId** | **String**|  | 
  **addAssetsDto** | [**AddAssetsDto**](AddAssetsDto.md)|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -65,7 +71,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -90,6 +96,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
@@ -116,7 +126,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -141,6 +151,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final createAlbumDto = CreateAlbumDto(); // CreateAlbumDto | 
@@ -165,7 +179,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -190,6 +204,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final createAlbumShareLinkDto = CreateAlbumShareLinkDto(); // CreateAlbumShareLinkDto | 
@@ -214,7 +232,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -239,6 +257,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
@@ -262,7 +284,7 @@ void (empty response body)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -272,7 +294,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **downloadArchive**
-> Object downloadArchive(albumId, skip)
+> MultipartFile downloadArchive(albumId, skip, key)
 
 
 
@@ -287,13 +309,18 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
 final skip = 8.14; // num | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.downloadArchive(albumId, skip);
+    final result = api_instance.downloadArchive(albumId, skip, key);
     print(result);
 } catch (e) {
     print('Exception when calling AlbumApi->downloadArchive: $e\n');
@@ -306,19 +333,20 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **albumId** | **String**|  | 
  **skip** | **num**|  | [optional] 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Accept**: application/zip
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -338,6 +366,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 
@@ -358,7 +390,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -368,7 +400,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getAlbumInfo**
-> AlbumResponseDto getAlbumInfo(albumId)
+> AlbumResponseDto getAlbumInfo(albumId, key)
 
 
 
@@ -383,12 +415,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.getAlbumInfo(albumId);
+    final result = api_instance.getAlbumInfo(albumId, key);
     print(result);
 } catch (e) {
     print('Exception when calling AlbumApi->getAlbumInfo: $e\n');
@@ -400,6 +437,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **albumId** | **String**|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -407,7 +445,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -432,6 +470,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final shared = true; // bool | 
@@ -458,7 +500,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -483,6 +525,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
@@ -509,7 +555,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -534,6 +580,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
@@ -559,7 +609,7 @@ void (empty response body)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -584,6 +634,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AlbumApi();
 final albumId = albumId_example; // String | 
@@ -610,7 +664,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -35,7 +35,7 @@ Method | HTTP request | Description
 
 
 # **addAssetsToSharedLink**
-> SharedLinkResponseDto addAssetsToSharedLink(addAssetsDto)
+> SharedLinkResponseDto addAssetsToSharedLink(addAssetsDto, key)
 
 
 
@@ -50,12 +50,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final addAssetsDto = AddAssetsDto(); // AddAssetsDto | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.addAssetsToSharedLink(addAssetsDto);
+    final result = api_instance.addAssetsToSharedLink(addAssetsDto, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->addAssetsToSharedLink: $e\n');
@@ -67,6 +72,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **addAssetsDto** | [**AddAssetsDto**](AddAssetsDto.md)|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -74,7 +80,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -84,7 +90,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **checkDuplicateAsset**
-> CheckDuplicateAssetResponseDto checkDuplicateAsset(checkDuplicateAssetDto)
+> CheckDuplicateAssetResponseDto checkDuplicateAsset(checkDuplicateAssetDto, key)
 
 
 
@@ -99,12 +105,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final checkDuplicateAssetDto = CheckDuplicateAssetDto(); // CheckDuplicateAssetDto | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.checkDuplicateAsset(checkDuplicateAssetDto);
+    final result = api_instance.checkDuplicateAsset(checkDuplicateAssetDto, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->checkDuplicateAsset: $e\n');
@@ -116,6 +127,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **checkDuplicateAssetDto** | [**CheckDuplicateAssetDto**](CheckDuplicateAssetDto.md)|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -123,7 +135,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -148,6 +160,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final checkExistingAssetsDto = CheckExistingAssetsDto(); // CheckExistingAssetsDto | 
@@ -172,7 +188,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -197,6 +213,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final createAssetsShareLinkDto = CreateAssetsShareLinkDto(); // CreateAssetsShareLinkDto | 
@@ -221,7 +241,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -246,6 +266,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final deleteAssetDto = DeleteAssetDto(); // DeleteAssetDto | 
@@ -270,7 +294,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -280,7 +304,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **downloadFile**
-> Object downloadFile(assetId)
+> MultipartFile downloadFile(assetId, key)
 
 
 
@@ -295,12 +319,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetId = assetId_example; // String | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.downloadFile(assetId);
+    final result = api_instance.downloadFile(assetId, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->downloadFile: $e\n');
@@ -312,24 +341,25 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **assetId** | **String**|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Accept**: application/octet-stream
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **downloadFiles**
-> Object downloadFiles(downloadFilesDto)
+> MultipartFile downloadFiles(downloadFilesDto, key)
 
 
 
@@ -344,12 +374,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final downloadFilesDto = DownloadFilesDto(); // DownloadFilesDto | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.downloadFiles(downloadFilesDto);
+    final result = api_instance.downloadFiles(downloadFilesDto, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->downloadFiles: $e\n');
@@ -361,24 +396,25 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **downloadFilesDto** | [**DownloadFilesDto**](DownloadFilesDto.md)|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: application/json
- - **Accept**: application/json
+ - **Accept**: application/octet-stream
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **downloadLibrary**
-> Object downloadLibrary(skip)
+> MultipartFile downloadLibrary(skip, key)
 
 
 
@@ -393,12 +429,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final skip = 8.14; // num | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.downloadLibrary(skip);
+    final result = api_instance.downloadLibrary(skip, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->downloadLibrary: $e\n');
@@ -410,19 +451,20 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **skip** | **num**|  | [optional] 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Accept**: application/octet-stream
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -442,6 +484,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final isFavorite = true; // bool | 
@@ -470,7 +516,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -480,7 +526,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getAssetById**
-> AssetResponseDto getAssetById(assetId)
+> AssetResponseDto getAssetById(assetId, key)
 
 
 
@@ -495,12 +541,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetId = assetId_example; // String | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.getAssetById(assetId);
+    final result = api_instance.getAssetById(assetId, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->getAssetById: $e\n');
@@ -512,6 +563,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **assetId** | **String**|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -519,7 +571,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -544,6 +596,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final getAssetByTimeBucketDto = GetAssetByTimeBucketDto(); // GetAssetByTimeBucketDto | 
@@ -568,7 +624,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -593,6 +649,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final getAssetCountByTimeBucketDto = GetAssetCountByTimeBucketDto(); // GetAssetCountByTimeBucketDto | 
@@ -617,7 +677,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -642,6 +702,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 
@@ -662,7 +726,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -687,6 +751,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 
@@ -707,7 +775,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -717,7 +785,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getAssetThumbnail**
-> Object getAssetThumbnail(assetId, format)
+> MultipartFile getAssetThumbnail(assetId, format, key)
 
 
 
@@ -732,13 +800,18 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetId = assetId_example; // String | 
 final format = ; // ThumbnailFormat | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.getAssetThumbnail(assetId, format);
+    final result = api_instance.getAssetThumbnail(assetId, format, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->getAssetThumbnail: $e\n');
@@ -751,19 +824,20 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **assetId** | **String**|  | 
  **format** | [**ThumbnailFormat**](.md)|  | [optional] 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Accept**: application/octet-stream
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -783,6 +857,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 
@@ -803,7 +881,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -828,6 +906,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 
@@ -848,7 +930,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -873,6 +955,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final deviceId = deviceId_example; // String | 
@@ -897,7 +983,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -907,7 +993,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **removeAssetsFromSharedLink**
-> SharedLinkResponseDto removeAssetsFromSharedLink(removeAssetsDto)
+> SharedLinkResponseDto removeAssetsFromSharedLink(removeAssetsDto, key)
 
 
 
@@ -922,12 +1008,17 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final removeAssetsDto = RemoveAssetsDto(); // RemoveAssetsDto | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.removeAssetsFromSharedLink(removeAssetsDto);
+    final result = api_instance.removeAssetsFromSharedLink(removeAssetsDto, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->removeAssetsFromSharedLink: $e\n');
@@ -939,6 +1030,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **removeAssetsDto** | [**RemoveAssetsDto**](RemoveAssetsDto.md)|  | 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -946,7 +1038,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -971,6 +1063,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final searchAssetDto = SearchAssetDto(); // SearchAssetDto | 
@@ -995,7 +1091,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -1005,7 +1101,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **serveFile**
-> Object serveFile(assetId, isThumb, isWeb)
+> MultipartFile serveFile(assetId, isThumb, isWeb, key)
 
 
 
@@ -1020,14 +1116,19 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetId = assetId_example; // String | 
 final isThumb = true; // bool | 
 final isWeb = true; // bool | 
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.serveFile(assetId, isThumb, isWeb);
+    final result = api_instance.serveFile(assetId, isThumb, isWeb, key);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->serveFile: $e\n');
@@ -1041,19 +1142,20 @@ Name | Type | Description  | Notes
  **assetId** | **String**|  | 
  **isThumb** | **bool**|  | [optional] 
  **isWeb** | **bool**|  | [optional] 
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
-[**Object**](Object.md)
+[**MultipartFile**](MultipartFile.md)
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/json
+ - **Accept**: application/octet-stream
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -1073,6 +1175,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetId = assetId_example; // String | 
@@ -1099,7 +1205,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -1109,7 +1215,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **uploadFile**
-> AssetFileUploadResponseDto uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, livePhotoData, isVisible, duration)
+> AssetFileUploadResponseDto uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, key, livePhotoData, isVisible, duration)
 
 
 
@@ -1124,6 +1230,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AssetApi();
 final assetType = ; // AssetTypeEnum | 
@@ -1134,12 +1244,13 @@ final fileCreatedAt = fileCreatedAt_example; // String |
 final fileModifiedAt = fileModifiedAt_example; // String | 
 final isFavorite = true; // bool | 
 final fileExtension = fileExtension_example; // String | 
+final key = key_example; // String | 
 final livePhotoData = BINARY_DATA_HERE; // MultipartFile | 
 final isVisible = true; // bool | 
 final duration = duration_example; // String | 
 
 try {
-    final result = api_instance.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, livePhotoData, isVisible, duration);
+    final result = api_instance.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, key, livePhotoData, isVisible, duration);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->uploadFile: $e\n');
@@ -1158,6 +1269,7 @@ Name | Type | Description  | Notes
  **fileModifiedAt** | **String**|  | 
  **isFavorite** | **bool**|  | 
  **fileExtension** | **String**|  | 
+ **key** | **String**|  | [optional] 
  **livePhotoData** | **MultipartFile**|  | [optional] 
  **isVisible** | **bool**|  | [optional] 
  **duration** | **String**|  | [optional] 
@@ -1168,7 +1280,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/AuthenticationApi.md
+++ b/mobile/openapi/doc/AuthenticationApi.md
@@ -75,6 +75,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AuthenticationApi();
 final changePasswordDto = ChangePasswordDto(); // ChangePasswordDto | 
@@ -99,7 +103,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -161,6 +165,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AuthenticationApi();
 
@@ -181,7 +195,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -206,6 +220,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = AuthenticationApi();
 
@@ -226,7 +244,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/DeviceInfoApi.md
+++ b/mobile/openapi/doc/DeviceInfoApi.md
@@ -28,6 +28,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = DeviceInfoApi();
 final upsertDeviceInfoDto = UpsertDeviceInfoDto(); // UpsertDeviceInfoDto | 
@@ -52,7 +56,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/JobApi.md
+++ b/mobile/openapi/doc/JobApi.md
@@ -29,6 +29,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = JobApi();
 
@@ -49,7 +53,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -74,6 +78,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = JobApi();
 final jobId = ; // JobId | 
@@ -100,7 +108,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/OAuthApi.md
+++ b/mobile/openapi/doc/OAuthApi.md
@@ -112,6 +112,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = OAuthApi();
 final oAuthCallbackDto = OAuthCallbackDto(); // OAuthCallbackDto | 
@@ -136,7 +146,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -193,6 +203,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = OAuthApi();
 
@@ -213,7 +233,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/ServerInfoApi.md
+++ b/mobile/openapi/doc/ServerInfoApi.md
@@ -103,6 +103,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ServerInfoApi();
 
@@ -123,7 +133,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/ShareApi.md
+++ b/mobile/openapi/doc/ShareApi.md
@@ -26,6 +26,16 @@ Method | HTTP request | Description
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ShareApi();
 final id = id_example; // String | 
@@ -52,7 +62,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -71,6 +81,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ShareApi();
 
@@ -91,7 +111,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -101,7 +121,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getMySharedLink**
-> SharedLinkResponseDto getMySharedLink()
+> SharedLinkResponseDto getMySharedLink(key)
 
 
 
@@ -110,11 +130,22 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ShareApi();
+final key = key_example; // String | 
 
 try {
-    final result = api_instance.getMySharedLink();
+    final result = api_instance.getMySharedLink(key);
     print(result);
 } catch (e) {
     print('Exception when calling ShareApi->getMySharedLink: $e\n');
@@ -122,7 +153,10 @@ try {
 ```
 
 ### Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **key** | **String**|  | [optional] 
 
 ### Return type
 
@@ -130,7 +164,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -149,6 +183,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ShareApi();
 final id = id_example; // String | 
@@ -173,7 +217,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -192,6 +236,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = ShareApi();
 final id = id_example; // String | 
@@ -215,7 +269,7 @@ void (empty response body)
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/SystemConfigApi.md
+++ b/mobile/openapi/doc/SystemConfigApi.md
@@ -31,6 +31,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = SystemConfigApi();
 
@@ -51,7 +55,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -76,6 +80,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = SystemConfigApi();
 
@@ -96,7 +104,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -121,6 +129,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = SystemConfigApi();
 
@@ -141,7 +153,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -166,6 +178,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = SystemConfigApi();
 final systemConfigDto = SystemConfigDto(); // SystemConfigDto | 
@@ -190,7 +206,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/TagApi.md
+++ b/mobile/openapi/doc/TagApi.md
@@ -26,6 +26,16 @@ Method | HTTP request | Description
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = TagApi();
 final createTagDto = CreateTagDto(); // CreateTagDto | 
@@ -50,7 +60,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -69,6 +79,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = TagApi();
 final id = id_example; // String | 
@@ -92,7 +112,7 @@ void (empty response body)
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -111,6 +131,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = TagApi();
 
@@ -131,7 +161,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -150,6 +180,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = TagApi();
 final id = id_example; // String | 
@@ -174,7 +214,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -193,6 +233,16 @@ No authorization required
 ### Example
 ```dart
 import 'package:openapi/api.dart';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = TagApi();
 final id = id_example; // String | 
@@ -219,7 +269,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/doc/UserApi.md
+++ b/mobile/openapi/doc/UserApi.md
@@ -37,6 +37,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final file = BINARY_DATA_HERE; // MultipartFile | 
@@ -61,7 +65,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -86,6 +90,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final createUserDto = CreateUserDto(); // CreateUserDto | 
@@ -110,7 +118,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -135,6 +143,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final userId = userId_example; // String | 
@@ -159,7 +171,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -184,6 +196,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final isAll = true; // bool | 
@@ -208,7 +224,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -233,6 +249,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 
@@ -253,7 +273,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -407,6 +427,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final userId = userId_example; // String | 
@@ -431,7 +455,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 
@@ -456,6 +480,10 @@ import 'package:openapi/api.dart';
 // Case 2. Use Function which generate token.
 // String yourTokenGeneratorFunction() { ... }
 //defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
 
 final api_instance = UserApi();
 final updateUserDto = UpdateUserDto(); // UpdateUserDto | 
@@ -480,7 +508,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-[bearer](../README.md#bearer)
+[bearer](../README.md#bearer), [cookie](../README.md#cookie)
 
 ### HTTP request headers
 

--- a/mobile/openapi/lib/api/album_api.dart
+++ b/mobile/openapi/lib/api/album_api.dart
@@ -25,7 +25,9 @@ class AlbumApi {
   /// * [String] albumId (required):
   ///
   /// * [AddAssetsDto] addAssetsDto (required):
-  Future<Response> addAssetsToAlbumWithHttpInfo(String albumId, AddAssetsDto addAssetsDto,) async {
+  ///
+  /// * [String] key:
+  Future<Response> addAssetsToAlbumWithHttpInfo(String albumId, AddAssetsDto addAssetsDto, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/album/{albumId}/assets'
       .replaceAll('{albumId}', albumId);
@@ -36,6 +38,10 @@ class AlbumApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -58,8 +64,10 @@ class AlbumApi {
   /// * [String] albumId (required):
   ///
   /// * [AddAssetsDto] addAssetsDto (required):
-  Future<AddAssetsResponseDto?> addAssetsToAlbum(String albumId, AddAssetsDto addAssetsDto,) async {
-    final response = await addAssetsToAlbumWithHttpInfo(albumId, addAssetsDto,);
+  ///
+  /// * [String] key:
+  Future<AddAssetsResponseDto?> addAssetsToAlbum(String albumId, AddAssetsDto addAssetsDto, { String? key, }) async {
+    final response = await addAssetsToAlbumWithHttpInfo(albumId, addAssetsDto,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -288,7 +296,9 @@ class AlbumApi {
   /// * [String] albumId (required):
   ///
   /// * [num] skip:
-  Future<Response> downloadArchiveWithHttpInfo(String albumId, { num? skip, }) async {
+  ///
+  /// * [String] key:
+  Future<Response> downloadArchiveWithHttpInfo(String albumId, { num? skip, String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/album/{albumId}/download'
       .replaceAll('{albumId}', albumId);
@@ -302,6 +312,9 @@ class AlbumApi {
 
     if (skip != null) {
       queryParams.addAll(_queryParams('', 'skip', skip));
+    }
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
     }
 
     const contentTypes = <String>[];
@@ -325,8 +338,10 @@ class AlbumApi {
   /// * [String] albumId (required):
   ///
   /// * [num] skip:
-  Future<Object?> downloadArchive(String albumId, { num? skip, }) async {
-    final response = await downloadArchiveWithHttpInfo(albumId,  skip: skip, );
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> downloadArchive(String albumId, { num? skip, String? key, }) async {
+    final response = await downloadArchiveWithHttpInfo(albumId,  skip: skip, key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -334,7 +349,7 @@ class AlbumApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -391,7 +406,9 @@ class AlbumApi {
   /// Parameters:
   ///
   /// * [String] albumId (required):
-  Future<Response> getAlbumInfoWithHttpInfo(String albumId,) async {
+  ///
+  /// * [String] key:
+  Future<Response> getAlbumInfoWithHttpInfo(String albumId, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/album/{albumId}'
       .replaceAll('{albumId}', albumId);
@@ -402,6 +419,10 @@ class AlbumApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>[];
 
@@ -422,8 +443,10 @@ class AlbumApi {
   /// Parameters:
   ///
   /// * [String] albumId (required):
-  Future<AlbumResponseDto?> getAlbumInfo(String albumId,) async {
-    final response = await getAlbumInfoWithHttpInfo(albumId,);
+  ///
+  /// * [String] key:
+  Future<AlbumResponseDto?> getAlbumInfo(String albumId, { String? key, }) async {
+    final response = await getAlbumInfoWithHttpInfo(albumId,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/asset_api.dart
+++ b/mobile/openapi/lib/api/asset_api.dart
@@ -23,7 +23,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [AddAssetsDto] addAssetsDto (required):
-  Future<Response> addAssetsToSharedLinkWithHttpInfo(AddAssetsDto addAssetsDto,) async {
+  ///
+  /// * [String] key:
+  Future<Response> addAssetsToSharedLinkWithHttpInfo(AddAssetsDto addAssetsDto, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/shared-link/add';
 
@@ -33,6 +35,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -53,8 +59,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [AddAssetsDto] addAssetsDto (required):
-  Future<SharedLinkResponseDto?> addAssetsToSharedLink(AddAssetsDto addAssetsDto,) async {
-    final response = await addAssetsToSharedLinkWithHttpInfo(addAssetsDto,);
+  ///
+  /// * [String] key:
+  Future<SharedLinkResponseDto?> addAssetsToSharedLink(AddAssetsDto addAssetsDto, { String? key, }) async {
+    final response = await addAssetsToSharedLinkWithHttpInfo(addAssetsDto,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -75,7 +83,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [CheckDuplicateAssetDto] checkDuplicateAssetDto (required):
-  Future<Response> checkDuplicateAssetWithHttpInfo(CheckDuplicateAssetDto checkDuplicateAssetDto,) async {
+  ///
+  /// * [String] key:
+  Future<Response> checkDuplicateAssetWithHttpInfo(CheckDuplicateAssetDto checkDuplicateAssetDto, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/check';
 
@@ -85,6 +95,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -105,8 +119,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [CheckDuplicateAssetDto] checkDuplicateAssetDto (required):
-  Future<CheckDuplicateAssetResponseDto?> checkDuplicateAsset(CheckDuplicateAssetDto checkDuplicateAssetDto,) async {
-    final response = await checkDuplicateAssetWithHttpInfo(checkDuplicateAssetDto,);
+  ///
+  /// * [String] key:
+  Future<CheckDuplicateAssetResponseDto?> checkDuplicateAsset(CheckDuplicateAssetDto checkDuplicateAssetDto, { String? key, }) async {
+    final response = await checkDuplicateAssetWithHttpInfo(checkDuplicateAssetDto,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -286,7 +302,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [String] assetId (required):
-  Future<Response> downloadFileWithHttpInfo(String assetId,) async {
+  ///
+  /// * [String] key:
+  Future<Response> downloadFileWithHttpInfo(String assetId, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/download/{assetId}'
       .replaceAll('{assetId}', assetId);
@@ -297,6 +315,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>[];
 
@@ -317,8 +339,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [String] assetId (required):
-  Future<Object?> downloadFile(String assetId,) async {
-    final response = await downloadFileWithHttpInfo(assetId,);
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> downloadFile(String assetId, { String? key, }) async {
+    final response = await downloadFileWithHttpInfo(assetId,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -326,7 +350,7 @@ class AssetApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -339,7 +363,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [DownloadFilesDto] downloadFilesDto (required):
-  Future<Response> downloadFilesWithHttpInfo(DownloadFilesDto downloadFilesDto,) async {
+  ///
+  /// * [String] key:
+  Future<Response> downloadFilesWithHttpInfo(DownloadFilesDto downloadFilesDto, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/download-files';
 
@@ -349,6 +375,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -369,8 +399,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [DownloadFilesDto] downloadFilesDto (required):
-  Future<Object?> downloadFiles(DownloadFilesDto downloadFilesDto,) async {
-    final response = await downloadFilesWithHttpInfo(downloadFilesDto,);
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> downloadFiles(DownloadFilesDto downloadFilesDto, { String? key, }) async {
+    final response = await downloadFilesWithHttpInfo(downloadFilesDto,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -378,7 +410,7 @@ class AssetApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -391,7 +423,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [num] skip:
-  Future<Response> downloadLibraryWithHttpInfo({ num? skip, }) async {
+  ///
+  /// * [String] key:
+  Future<Response> downloadLibraryWithHttpInfo({ num? skip, String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/download-library';
 
@@ -404,6 +438,9 @@ class AssetApi {
 
     if (skip != null) {
       queryParams.addAll(_queryParams('', 'skip', skip));
+    }
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
     }
 
     const contentTypes = <String>[];
@@ -425,8 +462,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [num] skip:
-  Future<Object?> downloadLibrary({ num? skip, }) async {
-    final response = await downloadLibraryWithHttpInfo( skip: skip, );
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> downloadLibrary({ num? skip, String? key, }) async {
+    final response = await downloadLibraryWithHttpInfo( skip: skip, key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -434,7 +473,7 @@ class AssetApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -523,7 +562,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [String] assetId (required):
-  Future<Response> getAssetByIdWithHttpInfo(String assetId,) async {
+  ///
+  /// * [String] key:
+  Future<Response> getAssetByIdWithHttpInfo(String assetId, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/assetById/{assetId}'
       .replaceAll('{assetId}', assetId);
@@ -534,6 +575,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>[];
 
@@ -554,8 +599,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [String] assetId (required):
-  Future<AssetResponseDto?> getAssetById(String assetId,) async {
-    final response = await getAssetByIdWithHttpInfo(assetId,);
+  ///
+  /// * [String] key:
+  Future<AssetResponseDto?> getAssetById(String assetId, { String? key, }) async {
+    final response = await getAssetByIdWithHttpInfo(assetId,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -776,7 +823,9 @@ class AssetApi {
   /// * [String] assetId (required):
   ///
   /// * [ThumbnailFormat] format:
-  Future<Response> getAssetThumbnailWithHttpInfo(String assetId, { ThumbnailFormat? format, }) async {
+  ///
+  /// * [String] key:
+  Future<Response> getAssetThumbnailWithHttpInfo(String assetId, { ThumbnailFormat? format, String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/thumbnail/{assetId}'
       .replaceAll('{assetId}', assetId);
@@ -790,6 +839,9 @@ class AssetApi {
 
     if (format != null) {
       queryParams.addAll(_queryParams('', 'format', format));
+    }
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
     }
 
     const contentTypes = <String>[];
@@ -813,8 +865,10 @@ class AssetApi {
   /// * [String] assetId (required):
   ///
   /// * [ThumbnailFormat] format:
-  Future<Object?> getAssetThumbnail(String assetId, { ThumbnailFormat? format, }) async {
-    final response = await getAssetThumbnailWithHttpInfo(assetId,  format: format, );
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> getAssetThumbnail(String assetId, { ThumbnailFormat? format, String? key, }) async {
+    final response = await getAssetThumbnailWithHttpInfo(assetId,  format: format, key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -822,7 +876,7 @@ class AssetApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -985,7 +1039,9 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [RemoveAssetsDto] removeAssetsDto (required):
-  Future<Response> removeAssetsFromSharedLinkWithHttpInfo(RemoveAssetsDto removeAssetsDto,) async {
+  ///
+  /// * [String] key:
+  Future<Response> removeAssetsFromSharedLinkWithHttpInfo(RemoveAssetsDto removeAssetsDto, { String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/shared-link/remove';
 
@@ -995,6 +1051,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['application/json'];
 
@@ -1015,8 +1075,10 @@ class AssetApi {
   /// Parameters:
   ///
   /// * [RemoveAssetsDto] removeAssetsDto (required):
-  Future<SharedLinkResponseDto?> removeAssetsFromSharedLink(RemoveAssetsDto removeAssetsDto,) async {
-    final response = await removeAssetsFromSharedLinkWithHttpInfo(removeAssetsDto,);
+  ///
+  /// * [String] key:
+  Future<SharedLinkResponseDto?> removeAssetsFromSharedLink(RemoveAssetsDto removeAssetsDto, { String? key, }) async {
+    final response = await removeAssetsFromSharedLinkWithHttpInfo(removeAssetsDto,  key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1096,7 +1158,9 @@ class AssetApi {
   /// * [bool] isThumb:
   ///
   /// * [bool] isWeb:
-  Future<Response> serveFileWithHttpInfo(String assetId, { bool? isThumb, bool? isWeb, }) async {
+  ///
+  /// * [String] key:
+  Future<Response> serveFileWithHttpInfo(String assetId, { bool? isThumb, bool? isWeb, String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/file/{assetId}'
       .replaceAll('{assetId}', assetId);
@@ -1113,6 +1177,9 @@ class AssetApi {
     }
     if (isWeb != null) {
       queryParams.addAll(_queryParams('', 'isWeb', isWeb));
+    }
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
     }
 
     const contentTypes = <String>[];
@@ -1138,8 +1205,10 @@ class AssetApi {
   /// * [bool] isThumb:
   ///
   /// * [bool] isWeb:
-  Future<Object?> serveFile(String assetId, { bool? isThumb, bool? isWeb, }) async {
-    final response = await serveFileWithHttpInfo(assetId,  isThumb: isThumb, isWeb: isWeb, );
+  ///
+  /// * [String] key:
+  Future<MultipartFile?> serveFile(String assetId, { bool? isThumb, bool? isWeb, String? key, }) async {
+    final response = await serveFileWithHttpInfo(assetId,  isThumb: isThumb, isWeb: isWeb, key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }
@@ -1147,7 +1216,7 @@ class AssetApi {
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Object',) as Object;
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'MultipartFile',) as MultipartFile;
     
     }
     return null;
@@ -1232,12 +1301,14 @@ class AssetApi {
   ///
   /// * [String] fileExtension (required):
   ///
+  /// * [String] key:
+  ///
   /// * [MultipartFile] livePhotoData:
   ///
   /// * [bool] isVisible:
   ///
   /// * [String] duration:
-  Future<Response> uploadFileWithHttpInfo(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { MultipartFile? livePhotoData, bool? isVisible, String? duration, }) async {
+  Future<Response> uploadFileWithHttpInfo(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { String? key, MultipartFile? livePhotoData, bool? isVisible, String? duration, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/upload';
 
@@ -1247,6 +1318,10 @@ class AssetApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>['multipart/form-data'];
 
@@ -1333,13 +1408,15 @@ class AssetApi {
   ///
   /// * [String] fileExtension (required):
   ///
+  /// * [String] key:
+  ///
   /// * [MultipartFile] livePhotoData:
   ///
   /// * [bool] isVisible:
   ///
   /// * [String] duration:
-  Future<AssetFileUploadResponseDto?> uploadFile(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { MultipartFile? livePhotoData, bool? isVisible, String? duration, }) async {
-    final response = await uploadFileWithHttpInfo(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension,  livePhotoData: livePhotoData, isVisible: isVisible, duration: duration, );
+  Future<AssetFileUploadResponseDto?> uploadFile(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { String? key, MultipartFile? livePhotoData, bool? isVisible, String? duration, }) async {
+    final response = await uploadFileWithHttpInfo(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension,  key: key, livePhotoData: livePhotoData, isVisible: isVisible, duration: duration, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/share_api.dart
+++ b/mobile/openapi/lib/api/share_api.dart
@@ -123,7 +123,11 @@ class ShareApi {
   /// 
   ///
   /// Note: This method returns the HTTP [Response].
-  Future<Response> getMySharedLinkWithHttpInfo() async {
+  ///
+  /// Parameters:
+  ///
+  /// * [String] key:
+  Future<Response> getMySharedLinkWithHttpInfo({ String? key, }) async {
     // ignore: prefer_const_declarations
     final path = r'/share/me';
 
@@ -133,6 +137,10 @@ class ShareApi {
     final queryParams = <QueryParam>[];
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
 
     const contentTypes = <String>[];
 
@@ -149,8 +157,12 @@ class ShareApi {
   }
 
   /// 
-  Future<SharedLinkResponseDto?> getMySharedLink() async {
-    final response = await getMySharedLinkWithHttpInfo();
+  ///
+  /// Parameters:
+  ///
+  /// * [String] key:
+  Future<SharedLinkResponseDto?> getMySharedLink({ String? key, }) async {
+    final response = await getMySharedLinkWithHttpInfo( key: key, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/test/album_api_test.dart
+++ b/mobile/openapi/test/album_api_test.dart
@@ -19,7 +19,7 @@ void main() {
   group('tests for AlbumApi', () {
     // 
     //
-    //Future<AddAssetsResponseDto> addAssetsToAlbum(String albumId, AddAssetsDto addAssetsDto) async
+    //Future<AddAssetsResponseDto> addAssetsToAlbum(String albumId, AddAssetsDto addAssetsDto, { String key }) async
     test('test addAssetsToAlbum', () async {
       // TODO
     });
@@ -54,7 +54,7 @@ void main() {
 
     // 
     //
-    //Future<Object> downloadArchive(String albumId, { num skip }) async
+    //Future<MultipartFile> downloadArchive(String albumId, { num skip, String key }) async
     test('test downloadArchive', () async {
       // TODO
     });
@@ -68,7 +68,7 @@ void main() {
 
     // 
     //
-    //Future<AlbumResponseDto> getAlbumInfo(String albumId) async
+    //Future<AlbumResponseDto> getAlbumInfo(String albumId, { String key }) async
     test('test getAlbumInfo', () async {
       // TODO
     });

--- a/mobile/openapi/test/asset_api_test.dart
+++ b/mobile/openapi/test/asset_api_test.dart
@@ -19,14 +19,14 @@ void main() {
   group('tests for AssetApi', () {
     // 
     //
-    //Future<SharedLinkResponseDto> addAssetsToSharedLink(AddAssetsDto addAssetsDto) async
+    //Future<SharedLinkResponseDto> addAssetsToSharedLink(AddAssetsDto addAssetsDto, { String key }) async
     test('test addAssetsToSharedLink', () async {
       // TODO
     });
 
     // Check duplicated asset before uploading - for Web upload used
     //
-    //Future<CheckDuplicateAssetResponseDto> checkDuplicateAsset(CheckDuplicateAssetDto checkDuplicateAssetDto) async
+    //Future<CheckDuplicateAssetResponseDto> checkDuplicateAsset(CheckDuplicateAssetDto checkDuplicateAssetDto, { String key }) async
     test('test checkDuplicateAsset', () async {
       // TODO
     });
@@ -54,21 +54,21 @@ void main() {
 
     // 
     //
-    //Future<Object> downloadFile(String assetId) async
+    //Future<MultipartFile> downloadFile(String assetId, { String key }) async
     test('test downloadFile', () async {
       // TODO
     });
 
     // 
     //
-    //Future<Object> downloadFiles(DownloadFilesDto downloadFilesDto) async
+    //Future<MultipartFile> downloadFiles(DownloadFilesDto downloadFilesDto, { String key }) async
     test('test downloadFiles', () async {
       // TODO
     });
 
     // Current this is not used in any UI element
     //
-    //Future<Object> downloadLibrary({ num skip }) async
+    //Future<MultipartFile> downloadLibrary({ num skip, String key }) async
     test('test downloadLibrary', () async {
       // TODO
     });
@@ -82,7 +82,7 @@ void main() {
 
     // Get a single asset's information
     //
-    //Future<AssetResponseDto> getAssetById(String assetId) async
+    //Future<AssetResponseDto> getAssetById(String assetId, { String key }) async
     test('test getAssetById', () async {
       // TODO
     });
@@ -117,7 +117,7 @@ void main() {
 
     // 
     //
-    //Future<Object> getAssetThumbnail(String assetId, { ThumbnailFormat format }) async
+    //Future<MultipartFile> getAssetThumbnail(String assetId, { ThumbnailFormat format, String key }) async
     test('test getAssetThumbnail', () async {
       // TODO
     });
@@ -145,7 +145,7 @@ void main() {
 
     // 
     //
-    //Future<SharedLinkResponseDto> removeAssetsFromSharedLink(RemoveAssetsDto removeAssetsDto) async
+    //Future<SharedLinkResponseDto> removeAssetsFromSharedLink(RemoveAssetsDto removeAssetsDto, { String key }) async
     test('test removeAssetsFromSharedLink', () async {
       // TODO
     });
@@ -159,7 +159,7 @@ void main() {
 
     // 
     //
-    //Future<Object> serveFile(String assetId, { bool isThumb, bool isWeb }) async
+    //Future<MultipartFile> serveFile(String assetId, { bool isThumb, bool isWeb, String key }) async
     test('test serveFile', () async {
       // TODO
     });
@@ -173,7 +173,7 @@ void main() {
 
     // 
     //
-    //Future<AssetFileUploadResponseDto> uploadFile(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { MultipartFile livePhotoData, bool isVisible, String duration }) async
+    //Future<AssetFileUploadResponseDto> uploadFile(AssetTypeEnum assetType, MultipartFile assetData, String deviceAssetId, String deviceId, String fileCreatedAt, String fileModifiedAt, bool isFavorite, String fileExtension, { String key, MultipartFile livePhotoData, bool isVisible, String duration }) async
     test('test uploadFile', () async {
       // TODO
     });

--- a/mobile/openapi/test/share_api_test.dart
+++ b/mobile/openapi/test/share_api_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     // 
     //
-    //Future<SharedLinkResponseDto> getMySharedLink() async
+    //Future<SharedLinkResponseDto> getMySharedLink({ String key }) async
     test('test getMySharedLink', () async {
       // TODO
     });

--- a/server/apps/immich/src/api-v1/album/album.controller.ts
+++ b/server/apps/immich/src/api-v1/album/album.controller.ts
@@ -22,7 +22,7 @@ import { AddUsersDto } from './dto/add-users.dto';
 import { RemoveAssetsDto } from './dto/remove-assets.dto';
 import { UpdateAlbumDto } from './dto/update-album.dto';
 import { GetAlbumsDto } from './dto/get-albums.dto';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AlbumResponseDto } from '@app/domain';
 import { AlbumCountResponseDto } from './response-dto/album-count-response.dto';
 import { AddAssetsResponseDto } from './response-dto/add-assets-response.dto';
@@ -37,7 +37,6 @@ import { CreateAlbumShareLinkDto as CreateAlbumSharedLinkDto } from './dto/creat
 
 // TODO might be worth creating a AlbumParamsDto that validates `albumId` instead of using the pipe.
 
-@ApiBearerAuth()
 @ApiTags('Album')
 @Controller('album')
 export class AlbumController {
@@ -134,12 +133,13 @@ export class AlbumController {
 
   @Authenticated({ isShared: true })
   @Get('/:albumId/download')
+  @ApiOkResponse({ content: { 'application/zip': { schema: { type: 'string', format: 'binary' } } } })
   async downloadArchive(
     @GetAuthUser() authUser: AuthUserDto,
     @Param('albumId', new ParseUUIDPipe({ version: '4' })) albumId: string,
     @Query(new ValidationPipe({ transform: true })) dto: DownloadDto,
     @Response({ passthrough: true }) res: Res,
-  ): Promise<any> {
+  ) {
     this.albumService.checkDownloadAccess(authUser);
 
     const { stream, fileName, fileSize, fileCount, complete } = await this.albumService.downloadArchive(

--- a/server/apps/immich/src/api-v1/job/job.controller.ts
+++ b/server/apps/immich/src/api-v1/job/job.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, Put, ValidationPipe } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../../decorators/authenticated.decorator';
 import { AllJobStatusResponseDto } from './response-dto/all-job-status-response.dto';
 import { GetJobDto } from './dto/get-job.dto';
@@ -8,7 +8,6 @@ import { JobCommandDto } from './dto/job-command.dto';
 
 @Authenticated({ admin: true })
 @ApiTags('Job')
-@ApiBearerAuth()
 @Controller('jobs')
 export class JobController {
   constructor(private readonly jobService: JobService) {}

--- a/server/apps/immich/src/controllers/auth.controller.ts
+++ b/server/apps/immich/src/controllers/auth.controller.ts
@@ -14,7 +14,7 @@ import {
   ValidateAccessTokenResponseDto,
 } from '@app/domain';
 import { Body, Controller, Ip, Post, Req, Res, ValidationPipe } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
@@ -45,7 +45,6 @@ export class AuthController {
   }
 
   @Authenticated()
-  @ApiBearerAuth()
   @Post('validateToken')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   validateAccessToken(@GetAuthUser() authUser: AuthUserDto): ValidateAccessTokenResponseDto {
@@ -53,7 +52,6 @@ export class AuthController {
   }
 
   @Authenticated()
-  @ApiBearerAuth()
   @Post('change-password')
   async changePassword(@GetAuthUser() authUser: AuthUserDto, @Body() dto: ChangePasswordDto): Promise<UserResponseDto> {
     return this.authService.changePassword(authUser, dto);

--- a/server/apps/immich/src/controllers/device-info.controller.ts
+++ b/server/apps/immich/src/controllers/device-info.controller.ts
@@ -5,12 +5,11 @@ import {
   UpsertDeviceInfoDto as UpsertDto,
 } from '@app/domain';
 import { Body, Controller, Put, ValidationPipe } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
 
 @Authenticated()
-@ApiBearerAuth()
 @ApiTags('Device Info')
 @Controller('device-info')
 export class DeviceInfoController {

--- a/server/apps/immich/src/controllers/system-config.controller.ts
+++ b/server/apps/immich/src/controllers/system-config.controller.ts
@@ -1,10 +1,9 @@
 import { SystemConfigDto, SystemConfigService, SystemConfigTemplateStorageOptionDto } from '@app/domain';
 import { Body, Controller, Get, Put, ValidationPipe } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../decorators/authenticated.decorator';
 
 @ApiTags('System Config')
-@ApiBearerAuth()
 @Authenticated({ admin: true })
 @Controller('system-config')
 export class SystemConfigController {

--- a/server/apps/immich/src/controllers/user.controller.ts
+++ b/server/apps/immich/src/controllers/user.controller.ts
@@ -23,7 +23,7 @@ import { UpdateUserDto } from '@app/domain';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { profileImageUploadOption } from '../config/profile-image-upload.config';
 import { Response as Res } from 'express';
-import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { UserResponseDto } from '@app/domain';
 import { UserCountResponseDto } from '@app/domain';
 import { CreateProfileImageDto } from '@app/domain';
@@ -36,7 +36,6 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Authenticated()
-  @ApiBearerAuth()
   @Get()
   async getAllUsers(
     @GetAuthUser() authUser: AuthUserDto,
@@ -51,14 +50,12 @@ export class UserController {
   }
 
   @Authenticated()
-  @ApiBearerAuth()
   @Get('me')
   async getMyUserInfo(@GetAuthUser() authUser: AuthUserDto): Promise<UserResponseDto> {
     return await this.userService.getUserInfo(authUser);
   }
 
   @Authenticated({ admin: true })
-  @ApiBearerAuth()
   @Post()
   async createUser(
     @Body(new ValidationPipe({ transform: true })) createUserDto: CreateUserDto,
@@ -72,21 +69,18 @@ export class UserController {
   }
 
   @Authenticated({ admin: true })
-  @ApiBearerAuth()
   @Delete('/:userId')
   async deleteUser(@GetAuthUser() authUser: AuthUserDto, @Param('userId') userId: string): Promise<UserResponseDto> {
     return await this.userService.deleteUser(authUser, userId);
   }
 
   @Authenticated({ admin: true })
-  @ApiBearerAuth()
   @Post('/:userId/restore')
   async restoreUser(@GetAuthUser() authUser: AuthUserDto, @Param('userId') userId: string): Promise<UserResponseDto> {
     return await this.userService.restoreUser(authUser, userId);
   }
 
   @Authenticated()
-  @ApiBearerAuth()
   @Put()
   async updateUser(
     @GetAuthUser() authUser: AuthUserDto,
@@ -97,7 +91,6 @@ export class UserController {
 
   @UseInterceptors(FileInterceptor('file', profileImageUploadOption))
   @Authenticated()
-  @ApiBearerAuth()
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     description: 'A new avatar for the user',

--- a/server/apps/immich/src/decorators/authenticated.decorator.ts
+++ b/server/apps/immich/src/decorators/authenticated.decorator.ts
@@ -1,4 +1,5 @@
 import { applyDecorators, SetMetadata } from '@nestjs/common';
+import { ApiBearerAuth, ApiCookieAuth, ApiQuery } from '@nestjs/swagger';
 
 interface AuthenticatedOptions {
   admin?: boolean;
@@ -12,7 +13,7 @@ export enum Metadata {
 }
 
 export const Authenticated = (options?: AuthenticatedOptions) => {
-  const decorators = [SetMetadata(Metadata.AUTH_ROUTE, true)];
+  const decorators: MethodDecorator[] = [ApiBearerAuth(), ApiCookieAuth(), SetMetadata(Metadata.AUTH_ROUTE, true)];
 
   options = options || {};
 
@@ -22,6 +23,7 @@ export const Authenticated = (options?: AuthenticatedOptions) => {
 
   if (options.isShared) {
     decorators.push(SetMetadata(Metadata.SHARED_ROUTE, true));
+    decorators.push(ApiQuery({ name: 'key', type: String, required: false }));
   }
 
   return applyDecorators(...decorators);

--- a/server/apps/immich/src/main.ts
+++ b/server/apps/immich/src/main.ts
@@ -11,6 +11,7 @@ import { RedisIoAdapter } from './middlewares/redis-io.adapter.middleware';
 import { json } from 'body-parser';
 import { patchOpenAPI } from './utils/patch-open-api.util';
 import { getLogLevels, MACHINE_LEARNING_ENABLED } from '@app/common';
+import { IMMICH_ACCESS_COOKIE } from '@app/domain';
 
 const logger = new Logger('ImmichServer');
 
@@ -42,6 +43,7 @@ async function bootstrap() {
       scheme: 'Bearer',
       in: 'header',
     })
+    .addCookieAuth(IMMICH_ACCESS_COOKIE)
     .addServer('/api')
     .build();
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -30,6 +30,14 @@
         },
         "tags": [
           "API Key"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "get": {
@@ -53,6 +61,14 @@
         },
         "tags": [
           "API Key"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -84,6 +100,14 @@
         },
         "tags": [
           "API Key"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "put": {
@@ -123,6 +147,14 @@
         },
         "tags": [
           "API Key"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "delete": {
@@ -145,6 +177,14 @@
         },
         "tags": [
           "API Key"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -238,6 +278,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -275,6 +318,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -298,6 +344,14 @@
         },
         "tags": [
           "Authentication"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -334,6 +388,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -446,6 +503,14 @@
         },
         "tags": [
           "OAuth"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -468,6 +533,14 @@
         },
         "tags": [
           "OAuth"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -493,6 +566,14 @@
         },
         "tags": [
           "share"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -500,7 +581,16 @@
       "get": {
         "operationId": "getMySharedLink",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -515,6 +605,14 @@
         },
         "tags": [
           "share"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -546,6 +644,14 @@
         },
         "tags": [
           "share"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "delete": {
@@ -568,6 +674,14 @@
         },
         "tags": [
           "share"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "patch": {
@@ -607,6 +721,14 @@
         },
         "tags": [
           "share"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -633,6 +755,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -668,6 +793,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -695,6 +823,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -722,6 +853,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -761,6 +895,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -796,6 +933,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -831,6 +971,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -889,6 +1032,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -957,6 +1103,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -993,6 +1142,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1031,6 +1183,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1070,7 +1225,16 @@
       "post": {
         "operationId": "uploadFile",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "description": "Asset Upload Information",
@@ -1100,6 +1264,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1116,18 +1283,27 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
           }
         },
         "tags": [
@@ -1136,6 +1312,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1144,7 +1323,16 @@
       "post": {
         "operationId": "downloadFiles",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1156,15 +1344,19 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "",
+          "200": {
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
+          },
+          "201": {
+            "description": ""
           }
         },
         "tags": [
@@ -1173,6 +1365,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1189,18 +1384,27 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
           }
         },
         "tags": [
@@ -1209,6 +1413,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1243,18 +1450,27 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
           }
         },
         "tags": [
@@ -1263,6 +1479,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1287,18 +1506,27 @@
             "schema": {
               "$ref": "#/components/schemas/ThumbnailFormat"
             }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
           }
         },
         "tags": [
@@ -1307,6 +1535,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1337,6 +1568,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1367,6 +1601,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1397,6 +1634,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1437,6 +1677,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1474,6 +1717,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1501,6 +1747,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1557,6 +1806,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -1595,6 +1847,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1635,6 +1890,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1674,6 +1932,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1687,6 +1948,14 @@
             "name": "assetId",
             "required": true,
             "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
             "schema": {
               "type": "string"
             }
@@ -1710,6 +1979,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1756,6 +2028,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1764,7 +2039,16 @@
       "post": {
         "operationId": "checkDuplicateAsset",
         "description": "Check duplicated asset before uploading - for Web upload used",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1793,6 +2077,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1830,6 +2117,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1867,6 +2157,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1875,7 +2168,16 @@
       "patch": {
         "operationId": "addAssetsToSharedLink",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1904,6 +2206,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1912,7 +2217,16 @@
       "patch": {
         "operationId": "removeAssetsFromSharedLink",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1941,6 +2255,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -1974,6 +2291,14 @@
         },
         "tags": [
           "Tag"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "get": {
@@ -1997,6 +2322,14 @@
         },
         "tags": [
           "Tag"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -2028,6 +2361,14 @@
         },
         "tags": [
           "Tag"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "patch": {
@@ -2067,6 +2408,14 @@
         },
         "tags": [
           "Tag"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       },
       "delete": {
@@ -2089,6 +2438,14 @@
         },
         "tags": [
           "Tag"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -2115,6 +2472,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2152,6 +2512,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -2198,6 +2561,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2244,6 +2610,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2257,6 +2626,14 @@
             "name": "albumId",
             "required": true,
             "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
             "schema": {
               "type": "string"
             }
@@ -2290,6 +2667,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -2334,6 +2714,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2347,6 +2730,14 @@
             "name": "albumId",
             "required": true,
             "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
             "schema": {
               "type": "string"
             }
@@ -2370,6 +2761,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -2397,6 +2791,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       },
@@ -2441,6 +2838,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2478,6 +2878,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2502,18 +2905,27 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "",
             "content": {
-              "application/json": {
+              "application/zip": {
                 "schema": {
-                  "type": "object"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
-            }
+            },
+            "description": ""
           }
         },
         "tags": [
@@ -2522,6 +2934,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2559,6 +2974,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2648,6 +3066,14 @@
         },
         "tags": [
           "Server Info"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          }
         ]
       }
     },
@@ -2674,6 +3100,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2720,6 +3149,9 @@
         "security": [
           {
             "bearer": []
+          },
+          {
+            "cookie": []
           }
         ]
       }
@@ -2744,6 +3176,11 @@
         "bearerFormat": "JWT",
         "type": "http",
         "in": "header"
+      },
+      "cookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "immich_access_token"
       }
     },
     "schemas": {

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -2328,6 +2328,12 @@ export const APIKeyApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -2364,6 +2370,12 @@ export const APIKeyApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -2397,6 +2409,12 @@ export const APIKeyApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -2425,6 +2443,12 @@ export const APIKeyApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -2461,6 +2485,12 @@ export const APIKeyApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -2668,10 +2698,11 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @param {string} albumId 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addAssetsToAlbum: async (albumId: string, addAssetsDto: AddAssetsDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addAssetsToAlbum: async (albumId: string, addAssetsDto: AddAssetsDto, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'albumId' is not null or undefined
             assertParamExists('addAssetsToAlbum', 'albumId', albumId)
             // verify required parameter 'addAssetsDto' is not null or undefined
@@ -2692,6 +2723,12 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -2736,6 +2773,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -2775,6 +2814,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -2813,6 +2854,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -2854,6 +2897,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -2869,10 +2914,11 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @param {string} albumId 
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadArchive: async (albumId: string, skip?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        downloadArchive: async (albumId: string, skip?: number, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'albumId' is not null or undefined
             assertParamExists('downloadArchive', 'albumId', albumId)
             const localVarPath = `/album/{albumId}/download`
@@ -2892,8 +2938,14 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
             if (skip !== undefined) {
                 localVarQueryParameter['skip'] = skip;
+            }
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
             }
 
 
@@ -2929,6 +2981,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -2943,10 +2997,11 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * 
          * @param {string} albumId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAlbumInfo: async (albumId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getAlbumInfo: async (albumId: string, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'albumId' is not null or undefined
             assertParamExists('getAlbumInfo', 'albumId', albumId)
             const localVarPath = `/album/{albumId}`
@@ -2965,6 +3020,12 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -3000,6 +3061,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
             if (shared !== undefined) {
                 localVarQueryParameter['shared'] = shared;
@@ -3049,6 +3112,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3093,6 +3158,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -3133,6 +3200,8 @@ export const AlbumApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3161,11 +3230,12 @@ export const AlbumApiFp = function(configuration?: Configuration) {
          * 
          * @param {string} albumId 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AddAssetsResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addAssetsToAlbum(albumId, addAssetsDto, options);
+        async addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AddAssetsResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addAssetsToAlbum(albumId, addAssetsDto, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3213,11 +3283,12 @@ export const AlbumApiFp = function(configuration?: Configuration) {
          * 
          * @param {string} albumId 
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadArchive(albumId: string, skip?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadArchive(albumId, skip, options);
+        async downloadArchive(albumId: string, skip?: number, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadArchive(albumId, skip, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3232,11 +3303,12 @@ export const AlbumApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {string} albumId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAlbumInfo(albumId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AlbumResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAlbumInfo(albumId, options);
+        async getAlbumInfo(albumId: string, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AlbumResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAlbumInfo(albumId, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -3297,11 +3369,12 @@ export const AlbumApiFactory = function (configuration?: Configuration, basePath
          * 
          * @param {string} albumId 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, options?: any): AxiosPromise<AddAssetsResponseDto> {
-            return localVarFp.addAssetsToAlbum(albumId, addAssetsDto, options).then((request) => request(axios, basePath));
+        addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, key?: string, options?: any): AxiosPromise<AddAssetsResponseDto> {
+            return localVarFp.addAssetsToAlbum(albumId, addAssetsDto, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3344,11 +3417,12 @@ export const AlbumApiFactory = function (configuration?: Configuration, basePath
          * 
          * @param {string} albumId 
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadArchive(albumId: string, skip?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.downloadArchive(albumId, skip, options).then((request) => request(axios, basePath));
+        downloadArchive(albumId: string, skip?: number, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.downloadArchive(albumId, skip, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3361,11 +3435,12 @@ export const AlbumApiFactory = function (configuration?: Configuration, basePath
         /**
          * 
          * @param {string} albumId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAlbumInfo(albumId: string, options?: any): AxiosPromise<AlbumResponseDto> {
-            return localVarFp.getAlbumInfo(albumId, options).then((request) => request(axios, basePath));
+        getAlbumInfo(albumId: string, key?: string, options?: any): AxiosPromise<AlbumResponseDto> {
+            return localVarFp.getAlbumInfo(albumId, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -3421,12 +3496,13 @@ export class AlbumApi extends BaseAPI {
      * 
      * @param {string} albumId 
      * @param {AddAssetsDto} addAssetsDto 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AlbumApi
      */
-    public addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, options?: AxiosRequestConfig) {
-        return AlbumApiFp(this.configuration).addAssetsToAlbum(albumId, addAssetsDto, options).then((request) => request(this.axios, this.basePath));
+    public addAssetsToAlbum(albumId: string, addAssetsDto: AddAssetsDto, key?: string, options?: AxiosRequestConfig) {
+        return AlbumApiFp(this.configuration).addAssetsToAlbum(albumId, addAssetsDto, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3478,12 +3554,13 @@ export class AlbumApi extends BaseAPI {
      * 
      * @param {string} albumId 
      * @param {number} [skip] 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AlbumApi
      */
-    public downloadArchive(albumId: string, skip?: number, options?: AxiosRequestConfig) {
-        return AlbumApiFp(this.configuration).downloadArchive(albumId, skip, options).then((request) => request(this.axios, this.basePath));
+    public downloadArchive(albumId: string, skip?: number, key?: string, options?: AxiosRequestConfig) {
+        return AlbumApiFp(this.configuration).downloadArchive(albumId, skip, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3499,12 +3576,13 @@ export class AlbumApi extends BaseAPI {
     /**
      * 
      * @param {string} albumId 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AlbumApi
      */
-    public getAlbumInfo(albumId: string, options?: AxiosRequestConfig) {
-        return AlbumApiFp(this.configuration).getAlbumInfo(albumId, options).then((request) => request(this.axios, this.basePath));
+    public getAlbumInfo(albumId: string, key?: string, options?: AxiosRequestConfig) {
+        return AlbumApiFp(this.configuration).getAlbumInfo(albumId, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3566,10 +3644,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addAssetsToSharedLink: async (addAssetsDto: AddAssetsDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        addAssetsToSharedLink: async (addAssetsDto: AddAssetsDto, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'addAssetsDto' is not null or undefined
             assertParamExists('addAssetsToSharedLink', 'addAssetsDto', addAssetsDto)
             const localVarPath = `/asset/shared-link/add`;
@@ -3588,6 +3667,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3605,10 +3690,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Check duplicated asset before uploading - for Web upload used
          * @param {CheckDuplicateAssetDto} checkDuplicateAssetDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        checkDuplicateAsset: async (checkDuplicateAssetDto: CheckDuplicateAssetDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        checkDuplicateAsset: async (checkDuplicateAssetDto: CheckDuplicateAssetDto, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'checkDuplicateAssetDto' is not null or undefined
             assertParamExists('checkDuplicateAsset', 'checkDuplicateAssetDto', checkDuplicateAssetDto)
             const localVarPath = `/asset/check`;
@@ -3626,6 +3712,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -3666,6 +3758,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3704,6 +3798,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -3744,6 +3840,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3761,10 +3859,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * 
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadFile: async (assetId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        downloadFile: async (assetId: string, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'assetId' is not null or undefined
             assertParamExists('downloadFile', 'assetId', assetId)
             const localVarPath = `/asset/download/{assetId}`
@@ -3784,6 +3883,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -3798,10 +3903,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * 
          * @param {DownloadFilesDto} downloadFilesDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadFiles: async (downloadFilesDto: DownloadFilesDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        downloadFiles: async (downloadFilesDto: DownloadFilesDto, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'downloadFilesDto' is not null or undefined
             assertParamExists('downloadFiles', 'downloadFilesDto', downloadFilesDto)
             const localVarPath = `/asset/download-files`;
@@ -3820,6 +3926,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -3837,10 +3949,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Current this is not used in any UI element
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadLibrary: async (skip?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        downloadLibrary: async (skip?: number, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/asset/download-library`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3857,8 +3970,14 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
             if (skip !== undefined) {
                 localVarQueryParameter['skip'] = skip;
+            }
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
             }
 
 
@@ -3897,6 +4016,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
             if (isFavorite !== undefined) {
                 localVarQueryParameter['isFavorite'] = isFavorite;
             }
@@ -3923,10 +4044,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * Get a single asset\'s information
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAssetById: async (assetId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getAssetById: async (assetId: string, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'assetId' is not null or undefined
             assertParamExists('getAssetById', 'assetId', assetId)
             const localVarPath = `/asset/assetById/{assetId}`
@@ -3945,6 +4067,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -3981,6 +4109,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -4021,6 +4151,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -4057,6 +4189,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -4090,6 +4224,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -4105,10 +4241,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @param {string} assetId 
          * @param {ThumbnailFormat} [format] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAssetThumbnail: async (assetId: string, format?: ThumbnailFormat, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getAssetThumbnail: async (assetId: string, format?: ThumbnailFormat, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'assetId' is not null or undefined
             assertParamExists('getAssetThumbnail', 'assetId', assetId)
             const localVarPath = `/asset/thumbnail/{assetId}`
@@ -4128,8 +4265,14 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
             if (format !== undefined) {
                 localVarQueryParameter['format'] = format;
+            }
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
             }
 
 
@@ -4165,6 +4308,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -4197,6 +4342,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -4235,6 +4382,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -4249,10 +4398,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         /**
          * 
          * @param {RemoveAssetsDto} removeAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        removeAssetsFromSharedLink: async (removeAssetsDto: RemoveAssetsDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        removeAssetsFromSharedLink: async (removeAssetsDto: RemoveAssetsDto, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'removeAssetsDto' is not null or undefined
             assertParamExists('removeAssetsFromSharedLink', 'removeAssetsDto', removeAssetsDto)
             const localVarPath = `/asset/shared-link/remove`;
@@ -4270,6 +4420,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -4310,6 +4466,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -4329,10 +4487,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * @param {string} assetId 
          * @param {boolean} [isThumb] 
          * @param {boolean} [isWeb] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serveFile: async (assetId: string, isThumb?: boolean, isWeb?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        serveFile: async (assetId: string, isThumb?: boolean, isWeb?: boolean, key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'assetId' is not null or undefined
             assertParamExists('serveFile', 'assetId', assetId)
             const localVarPath = `/asset/file/{assetId}`
@@ -4352,12 +4511,18 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
             if (isThumb !== undefined) {
                 localVarQueryParameter['isThumb'] = isThumb;
             }
 
             if (isWeb !== undefined) {
                 localVarQueryParameter['isWeb'] = isWeb;
+            }
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
             }
 
 
@@ -4400,6 +4565,8 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -4424,13 +4591,14 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * @param {string} fileModifiedAt 
          * @param {boolean} isFavorite 
          * @param {string} fileExtension 
+         * @param {string} [key] 
          * @param {any} [livePhotoData] 
          * @param {boolean} [isVisible] 
          * @param {string} [duration] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile: async (assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        uploadFile: async (assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, key?: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'assetType' is not null or undefined
             assertParamExists('uploadFile', 'assetType', assetType)
             // verify required parameter 'assetData' is not null or undefined
@@ -4463,6 +4631,12 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
             if (assetType !== undefined) { 
@@ -4535,21 +4709,23 @@ export const AssetApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async addAssetsToSharedLink(addAssetsDto: AddAssetsDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addAssetsToSharedLink(addAssetsDto, options);
+        async addAssetsToSharedLink(addAssetsDto: AddAssetsDto, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.addAssetsToSharedLink(addAssetsDto, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Check duplicated asset before uploading - for Web upload used
          * @param {CheckDuplicateAssetDto} checkDuplicateAssetDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CheckDuplicateAssetResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.checkDuplicateAsset(checkDuplicateAssetDto, options);
+        async checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CheckDuplicateAssetResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.checkDuplicateAsset(checkDuplicateAssetDto, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4585,31 +4761,34 @@ export const AssetApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadFile(assetId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadFile(assetId, options);
+        async downloadFile(assetId: string, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadFile(assetId, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * 
          * @param {DownloadFilesDto} downloadFilesDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadFiles(downloadFilesDto: DownloadFilesDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadFiles(downloadFilesDto, options);
+        async downloadFiles(downloadFilesDto: DownloadFilesDto, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadFiles(downloadFilesDto, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
          * Current this is not used in any UI element
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async downloadLibrary(skip?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadLibrary(skip, options);
+        async downloadLibrary(skip?: number, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadLibrary(skip, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4627,11 +4806,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
         /**
          * Get a single asset\'s information
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAssetById(assetId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AssetResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAssetById(assetId, options);
+        async getAssetById(assetId: string, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AssetResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAssetById(assetId, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4676,11 +4856,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * 
          * @param {string} assetId 
          * @param {ThumbnailFormat} [format] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAssetThumbnail(assetId: string, format?: ThumbnailFormat, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAssetThumbnail(assetId, format, options);
+        async getAssetThumbnail(assetId: string, format?: ThumbnailFormat, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAssetThumbnail(assetId, format, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4714,11 +4895,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {RemoveAssetsDto} removeAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.removeAssetsFromSharedLink(removeAssetsDto, options);
+        async removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.removeAssetsFromSharedLink(removeAssetsDto, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4736,11 +4918,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * @param {string} assetId 
          * @param {boolean} [isThumb] 
          * @param {boolean} [isWeb] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<object>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.serveFile(assetId, isThumb, isWeb, options);
+        async serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.serveFile(assetId, isThumb, isWeb, key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -4764,14 +4947,15 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * @param {string} fileModifiedAt 
          * @param {boolean} isFavorite 
          * @param {string} fileExtension 
+         * @param {string} [key] 
          * @param {any} [livePhotoData] 
          * @param {boolean} [isVisible] 
          * @param {string} [duration] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AssetFileUploadResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, livePhotoData, isVisible, duration, options);
+        async uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, key?: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AssetFileUploadResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, key, livePhotoData, isVisible, duration, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -4787,20 +4971,22 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
         /**
          * 
          * @param {AddAssetsDto} addAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        addAssetsToSharedLink(addAssetsDto: AddAssetsDto, options?: any): AxiosPromise<SharedLinkResponseDto> {
-            return localVarFp.addAssetsToSharedLink(addAssetsDto, options).then((request) => request(axios, basePath));
+        addAssetsToSharedLink(addAssetsDto: AddAssetsDto, key?: string, options?: any): AxiosPromise<SharedLinkResponseDto> {
+            return localVarFp.addAssetsToSharedLink(addAssetsDto, key, options).then((request) => request(axios, basePath));
         },
         /**
          * Check duplicated asset before uploading - for Web upload used
          * @param {CheckDuplicateAssetDto} checkDuplicateAssetDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, options?: any): AxiosPromise<CheckDuplicateAssetResponseDto> {
-            return localVarFp.checkDuplicateAsset(checkDuplicateAssetDto, options).then((request) => request(axios, basePath));
+        checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, key?: string, options?: any): AxiosPromise<CheckDuplicateAssetResponseDto> {
+            return localVarFp.checkDuplicateAsset(checkDuplicateAssetDto, key, options).then((request) => request(axios, basePath));
         },
         /**
          * Checks if multiple assets exist on the server and returns all existing - used by background backup
@@ -4832,29 +5018,32 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
         /**
          * 
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadFile(assetId: string, options?: any): AxiosPromise<object> {
-            return localVarFp.downloadFile(assetId, options).then((request) => request(axios, basePath));
+        downloadFile(assetId: string, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.downloadFile(assetId, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
          * @param {DownloadFilesDto} downloadFilesDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadFiles(downloadFilesDto: DownloadFilesDto, options?: any): AxiosPromise<object> {
-            return localVarFp.downloadFiles(downloadFilesDto, options).then((request) => request(axios, basePath));
+        downloadFiles(downloadFilesDto: DownloadFilesDto, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.downloadFiles(downloadFilesDto, key, options).then((request) => request(axios, basePath));
         },
         /**
          * Current this is not used in any UI element
          * @param {number} [skip] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        downloadLibrary(skip?: number, options?: any): AxiosPromise<object> {
-            return localVarFp.downloadLibrary(skip, options).then((request) => request(axios, basePath));
+        downloadLibrary(skip?: number, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.downloadLibrary(skip, key, options).then((request) => request(axios, basePath));
         },
         /**
          * Get all AssetEntity belong to the user
@@ -4870,11 +5059,12 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
         /**
          * Get a single asset\'s information
          * @param {string} assetId 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAssetById(assetId: string, options?: any): AxiosPromise<AssetResponseDto> {
-            return localVarFp.getAssetById(assetId, options).then((request) => request(axios, basePath));
+        getAssetById(assetId: string, key?: string, options?: any): AxiosPromise<AssetResponseDto> {
+            return localVarFp.getAssetById(assetId, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -4914,11 +5104,12 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * 
          * @param {string} assetId 
          * @param {ThumbnailFormat} [format] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAssetThumbnail(assetId: string, format?: ThumbnailFormat, options?: any): AxiosPromise<object> {
-            return localVarFp.getAssetThumbnail(assetId, format, options).then((request) => request(axios, basePath));
+        getAssetThumbnail(assetId: string, format?: ThumbnailFormat, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.getAssetThumbnail(assetId, format, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -4948,11 +5139,12 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
         /**
          * 
          * @param {RemoveAssetsDto} removeAssetsDto 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, options?: any): AxiosPromise<SharedLinkResponseDto> {
-            return localVarFp.removeAssetsFromSharedLink(removeAssetsDto, options).then((request) => request(axios, basePath));
+        removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, key?: string, options?: any): AxiosPromise<SharedLinkResponseDto> {
+            return localVarFp.removeAssetsFromSharedLink(removeAssetsDto, key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -4968,11 +5160,12 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * @param {string} assetId 
          * @param {boolean} [isThumb] 
          * @param {boolean} [isWeb] 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, options?: any): AxiosPromise<object> {
-            return localVarFp.serveFile(assetId, isThumb, isWeb, options).then((request) => request(axios, basePath));
+        serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, key?: string, options?: any): AxiosPromise<any> {
+            return localVarFp.serveFile(assetId, isThumb, isWeb, key, options).then((request) => request(axios, basePath));
         },
         /**
          * Update an asset
@@ -4994,14 +5187,15 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * @param {string} fileModifiedAt 
          * @param {boolean} isFavorite 
          * @param {string} fileExtension 
+         * @param {string} [key] 
          * @param {any} [livePhotoData] 
          * @param {boolean} [isVisible] 
          * @param {string} [duration] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: any): AxiosPromise<AssetFileUploadResponseDto> {
-            return localVarFp.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, livePhotoData, isVisible, duration, options).then((request) => request(axios, basePath));
+        uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, key?: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: any): AxiosPromise<AssetFileUploadResponseDto> {
+            return localVarFp.uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, key, livePhotoData, isVisible, duration, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -5016,23 +5210,25 @@ export class AssetApi extends BaseAPI {
     /**
      * 
      * @param {AddAssetsDto} addAssetsDto 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public addAssetsToSharedLink(addAssetsDto: AddAssetsDto, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).addAssetsToSharedLink(addAssetsDto, options).then((request) => request(this.axios, this.basePath));
+    public addAssetsToSharedLink(addAssetsDto: AddAssetsDto, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).addAssetsToSharedLink(addAssetsDto, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Check duplicated asset before uploading - for Web upload used
      * @param {CheckDuplicateAssetDto} checkDuplicateAssetDto 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).checkDuplicateAsset(checkDuplicateAssetDto, options).then((request) => request(this.axios, this.basePath));
+    public checkDuplicateAsset(checkDuplicateAssetDto: CheckDuplicateAssetDto, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).checkDuplicateAsset(checkDuplicateAssetDto, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5071,34 +5267,37 @@ export class AssetApi extends BaseAPI {
     /**
      * 
      * @param {string} assetId 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public downloadFile(assetId: string, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).downloadFile(assetId, options).then((request) => request(this.axios, this.basePath));
+    public downloadFile(assetId: string, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).downloadFile(assetId, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * 
      * @param {DownloadFilesDto} downloadFilesDto 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public downloadFiles(downloadFilesDto: DownloadFilesDto, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).downloadFiles(downloadFilesDto, options).then((request) => request(this.axios, this.basePath));
+    public downloadFiles(downloadFilesDto: DownloadFilesDto, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).downloadFiles(downloadFilesDto, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
      * Current this is not used in any UI element
      * @param {number} [skip] 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public downloadLibrary(skip?: number, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).downloadLibrary(skip, options).then((request) => request(this.axios, this.basePath));
+    public downloadLibrary(skip?: number, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).downloadLibrary(skip, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5117,12 +5316,13 @@ export class AssetApi extends BaseAPI {
     /**
      * Get a single asset\'s information
      * @param {string} assetId 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public getAssetById(assetId: string, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getAssetById(assetId, options).then((request) => request(this.axios, this.basePath));
+    public getAssetById(assetId: string, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).getAssetById(assetId, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5171,12 +5371,13 @@ export class AssetApi extends BaseAPI {
      * 
      * @param {string} assetId 
      * @param {ThumbnailFormat} [format] 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public getAssetThumbnail(assetId: string, format?: ThumbnailFormat, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getAssetThumbnail(assetId, format, options).then((request) => request(this.axios, this.basePath));
+    public getAssetThumbnail(assetId: string, format?: ThumbnailFormat, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).getAssetThumbnail(assetId, format, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5213,12 +5414,13 @@ export class AssetApi extends BaseAPI {
     /**
      * 
      * @param {RemoveAssetsDto} removeAssetsDto 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).removeAssetsFromSharedLink(removeAssetsDto, options).then((request) => request(this.axios, this.basePath));
+    public removeAssetsFromSharedLink(removeAssetsDto: RemoveAssetsDto, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).removeAssetsFromSharedLink(removeAssetsDto, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5237,12 +5439,13 @@ export class AssetApi extends BaseAPI {
      * @param {string} assetId 
      * @param {boolean} [isThumb] 
      * @param {boolean} [isWeb] 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).serveFile(assetId, isThumb, isWeb, options).then((request) => request(this.axios, this.basePath));
+    public serveFile(assetId: string, isThumb?: boolean, isWeb?: boolean, key?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).serveFile(assetId, isThumb, isWeb, key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5267,6 +5470,7 @@ export class AssetApi extends BaseAPI {
      * @param {string} fileModifiedAt 
      * @param {boolean} isFavorite 
      * @param {string} fileExtension 
+     * @param {string} [key] 
      * @param {any} [livePhotoData] 
      * @param {boolean} [isVisible] 
      * @param {string} [duration] 
@@ -5274,8 +5478,8 @@ export class AssetApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof AssetApi
      */
-    public uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, livePhotoData, isVisible, duration, options).then((request) => request(this.axios, this.basePath));
+    public uploadFile(assetType: AssetTypeEnum, assetData: any, deviceAssetId: string, deviceId: string, fileCreatedAt: string, fileModifiedAt: string, isFavorite: boolean, fileExtension: string, key?: string, livePhotoData?: any, isVisible?: boolean, duration?: string, options?: AxiosRequestConfig) {
+        return AssetApiFp(this.configuration).uploadFile(assetType, assetData, deviceAssetId, deviceId, fileCreatedAt, fileModifiedAt, isFavorite, fileExtension, key, livePhotoData, isVisible, duration, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -5346,6 +5550,8 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -5413,6 +5619,12 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -5445,6 +5657,8 @@ export const AuthenticationApiAxiosParamCreator = function (configuration?: Conf
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -5664,6 +5878,8 @@ export const DeviceInfoApiAxiosParamCreator = function (configuration?: Configur
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -5768,6 +5984,8 @@ export const JobApiAxiosParamCreator = function (configuration?: Configuration) 
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -5807,6 +6025,8 @@ export const JobApiAxiosParamCreator = function (configuration?: Configuration) 
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -6011,6 +6231,12 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -6071,6 +6297,12 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -6341,6 +6573,12 @@ export const ServerInfoApiAxiosParamCreator = function (configuration?: Configur
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -6552,6 +6790,12 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -6584,6 +6828,12 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -6597,10 +6847,11 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
         },
         /**
          * 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMySharedLink: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getMySharedLink: async (key?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/share/me`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -6612,6 +6863,16 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
+            if (key !== undefined) {
+                localVarQueryParameter['key'] = key;
+            }
 
 
     
@@ -6646,6 +6907,12 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -6678,6 +6945,12 @@ export const ShareApiAxiosParamCreator = function (configuration?: Configuration
             const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -6722,11 +6995,12 @@ export const ShareApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMySharedLink(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getMySharedLink(options);
+        async getMySharedLink(key?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SharedLinkResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMySharedLink(key, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -6779,11 +7053,12 @@ export const ShareApiFactory = function (configuration?: Configuration, basePath
         },
         /**
          * 
+         * @param {string} [key] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMySharedLink(options?: any): AxiosPromise<SharedLinkResponseDto> {
-            return localVarFp.getMySharedLink(options).then((request) => request(axios, basePath));
+        getMySharedLink(key?: string, options?: any): AxiosPromise<SharedLinkResponseDto> {
+            return localVarFp.getMySharedLink(key, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -6837,12 +7112,13 @@ export class ShareApi extends BaseAPI {
 
     /**
      * 
+     * @param {string} [key] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ShareApi
      */
-    public getMySharedLink(options?: AxiosRequestConfig) {
-        return ShareApiFp(this.configuration).getMySharedLink(options).then((request) => request(this.axios, this.basePath));
+    public getMySharedLink(key?: string, options?: AxiosRequestConfig) {
+        return ShareApiFp(this.configuration).getMySharedLink(key, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -6897,6 +7173,8 @@ export const SystemConfigApiAxiosParamCreator = function (configuration?: Config
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -6930,6 +7208,8 @@ export const SystemConfigApiAxiosParamCreator = function (configuration?: Config
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -6962,6 +7242,8 @@ export const SystemConfigApiAxiosParamCreator = function (configuration?: Config
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -6998,6 +7280,8 @@ export const SystemConfigApiAxiosParamCreator = function (configuration?: Config
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -7184,6 +7468,12 @@ export const TagApiAxiosParamCreator = function (configuration?: Configuration) 
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -7215,6 +7505,12 @@ export const TagApiAxiosParamCreator = function (configuration?: Configuration) 
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -7248,6 +7544,12 @@ export const TagApiAxiosParamCreator = function (configuration?: Configuration) 
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -7280,6 +7582,12 @@ export const TagApiAxiosParamCreator = function (configuration?: Configuration) 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -7316,6 +7624,12 @@ export const TagApiAxiosParamCreator = function (configuration?: Configuration) 
             const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -7545,6 +7859,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
             if (file !== undefined) { 
                 localVarFormParams.append('file', file as any);
@@ -7588,6 +7904,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -7628,6 +7946,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -7663,6 +7983,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
             if (isAll !== undefined) {
                 localVarQueryParameter['isAll'] = isAll;
@@ -7700,6 +8022,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     
@@ -7838,6 +8162,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
 
+            // authentication cookie required
+
 
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -7873,6 +8199,8 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
             // authentication bearer required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            // authentication cookie required
 
 
     

--- a/web/src/lib/components/album-page/__tests__/album-card.spec.ts
+++ b/web/src/lib/components/album-page/__tests__/album-card.spec.ts
@@ -93,6 +93,7 @@ describe('AlbumCard component', () => {
 		expect(apiMock.assetApi.getAssetThumbnail).toHaveBeenCalledWith(
 			'thumbnailIdOne',
 			ThumbnailFormat.Jpeg,
+			undefined,
 			{ responseType: 'blob' }
 		);
 		expect(createObjectURLMock).toHaveBeenCalledWith(thumbnailBlob);

--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -34,9 +34,14 @@
 			return;
 		}
 
-		const { data } = await api.assetApi.getAssetThumbnail(thubmnailId, ThumbnailFormat.Jpeg, {
-			responseType: 'blob'
-		});
+		const { data } = await api.assetApi.getAssetThumbnail(
+			thubmnailId,
+			ThumbnailFormat.Jpeg,
+			undefined,
+			{
+				responseType: 'blob'
+			}
+		);
 
 		if (data instanceof Blob) {
 			return URL.createObjectURL(data);

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -170,11 +170,7 @@
 				{
 					assetIds: assets.map((a) => a.id)
 				},
-				{
-					params: {
-						key: sharedLink?.key
-					}
-				}
+				sharedLink?.key
 			);
 
 			if (data.album) {
@@ -269,10 +265,8 @@
 				const { data, status, headers } = await api.albumApi.downloadArchive(
 					album.id,
 					skip || undefined,
+					sharedLink?.key,
 					{
-						params: {
-							key: sharedLink?.key
-						},
 						responseType: 'blob',
 						onDownloadProgress: function (progressEvent) {
 							const request = this as XMLHttpRequest;

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -145,8 +145,7 @@
 
 			$downloadAssets[imageFileName] = 0;
 
-			const { data, status } = await api.assetApi.downloadFile(assetId, {
-				params: { key },
+			const { data, status } = await api.assetApi.downloadFile(assetId, key, {
 				responseType: 'blob',
 				onDownloadProgress: (progressEvent) => {
 					if (progressEvent.lengthComputable) {

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -26,10 +26,7 @@
 
 	const loadAssetData = async () => {
 		try {
-			const { data } = await api.assetApi.serveFile(asset.id, false, true, {
-				params: {
-					key: publicSharedKey
-				},
+			const { data } = await api.assetApi.serveFile(asset.id, false, true, publicSharedKey, {
 				responseType: 'blob'
 			});
 

--- a/web/src/lib/components/share-page/individual-shared-viewer.svelte
+++ b/web/src/lib/components/share-page/individual-shared-viewer.svelte
@@ -54,11 +54,7 @@
 				{
 					assetIds
 				},
-				{
-					params: {
-						key: sharedLink?.key
-					}
-				}
+				sharedLink?.key
 			);
 
 			notificationController.show({
@@ -76,11 +72,7 @@
 				{
 					assetIds: assets.filter((a) => !selectedAssets.has(a)).map((a) => a.id)
 				},
-				{
-					params: {
-						key: sharedLink?.key
-					}
-				}
+				sharedLink?.key
 			);
 
 			assets = assets.filter((a) => !selectedAssets.has(a));

--- a/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
+++ b/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
@@ -11,9 +11,14 @@
 			return noThumbnailUrl;
 		}
 
-		const { data } = await api.assetApi.getAssetThumbnail(thubmnailId, ThumbnailFormat.Webp, {
-			responseType: 'blob'
-		});
+		const { data } = await api.assetApi.getAssetThumbnail(
+			thubmnailId,
+			ThumbnailFormat.Webp,
+			undefined,
+			{
+				responseType: 'blob'
+			}
+		);
 		if (data instanceof Blob) {
 			return URL.createObjectURL(data);
 		}

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -108,11 +108,7 @@ async function fileUploader(
 				deviceAssetId: String(deviceAssetId),
 				deviceId: 'WEB'
 			},
-			{
-				params: {
-					key: sharedKey
-				}
-			}
+			sharedKey
 		);
 
 		if (status === 200 && data.isExist && data.id) {

--- a/web/src/routes/share/[key]/+page.server.ts
+++ b/web/src/routes/share/[key]/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 	const { key } = params;
 
 	try {
-		const { data: sharedLink } = await api.shareApi.getMySharedLink({ params: { key } });
+		const { data: sharedLink } = await api.shareApi.getMySharedLink(key);
 
 		const assetCount = sharedLink.assets.length;
 		const assetId = sharedLink.album?.albumThumbnailAssetId || sharedLink.assets[0]?.id;

--- a/web/src/routes/share/[key]/photos/[assetId]/+page.server.ts
+++ b/web/src/routes/share/[key]/photos/[assetId]/+page.server.ts
@@ -7,9 +7,7 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ params }) => {
 	try {
 		const { key, assetId } = params;
-		const { data: asset } = await api.assetApi.getAssetById(assetId, {
-			params: { key }
-		});
+		const { data: asset } = await api.assetApi.getAssetById(assetId, key);
 
 		if (!asset) {
 			return error(404, 'Asset not found');


### PR DESCRIPTION
Changed the `Authenticated` decorator to include the `key` URL query string. Also added `cookie` as an authentication method and included both Bearer and cookie auth in the decorator, so `@Authenticated` doesn't need additional decorators.

Also modified endpoints that return files to have the correct return type. The `{ type: 'string', format: 'binary' }` format used comes from the OpenAPI 3 [spec for file uploads](https://spec.openapis.org/oas/v3.0.3#considerations-for-file-uploads).

As a result of these changes had to make minor adjustments to API calls from the web.