### PR TITLE
feat(server): improve thumbnail relation and updating

### DIFF
--- a/server/apps/immich/src/api-v1/album/album.module.ts
+++ b/server/apps/immich/src/api-v1/album/album.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { AlbumService } from './album.service';
 import { AlbumController } from './album.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { AlbumEntity } from '@app/infra';
+import { AlbumEntity, AssetEntity } from '@app/infra';
 import { AlbumRepository, IAlbumRepository } from './album-repository';
 import { DownloadModule } from '../../modules/download/download.module';
 
@@ -12,7 +12,7 @@ const ALBUM_REPOSITORY_PROVIDER = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AlbumEntity]), DownloadModule],
+  imports: [TypeOrmModule.forFeature([AlbumEntity, AssetEntity]), DownloadModule],
   controllers: [AlbumController],
   providers: [AlbumService, ALBUM_REPOSITORY_PROVIDER],
   exports: [ALBUM_REPOSITORY_PROVIDER],

--- a/server/apps/immich/src/api-v1/album/album.service.spec.ts
+++ b/server/apps/immich/src/api-v1/album/album.service.spec.ts
@@ -503,59 +503,47 @@ describe('Album service', () => {
   it('updates the album thumbnail by listing all albums', async () => {
     const albumEntity = _getOwnedAlbum();
     const assetEntity = new AssetEntity();
-    const newThumbnailAssetId = 'e5e65c02-b889-4f3c-afe1-a39a96d578ed';
+    const newThumbnailAsset = new AssetEntity();
+    newThumbnailAsset.id = 'e5e65c02-b889-4f3c-afe1-a39a96d578ed';
 
     albumEntity.albumThumbnailAssetId = 'nonexistent';
-    assetEntity.id = newThumbnailAssetId;
+    assetEntity.id = newThumbnailAsset.id;
     albumEntity.assets = [assetEntity];
     albumRepositoryMock.getList.mockImplementation(async () => [albumEntity]);
-    albumRepositoryMock.updateAlbum.mockImplementation(async () => ({
-      ...albumEntity,
-      albumThumbnailAssetId: newThumbnailAssetId,
-    }));
+    albumRepositoryMock.updateThumbnails.mockImplementation(async () => {
+      albumEntity.albumThumbnailAsset = newThumbnailAsset;
+      albumEntity.albumThumbnailAssetId = newThumbnailAsset.id;
+
+      return 1;
+    });
 
     const result = await sut.getAllAlbums(authUser, {});
 
     expect(result).toHaveLength(1);
-    expect(result[0].albumThumbnailAssetId).toEqual(newThumbnailAssetId);
+    expect(result[0].albumThumbnailAssetId).toEqual(newThumbnailAsset.id);
     expect(albumRepositoryMock.getList).toHaveBeenCalledTimes(1);
-    expect(albumRepositoryMock.updateAlbum).toHaveBeenCalledTimes(1);
+    expect(albumRepositoryMock.updateThumbnails).toHaveBeenCalledTimes(1);
     expect(albumRepositoryMock.getList).toHaveBeenCalledWith(albumEntity.ownerId, {});
-    expect(albumRepositoryMock.updateAlbum).toHaveBeenCalledWith(albumEntity, {
-      albumThumbnailAssetId: newThumbnailAssetId,
-    });
   });
 
   it('removes the thumbnail for an empty album', async () => {
     const albumEntity = _getOwnedAlbum();
-    const newAlbumEntity = { ...albumEntity, albumThumbnailAssetId: null };
 
     albumEntity.albumThumbnailAssetId = 'e5e65c02-b889-4f3c-afe1-a39a96d578ed';
     albumRepositoryMock.getList.mockImplementation(async () => [albumEntity]);
-    albumRepositoryMock.updateAlbum.mockImplementation(async () => newAlbumEntity);
+    albumRepositoryMock.updateThumbnails.mockImplementation(async () => {
+      albumEntity.albumThumbnailAsset = null;
+      albumEntity.albumThumbnailAssetId = null;
+
+      return 1;
+    });
 
     const result = await sut.getAllAlbums(authUser, {});
 
     expect(result).toHaveLength(1);
     expect(result[0].albumThumbnailAssetId).toBeNull();
     expect(albumRepositoryMock.getList).toHaveBeenCalledTimes(1);
-    expect(albumRepositoryMock.updateAlbum).toHaveBeenCalledTimes(1);
-    expect(albumRepositoryMock.getList).toHaveBeenCalledWith(albumEntity.ownerId, {});
-    expect(albumRepositoryMock.updateAlbum).toHaveBeenCalledWith(newAlbumEntity, {
-      albumThumbnailAssetId: undefined,
-    });
-  });
-
-  it('listing empty albums does not unnecessarily update the album', async () => {
-    const albumEntity = _getOwnedAlbum();
-    albumRepositoryMock.getList.mockImplementation(async () => [albumEntity]);
-    albumRepositoryMock.updateAlbum.mockImplementation(async () => albumEntity);
-
-    const result = await sut.getAllAlbums(authUser, {});
-
-    expect(result).toHaveLength(1);
-    expect(albumRepositoryMock.getList).toHaveBeenCalledTimes(1);
-    expect(albumRepositoryMock.updateAlbum).toHaveBeenCalledTimes(0);
+    expect(albumRepositoryMock.updateThumbnails).toHaveBeenCalledTimes(1);
     expect(albumRepositoryMock.getList).toHaveBeenCalledWith(albumEntity.ownerId, {});
   });
 });

--- a/server/apps/immich/src/api-v1/album/album.service.spec.ts
+++ b/server/apps/immich/src/api-v1/album/album.service.spec.ts
@@ -129,6 +129,7 @@ describe('Album service', () => {
       removeAssets: jest.fn(),
       removeUser: jest.fn(),
       updateAlbum: jest.fn(),
+      updateThumbnails: jest.fn(),
       getListByAssetId: jest.fn(),
       getCountByUserId: jest.fn(),
       getSharedWithUserAlbumCount: jest.fn(),

--- a/server/apps/immich/src/api-v1/album/album.service.ts
+++ b/server/apps/immich/src/api-v1/album/album.service.ts
@@ -41,6 +41,8 @@ export class AlbumService {
     albumId: string;
     validateIsOwner?: boolean;
   }): Promise<AlbumEntity> {
+    await this.albumRepository.updateThumbnails();
+
     const album = await this.albumRepository.get(albumId);
     if (!album) {
       throw new NotFoundException('Album Not Found');
@@ -128,10 +130,6 @@ export class AlbumService {
     const album = await this._getAlbum({ authUser, albumId });
     const deletedCount = await this.albumRepository.removeAssets(album, removeAssetsDto);
     const newAlbum = await this._getAlbum({ authUser, albumId });
-
-    if (newAlbum) {
-      await this.albumRepository.updateThumbnails();
-    }
 
     if (deletedCount !== removeAssetsDto.assetIds.length) {
       throw new BadRequestException('Some assets were not found in the album');

--- a/server/libs/domain/test/fixtures.ts
+++ b/server/libs/domain/test/fixtures.ts
@@ -422,6 +422,7 @@ export const sharedLinkStub = {
       albumName: 'Test Album',
       createdAt: today.toISOString(),
       updatedAt: today.toISOString(),
+      albumThumbnailAsset: null,
       albumThumbnailAssetId: null,
       sharedUsers: [],
       sharedLinks: [],

--- a/server/libs/domain/test/fixtures.ts
+++ b/server/libs/domain/test/fixtures.ts
@@ -163,6 +163,7 @@ export const albumStub = {
     ownerId: authStub.admin.id,
     owner: userEntityStub.admin,
     assets: [],
+    albumThumbnailAsset: null,
     albumThumbnailAssetId: null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/server/libs/infra/src/db/entities/album.entity.ts
+++ b/server/libs/infra/src/db/entities/album.entity.ts
@@ -33,7 +33,10 @@ export class AlbumEntity {
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt!: string;
 
-  @Column({ comment: 'Asset ID to be used as thumbnail', type: 'varchar', nullable: true })
+  @ManyToOne(() => AssetEntity, { nullable: true, onDelete: 'SET NULL', onUpdate: 'CASCADE' })
+  albumThumbnailAsset!: AssetEntity | null;
+
+  @Column({ comment: 'Asset ID to be used as thumbnail', nullable: true })
   albumThumbnailAssetId!: string | null;
 
   @ManyToMany(() => UserEntity)

--- a/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
+++ b/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlbumThumbnailRelation1677613712565 implements MigrationInterface {
+  name = 'AlbumThumbnailRelation1677613712565';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "albums"
+      ALTER COLUMN "albumThumbnailAssetId"
+      TYPE uuid USING "albumThumbnailAssetId"::uuid
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "albums" ADD CONSTRAINT "FK_05895aa505a670300d4816debce" FOREIGN KEY ("albumThumbnailAssetId") REFERENCES "assets"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "albums" DROP CONSTRAINT "FK_05895aa505a670300d4816debce"`);
+
+    await queryRunner.query(`
+      ALTER TABLE "albums" ALTER COLUMN "albumThumbnailAssetId" TYPE varchar USING "albumThumbnailAssetId"::varchar
+    `);
+  }
+}

--- a/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
+++ b/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
@@ -4,6 +4,41 @@ export class AlbumThumbnailRelation1677613712565 implements MigrationInterface {
   name = 'AlbumThumbnailRelation1677613712565';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Make sure all albums have a valid albumThumbnailAssetId UUID or NULL.
+    await queryRunner.query(`
+      UPDATE "albums"
+      SET
+        "albumThumbnailAssetId" = (
+            SELECT
+              "albums_assets2"."assetsId"
+            FROM
+              "assets" "assets",
+              "albums_assets_assets" "albums_assets2"
+            WHERE
+                "albums_assets2"."assetsId" = "assets"."id"
+                AND "albums_assets2"."albumsId" = "albums"."id"
+            ORDER BY
+              "assets"."fileCreatedAt" DESC
+            LIMIT 1
+        ),
+        "updatedAt" = CURRENT_TIMESTAMP
+      WHERE
+        "albums"."albumThumbnailAssetId" IS NULL
+        AND EXISTS (
+            SELECT 1
+            FROM "albums_assets_assets" "albums_assets"
+            WHERE "albums"."id" = "albums_assets"."albumsId"
+        )
+        OR "albums"."albumThumbnailAssetId" IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "albums_assets_assets" "albums_assets"
+          WHERE
+            "albums"."id" = "albums_assets"."albumsId"
+            AND "albums"."albumThumbnailAssetId" = "albums_assets"."assetsId"::varchar
+      )
+    `);
+
     await queryRunner.query(`
       ALTER TABLE "albums"
       ALTER COLUMN "albumThumbnailAssetId"

--- a/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
+++ b/server/libs/infra/src/db/migrations/1677613712565-AlbumThumbnailRelation.ts
@@ -11,7 +11,7 @@ export class AlbumThumbnailRelation1677613712565 implements MigrationInterface {
     `);
 
     await queryRunner.query(`
-      ALTER TABLE "albums" ADD CONSTRAINT "FK_05895aa505a670300d4816debce" FOREIGN KEY ("albumThumbnailAssetId") REFERENCES "assets"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
+      ALTER TABLE "albums" ADD CONSTRAINT "FK_05895aa505a670300d4816debce" FOREIGN KEY ("albumThumbnailAssetId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE
     `);
   }
 


### PR DESCRIPTION
Added `albumThumnailAssetId` foreign key to `AssetEntity`. It should actually be a composite foreign key to the linking table of assets and albums, but I've not done that due to quite some added complexity, because the linking table has to be defined explicitly.

Reworking `AlbumService._checkValidThumbnail` means we no longer need to pull all assets from the database in `AlbumService.getAllAlbums` and then those queries can be optimized further, which has recently been causing some performance bottlenecks.

Still WIP and haven't tested it beyond the basics
