### PR TITLE
fix(docs): added note on scope of redis optional parameters in example.env

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -17,6 +17,11 @@ DB_DATABASE_NAME=immich
 REDIS_HOSTNAME=immich_redis
 
 # Optional Redis settings:
+
+# Note: these parameters are not automatically passed to the Redis Container
+# to do so, please edit the docker-compose.yml file as well. Redis is not configured
+# via environment variables, only redis.conf or the command line
+
 # REDIS_PORT=6379
 # REDIS_DBINDEX=0
 # REDIS_PASSWORD=

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -46,6 +46,11 @@ DB_DATABASE_NAME=immich
 REDIS_HOSTNAME=immich_redis
 
 # Optional Redis settings:
+
+# Note: these parameters are not automatically passed to the Redis Container
+# to do so, please edit the docker-compose.yml file as well. Redis is not configured
+# via environment variables, only redis.conf or the command line
+
 # REDIS_PORT=6379
 # REDIS_DBINDEX=0
 # REDIS_PASSWORD=


### PR DESCRIPTION
reference: #1973