### PR TITLE
feat(server): change clipembedding entity type

### DIFF
--- a/server/libs/infra/src/db/entities/smart-info.entity.ts
+++ b/server/libs/infra/src/db/entities/smart-info.entity.ts
@@ -17,7 +17,7 @@ export class SmartInfoEntity {
   objects!: string[] | null;
 
   @Column({
-    type: 'float8',
+    type: 'float4',
     array: true,
     nullable: true,
   })

--- a/server/libs/infra/src/db/entities/smart-info.entity.ts
+++ b/server/libs/infra/src/db/entities/smart-info.entity.ts
@@ -17,12 +17,9 @@ export class SmartInfoEntity {
   objects!: string[] | null;
 
   @Column({
-    type: 'numeric',
+    type: 'float8',
     array: true,
     nullable: true,
-    // note: migration generator is broken for numeric[], but these _are_ set in the database
-    // precision: 20,
-    // scale: 19,
   })
   clipEmbedding!: number[] | null;
 }

--- a/server/libs/infra/src/db/migrations/1679901204458-ClipEmbeddingFloat4.ts
+++ b/server/libs/infra/src/db/migrations/1679901204458-ClipEmbeddingFloat4.ts
@@ -1,11 +1,11 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class ClipEmbeddingFloat81679901204458 implements MigrationInterface {
-  name = 'ClipEmbeddingFloat81679901204458';
+export class ClipEmbeddingFloat41679901204458 implements MigrationInterface {
+  name = 'ClipEmbeddingFloat41679901204458';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "smart_info" ALTER COLUMN "clipEmbedding" TYPE double precision array USING "clipEmbedding"::double precision array`,
+      `ALTER TABLE "smart_info" ALTER COLUMN "clipEmbedding" TYPE real array USING "clipEmbedding"::real array`,
     );
   }
 

--- a/server/libs/infra/src/db/migrations/1679901204458-ClipEmbeddingFloat8.ts
+++ b/server/libs/infra/src/db/migrations/1679901204458-ClipEmbeddingFloat8.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ClipEmbeddingFloat81679901204458 implements MigrationInterface {
+  name = 'ClipEmbeddingFloat81679901204458';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "smart_info" ALTER COLUMN "clipEmbedding" TYPE double precision array USING "clipEmbedding"::double precision array`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "smart_info" ALTER COLUMN "clipEmbedding" TYPE numeric(20,19) array USING "clipEmbedding"::numeric(20,19) array`,
+    );
+  }
+}


### PR DESCRIPTION
Currently `clipEmbedding` is stored as `numeric(20, 19)`, but I think it's better to convert that to `float8`. According to my tests, Typesense limits floats to 17 significant digits anyway.

With a dataset of 830 assets with 512 clipEmbedding values each (424.960 numbers), I tested converting the numeric type to float4 and float8.
- Converting to float4 meant that 338 out of 424.960 numbers lost some precision
- And converting to float8 saw 0 numbers lose precision

The `numeric(20, 19)` type can only store values between -9.999... and 9.999..., but in my dataset there was a value of `-9.9260091781616210000` which is pretty close to that limit. There are also some reports of `QueryFailedError: numeric field overflow` errors when inserting to the `smart_info` table. There could be a hard limit on the values of clipEmbedding that prevents them from going below -10, but by using a floating point this is no longer a concern.

And as an added bonus the table size shrinked from 5.1MiB to 2.8MiB (830 assets)
