### PR TITLE
feat(server): add faststart to ffmpeg options

### DIFF
--- a/server/apps/microservices/src/processors/video-transcode.processor.ts
+++ b/server/apps/microservices/src/processors/video-transcode.processor.ts
@@ -136,6 +136,10 @@ export class VideoTranscodeProcessor {
           `-vcodec ${config.ffmpeg.targetVideoCodec}`,
           `-acodec ${config.ffmpeg.targetAudioCodec}`,
           `-vf scale=${config.ffmpeg.targetScaling}`,
+
+          // Makes a second pass moving the moov atom to the beginning of
+          // the file for improved playback speed.
+          `-movflags faststart`,
         ])
         .output(savedEncodedPath)
         .on('start', () => {


### PR DESCRIPTION
Typically, the moov atom in recorded videos is located at the end of files since the necessary information isn't available at the beginning of the recording. To play a mp4 file, browsers follow a general process:
1. Start downloading file and assume moov atom is at start
2. If moov atom not found, cancel request and start downloading end of file
3. Use data in moov atom to start downloading file again

When the moov atom is located at the start of a file, only one request is necessary resulting in faster playback. This PR achieves exactly that at the cost of a second pass that slightly increases the transcoding time.