### PR TITLE
fix(server): storage template unit test

### DIFF
--- a/server/libs/domain/src/system-config/system-config.service.spec.ts
+++ b/server/libs/domain/src/system-config/system-config.service.spec.ts
@@ -113,6 +113,7 @@ describe(SystemConfigService.name, () => {
           '{{y}}-{{MM}}-{{dd}}/{{filename}}',
           '{{y}}-{{MMM}}-{{dd}}/{{filename}}',
           '{{y}}-{{MMMM}}-{{dd}}/{{filename}}',
+          '{{y}}/{{y}}-{{MM}}/{{filename}}',
         ],
         secondOptions: ['s', 'ss'],
         yearOptions: ['y', 'yy'],


### PR DESCRIPTION
In #1903 a storage preset was added, but the unit test wasn't updated. This should fix the server tests failing.