### PR TITLE
feat(server): improve get albums performance

### DIFF
--- a/server/apps/immich/src/api-v1/album/album.module.ts
+++ b/server/apps/immich/src/api-v1/album/album.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { AlbumService } from './album.service';
 import { AlbumController } from './album.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { AlbumEntity, AssetEntity } from '@app/infra';
+import { AlbumEntity, AssetEntity, SharedLinkEntity } from '@app/infra';
 import { AlbumRepository, IAlbumRepository } from './album-repository';
 import { DownloadModule } from '../../modules/download/download.module';
 
@@ -12,7 +12,7 @@ const ALBUM_REPOSITORY_PROVIDER = {
 };
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AlbumEntity, AssetEntity]), DownloadModule],
+  imports: [TypeOrmModule.forFeature([AlbumEntity, AssetEntity, SharedLinkEntity]), DownloadModule],
   controllers: [AlbumController],
   providers: [AlbumService, ALBUM_REPOSITORY_PROVIDER],
   exports: [ALBUM_REPOSITORY_PROVIDER],

--- a/server/apps/immich/src/api-v1/album/album.service.ts
+++ b/server/apps/immich/src/api-v1/album/album.service.ts
@@ -6,7 +6,7 @@ import { AddUsersDto } from './dto/add-users.dto';
 import { RemoveAssetsDto } from './dto/remove-assets.dto';
 import { UpdateAlbumDto } from './dto/update-album.dto';
 import { GetAlbumsDto } from './dto/get-albums.dto';
-import { AlbumResponseDto, IJobRepository, JobName, mapAlbum, mapAlbumExcludeAssetInfo } from '@app/domain';
+import { AlbumResponseDto, IJobRepository, JobName, mapAlbum } from '@app/domain';
 import { IAlbumRepository } from './album-repository';
 import { AlbumCountResponseDto } from './response-dto/album-count-response.dto';
 import { AddAssetsResponseDto } from './response-dto/add-assets-response.dto';
@@ -15,7 +15,6 @@ import { DownloadService } from '../../modules/download/download.service';
 import { DownloadDto } from '../asset/dto/download-library.dto';
 import { ShareCore, ISharedLinkRepository, mapSharedLink, SharedLinkResponseDto, ICryptoRepository } from '@app/domain';
 import { CreateAlbumShareLinkDto } from './dto/create-album-shared-link.dto';
-import _ from 'lodash';
 
 @Injectable()
 export class AlbumService {
@@ -70,22 +69,7 @@ export class AlbumService {
    */
   async getAllAlbums(authUser: AuthUserDto, getAlbumsDto: GetAlbumsDto): Promise<AlbumResponseDto[]> {
     await this.albumRepository.updateThumbnails();
-
-    let albums: AlbumEntity[];
-    if (typeof getAlbumsDto.assetId === 'string') {
-      albums = await this.albumRepository.getListByAssetId(authUser.id, getAlbumsDto.assetId);
-    } else {
-      albums = await this.albumRepository.getList(authUser.id, getAlbumsDto);
-
-      if (getAlbumsDto.shared) {
-        const publicSharingAlbums = await this.albumRepository.getPublicSharingList(authUser.id);
-        albums = [...albums, ...publicSharingAlbums];
-      }
-    }
-
-    albums = _.uniqBy(albums, (album) => album.id);
-
-    return albums.map((album) => mapAlbumExcludeAssetInfo(album));
+    return this.albumRepository.getList(authUser.id, getAlbumsDto);
   }
 
   async getAlbumInfo(authUser: AuthUserDto, albumId: string): Promise<AlbumResponseDto> {

--- a/server/apps/immich/src/api-v1/album/dto/get-albums.dto.ts
+++ b/server/apps/immich/src/api-v1/album/dto/get-albums.dto.ts
@@ -1,5 +1,5 @@
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsBoolean, IsOptional, IsUUID } from 'class-validator';
 import { toBoolean } from '../../../utils/transform.util';
 
 export class GetAlbumsDto {
@@ -18,5 +18,7 @@ export class GetAlbumsDto {
    * Ignores the shared parameter
    * undefined: get all albums
    */
+  @IsOptional()
+  @IsUUID(4)
   assetId?: string;
 }

--- a/server/libs/domain/src/share/share.core.ts
+++ b/server/libs/domain/src/share/share.core.ts
@@ -34,7 +34,7 @@ export class ShareCore {
         expiresAt: dto.expiresAt ?? null,
         type: dto.type,
         assets: dto.assets,
-        album: dto.album,
+        albumId: dto.album?.id ?? null,
         allowUpload: dto.allowUpload ?? false,
         allowDownload: dto.allowDownload ?? true,
         showExif: dto.showExif ?? true,

--- a/server/libs/domain/test/fixtures.ts
+++ b/server/libs/domain/test/fixtures.ts
@@ -389,6 +389,7 @@ export const sharedLinkStub = {
     allowDownload: true,
     showExif: true,
     album: undefined,
+    albumId: null,
     assets: [],
   } as SharedLinkEntity),
   expired: Object.freeze({
@@ -403,6 +404,7 @@ export const sharedLinkStub = {
     allowDownload: true,
     showExif: true,
     assets: [],
+    albumId: null,
   } as SharedLinkEntity),
   readonly: Object.freeze<SharedLinkEntity>({
     id: '123',
@@ -487,6 +489,7 @@ export const sharedLinkStub = {
         },
       ],
     },
+    albumId: 'album-123',
   }),
 };
 

--- a/server/libs/infra/src/db/entities/shared-link.entity.ts
+++ b/server/libs/infra/src/db/entities/shared-link.entity.ts
@@ -55,6 +55,9 @@ export class SharedLinkEntity {
   @Index('IDX_sharedlink_albumId')
   @ManyToOne(() => AlbumEntity, (album) => album.sharedLinks)
   album?: AlbumEntity;
+
+  @Column({ nullable: true })
+  albumId!: string | null;
 }
 
 export enum SharedLinkType {


### PR DESCRIPTION
Improved performance for `/api/album` endpoint by optimizing the used query and no longer selecting all assets of all albums. Removed `AlbumRepository.getListByAssetId(ownerId, assetId)` because it has become redundant. Also extended the E2E tests to include shared links and tests for the different query params that the endpoint uses.

Below are some query times from benchmarks ran directly against the DB. I only measured the API time for the 100.000 assets one and before it took 2132ms on average, now the API responds in 40ms.

| Asset count | Old query  | New query |
| ------------- | ------------- |------------- |
| 5 x 5000 = 25.000 | 127ms  | 4.9ms |
| 10 x 5000 = 50.000 | 501ms | 7.8ms  |
| 20 x 5000 = 100.000 | 994ms | 14.9ms  |