### PR TITLE
fix(mobile): video player disposes early

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -82,6 +82,14 @@ class TopControlAppBar extends HookConsumerWidget {
               color: Colors.grey[200],
             ),
           ),
+        if (asset.storage == AssetState.merged)
+          IconButton(
+            onPressed: onDownloadPressed,
+            icon: Icon(
+              Icons.cloud_download_outlined,
+              color: Colors.grey[200],
+            ),
+          ),
         if (asset.isRemote)
           IconButton(
             onPressed: () {

--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -27,7 +27,7 @@ class TopControlAppBar extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    const double iconSize = 18.0;
+    const double iconSize = 22.0;
 
     Widget buildFavoriteButton() {
       return IconButton(

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -517,17 +517,19 @@ class GalleryViewerPage extends HookConsumerWidget {
                     filterQuality: FilterQuality.high,
                     maxScale: 1.0,
                     minScale: 1.0,
-                    basePosition: Alignment.topCenter,
-                    child: VideoViewerPage(
-                      onPlaying: () => isPlayingVideo.value = true,
-                      onPaused: () => isPlayingVideo.value = false,
-                      asset: assetList[index],
-                      isMotionVideo: isPlayingMotionVideo.value,
-                      onVideoEnded: () {
-                        if (isPlayingMotionVideo.value) {
-                          isPlayingMotionVideo.value = false;
-                        }
-                      },
+                    basePosition: Alignment.bottomCenter,
+                    child: SafeArea(
+                      child: VideoViewerPage(
+                        onPlaying: () => isPlayingVideo.value = true,
+                        onPaused: () => isPlayingVideo.value = false,
+                        asset: assetList[index],
+                        isMotionVideo: isPlayingMotionVideo.value,
+                        onVideoEnded: () {
+                          if (isPlayingMotionVideo.value) {
+                            isPlayingMotionVideo.value = false;
+                          }
+                        },
+                      ),
                     ),
                   );
                 }

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -392,7 +392,7 @@ class GalleryViewerPage extends HookConsumerWidget {
               scrollPhysics: isZoomed.value
                   ? const NeverScrollableScrollPhysics() // Don't allow paging while scrolled in
                   : (Platform.isIOS
-                      ? const BouncingScrollPhysics() // Use bouncing physics for iOS
+                      ? const ScrollPhysics() // Use bouncing physics for iOS
                       : const ClampingScrollPhysics() // Use heavy physics for Android
                   ),
               itemCount: assetList.length,

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -517,19 +517,17 @@ class GalleryViewerPage extends HookConsumerWidget {
                     filterQuality: FilterQuality.high,
                     maxScale: 1.0,
                     minScale: 1.0,
-                    child: SafeArea(
-                      maintainBottomViewPadding: true,
-                      child: VideoViewerPage(
-                        onPlaying: () => isPlayingVideo.value = true,
-                        onPaused: () => isPlayingVideo.value = false,
-                        asset: assetList[index],
-                        isMotionVideo: isPlayingMotionVideo.value,
-                        onVideoEnded: () {
-                          if (isPlayingMotionVideo.value) {
-                            isPlayingMotionVideo.value = false;
-                          }
-                        },
-                      ),
+                    basePosition: Alignment.topCenter,
+                    child: VideoViewerPage(
+                      onPlaying: () => isPlayingVideo.value = true,
+                      onPaused: () => isPlayingVideo.value = false,
+                      asset: assetList[index],
+                      isMotionVideo: isPlayingMotionVideo.value,
+                      onVideoEnded: () {
+                        if (isPlayingMotionVideo.value) {
+                          isPlayingMotionVideo.value = false;
+                        }
+                      },
                     ),
                   );
                 }

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -301,7 +301,8 @@ class GalleryViewerPage extends HookConsumerWidget {
             onFavorite: () {
               toggleFavorite(assetList[indexOfAsset.value]);
             },
-            onDownloadPressed: assetList[indexOfAsset.value].isLocal
+            onDownloadPressed: assetList[indexOfAsset.value].storage ==
+                    AssetState.local
                 ? null
                 : () {
                     ref.watch(imageViewerStateProvider.notifier).downloadAsset(
@@ -517,6 +518,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                     maxScale: 1.0,
                     minScale: 1.0,
                     child: SafeArea(
+                      maintainBottomViewPadding: true,
                       child: VideoViewerPage(
                         onPlaying: () => isPlayingVideo.value = true,
                         onPaused: () => isPlayingVideo.value = false,

--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -59,15 +59,13 @@ class VideoViewerPage extends HookConsumerWidget {
 
     return Stack(
       children: [
-        SafeArea(
-          child: VideoPlayer(
-            url: videoUrl,
-            jwtToken: Store.get(StoreKey.accessToken),
-            isMotionVideo: isMotionVideo,
-            onVideoEnded: onVideoEnded,
-            onPaused: onPaused,
-            onPlaying: onPlaying,
-          ),
+        VideoPlayer(
+          url: videoUrl,
+          jwtToken: Store.get(StoreKey.accessToken),
+          isMotionVideo: isMotionVideo,
+          onVideoEnded: onVideoEnded,
+          onPaused: onPaused,
+          onPlaying: onPlaying,
         ),
         if (downloadAssetStatus == DownloadAssetStatus.loading)
           const Center(
@@ -165,6 +163,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
       autoPlay: true,
       autoInitialize: true,
       allowFullScreen: true,
+      allowedScreenSleep: false,
       showControls: !widget.isMotionVideo,
       hideControlsTimer: const Duration(seconds: 5),
     );
@@ -180,20 +179,24 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return chewieController?.videoPlayerController.value.isInitialized == true
-        ? SizedBox(
-            child: Chewie(
-              controller: chewieController!,
-            ),
-          )
-        : const Center(
-            child: SizedBox(
-              width: 75,
-              height: 75,
-              child: CircularProgressIndicator.adaptive(
-                strokeWidth: 2,
-              ),
-            ),
-          );
+    if (chewieController?.videoPlayerController.value.isInitialized == true) {
+      return SafeArea(
+        child: SizedBox(
+          child: Chewie(
+            controller: chewieController!,
+          ),
+        ),
+      );
+    } else {
+      return const Center(
+        child: SizedBox(
+          width: 75,
+          height: 75,
+          child: CircularProgressIndicator.adaptive(
+            strokeWidth: 2,
+          ),
+        ),
+      );
+    }
   }
 }

--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -155,7 +155,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
   _createChewieController() {
     chewieController = ChewieController(
       controlsSafeAreaMinimum: const EdgeInsets.only(
-        bottom: 156,
+        bottom: 100,
       ),
       showOptions: true,
       showControlsOnInitialize: false,
@@ -180,11 +180,9 @@ class _VideoPlayerState extends State<VideoPlayer> {
   @override
   Widget build(BuildContext context) {
     if (chewieController?.videoPlayerController.value.isInitialized == true) {
-      return SafeArea(
-        child: SizedBox(
-          child: Chewie(
-            controller: chewieController!,
-          ),
+      return SizedBox(
+        child: Chewie(
+          controller: chewieController!,
         ),
       );
     } else {

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -371,6 +371,8 @@ class Asset {
   "fileName": "$fileName", 
   "isFavorite": $isFavorite, 
   "isLocal": $isLocal,
+  "isRemote: $isRemote,
+  "storage": $storage,
   "width": ${width ?? "N/A"},
   "height": ${height ?? "N/A"},
   "isArchived": $isArchived


### PR DESCRIPTION
* Fixed issue with video player is disposed early due to missing check if the video is initialized while comparing the duration with the current cursor of the video to call the `onVideoEnded` callback function and cause the gallery viewer to change the state, or disposing the video.
* Fixed issue with LivePhotos cannot be played if it is the local asset
* Fixed issue with download button not available on LivePhotos asset