### PR TITLE
fix(server): increase typesense start-up settings

### DIFF
--- a/server/libs/infra/src/search/typesense.repository.ts
+++ b/server/libs/infra/src/search/typesense.repository.ts
@@ -65,7 +65,8 @@ export class TypesenseRepository implements ISearchRepository {
         },
       ],
       apiKey,
-      numRetries: 3,
+      numRetries: 15,
+      retryIntervalSeconds: 4,
       connectionTimeoutSeconds: 10,
     });
   }


### PR DESCRIPTION
This should allow typesense 60 seconds to startup before the server errors out.