### PR TITLE
Fix timezone mismatch in server tests

### DIFF
--- a/server/libs/common/src/utils/time-utils.spec.ts
+++ b/server/libs/common/src/utils/time-utils.spec.ts
@@ -3,6 +3,12 @@
 import { timeUtils } from './time-utils';
 
 describe('Time Utilities', () => {
+  describe('timezone', () => {
+    it('should always be UTC', () => {
+      expect(new Date().getTimezoneOffset()).toBe(0);
+    });
+  });
+
   describe('checkValidTimestamp', () => {
     it('check for year 0000', () => {
       const result = timeUtils.checkValidTimestamp('0000-00-00T00:00:00.000Z');

--- a/server/libs/domain/test/global-setup.js
+++ b/server/libs/domain/test/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/server/package.json
+++ b/server/package.json
@@ -158,6 +158,7 @@
       "@app/common": "<rootDir>/libs/common/src",
       "^@app/infra(|/.*)$": "<rootDir>/libs/infra/src/$1",
       "^@app/domain(|/.*)$": "<rootDir>/libs/domain/src/$1"
-    }
+    },
+    "globalSetup": "<rootDir>/libs/domain/test/global-setup.js"
   }
 }


### PR DESCRIPTION
My local timezone is `UTC+3`. I cloned repository, switched to v1.50.1 tag and run server tests. Two tests failed:
1. All `checkValidTimestamp` tests pass UTC time as input values but implementation of `checkValidTimestamp` uses local time in its internal checks. As a result test `check for year before 1583` fails. So I changed input values from UTC to local time

2. Test `should handle a file upload` passes input asset with UTC time but upload directory is named after local time. So I modified `fileModifiedAt`, `fileCreatedAt` and `updatedAt` values in test asset from UTC to local time

All tests are green now

**UPDATE:** Instead of changing input values from UTC to local time I set timezone in jest config