### PR TITLE
fix(proxy): turn off nginx_proxy_buffer

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -44,6 +44,7 @@ server {
     text/css;
 
   proxy_buffering off;
+  proxy_request_buffering off;
   proxy_buffer_size 16k;
   proxy_busy_buffers_size 24k;
   proxy_buffers 64 4k;

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -43,20 +43,21 @@ server {
     image/svg+xml
     text/css;
 
-  location /api {
-    proxy_buffering off;
-    proxy_buffer_size 16k;
-    proxy_busy_buffers_size 24k;
-    proxy_buffers 64 4k;
-    proxy_force_ranges on;
+  proxy_buffering off;
+  proxy_buffer_size 16k;
+  proxy_busy_buffers_size 24k;
+  proxy_buffers 64 4k;
+  proxy_force_ranges on;
 
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Host $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_protocol;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
+  proxy_http_version 1.1;
+  proxy_set_header Host $http_host;
+  proxy_set_header X-Forwarded-Host $http_host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $forwarded_protocol;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $connection_upgrade;
+
+  location /api {
 
     rewrite /api/(.*) /$1 break;
 
@@ -64,19 +65,6 @@ server {
   }
 
   location / {
-    proxy_buffering off;
-    proxy_buffer_size 16k;
-    proxy_busy_buffers_size 24k;
-    proxy_buffers 64 4k;
-    proxy_force_ranges on;
-
-    proxy_http_version 1.1;
-    proxy_set_header Host $http_host;
-    proxy_set_header X-Forwarded-Host $http_host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_protocol;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
 
     proxy_pass ${IMMICH_WEB_SCHEME}web;
   }


### PR DESCRIPTION
proxy_buffering is already off, no reason to have proxy_request_buffering on. In fact, leaving it on can cause nginx to (temporarily) use a lot of disk space during uploads.

This PR has 2 commits, the first one conslidates most poxy_* directives by moving them from location to server context, as they are identical. The second one just adds "proxy_request_buffering off;"