### PR TITLE
chore(mobile): add isar build script for F-Droid

### DIFF
--- a/mobile/scripts/fdroid_build_isar.sh
+++ b/mobile/scripts/fdroid_build_isar.sh
@@ -1,0 +1,14 @@
+cd .isar
+bash tool/build_android.sh x86
+bash tool/build_android.sh x64
+bash tool/build_android.sh armv7
+bash tool/build_android.sh arm64
+mv libisar_android_arm64.so libisar.so
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_flutter_libs-*/android/src/main/jniLibs/arm64-v8a/
+mv libisar_android_armv7.so libisar.so
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_flutter_libs-*/android/src/main/jniLibs/armeabi-v7a/
+mv libisar_android_x64.so libisar.so
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_flutter_libs-*/android/src/main/jniLibs/x86_64/
+mv libisar_android_x86.so libisar.so
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_flutter_libs-*/android/src/main/jniLibs/x86/
+cd ..


### PR DESCRIPTION
f-droid requires binary libraries to be build from source. this script builds the libs for isar and moves them to the .pub-cache of the isar_flutter_libs folder. Prob this is just a workaround and can be improved.

addresses #1815 