### PR TITLE
fix(mobile): Adds safe area to album to stop from clipping bottom of albums

### DIFF
--- a/mobile/lib/modules/album/views/album_viewer_page.dart
+++ b/mobile/lib/modules/album/views/album_viewer_page.dart
@@ -278,7 +278,9 @@ class AlbumViewerPage extends HookConsumerWidget {
                     ),
                   ),
                 ),
-                buildImageGrid(album)
+                SliverSafeArea(
+                  sliver: buildImageGrid(album),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
Fixes #1888 