### PR TITLE
fix(server): add paused property to JobCountsDto

### DIFF
--- a/mobile/openapi/doc/JobCountsDto.md
+++ b/mobile/openapi/doc/JobCountsDto.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **failed** | **int** |  | 
 **delayed** | **int** |  | 
 **waiting** | **int** |  | 
+**paused** | **int** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/job_counts_dto.dart
+++ b/mobile/openapi/lib/model/job_counts_dto.dart
@@ -18,6 +18,7 @@ class JobCountsDto {
     required this.failed,
     required this.delayed,
     required this.waiting,
+    required this.paused,
   });
 
   int active;
@@ -30,13 +31,16 @@ class JobCountsDto {
 
   int waiting;
 
+  int paused;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is JobCountsDto &&
      other.active == active &&
      other.completed == completed &&
      other.failed == failed &&
      other.delayed == delayed &&
-     other.waiting == waiting;
+     other.waiting == waiting &&
+     other.paused == paused;
 
   @override
   int get hashCode =>
@@ -45,10 +49,11 @@ class JobCountsDto {
     (completed.hashCode) +
     (failed.hashCode) +
     (delayed.hashCode) +
-    (waiting.hashCode);
+    (waiting.hashCode) +
+    (paused.hashCode);
 
   @override
-  String toString() => 'JobCountsDto[active=$active, completed=$completed, failed=$failed, delayed=$delayed, waiting=$waiting]';
+  String toString() => 'JobCountsDto[active=$active, completed=$completed, failed=$failed, delayed=$delayed, waiting=$waiting, paused=$paused]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -57,6 +62,7 @@ class JobCountsDto {
       json[r'failed'] = this.failed;
       json[r'delayed'] = this.delayed;
       json[r'waiting'] = this.waiting;
+      json[r'paused'] = this.paused;
     return json;
   }
 
@@ -84,6 +90,7 @@ class JobCountsDto {
         failed: mapValueOfType<int>(json, r'failed')!,
         delayed: mapValueOfType<int>(json, r'delayed')!,
         waiting: mapValueOfType<int>(json, r'waiting')!,
+        paused: mapValueOfType<int>(json, r'paused')!,
       );
     }
     return null;
@@ -138,6 +145,7 @@ class JobCountsDto {
     'failed',
     'delayed',
     'waiting',
+    'paused',
   };
 }
 

--- a/mobile/openapi/test/job_counts_dto_test.dart
+++ b/mobile/openapi/test/job_counts_dto_test.dart
@@ -41,6 +41,11 @@ void main() {
       // TODO
     });
 
+    // int paused
+    test('to test the property `paused`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -4074,6 +4074,9 @@
           },
           "waiting": {
             "type": "integer"
+          },
+          "paused": {
+            "type": "integer"
           }
         },
         "required": [
@@ -4081,7 +4084,8 @@
           "completed",
           "failed",
           "delayed",
-          "waiting"
+          "waiting",
+          "paused"
         ]
       },
       "AllJobStatusResponseDto": {

--- a/server/libs/domain/src/job/job.repository.ts
+++ b/server/libs/domain/src/job/job.repository.ts
@@ -15,6 +15,7 @@ export interface JobCounts {
   failed: number;
   delayed: number;
   waiting: number;
+  paused: number;
 }
 
 export type JobItem =

--- a/server/libs/domain/src/job/job.service.spec.ts
+++ b/server/libs/domain/src/job/job.service.spec.ts
@@ -23,6 +23,7 @@ describe(JobService.name, () => {
         failed: 1,
         delayed: 1,
         waiting: 1,
+        paused: 1,
       });
 
       await expect(sut.getAllJobsStatus()).resolves.toEqual({
@@ -32,6 +33,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'clip-encoding-queue': {
           active: 1,
@@ -39,6 +41,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'metadata-extraction-queue': {
           active: 1,
@@ -46,6 +49,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'object-tagging-queue': {
           active: 1,
@@ -53,6 +57,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'search-queue': {
           active: 1,
@@ -60,6 +65,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'storage-template-migration-queue': {
           active: 1,
@@ -67,6 +73,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'thumbnail-generation-queue': {
           active: 1,
@@ -74,6 +81,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
         'video-conversion-queue': {
           active: 1,
@@ -81,6 +89,7 @@ describe(JobService.name, () => {
           delayed: 1,
           failed: 1,
           waiting: 1,
+          paused: 1,
         },
       });
     });

--- a/server/libs/domain/src/job/response-dto/all-job-status-response.dto.ts
+++ b/server/libs/domain/src/job/response-dto/all-job-status-response.dto.ts
@@ -12,6 +12,8 @@ export class JobCountsDto {
   delayed!: number;
   @ApiProperty({ type: 'integer' })
   waiting!: number;
+  @ApiProperty({ type: 'integer' })
+  paused!: number;
 }
 
 export class AllJobStatusResponseDto implements Record<QueueName, JobCountsDto> {

--- a/server/libs/infra/src/job/job.repository.ts
+++ b/server/libs/infra/src/job/job.repository.ts
@@ -10,7 +10,7 @@ import {
 } from '@app/domain';
 import { InjectQueue } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
-import { Queue } from 'bull';
+import { Queue, type JobCounts as BullJobCounts } from 'bull';
 
 export class JobRepository implements IJobRepository {
   private logger = new Logger(JobRepository.name);
@@ -54,7 +54,9 @@ export class JobRepository implements IJobRepository {
   }
 
   getJobCounts(name: QueueName): Promise<JobCounts> {
-    return this.queueMap[name].getJobCounts();
+    // Typecast needed because the `paused` key is missing from Bull's
+    // type definition. Can be removed once fixed upstream.
+    return this.queueMap[name].getJobCounts() as Promise<BullJobCounts & { paused: number }>;
   }
 
   async queue(item: JobItem): Promise<void> {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "immich",
-      "version": "1.51.0",
+      "version": "1.52.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -60,7 +60,6 @@
         "@openapitools/openapi-generator-cli": "2.5.1",
         "@types/archiver": "^5.3.1",
         "@types/bcrypt": "^5.0.0",
-        "@types/bull": "^3.15.9",
         "@types/cookie-parser": "^1.4.3",
         "@types/cron": "^2.0.0",
         "@types/express": "^4.17.13",
@@ -2511,16 +2510,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/bull": {
-      "version": "3.15.9",
-      "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
-      "integrity": "sha512-MPUcyPPQauAmynoO3ezHAmCOhbB0pWmYyijr/5ctaCqhbKWsjW0YCod38ZcLzUBprosfZ9dPqfYIcfdKjk7RNQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/ioredis": "*",
-        "@types/redis": "^2.8.0"
-      }
-    },
     "node_modules/@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -2671,15 +2660,6 @@
         "@types/through": "*"
       }
     },
-    "node_modules/@types/ioredis": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.8.tgz",
-      "integrity": "sha512-mULOyO2smtvkE1zmzRRA4P0+1UjEqusi014kXOL1q3CY0RgqkR5/wKvv+vAJbPw2Q66wPyylKeevUy+m/FaRMg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -2800,15 +2780,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/redis": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -13471,16 +13442,6 @@
         "@types/node": "*"
       }
     },
-    "@types/bull": {
-      "version": "3.15.9",
-      "resolved": "https://registry.npmjs.org/@types/bull/-/bull-3.15.9.tgz",
-      "integrity": "sha512-MPUcyPPQauAmynoO3ezHAmCOhbB0pWmYyijr/5ctaCqhbKWsjW0YCod38ZcLzUBprosfZ9dPqfYIcfdKjk7RNQ==",
-      "dev": true,
-      "requires": {
-        "@types/ioredis": "*",
-        "@types/redis": "^2.8.0"
-      }
-    },
     "@types/component-emitter": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
@@ -13631,15 +13592,6 @@
         "@types/through": "*"
       }
     },
-    "@types/ioredis": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.8.tgz",
-      "integrity": "sha512-mULOyO2smtvkE1zmzRRA4P0+1UjEqusi014kXOL1q3CY0RgqkR5/wKvv+vAJbPw2Q66wPyylKeevUy+m/FaRMg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -13760,15 +13712,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "@types/redis": {
-      "version": "2.8.32",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
-      "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/semver": {
       "version": "7.3.13",

--- a/server/package.json
+++ b/server/package.json
@@ -88,7 +88,6 @@
     "@openapitools/openapi-generator-cli": "2.5.1",
     "@types/archiver": "^5.3.1",
     "@types/bcrypt": "^5.0.0",
-    "@types/bull": "^3.15.9",
     "@types/cookie-parser": "^1.4.3",
     "@types/cron": "^2.0.0",
     "@types/express": "^4.17.13",

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1284,6 +1284,12 @@ export interface JobCountsDto {
      * @memberof JobCountsDto
      */
     'waiting': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof JobCountsDto
+     */
+    'paused': number;
 }
 /**
  * 


### PR DESCRIPTION
Removed `@types/bull` package because `bull` has their own types now and the package is deprecated

Added missing `paused` property to `JobCountsDto`. Also added a typecast to `JobRepository.getJobCounts` because the upstream types are wrong. I've submitted a pull request to [their repo](https://github.com/OptimalBits/bull) to fix that.