### PR TITLE
feature(mobile): Hardening synchronization mechanism + Pull to refresh

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -50,6 +50,7 @@ void main() async {
   await initApp();
   await migrateHiveToStoreIfNecessary();
   await migrateJsonCacheIfNecessary();
+  await migrateDatabaseIfNeeded(db);
   runApp(getMainWidget(db));
 }
 

--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -53,7 +53,7 @@ class AlbumThumbnailCard extends StatelessWidget {
           // Add the owner name to the subtitle
           String? owner;
           if (showOwner) {
-            if (album.ownerId == Store.get(StoreKey.userRemoteId)) {
+            if (album.ownerId == Store.get(StoreKey.currentUser).id) {
               owner = 'album_thumbnail_owned'.tr();
             } else if (album.ownerName != null) {
               owner = 'album_thumbnail_shared_by'.tr(args: [album.ownerName!]);

--- a/mobile/lib/modules/album/views/sharing_page.dart
+++ b/mobile/lib/modules/album/views/sharing_page.dart
@@ -17,7 +17,7 @@ class SharingPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<Album> sharedAlbums = ref.watch(sharedAlbumProvider);
-    final userId = store.Store.get(store.StoreKey.userRemoteId);
+    final userId = store.Store.get(store.StoreKey.currentUser).id;
     var isDarkMode = Theme.of(context).brightness == Brightness.dark;
 
     useEffect(

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -17,10 +17,12 @@ class ImmichAssetGrid extends HookConsumerWidget {
   final bool selectionActive;
   final List<Asset> assets;
   final RenderList? renderList;
+  final Future<void> Function()? onRefresh;
 
   const ImmichAssetGrid({
     super.key,
     required this.assets,
+    this.onRefresh,
     this.renderList,
     this.assetsPerRow,
     this.showStorageIndicator,
@@ -62,11 +64,12 @@ class ImmichAssetGrid extends HookConsumerWidget {
           enabled: enableHeroAnimations.value,
           child: ImmichAssetGridView(
             allAssets: assets,
-            assetsPerRow: assetsPerRow 
-              ?? settings.getSetting(AppSettingsEnum.tilesPerRow),
+            onRefresh: onRefresh,
+            assetsPerRow: assetsPerRow ??
+                settings.getSetting(AppSettingsEnum.tilesPerRow),
             listener: listener,
-            showStorageIndicator: showStorageIndicator 
-              ?? settings.getSetting(AppSettingsEnum.storageIndicator),
+            showStorageIndicator: showStorageIndicator ??
+                settings.getSetting(AppSettingsEnum.storageIndicator),
             renderList: renderList!,
             margin: margin,
             selectionActive: selectionActive,
@@ -76,26 +79,25 @@ class ImmichAssetGrid extends HookConsumerWidget {
     }
 
     return renderListFuture.when(
-      data: (renderList) =>
-        WillPopScope(
-          onWillPop: onWillPop,
-          child: HeroMode(
-            enabled: enableHeroAnimations.value,
-            child: ImmichAssetGridView(
-              allAssets: assets,
-              assetsPerRow: assetsPerRow 
-                ?? settings.getSetting(AppSettingsEnum.tilesPerRow),
-              listener: listener,
-              showStorageIndicator: showStorageIndicator 
-                ?? settings.getSetting(AppSettingsEnum.storageIndicator),
-              renderList: renderList,
-              margin: margin,
-              selectionActive: selectionActive,
-            ),
+      data: (renderList) => WillPopScope(
+        onWillPop: onWillPop,
+        child: HeroMode(
+          enabled: enableHeroAnimations.value,
+          child: ImmichAssetGridView(
+            allAssets: assets,
+            onRefresh: onRefresh,
+            assetsPerRow: assetsPerRow ??
+                settings.getSetting(AppSettingsEnum.tilesPerRow),
+            listener: listener,
+            showStorageIndicator: showStorageIndicator ??
+                settings.getSetting(AppSettingsEnum.storageIndicator),
+            renderList: renderList,
+            margin: margin,
+            selectionActive: selectionActive,
           ),
         ),
-      error: (err, stack) =>
-        Center(child: Text("$err")),
+      ),
+      error: (err, stack) => Center(child: Text("$err")),
       loading: () => const Center(
         child: ImmichLoadingIndicator(),
       ),

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -199,21 +199,23 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
       addRepaintBoundaries: true,
     );
 
-    if (!useDragScrolling) {
-      return listWidget;
-    }
+    final child = useDragScrolling
+        ? DraggableScrollbar.semicircle(
+            scrollStateListener: dragScrolling,
+            itemPositionsListener: _itemPositionsListener,
+            controller: _itemScrollController,
+            backgroundColor: Theme.of(context).hintColor,
+            labelTextBuilder: _labelBuilder,
+            labelConstraints: const BoxConstraints(maxHeight: 28),
+            scrollbarAnimationDuration: const Duration(seconds: 1),
+            scrollbarTimeToFade: const Duration(seconds: 4),
+            child: listWidget,
+          )
+        : listWidget;
 
-    return DraggableScrollbar.semicircle(
-      scrollStateListener: dragScrolling,
-      itemPositionsListener: _itemPositionsListener,
-      controller: _itemScrollController,
-      backgroundColor: Theme.of(context).hintColor,
-      labelTextBuilder: _labelBuilder,
-      labelConstraints: const BoxConstraints(maxHeight: 28),
-      scrollbarAnimationDuration: const Duration(seconds: 1),
-      scrollbarTimeToFade: const Duration(seconds: 4),
-      child: listWidget,
-    );
+    return widget.onRefresh == null
+        ? child
+        : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
   }
 
   @override
@@ -248,7 +250,7 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
   }
 
   void _scrollToTop() {
-    // for some reason, this is necessary as well in order 
+    // for some reason, this is necessary as well in order
     // to correctly reposition the drag thumb scroll bar
     _itemScrollController.jumpTo(
       index: 0,
@@ -281,6 +283,7 @@ class ImmichAssetGridView extends StatefulWidget {
   final ImmichAssetGridSelectionListener? listener;
   final bool selectionActive;
   final List<Asset> allAssets;
+  final Future<void> Function()? onRefresh;
 
   const ImmichAssetGridView({
     super.key,
@@ -291,6 +294,7 @@ class ImmichAssetGridView extends StatefulWidget {
     this.listener,
     this.margin = 5.0,
     this.selectionActive = false,
+    this.onRefresh,
   });
 
   @override

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -78,7 +78,6 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       await Future.wait([
         _apiService.authenticationApi.logout(),
         Store.delete(StoreKey.assetETag),
-        Store.delete(StoreKey.userRemoteId),
         Store.delete(StoreKey.currentUser),
         Store.delete(StoreKey.accessToken),
       ]);
@@ -133,7 +132,6 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       var deviceInfo = await _deviceInfoService.getDeviceInfo();
       Store.put(StoreKey.deviceId, deviceInfo["deviceId"]);
       Store.put(StoreKey.deviceIdHash, fastHash(deviceInfo["deviceId"]));
-      Store.put(StoreKey.userRemoteId, userResponseDto.id);
       Store.put(StoreKey.currentUser, User.fromDto(userResponseDto));
       Store.put(StoreKey.serverUrl, serverUrl);
       Store.put(StoreKey.accessToken, accessToken);

--- a/mobile/lib/shared/models/asset.g.dart
+++ b/mobile/lib/shared/models/asset.g.dart
@@ -77,13 +77,19 @@ const AssetSchema = CollectionSchema(
       name: r'remoteId',
       type: IsarType.string,
     ),
-    r'updatedAt': PropertySchema(
+    r'type': PropertySchema(
       id: 12,
+      name: r'type',
+      type: IsarType.byte,
+      enumMap: _AssettypeEnumValueMap,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 13,
       name: r'updatedAt',
       type: IsarType.dateTime,
     ),
     r'width': PropertySchema(
-      id: 13,
+      id: 14,
       name: r'width',
       type: IsarType.int,
     )
@@ -110,7 +116,7 @@ const AssetSchema = CollectionSchema(
     r'localId_deviceId': IndexSchema(
       id: 7649417350086526165,
       name: r'localId_deviceId',
-      unique: true,
+      unique: false,
       replace: false,
       properties: [
         IndexPropertySchema(
@@ -175,8 +181,9 @@ void _assetSerialize(
   writer.writeString(offsets[9], object.localId);
   writer.writeLong(offsets[10], object.ownerId);
   writer.writeString(offsets[11], object.remoteId);
-  writer.writeDateTime(offsets[12], object.updatedAt);
-  writer.writeInt(offsets[13], object.width);
+  writer.writeByte(offsets[12], object.type.index);
+  writer.writeDateTime(offsets[13], object.updatedAt);
+  writer.writeInt(offsets[14], object.width);
 }
 
 Asset _assetDeserialize(
@@ -198,8 +205,10 @@ Asset _assetDeserialize(
     localId: reader.readString(offsets[9]),
     ownerId: reader.readLong(offsets[10]),
     remoteId: reader.readStringOrNull(offsets[11]),
-    updatedAt: reader.readDateTime(offsets[12]),
-    width: reader.readIntOrNull(offsets[13]),
+    type: _AssettypeValueEnumMap[reader.readByteOrNull(offsets[12])] ??
+        AssetType.other,
+    updatedAt: reader.readDateTime(offsets[13]),
+    width: reader.readIntOrNull(offsets[14]),
   );
   object.id = id;
   return object;
@@ -237,13 +246,29 @@ P _assetDeserializeProp<P>(
     case 11:
       return (reader.readStringOrNull(offset)) as P;
     case 12:
-      return (reader.readDateTime(offset)) as P;
+      return (_AssettypeValueEnumMap[reader.readByteOrNull(offset)] ??
+          AssetType.other) as P;
     case 13:
+      return (reader.readDateTime(offset)) as P;
+    case 14:
       return (reader.readIntOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
   }
 }
+
+const _AssettypeEnumValueMap = {
+  'other': 0,
+  'image': 1,
+  'video': 2,
+  'audio': 3,
+};
+const _AssettypeValueEnumMap = {
+  0: AssetType.other,
+  1: AssetType.image,
+  2: AssetType.video,
+  3: AssetType.audio,
+};
 
 Id _assetGetId(Asset object) {
   return object.id;
@@ -255,94 +280,6 @@ List<IsarLinkBase<dynamic>> _assetGetLinks(Asset object) {
 
 void _assetAttach(IsarCollection<dynamic> col, Id id, Asset object) {
   object.id = id;
-}
-
-extension AssetByIndex on IsarCollection<Asset> {
-  Future<Asset?> getByLocalIdDeviceId(String localId, int deviceId) {
-    return getByIndex(r'localId_deviceId', [localId, deviceId]);
-  }
-
-  Asset? getByLocalIdDeviceIdSync(String localId, int deviceId) {
-    return getByIndexSync(r'localId_deviceId', [localId, deviceId]);
-  }
-
-  Future<bool> deleteByLocalIdDeviceId(String localId, int deviceId) {
-    return deleteByIndex(r'localId_deviceId', [localId, deviceId]);
-  }
-
-  bool deleteByLocalIdDeviceIdSync(String localId, int deviceId) {
-    return deleteByIndexSync(r'localId_deviceId', [localId, deviceId]);
-  }
-
-  Future<List<Asset?>> getAllByLocalIdDeviceId(
-      List<String> localIdValues, List<int> deviceIdValues) {
-    final len = localIdValues.length;
-    assert(deviceIdValues.length == len,
-        'All index values must have the same length');
-    final values = <List<dynamic>>[];
-    for (var i = 0; i < len; i++) {
-      values.add([localIdValues[i], deviceIdValues[i]]);
-    }
-
-    return getAllByIndex(r'localId_deviceId', values);
-  }
-
-  List<Asset?> getAllByLocalIdDeviceIdSync(
-      List<String> localIdValues, List<int> deviceIdValues) {
-    final len = localIdValues.length;
-    assert(deviceIdValues.length == len,
-        'All index values must have the same length');
-    final values = <List<dynamic>>[];
-    for (var i = 0; i < len; i++) {
-      values.add([localIdValues[i], deviceIdValues[i]]);
-    }
-
-    return getAllByIndexSync(r'localId_deviceId', values);
-  }
-
-  Future<int> deleteAllByLocalIdDeviceId(
-      List<String> localIdValues, List<int> deviceIdValues) {
-    final len = localIdValues.length;
-    assert(deviceIdValues.length == len,
-        'All index values must have the same length');
-    final values = <List<dynamic>>[];
-    for (var i = 0; i < len; i++) {
-      values.add([localIdValues[i], deviceIdValues[i]]);
-    }
-
-    return deleteAllByIndex(r'localId_deviceId', values);
-  }
-
-  int deleteAllByLocalIdDeviceIdSync(
-      List<String> localIdValues, List<int> deviceIdValues) {
-    final len = localIdValues.length;
-    assert(deviceIdValues.length == len,
-        'All index values must have the same length');
-    final values = <List<dynamic>>[];
-    for (var i = 0; i < len; i++) {
-      values.add([localIdValues[i], deviceIdValues[i]]);
-    }
-
-    return deleteAllByIndexSync(r'localId_deviceId', values);
-  }
-
-  Future<Id> putByLocalIdDeviceId(Asset object) {
-    return putByIndex(r'localId_deviceId', object);
-  }
-
-  Id putByLocalIdDeviceIdSync(Asset object, {bool saveLinks = true}) {
-    return putByIndexSync(r'localId_deviceId', object, saveLinks: saveLinks);
-  }
-
-  Future<List<Id>> putAllByLocalIdDeviceId(List<Asset> objects) {
-    return putAllByIndex(r'localId_deviceId', objects);
-  }
-
-  List<Id> putAllByLocalIdDeviceIdSync(List<Asset> objects,
-      {bool saveLinks = true}) {
-    return putAllByIndexSync(r'localId_deviceId', objects,
-        saveLinks: saveLinks);
-  }
 }
 
 extension AssetQueryWhereSort on QueryBuilder<Asset, Asset, QWhere> {
@@ -1582,6 +1519,59 @@ extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> typeEqualTo(
+      AssetType value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'type',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> typeGreaterThan(
+    AssetType value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'type',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> typeLessThan(
+    AssetType value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'type',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> typeBetween(
+    AssetType lower,
+    AssetType upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'type',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Asset, Asset, QAfterFilterCondition> updatedAtEqualTo(
       DateTime value) {
     return QueryBuilder.apply(this, (query) {
@@ -1853,6 +1843,18 @@ extension AssetQuerySortBy on QueryBuilder<Asset, Asset, QSortBy> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> sortByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+
   QueryBuilder<Asset, Asset, QAfterSortBy> sortByUpdatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'updatedAt', Sort.asc);
@@ -2035,6 +2037,18 @@ extension AssetQuerySortThenBy on QueryBuilder<Asset, Asset, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterSortBy> thenByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+
   QueryBuilder<Asset, Asset, QAfterSortBy> thenByUpdatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'updatedAt', Sort.asc);
@@ -2138,6 +2152,12 @@ extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QDistinct> distinctByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'type');
+    });
+  }
+
   QueryBuilder<Asset, Asset, QDistinct> distinctByUpdatedAt() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'updatedAt');
@@ -2227,6 +2247,12 @@ extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
   QueryBuilder<Asset, String?, QQueryOperations> remoteIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'remoteId');
+    });
+  }
+
+  QueryBuilder<Asset, AssetType, QQueryOperations> typeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'type');
     });
   }
 

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -138,7 +138,7 @@ class StoreKeyNotFoundException implements Exception {
 /// Key for each possible value in the `Store`.
 /// Defines the data type for each value
 enum StoreKey<T> {
-  userRemoteId<String>(0, type: String),
+  version<int>(0, type: int),
   assetETag<String>(1, type: String),
   currentUser<User>(2, type: User, fromDb: _getUser, toDb: _toUser),
   deviceIdHash<int>(3, type: int),

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -1,6 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/album/services/album.service.dart';
-import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
@@ -11,6 +10,9 @@ import 'package:immich_mobile/modules/settings/providers/app_settings.provider.d
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:collection/collection.dart';
+import 'package:immich_mobile/shared/services/sync.service.dart';
+import 'package:immich_mobile/utils/async_mutex.dart';
+import 'package:immich_mobile/utils/db.dart';
 import 'package:intl/intl.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
@@ -52,15 +54,18 @@ class AssetNotifier extends StateNotifier<AssetsState> {
   final AssetService _assetService;
   final AppSettingsService _settingsService;
   final AlbumService _albumService;
+  final SyncService _syncService;
   final Isar _db;
   final log = Logger('AssetNotifier');
   bool _getAllAssetInProgress = false;
   bool _deleteInProgress = false;
+  final AsyncMutex _stateUpdateLock = AsyncMutex();
 
   AssetNotifier(
     this._assetService,
     this._settingsService,
     this._albumService,
+    this._syncService,
     this._db,
   ) : super(AssetsState.fromAssetList([]));
 
@@ -80,24 +85,30 @@ class AssetNotifier extends StateNotifier<AssetsState> {
     await _updateAssetsState(state.allAssets);
   }
 
-  getAllAsset() async {
+  Future<void> getAllAsset({bool clear = false}) async {
     if (_getAllAssetInProgress || _deleteInProgress) {
       // guard against multiple calls to this method while it's still working
       return;
     }
-    final stopwatch = Stopwatch();
+    final stopwatch = Stopwatch()..start();
     try {
       _getAllAssetInProgress = true;
       final User me = Store.get(StoreKey.currentUser);
-      final int cachedCount =
-          await _db.assets.filter().ownerIdEqualTo(me.isarId).count();
-      stopwatch.start();
-      if (cachedCount > 0 && cachedCount != state.allAssets.length) {
-        await _updateAssetsState(await _getUserAssets(me.isarId));
-        log.info(
-          "Reading assets ${state.allAssets.length} from DB: ${stopwatch.elapsedMilliseconds}ms",
-        );
-        stopwatch.reset();
+      if (clear) {
+        await clearAssetsAndAlbums(_db);
+        log.info("Manual refresh requested, cleared assets and albums from db");
+      } else if (_stateUpdateLock.enqueued <= 1) {
+        final int cachedCount =
+            await _db.assets.filter().ownerIdEqualTo(me.isarId).count();
+        if (cachedCount > 0 && cachedCount != state.allAssets.length) {
+          await _stateUpdateLock.run(
+            () async => _updateAssetsState(await _getUserAssets(me.isarId)),
+          );
+          log.info(
+            "Reading assets ${state.allAssets.length} from DB: ${stopwatch.elapsedMilliseconds}ms",
+          );
+          stopwatch.reset();
+        }
       }
       final bool newRemote = await _assetService.refreshRemoteAssets();
       final bool newLocal = await _albumService.refreshDeviceAlbums();
@@ -111,10 +122,14 @@ class AssetNotifier extends StateNotifier<AssetsState> {
         return;
       }
       stopwatch.reset();
-      final assets = await _getUserAssets(me.isarId);
-      if (!const ListEquality().equals(assets, state.allAssets)) {
-        log.info("setting new asset state");
-        await _updateAssetsState(assets);
+      if (_stateUpdateLock.enqueued <= 1) {
+        _stateUpdateLock.run(() async {
+          final assets = await _getUserAssets(me.isarId);
+          if (!const ListEquality().equals(assets, state.allAssets)) {
+            log.info("setting new asset state");
+            await _updateAssetsState(assets);
+          }
+        });
       }
     } finally {
       _getAllAssetInProgress = false;
@@ -129,47 +144,18 @@ class AssetNotifier extends StateNotifier<AssetsState> {
 
   Future<void> clearAllAsset() {
     state = AssetsState.empty();
-    return _db.writeTxn(() async {
-      await _db.assets.clear();
-      await _db.exifInfos.clear();
-      await _db.albums.clear();
-    });
+    return clearAssetsAndAlbums(_db);
   }
 
   Future<void> onNewAssetUploaded(Asset newAsset) async {
-    final int i = state.allAssets.indexWhere(
-      (a) =>
-          a.isRemote ||
-          (a.localId == newAsset.localId && a.deviceId == newAsset.deviceId),
-    );
-
-    if (i == -1 ||
-        state.allAssets[i].localId != newAsset.localId ||
-        state.allAssets[i].deviceId != newAsset.deviceId) {
-      await _updateAssetsState([...state.allAssets, newAsset]);
-    } else {
-      // unify local/remote assets by replacing the
-      // local-only asset in the DB with a local&remote asset
-      final Asset? inDb = await _db.assets
-          .where()
-          .localIdDeviceIdEqualTo(newAsset.localId, newAsset.deviceId)
-          .findFirst();
-      if (inDb != null) {
-        newAsset.id = inDb.id;
-        newAsset.isLocal = inDb.isLocal;
-      }
-
-      // order is important to keep all local-only assets at the beginning!
-      await _updateAssetsState([
-        ...state.allAssets.slice(0, i),
-        ...state.allAssets.slice(i + 1),
-        newAsset,
-      ]);
-    }
-    try {
-      await _db.writeTxn(() => newAsset.put(_db));
-    } on IsarError catch (e) {
-      log.severe("Failed to put new asset into db: $e");
+    final bool ok = await _syncService.syncNewAssetToDb(newAsset);
+    if (ok && _stateUpdateLock.enqueued <= 1) {
+      // run this sequentially if there is at most 1 other task waiting
+      await _stateUpdateLock.run(() async {
+        final userId = Store.get(StoreKey.currentUser).isarId;
+        final assets = await _getUserAssets(userId);
+        await _updateAssetsState(assets);
+      });
     }
   }
 
@@ -252,6 +238,7 @@ final assetProvider = StateNotifierProvider<AssetNotifier, AssetsState>((ref) {
     ref.watch(assetServiceProvider),
     ref.watch(appSettingsServiceProvider),
     ref.watch(albumServiceProvider),
+    ref.watch(syncServiceProvider),
     ref.watch(dbProvider),
   );
 });

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/album/services/album.service.dart';
 import 'package:immich_mobile/shared/models/album.dart';
@@ -170,7 +169,7 @@ class AssetNotifier extends StateNotifier<AssetsState> {
     try {
       await _db.writeTxn(() => newAsset.put(_db));
     } on IsarError catch (e) {
-      debugPrint(e.toString());
+      log.severe("Failed to put new asset into db: $e");
     }
   }
 

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -45,14 +45,11 @@ class AssetService {
         .filter()
         .ownerIdEqualTo(Store.get(StoreKey.currentUser).isarId)
         .count();
-    final List<AssetResponseDto>? dtos =
-        await _getRemoteAssets(hasCache: numOwnedRemoteAssets > 0);
-    if (dtos == null) {
-      debugPrint("refreshRemoteAssets fast took ${sw.elapsedMilliseconds}ms");
-      return false;
-    }
-    final bool changes = await _syncService
-        .syncRemoteAssetsToDb(dtos.map(Asset.remote).toList());
+    final bool changes = await _syncService.syncRemoteAssetsToDb(
+      () async => (await _getRemoteAssets(hasCache: numOwnedRemoteAssets > 0))
+          ?.map(Asset.remote)
+          .toList(),
+    );
     debugPrint("refreshRemoteAssets full took ${sw.elapsedMilliseconds}ms");
     return changes;
   }

--- a/mobile/lib/utils/async_mutex.dart
+++ b/mobile/lib/utils/async_mutex.dart
@@ -3,12 +3,17 @@ import 'dart:async';
 /// Async mutex to guarantee actions are performed sequentially and do not interleave
 class AsyncMutex {
   Future _running = Future.value(null);
+  int _enqueued = 0;
+
+  get enqueued => _enqueued;
 
   /// Execute [operation] exclusively, after any currently running operations.
   /// Returns a [Future] with the result of the [operation].
   Future<T> run<T>(Future<T> Function() operation) {
     final completer = Completer<T>();
+    _enqueued++;
     _running.whenComplete(() {
+      _enqueued--;
       completer.complete(Future<T>.sync(operation));
     });
     return _running = completer.future;

--- a/mobile/lib/utils/db.dart
+++ b/mobile/lib/utils/db.dart
@@ -1,0 +1,14 @@
+import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
+import 'package:immich_mobile/shared/models/store.dart';
+import 'package:isar/isar.dart';
+
+Future<void> clearAssetsAndAlbums(Isar db) async {
+  await Store.delete(StoreKey.assetETag);
+  await db.writeTxn(() async {
+    await db.assets.clear();
+    await db.exifInfos.clear();
+    await db.albums.clear();
+  });
+}

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -12,11 +12,10 @@ import 'package:immich_mobile/modules/backup/models/hive_backup_albums.model.dar
 import 'package:immich_mobile/modules/backup/models/hive_duplicated_assets.model.dart';
 import 'package:immich_mobile/modules/login/models/hive_saved_login_info.model.dart';
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
-import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:immich_mobile/shared/models/exif_info.dart';
 import 'package:immich_mobile/shared/models/immich_logger_message.model.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/services/asset_cache.service.dart';
+import 'package:immich_mobile/utils/db.dart';
 import 'package:isar/isar.dart';
 
 Future<void> migrateHiveToStoreIfNecessary() async {
@@ -154,10 +153,6 @@ Future<void> migrateDatabaseIfNeeded(Isar db) async {
 }
 
 Future<void> _migrateV1ToV2(Isar db) async {
-  await Store.delete(StoreKey.assetETag);
-  await db.writeTxn(() async {
-    await db.assets.clear();
-    await db.exifInfos.clear();
-  });
+  await clearAssetsAndAlbums(db);
   await Store.put(StoreKey.version, 2);
 }

--- a/mobile/test/asset_grid_data_structure_test.dart
+++ b/mobile/test/asset_grid_data_structure_test.dart
@@ -20,6 +20,7 @@ void main() {
         fileModifiedAt: date,
         updatedAt: date,
         durationInSeconds: 0,
+        type: AssetType.image,
         fileName: '',
         isFavorite: false,
         isLocal: false,

--- a/mobile/test/async_mutex_test.dart
+++ b/mobile/test/async_mutex_test.dart
@@ -6,30 +6,35 @@ void main() {
     test('test ordered execution', () async {
       AsyncMutex lock = AsyncMutex();
       List<int> events = [];
+      expect(0, lock.enqueued);
       lock.run(
         () => Future.delayed(
           const Duration(milliseconds: 10),
           () => events.add(1),
         ),
       );
+      expect(1, lock.enqueued);
       lock.run(
         () => Future.delayed(
           const Duration(milliseconds: 3),
           () => events.add(2),
         ),
       );
+      expect(2, lock.enqueued);
       lock.run(
         () => Future.delayed(
           const Duration(milliseconds: 1),
           () => events.add(3),
         ),
       );
+      expect(3, lock.enqueued);
       await lock.run(
         () => Future.delayed(
           const Duration(milliseconds: 10),
           () => events.add(4),
         ),
       );
+      expect(0, lock.enqueued);
       expect(events, [1, 2, 3, 4]);
     });
   });

--- a/mobile/test/async_mutex_test.dart
+++ b/mobile/test/async_mutex_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/async_mutex.dart';
+
+void main() {
+  group('Test AsyncMutex grouped', () {
+    test('test ordered execution', () async {
+      AsyncMutex lock = AsyncMutex();
+      List<int> events = [];
+      lock.run(
+        () => Future.delayed(
+          const Duration(milliseconds: 10),
+          () => events.add(1),
+        ),
+      );
+      lock.run(
+        () => Future.delayed(
+          const Duration(milliseconds: 3),
+          () => events.add(2),
+        ),
+      );
+      lock.run(
+        () => Future.delayed(
+          const Duration(milliseconds: 1),
+          () => events.add(3),
+        ),
+      );
+      await lock.run(
+        () => Future.delayed(
+          const Duration(milliseconds: 10),
+          () => events.add(4),
+        ),
+      );
+      expect(events, [1, 2, 3, 4]);
+    });
+  });
+}

--- a/mobile/test/favorite_provider_test.dart
+++ b/mobile/test/favorite_provider_test.dart
@@ -23,6 +23,7 @@ Asset _getTestAsset(int id, bool favorite) {
     updatedAt: DateTime.now(),
     isLocal: false,
     durationInSeconds: 0,
+    type: AssetType.image,
     fileName: '',
     isFavorite: favorite,
   );

--- a/mobile/test/sync_service_test.dart
+++ b/mobile/test/sync_service_test.dart
@@ -53,6 +53,7 @@ void main() {
     late final Isar db;
     setUpAll(() async {
       WidgetsFlutterBinding.ensureInitialized();
+      await Isar.initializeIsarCore(download: true);
       db = loadDb();
       ImmichLogger();
       db.writeTxnSync(() => db.clearSync());

--- a/mobile/test/sync_service_test.dart
+++ b/mobile/test/sync_service_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/shared/models/album.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/models/exif_info.dart';
+import 'package:immich_mobile/shared/models/logger_message.model.dart';
+import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/shared/services/immich_logger.service.dart';
+import 'package:immich_mobile/shared/services/sync.service.dart';
+import 'package:isar/isar.dart';
+
+void main() {
+  Asset makeAsset({
+    required String localId,
+    String? remoteId,
+    int deviceId = 1,
+    int ownerId = 590700560494856554, // hash of "1"
+    bool isLocal = false,
+  }) {
+    final DateTime date = DateTime(2000);
+    return Asset(
+      localId: localId,
+      remoteId: remoteId,
+      deviceId: deviceId,
+      ownerId: ownerId,
+      fileCreatedAt: date,
+      fileModifiedAt: date,
+      updatedAt: date,
+      durationInSeconds: 0,
+      type: AssetType.image,
+      fileName: localId,
+      isFavorite: false,
+      isLocal: isLocal,
+    );
+  }
+
+  Isar loadDb() {
+    return Isar.openSync(
+      [
+        ExifInfoSchema,
+        AssetSchema,
+        AlbumSchema,
+        UserSchema,
+        StoreValueSchema,
+        LoggerMessageSchema
+      ],
+      maxSizeMiB: 256,
+    );
+  }
+
+  group('Test SyncService grouped', () {
+    late final Isar db;
+    setUpAll(() async {
+      WidgetsFlutterBinding.ensureInitialized();
+      db = loadDb();
+      ImmichLogger();
+      db.writeTxnSync(() => db.clearSync());
+      Store.init(db);
+      await Store.put(
+        StoreKey.currentUser,
+        User(
+          id: "1",
+          updatedAt: DateTime.now(),
+          email: "a@b.c",
+          firstName: "first",
+          lastName: "last",
+          isAdmin: false,
+        ),
+      );
+    });
+    final List<Asset> initialAssets = [
+      makeAsset(localId: "1", remoteId: "0-1", deviceId: 0),
+      makeAsset(localId: "1", remoteId: "2-1", deviceId: 2),
+      makeAsset(localId: "1", remoteId: "1-1", isLocal: true),
+      makeAsset(localId: "2", isLocal: true),
+      makeAsset(localId: "3", isLocal: true),
+    ];
+    setUp(() {
+      db.writeTxnSync(() {
+        db.assets.clearSync();
+        db.assets.putAllSync(initialAssets);
+      });
+    });
+    test('test inserting existing assets', () async {
+      SyncService s = SyncService(db);
+      final List<Asset> remoteAssets = [
+        makeAsset(localId: "1", remoteId: "0-1", deviceId: 0),
+        makeAsset(localId: "1", remoteId: "2-1", deviceId: 2),
+        makeAsset(localId: "1", remoteId: "1-1"),
+      ];
+      expect(db.assets.countSync(), 5);
+      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c1, false);
+      expect(db.assets.countSync(), 5);
+    });
+
+    test('test inserting new assets', () async {
+      SyncService s = SyncService(db);
+      final List<Asset> remoteAssets = [
+        makeAsset(localId: "1", remoteId: "0-1", deviceId: 0),
+        makeAsset(localId: "1", remoteId: "2-1", deviceId: 2),
+        makeAsset(localId: "1", remoteId: "1-1"),
+        makeAsset(localId: "2", remoteId: "1-2"),
+        makeAsset(localId: "4", remoteId: "1-4"),
+        makeAsset(localId: "1", remoteId: "3-1", deviceId: 3),
+      ];
+      expect(db.assets.countSync(), 5);
+      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c1, true);
+      expect(db.assets.countSync(), 7);
+    });
+
+    test('test syncing duplicate assets', () async {
+      SyncService s = SyncService(db);
+      final List<Asset> remoteAssets = [
+        makeAsset(localId: "1", remoteId: "0-1", deviceId: 0),
+        makeAsset(localId: "1", remoteId: "1-1"),
+        makeAsset(localId: "1", remoteId: "2-1", deviceId: 2),
+        makeAsset(localId: "1", remoteId: "2-1b", deviceId: 2),
+        makeAsset(localId: "1", remoteId: "2-1c", deviceId: 2),
+        makeAsset(localId: "1", remoteId: "2-1d", deviceId: 2),
+      ];
+      expect(db.assets.countSync(), 5);
+      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c1, true);
+      expect(db.assets.countSync(), 8);
+      final bool c2 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c2, false);
+      expect(db.assets.countSync(), 8);
+      remoteAssets.removeAt(4);
+      final bool c3 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c3, true);
+      expect(db.assets.countSync(), 7);
+      remoteAssets.add(makeAsset(localId: "1", remoteId: "2-1e", deviceId: 2));
+      remoteAssets.add(makeAsset(localId: "2", remoteId: "2-2", deviceId: 2));
+      final bool c4 = await s.syncRemoteAssetsToDb(remoteAssets);
+      expect(c4, true);
+      expect(db.assets.countSync(), 9);
+    });
+  });
+}

--- a/mobile/test/sync_service_test.dart
+++ b/mobile/test/sync_service_test.dart
@@ -91,7 +91,7 @@ void main() {
         makeAsset(localId: "1", remoteId: "1-1"),
       ];
       expect(db.assets.countSync(), 5);
-      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c1 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c1, false);
       expect(db.assets.countSync(), 5);
     });
@@ -107,7 +107,7 @@ void main() {
         makeAsset(localId: "1", remoteId: "3-1", deviceId: 3),
       ];
       expect(db.assets.countSync(), 5);
-      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c1 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c1, true);
       expect(db.assets.countSync(), 7);
     });
@@ -123,19 +123,19 @@ void main() {
         makeAsset(localId: "1", remoteId: "2-1d", deviceId: 2),
       ];
       expect(db.assets.countSync(), 5);
-      final bool c1 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c1 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c1, true);
       expect(db.assets.countSync(), 8);
-      final bool c2 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c2 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c2, false);
       expect(db.assets.countSync(), 8);
       remoteAssets.removeAt(4);
-      final bool c3 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c3 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c3, true);
       expect(db.assets.countSync(), 7);
       remoteAssets.add(makeAsset(localId: "1", remoteId: "2-1e", deviceId: 2));
       remoteAssets.add(makeAsset(localId: "2", remoteId: "2-2", deviceId: 2));
-      final bool c4 = await s.syncRemoteAssetsToDb(remoteAssets);
+      final bool c4 = await s.syncRemoteAssetsToDb(() => remoteAssets);
       expect(c4, true);
       expect(db.assets.countSync(), 9);
     });


### PR DESCRIPTION
This PR tries to fix several issues with the new client database sync:

- #2069
- #2063
- #2053

and adds pull to refresh on the main timeline:

You can refresh assets on the main timeline with the usual material design refresh gesture by pulling down. If you that twice (within 2 seconds after the first refresh finished), a full clean and reload is performed, i.e. all assets and albums are purged from the DB and re-synced from device and server.


Changes:

- Removes the unique constraint on `localId` & `deviceId`: allows duplicates from web/cli or uploaded from the same mobile device with different users
- syncing remote to local assets is updated to allow for duplicates: sort and compare by userId, deviceId, localId and modification time (to account for duplicates originating from edited files imported via CLI)
- keeps backed-up assets as remote in teh database after deleting the local files on the device
- Add `AssetType` to `Asset`
- Adds a version setting to the database 
- Migrate client database: clears the assets in the client database once
- No longer uses UTC when creating `Asset` (as Isar always returns dates in local time)
- implements `==` and `hashCode` for `Asset` so that changes to the list of assets actually result in a re-render of the timeline
- adjust log level of database errors
- changes logging to async write (because you cannot run sync and async write operations in the same isolate at the same time)
- adds some tests for the `SyncService`
- serialize sync operations to guard against concurrency bugs
- reworked `onNewAssetUploaded`  