### PR TITLE
feat(server) Enable ML support for ARM CPUs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
             platforms: "linux/arm/v7,linux/amd64,linux/arm64"
           - context: "machine-learning"
             image: "immich-machine-learning"
-            platforms: "linux/amd64"
+            platforms: "linux/arm/v7,linux/amd64,linux/arm64"
           - context: "nginx"
             image: "immich-proxy"
             platforms: "linux/arm/v7,linux/amd64,linux/arm64"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
             platforms: "linux/arm/v7,linux/amd64,linux/arm64"
           - context: "machine-learning"
             image: "immich-machine-learning"
-            platforms: "linux/arm/v7,linux/amd64,linux/arm64"
+            platforms: "linux/amd64,linux/arm64"
           - context: "nginx"
             image: "immich-proxy"
             platforms: "linux/arm/v7,linux/amd64,linux/arm64"

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install --no-cache-dir torch==1.13.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install --pre torch  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 RUN pip install transformers tqdm numpy scikit-learn scipy nltk sentencepiece flask Pillow
 RUN pip install --no-deps sentence-transformers
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -1,15 +1,16 @@
 FROM python:3.10
 
-ENV TRANSFORMERS_CACHE=/cache
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV TRANSFORMERS_CACHE=/cache \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=true
 
 WORKDIR /usr/src/app
 
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install --no-cache-dir --pre torch  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+RUN pip install --pre torch  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 RUN pip install transformers tqdm numpy scikit-learn scipy nltk sentencepiece flask Pillow
 RUN pip install --no-deps sentence-transformers
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /usr/src/app
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install --pre torch  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+RUN pip install --no-cache-dir --pre torch  -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 RUN pip install transformers tqdm numpy scikit-learn scipy nltk sentencepiece flask Pillow
 RUN pip install --no-deps sentence-transformers
 


### PR DESCRIPTION
Hi there, thought I'd create a quick PR to enable the ML image to be built on ARM CPUs. As per [pytorch's website](https://pytorch.org/blog/prototype-features-now-available-apis-for-hardware-accelerated-mobile-and-arm64-builds/), their nightly builds have ARM64 support. Using this would be great for us Raspberry Pi users!

On a side note, love this project, and keen to contribute back. Let me know if there's anything else I need to do for this to be considered :)