### PR TITLE
Add missing space in version_announcement_overlay_text_2 for ru-RU locale

### DIFF
--- a/mobile/assets/i18n/ru-RU.json
+++ b/mobile/assets/i18n/ru-RU.json
@@ -227,7 +227,7 @@
   "version_announcement_overlay_ack": "Подтверждение",
   "version_announcement_overlay_release_notes": "примечания к выпуску",
   "version_announcement_overlay_text_1": "Привет друг, вышел новый релиз",
-  "version_announcement_overlay_text_2": "пожалуйста, найдите время, чтобы посетить",
+  "version_announcement_overlay_text_2": "пожалуйста, найдите время, чтобы посетить ",
   "version_announcement_overlay_text_3": " и убедитесь, что ваши настройки docker-compose и .env обновлены, чтобы предотвратить любые неправильные настройки, особенно если вы используете WatchTower или любой другой механизм, который обрабатывает обновление вашего серверного приложения автоматически.",
   "version_announcement_overlay_title": "Доступна новая версия сервера \uD83C\uDF89"
 }


### PR DESCRIPTION
I fixed only ru-RU locale though I see some other locales with the same issue. I'm 90% sure that all locales must have trailing space in `version_announcement_overlay_text_2` string but decided not to modify them yet