### PR TITLE
fix(web): remove protocol header

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -4,8 +4,6 @@
 export PUBLIC_IMMICH_SERVER_URL=$IMMICH_SERVER_URL
 export PUBLIC_IMMICH_API_URL_EXTERNAL=$IMMICH_API_URL_EXTERNAL
 
-export PROTOCOL_HEADER=X-Forwarded-Proto
-
 if [ "$(id -u)" -eq 0 ] && [ -n "$PUID" ] && [ -n "$PGID" ]; then
     exec setpriv --reuid "$PUID" --regid "$PGID" --clear-groups node /usr/src/app/build/index.js
 else


### PR DESCRIPTION
Remove protocol header from web container, because it was causing issues for some deployments as reported on [Discord](https://discord.com/channels/979116623879368755/1088441306130432080). Unable to reproduce the issue myself, but I suspect [this error](https://github.com/sveltejs/kit/blob/becf2b0e630ea5d23070873dfd30cecc07d5e498/packages/adapter-node/src/handler.js#L88-L92) is being returned. The value is not yet used in SvelteKit and can be safely removed.