### PR TITLE
feat(web): bundle and 'sveltify' leaflet

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -8,9 +8,6 @@
 	import { AssetResponseDto, AlbumResponseDto } from '@api';
 	import { asByteUnitString } from '../../utils/byte-units';
 	import { locale } from '$lib/stores/preferences.store';
-	import Map from '../shared-components/leaflet/map.svelte';
-	import TileLayer from '../shared-components/leaflet/tile-layer.svelte';
-	import Marker from '../shared-components/leaflet/marker.svelte';
 	import type { LatLngTuple } from 'leaflet';
 
 	export let asset: AssetResponseDto;
@@ -154,15 +151,18 @@
 
 {#if latlng}
 	<div class="h-[360px]">
-		<Map {latlng} zoom={14}>
-			<TileLayer
-				urlTemplate={'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'}
-				options={{
-					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-				}}
-			/>
-			<Marker {latlng} popupContent="{latlng[0].toFixed(7)},{latlng[1].toFixed(7)}" />
-		</Map>
+		{#await import('../shared-components/leaflet') then { Map, TileLayer, Marker }}
+			<Map {latlng} zoom={14}>
+				<TileLayer
+					urlTemplate={'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'}
+					options={{
+						attribution:
+							'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+					}}
+				/>
+				<Marker {latlng} popupContent="{latlng[0].toFixed(7)},{latlng[1].toFixed(7)}" />
+			</Map>
+		{/await}
 	</div>
 {/if}
 

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -4,60 +4,26 @@
 	import ImageOutline from 'svelte-material-icons/ImageOutline.svelte';
 	import CameraIris from 'svelte-material-icons/CameraIris.svelte';
 	import MapMarkerOutline from 'svelte-material-icons/MapMarkerOutline.svelte';
-	import { createEventDispatcher, onMount } from 'svelte';
-	import { browser } from '$app/environment';
+	import { createEventDispatcher } from 'svelte';
 	import { AssetResponseDto, AlbumResponseDto } from '@api';
 	import { asByteUnitString } from '../../utils/byte-units';
 	import { locale } from '$lib/stores/preferences.store';
-
-	type Leaflet = typeof import('leaflet');
-	type LeafletMap = import('leaflet').Map;
-	type LeafletMarker = import('leaflet').Marker;
-
-	// Map Property
-	let map: LeafletMap;
-	let leaflet: Leaflet;
-	let marker: LeafletMarker;
+	import Map from '../shared-components/leaflet/map.svelte';
+	import TileLayer from '../shared-components/leaflet/tile-layer.svelte';
+	import Marker from '../shared-components/leaflet/marker.svelte';
+	import type { LatLngTuple } from 'leaflet';
 
 	export let asset: AssetResponseDto;
-	$: if (asset.exifInfo?.latitude != null && asset.exifInfo?.longitude != null) {
-		drawMap(asset.exifInfo.latitude, asset.exifInfo.longitude);
-	}
-
 	export let albums: AlbumResponseDto[] = [];
 
-	onMount(async () => {
-		if (browser) {
-			if (asset.exifInfo?.latitude != null && asset.exifInfo?.longitude != null) {
-				await drawMap(asset.exifInfo.latitude, asset.exifInfo.longitude);
-			}
+	$: latlng = (() => {
+		const lat = asset.exifInfo?.latitude;
+		const lng = asset.exifInfo?.longitude;
+
+		if (lat && lng) {
+			return [lat, lng] as LatLngTuple;
 		}
-	});
-
-	async function drawMap(lat: number, lon: number) {
-		if (!leaflet) {
-			leaflet = await import('leaflet');
-		}
-
-		if (!map) {
-			map = leaflet.map('map');
-			leaflet
-				.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-				})
-				.addTo(map);
-		}
-
-		if (marker) {
-			map.removeLayer(marker);
-		}
-
-		map.setView([lat || 0, lon || 0], 17);
-
-		marker = leaflet.marker([lat || 0, lon || 0]);
-		marker.bindPopup(`${(lat || 0).toFixed(7)},${(lon || 0).toFixed(7)}`);
-		map.addLayer(marker);
-	}
+	})();
 
 	const dispatch = createEventDispatcher();
 
@@ -186,9 +152,19 @@
 	</div>
 </section>
 
-<div class={`${asset.exifInfo?.latitude ? 'visible' : 'hidden'}`}>
-	<div class="h-[360px] w-full" id="map" />
-</div>
+{#if latlng}
+	<div class="h-[360px]">
+		<Map {latlng} zoom={14}>
+			<TileLayer
+				urlTemplate={'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'}
+				options={{
+					attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+				}}
+			/>
+			<Marker {latlng} popupContent="{latlng[0].toFixed(7)},{latlng[1].toFixed(7)}" />
+		</Map>
+	</div>
+{/if}
 
 <section class="p-2 dark:text-immich-dark-fg">
 	<div class="px-4 py-4">
@@ -225,7 +201,3 @@
 		{/each}
 	</div>
 </section>
-
-<style>
-	@import 'https://unpkg.com/leaflet@1.7.1/dist/leaflet.css';
-</style>

--- a/web/src/lib/components/shared-components/leaflet/index.ts
+++ b/web/src/lib/components/shared-components/leaflet/index.ts
@@ -1,0 +1,3 @@
+export { default as Map } from './map.svelte';
+export { default as Marker } from './marker.svelte';
+export { default as TileLayer } from './tile-layer.svelte';

--- a/web/src/lib/components/shared-components/leaflet/map.svelte
+++ b/web/src/lib/components/shared-components/leaflet/map.svelte
@@ -1,0 +1,42 @@
+<script lang="ts" context="module">
+	import { createContext } from '$lib/utils/context';
+
+	const { get: getContext, set: setMapContext } = createContext<() => Map>();
+
+	export const getMapContext = () => {
+		const getMap = getContext();
+		return getMap();
+	};
+</script>
+
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { browser } from '$app/environment';
+	import { Map, type LatLngExpression } from 'leaflet';
+	import 'leaflet/dist/leaflet.css';
+
+	export let latlng: LatLngExpression;
+	export let zoom: number;
+	let container: HTMLDivElement;
+	let map: Map;
+
+	setMapContext(() => map);
+
+	onMount(() => {
+		if (browser) {
+			map = new Map(container);
+		}
+	});
+
+	onDestroy(() => {
+		if (map) map.remove();
+	});
+
+	$: if (map) map.setView(latlng, zoom);
+</script>
+
+<div bind:this={container} class="w-full h-full">
+	{#if map}
+		<slot />
+	{/if}
+</div>

--- a/web/src/lib/components/shared-components/leaflet/marker.svelte
+++ b/web/src/lib/components/shared-components/leaflet/marker.svelte
@@ -13,7 +13,14 @@
 	const defaultIcon = new Icon({
 		iconUrl,
 		iconRetinaUrl,
-		shadowUrl
+		shadowUrl,
+
+		// Default values from Leaflet
+		iconSize: [25, 41],
+		iconAnchor: [12, 41],
+		popupAnchor: [1, -34],
+		tooltipAnchor: [16, -28],
+		shadowSize: [41, 41]
 	});
 	const map = getMapContext();
 
@@ -27,8 +34,9 @@
 		if (marker) marker.remove();
 	});
 
-	$: if (marker) marker.setLatLng(latlng);
 	$: if (marker) {
+		marker.setLatLng(latlng);
+
 		if (popupContent) {
 			marker.bindPopup(popupContent);
 		} else {

--- a/web/src/lib/components/shared-components/leaflet/marker.svelte
+++ b/web/src/lib/components/shared-components/leaflet/marker.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { Marker, Icon, type LatLngExpression, type Content } from 'leaflet';
+	import { getMapContext } from './map.svelte';
+	import iconUrl from 'leaflet/dist/images/marker-icon.png';
+	import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+	import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
+	export let latlng: LatLngExpression;
+	export let popupContent: Content | undefined = undefined;
+	let marker: Marker;
+
+	const defaultIcon = new Icon({
+		iconUrl,
+		iconRetinaUrl,
+		shadowUrl
+	});
+	const map = getMapContext();
+
+	onMount(() => {
+		marker = new Marker(latlng, {
+			icon: defaultIcon
+		}).addTo(map);
+	});
+
+	onDestroy(() => {
+		if (marker) marker.remove();
+	});
+
+	$: if (marker) marker.setLatLng(latlng);
+	$: if (marker) {
+		if (popupContent) {
+			marker.bindPopup(popupContent);
+		} else {
+			marker.unbindPopup();
+		}
+	}
+</script>

--- a/web/src/lib/components/shared-components/leaflet/tile-layer.svelte
+++ b/web/src/lib/components/shared-components/leaflet/tile-layer.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { TileLayer, type TileLayerOptions } from 'leaflet';
+	import { getMapContext } from './map.svelte';
+
+	export let urlTemplate: string;
+	export let options: TileLayerOptions | undefined = undefined;
+	let tileLayer: TileLayer;
+
+	const map = getMapContext();
+
+	onMount(() => {
+		tileLayer = new TileLayer(urlTemplate, options).addTo(map);
+	});
+
+	onDestroy(() => {
+		if (tileLayer) tileLayer.remove();
+	});
+</script>

--- a/web/src/lib/utils/context.ts
+++ b/web/src/lib/utils/context.ts
@@ -1,0 +1,8 @@
+import { getContext, setContext } from 'svelte';
+
+export function createContext<T>(key: string | symbol = Symbol()) {
+	return {
+		get: () => getContext<T>(key),
+		set: (context: T) => setContext<T>(key, context)
+	};
+}


### PR DESCRIPTION
Bundled Leaflet CSS to prevent loading it from the unpkg CDN, closes #1191. I've also created Svelte components for using Leaflet. Lastly, the zoom level has been changed from `17` to `14` for a more generalized and zoomed-out view of the map. This value is pretty arbitrary and can be discussed/changed further, but I think seeing the general area is more important than the exact building.