### PR TITLE
fix(web): short layout retention after navigation

### DIFF
--- a/web/src/lib/components/shared-components/control-app-bar.svelte
+++ b/web/src/lib/components/shared-components/control-app-bar.svelte
@@ -35,10 +35,7 @@
 	});
 </script>
 
-<div
-	transition:fly|local={{ y: 10, duration: 200 }}
-	class="fixed top-0 w-full bg-transparent z-[100]"
->
+<div in:fly={{ y: 10, duration: 200 }} class="fixed top-0 w-full bg-transparent z-[100]">
 	<div
 		id="asset-selection-app-bar"
 		class={`flex justify-between ${appBarBorder} rounded-lg p-2 mx-2 mt-2 transition-all place-items-center ${tailwindClasses} dark:bg-immich-dark-gray`}


### PR DESCRIPTION
Pages that use the `ControlAppBar` component would shortly retain the layout of the previous and current page after navigating.

Steps to reproduce:
1. Go to `/sharing/sharedlinks`
2. Click on the back button

Both pages are visible for a split second (this also happens on the new `/search` page). This is caused by `ControlAppBar` only unmounting after finishing the transition.

Resolved by only applying a transition when the element is first rendered
