### PR TITLE
Implement a cleanup of old Docker images and untagged images

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,77 @@
+# This workflow runs on certain conditions to check for and potentially
+# delete container images from the GHCR which no longer have an associated
+# code branch.
+# Requires a PAT with the correct scope set in the secrets.
+#
+# This workflow will not trigger runs on forked repos.
+
+name: Cleanup Old Docker Images
+
+on:
+  pull_request:
+    types:
+      - "closed"
+  push:
+    paths:
+      - ".github/workflows/docker-cleanup.yml"
+
+concurrency:
+  group: registry-tags-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup-images:
+    name: Cleanup Stale Images Tags for ${{ matrix.primary-name }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - primary-name: "immich-server"
+          - primary-name: "immich-machine-learning"
+          - primary-name: "immich-web"
+          - primary-name: "immich-proxy"
+    env:
+      # Requires a personal access token with the OAuth scope delete:packages
+      TOKEN: ${{ secrets.PACKAGE_DELETE_TOKEN }}
+    steps:
+      -
+        name: Clean temporary images
+        if: "${{ env.TOKEN != '' }}"
+        uses: stumpylog/image-cleaner-action/ephemeral@develop
+        with:
+          token: "${{ env.TOKEN }}"
+          owner: "immich-app"
+          is_org: "true"
+          package_name: "${{ matrix.primary-name }}"
+          scheme: "pull_request"
+          repo_name: "immich"
+          match_regex: '^pr-(\d+)$|^(\d+)$'
+
+  cleanup-untagged-images:
+    name: Cleanup Untagged Images Tags for ${{ matrix.primary-name }}
+    runs-on: ubuntu-22.04
+    needs:
+      - cleanup-images
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - primary-name: "immich-server"
+          - primary-name: "immich-machine-learning"
+          - primary-name: "immich-web"
+          - primary-name: "immich-proxy"
+          - primary-name: "immich-build-cache"
+    env:
+      # Requires a personal access token with the OAuth scope delete:packages
+      TOKEN: ${{ secrets.PACKAGE_DELETE_TOKEN }}
+    steps:
+      -
+        name: Clean untagged images
+        if: "${{ env.TOKEN != '' }}"
+        uses: stumpylog/image-cleaner-action/untagged@develop
+        with:
+          token: "${{ env.TOKEN }}"
+          owner: "immich-app"
+          is_org: "true"
+          package_name: "${{ matrix.primary-name }}"


### PR DESCRIPTION
This PR adds a new workflow which will runs when a PR closes to remove the associated Docker image which was built from the PR and images which are untagged.  In an ideal world, this would be something built into github, but until that day...  This helps keep the [packages with tags](https://github.com/immich-app/immich/pkgs/container/immich-server/versions?filters%5Bversion_type%5D=tagged) down to just the released versions and those PRs which are still in some sort of active state.

## Stale Images

I've tested this with a read PAT in a sample repository here: https://github.com/stumpylog/immich-sample-repo/actions/runs/4791378901

Taking `immich-server` as the example, [the list of images which would be removed](https://github.com/stumpylog/immich-sample-repo/actions/runs/4791378901/jobs/8525616166#step:2:129).

The logic is pretty simple (and encapsulated into an action).  It filters to packages with 1 tag (extra security), with match the regex `^pr-(\d+)$|^(\d+)$`.  The capturing groups are used to get a PR number.  If the PR is closed (which also means merged), the package is considered done with and can be removed

## Untagged Images

Requires a little more knowledge of Docker and registries to understand, but not terrible.

Basically, when a tag is updated to point to a newly built image (say the PR or branch was updated), the old image doesn't get removed.  In fact, it could still be accessed via a tag of the form `@sha256:<digest>`.  But most people are using `:main` or `:pr-1234`, not a SHA.

So the action looks for images with no tags applied and not pointed to by a multi-arch manifest and removes those.

## TBD
- The repository would need a PAT with the OAuth scope of package deletion in the secrets
- The action requires the `delete` option to be set to actually delete anything.  For now, it's more like a dry run
