### PR TITLE
fix(web): fix search 400 error when only entering m:

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -71,6 +71,7 @@
 				: 'rounded-3xl bg-gray-200 border border-transparent'}"
 			placeholder="Search your photos"
 			required
+			pattern="^(?!m:$).*$"
 			bind:value
 		/>
 	</label>


### PR DESCRIPTION
Fixes #2256 on the web side, by adding a pattern that matches all strings except only m:
![fix-400-web](https://user-images.githubusercontent.com/22776173/232314445-9ab1c2ee-aa92-4a03-9722-b29a948688de.png)