### PR TITLE
fix(server): exif extraction swapped params

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -183,8 +183,8 @@ export class MetadataExtractionProcessor {
       if (newExif.livePhotoCID && !asset.livePhotoVideoId) {
         const motionAsset = await this.assetRepository.findLivePhotoMatch(
           newExif.livePhotoCID,
-          AssetType.VIDEO,
           asset.id,
+          AssetType.VIDEO,
         );
         if (motionAsset) {
           await this.assetRepository.save({ id: asset.id, livePhotoVideoId: motionAsset.id });
@@ -294,8 +294,8 @@ export class MetadataExtractionProcessor {
       if (newExif.livePhotoCID) {
         const photoAsset = await this.assetRepository.findLivePhotoMatch(
           newExif.livePhotoCID,
-          AssetType.IMAGE,
           asset.id,
+          AssetType.IMAGE,
         );
         if (photoAsset) {
           await this.assetRepository.save({ id: photoAsset.id, livePhotoVideoId: asset.id });

--- a/server/libs/domain/src/asset/asset.repository.ts
+++ b/server/libs/domain/src/asset/asset.repository.ts
@@ -6,5 +6,5 @@ export interface IAssetRepository {
   deleteAll(ownerId: string): Promise<void>;
   getAll(): Promise<AssetEntity[]>;
   save(asset: Partial<AssetEntity>): Promise<AssetEntity>;
-  findLivePhotoMatch(livePhotoCID: string, type: AssetType, otherAssetId: string): Promise<AssetEntity | null>;
+  findLivePhotoMatch(livePhotoCID: string, otherAssetId: string, type: AssetType): Promise<AssetEntity | null>;
 }


### PR DESCRIPTION
The parameters for `AssetRepository.findLivePhotoMatch` were swapped in [#1787](https://github.com/immich-app/immich/pull/1787/files#diff-10b08bbb8828f4e5976bce7d7e4b15169400847dc32e002fb78cdb050ef9497aR24), but not in `IAssetRepository`. This causes metadata extraction to fail for all videos and based on the code also for the photo part of live images. I'm not sure how this all links together and why TypeScript didn't catch any of this, but I've corrected the parameter order.