### PR TITLE
fix(web): accountinfopanel not closing on button press

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { clickOutside } from '$lib/utils/click-outside';
 	import { UserResponseDto } from '@api';
 	import { createEventDispatcher } from 'svelte';
 	import { page } from '$app/stores';
@@ -26,8 +25,6 @@
 	out:fade={{ duration: 100 }}
 	id="account-info-panel"
 	class="absolute right-[25px] top-[75px] bg-gray-200 dark:bg-immich-dark-gray dark:border dark:border-immich-dark-gray shadow-lg rounded-3xl w-[360px] text-center z-[100]"
-	use:clickOutside
-	on:outclick={() => dispatch('close')}
 >
 	<div class="bg-white dark:bg-immich-dark-primary/10 rounded-3xl mx-4 mt-4 pb-4">
 		<div class="flex place-items-center place-content-center">

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { clickOutside } from '$lib/utils/click-outside';
 	import { createEventDispatcher } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 	import TrayArrowUp from 'svelte-material-icons/TrayArrowUp.svelte';
@@ -18,6 +19,8 @@
 	export let shouldShowUploadButton = true;
 
 	let shouldShowAccountInfo = false;
+	let clickedOutsidePanel = false;
+	let clickedOutsideButton = false;
 
 	// Show fallback while loading profile picture and hide when image loads.
 	let showProfilePictureFallback = true;
@@ -30,7 +33,20 @@
 	};
 
 	const showAccountInfoPanel = () => {
-		shouldShowAccountInfoPanel = true;
+		if (clickedOutsidePanel) {
+			clickedOutsidePanel = false;
+			return;
+		}
+		shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel;
+	};
+
+	const closeOutsideClick = () => {
+		shouldShowAccountInfoPanel = false;
+		if (clickedOutsideButton) {
+			clickedOutsideButton = false;
+			return;
+		}
+		clickedOutsidePanel = true;
 	};
 
 	const logOut = async () => {
@@ -122,6 +138,8 @@
 					on:mouseleave={() => (shouldShowAccountInfo = false)}
 					on:click={showAccountInfoPanel}
 					on:keydown={showAccountInfoPanel}
+					use:clickOutside
+					on:outclick={() => (clickedOutsideButton = true)}
 				>
 					<button
 						class="flex place-items-center place-content-center rounded-full bg-immich-primary hover:bg-immich-primary/80 h-12 w-12 text-gray-100 dark:text-immich-dark-bg dark:bg-immich-dark-primary"
@@ -142,7 +160,7 @@
 						{/if}
 					</button>
 
-					{#if shouldShowAccountInfo}
+					{#if shouldShowAccountInfo && !shouldShowAccountInfoPanel}
 						<div
 							in:fade={{ delay: 500, duration: 150 }}
 							out:fade={{ delay: 200, duration: 150 }}
@@ -158,10 +176,6 @@
 	</div>
 
 	{#if shouldShowAccountInfoPanel}
-		<AccountInfoPanel
-			{user}
-			on:close={() => (shouldShowAccountInfoPanel = false)}
-			on:logout={logOut}
-		/>
+		<AccountInfoPanel {user} on:close={closeOutsideClick} on:logout={logOut} />
 	{/if}
 </section>

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -19,34 +19,15 @@
 	export let shouldShowUploadButton = true;
 
 	let shouldShowAccountInfo = false;
-	let clickedOutsidePanel = false;
-	let clickedOutsideButton = false;
+	let shouldShowAccountInfoPanel = false;
 
 	// Show fallback while loading profile picture and hide when image loads.
 	let showProfilePictureFallback = true;
 
 	const dispatch = createEventDispatcher();
-	let shouldShowAccountInfoPanel = false;
 
 	const getFirstLetter = (text?: string) => {
 		return text?.charAt(0).toUpperCase();
-	};
-
-	const showAccountInfoPanel = () => {
-		if (clickedOutsidePanel) {
-			clickedOutsidePanel = false;
-			return;
-		}
-		shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel;
-	};
-
-	const closeOutsideClick = () => {
-		shouldShowAccountInfoPanel = false;
-		if (clickedOutsideButton) {
-			clickedOutsideButton = false;
-			return;
-		}
-		clickedOutsidePanel = true;
 	};
 
 	const logOut = async () => {
@@ -132,17 +113,15 @@
 					</a>
 				{/if}
 
-				<div
-					on:mouseover={() => (shouldShowAccountInfo = true)}
-					on:focus={() => (shouldShowAccountInfo = true)}
-					on:mouseleave={() => (shouldShowAccountInfo = false)}
-					on:click={showAccountInfoPanel}
-					on:keydown={showAccountInfoPanel}
-					use:clickOutside
-					on:outclick={() => (clickedOutsideButton = true)}
-				>
+				<div use:clickOutside on:outclick={() => (shouldShowAccountInfoPanel = false)}>
 					<button
 						class="flex place-items-center place-content-center rounded-full bg-immich-primary hover:bg-immich-primary/80 h-12 w-12 text-gray-100 dark:text-immich-dark-bg dark:bg-immich-dark-primary"
+						on:mouseover={() => (shouldShowAccountInfo = true)}
+						on:focus={() => (shouldShowAccountInfo = true)}
+						on:blur={() => (shouldShowAccountInfo = false)}
+						on:mouseleave={() => (shouldShowAccountInfo = false)}
+						on:click={() => (shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel)}
+						on:keydown={() => (shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel)}
 					>
 						{#if user.profileImagePath}
 							<img
@@ -170,12 +149,12 @@
 							<p>{user.email}</p>
 						</div>
 					{/if}
+
+					{#if shouldShowAccountInfoPanel}
+						<AccountInfoPanel {user} on:logout={logOut} />
+					{/if}
 				</div>
 			</section>
 		</div>
 	</div>
-
-	{#if shouldShowAccountInfoPanel}
-		<AccountInfoPanel {user} on:close={closeOutsideClick} on:logout={logOut} />
-	{/if}
 </section>

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -121,7 +121,6 @@
 						on:blur={() => (shouldShowAccountInfo = false)}
 						on:mouseleave={() => (shouldShowAccountInfo = false)}
 						on:click={() => (shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel)}
-						on:keydown={() => (shouldShowAccountInfoPanel = !shouldShowAccountInfoPanel)}
 					>
 						{#if user.profileImagePath}
 							<img


### PR DESCRIPTION
When pressing on the profile button the accountinfopanel opens. When clicking outside of the panel it should close. But thats not the case if you press on the profile button again. Thats extremly annoying on mobile. This request fixes that.
<img width="958" alt="accountinfopanel" src="https://user-images.githubusercontent.com/22776173/232784618-dda6e950-8ddb-4990-92d0-11ddc39ba59f.png">
