### PR TITLE
chore(server): redis error handling

### DIFF
--- a/server/libs/infra/src/infra.config.ts
+++ b/server/libs/infra/src/infra.config.ts
@@ -26,7 +26,11 @@ function parseRedisConfig(): RedisOptions {
 
 export const redisConfig: RedisOptions = parseRedisConfig();
 
-export const bullConfig: BullModuleOptions = {
+interface CustomBullModuleOptions extends BullModuleOptions {
+  onError?: (error: any) => void;
+}
+
+export const bullConfig: CustomBullModuleOptions = {
   prefix: 'immich_bull',
   redis: redisConfig,
   defaultJobOptions: {
@@ -34,9 +38,12 @@ export const bullConfig: BullModuleOptions = {
     removeOnComplete: true,
     removeOnFail: false,
   },
+  onError: (error) => {
+    console.log(error);
+  },
 };
 
-export const bullQueues: BullModuleOptions[] = Object.values(QueueName).map((name) => ({ name }));
+export const bullQueues: CustomBullModuleOptions[] = Object.values(QueueName).map((name) => ({ name }));
 
 function parseTypeSenseConfig(): ConfigurationOptions {
   const typesenseURL = process.env.TYPESENSE_URL;

--- a/server/libs/infra/src/infra.config.ts
+++ b/server/libs/infra/src/infra.config.ts
@@ -1,8 +1,11 @@
 import { QueueName } from '@app/domain';
+import { Logger } from '@nestjs/common';
 import { BullModuleOptions } from '@nestjs/bull';
 import { RedisOptions } from 'ioredis';
 import { InitOptions } from 'local-reverse-geocoder';
 import { ConfigurationOptions } from 'typesense/lib/Typesense/Configuration';
+
+const logger = new Logger('infra.config');
 
 function parseRedisConfig(): RedisOptions {
   const redisUrl = process.env.REDIS_URL;
@@ -39,11 +42,11 @@ export const bullConfig: CustomBullModuleOptions = {
     removeOnFail: false,
   },
   onError: (error) => {
-    console.log(error);
+    logger.error(error);
   },
 };
 
-export const bullQueues: CustomBullModuleOptions[] = Object.values(QueueName).map((name) => ({ name }));
+export const bullQueues: BullModuleOptions[] = Object.values(QueueName).map((name) => ({ name }));
 
 function parseTypeSenseConfig(): ConfigurationOptions {
   const typesenseURL = process.env.TYPESENSE_URL;

--- a/server/libs/infra/src/infra.config.ts
+++ b/server/libs/infra/src/infra.config.ts
@@ -1,11 +1,8 @@
 import { QueueName } from '@app/domain';
-import { Logger } from '@nestjs/common';
 import { BullModuleOptions } from '@nestjs/bull';
 import { RedisOptions } from 'ioredis';
 import { InitOptions } from 'local-reverse-geocoder';
 import { ConfigurationOptions } from 'typesense/lib/Typesense/Configuration';
-
-const logger = new Logger('infra.config');
 
 function parseRedisConfig(): RedisOptions {
   const redisUrl = process.env.REDIS_URL;
@@ -29,20 +26,13 @@ function parseRedisConfig(): RedisOptions {
 
 export const redisConfig: RedisOptions = parseRedisConfig();
 
-interface CustomBullModuleOptions extends BullModuleOptions {
-  onError?: (error: any) => void;
-}
-
-export const bullConfig: CustomBullModuleOptions = {
+export const bullConfig: BullModuleOptions = {
   prefix: 'immich_bull',
   redis: redisConfig,
   defaultJobOptions: {
     attempts: 3,
     removeOnComplete: true,
     removeOnFail: false,
-  },
-  onError: (error) => {
-    logger.error(error);
   },
 };
 

--- a/server/libs/infra/src/redis-io.adapter.ts
+++ b/server/libs/infra/src/redis-io.adapter.ts
@@ -1,13 +1,21 @@
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
 import Redis from 'ioredis';
+import { Logger } from '@nestjs/common';
 import { ServerOptions } from 'socket.io';
 import { redisConfig } from './infra.config';
 
 export class RedisIoAdapter extends IoAdapter {
+  private readonly logger = new Logger(RedisIoAdapter.name);
   createIOServer(port: number, options?: ServerOptions): any {
     const pubClient = new Redis(redisConfig);
+    pubClient.on('error', (error) => {
+      this.logger.error(`Redis pubClient: ${error}`);
+    });
     const subClient = pubClient.duplicate();
+    subClient.on('error', (error) => {
+      this.logger.error(`Redis subClient: ${error}`);
+    });
     const server = super.createIOServer(port, options);
     server.adapter(createAdapter(pubClient, subClient));
     return server;


### PR DESCRIPTION
Should prevent errors like:

```
missing 'error' handler on this Redis client
missing 'error' handler on this Redis client
```