### PR TITLE
fix(server): update asset alias on new install

### DIFF
--- a/server/libs/domain/src/search/search.service.spec.ts
+++ b/server/libs/domain/src/search/search.service.spec.ts
@@ -173,12 +173,23 @@ describe(SearchService.name, () => {
   });
 
   describe('handleIndexAssets', () => {
+    it('should call done, even when there are no assets', async () => {
+      assetMock.getAll.mockResolvedValue([]);
+
+      await sut.handleIndexAssets();
+
+      expect(searchMock.importAssets).toHaveBeenCalledWith([], true);
+    });
+
     it('should index all the assets', async () => {
       assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
 
       await sut.handleIndexAssets();
 
-      expect(searchMock.importAssets).toHaveBeenCalledWith([assetEntityStub.image], true);
+      expect(searchMock.importAssets.mock.calls).toEqual([
+        [[assetEntityStub.image], false],
+        [[], true],
+      ]);
     });
 
     it('should log an error', async () => {

--- a/server/libs/domain/src/search/search.service.ts
+++ b/server/libs/domain/src/search/search.service.ts
@@ -148,11 +148,10 @@ export class SearchService {
 
       const chunkSize = 1000;
       for (let i = 0; i < assets.length; i += chunkSize) {
-        const end = i + chunkSize;
-        const chunk = assets.slice(i, end);
-        const done = end >= assets.length - 1;
-        await this.searchRepository.importAssets(chunk, done);
+        await this.searchRepository.importAssets(assets.slice(i, i + chunkSize), false);
       }
+
+      await this.searchRepository.importAssets([], true);
 
       this.logger.debug('Finished re-indexing all assets');
     } catch (error: any) {


### PR DESCRIPTION
The alias for assets stopped being set on a new install, due to the new chunking code. This changes that to always call `done`, regardless of the number of assets.