### PR TITLE
fix(server): remove encoded video file on asset delete

### DIFF
--- a/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
@@ -412,7 +412,7 @@ describe('AssetService', () => {
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.DELETE_FILES,
         data: {
-          files: ['fake_path/asset_1.jpeg', undefined, undefined, 'fake_path/asset_1.mp4', undefined, undefined],
+          files: ['fake_path/asset_1.jpeg', undefined, undefined, undefined, 'fake_path/asset_1.mp4', undefined, undefined, undefined],
         },
       });
     });

--- a/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
@@ -423,7 +423,6 @@ describe('AssetService', () => {
         originalPath: 'original-path-1',
         resizePath: 'resize-path-1',
         webpPath: 'web-path-1',
-        encodedVideoPath: undefined,
       };
 
       const asset2 = {

--- a/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
@@ -423,6 +423,7 @@ describe('AssetService', () => {
         originalPath: 'original-path-1',
         resizePath: 'resize-path-1',
         webpPath: 'web-path-1',
+        encodedVideoPath: undefined,
       };
 
       const asset2 = {
@@ -456,6 +457,7 @@ describe('AssetService', () => {
                 'original-path-1',
                 'web-path-1',
                 'resize-path-1',
+                undefined,
                 'original-path-2',
                 'web-path-2',
                 'resize-path-2',

--- a/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
@@ -430,6 +430,7 @@ describe('AssetService', () => {
         originalPath: 'original-path-2',
         resizePath: 'resize-path-2',
         webpPath: 'web-path-2',
+        encodedVideoPath: 'encoded-video-path-2',
       };
 
       when(assetRepositoryMock.get)
@@ -458,6 +459,7 @@ describe('AssetService', () => {
                 'original-path-2',
                 'web-path-2',
                 'resize-path-2',
+                'encoded-video-path-2',
               ],
             },
           },

--- a/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.spec.ts
@@ -412,7 +412,16 @@ describe('AssetService', () => {
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.DELETE_FILES,
         data: {
-          files: ['fake_path/asset_1.jpeg', undefined, undefined, undefined, 'fake_path/asset_1.mp4', undefined, undefined, undefined],
+          files: [
+            'fake_path/asset_1.jpeg',
+            undefined,
+            undefined,
+            undefined,
+            'fake_path/asset_1.mp4',
+            undefined,
+            undefined,
+            undefined,
+          ],
         },
       });
     });

--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -430,11 +430,7 @@ export class AssetService {
         await this.jobRepository.queue({ name: JobName.SEARCH_REMOVE_ASSET, data: { id } });
 
         result.push({ id, status: DeleteAssetStatusEnum.SUCCESS });
-        deleteQueue.push(asset.originalPath, asset.webpPath, asset.resizePath);
-
-        if (asset.encodedVideoPath) {
-          deleteQueue.push(asset.encodedVideoPath);
-        }
+        deleteQueue.push(asset.originalPath, asset.webpPath, asset.resizePath, asset.encodedVideoPath);
 
         // TODO refactor this to use cascades
         if (asset.livePhotoVideoId && !ids.includes(asset.livePhotoVideoId)) {

--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -432,6 +432,10 @@ export class AssetService {
         result.push({ id, status: DeleteAssetStatusEnum.SUCCESS });
         deleteQueue.push(asset.originalPath, asset.webpPath, asset.resizePath);
 
+        if (asset.encodedVideoPath) {
+          deleteQueue.push(asset.encodedVideoPath);
+        }
+
         // TODO refactor this to use cascades
         if (asset.livePhotoVideoId && !ids.includes(asset.livePhotoVideoId)) {
           ids.push(asset.livePhotoVideoId);


### PR DESCRIPTION
#792 is back. Introduced a simple check for encoded video file path during object insertion into delete queue. Sorry in advance if this solution is cumbersome. I'm not apt in anything js related.