### PR TITLE
chores(docs): fix bulk upload example commands to work with paths with spaces

### DIFF
--- a/docs/docs/features/bulk-upload.md
+++ b/docs/docs/features/bulk-upload.md
@@ -60,15 +60,15 @@ Be aware that as this runs inside a container, you need to mount the folder from
 
 ```bash title="Upload current directory"
 cd /DIRECTORY/WITH/IMAGES
-docker run -it --rm -v $(pwd):/import ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://192.168.1.216:2283/api
+docker run -it --rm -v "$(pwd):/import" ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://192.168.1.216:2283/api
 ```
 
 ```bash title="Upload target directory"
-docker run -it --rm -v /DIRECTORY/WITH/IMAGES:/import ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://192.168.1.216:2283/api
+docker run -it --rm -v "/DIRECTORY/WITH/IMAGES:/import" ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://192.168.1.216:2283/api
 ```
 
 ```bash title="Create an alias"
-alias immich="docker run -it --rm -v $(pwd):/import ghcr.io/immich-app/immich-cli:latest"
+alias immich='docker run -it --rm -v "$(pwd):/import" ghcr.io/immich-app/immich-cli:latest'
 immich upload --key HFEJ38DNSDUEG --server http://192.168.1.216:2283/api
 ```
 
@@ -79,7 +79,7 @@ If you are running the CLI container on the same machine as your Immich server, 
 3. Use `--server http://immich-server:3001/` for the upload command instead of the external address.
 
 ```bash title="Upload to internal address"
-docker run --network immich_default -it --rm -v $(pwd):/import ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://immich-server:3001/
+docker run --network immich_default -it --rm -v "$(pwd):/import" ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://immich-server:3001/
 ```
 :::
 


### PR DESCRIPTION
The examples commands didn't work when the result of the subcommand `$(pwd)` contained spaces. This CR adds the proper escaping for them to work. This change also fixes the behavior of the alias allowing the correct current directory to be passed when it is placed inside the `.bashrc` file.