### PR TITLE
feat(web): require page load to export title

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -8,7 +8,13 @@ declare namespace App {
 		api: import('@api').ImmichApi;
 	}
 
-	// interface Platform {}
+	interface PageData {
+		meta: {
+			title: string;
+			description?: string;
+			imageUrl?: string;
+		};
+	}
 
 	interface Error {
 		message: string;

--- a/web/src/routes/(user)/explore/+page.server.ts
+++ b/web/src/routes/(user)/explore/+page.server.ts
@@ -9,5 +9,11 @@ export const load = (async ({ locals, parent }) => {
 
 	const { data: items } = await locals.api.searchApi.getExploreData();
 
-	return { user, items };
+	return {
+		user,
+		items,
+		meta: {
+			title: 'Explore'
+		}
+	};
 }) satisfies PageServerLoad;

--- a/web/src/routes/(user)/search/+page.server.ts
+++ b/web/src/routes/(user)/search/+page.server.ts
@@ -23,5 +23,13 @@ export const load = (async ({ locals, parent, url }) => {
 		undefined,
 		{ params: url.searchParams }
 	);
-	return { user, term, results };
+
+	return {
+		user,
+		term,
+		results,
+		meta: {
+			title: 'Search'
+		}
+	};
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Require page load functions to contain `meta.title` when returning and added a title to pages without one.