### PR TITLE
chore(docker): Default NODE_ENV to production for server image and update alpine version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
     depends_on:
       - redis
       - database
@@ -25,8 +23,6 @@ services:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
     depends_on:
       - redis
       - database
@@ -41,8 +37,6 @@ services:
       - model-cache:/cache
     env_file:
       - .env
-    environment:
-      - NODE_ENV=production
     restart: always
 
   immich-web:

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -11,6 +11,8 @@ RUN /opt/venv/bin/pip install --no-deps sentence-transformers
 
 FROM python:3.10-slim
 
+ENV NODE_ENV=production
+
 COPY --from=builder /opt/venv /opt/venv
 
 ENV TRANSFORMERS_CACHE=/cache \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14 as builder
+FROM node:16-alpine3.17 as builder
 
 WORKDIR /usr/src/app
 
@@ -17,7 +17,7 @@ RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 
 
-FROM node:16-alpine3.14
+FROM node:16-alpine3.17
 
 ENV NODE_ENV=production
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,6 +19,8 @@ RUN npm prune --omit=dev --omit=optional
 
 FROM node:16-alpine3.14
 
+ENV NODE_ENV=production
+
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache libheif vips ffmpeg perl

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Our Node base image
-FROM node:16-alpine3.14 as base
+FROM node:16-alpine3.17 as base
 
 WORKDIR /usr/src/app
 EXPOSE 3000


### PR DESCRIPTION
This PR sets the `NODE_ENV` to `production` in the server image, this ENV is already set on the web container so it could be set here as well.

I have also updated the alpine version to 3.17 (previously 3.14) off node 16
