### PR TITLE
feat(web): smaller thumbnail in explore so at least 2 photos are in a row

### DIFF
--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -48,7 +48,9 @@
 				<div class="flex flex-row flex-wrap gap-4">
 					{#each places as item}
 						<a class="relative" href="/search?{Field.CITY}={item.value}" draggable="false">
-							<div class="filter brightness-75 rounded-xl overflow-hidden">
+							<div
+								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px]"
+							>
 								<Thumbnail thumbnailSize={156} asset={item.data} readonly />
 							</div>
 							<span
@@ -70,7 +72,9 @@
 				<div class="flex flex-row flex-wrap gap-4">
 					{#each things as item}
 						<a class="relative" href="/search?{Field.OBJECTS}={item.value}" draggable="false">
-							<div class="filter brightness-75 rounded-xl overflow-hidden">
+							<div
+								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px]"
+							>
 								<Thumbnail thumbnailSize={156} asset={item.data} readonly />
 							</div>
 							<span

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -49,7 +49,7 @@
 					{#each places as item}
 						<a class="relative" href="/search?{Field.CITY}={item.value}" draggable="false">
 							<div
-								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px]"
+								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px] flex justify-center"
 							>
 								<Thumbnail thumbnailSize={156} asset={item.data} readonly />
 							</div>
@@ -73,7 +73,7 @@
 					{#each things as item}
 						<a class="relative" href="/search?{Field.OBJECTS}={item.value}" draggable="false">
 							<div
-								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px]"
+								class="filter brightness-75 rounded-xl overflow-hidden w-[calc((100vw-(72px+5rem))/2)] max-w-[156px] justify-center flex"
 							>
 								<Thumbnail thumbnailSize={156} asset={item.data} readonly />
 							</div>


### PR DESCRIPTION
Thumbnails are reduced in their width, so at least 2 can fit in a row. Thats only for small screens. For screens large enough, the normal width of 156px remains
![smaller thumbnails](https://user-images.githubusercontent.com/22776173/232819360-98bf2371-8f69-4136-98ca-a530c49475c4.png)
![normal thumbnail](https://user-images.githubusercontent.com/22776173/232819724-6dbbaf54-2ab4-466f-8415-e69221c0f107.png)
