### PR TITLE
feat(server): improve validation in controllers

### DIFF
--- a/server/apps/immich/src/controllers/album.controller.ts
+++ b/server/apps/immich/src/controllers/album.controller.ts
@@ -1,14 +1,15 @@
 import { AlbumService, AuthUserDto } from '@app/domain';
 import { GetAlbumsDto } from '@app/domain/album/dto/get-albums.dto';
-import { Controller, Get, Query, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Album')
 @Controller('album')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class AlbumController {
   constructor(private service: AlbumService) {}
 

--- a/server/apps/immich/src/controllers/album.controller.ts
+++ b/server/apps/immich/src/controllers/album.controller.ts
@@ -8,7 +8,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('Album')
 @Controller('album')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class AlbumController {
   constructor(private service: AlbumService) {}
 

--- a/server/apps/immich/src/controllers/api-key.controller.ts
+++ b/server/apps/immich/src/controllers/api-key.controller.ts
@@ -6,15 +6,16 @@ import {
   APIKeyUpdateDto,
   AuthUserDto,
 } from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Post, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('API Key')
 @Controller('api-key')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class APIKeyController {
   constructor(private service: APIKeyService) {}
 

--- a/server/apps/immich/src/controllers/api-key.controller.ts
+++ b/server/apps/immich/src/controllers/api-key.controller.ts
@@ -14,7 +14,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('API Key')
 @Controller('api-key')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class APIKeyController {
   constructor(private service: APIKeyService) {}
 

--- a/server/apps/immich/src/controllers/auth.controller.ts
+++ b/server/apps/immich/src/controllers/auth.controller.ts
@@ -21,7 +21,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 
 @ApiTags('Authentication')
 @Controller('auth')
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class AuthController {
   constructor(private readonly service: AuthService) {}
 

--- a/server/apps/immich/src/controllers/auth.controller.ts
+++ b/server/apps/immich/src/controllers/auth.controller.ts
@@ -13,15 +13,16 @@ import {
   UserResponseDto,
   ValidateAccessTokenResponseDto,
 } from '@app/domain';
-import { Body, Controller, Ip, Post, Req, Res, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Ip, Post, Req, Res } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Authentication')
 @Controller('auth')
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class AuthController {
   constructor(private readonly service: AuthService) {}
 

--- a/server/apps/immich/src/controllers/device-info.controller.ts
+++ b/server/apps/immich/src/controllers/device-info.controller.ts
@@ -12,7 +12,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('Device Info')
 @Controller('device-info')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class DeviceInfoController {
   constructor(private readonly service: DeviceInfoService) {}
 

--- a/server/apps/immich/src/controllers/device-info.controller.ts
+++ b/server/apps/immich/src/controllers/device-info.controller.ts
@@ -4,15 +4,16 @@ import {
   DeviceInfoService,
   UpsertDeviceInfoDto as UpsertDto,
 } from '@app/domain';
-import { Body, Controller, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Device Info')
 @Controller('device-info')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class DeviceInfoController {
   constructor(private readonly service: DeviceInfoService) {}
 

--- a/server/apps/immich/src/controllers/job.controller.ts
+++ b/server/apps/immich/src/controllers/job.controller.ts
@@ -6,7 +6,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('Job')
 @Controller('jobs')
 @Authenticated({ admin: true })
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class JobController {
   constructor(private service: JobService) {}
 

--- a/server/apps/immich/src/controllers/job.controller.ts
+++ b/server/apps/immich/src/controllers/job.controller.ts
@@ -1,12 +1,13 @@
 import { AllJobStatusResponseDto, JobCommandDto, JobStatusDto, JobIdDto, JobService } from '@app/domain';
-import { Body, Controller, Get, Param, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Get, Param, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Job')
 @Controller('jobs')
 @Authenticated({ admin: true })
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class JobController {
   constructor(private service: JobService) {}
 

--- a/server/apps/immich/src/controllers/oauth.controller.ts
+++ b/server/apps/immich/src/controllers/oauth.controller.ts
@@ -15,7 +15,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 
 @ApiTags('OAuth')
 @Controller('oauth')
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class OAuthController {
   constructor(private service: OAuthService) {}
 

--- a/server/apps/immich/src/controllers/oauth.controller.ts
+++ b/server/apps/immich/src/controllers/oauth.controller.ts
@@ -7,15 +7,16 @@ import {
   OAuthService,
   UserResponseDto,
 } from '@app/domain';
-import { Body, Controller, Get, HttpStatus, Post, Redirect, Req, Res, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Post, Redirect, Req, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('OAuth')
 @Controller('oauth')
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class OAuthController {
   constructor(private service: OAuthService) {}
 

--- a/server/apps/immich/src/controllers/search.controller.ts
+++ b/server/apps/immich/src/controllers/search.controller.ts
@@ -6,15 +6,16 @@ import {
   SearchResponseDto,
   SearchService,
 } from '@app/domain';
-import { Controller, Get, Query, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Search')
 @Controller('search')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class SearchController {
   constructor(private service: SearchService) {}
 

--- a/server/apps/immich/src/controllers/search.controller.ts
+++ b/server/apps/immich/src/controllers/search.controller.ts
@@ -14,7 +14,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('Search')
 @Controller('search')
 @Authenticated()
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class SearchController {
   constructor(private service: SearchService) {}
 

--- a/server/apps/immich/src/controllers/server-info.controller.ts
+++ b/server/apps/immich/src/controllers/server-info.controller.ts
@@ -5,13 +5,14 @@ import {
   ServerStatsResponseDto,
   ServerVersionReponseDto,
 } from '@app/domain';
-import { Controller, Get, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('Server Info')
 @Controller('server-info')
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class ServerInfoController {
   constructor(private service: ServerInfoService) {}
 

--- a/server/apps/immich/src/controllers/server-info.controller.ts
+++ b/server/apps/immich/src/controllers/server-info.controller.ts
@@ -11,7 +11,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 
 @ApiTags('Server Info')
 @Controller('server-info')
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class ServerInfoController {
   constructor(private service: ServerInfoService) {}
 

--- a/server/apps/immich/src/controllers/share.controller.ts
+++ b/server/apps/immich/src/controllers/share.controller.ts
@@ -1,12 +1,13 @@
 import { AuthUserDto, EditSharedLinkDto, SharedLinkResponseDto, ShareService } from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Patch, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GetAuthUser } from '../decorators/auth-user.decorator';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('share')
 @Controller('share')
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class ShareController {
   constructor(private readonly service: ShareService) {}
 

--- a/server/apps/immich/src/controllers/share.controller.ts
+++ b/server/apps/immich/src/controllers/share.controller.ts
@@ -6,7 +6,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 
 @ApiTags('share')
 @Controller('share')
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class ShareController {
   constructor(private readonly service: ShareService) {}
 

--- a/server/apps/immich/src/controllers/system-config.controller.ts
+++ b/server/apps/immich/src/controllers/system-config.controller.ts
@@ -6,7 +6,7 @@ import { Authenticated } from '../decorators/authenticated.decorator';
 @ApiTags('System Config')
 @Controller('system-config')
 @Authenticated({ admin: true })
-@UsePipes(new ValidationPipe({ transform: true }))
+@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
 export class SystemConfigController {
   constructor(private readonly service: SystemConfigService) {}
 

--- a/server/apps/immich/src/controllers/system-config.controller.ts
+++ b/server/apps/immich/src/controllers/system-config.controller.ts
@@ -1,12 +1,13 @@
 import { SystemConfigDto, SystemConfigService, SystemConfigTemplateStorageOptionDto } from '@app/domain';
-import { Body, Controller, Get, Put, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Get, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Authenticated } from '../decorators/authenticated.decorator';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('System Config')
 @Controller('system-config')
 @Authenticated({ admin: true })
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class SystemConfigController {
   constructor(private readonly service: SystemConfigService) {}
 

--- a/server/apps/immich/src/controllers/user.controller.ts
+++ b/server/apps/immich/src/controllers/user.controller.ts
@@ -5,7 +5,6 @@ import {
   Delete,
   Body,
   Param,
-  ValidationPipe,
   Put,
   Query,
   UseInterceptors,
@@ -13,7 +12,6 @@ import {
   Response,
   StreamableFile,
   Header,
-  UsePipes,
 } from '@nestjs/common';
 import { UserService } from '@app/domain';
 import { Authenticated } from '../decorators/authenticated.decorator';
@@ -29,10 +27,11 @@ import { UserCountResponseDto } from '@app/domain';
 import { CreateProfileImageDto } from '@app/domain';
 import { CreateProfileImageResponseDto } from '@app/domain';
 import { UserCountDto } from '@app/domain';
+import { UseValidation } from '../decorators/use-validation.decorator';
 
 @ApiTags('User')
 @Controller('user')
-@UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+@UseValidation()
 export class UserController {
   constructor(private service: UserService) {}
 

--- a/server/apps/immich/src/decorators/use-validation.decorator.ts
+++ b/server/apps/immich/src/decorators/use-validation.decorator.ts
@@ -1,0 +1,12 @@
+import { applyDecorators, UsePipes, ValidationPipe } from '@nestjs/common';
+
+export function UseValidation() {
+  return applyDecorators(
+    UsePipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+      }),
+    ),
+  );
+}

--- a/server/libs/domain/src/system-config/dto/system-config.dto.ts
+++ b/server/libs/domain/src/system-config/dto/system-config.dto.ts
@@ -1,21 +1,30 @@
 import { SystemConfig } from '@app/infra/entities';
-import { ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsObject, ValidateNested } from 'class-validator';
 import { SystemConfigFFmpegDto } from './system-config-ffmpeg.dto';
 import { SystemConfigOAuthDto } from './system-config-oauth.dto';
 import { SystemConfigPasswordLoginDto } from './system-config-password-login.dto';
 import { SystemConfigStorageTemplateDto } from './system-config-storage-template.dto';
 
 export class SystemConfigDto {
+  @Type(() => SystemConfigFFmpegDto)
   @ValidateNested()
+  @IsObject()
   ffmpeg!: SystemConfigFFmpegDto;
 
+  @Type(() => SystemConfigOAuthDto)
   @ValidateNested()
+  @IsObject()
   oauth!: SystemConfigOAuthDto;
 
+  @Type(() => SystemConfigPasswordLoginDto)
   @ValidateNested()
+  @IsObject()
   passwordLogin!: SystemConfigPasswordLoginDto;
 
+  @Type(() => SystemConfigStorageTemplateDto)
   @ValidateNested()
+  @IsObject()
   storageTemplate!: SystemConfigStorageTemplateDto;
 }
 


### PR DESCRIPTION
Add `whitelist: true` to `ValidationPipe` of all refactored controllers to only keep properties of incoming DTOs that have decorators. All other properties are stripped. The current behavior could become an issue when a dto is passed as an object and used without further validation, for example when passing a DTO directly to the update function of a repository.

Nested objects are only validated when they are an instance of a class. This means that `SystemConfigDto` didn't have proper validation and nested values were empty after applying `whitelist: true`. This has been fixed in this PR.

```ts
class Dto {
    @IsNotEmpty()
    @IsString()
    validated: string;
    
    unvalidated: string;
}

// Update endpoint in controller
update(@Body() dto: Dto)

// Request body to update endpoint
{ validated: 'value', unvalidated: 'value', other: 10 }


// Current value of dto:
{ validated: 'value', unvalidated: 'value', other: 10 }

// Value of dto after adding `whitelist: true`
{ validated: 'value' }
```