### PR TITLE
feat(mobile): uploading files in chunk

### DIFF
--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -243,6 +243,7 @@ class BackupService {
           );
           req.headers["Authorization"] =
               "Bearer ${Store.get(StoreKey.accessToken)}";
+          req.headers["Transfer-Encoding"] = "chunked";
 
           req.fields['deviceAssetId'] = entity.id;
           req.fields['deviceId'] = deviceId;


### PR DESCRIPTION
If your server is running behind a CloudFlare tunnel, the Flutter app fails to upload files larger than 100 MB. This can be solved if we add a `Transfer-Encoding: chunked` header to the request.