### PR TITLE
chore(web): update svelte related packages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3155,9 +3155,9 @@
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"node_modules/@sveltejs/adapter-node": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.1.tgz",
-			"integrity": "sha512-mEGDCaZVU3qvFdUI8CMKv+BSzpBYpTpcx85u8bfJ+vcv57pu4UXjZg7ivOoxWZdunUeqq4oEyE+kHmlgBRAalg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.3.tgz",
+			"integrity": "sha512-Fv6NyVpVWYA63KRaV6dDjcU8ytcWFiUr0siJOoHl+oWy5WHNEuRiJOUdiZzYbZo8MmvFaCoxHkTgPrVQhpqaRA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/plugin-commonjs": "^24.0.0",
@@ -3170,9 +3170,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
-			"integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
+			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3658,16 +3658,6 @@
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true
-		},
-		"node_modules/@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-			"deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"sass": "*"
-			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.3.13",
@@ -6389,7 +6379,9 @@
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
 			"integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -10290,6 +10282,8 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
 			"integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -10633,17 +10627,17 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.55.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
-			"integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==",
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
+			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.0.4.tgz",
-			"integrity": "sha512-feIyBAA5cSIxq4vq6mwGvGQTHy/wBVQbs5b+/VvE21WN8X7nonAuSqwvZv0UDBowzRka3Rh4gmLPH8rPePz3/w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
+			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -10652,14 +10646,27 @@
 				"import-fresh": "^3.2.1",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"svelte-preprocess": "^5.0.0",
-				"typescript": "^4.9.4"
+				"svelte-preprocess": "^5.0.3",
+				"typescript": "^5.0.3"
 			},
 			"bin": {
 				"svelte-check": "bin/svelte-check"
 			},
 			"peerDependencies": {
 				"svelte": "^3.55.0"
+			}
+		},
+		"node_modules/svelte-check/node_modules/typescript": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+			"integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=12.20"
 			}
 		},
 		"node_modules/svelte-hmr": {
@@ -10707,14 +10714,13 @@
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
-			"integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz",
+			"integrity": "sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"@types/pug": "^2.0.6",
-				"@types/sass": "^1.43.1",
 				"detect-indent": "^6.1.0",
 				"magic-string": "^0.27.0",
 				"sorcery": "^0.11.0",
@@ -10734,7 +10740,7 @@
 				"stylus": "^0.55.0",
 				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
 				"svelte": "^3.23.0",
-				"typescript": "^3.9.5 || ^4.0.0"
+				"typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -13653,9 +13659,9 @@
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"@sveltejs/adapter-node": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.1.tgz",
-			"integrity": "sha512-mEGDCaZVU3qvFdUI8CMKv+BSzpBYpTpcx85u8bfJ+vcv57pu4UXjZg7ivOoxWZdunUeqq4oEyE+kHmlgBRAalg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.3.tgz",
+			"integrity": "sha512-Fv6NyVpVWYA63KRaV6dDjcU8ytcWFiUr0siJOoHl+oWy5WHNEuRiJOUdiZzYbZo8MmvFaCoxHkTgPrVQhpqaRA==",
 			"dev": true,
 			"requires": {
 				"@rollup/plugin-commonjs": "^24.0.0",
@@ -13665,9 +13671,9 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.10.0.tgz",
-			"integrity": "sha512-0P35zHrByfbF3Ym3RdQL+RvzgsCDSyO3imSwuZ67XAD5HoCQFF3a8Mhh0V3sObz3rc5aJd4Qn82UpAihJqZ6gQ==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
+			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -14074,15 +14080,6 @@
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true
-		},
-		"@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-			"dev": true,
-			"requires": {
-				"sass": "*"
-			}
 		},
 		"@types/semver": {
 			"version": "7.3.13",
@@ -16064,7 +16061,9 @@
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
 			"integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -18906,6 +18905,8 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.58.3.tgz",
 			"integrity": "sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -19161,14 +19162,14 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "3.55.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
-			"integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ=="
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
+			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A=="
 		},
 		"svelte-check": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.0.4.tgz",
-			"integrity": "sha512-feIyBAA5cSIxq4vq6mwGvGQTHy/wBVQbs5b+/VvE21WN8X7nonAuSqwvZv0UDBowzRka3Rh4gmLPH8rPePz3/w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
+			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -19177,8 +19178,16 @@
 				"import-fresh": "^3.2.1",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"svelte-preprocess": "^5.0.0",
-				"typescript": "^4.9.4"
+				"svelte-preprocess": "^5.0.3",
+				"typescript": "^5.0.3"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+					"integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+					"dev": true
+				}
 			}
 		},
 		"svelte-hmr": {
@@ -19208,13 +19217,12 @@
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
-			"integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.3.tgz",
+			"integrity": "sha512-GrHF1rusdJVbOZOwgPWtpqmaexkydznKzy5qIC2FabgpFyKN57bjMUUUqPRfbBXK5igiEWn1uO/DXsa2vJ5VHA==",
 			"dev": true,
 			"requires": {
 				"@types/pug": "^2.0.6",
-				"@types/sass": "^1.43.1",
 				"detect-indent": "^6.1.0",
 				"magic-string": "^0.27.0",
 				"sorcery": "^0.11.0",


### PR DESCRIPTION
- `@sveltejs/adapter-node` from 1.2.1 to 1.2.3
- `@sveltejs/kit` from 1.10.0 to 1.15.1 (fixes [CVE-2023-29003](https://github.com/advisories/GHSA-5p75-vc5g-8rv2))
- `svelte` from 3.55.1 to 3.58.0
- `svelte-check` from 3.0.4 to 3.2.0
- `svelte-preprocess` from 5.0.1 to 5.0.3