### PR TITLE
fix(server): generate thumbnail job uses stale path

### DIFF
--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -79,6 +79,7 @@ describe(MediaService.name, () => {
 
   describe('handleGenerateJpegThumbnail', () => {
     it('should generate a thumbnail for an image', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       await sut.handleGenerateJpegThumbnail({ asset: _.cloneDeep(assetEntityStub.image) });
 
       expect(storageMock.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id');
@@ -94,6 +95,7 @@ describe(MediaService.name, () => {
     });
 
     it('should generate a thumbnail for an image from exif', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       mediaMock.resize.mockRejectedValue(new Error('unsupported format'));
 
       await sut.handleGenerateJpegThumbnail({ asset: _.cloneDeep(assetEntityStub.image) });
@@ -114,6 +116,7 @@ describe(MediaService.name, () => {
     });
 
     it('should generate a thumbnail for a video', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.video]);
       await sut.handleGenerateJpegThumbnail({ asset: _.cloneDeep(assetEntityStub.video) });
 
       expect(storageMock.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id');
@@ -130,7 +133,7 @@ describe(MediaService.name, () => {
 
     it('should queue some jobs', async () => {
       const asset = _.cloneDeep(assetEntityStub.image);
-
+      assetMock.getByIds.mockResolvedValue([asset]);
       await sut.handleGenerateJpegThumbnail({ asset });
 
       expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.GENERATE_WEBP_THUMBNAIL, data: { asset } });
@@ -140,6 +143,7 @@ describe(MediaService.name, () => {
     });
 
     it('should log an error', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       mediaMock.resize.mockRejectedValue(new Error('unsupported format'));
       mediaMock.extractThumbnailFromExif.mockRejectedValue(new Error('unsupported format'));
 

--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -155,12 +155,14 @@ describe(MediaService.name, () => {
 
   describe('handleGenerateWebpThumbnail', () => {
     it('should skip thumbnail generate if resize path is missing', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.noResizePath]);
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.noResizePath });
 
       expect(mediaMock.resize).not.toHaveBeenCalled();
     });
 
     it('should generate a thumbnail', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.image });
 
       expect(mediaMock.resize).toHaveBeenCalledWith(
@@ -172,6 +174,7 @@ describe(MediaService.name, () => {
     });
 
     it('should log an error', async () => {
+      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       mediaMock.resize.mockRejectedValue(new Error('service unavailable'));
 
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.image });

--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -155,14 +155,12 @@ describe(MediaService.name, () => {
 
   describe('handleGenerateWebpThumbnail', () => {
     it('should skip thumbnail generate if resize path is missing', async () => {
-      assetMock.getByIds.mockResolvedValue([assetEntityStub.noResizePath]);
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.noResizePath });
 
       expect(mediaMock.resize).not.toHaveBeenCalled();
     });
 
     it('should generate a thumbnail', async () => {
-      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.image });
 
       expect(mediaMock.resize).toHaveBeenCalledWith(
@@ -174,7 +172,6 @@ describe(MediaService.name, () => {
     });
 
     it('should log an error', async () => {
-      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
       mediaMock.resize.mockRejectedValue(new Error('service unavailable'));
 
       await sut.handleGenerateWepbThumbnail({ asset: assetEntityStub.image });

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -91,7 +91,7 @@ export class MediaService {
   }
 
   async handleGenerateWepbThumbnail(data: IAssetJob): Promise<void> {
-    const [asset] = await this.assetRepository.getByIds([data.asset.id]);
+    const { asset } = data;
 
     if (!asset.resizePath) {
       return;

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -46,6 +46,9 @@ export class MediaService {
     const [asset] = await this.assetRepository.getByIds([data.asset.id]);
 
     if (!asset) {
+      this.logger.warn(
+        `Asset not found: ${data.asset.id} - Original Path: ${data.asset.originalPath} - Resize Path: ${data.asset.resizePath}`,
+      );
       return;
     }
 
@@ -126,6 +129,7 @@ export class MediaService {
     const [asset] = await this.assetRepository.getByIds([job.asset.id]);
 
     if (!asset) {
+      this.logger.warn(`Asset not found: ${job.asset.id} - Original Path: ${job.asset.originalPath}`);
       return;
     }
 

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -91,7 +91,7 @@ export class MediaService {
   }
 
   async handleGenerateWepbThumbnail(data: IAssetJob): Promise<void> {
-    const { asset } = data;
+    const [asset] = await this.assetRepository.getByIds([data.asset.id]);
 
     if (!asset.resizePath) {
       return;

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -43,7 +43,11 @@ export class MediaService {
   }
 
   async handleGenerateJpegThumbnail(data: IAssetJob): Promise<void> {
-    const { asset } = data;
+    const [asset] = await this.assetRepository.getByIds([data.asset.id]);
+
+    if (!asset) {
+      return;
+    }
 
     try {
       const resizePath = this.storageCore.getFolderLocation(StorageFolder.THUMBNAILS, asset.ownerId);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2115


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Update photos to have thumbnails generated 

## Screenshots (if appropriate):


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable