### PR TITLE
refactor(mobile): migrate all Hive boxes to Isar database

### DIFF
--- a/mobile/integration_test/test_utils/general_helper.dart
+++ b/mobile/integration_test/test_utils/general_helper.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:isar/isar.dart';
@@ -35,9 +34,7 @@ class ImmichTestHelper {
   }
 
   static Future<void> loadApp(WidgetTester tester) async {
-    // Clear all data from Hive
-    await Hive.deleteFromDisk();
-    await app.openBoxes();
+    await EasyLocalization.ensureInitialized();
     // Clear all data from Isar (reuse existing instance if available)
     final db = Isar.getInstance() ?? await app.loadDb();
     await Store.clear();
@@ -65,12 +62,13 @@ void immichWidgetTest(
 }
 
 Future<void> pumpUntilFound(
-    WidgetTester tester,
-    Finder finder, {
-      Duration timeout = const Duration(seconds: 120),
-    }) async {
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 120),
+}) async {
   bool found = false;
-  final timer = Timer(timeout, () => throw TimeoutException("Pump until has timed out"));
+  final timer =
+      Timer(timeout, () => throw TimeoutException("Pump until has timed out"));
   while (found != true) {
     await tester.pump();
     found = tester.any(finder);

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/immich_logger_message.model.dart';
+import 'package:immich_mobile/shared/models/logger_message.model.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/app_state.provider.dart';
@@ -42,25 +43,14 @@ import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'constants/hive_box.dart';
 
 void main() async {
-  await initApp();
+  WidgetsFlutterBinding.ensureInitialized();
   final db = await loadDb();
+  await initApp();
   await migrateHiveToStoreIfNecessary();
   await migrateJsonCacheIfNecessary();
   runApp(getMainWidget(db));
-}
-
-Future<void> openBoxes() async {
-  await Future.wait([
-    Hive.openBox<ImmichLoggerMessage>(immichLoggerBox),
-    Hive.openBox(userInfoBox),
-    Hive.openBox<HiveSavedLoginInfo>(hiveLoginInfoBox),
-    Hive.openBox(hiveGithubReleaseInfoBox),
-    Hive.openBox(userSettingInfoBox),
-    EasyLocalization.ensureInitialized(),
-  ]);
 }
 
 Future<void> initApp() async {
@@ -69,8 +59,7 @@ Future<void> initApp() async {
   Hive.registerAdapter(HiveBackupAlbumsAdapter());
   Hive.registerAdapter(HiveDuplicatedAssetsAdapter());
   Hive.registerAdapter(ImmichLoggerMessageAdapter());
-
-  await openBoxes();
+  await EasyLocalization.ensureInitialized();
 
   if (kReleaseMode && Platform.isAndroid) {
     try {
@@ -82,7 +71,7 @@ Future<void> initApp() async {
   }
 
   // Initialize Immich Logger Service
-  ImmichLogger().init();
+  ImmichLogger();
 
   var log = Logger("ImmichErrorLogger");
 
@@ -108,6 +97,7 @@ Future<Isar> loadDb() async {
       UserSchema,
       BackupAlbumSchema,
       DuplicatedAssetSchema,
+      LoggerMessageSchema,
     ],
     directory: dir.path,
     maxSizeMiB: 256,
@@ -174,6 +164,7 @@ class ImmichAppState extends ConsumerState<ImmichApp>
       case AppLifecycleState.inactive:
         debugPrint("[APP STATE] inactive");
         ref.watch(appStateProvider.notifier).state = AppStateEnum.inactive;
+        ImmichLogger().flush();
         ref.watch(websocketProvider.notifier).disconnect();
         ref.watch(backupProvider.notifier).cancelBackup();
 

--- a/mobile/lib/modules/album/services/album.service.dart
+++ b/mobile/lib/modules/album/services/album.service.dart
@@ -265,7 +265,7 @@ class AlbumService {
 
   Future<bool> deleteAlbum(Album album) async {
     try {
-      final userId = Store.get<User>(StoreKey.currentUser)!.isarId;
+      final userId = Store.get(StoreKey.currentUser).isarId;
       if (album.owner.value?.isarId == userId) {
         await _apiService.albumApi.deleteAlbum(album.remoteId!);
       }

--- a/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
@@ -2,10 +2,9 @@ import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:openapi/api.dart';
 
@@ -21,7 +20,6 @@ class AlbumThumbnailListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var box = Hive.box(userInfoBox);
     var cardSize = 68.0;
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
 
@@ -50,7 +48,9 @@ class AlbumThumbnailListTile extends StatelessWidget {
           album,
           type: ThumbnailFormat.JPEG,
         ),
-        httpHeaders: {"Authorization": "Bearer ${box.get(accessTokenKey)}"},
+        httpHeaders: {
+          "Authorization": "Bearer ${Store.get(StoreKey.accessToken)}"
+        },
         cacheKey: getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.JPEG),
         errorWidget: (context, url, error) =>
             const Icon(Icons.image_not_supported_outlined),

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -4,16 +4,15 @@ import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hive/hive.dart';
+import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/album/ui/add_to_album_bottom_sheet.dart';
 import 'package:immich_mobile/modules/asset_viewer/providers/image_viewer_page_state.provider.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/exif_bottom_sheet.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/top_control_app_bar.dart';
 import 'package:immich_mobile/modules/asset_viewer/views/video_viewer_page.dart';
 import 'package:immich_mobile/modules/favorite/providers/favorite_provider.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/services/asset.service.dart';
 import 'package:immich_mobile/modules/home/ui/delete_dialog.dart';
 import 'package:immich_mobile/modules/settings/providers/app_settings.provider.dart';
@@ -47,7 +46,6 @@ class GalleryViewerPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final Box<dynamic> box = Hive.box(userInfoBox);
     final settings = ref.watch(appSettingsServiceProvider);
     final isLoadPreview = useState(AppSettingsEnum.loadPreview.defaultValue);
     final isLoadOriginal = useState(AppSettingsEnum.loadOriginal.defaultValue);
@@ -57,7 +55,7 @@ class GalleryViewerPage extends HookConsumerWidget {
     final isPlayingMotionVideo = useState(false);
     final isPlayingVideo = useState(false);
     late Offset localPosition;
-    final authToken = 'Bearer ${box.get(accessTokenKey)}';
+    final authToken = 'Bearer ${Store.get(StoreKey.accessToken)}';
 
     showAppBar.addListener(() {
       // Change to and from immersive mode, hiding navigation and app bar

--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:chewie/chewie.dart';
 import 'package:immich_mobile/modules/asset_viewer/models/image_viewer_page_state.model.dart';
 import 'package:immich_mobile/modules/asset_viewer/providers/image_viewer_page_state.provider.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:video_player/video_player.dart';
@@ -54,17 +53,15 @@ class VideoViewerPage extends HookConsumerWidget {
     }
     final downloadAssetStatus =
         ref.watch(imageViewerStateProvider).downloadAssetStatus;
-    final box = Hive.box(userInfoBox);
-    final String jwtToken = box.get(accessTokenKey);
     final String videoUrl = isMotionVideo
-        ? '${box.get(serverEndpointKey)}/asset/file/${asset.livePhotoVideoId}'
-        : '${box.get(serverEndpointKey)}/asset/file/${asset.remoteId}';
+        ? '${Store.get(StoreKey.serverEndpoint)}/asset/file/${asset.livePhotoVideoId}'
+        : '${Store.get(StoreKey.serverEndpoint)}/asset/file/${asset.remoteId}';
 
     return Stack(
       children: [
         VideoThumbnailPlayer(
           url: videoUrl,
-          jwtToken: jwtToken,
+          jwtToken: Store.get(StoreKey.accessToken),
           isMotionVideo: isMotionVideo,
           onVideoEnded: onVideoEnded,
           onPaused: onPaused,

--- a/mobile/lib/modules/home/ui/home_page_app_bar.dart
+++ b/mobile/lib/modules/home/ui/home_page_app_bar.dart
@@ -2,9 +2,7 @@ import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 
@@ -12,6 +10,7 @@ import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/modules/backup/models/backup_state.model.dart';
 import 'package:immich_mobile/shared/models/server_info_state.model.dart';
 import 'package:immich_mobile/modules/backup/providers/backup.provider.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/providers/server_info.provider.dart';
 import 'package:immich_mobile/shared/ui/transparent_image.dart';
 
@@ -47,7 +46,7 @@ class HomePageAppBar extends ConsumerWidget with PreferredSizeWidget {
           },
         );
       } else {
-        String endpoint = Hive.box(userInfoBox).get(serverEndpointKey);
+        final String? endpoint = Store.get(StoreKey.serverEndpoint);
         var dummy = Random().nextInt(1024);
         return InkWell(
           onTap: () {

--- a/mobile/lib/modules/home/ui/profile_drawer/profile_drawer_header.dart
+++ b/mobile/lib/modules/home/ui/profile_drawer/profile_drawer_header.dart
@@ -1,14 +1,13 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/home/providers/upload_profile_image.provider.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:immich_mobile/shared/ui/transparent_image.dart';
 
@@ -19,7 +18,7 @@ class ProfileDrawerHeader extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    String endpoint = Hive.box(userInfoBox).get(serverEndpointKey);
+    final String endpoint = Store.get(StoreKey.serverEndpoint);
     AuthenticationState authState = ref.watch(authenticationProvider);
     final uploadProfileImageStatus =
         ref.watch(uploadProfileImageProvider).status;

--- a/mobile/lib/modules/search/ui/thumbnail_with_info.dart
+++ b/mobile/lib/modules/search/ui/thumbnail_with_info.dart
@@ -1,7 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 
 class ThumbnailWithInfo extends StatelessWidget {
   const ThumbnailWithInfo({
@@ -19,7 +18,6 @@ class ThumbnailWithInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var box = Hive.box(userInfoBox);
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
     var textAndIconColor = isDarkMode ? Colors.grey[100] : Colors.grey[700];
     return GestureDetector(
@@ -51,7 +49,8 @@ class ThumbnailWithInfo extends StatelessWidget {
                           fit: BoxFit.cover,
                           imageUrl: imageUrl!,
                           httpHeaders: {
-                            "Authorization": "Bearer ${box.get(accessTokenKey)}"
+                            "Authorization":
+                                "Bearer ${Store.get(StoreKey.accessToken)}"
                           },
                           errorWidget: (context, url, error) =>
                               const Icon(Icons.image_not_supported_outlined),

--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -1,15 +1,14 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
 import 'package:immich_mobile/modules/search/ui/search_bar.dart';
 import 'package:immich_mobile/modules/search/ui/search_suggestion_list.dart';
 import 'package:immich_mobile/modules/search/ui/thumbnail_with_info.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:immich_mobile/utils/capitalize_first_letter.dart';
 import 'package:openapi/api.dart';
@@ -22,7 +21,6 @@ class SearchPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var box = Hive.box(userInfoBox);
     final isSearchEnabled = ref.watch(searchPageStateProvider).isSearchEnabled;
     AsyncValue<List<CuratedLocationsResponseDto>> curatedLocation =
         ref.watch(getCuratedLocationProvider);
@@ -64,7 +62,7 @@ class SearchPage extends HookConsumerWidget {
                     itemBuilder: ((context, index) {
                       var locationInfo = curatedLocations[index];
                       var thumbnailRequestUrl =
-                          '${box.get(serverEndpointKey)}/asset/thumbnail/${locationInfo.id}';
+                          '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${locationInfo.id}';
                       return ThumbnailWithInfo(
                         imageUrl: thumbnailRequestUrl,
                         textInfo: locationInfo.city,
@@ -113,7 +111,7 @@ class SearchPage extends HookConsumerWidget {
                     itemBuilder: ((context, index) {
                       var curatedObjectInfo = objects[index];
                       var thumbnailRequestUrl =
-                          '${box.get(serverEndpointKey)}/asset/thumbnail/${curatedObjectInfo.id}';
+                          '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
 
                       return ThumbnailWithInfo(
                         imageUrl: thumbnailRequestUrl,

--- a/mobile/lib/modules/settings/services/app_settings.service.dart
+++ b/mobile/lib/modules/settings/services/app_settings.service.dart
@@ -1,59 +1,63 @@
-import 'package:hive_flutter/hive_flutter.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 
 enum AppSettingsEnum<T> {
-  loadPreview<bool>("loadPreview", true),
-  loadOriginal<bool>("loadOriginal", false),
-  themeMode<String>("themeMode", "system"), // "light","dark","system"
-  tilesPerRow<int>("tilesPerRow", 4),
-  dynamicLayout<bool>("dynamicLayout", false),
-  groupAssetsBy<int>("groupBy", 0),
+  loadPreview<bool>(StoreKey.loadPreview, "loadPreview", true),
+  loadOriginal<bool>(StoreKey.loadOriginal, "loadOriginal", false),
+  themeMode<String>(
+    StoreKey.themeMode,
+    "themeMode",
+    "system",
+  ), // "light","dark","system"
+  tilesPerRow<int>(StoreKey.tilesPerRow, "tilesPerRow", 4),
+  dynamicLayout<bool>(StoreKey.dynamicLayout, "dynamicLayout", false),
+  groupAssetsBy<int>(StoreKey.groupAssetsBy, "groupBy", 0),
   uploadErrorNotificationGracePeriod<int>(
+    StoreKey.uploadErrorNotificationGracePeriod,
     "uploadErrorNotificationGracePeriod",
     2,
   ),
-  backgroundBackupTotalProgress<bool>("backgroundBackupTotalProgress", true),
-  backgroundBackupSingleProgress<bool>("backgroundBackupSingleProgress", false),
-  storageIndicator<bool>("storageIndicator", true),
-  thumbnailCacheSize<int>("thumbnailCacheSize", 10000),
-  imageCacheSize<int>("imageCacheSize", 350),
-  albumThumbnailCacheSize<int>("albumThumbnailCacheSize", 200),
-  useExperimentalAssetGrid<bool>("useExperimentalAssetGrid", false),
-  selectedAlbumSortOrder<int>("selectedAlbumSortOrder", 0);
+  backgroundBackupTotalProgress<bool>(
+    StoreKey.backgroundBackupTotalProgress,
+    "backgroundBackupTotalProgress",
+    true,
+  ),
+  backgroundBackupSingleProgress<bool>(
+    StoreKey.backgroundBackupSingleProgress,
+    "backgroundBackupSingleProgress",
+    false,
+  ),
+  storageIndicator<bool>(StoreKey.storageIndicator, "storageIndicator", true),
+  thumbnailCacheSize<int>(
+    StoreKey.thumbnailCacheSize,
+    "thumbnailCacheSize",
+    10000,
+  ),
+  imageCacheSize<int>(StoreKey.imageCacheSize, "imageCacheSize", 350),
+  albumThumbnailCacheSize<int>(
+    StoreKey.albumThumbnailCacheSize,
+    "albumThumbnailCacheSize",
+    200,
+  ),
+  selectedAlbumSortOrder<int>(
+    StoreKey.selectedAlbumSortOrder,
+    "selectedAlbumSortOrder",
+    0,
+  ),
+  ;
 
-  const AppSettingsEnum(this.hiveKey, this.defaultValue);
+  const AppSettingsEnum(this.storeKey, this.hiveKey, this.defaultValue);
 
+  final StoreKey<T> storeKey;
   final String hiveKey;
   final T defaultValue;
 }
 
 class AppSettingsService {
-  late final Box hiveBox;
-
-  AppSettingsService() {
-    hiveBox = Hive.box(userSettingInfoBox);
+  T getSetting<T>(AppSettingsEnum<T> setting) {
+    return Store.get(setting.storeKey, setting.defaultValue);
   }
 
-  T getSetting<T>(AppSettingsEnum<T> settingType) {
-    if (!hiveBox.containsKey(settingType.hiveKey)) {
-      return _setDefault(settingType);
-    }
-
-    var result = hiveBox.get(settingType.hiveKey);
-
-    if (result is! T) {
-      return _setDefault(settingType);
-    }
-
-    return result;
-  }
-
-  setSetting<T>(AppSettingsEnum<T> settingType, T value) {
-    hiveBox.put(settingType.hiveKey, value);
-  }
-
-  T _setDefault<T>(AppSettingsEnum<T> settingType) {
-    hiveBox.put(settingType.hiveKey, settingType.defaultValue);
-    return settingType.defaultValue;
+  void setSetting<T>(AppSettingsEnum<T> setting, T value) {
+    Store.put(setting.storeKey, value);
   }
 }

--- a/mobile/lib/routing/auth_guard.dart
+++ b/mobile/lib/routing/auth_guard.dart
@@ -13,7 +13,6 @@ class AuthGuard extends AutoRouteGuard {
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
     try {
       var res = await _apiService.authenticationApi.validateAccessToken();
-
       if (res != null && res.authStatus) {
         resolver.next(true);
       } else {

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -1,6 +1,5 @@
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
-import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/utils/hash.dart';
 import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
@@ -40,7 +39,7 @@ class Asset {
         width = local.width,
         fileName = local.title!,
         deviceId = Store.get(StoreKey.deviceIdHash),
-        ownerId = Store.get<User>(StoreKey.currentUser)!.isarId,
+        ownerId = Store.get(StoreKey.currentUser).isarId,
         fileModifiedAt = local.modifiedDateTime.toUtc(),
         updatedAt = local.modifiedDateTime.toUtc(),
         isFavorite = local.isFavorite,

--- a/mobile/lib/shared/models/logger_message.model.dart
+++ b/mobile/lib/shared/models/logger_message.model.dart
@@ -1,0 +1,48 @@
+// ignore_for_file: constant_identifier_names
+
+import 'package:isar/isar.dart';
+import 'package:logging/logging.dart';
+
+part 'logger_message.model.g.dart';
+
+@Collection(inheritance: false)
+class LoggerMessage {
+  Id id = Isar.autoIncrement;
+  String message;
+  @Enumerated(EnumType.ordinal)
+  LogLevel level = LogLevel.INFO;
+  DateTime createdAt;
+  String? context1;
+  String? context2;
+
+  LoggerMessage({
+    required this.message,
+    required this.level,
+    required this.createdAt,
+    required this.context1,
+    required this.context2,
+  });
+
+  @override
+  String toString() {
+    return 'InAppLoggerMessage(message: $message, level: $level, createdAt: $createdAt)';
+  }
+}
+
+/// Log levels according to dart logging [Level]
+enum LogLevel {
+  ALL,
+  FINEST,
+  FINER,
+  FINE,
+  CONFIG,
+  INFO,
+  WARNING,
+  SEVERE,
+  SHOUT,
+  OFF,
+}
+
+extension LevelExtension on Level {
+  LogLevel toLogLevel() => LogLevel.values[Level.LEVELS.indexOf(this)];
+}

--- a/mobile/lib/shared/models/logger_message.model.g.dart
+++ b/mobile/lib/shared/models/logger_message.model.g.dart
@@ -1,0 +1,1092 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'logger_message.model.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters
+
+extension GetLoggerMessageCollection on Isar {
+  IsarCollection<LoggerMessage> get loggerMessages => this.collection();
+}
+
+const LoggerMessageSchema = CollectionSchema(
+  name: r'LoggerMessage',
+  id: -1606100856208753787,
+  properties: {
+    r'context1': PropertySchema(
+      id: 0,
+      name: r'context1',
+      type: IsarType.string,
+    ),
+    r'context2': PropertySchema(
+      id: 1,
+      name: r'context2',
+      type: IsarType.string,
+    ),
+    r'createdAt': PropertySchema(
+      id: 2,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'level': PropertySchema(
+      id: 3,
+      name: r'level',
+      type: IsarType.byte,
+      enumMap: _LoggerMessagelevelEnumValueMap,
+    ),
+    r'message': PropertySchema(
+      id: 4,
+      name: r'message',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _loggerMessageEstimateSize,
+  serialize: _loggerMessageSerialize,
+  deserialize: _loggerMessageDeserialize,
+  deserializeProp: _loggerMessageDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _loggerMessageGetId,
+  getLinks: _loggerMessageGetLinks,
+  attach: _loggerMessageAttach,
+  version: '3.0.5',
+);
+
+int _loggerMessageEstimateSize(
+  LoggerMessage object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.context1;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.context2;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.message.length * 3;
+  return bytesCount;
+}
+
+void _loggerMessageSerialize(
+  LoggerMessage object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.context1);
+  writer.writeString(offsets[1], object.context2);
+  writer.writeDateTime(offsets[2], object.createdAt);
+  writer.writeByte(offsets[3], object.level.index);
+  writer.writeString(offsets[4], object.message);
+}
+
+LoggerMessage _loggerMessageDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = LoggerMessage(
+    context1: reader.readStringOrNull(offsets[0]),
+    context2: reader.readStringOrNull(offsets[1]),
+    createdAt: reader.readDateTime(offsets[2]),
+    level: _LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offsets[3])] ??
+        LogLevel.ALL,
+    message: reader.readString(offsets[4]),
+  );
+  object.id = id;
+  return object;
+}
+
+P _loggerMessageDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    case 2:
+      return (reader.readDateTime(offset)) as P;
+    case 3:
+      return (_LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offset)] ??
+          LogLevel.ALL) as P;
+    case 4:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+const _LoggerMessagelevelEnumValueMap = {
+  'ALL': 0,
+  'FINEST': 1,
+  'FINER': 2,
+  'FINE': 3,
+  'CONFIG': 4,
+  'INFO': 5,
+  'WARNING': 6,
+  'SEVERE': 7,
+  'SHOUT': 8,
+  'OFF': 9,
+};
+const _LoggerMessagelevelValueEnumMap = {
+  0: LogLevel.ALL,
+  1: LogLevel.FINEST,
+  2: LogLevel.FINER,
+  3: LogLevel.FINE,
+  4: LogLevel.CONFIG,
+  5: LogLevel.INFO,
+  6: LogLevel.WARNING,
+  7: LogLevel.SEVERE,
+  8: LogLevel.SHOUT,
+  9: LogLevel.OFF,
+};
+
+Id _loggerMessageGetId(LoggerMessage object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _loggerMessageGetLinks(LoggerMessage object) {
+  return [];
+}
+
+void _loggerMessageAttach(
+    IsarCollection<dynamic> col, Id id, LoggerMessage object) {
+  object.id = id;
+}
+
+extension LoggerMessageQueryWhereSort
+    on QueryBuilder<LoggerMessage, LoggerMessage, QWhere> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension LoggerMessageQueryWhere
+    on QueryBuilder<LoggerMessage, LoggerMessage, QWhereClause> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhereClause> idEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhereClause> idNotEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhereClause> idGreaterThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhereClause> idLessThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension LoggerMessageQueryFilter
+    on QueryBuilder<LoggerMessage, LoggerMessage, QFilterCondition> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1IsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'context1',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1IsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'context1',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1EqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1GreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1LessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1Between(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'context1',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1StartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1EndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1Contains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'context1',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1Matches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'context1',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1IsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'context1',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context1IsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'context1',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2IsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'context2',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2IsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'context2',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2EqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2GreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2LessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2Between(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'context2',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2StartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2EndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2Contains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'context2',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2Matches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'context2',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2IsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'context2',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      context2IsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'context2',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      createdAtEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      levelEqualTo(LogLevel value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'level',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      levelGreaterThan(
+    LogLevel value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'level',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      levelLessThan(
+    LogLevel value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'level',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      levelBetween(
+    LogLevel lower,
+    LogLevel upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'level',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'message',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'message',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'message',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'message',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      messageIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'message',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension LoggerMessageQueryObject
+    on QueryBuilder<LoggerMessage, LoggerMessage, QFilterCondition> {}
+
+extension LoggerMessageQueryLinks
+    on QueryBuilder<LoggerMessage, LoggerMessage, QFilterCondition> {}
+
+extension LoggerMessageQuerySortBy
+    on QueryBuilder<LoggerMessage, LoggerMessage, QSortBy> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByContext1() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context1', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      sortByContext1Desc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context1', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByContext2() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context2', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      sortByContext2Desc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context2', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByLevel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'level', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByLevelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'level', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByMessage() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'message', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByMessageDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'message', Sort.desc);
+    });
+  }
+}
+
+extension LoggerMessageQuerySortThenBy
+    on QueryBuilder<LoggerMessage, LoggerMessage, QSortThenBy> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByContext1() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context1', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      thenByContext1Desc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context1', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByContext2() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context2', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      thenByContext2Desc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'context2', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy>
+      thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByLevel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'level', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByLevelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'level', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByMessage() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'message', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByMessageDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'message', Sort.desc);
+    });
+  }
+}
+
+extension LoggerMessageQueryWhereDistinct
+    on QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> {
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByContext1(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'context1', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByContext2(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'context2', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByLevel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'level');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByMessage(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'message', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension LoggerMessageQueryProperty
+    on QueryBuilder<LoggerMessage, LoggerMessage, QQueryProperty> {
+  QueryBuilder<LoggerMessage, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, String?, QQueryOperations> context1Property() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'context1');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, String?, QQueryOperations> context2Property() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'context2');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LogLevel, QQueryOperations> levelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'level');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, String, QQueryOperations> messageProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'message');
+    });
+  }
+}

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:immich_mobile/shared/models/user.dart';
 import 'package:isar/isar.dart';
-import 'dart:convert';
 
 part 'store.g.dart';
 
@@ -26,12 +25,21 @@ class Store {
     return _db.writeTxn(() => _db.storeValues.clear());
   }
 
-  /// Returns the stored value for the given key, or the default value if null
-  static T? get<T>(StoreKey key, [T? defaultValue]) =>
-      _cache[key.id] ?? defaultValue;
+  /// Returns the stored value for the given key or if null the [defaultValue]
+  /// Throws a [StoreKeyNotFoundException] if both are null
+  static T get<T>(StoreKey<T> key, [T? defaultValue]) {
+    final value = _cache[key.id] ?? defaultValue;
+    if (value == null) {
+      throw StoreKeyNotFoundException(key);
+    }
+    return value;
+  }
+
+  /// Returns the stored value for the given key (possibly null)
+  static T? tryGet<T>(StoreKey<T> key) => _cache[key.id];
 
   /// Stores the value synchronously in the cache and asynchronously in the DB
-  static Future<void> put<T>(StoreKey key, T value) {
+  static Future<void> put<T>(StoreKey<T> key, T value) {
     _cache[key.id] = value;
     return _db.writeTxn(
       () async => _db.storeValues.put(await StoreValue._of(value, key)),
@@ -39,7 +47,7 @@ class Store {
   }
 
   /// Removes the value synchronously from the cache and asynchronously from the DB
-  static Future<void> delete(StoreKey key) {
+  static Future<void> delete<T>(StoreKey<T> key) {
     _cache[key.id] = null;
     return _db.writeTxn(() => _db.storeValues.delete(key.id));
   }
@@ -58,7 +66,8 @@ class Store {
   static void _onChangeListener(List<StoreValue>? data) {
     if (data != null) {
       for (StoreValue value in data) {
-        _cache[value.id] = value._extract(StoreKey.values[value.id]);
+        _cache[value.id] =
+            value._extract(StoreKey.values.firstWhere((e) => e.id == value.id));
       }
     }
   }
@@ -72,76 +81,113 @@ class StoreValue {
   int? intValue;
   String? strValue;
 
-  dynamic _extract(StoreKey key) {
+  T? _extract<T>(StoreKey<T> key) {
     switch (key.type) {
       case int:
-        return key.fromDb == null
-            ? intValue
-            : key.fromDb!.call(Store._db, intValue!);
+        return intValue as T?;
       case bool:
-        return intValue == null ? null : intValue! == 1;
+        return intValue == null ? null : (intValue! == 1) as T;
       case DateTime:
         return intValue == null
             ? null
-            : DateTime.fromMicrosecondsSinceEpoch(intValue!);
+            : DateTime.fromMicrosecondsSinceEpoch(intValue!) as T;
       case String:
-        return key.fromJson != null
-            ? key.fromJson!.call(json.decode(strValue!))
-            : strValue;
+        return strValue as T?;
+      default:
+        if (key.fromDb != null) {
+          return key.fromDb!.call(Store._db, intValue!);
+        }
     }
+    throw TypeError();
   }
 
-  static Future<StoreValue> _of(dynamic value, StoreKey key) async {
+  static Future<StoreValue> _of<T>(T? value, StoreKey<T> key) async {
     int? i;
     String? s;
     switch (key.type) {
       case int:
-        i = (key.toDb == null ? value : await key.toDb!.call(Store._db, value));
+        i = value as int?;
         break;
       case bool:
-        i = value == null ? null : (value ? 1 : 0);
+        i = value == null ? null : (value == true ? 1 : 0);
         break;
       case DateTime:
         i = value == null ? null : (value as DateTime).microsecondsSinceEpoch;
         break;
       case String:
-        s = key.fromJson == null ? value : json.encode(value.toJson());
+        s = value as String?;
         break;
+      default:
+        if (key.toDb != null) {
+          i = await key.toDb!.call(Store._db, value);
+          break;
+        }
+        throw TypeError();
     }
     return StoreValue(key.id, intValue: i, strValue: s);
   }
 }
 
+class StoreKeyNotFoundException implements Exception {
+  final StoreKey key;
+  StoreKeyNotFoundException(this.key);
+  @override
+  String toString() => "Key '${key.name}' not found in Store";
+}
+
 /// Key for each possible value in the `Store`.
-/// Defines the data type (int, String, JSON) for each value
-enum StoreKey {
-  userRemoteId(0),
-  assetETag(1),
-  currentUser(2, type: int, fromDb: _getUser, toDb: _toUser),
-  deviceIdHash(3, type: int),
-  deviceId(4),
-  backupFailedSince(5, type: DateTime),
-  backupRequireWifi(6, type: bool),
-  backupRequireCharging(7, type: bool),
-  backupTriggerDelay(8, type: int);
+/// Defines the data type for each value
+enum StoreKey<T> {
+  userRemoteId<String>(0, type: String),
+  assetETag<String>(1, type: String),
+  currentUser<User>(2, type: User, fromDb: _getUser, toDb: _toUser),
+  deviceIdHash<int>(3, type: int),
+  deviceId<String>(4, type: String),
+  backupFailedSince<DateTime>(5, type: DateTime),
+  backupRequireWifi<bool>(6, type: bool),
+  backupRequireCharging<bool>(7, type: bool),
+  backupTriggerDelay<int>(8, type: int),
+  githubReleaseInfo<String>(9, type: String),
+  serverUrl<String>(10, type: String),
+  accessToken<String>(11, type: String),
+  serverEndpoint<String>(12, type: String),
+  // user settings from [AppSettingsEnum] below:
+  loadPreview<bool>(100, type: bool),
+  loadOriginal<bool>(101, type: bool),
+  themeMode<String>(102, type: String),
+  tilesPerRow<int>(103, type: int),
+  dynamicLayout<bool>(104, type: bool),
+  groupAssetsBy<int>(105, type: int),
+  uploadErrorNotificationGracePeriod<int>(106, type: int),
+  backgroundBackupTotalProgress<bool>(107, type: bool),
+  backgroundBackupSingleProgress<bool>(108, type: bool),
+  storageIndicator<bool>(109, type: bool),
+  thumbnailCacheSize<int>(110, type: int),
+  imageCacheSize<int>(111, type: int),
+  albumThumbnailCacheSize<int>(112, type: int),
+  selectedAlbumSortOrder<int>(113, type: int),
+  ;
 
   const StoreKey(
     this.id, {
-    this.type = String,
+    required this.type,
     this.fromDb,
     this.toDb,
-    // ignore: unused_element
-    this.fromJson,
   });
   final int id;
   final Type type;
-  final dynamic Function(Isar, int)? fromDb;
-  final Future<int> Function(Isar, dynamic)? toDb;
-  final Function(dynamic)? fromJson;
+  final T? Function<T>(Isar, int)? fromDb;
+  final Future<int> Function<T>(Isar, T)? toDb;
 }
 
-User? _getUser(Isar db, int i) => db.users.getSync(i);
-Future<int> _toUser(Isar db, dynamic u) {
-  User user = (u as User);
-  return db.users.put(user);
+T? _getUser<T>(Isar db, int i) {
+  final User? u = db.users.getSync(i);
+  return u as T?;
+}
+
+Future<int> _toUser<T>(Isar db, T u) {
+  if (u is User) {
+    return db.users.put(u);
+  }
+  throw TypeError();
 }

--- a/mobile/lib/shared/providers/release_info.provider.dart
+++ b/mobile/lib/shared/providers/release_info.provider.dart
@@ -1,10 +1,9 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/views/version_announcement_overlay.dart';
 import 'package:logging/logging.dart';
 
@@ -13,10 +12,10 @@ class ReleaseInfoNotifier extends StateNotifier<String> {
   final log = Logger('ReleaseInfoNotifier');
   void checkGithubReleaseInfo() async {
     final Client client = Client();
-    var box = Hive.box(hiveGithubReleaseInfoBox);
 
     try {
-      String? localReleaseVersion = box.get(githubReleaseInfoKey);
+      final String? localReleaseVersion =
+          Store.tryGet(StoreKey.githubReleaseInfo);
       final res = await client.get(
         Uri.parse(
           "https://api.github.com/repos/immich-app/immich/releases/latest",
@@ -48,9 +47,7 @@ class ReleaseInfoNotifier extends StateNotifier<String> {
   }
 
   void acknowledgeNewVersion() {
-    var box = Hive.box(hiveGithubReleaseInfoBox);
-
-    box.put(githubReleaseInfoKey, state);
+    Store.put(StoreKey.githubReleaseInfo, state);
     VersionAnnouncementOverlayController.appLoader.hide();
   }
 }

--- a/mobile/lib/shared/providers/websocket.provider.dart
+++ b/mobile/lib/shared/providers/websocket.provider.dart
@@ -1,11 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
@@ -58,9 +57,9 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
     var authenticationState = ref.read(authenticationProvider);
 
     if (authenticationState.isAuthenticated) {
-      var accessToken = Hive.box(userInfoBox).get(accessTokenKey);
+      final accessToken = Store.get(StoreKey.accessToken);
       try {
-        var endpoint = Uri.parse(Hive.box(userInfoBox).get(serverEndpointKey));
+        final endpoint = Uri.parse(Store.get(StoreKey.serverEndpoint));
 
         debugPrint("Attempting to connect to websocket");
         // Configure socket transports must be specified

--- a/mobile/lib/shared/services/api.service.dart
+++ b/mobile/lib/shared/services/api.service.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:hive/hive.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:openapi/api.dart';
 import 'package:http/http.dart';
@@ -19,13 +18,9 @@ class ApiService {
   late DeviceInfoApi deviceInfoApi;
 
   ApiService() {
-    if (Hive.isBoxOpen(userInfoBox)) {
-      final endpoint = Hive.box(userInfoBox).get(serverEndpointKey) as String?;
-      if (endpoint != null && endpoint.isNotEmpty) {
-        setEndpoint(endpoint);
-      }
-    } else {
-      debugPrint("Cannot init ApiServer endpoint, userInfoBox not open yet.");
+    final endpoint = Store.tryGet(StoreKey.serverEndpoint);
+    if (endpoint != null && endpoint.isNotEmpty) {
+      setEndpoint(endpoint);
     }
   }
   String? _authToken;
@@ -49,7 +44,7 @@ class ApiService {
     setEndpoint(endpoint);
 
     // Save in hivebox for next startup
-    Hive.box(userInfoBox).put(serverEndpointKey, endpoint);
+    Store.put(StoreKey.serverEndpoint, endpoint);
     return endpoint;
   }
 

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -5,7 +5,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
-import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
@@ -44,7 +43,7 @@ class AssetService {
         .where()
         .remoteIdIsNotNull()
         .filter()
-        .ownerIdEqualTo(Store.get<User>(StoreKey.currentUser)!.isarId)
+        .ownerIdEqualTo(Store.get(StoreKey.currentUser).isarId)
         .count();
     final List<AssetResponseDto>? dtos =
         await _getRemoteAssets(hasCache: numOwnedRemoteAssets > 0);
@@ -63,7 +62,7 @@ class AssetService {
     required bool hasCache,
   }) async {
     try {
-      final etag = hasCache ? Store.get(StoreKey.assetETag) : null;
+      final etag = hasCache ? Store.tryGet(StoreKey.assetETag) : null;
       final Pair<List<AssetResponseDto>, String?>? remote =
           await _apiService.assetApi.getAllAssetsWithETag(eTag: etag);
       if (remote == null) {

--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -241,7 +241,7 @@ class SyncService {
     }
 
     if (album.shared || dto.shared) {
-      final userId = Store.get<User>(StoreKey.currentUser)!.isarId;
+      final userId = Store.get(StoreKey.currentUser).isarId;
       final foreign =
           await album.assets.filter().not().ownerIdEqualTo(userId).findAll();
       existing.addAll(foreign);

--- a/mobile/lib/shared/services/user.service.dart
+++ b/mobile/lib/shared/services/user.service.dart
@@ -42,7 +42,7 @@ class UserService {
     if (self) {
       return _db.users.where().findAll();
     }
-    final int userId = Store.get<User>(StoreKey.currentUser)!.isarId;
+    final int userId = Store.get(StoreKey.currentUser).isarId;
     return _db.users.where().isarIdNotEqualTo(userId).findAll();
   }
 

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -1,9 +1,8 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:hive_flutter/hive_flutter.dart';
-import 'package:immich_mobile/constants/hive_box.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -84,7 +83,7 @@ class ImmichImage extends StatelessWidget {
         },
       );
     }
-    final String? token = Hive.box(userInfoBox).get(accessTokenKey);
+    final String? token = Store.get(StoreKey.accessToken);
     final String thumbnailRequestUrl = getThumbnailUrl(asset);
     return CachedNetworkImage(
       imageUrl: thumbnailRequestUrl,

--- a/mobile/lib/shared/views/app_log_page.dart
+++ b/mobile/lib/shared/views/app_log_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/shared/models/logger_message.model.dart';
 import 'package:immich_mobile/shared/services/immich_logger.service.dart';
 import 'package:intl/intl.dart';
 
@@ -31,29 +32,29 @@ class AppLogPage extends HookConsumerWidget {
       );
     }
 
-    Widget buildLeadingIcon(String level) {
+    Widget buildLeadingIcon(LogLevel level) {
       switch (level) {
-        case "INFO":
+        case LogLevel.INFO:
           return colorStatusIndicator(Theme.of(context).primaryColor);
-        case "SEVERE":
+        case LogLevel.SEVERE:
           return colorStatusIndicator(Colors.redAccent);
 
-        case "WARNING":
+        case LogLevel.WARNING:
           return colorStatusIndicator(Colors.orangeAccent);
         default:
           return colorStatusIndicator(Colors.grey);
       }
     }
 
-    getTileColor(String level) {
+    getTileColor(LogLevel level) {
       switch (level) {
-        case "INFO":
+        case LogLevel.INFO:
           return Colors.transparent;
-        case "SEVERE":
+        case LogLevel.SEVERE:
           return Theme.of(context).brightness == Brightness.dark
               ? Colors.redAccent.withOpacity(0.25)
               : Colors.redAccent.withOpacity(0.075);
-        case "WARNING":
+        case LogLevel.WARNING:
           return Theme.of(context).brightness == Brightness.dark
               ? Colors.orangeAccent.withOpacity(0.25)
               : Colors.orangeAccent.withOpacity(0.075);

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -1,9 +1,7 @@
-import 'package:hive/hive.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/store.dart';
 import 'package:openapi/api.dart';
-
-import '../constants/hive_box.dart';
 
 String getThumbnailUrl(
   final Asset asset, {
@@ -48,8 +46,7 @@ String getAlbumThumbNailCacheKey(
 }
 
 String getImageUrl(final Asset asset) {
-  final box = Hive.box(userInfoBox);
-  return '${box.get(serverEndpointKey)}/asset/file/${asset.remoteId}?isThumb=false';
+  return '${Store.get(StoreKey.serverEndpoint)}/asset/file/${asset.remoteId}?isThumb=false';
 }
 
 String getImageCacheKey(final Asset asset) {
@@ -60,7 +57,5 @@ String _getThumbnailUrl(
   final String id, {
   ThumbnailFormat type = ThumbnailFormat.WEBP,
 }) {
-  final box = Hive.box(userInfoBox);
-
-  return '${box.get(serverEndpointKey)}/asset/thumbnail/$id?format=${type.value}';
+  return '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/$id?format=${type.value}';
 }


### PR DESCRIPTION
This PR removes all Hive usage across the mobile app and replaces it with the custom `Store` class.
The `Store` is now also type-safe.

Migrations for existing Hive boxes are performed once on app start. After successful migration, the Hive boxes are removed.

We can delete the (generated) Hive classes and migration once enough releases have passed (so that users had a chance to update).