### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - .env
     environment:
       - NODE_ENV=production
+      - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
     depends_on:
       - redis
       - database


### PR DESCRIPTION
add TYPESENSE_API_KEY to immich-server / environment to be able to boot up the service or else users get an error  Error: Config validation error: "TYPESENSE_API_KEY" is required
https://github.com/immich-app/immich/issues/2034