### PR TITLE
fix(web): don't log unauthorized errors

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -16,8 +16,10 @@ export const handle = (async ({ event, resolve }) => {
 			const { data: user } = await api.userApi.getMyUserInfo();
 			event.locals.user = user;
 		} catch (err) {
+			const apiError = err as AxiosError;
+
 			// Ignore 401 unauthorized errors and log all others.
-			if (err instanceof AxiosError && err.response?.status !== 401) {
+			if (apiError.response?.status !== 401) {
 				console.error('[ERROR] hooks.server.ts [handle]:', err);
 			}
 		}

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -4,10 +4,24 @@ import { env } from '$env/dynamic/public';
 import { ImmichApi } from './api/api';
 
 export const handle = (async ({ event, resolve }) => {
-	event.locals.api = new ImmichApi({
-		basePath: env.PUBLIC_IMMICH_SERVER_URL || 'http://immich-server:3001',
-		accessToken: event.cookies.get('immich_access_token')
-	});
+	const basePath = env.PUBLIC_IMMICH_SERVER_URL || 'http://immich-server:3001';
+	const accessToken = event.cookies.get('immich_access_token');
+	const api = new ImmichApi({ basePath, accessToken });
+
+	// API instance that should be used for all server-side requests.
+	event.locals.api = api;
+
+	if (accessToken) {
+		try {
+			const { data: user } = await api.userApi.getMyUserInfo();
+			event.locals.user = user;
+		} catch (err) {
+			// Ignore 401 unauthorized errors and log all others.
+			if (err instanceof AxiosError && err.response?.status !== 401) {
+				console.error('[ERROR] hooks.server.ts [handle]:', err);
+			}
+		}
+	}
 
 	const res = await resolve(event);
 

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,12 +1,5 @@
 import type { LayoutServerLoad } from './$types';
 
-export const load = (async ({ locals: { api } }) => {
-	try {
-		const { data: user } = await api.userApi.getMyUserInfo();
-
-		return { user };
-	} catch (e) {
-		console.error('[ERROR] layout.server.ts [LayoutServerLoad]: ');
-		return { user: undefined };
-	}
+export const load = (async ({ locals: { user } }) => {
+	return { user };
 }) satisfies LayoutServerLoad;


### PR DESCRIPTION
Fixes minor regression from #1858 where the API gets called when no access token is present. This led to some errors being logged, but it didn't impact any functionality.

This PR goes back to the old behavior of only calling the API when an access token is present and logs the error for a failed API call.