### PR TITLE
fix(mobile): Fixes hero animation on main timeline

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -127,7 +127,10 @@ class GalleryViewerPage extends HookConsumerWidget {
 
     /// Original (large) image of a local asset. Required asset.isLocal
     ImageProvider localImageProvider(Asset asset) {
-      return AssetEntityImageProvider(asset.local!);
+      return AssetEntityImageProvider(
+        isOriginal: true,
+        asset.local!,
+      );
     }
 
     void precacheNextImage(int index) {
@@ -389,8 +392,11 @@ class GalleryViewerPage extends HookConsumerWidget {
                   onTapDown: (_, __, ___) =>
                       showAppBar.value = !showAppBar.value,
                   imageProvider: provider,
-                  heroAttributes:
-                      PhotoViewHeroAttributes(tag: assetList[index].id),
+                  heroAttributes: PhotoViewHeroAttributes(
+                    tag: assetList[index].id,
+                  ),
+                  filterQuality: FilterQuality.high,
+                  tightMode: true,
                   minScale: PhotoViewComputedScale.contained,
                 );
               } else {
@@ -398,8 +404,10 @@ class GalleryViewerPage extends HookConsumerWidget {
                   onDragStart: (_, details, __) =>
                       localPosition = details.localPosition,
                   onDragUpdate: (_, details, __) => handleSwipeUpDown(details),
-                  heroAttributes:
-                      PhotoViewHeroAttributes(tag: assetList[index].id),
+                  heroAttributes: PhotoViewHeroAttributes(
+                    tag: assetList[index].id,
+                  ),
+                  filterQuality: FilterQuality.high,
                   maxScale: 1.0,
                   minScale: 1.0,
                   child: SafeArea(

--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -70,6 +70,31 @@ class ThumbnailImage extends HookConsumerWidget {
         HapticFeedback.heavyImpact();
       },
       child: Hero(
+        createRectTween: (begin, end) {
+          double? top;
+          // Uses the [BoxFit.contain] algorithm
+          if (asset.width != null && asset.height != null) {
+            final assetAR = asset.width! / asset.height!;
+            final w = MediaQuery.of(context).size.width;
+            final deviceAR = MediaQuery.of(context).size.aspectRatio;
+            if (deviceAR < assetAR) {
+              top = asset.height! * w / asset.width!;
+            } else {
+              top = 0;
+            }
+            // get the height offset
+          }
+
+          return MaterialRectCenterArcTween(
+            begin: Rect.fromLTRB(
+              0,
+              top ?? 0.0,
+              MediaQuery.of(context).size.width,
+              MediaQuery.of(context).size.height,
+            ),
+            end: end,
+          );
+        },
         tag: asset.id,
         child: Stack(
           children: [

--- a/mobile/lib/shared/ui/photo_view/photo_view_gallery.dart
+++ b/mobile/lib/shared/ui/photo_view/photo_view_gallery.dart
@@ -259,7 +259,6 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             controller: pageOption.controller,
             scaleStateController: pageOption.scaleStateController,
             customSize: widget.customSize,
-            heroAttributes: pageOption.heroAttributes,
             scaleStateChangedCallback: scaleStateChangedCallback,
             enableRotation: widget.enableRotation,
             initialScale: pageOption.initialScale,
@@ -289,7 +288,6 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             scaleStateController: pageOption.scaleStateController,
             customSize: widget.customSize,
             gaplessPlayback: widget.gaplessPlayback,
-            heroAttributes: pageOption.heroAttributes,
             scaleStateChangedCallback: scaleStateChangedCallback,
             enableRotation: widget.enableRotation,
             initialScale: pageOption.initialScale,
@@ -309,6 +307,19 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
             disableGestures: pageOption.disableGestures,
             errorBuilder: pageOption.errorBuilder,
           );
+
+    if (pageOption.heroAttributes != null) {
+      return Hero(
+        tag: pageOption.heroAttributes!.tag,
+        createRectTween: pageOption.heroAttributes!.createRectTween,
+        flightShuttleBuilder: pageOption.heroAttributes!.flightShuttleBuilder,
+        placeholderBuilder: pageOption.heroAttributes!.placeholderBuilder,
+        transitionOnUserGestures: pageOption.heroAttributes!.transitionOnUserGestures,
+        child: ClipRect(
+          child: photoView,
+        ),
+      );
+    }
 
     return ClipRect(
       child: photoView,


### PR DESCRIPTION
The main timeline hero animation is a bit funky with some flickering and things not quite lining up properly.

- I tested this with mostly local assets, as that was the main bug I wanted to fix here. Please test this and make sure it behaves nicely with remote assets.
- There's still a slight flicker with video hero animations.

> The below animations are slowed down ~ 4x so you can see them better

## Before
[Screencast from 03-02-2023 09:10:16 PM.webm](https://user-images.githubusercontent.com/100457/222613772-009c01ef-663f-4790-934c-2ae765fa23b3.webm)

## After
[Screencast from 03-02-2023 09:07:35 PM.webm](https://user-images.githubusercontent.com/100457/222613624-742eafb1-cfe9-4e8a-bda6-48f00c04f485.webm)
