### PR TITLE
fix(server): Return the original path for gif playback

### DIFF
--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -279,19 +279,7 @@ export class AssetService {
         /**
          * Serve file viewer on the web
          */
-        if (query.isWeb && asset.mimeType == 'image/gif') {
-          res.set({
-            'Content-Type': asset.mimeType,
-          });
-
-          if (await processETag(asset.originalPath, res, headers)) {
-            return;
-          }
-          await fs.access(asset.originalPath, constants.R_OK | constants.W_OK);
-          fileReadStream = createReadStream(asset.originalPath);
-
-          return new StreamableFile(fileReadStream);
-        } else if (query.isWeb) {
+        if (query.isWeb) {
           res.set({
             'Content-Type': 'image/jpeg',
           });
@@ -314,7 +302,7 @@ export class AssetService {
         /**
          * Serve thumbnail image for both web and mobile app
          */
-        if (!query.isThumb && allowOriginalFile) {
+        if ((!query.isThumb && allowOriginalFile) || (query.isWeb && asset.mimeType === 'image/gif')) {
           res.set({
             'Content-Type': asset.mimeType,
           });

--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -279,17 +279,32 @@ export class AssetService {
         /**
          * Serve file viewer on the web
          */
-        if (query.isWeb) {
+        if (query.isWeb && asset.mimeType == 'image/gif') {
+          res.set({
+            'Content-Type': asset.mimeType,
+          });
+
+          if (await processETag(asset.originalPath, res, headers)) {
+            return;
+          }
+          await fs.access(asset.originalPath, constants.R_OK | constants.W_OK);
+          fileReadStream = createReadStream(asset.originalPath);
+
+          return new StreamableFile(fileReadStream);
+        } else if (query.isWeb) {
           res.set({
             'Content-Type': 'image/jpeg',
           });
+
           if (!asset.resizePath) {
             Logger.error('Error serving IMAGE asset for web', 'ServeFile');
             throw new InternalServerErrorException(`Failed to serve image asset for web`, 'ServeFile');
           }
+
           if (await processETag(asset.resizePath, res, headers)) {
             return;
           }
+
           await fs.access(asset.resizePath, constants.R_OK | constants.W_OK);
           fileReadStream = createReadStream(asset.resizePath);
 

--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -279,7 +279,7 @@ export class AssetService {
         /**
          * Serve file viewer on the web
          */
-        if (query.isWeb) {
+        if (query.isWeb && asset.mimeType != 'image/gif') {
           res.set({
             'Content-Type': 'image/jpeg',
           });


### PR DESCRIPTION
Usually browser is able to play them directly.