### PR TITLE
fix(nginx): x-forwarded-* headers

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 2
----
-
 # Reverse Proxy
 
 When deploying Immich it is important to understand that a reverse proxy is required in front of the server and web container. The reverse proxy acts as an intermediary between the user and container, forwarding requests to the correct container based on the URL path.
@@ -23,4 +19,4 @@ Users can deploy a custom reverse proxy that forwards requests to Immich's rever
 
 ## Replacing the Default Reverse Proxy
 
-Replacing Immich's default reverse proxy is an advanced deployment and support may be limited. When replacing Immich's default proxy it is important to ensure that requests to `/api/*` are routed to the server container and all other requests to the web container. Additionally, the previously mentioned headers should be configured accordingly.
+Replacing Immich's default reverse proxy is an advanced deployment and support may be limited. When replacing Immich's default proxy it is important to ensure that requests to `/api/*` are routed to the server container and all other requests to the web container. Additionally, the previously mentioned headers should be configured accordingly. You may find our [nginx configuration file](https://github.com/immich-app/immich/blob/main/nginx/templates/default.conf.template) a helpful reference.

--- a/docs/docs/guides/reverse-proxy.md
+++ b/docs/docs/guides/reverse-proxy.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 2
+---
+
+# Reverse Proxy
+
+When deploying Immich it is important to understand that a reverse proxy is required in front of the server and web container. The reverse proxy acts as an intermediary between the user and container, forwarding requests to the correct container based on the URL path.
+
+## Default Reverse Proxy
+
+Immich provides a default nginx reverse proxy preconfigured to perform the correct routing and set the necessary headers for the server and web container to use. These headers are crucial to redirect to the correct URL and determine the client's IP address.
+
+## Using a Different Reverse Proxy
+
+While the reverse proxy provided by Immich works well for basic deployments, some users may want to use a different reverse proxy. Fortunately, Immich is flexible enough to accommodate different reverse proxies. Users can either:
+
+1. Add another reverse proxy on top of Immich's reverse proxy
+2. Completely replace the default reverse proxy
+
+## Adding a Custom Reverse Proxy
+
+Users can deploy a custom reverse proxy that forwards requests to Immich's reverse proxy. This way, the new reverse proxy can handle TLS termination, load balancing, or other advanced features, while still delegating routing decisions to Immich's reverse proxy. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
+
+## Replacing the Default Reverse Proxy
+
+Replacing Immich's default reverse proxy is an advanced deployment and support may be limited. When replacing Immich's default proxy it is important to ensure that requests to `/api/*` are routed to the server container and all other requests to the web container. Additionally, the previously mentioned headers should be configured accordingly.

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -3,6 +3,14 @@ map $http_upgrade $connection_upgrade {
   '' close;
 }
 
+map $http_x_forwarded_proto $forwarded_protocol {
+  default $scheme;
+
+  # Only allow the values 'http' and 'https' for the X-Forwarded-Proto header.
+  http http;
+  https https;
+}
+
 upstream server {
   server ${IMMICH_SERVER_HOST};
   keepalive 2;
@@ -43,13 +51,12 @@ server {
     proxy_force_ranges on;
 
     proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwarded_protocol;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
-    proxy_set_header Host $host;
 
     rewrite /api/(.*) /$1 break;
 
@@ -64,13 +71,12 @@ server {
     proxy_force_ranges on;
 
     proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwarded_protocol;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
-    proxy_set_header Host $host;
 
     proxy_pass ${IMMICH_WEB_SCHEME}web;
   }

--- a/server/apps/immich/src/main.ts
+++ b/server/apps/immich/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
     logger: getLogLevels(),
   });
 
-  app.set('trust proxy');
+  app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
   app.set('etag', 'strong');
   app.use(cookieParser());
   app.use(json({ limit: '10mb' }));

--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -4,6 +4,8 @@
 export PUBLIC_IMMICH_SERVER_URL=$IMMICH_SERVER_URL
 export PUBLIC_IMMICH_API_URL_EXTERNAL=$IMMICH_API_URL_EXTERNAL
 
+export PROTOCOL_HEADER=X-Forwarded-Proto
+
 if [ "$(id -u)" -eq 0 ] && [ -n "$PUID" ] && [ -n "$PGID" ]; then
     exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups node /usr/src/app/build/index.js
 else


### PR DESCRIPTION
Fixes issues surrounding X-Forwarded-* headers for both server and web:
1. Invalid login attempts are logged on the server with the wrong IP address
2. Cookies are never set with the `Secure` flag
3. URL.protocol is always `http` and URL.host doesn't include the port
4. `app.set('trust proxy')` on the server doesn't have a value so X-Forwarded-* headers are ignored

These issues have been resolved. Below some more details and choices that have been made for the various headers. I've also added a guide to the documentation regarding reverse proxies.

**Host / X-Forwarded-Host**
Changed to `$http_host` which also includes the port while `$host` strips the port. Removing the port leads to issues when using a different port than `80` or `443`.

**X-Forwarded-Proto**
Nginx only listens on HTTP so the value is always `http`. Often, another reverse proxy handles TLS termination and sets the 'X-Forwarded-Proto' header, allowing us to reuse that value while using '$scheme' as a fallback.

**X-Forwarded-For**
This is the most tricky header, because getting it wrong means the user can supply any IP. The header contains a comma-separated list of IP addresses, with the first IP in the list being the original client IP, followed by any intermediary proxies.

One common method for extracting the correct client IP address from the X-Forwarded-For header, is to supply the proxy depth and then extract the IP address accordingly. However, this requires manual configuration by every user and is therefore more error-prone.

The second method works by getting the first public IP address when checking the list from right to left. This method is incompatible with SvelteKit, but we don't need the client's IP there. I've chosen this method only for ease of configuration.
