### PR TITLE
fix(web): hide assets when selecting album cover

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -364,7 +364,7 @@
 	};
 </script>
 
-<section class="bg-immich-bg dark:bg-immich-dark-bg">
+<section class="bg-immich-bg dark:bg-immich-dark-bg" class:hidden={isShowThumbnailSelection}>
 	<!-- Multiselection mode app bar -->
 	{#if isMultiSelectionMode}
 		<ControlAppBar


### PR DESCRIPTION
Hides the album assets while selecting the album cover. Otherwise, the album assets could show underneath or below when selecting an album cover thumbnail. Fixes #2041