### PR TITLE
fix(web): small gap in navbar

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -38,12 +38,9 @@
 	};
 </script>
 
-<section
-	id="dashboard-navbar"
-	class="fixed h-[4.25rem] w-screen z-[900] bg-immich-bg dark:bg-immich-dark-bg text-sm"
->
+<section id="dashboard-navbar" class="fixed h-[4.25rem] w-screen z-[900] text-sm">
 	<div
-		class="grid grid-cols-[250px_auto] border-b dark:border-b-immich-dark-gray items-center py-2"
+		class="grid grid-cols-[250px_auto] border-b dark:border-b-immich-dark-gray items-center py-2 bg-immich-bg dark:bg-immich-dark-bg"
 	>
 		<a
 			data-sveltekit-preload-data="hover"


### PR DESCRIPTION
Just noticed it and now I can't unsee it. There is a small gap between the navbar and the border that surrounds it.
![before](https://user-images.githubusercontent.com/59014050/230086205-344eebc6-031e-49ec-b497-4489675d5a0a.png)![after](https://user-images.githubusercontent.com/59014050/230086209-40eb96b6-6e59-455f-806f-260377edab09.png)

