### PR TITLE
fix(web): use correct api for asset share page

### DIFF
--- a/web/src/routes/share/[key]/+page.server.ts
+++ b/web/src/routes/share/[key]/+page.server.ts
@@ -2,11 +2,11 @@ export const prerender = false;
 import { error } from '@sveltejs/kit';
 
 import { getThumbnailUrl } from '$lib/utils/asset-utils';
-import { api, ThumbnailFormat } from '@api';
+import { ThumbnailFormat } from '@api';
 import type { PageServerLoad } from './$types';
 import featurePanelUrl from '$lib/assets/feature-panel.png';
 
-export const load: PageServerLoad = async ({ params, parent }) => {
+export const load: PageServerLoad = async ({ params, parent, locals: { api } }) => {
 	const { user } = await parent();
 
 	const { key } = params;


### PR DESCRIPTION
Somehow missed this one in #1858. The `/share/[key]` page still uses the global API instance which causes the page to always fail loading. Replaced API import with `locals.api` to fix this.