### PR TITLE
feat(mobile): Use new search API and GridView for Places / Locations

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -246,5 +246,7 @@
   "permission_onboarding_log_out": "Log out",
   "login_form_next_button": "Next",
   "album_thumbnail_shared_by": "Shared by {}",
-  "album_thumbnail_owned": "Owned"
+  "album_thumbnail_owned": "Owned",
+  "curated_object_page_title": "Things",
+  "curated_location_page_title": "Places"
 }

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -248,5 +248,6 @@
   "album_thumbnail_shared_by": "Shared by {}",
   "album_thumbnail_owned": "Owned",
   "curated_object_page_title": "Things",
-  "curated_location_page_title": "Places"
+  "curated_location_page_title": "Places",
+  "search_page_view_all_button": "View All"
 }

--- a/mobile/lib/modules/search/models/curated_content.dart
+++ b/mobile/lib/modules/search/models/curated_content.dart
@@ -1,0 +1,15 @@
+/// A wrapper for [CuratedLocationsResponseDto] objects
+/// and [CuratedObjectsResponseDto] to be displayed in 
+/// a view
+class CuratedContent {
+  /// The label to show associated with this curated object
+  final String label;
+
+  /// The id to lookup the asset from the server
+  final String id;
+
+  CuratedContent({
+    required this.id,
+    required this.label,
+  });
+}

--- a/mobile/lib/modules/search/services/search.service.dart
+++ b/mobile/lib/modules/search/services/search.service.dart
@@ -33,7 +33,7 @@ class SearchService {
     // TODO search in local DB: 1. when offline, 2. to find local assets
     try {
       final SearchResponseDto? results = await _apiService.searchApi
-          .search(query: searchTerm, q: searchTerm);
+          .search(query: searchTerm, clip: true);
       if (results == null) {
         return null;
       }

--- a/mobile/lib/modules/search/services/search.service.dart
+++ b/mobile/lib/modules/search/services/search.service.dart
@@ -32,13 +32,13 @@ class SearchService {
   Future<List<Asset>?> searchAsset(String searchTerm) async {
     // TODO search in local DB: 1. when offline, 2. to find local assets
     try {
-      final List<AssetResponseDto>? results = await _apiService.assetApi
-          .searchAsset(SearchAssetDto(searchTerm: searchTerm));
+      final SearchResponseDto? results = await _apiService.searchApi
+          .search(query: searchTerm, q: searchTerm);
       if (results == null) {
         return null;
       }
       // TODO local DB might be out of date; add assets not yet in DB?
-      return _db.assets.getAllByRemoteId(results.map((e) => e.id));
+      return _db.assets.getAllByRemoteId(results.assets.items.map((e) => e.id));
     } catch (e) {
       debugPrint("[ERROR] [searchAsset] ${e.toString()}");
       return null;

--- a/mobile/lib/modules/search/ui/explore_grid.dart
+++ b/mobile/lib/modules/search/ui/explore_grid.dart
@@ -1,0 +1,41 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:immich_mobile/modules/search/models/curated_content.dart';
+import 'package:immich_mobile/modules/search/ui/thumbnail_with_info.dart';
+import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/shared/models/store.dart';
+
+class ExploreGrid extends StatelessWidget {
+  final List<CuratedContent> curatedContent;
+  const ExploreGrid({
+    super.key,
+    required this.curatedContent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 140,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+      ),
+      itemBuilder: (context, index) {
+        final content = curatedContent[index];
+        final thumbnailRequestUrl =
+            '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${content.id}';
+        return ThumbnailWithInfo(
+          imageUrl: thumbnailRequestUrl,
+          textInfo: content.label,
+          onTap: () {
+            AutoRouter.of(context).push(
+              SearchResultRoute(searchTerm: content.label),
+            );
+          },
+        );
+      },
+      itemCount: curatedContent.length,
+    );
+  }
+
+}

--- a/mobile/lib/modules/search/ui/explore_grid.dart
+++ b/mobile/lib/modules/search/ui/explore_grid.dart
@@ -14,6 +14,21 @@ class ExploreGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (curatedContent.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: SizedBox(
+          height: 100,
+          width: 100,
+          child: ThumbnailWithInfo(
+            textInfo: '',
+            onTap: () {
+            },
+          ),
+        ),
+      );
+    }
+
     return GridView.builder(
       gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
         maxCrossAxisExtent: 140,

--- a/mobile/lib/modules/search/ui/thumbnail_with_info.dart
+++ b/mobile/lib/modules/search/ui/thumbnail_with_info.dart
@@ -24,63 +24,53 @@ class ThumbnailWithInfo extends StatelessWidget {
       onTap: () {
         onTap();
       },
-      child: Padding(
-        padding: const EdgeInsets.only(right: 8.0),
-        child: SizedBox(
-          width: MediaQuery.of(context).size.width / 3,
-          child: Stack(
-            alignment: Alignment.bottomCenter,
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(25),
-                  color: isDarkMode ? Colors.grey[900] : Colors.grey[100],
-                  border: Border.all(
-                    color: isDarkMode ? Colors.grey[800]! : Colors.grey[400]!,
-                    width: 1,
-                  ),
-                ),
-                child: imageUrl != null
-                    ? ClipRRect(
-                        borderRadius: BorderRadius.circular(20),
-                        child: CachedNetworkImage(
-                          width: 250,
-                          height: 250,
-                          fit: BoxFit.cover,
-                          imageUrl: imageUrl!,
-                          httpHeaders: {
-                            "Authorization":
-                                "Bearer ${Store.get(StoreKey.accessToken)}"
-                          },
-                          errorWidget: (context, url, error) =>
-                              const Icon(Icons.image_not_supported_outlined),
-                        ),
-                      )
-                    : Center(
-                        child: Icon(
-                          noImageIcon ?? Icons.not_listed_location,
-                          color: textAndIconColor,
-                        ),
-                      ),
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(25),
+              color: isDarkMode ? Colors.grey[900] : Colors.grey[100],
+              border: Border.all(
+                color: isDarkMode ? Colors.grey[800]! : Colors.grey[400]!,
+                width: 1,
               ),
-              Positioned(
-                bottom: 12,
-                left: 14,
-                child: SizedBox(
-                  width: MediaQuery.of(context).size.width / 3,
-                  child: Text(
-                    textInfo,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 12,
+            ),
+            child: imageUrl != null
+                ? ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    child: CachedNetworkImage(
+                      width: double.infinity,
+                      height: double.infinity,
+                      fit: BoxFit.cover,
+                      imageUrl: imageUrl!,
+                      httpHeaders: {
+                        "Authorization": "Bearer ${box.get(accessTokenKey)}"
+                      },
+                      errorWidget: (context, url, error) =>
+                          const Icon(Icons.image_not_supported_outlined),
+                    ),
+                  )
+                : Center(
+                    child: Icon(
+                      noImageIcon ?? Icons.not_listed_location,
+                      color: textAndIconColor,
                     ),
                   ),
-                ),
-              ),
-            ],
           ),
-        ),
+          Positioned(
+            bottom: 12,
+            left: 14,
+            child: Text(
+              textInfo,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/modules/search/ui/thumbnail_with_info.dart
+++ b/mobile/lib/modules/search/ui/thumbnail_with_info.dart
@@ -45,7 +45,7 @@ class ThumbnailWithInfo extends StatelessWidget {
                       fit: BoxFit.cover,
                       imageUrl: imageUrl!,
                       httpHeaders: {
-                        "Authorization": "Bearer ${box.get(accessTokenKey)}"
+                        "Authorization": "Bearer ${Store.get(StoreKey.accessToken)}"
                       },
                       errorWidget: (context, url, error) =>
                           const Icon(Icons.image_not_supported_outlined),

--- a/mobile/lib/modules/search/ui/thumbnail_with_info.dart
+++ b/mobile/lib/modules/search/ui/thumbnail_with_info.dart
@@ -31,10 +31,6 @@ class ThumbnailWithInfo extends StatelessWidget {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(25),
               color: isDarkMode ? Colors.grey[900] : Colors.grey[100],
-              border: Border.all(
-                color: isDarkMode ? Colors.grey[800]! : Colors.grey[400]!,
-                width: 1,
-              ),
             ),
             child: imageUrl != null
                 ? ClipRRect(
@@ -45,7 +41,8 @@ class ThumbnailWithInfo extends StatelessWidget {
                       fit: BoxFit.cover,
                       imageUrl: imageUrl!,
                       httpHeaders: {
-                        "Authorization": "Bearer ${Store.get(StoreKey.accessToken)}"
+                        "Authorization":
+                            "Bearer ${Store.get(StoreKey.accessToken)}"
                       },
                       errorWidget: (context, url, error) =>
                           const Icon(Icons.image_not_supported_outlined),

--- a/mobile/lib/modules/search/views/curated_location_page.dart
+++ b/mobile/lib/modules/search/views/curated_location_page.dart
@@ -1,0 +1,41 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/modules/search/models/curated_content.dart';
+import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
+import 'package:immich_mobile/modules/search/ui/explore_grid.dart';
+import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
+import 'package:openapi/api.dart';
+
+class CuratedLocationPage extends HookConsumerWidget {
+
+  const CuratedLocationPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AsyncValue<List<CuratedLocationsResponseDto>> curatedLocation =
+        ref.watch(getCuratedLocationProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('curated_location_page_title').tr(),
+      ),
+      body: curatedLocation.when(
+        loading: () => const Center(child: ImmichLoadingIndicator()),
+        error: (err, stack) => Center(
+          child: Text('Error: $err'),
+        ),
+        data: (curatedLocations) =>
+          ExploreGrid(
+            curatedContent: curatedLocations.map(
+              (l) => CuratedContent(
+                label: l.city,
+                id: l.id,
+              ),
+            ).toList(),
+          ),
+      ),
+    );
+  }
+
+}

--- a/mobile/lib/modules/search/views/curated_location_page.dart
+++ b/mobile/lib/modules/search/views/curated_location_page.dart
@@ -8,7 +8,6 @@ import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
 import 'package:openapi/api.dart';
 
 class CuratedLocationPage extends HookConsumerWidget {
-
   const CuratedLocationPage({super.key});
 
   @override
@@ -18,24 +17,31 @@ class CuratedLocationPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('curated_location_page_title').tr(),
+        title: Text(
+          'curated_location_page_title',
+          style: TextStyle(
+            color: Theme.of(context).primaryColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 16.0,
+          ),
+        ).tr(),
       ),
       body: curatedLocation.when(
         loading: () => const Center(child: ImmichLoadingIndicator()),
         error: (err, stack) => Center(
           child: Text('Error: $err'),
         ),
-        data: (curatedLocations) =>
-          ExploreGrid(
-            curatedContent: curatedLocations.map(
-              (l) => CuratedContent(
-                label: l.city,
-                id: l.id,
-              ),
-            ).toList(),
-          ),
+        data: (curatedLocations) => ExploreGrid(
+          curatedContent: curatedLocations
+              .map(
+                (l) => CuratedContent(
+                  label: l.city,
+                  id: l.id,
+                ),
+              )
+              .toList(),
+        ),
       ),
     );
   }
-
 }

--- a/mobile/lib/modules/search/views/curated_object_page.dart
+++ b/mobile/lib/modules/search/views/curated_object_page.dart
@@ -9,7 +9,6 @@ import 'package:immich_mobile/utils/capitalize_first_letter.dart';
 import 'package:openapi/api.dart';
 
 class CuratedObjectPage extends HookConsumerWidget {
-
   const CuratedObjectPage({
     super.key,
   });
@@ -21,24 +20,31 @@ class CuratedObjectPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('curated_object_page_title').tr(),
+        title: Text(
+          'curated_object_page_title',
+          style: TextStyle(
+            color: Theme.of(context).primaryColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 16.0,
+          ),
+        ).tr(),
       ),
       body: curatedObjects.when(
         loading: () => const Center(child: ImmichLoadingIndicator()),
         error: (err, stack) => Center(
           child: Text('Error: $err'),
         ),
-        data: (curatedLocations) =>
-          ExploreGrid(
-            curatedContent: curatedLocations.map(
-              (l) => CuratedContent(
-                label: l.object.capitalizeFirstLetter(),
-                id: l.id,
-              ),
-            ).toList(),
-          ),
+        data: (curatedLocations) => ExploreGrid(
+          curatedContent: curatedLocations
+              .map(
+                (l) => CuratedContent(
+                  label: l.object.capitalizeFirstLetter(),
+                  id: l.id,
+                ),
+              )
+              .toList(),
+        ),
       ),
     );
   }
-
 }

--- a/mobile/lib/modules/search/views/curated_object_page.dart
+++ b/mobile/lib/modules/search/views/curated_object_page.dart
@@ -1,0 +1,44 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/modules/search/models/curated_content.dart';
+import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
+import 'package:immich_mobile/modules/search/ui/explore_grid.dart';
+import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
+import 'package:immich_mobile/utils/capitalize_first_letter.dart';
+import 'package:openapi/api.dart';
+
+class CuratedObjectPage extends HookConsumerWidget {
+
+  const CuratedObjectPage({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    AsyncValue<List<CuratedObjectsResponseDto>> curatedObjects =
+        ref.watch(getCuratedObjectProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('curated_object_page_title').tr(),
+      ),
+      body: curatedObjects.when(
+        loading: () => const Center(child: ImmichLoadingIndicator()),
+        error: (err, stack) => Center(
+          child: Text('Error: $err'),
+        ),
+        data: (curatedLocations) =>
+          ExploreGrid(
+            curatedContent: curatedLocations.map(
+              (l) => CuratedContent(
+                label: l.object.capitalizeFirstLetter(),
+                id: l.id,
+              ),
+            ).toList(),
+          ),
+      ),
+    );
+  }
+
+}

--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -110,35 +110,39 @@ class SearchPage extends HookConsumerWidget {
         ),
         data: (objects) => objects.isEmpty
             ? buildEmptyThumbnail()
-            : ListView.builder(
-                scrollDirection: Axis.horizontal,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                ),
-                itemBuilder: (context, index) {
-                  final curatedObjectInfo = objects[index];
-                  final thumbnailRequestUrl =
-                      '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
-                  return SizedBox(
-                    width: imageSize,
-                    child: Padding(
-                      padding: const EdgeInsets.only(right: 4.0),
-                      child: ThumbnailWithInfo(
-                        imageUrl: thumbnailRequestUrl,
-                        textInfo: curatedObjectInfo.object,
-                        onTap: () {
-                          AutoRouter.of(context).push(
-                            SearchResultRoute(
-                              searchTerm: curatedObjectInfo.object
-                                  .capitalizeFirstLetter(),
-                            ),
-                          );
-                        },
+            : SizedBox(
+                height: imageSize,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                  ),
+                  itemBuilder: (context, index) {
+                    final curatedObjectInfo = objects[index];
+                    final thumbnailRequestUrl =
+                        '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
+                    return SizedBox(
+                      width: imageSize,
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 4.0),
+                        child: ThumbnailWithInfo(
+                          imageUrl: thumbnailRequestUrl,
+                          textInfo: curatedObjectInfo.object,
+                          onTap: () {
+                            AutoRouter.of(context).push(
+                              SearchResultRoute(
+                                searchTerm: curatedObjectInfo.object
+                                    .capitalizeFirstLetter(),
+                              ),
+                            );
+                          },
+                        ),
                       ),
-                    ),
-                  );
-                },
-                itemCount: objects.length.clamp(0, 4),
+                    );
+                  },
+                  itemCount: objects.length.clamp(0, 10),
+                ),
               ),
       );
     }

--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -169,7 +169,7 @@ class SearchPage extends HookConsumerWidget {
                         style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
                       ).tr(),
                       TextButton(
-                        child: const Text('View all'),
+                        child: const Text('search_page_view_all_button').tr(),
                         onPressed: () => AutoRouter.of(context).push(
                           const CuratedLocationRoute(),
                         ),
@@ -191,7 +191,7 @@ class SearchPage extends HookConsumerWidget {
                         style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
                       ).tr(),
                       TextButton(
-                        child: const Text('View all'),
+                        child: const Text('search_page_view_all_button').tr(),
                         onPressed: () => AutoRouter.of(context).push(
                           const CuratedObjectRoute(),
                         ),

--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -48,11 +48,12 @@ class SearchPage extends HookConsumerWidget {
       return SizedBox(
         height: imageSize,
         child: curatedLocation.when(
-        loading: () => const Center(child: ImmichLoadingIndicator()),
-        error: (err, stack) => Center(child: Text('Error: $err')),
-        data: (curatedLocations) =>
-          ListView.builder(
-            padding: const EdgeInsets.symmetric(horizontal: 16,),
+          loading: () => const Center(child: ImmichLoadingIndicator()),
+          error: (err, stack) => Center(child: Text('Error: $err')),
+          data: (curatedLocations) => ListView.builder(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16,
+            ),
             scrollDirection: Axis.horizontal,
             itemBuilder: (context, index) {
               final locationInfo = curatedLocations[index];
@@ -90,13 +91,11 @@ class SearchPage extends HookConsumerWidget {
             height: imageSize,
             child: ThumbnailWithInfo(
               textInfo: '',
-              onTap: () {
-              },
+              onTap: () {},
             ),
           ),
         ),
       );
-
     }
 
     buildThings() {
@@ -110,36 +109,38 @@ class SearchPage extends HookConsumerWidget {
           child: Center(child: Text('Error: $err')),
         ),
         data: (objects) => objects.isEmpty
-          ? buildEmptyThumbnail()
-          : ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 16,),
-            itemBuilder: (context, index) {
-              final curatedObjectInfo = objects[index];
-              final thumbnailRequestUrl =
-                  '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
-              return SizedBox(
-                width: imageSize,
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 4.0),
-                  child: ThumbnailWithInfo(
-                    imageUrl: thumbnailRequestUrl,
-                    textInfo: curatedObjectInfo.object,
-                    onTap: () {
-                      AutoRouter.of(context).push(
-                        SearchResultRoute(
-                          searchTerm: curatedObjectInfo.object
-                              .capitalizeFirstLetter(),
-                        ),
-                      );
-                    },
-                  ),
+            ? buildEmptyThumbnail()
+            : ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
                 ),
-              );
-            },
-            itemCount: objects.length.clamp(0, 4),
-          ),
-        );
+                itemBuilder: (context, index) {
+                  final curatedObjectInfo = objects[index];
+                  final thumbnailRequestUrl =
+                      '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
+                  return SizedBox(
+                    width: imageSize,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 4.0),
+                      child: ThumbnailWithInfo(
+                        imageUrl: thumbnailRequestUrl,
+                        textInfo: curatedObjectInfo.object,
+                        onTap: () {
+                          AutoRouter.of(context).push(
+                            SearchResultRoute(
+                              searchTerm: curatedObjectInfo.object
+                                  .capitalizeFirstLetter(),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  );
+                },
+                itemCount: objects.length.clamp(0, 4),
+              ),
+      );
     }
 
     return Scaffold(
@@ -166,10 +167,20 @@ class SearchPage extends HookConsumerWidget {
                     children: [
                       const Text(
                         "search_page_places",
-                        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
                       ).tr(),
                       TextButton(
-                        child: const Text('search_page_view_all_button').tr(),
+                        child: Text(
+                          'search_page_view_all_button',
+                          style: TextStyle(
+                            color: Theme.of(context).primaryColor,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14.0,
+                          ),
+                        ).tr(),
                         onPressed: () => AutoRouter.of(context).push(
                           const CuratedLocationRoute(),
                         ),
@@ -188,10 +199,20 @@ class SearchPage extends HookConsumerWidget {
                     children: [
                       const Text(
                         "search_page_things",
-                        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
                       ).tr(),
                       TextButton(
-                        child: const Text('search_page_view_all_button').tr(),
+                        child: Text(
+                          'search_page_view_all_button',
+                          style: TextStyle(
+                            color: Theme.of(context).primaryColor,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14.0,
+                          ),
+                        ).tr(),
                         onPressed: () => AutoRouter.of(context).push(
                           const CuratedObjectRoute(),
                         ),

--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -46,103 +46,84 @@ class SearchPage extends HookConsumerWidget {
 
     buildPlaces() {
       return curatedLocation.when(
-        loading: () => SizedBox(
-          height: imageSize,
-          child: const Center(child: ImmichLoadingIndicator()),
+        loading: () => SliverToBoxAdapter(
+          child: SizedBox(
+            height: imageSize,
+            child: const Center(child: ImmichLoadingIndicator()),
+          ),
         ),
-        error: (err, stack) => Text('Error: $err'),
+        error: (err, stack) => SliverToBoxAdapter(
+          child: Text('Error: $err'),
+        ),
         data: (curatedLocations) {
-          return curatedLocations.isNotEmpty
-              ? SizedBox(
-                  height: imageSize,
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(left: 16),
-                    scrollDirection: Axis.horizontal,
-                    itemCount: curatedLocation.value?.length,
-                    itemBuilder: ((context, index) {
-                      var locationInfo = curatedLocations[index];
-                      var thumbnailRequestUrl =
-                          '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${locationInfo.id}';
-                      return ThumbnailWithInfo(
-                        imageUrl: thumbnailRequestUrl,
-                        textInfo: locationInfo.city,
-                        onTap: () {
-                          AutoRouter.of(context).push(
-                            SearchResultRoute(searchTerm: locationInfo.city),
-                          );
-                        },
-                      );
-                    }),
-                  ),
-                )
-              : SizedBox(
-                  height: imageSize,
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(left: 16),
-                    scrollDirection: Axis.horizontal,
-                    itemCount: 1,
-                    itemBuilder: ((context, index) {
-                      return ThumbnailWithInfo(
-                        textInfo: '',
-                        onTap: () {},
-                      );
-                    }),
-                  ),
+          return SliverGrid(
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 140,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final locationInfo = curatedLocations[index];
+                final thumbnailRequestUrl =
+                    '${box.get(serverEndpointKey)}/asset/thumbnail/${locationInfo.id}';
+                return ThumbnailWithInfo(
+                  imageUrl: thumbnailRequestUrl,
+                  textInfo: locationInfo.city,
+                  onTap: () {
+                    AutoRouter.of(context).push(
+                      SearchResultRoute(searchTerm: locationInfo.city),
+                    );
+                  },
                 );
+              },
+              childCount: curatedLocations.length,
+            ),
+          );
         },
       );
     }
 
     buildThings() {
       return curatedObjects.when(
-        loading: () => SizedBox(
-          height: imageSize,
-          child: const Center(child: ImmichLoadingIndicator()),
+        loading: () => SliverToBoxAdapter(
+          child: SizedBox(
+            height: imageSize,
+            child: const Center(child: ImmichLoadingIndicator()),
+          ),
         ),
-        error: (err, stack) => Text('Error: $err'),
+        error: (err, stack) => SliverToBoxAdapter(
+          child: Text('Error: $err'),
+        ),
         data: (objects) {
-          return objects.isNotEmpty
-              ? SizedBox(
-                  height: imageSize,
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(left: 16),
-                    scrollDirection: Axis.horizontal,
-                    itemCount: curatedObjects.value?.length,
-                    itemBuilder: ((context, index) {
-                      var curatedObjectInfo = objects[index];
-                      var thumbnailRequestUrl =
-                          '${Store.get(StoreKey.serverEndpoint)}/asset/thumbnail/${curatedObjectInfo.id}';
+          return SliverGrid(
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 140,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final curatedObjectInfo = objects[index];
+                final thumbnailRequestUrl =
+                    '${box.get(serverEndpointKey)}/asset/thumbnail/${curatedObjectInfo.id}';
 
-                      return ThumbnailWithInfo(
-                        imageUrl: thumbnailRequestUrl,
-                        textInfo: curatedObjectInfo.object,
-                        onTap: () {
-                          AutoRouter.of(context).push(
-                            SearchResultRoute(
-                              searchTerm: curatedObjectInfo.object
-                                  .capitalizeFirstLetter(),
-                            ),
-                          );
-                        },
-                      );
-                    }),
-                  ),
-                )
-              : SizedBox(
-                  height: imageSize,
-                  child: ListView.builder(
-                    padding: const EdgeInsets.only(left: 16),
-                    scrollDirection: Axis.horizontal,
-                    itemCount: 1,
-                    itemBuilder: ((context, index) {
-                      return ThumbnailWithInfo(
-                        textInfo: '',
-                        noImageIcon: Icons.signal_cellular_no_sim_sharp,
-                        onTap: () {},
-                      );
-                    }),
-                  ),
+                return ThumbnailWithInfo(
+                  imageUrl: thumbnailRequestUrl,
+                  textInfo: curatedObjectInfo.object,
+                  onTap: () {
+                    AutoRouter.of(context).push(
+                      SearchResultRoute(
+                        searchTerm: curatedObjectInfo.object
+                            .capitalizeFirstLetter(),
+                      ),
+                    );
+                  },
                 );
+              },
+              childCount: objects.length,
+            ),
+          );
         },
       );
     }
@@ -159,25 +140,34 @@ class SearchPage extends HookConsumerWidget {
         },
         child: Stack(
           children: [
-            ListView(
-              shrinkWrap: true,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: const Text(
-                    "search_page_places",
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
-                  ).tr(),
+            CustomScrollView(
+              slivers: [
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: const Text(
+                      "search_page_places",
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                    ).tr(),
+                  ),
                 ),
-                buildPlaces(),
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: const Text(
-                    "search_page_things",
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
-                  ).tr(),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  sliver: buildPlaces(),
                 ),
-                buildThings()
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: const Text(
+                      "search_page_things",
+                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+                    ).tr(),
+                  ),
+                ),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  sliver: buildThings(),
+                ),
               ],
             ),
             if (isSearchEnabled)

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -21,6 +21,8 @@ import 'package:immich_mobile/modules/login/views/change_password_page.dart';
 import 'package:immich_mobile/modules/login/views/login_page.dart';
 import 'package:immich_mobile/modules/onboarding/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/modules/onboarding/views/permission_onboarding_page.dart';
+import 'package:immich_mobile/modules/search/views/curated_location_page.dart';
+import 'package:immich_mobile/modules/search/views/curated_object_page.dart';
 import 'package:immich_mobile/modules/search/views/search_page.dart';
 import 'package:immich_mobile/modules/search/views/search_result_page.dart';
 import 'package:immich_mobile/modules/settings/views/settings_page.dart';
@@ -64,6 +66,8 @@ part 'router.gr.dart';
     AutoRoute(page: VideoViewerPage, guards: [AuthGuard, DuplicateGuard]),
     AutoRoute(page: BackupControllerPage, guards: [AuthGuard, DuplicateGuard]),
     AutoRoute(page: SearchResultPage, guards: [AuthGuard, DuplicateGuard]),
+    AutoRoute(page: CuratedLocationPage, guards: [AuthGuard, DuplicateGuard]),
+    AutoRoute(page: CuratedObjectPage, guards: [AuthGuard, DuplicateGuard]),
     AutoRoute(page: CreateAlbumPage, guards: [AuthGuard, DuplicateGuard]),
     AutoRoute(page: FavoritesPage, guards: [AuthGuard, DuplicateGuard]),
     CustomRoute<AssetSelectionPageResult?>(

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -102,6 +102,18 @@ class _$AppRouter extends RootStackRouter {
         ),
       );
     },
+    CuratedLocationRoute.name: (routeData) {
+      return MaterialPageX<dynamic>(
+        routeData: routeData,
+        child: const CuratedLocationPage(),
+      );
+    },
+    CuratedObjectRoute.name: (routeData) {
+      return MaterialPageX<dynamic>(
+        routeData: routeData,
+        child: const CuratedObjectPage(),
+      );
+    },
     CreateAlbumRoute.name: (routeData) {
       final args = routeData.argsAs<CreateAlbumRouteArgs>();
       return MaterialPageX<dynamic>(
@@ -326,6 +338,22 @@ class _$AppRouter extends RootStackRouter {
         RouteConfig(
           SearchResultRoute.name,
           path: '/search-result-page',
+          guards: [
+            authGuard,
+            duplicateGuard,
+          ],
+        ),
+        RouteConfig(
+          CuratedLocationRoute.name,
+          path: '/curated-location-page',
+          guards: [
+            authGuard,
+            duplicateGuard,
+          ],
+        ),
+        RouteConfig(
+          CuratedObjectRoute.name,
+          path: '/curated-object-page',
           guards: [
             authGuard,
             duplicateGuard,
@@ -616,6 +644,30 @@ class SearchResultRouteArgs {
   String toString() {
     return 'SearchResultRouteArgs{key: $key, searchTerm: $searchTerm}';
   }
+}
+
+/// generated route for
+/// [CuratedLocationPage]
+class CuratedLocationRoute extends PageRouteInfo<void> {
+  const CuratedLocationRoute()
+      : super(
+          CuratedLocationRoute.name,
+          path: '/curated-location-page',
+        );
+
+  static const String name = 'CuratedLocationRoute';
+}
+
+/// generated route for
+/// [CuratedObjectPage]
+class CuratedObjectRoute extends PageRouteInfo<void> {
+  const CuratedObjectRoute()
+      : super(
+          CuratedObjectRoute.name,
+          path: '/curated-object-page',
+        );
+
+  static const String name = 'CuratedObjectRoute';
 }
 
 /// generated route for

--- a/mobile/lib/shared/services/api.service.dart
+++ b/mobile/lib/shared/services/api.service.dart
@@ -14,6 +14,7 @@ class ApiService {
   late OAuthApi oAuthApi;
   late AlbumApi albumApi;
   late AssetApi assetApi;
+  late SearchApi searchApi;
   late ServerInfoApi serverInfoApi;
   late DeviceInfoApi deviceInfoApi;
 
@@ -36,6 +37,7 @@ class ApiService {
     albumApi = AlbumApi(_apiClient);
     assetApi = AssetApi(_apiClient);
     serverInfoApi = ServerInfoApi(_apiClient);
+    searchApi = SearchApi(_apiClient);
     deviceInfoApi = DeviceInfoApi(_apiClient);
   }
 


### PR DESCRIPTION
## Places and Things
- Uses a `GridView` with 140 max extent, so wider displays will show more elements per row at a max size of 140 device pixels.
- Same layout for Things, but I don't have any Things to show... I'm not sure if "Things" are relevant for the new search, so maybe they should be suppressed?
- I didn't include the "broken image" looking element for when there are no places or things. I don't have any UI element to show that there are no places or things currently; it's just empty with the headers visible. I'd be happy to put something in for the empty element case!
- Still shows the loading throbbers while waiting to load these in.

![image](https://user-images.githubusercontent.com/100457/226922273-2e941cf5-3ede-42ec-af46-88d31ecb690f.png)


## Search Results
- Uses CLIP with the new `SearchApi`.
- Didn't change anything else; they seem to show up in a "timeline" like view.

![image](https://user-images.githubusercontent.com/100457/226921673-cbd3d869-1fa9-4d35-9edf-bd19ee40ce61.png)
