### PR TITLE
[ Mobile ] Fixed mobile app not reporting webm MIME type

### DIFF
--- a/mobile/lib/utils/files_helper.dart
+++ b/mobile/lib/utils/files_helper.dart
@@ -44,6 +44,9 @@ class FileHelper {
       case '3gp':
         return {"type": "video", "subType": "3gpp"};
 
+      case 'webm':
+        return {"type": "video", "subType": "webm"};
+
       default:
         return {"type": "unsupport", "subType": "unsupport"};
     }


### PR DESCRIPTION
This change fixes a small BUG with the mobile app's `webm` handling logic. Specifically, the app seems to correctly brows, play back, and attempt to upload `webm` files to the server. However, it seems to not correctly set the MIME type on the upload request resulting in the server rejecting it.

The fix here seems to be pretty straight forward as we just need to add a case statement to the file name -> mime type handling logic. As per Mozilla's guide on MIME types, we always set `.webm`s to be `video/webm`.

No changes need to be done on the server as Webm support seems to have merged as of  #1365.

This PR closes #2086


This change was tested on my personal android 13 device and seems to have worked as the app is now able to upload `webm` files to the server with no errors.