### PR TITLE
fix(mobile): Fixed hero animation re-enabling on immich asset grid

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -38,19 +38,24 @@ class ImmichAssetGrid extends HookConsumerWidget {
 
     // Needs to suppress hero animations when navigating to this widget
     final enableHeroAnimations = useState(false);
+    final transitionDuration = ModalRoute.of(context)?.transitionDuration;
 
-    // Wait for transition to complete, then re-enable
-    ModalRoute.of(context)?.animation?.addListener(() {
-      // If we've already enabled, we are done
-      if (enableHeroAnimations.value) {
-        return;
-      }
-      final animation = ModalRoute.of(context)?.animation;
-      if (animation != null) {
-        // When the animation is complete, re-enable hero animations
-        enableHeroAnimations.value = animation.isCompleted;
-      }
-    });
+    useEffect(
+      () {
+        // Wait for transition to complete, then re-enable
+        if (transitionDuration == null) {
+          // No route transition found, maybe we opened this up first
+          enableHeroAnimations.value = true;
+        } else {
+          Future.delayed(transitionDuration)
+              .then((_) {
+                enableHeroAnimations.value = true;
+              });
+        }
+        return null;
+      },
+      [],
+    );
 
     Future<bool> onWillPop() async {
       enableHeroAnimations.value = false;

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -47,6 +47,9 @@ class ImmichAssetGrid extends HookConsumerWidget {
           // No route transition found, maybe we opened this up first
           enableHeroAnimations.value = true;
         } else {
+          // Unfortunately, using the transition animation itself didn't
+          // seem to work reliably. So instead, wait until the duration of the
+          // animation has elapsed to re-enable the hero animations
           Future.delayed(transitionDuration)
               .then((_) {
                 enableHeroAnimations.value = true;


### PR DESCRIPTION
> N.B. Before the windstorm knocked out my power, I was scrambling to fix this bad code I wrote which made it in the latest release. 

Fixes the issue where Hero animations were disabled on the Immich asset grid.

- No longer adds a new listener to the animation on each `build`
- Uses the animation transition duration instead of the animation itself to be more robust
