### PR TITLE
fix(mobile): fix null check operator on null value

### DIFF
--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -447,7 +447,7 @@ class SyncService {
     deleteCandidates.addAll(toDelete);
     existing.addAll(result.first);
     album.name = ape.name;
-    album.modifiedAt = ape.lastModified!;
+    album.modifiedAt = ape.lastModified ?? DateTime.now();
     if (album.thumbnail.value != null &&
         toDelete.contains(album.thumbnail.value)) {
       album.thumbnail.value = null;
@@ -491,7 +491,7 @@ class SyncService {
     if (totalOnDevice != album.assets.length + newAssets.length) {
       return false;
     }
-    album.modifiedAt = ape.lastModified!.toUtc();
+    album.modifiedAt = ape.lastModified?.toUtc() ?? DateTime.now().toUtc();
     final result = await _linkWithExistingFromDb(newAssets);
     try {
       await _db.writeTxn(() async {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix scenarios where the album doesn't have `lastModified` property on iOS, and the code uses the null check operator (`!`) on the property, which causes the local album sync mechanism to fail


## How Has This Been Tested?

I cannot reproduce this on my device. I will need to push out this implementation for people that ran into this issue to test it.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation