### PR TITLE
chore: Move away from docker hub where possible

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   immich-server:
     container_name: immich_server
-    image: altran1502/immich-server:release
+    image: ghcr.io/immich-app/immich-server:release
     entrypoint: [ "/bin/sh", "./start-server.sh" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
@@ -19,7 +19,7 @@ services:
 
   immich-microservices:
     container_name: immich_microservices
-    image: altran1502/immich-server:release
+    image: ghcr.io/immich-app/immich-server:release
     entrypoint: [ "/bin/sh", "./start-microservices.sh" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
@@ -35,7 +35,7 @@ services:
 
   immich-machine-learning:
     container_name: immich_machine_learning
-    image: altran1502/immich-machine-learning:release
+    image: ghcr.io/immich-app/immich-machine-learning:release
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - model-cache:/cache
@@ -47,7 +47,7 @@ services:
 
   immich-web:
     container_name: immich_web
-    image: altran1502/immich-web:release
+    image: ghcr.io/immich-app/immich-web:release
     entrypoint: [ "/bin/sh", "./entrypoint.sh" ]
     env_file:
       - .env
@@ -85,7 +85,7 @@ services:
 
   immich-proxy:
     container_name: immich_proxy
-    image: altran1502/immich-proxy:release
+    image: ghcr.io/immich-app/immich-proxy:release
     environment:
       # Make sure these values get passed through from the env file
       - IMMICH_SERVER_URL

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nginxinc/nginx-unprivileged:latest
+FROM ghcr.io/nginxinc/nginx-unprivileged:1.23
 
 COPY LICENSE /licenses/LICENSE.txt
 COPY LICENSE /LICENSE


### PR DESCRIPTION
This PR changes our standard docker-compose.yml to use the Immich images from ghcr.io by default. I've also moved the nginx base-image over to ghcr, and lightly pinned its tag instead of using `latest`. I would've liked to change the typesense image to not use docker hub, but as far as I can tell it isn't available anywhere else.

I haven't changed the `node`, `python`, `redis` and `postgres` images since they are "official" docker hub images and so shouldn't be affected, and I couldn't find them hosted elsewhere either.