### PR TITLE
feat(web): Make scaling of albums overview more responsive

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -61,7 +61,7 @@
 </script>
 
 <div
-	class="h-[339px] w-[275px] hover:cursor-pointer mt-4 relative"
+	class="hover:cursor-pointer mt-4 relative"
 	on:click={() => dispatchClick('click', album)}
 	on:keydown={() => dispatchClick('click', album)}
 	data-testid="album-card"
@@ -76,7 +76,7 @@
 		<CircleIconButton logo={DotsVertical} size={'20'} hoverColor={'rgba(95,99,104, 0.5)'} />
 	</div>
 
-	<div class={`h-[275px] w-[275px] z-[-1]`}>
+	<div class={`aspect-square z-[-1]`}>
 		<img
 			src={imageData}
 			alt={album.id}

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -70,9 +70,7 @@
 			</div>
 
 			<!-- Album Card -->
-			<div
-				class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 4xl:grid-cols-7 5xl:grid-cols-8 gap-8"
-			>
+			<div class="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-8">
 				{#each $albums as album}
 					{#key album.id}
 						<a data-sveltekit-preload-data="hover" href={`albums/${album.id}`}>

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -70,7 +70,7 @@
 			</div>
 
 			<!-- Album Card -->
-			<div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-7 4xl:grid-cols-8 5xl:grid-cols-9 gap-8">
+			<div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 4xl:grid-cols-7 5xl:grid-cols-8 gap-8">
 				{#each $albums as album}
 					{#key album.id}
 						<a data-sveltekit-preload-data="hover" href={`albums/${album.id}`}>

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -70,7 +70,9 @@
 			</div>
 
 			<!-- Album Card -->
-			<div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 4xl:grid-cols-7 5xl:grid-cols-8 gap-8">
+			<div
+				class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 3xl:grid-cols-6 4xl:grid-cols-7 5xl:grid-cols-8 gap-8"
+			>
 				{#each $albums as album}
 					{#key album.id}
 						<a data-sveltekit-preload-data="hover" href={`albums/${album.id}`}>

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -45,7 +45,7 @@
 	<section class="overflow-y-auto relative immich-scrollbar">
 		<section
 			id="album-content"
-			class="relative pt-8 pl-4 mb-12 bg-immich-bg dark:bg-immich-dark-bg"
+			class="relative pt-8 pl-4 pr-4 mb-12 bg-immich-bg dark:bg-immich-dark-bg"
 		>
 			<div class="px-4 flex justify-between place-items-center dark:text-immich-dark-fg">
 				<div>
@@ -70,7 +70,7 @@
 			</div>
 
 			<!-- Album Card -->
-			<div class="flex flex-wrap gap-8">
+			<div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 3xl:grid-cols-7 4xl:grid-cols-8 5xl:grid-cols-9 gap-8">
 				{#each $albums as album}
 					{#key album.id}
 						<a data-sveltekit-preload-data="hover" href={`albums/${album.id}`}>

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -18,11 +18,6 @@ module.exports = {
 			},
 			fontFamily: {
 				'immich-title': ['Snowburst One', 'cursive']
-			},
-			screens: {
-				'3xl': '1700px',
-				'4xl': '1900px',
-				'5xl': '2100px'
 			}
 		}
 	},

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -18,6 +18,11 @@ module.exports = {
 			},
 			fontFamily: {
 				'immich-title': ['Snowburst One', 'cursive']
+			},
+			screens: {
+				'3xl': '1700px',
+				'4xl': '1900px',
+				'5xl': '2100px'
 			}
 		}
 	},


### PR DESCRIPTION
Problem:

If an album in the overview does not fit in a row it gets pushed to the next one leaving a gap.
This, for example, happens on my 13" MBP and looks following:

<img width="1437" alt="Screenshot_2023-03-11_at_16_42_55" src="https://user-images.githubusercontent.com/6898797/224505576-38420079-c3ea-4747-a86e-89ddbc256a7a.png">

Solution:

Use tailwinds grid system together with media breakpoints and a fixed aspect ratio of the preview image and scale thumbnails to always fill the whole row.

Same screen size after the change:

<img width="1435" alt="Screenshot 2023-03-11 at 19 35 31" src="https://user-images.githubusercontent.com/6898797/224505784-69f1648e-066b-403d-aac9-182613d4dceb.png">

