### PR TITLE
fix(web): noscript message

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -16,32 +16,6 @@
 	</head>
 
 	<body class="bg-immich-bg dark:bg-immich-dark-bg">
-		<noscript>
-			<section
-				class="h-screen w-screen absolute z-[1000] flex place-items-center place-content-center p-4 bg-immich-bg dark:bg-immich-dark-bg"
-			>
-				<div
-					class="flex flex-col gap-4 border bg-white dark:bg-immich-dark-gray dark:border-immich-dark-gray p-8 shadow-sm w-full max-w-lg rounded-3xl"
-				>
-					<div class="flex flex-col place-items-center place-content-center gap-4 py-4">
-						<img
-							src="/src/lib/assets/immich-logo.svg"
-							alt="Immich Logo"
-							draggable="false"
-							class="h-24 w-24"
-						/>
-						<h1 class="text-2xl text-immich-primary dark:text-immich-dark-primary font-medium">
-							Welcome to Immich
-						</h1>
-					</div>
-					<div>
-						<p class="dark:text-immich-dark-fg text-center">
-							To use Immich, you must enable JavaScript or use a JavaScript compatible browser.
-						</p>
-					</div>
-				</div>
-			</section>
-		</noscript>
 		<div>%sveltekit.body%</div>
 	</body>
 </html>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	import type { LayoutData } from './$types';
 	import { fileUploadHandler } from '$lib/utils/file-uploader';
 	import UploadCover from '$lib/components/shared-components/drag-and-drop-upload-overlay.svelte';
+	import FullscreenContainer from '$lib/components/shared-components/fullscreen-container.svelte';
 
 	let showNavigationLoadingBar = false;
 	export let data: LayoutData;
@@ -58,6 +59,14 @@
 		<meta name="twitter:image" content={$page.data.meta.imageUrl} />
 	{/if}
 </svelte:head>
+
+<noscript
+	class="h-screen w-screen absolute z-[1000] flex place-items-center place-content-center bg-immich-bg dark:bg-immich-dark-bg dark:text-immich-dark-fg"
+>
+	<FullscreenContainer title="Welcome to Immich">
+		To use Immich, you must enable JavaScript or use a JavaScript compatible browser.
+	</FullscreenContainer>
+</noscript>
 
 {#if showNavigationLoadingBar}
 	<NavigationLoadingBar />


### PR DESCRIPTION
#2274 added a noscript message, but the image won't show in production builds because only assets in the `static` folder are copied to the production build. The noscript element was added to `app.html`, but since SvelteKit does SSR the message can be added to the root layout and use existing components.