### PR TITLE
fix(mobile): do not crash on malformed asset duration

### DIFF
--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -19,7 +19,8 @@ class Asset {
         fileCreatedAt = DateTime.parse(remote.fileCreatedAt).toUtc(),
         fileModifiedAt = DateTime.parse(remote.fileModifiedAt).toUtc(),
         updatedAt = DateTime.parse(remote.updatedAt).toUtc(),
-        durationInSeconds = remote.duration.toDuration().inSeconds,
+        // use -1 as fallback duration (to not mix it up with non-video assets correctly having duration=0)
+        durationInSeconds = remote.duration.toDuration()?.inSeconds ?? -1,
         fileName = p.basename(remote.originalPath),
         height = remote.exifInfo?.exifImageHeight?.toInt(),
         width = remote.exifInfo?.exifImageWidth?.toInt(),

--- a/mobile/lib/utils/builtin_extensions.dart
+++ b/mobile/lib/utils/builtin_extensions.dart
@@ -1,8 +1,13 @@
 extension DurationExtension on String {
-  Duration toDuration() {
-    final parts =
-        split(':').map((e) => double.parse(e).toInt()).toList(growable: false);
-    return Duration(hours: parts[0], minutes: parts[1], seconds: parts[2]);
+  Duration? toDuration() {
+    try {
+      final parts = split(':')
+          .map((e) => double.parse(e).toInt())
+          .toList(growable: false);
+      return Duration(hours: parts[0], minutes: parts[1], seconds: parts[2]);
+    } catch (e) {
+      return null;
+    }
   }
 
   double toDouble() {

--- a/mobile/test/builtin_extensions_text.dart
+++ b/mobile/test/builtin_extensions_text.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/builtin_extensions.dart';
+
+void main() {
+  group('Test toDuration', () {
+    test('ok', () {
+      expect(
+        "1:02:33".toDuration(),
+        const Duration(hours: 1, minutes: 2, seconds: 33),
+      );
+    });
+    test('malformed', () {
+      expect("".toDuration(), null);
+      expect("1:2".toDuration(), null);
+      expect("a:b:c".toDuration(), null);
+    });
+  });
+}


### PR DESCRIPTION
fixes / workaround for #1907

properly done, we should store the duration in milliseconds as an int in the database. this would solve such parsing issues 