### PR TITLE
fix(mobile): add isar source code as a git submodule for F-Droid build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mobile/.isar"]
+	path = mobile/.isar
+	url = https://github.com/isar/isar


### PR DESCRIPTION
we need to add isar as a submodule to build its binaries from source for inclusion in F-Droid