### PR TITLE
feat(server): enhanced thumbnails generation code

### DIFF
--- a/server/libs/domain/src/media/media.repository.ts
+++ b/server/libs/domain/src/media/media.repository.ts
@@ -7,6 +7,6 @@ export interface ResizeOptions {
 
 export interface IMediaRepository {
   resize(input: string, output: string, options: ResizeOptions): Promise<void>;
-  extractVideoThumbnail(input: string, output: string): Promise<void>;
+  extractVideoThumbnail(input: string, output: string, size: number): Promise<void>;
   extractThumbnailFromExif(input: string, output: string): Promise<void>;
 }

--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -114,6 +114,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.extractVideoThumbnail).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/thumbs/user-id/asset-id.jpeg',
+        1440,
       );
       expect(assetMock.save).toHaveBeenCalledWith({
         id: 'asset-id',

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -44,9 +44,13 @@ export class MediaService {
       this.storageRepository.mkdirSync(resizePath);
       const jpegThumbnailPath = join(resizePath, `${asset.id}.jpeg`);
 
+      const thumbnailDimension = 1440;
       if (asset.type == AssetType.IMAGE) {
         try {
-          await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, { size: 1440, format: 'jpeg' });
+          await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, {
+            size: thumbnailDimension,
+            format: 'jpeg',
+          });
         } catch (error) {
           this.logger.warn(
             `Failed to generate jpeg thumbnail using sharp, trying with exiftool-vendored (asset=${asset.id})`,
@@ -57,7 +61,7 @@ export class MediaService {
 
       if (asset.type == AssetType.VIDEO) {
         this.logger.log('Start Generating Video Thumbnail');
-        await this.mediaRepository.extractVideoThumbnail(asset.originalPath, jpegThumbnailPath);
+        await this.mediaRepository.extractVideoThumbnail(asset.originalPath, jpegThumbnailPath, thumbnailDimension);
         this.logger.log(`Generating Video Thumbnail Success ${asset.id}`);
       }
 

--- a/server/libs/infra/src/repositories/media.repository.ts
+++ b/server/libs/infra/src/repositories/media.repository.ts
@@ -24,10 +24,14 @@ export class MediaRepository implements IMediaRepository {
     }
   }
 
-  extractVideoThumbnail(input: string, output: string) {
+  extractVideoThumbnail(input: string, output: string, size: number) {
     return new Promise<void>((resolve, reject) => {
       ffmpeg(input)
-        .outputOptions(['-ss 00:00:00.000', '-frames:v 1'])
+        .outputOptions([
+          '-ss 00:00:00.000',
+          '-frames:v 1',
+          `-vf scale='min(${size},iw)':'min(${size},ih)':force_original_aspect_ratio=increase`,
+        ])
         .output(output)
         .on('error', reject)
         .on('end', resolve)

--- a/server/libs/infra/src/repositories/media.repository.ts
+++ b/server/libs/infra/src/repositories/media.repository.ts
@@ -11,7 +11,11 @@ export class MediaRepository implements IMediaRepository {
   async resize(input: string, output: string, options: ResizeOptions): Promise<void> {
     switch (options.format) {
       case 'webp':
-        await sharp(input, { failOnError: false }).resize(250).webp().rotate().toFile(output);
+        await sharp(input, { failOnError: false })
+          .resize(options.size, options.size, { fit: 'outside', withoutEnlargement: true })
+          .webp()
+          .rotate()
+          .toFile(output);
         return;
 
       case 'jpeg':


### PR DESCRIPTION
This PR implements the following enhancements of the thumbnail generation code.

## Video thumbnails

Immich now uses `outside` mode to generate JPEG thumbnails to make them as small as possible while ensuring their dimensions are greater or equal than 1440. There is an exception for smaller images that are not enlarged.

I've noticed that the algorithm is not the same for video files (Immich saves the video frame in its original resolution as a JPEG thumbnail). I've added an option for ffmpeg inside `extractVideoThumbnail` to implement the same behavior for videos.

For example:

- For 4K videos (3840x2160), a JPEG thumbnail size now equals to 2560x1440 instead of 3840x2160
- For 1920x1080 videos, a JPEG thumbnail size equals to the original resolution (1920x1080)

## WEBP thumbnails dimensions

All WEBP thumbnails are being generated to fit inside 250x250 rectangle. For example, for 1920x1080 video, the size of the generated WEBP thumbnail is 250x141. Afterward that small image is being enlarged by the browser (in the case of a web client) to make its size at least 235 thus additionally loosing visual quality.

I've changed the mode to `outside` that resizes the image to be as small as possible while ensuring its dimensions are greater than or equal to 250.
