### PR TITLE
fix(mobile): Add bottom safe area to video player controls

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -151,6 +151,9 @@ class _VideoThumbnailPlayerState extends State<VideoThumbnailPlayer> {
 
   _createChewieController() {
     chewieController = ChewieController(
+      controlsSafeAreaMinimum: const EdgeInsets.only(
+        bottom: 156,
+      ),
       showOptions: true,
       showControlsOnInitialize: false,
       videoPlayerController: videoPlayerController,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/100457/230455314-f5946f35-3cfd-4015-b2e5-e5326a0b6cec.png)
