### PR TITLE
fix(server): jobs using stale path

### DIFF
--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -213,6 +213,10 @@ describe(MediaService.name, () => {
   });
 
   describe('handleVideoConversion', () => {
+    beforeEach(() => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.video]);
+    });
+
     it('should log an error', async () => {
       mediaMock.transcode.mockRejectedValue(new Error('unable to transcode'));
 

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -119,7 +119,12 @@ export class MediaService {
   }
 
   async handleVideoConversion(job: IAssetJob) {
-    const { asset } = job;
+    const assets = await this.assetRepository.getByIds([job.asset.id]);
+    const asset = assets[0];
+
+    if (!asset) {
+      return;
+    }
 
     try {
       const input = asset.originalPath;

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -119,8 +119,7 @@ export class MediaService {
   }
 
   async handleVideoConversion(job: IAssetJob) {
-    const assets = await this.assetRepository.getByIds([job.asset.id]);
-    const asset = assets[0];
+    const [asset] = await this.assetRepository.getByIds([job.asset.id]);
 
     if (!asset) {
       return;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixed issue when video extract exif job executes first and moves the asset to the correct location, then the video encoding job executes later and uses stale data with the path before being moved lead to a failed job.


## How Has This Been Tested?

- [x] Upload LivePhotos in bulk and make sure that there is no failed video conversion

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation