### PR TITLE
fix(mobile): Gallery viewer fullscreen edge case

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -59,6 +59,15 @@ class GalleryViewerPage extends HookConsumerWidget {
     late Offset localPosition;
     final authToken = 'Bearer ${box.get(accessTokenKey)}';
 
+    showAppBar.addListener(() {
+      // Change to and from immersive mode, hiding navigation and app bar
+      if (showAppBar.value) {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      } else {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+      }
+    });
+
     useEffect(
       () {
         isLoadPreview.value =
@@ -246,13 +255,6 @@ class GalleryViewerPage extends HookConsumerWidget {
       final show = (showAppBar.value || // onTap has the final say
               (showAppBar.value && !isZoomed.value)) &&
           !isPlayingVideo.value;
-
-      // Change to and from immersive mode, hiding navigation and app bar
-      if (show) {
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-      } else {
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
-      }
 
       return AnimatedOpacity(
         duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
Improves the fullscreen effect by only setting it when the app bar is toggled. Fixes an edge case where you could be in full screen mode and then swipe down to close, keeping you in immersive mode even while in the main timeline and rest of the app.