### PR TITLE
fix(mobile): iOS backup debug info tile only shown in iOS

### DIFF
--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -392,7 +392,7 @@ class BackupControllerPage extends HookConsumerWidget {
                 return Container();
               },
             ),
-          if (isBackgroundEnabled && settings != null)
+          if (Platform.isIOS && isBackgroundEnabled && settings != null)
             IosDebugInfoTile(
               settings: settings,
           ),


### PR DESCRIPTION
I noticed in the latest build that my Android phone is showing the iOS debug information for the iOS backup processes, so this will now correctly suppress this information in Android.