### PR TITLE
feat(web): Add action button to search result page

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -23,7 +23,7 @@
 	export let disabled = false;
 	export let readonly = false;
 	export let publicSharedKey: string | undefined = undefined;
-	export let isSearchResult = false;
+	export let showArchiveIcon = false;
 
 	let mouseOver = false;
 
@@ -116,7 +116,7 @@
 					</div>
 				{/if}
 
-				{#if isSearchResult && asset.isArchived}
+				{#if showArchiveIcon && asset.isArchived}
 					<div class="absolute {asset.isFavorite ? 'bottom-10' : 'bottom-2'} left-2 z-10">
 						<ArchiveArrowDownOutline size="24" class="text-white" />
 					</div>

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -7,6 +7,7 @@
 	import MotionPauseOutline from 'svelte-material-icons/MotionPauseOutline.svelte';
 	import MotionPlayOutline from 'svelte-material-icons/MotionPlayOutline.svelte';
 	import Star from 'svelte-material-icons/Star.svelte';
+	import ArchiveArrowDownOutline from 'svelte-material-icons/ArchiveArrowDownOutline.svelte';
 	import ImageThumbnail from './image-thumbnail.svelte';
 	import VideoThumbnail from './video-thumbnail.svelte';
 
@@ -22,6 +23,7 @@
 	export let disabled = false;
 	export let readonly = false;
 	export let publicSharedKey: string | undefined = undefined;
+	export let isSearchResult = false;
 
 	let mouseOver = false;
 
@@ -114,6 +116,11 @@
 					</div>
 				{/if}
 
+				{#if isSearchResult && asset.isArchived}
+					<div class="absolute {asset.isFavorite ? 'bottom-10' : 'bottom-2'} left-2 z-10">
+						<ArchiveArrowDownOutline size="24" class="text-white" />
+					</div>
+				{/if}
 				<ImageThumbnail
 					url={api.getAssetThumbnailUrl(asset.id, format, publicSharedKey)}
 					altText={asset.originalFileName}

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -22,7 +22,7 @@
 	export let selectedAssets: Set<AssetResponseDto> = new Set();
 	export let disableAssetSelect = false;
 	export let viewFrom: ViewFrom;
-	export let isSearchResult = false;
+	export let showArchiveIcon = false;
 
 	let isShowAssetViewer = false;
 
@@ -142,7 +142,7 @@
 						on:click={(e) => (isMultiSelectionMode ? selectAssetHandler(e) : viewAssetHandler(e))}
 						on:select={selectAssetHandler}
 						selected={selectedAssets.has(asset)}
-						{isSearchResult}
+						{showArchiveIcon}
 					/>
 				</div>
 			{/each}

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -22,6 +22,7 @@
 	export let selectedAssets: Set<AssetResponseDto> = new Set();
 	export let disableAssetSelect = false;
 	export let viewFrom: ViewFrom;
+	export let isSearchResult = false;
 
 	let isShowAssetViewer = false;
 
@@ -141,6 +142,7 @@
 						on:click={(e) => (isMultiSelectionMode ? selectAssetHandler(e) : viewAssetHandler(e))}
 						on:select={selectAssetHandler}
 						selected={selectedAssets.has(asset)}
+						{isSearchResult}
 					/>
 				</div>
 			{/each}

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -7,7 +7,25 @@
 	import ImageOffOutline from 'svelte-material-icons/ImageOffOutline.svelte';
 	import SearchBar from '$lib/components/shared-components/search-bar/search-bar.svelte';
 	import { afterNavigate, goto } from '$app/navigation';
-
+	import AlbumSelectionModal from '$lib/components/shared-components/album-selection-modal.svelte';
+	import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
+	import ContextMenu from '$lib/components/shared-components/context-menu/context-menu.svelte';
+	import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
+	import CreateSharedLinkModal from '$lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte';
+	import {
+		notificationController,
+		NotificationType
+	} from '$lib/components/shared-components/notification/notification';
+	import { addAssetsToAlbum, bulkDownload } from '$lib/utils/asset-utils';
+	import { AlbumResponseDto, api, AssetResponseDto, SharedLinkType } from '@api';
+	import Close from 'svelte-material-icons/Close.svelte';
+	import CloudDownloadOutline from 'svelte-material-icons/CloudDownloadOutline.svelte';
+	import ArchiveArrowUpOutline from 'svelte-material-icons/ArchiveArrowUpOutline.svelte';
+	import ArchiveArrowDownOutline from 'svelte-material-icons/ArchiveArrowDownOutline.svelte';
+	import DeleteOutline from 'svelte-material-icons/DeleteOutline.svelte';
+	import Plus from 'svelte-material-icons/Plus.svelte';
+	import ShareVariantOutline from 'svelte-material-icons/ShareVariantOutline.svelte';
+	import { locale } from '$lib/stores/preferences.store';
 	export let data: PageData;
 
 	// The GalleryViewer pushes it's own history state, which causes weird
@@ -23,14 +41,191 @@
 	});
 
 	$: term = $page.url.searchParams.get('q') || data.term || '';
+
+	let selectedAssets: Set<AssetResponseDto> = new Set();
+	$: isMultiSelectionMode = selectedAssets.size > 0;
+	$: isAllArchived = Array.from(selectedAssets).every((asset) => asset.isArchived);
+	$: isAllFavorite = Array.from(selectedAssets).every((asset) => asset.isFavorite);
+
+	let contextMenuPosition = { x: 0, y: 0 };
+	let isShowCreateSharedLinkModal = false;
+	let isShowAddMenu = false;
+	let isShowAlbumPicker = false;
+	let addToSharedAlbum = false;
+
+	const handleShowMenu = ({ x, y }: MouseEvent) => {
+		contextMenuPosition = { x, y };
+		isShowAddMenu = !isShowAddMenu;
+	};
+
+	const handleShowAlbumPicker = (shared: boolean) => {
+		isShowAddMenu = false;
+		isShowAlbumPicker = true;
+		addToSharedAlbum = shared;
+	};
+
+	const handleAddToNewAlbum = (event: CustomEvent) => {
+		isShowAlbumPicker = false;
+
+		const { albumName }: { albumName: string } = event.detail;
+		const assetIds = Array.from(selectedAssets).map((asset) => asset.id);
+		api.albumApi.createAlbum({ albumName, assetIds }).then((response) => {
+			const { id, albumName } = response.data;
+
+			notificationController.show({
+				message: `Added ${assetIds.length} to ${albumName}`,
+				type: NotificationType.Info
+			});
+
+			clearMultiSelectAssetAssetHandler();
+
+			goto('/albums/' + id);
+		});
+	};
+
+	const handleAddToAlbum = async (event: CustomEvent<{ album: AlbumResponseDto }>) => {
+		isShowAlbumPicker = false;
+		const album = event.detail.album;
+
+		const assetIds = Array.from(selectedAssets).map((asset) => asset.id);
+
+		addAssetsToAlbum(album.id, assetIds).then(() => {
+			clearMultiSelectAssetAssetHandler();
+		});
+	};
+
+	const handleDownloadFiles = async () => {
+		await bulkDownload('immich', Array.from(selectedAssets), () => {
+			clearMultiSelectAssetAssetHandler();
+		});
+	};
+
+	const toggleArchive = async () => {
+		let cnt = 0;
+		for (const asset of selectedAssets) {
+			api.assetApi.updateAsset(asset.id, {
+				isArchived: !isAllArchived
+			});
+			cnt = cnt + 1;
+
+			asset.isArchived = !isAllArchived;
+		}
+
+		notificationController.show({
+			message: `${isAllArchived ? `Remove ${cnt} from` : `Add ${cnt} to`} archive`,
+			type: NotificationType.Info
+		});
+
+		clearMultiSelectAssetAssetHandler();
+	};
+
+	const toggleFavorite = () => {
+		isShowAddMenu = false;
+
+		let cnt = 0;
+		for (const asset of selectedAssets) {
+			api.assetApi.updateAsset(asset.id, {
+				isFavorite: !isAllFavorite
+			});
+			cnt = cnt + 1;
+
+			asset.isFavorite = !isAllFavorite;
+		}
+
+		notificationController.show({
+			message: `${isAllFavorite ? `Remove ${cnt} from` : `Add ${cnt} to`} favorites`,
+			type: NotificationType.Info
+		});
+
+		clearMultiSelectAssetAssetHandler();
+	};
+
+	const clearMultiSelectAssetAssetHandler = () => {
+		selectedAssets = new Set();
+	};
+
+	const deleteSelectedAssetHandler = async () => {
+		try {
+			if (
+				window.confirm(
+					`Caution! Are you sure you want to delete ${selectedAssets.size} assets? This step also deletes assets in the album(s) to which they belong. You can not undo this action!`
+				)
+			) {
+				const { data: deletedAssets } = await api.assetApi.deleteAsset({
+					ids: Array.from(selectedAssets).map((a) => a.id)
+				});
+
+				for (const asset of deletedAssets) {
+					if (asset.status == 'SUCCESS') {
+						data.results.assets.items = data.results.assets.items.filter((a) => a.id != asset.id);
+					}
+				}
+
+				clearMultiSelectAssetAssetHandler();
+			}
+		} catch (e) {
+			notificationController.show({
+				type: NotificationType.Error,
+				message: 'Error deleting assets, check console for more details'
+			});
+			console.error('Error deleteSelectedAssetHandler', e);
+		}
+	};
+	const handleCreateSharedLink = async () => {
+		isShowCreateSharedLinkModal = true;
+	};
+
+	const handleCloseSharedLinkModal = () => {
+		clearMultiSelectAssetAssetHandler();
+		isShowCreateSharedLinkModal = false;
+	};
 </script>
 
 <section>
-	<ControlAppBar on:close-button-click={() => goto(previousRoute)} backIcon={ArrowLeft}>
-		<div class="w-full max-w-2xl flex-1 pl-4">
-			<SearchBar grayTheme={false} value={term} />
-		</div>
-	</ControlAppBar>
+	{#if isMultiSelectionMode}
+		<ControlAppBar
+			on:close-button-click={clearMultiSelectAssetAssetHandler}
+			backIcon={Close}
+			tailwindClasses={'bg-white shadow-md'}
+		>
+			<svelte:fragment slot="leading">
+				<p class="font-medium text-immich-primary dark:text-immich-dark-primary">
+					Selected {selectedAssets.size.toLocaleString($locale)}
+				</p>
+			</svelte:fragment>
+			<svelte:fragment slot="trailing">
+				<CircleIconButton
+					title="Share"
+					logo={ShareVariantOutline}
+					on:click={handleCreateSharedLink}
+				/>
+
+				<CircleIconButton
+					title="Unarchive"
+					logo={isAllArchived ? ArchiveArrowUpOutline : ArchiveArrowDownOutline}
+					on:click={toggleArchive}
+				/>
+
+				<CircleIconButton
+					title="Download"
+					logo={CloudDownloadOutline}
+					on:click={handleDownloadFiles}
+				/>
+				<CircleIconButton title="Add" logo={Plus} on:click={handleShowMenu} />
+				<CircleIconButton
+					title="Delete"
+					logo={DeleteOutline}
+					on:click={deleteSelectedAssetHandler}
+				/>
+			</svelte:fragment>
+		</ControlAppBar>
+	{:else}
+		<ControlAppBar on:close-button-click={() => goto(previousRoute)} backIcon={ArrowLeft}>
+			<div class="w-full max-w-2xl flex-1 pl-4">
+				<SearchBar grayTheme={false} value={term} />
+			</div>
+		</ControlAppBar>
+	{/if}
 </section>
 
 <section class="relative pt-32 mb-12 bg-immich-bg dark:bg-immich-dark-bg">
@@ -40,8 +235,9 @@
 				<div class="pl-4">
 					<GalleryViewer
 						assets={data.results.assets.items}
-						disableAssetSelect
+						bind:selectedAssets
 						viewFrom="search-page"
+						isSearchResult={true}
 					/>
 				</div>
 			{:else}
@@ -57,4 +253,35 @@
 			{/if}
 		</section>
 	</section>
+
+	{#if isShowAddMenu}
+		<ContextMenu {...contextMenuPosition} on:clickoutside={() => (isShowAddMenu = false)}>
+			<div class="flex flex-col rounded-lg ">
+				<MenuOption
+					on:click={toggleFavorite}
+					text={isAllFavorite ? 'Remove from favorites' : 'Add to favorites'}
+				/>
+				<MenuOption on:click={() => handleShowAlbumPicker(false)} text="Add to Album" />
+				<MenuOption on:click={() => handleShowAlbumPicker(true)} text="Add to Shared Album" />
+			</div>
+		</ContextMenu>
+	{/if}
+
+	{#if isShowAlbumPicker}
+		<AlbumSelectionModal
+			shared={addToSharedAlbum}
+			on:newAlbum={handleAddToNewAlbum}
+			on:newSharedAlbum={handleAddToNewAlbum}
+			on:album={handleAddToAlbum}
+			on:close={() => (isShowAlbumPicker = false)}
+		/>
+	{/if}
+
+	{#if isShowCreateSharedLinkModal}
+		<CreateSharedLinkModal
+			sharedAssets={Array.from(selectedAssets)}
+			shareType={SharedLinkType.Individual}
+			on:close={handleCloseSharedLinkModal}
+		/>
+	{/if}
 </section>

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -111,7 +111,7 @@
 
 			asset.isArchived = !isAllArchived;
 
-			searchResultAssets = searchResultAssets.map((a) => {
+			searchResultAssets = searchResultAssets.map((a: AssetResponseDto) => {
 				if (a.id === asset.id) {
 					a = asset;
 				}
@@ -140,7 +140,7 @@
 
 			asset.isFavorite = !isAllFavorite;
 
-			searchResultAssets = searchResultAssets.map((a) => {
+			searchResultAssets = searchResultAssets.map((a: AssetResponseDto) => {
 				if (a.id === asset.id) {
 					a = asset;
 				}

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -239,7 +239,7 @@
 						assets={data.results.assets.items}
 						bind:selectedAssets
 						viewFrom="search-page"
-						isSearchResult={true}
+						showArchiveIcon={true}
 					/>
 				</div>
 			{:else}

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -113,8 +113,9 @@
 
 			searchResultAssets = searchResultAssets.map((a) => {
 				if (a.id === asset.id) {
-					a.isArchived = !isAllArchived;
+					a = asset;
 				}
+
 				return a;
 			});
 		}
@@ -141,7 +142,7 @@
 
 			searchResultAssets = searchResultAssets.map((a) => {
 				if (a.id === asset.id) {
-					a.isFavorite = !isAllFavorite;
+					a = asset;
 				}
 				return a;
 			});

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -52,6 +52,7 @@
 	let isShowAddMenu = false;
 	let isShowAlbumPicker = false;
 	let addToSharedAlbum = false;
+	$: searchResultAssets = data.results.assets.items;
 
 	const handleShowMenu = ({ x, y }: MouseEvent) => {
 		contextMenuPosition = { x, y };
@@ -109,6 +110,13 @@
 			cnt = cnt + 1;
 
 			asset.isArchived = !isAllArchived;
+
+			searchResultAssets = searchResultAssets.map((a) => {
+				if (a.id === asset.id) {
+					a.isArchived = !isAllArchived;
+				}
+				return a;
+			});
 		}
 
 		notificationController.show({
@@ -130,6 +138,13 @@
 			cnt = cnt + 1;
 
 			asset.isFavorite = !isAllFavorite;
+
+			searchResultAssets = searchResultAssets.map((a) => {
+				if (a.id === asset.id) {
+					a.isFavorite = !isAllFavorite;
+				}
+				return a;
+			});
 		}
 
 		notificationController.show({
@@ -157,7 +172,7 @@
 
 				for (const asset of deletedAssets) {
 					if (asset.status == 'SUCCESS') {
-						data.results.assets.items = data.results.assets.items.filter(
+						searchResultAssets = searchResultAssets.filter(
 							(a: AssetResponseDto) => a.id != asset.id
 						);
 					}
@@ -203,7 +218,7 @@
 				/>
 
 				<CircleIconButton
-					title="Unarchive"
+					title={isAllArchived ? 'Unarchive' : 'Archive'}
 					logo={isAllArchived ? ArchiveArrowUpOutline : ArchiveArrowDownOutline}
 					on:click={toggleArchive}
 				/>
@@ -236,7 +251,7 @@
 			{#if data.results?.assets?.items.length > 0}
 				<div class="pl-4">
 					<GalleryViewer
-						assets={data.results.assets.items}
+						assets={searchResultAssets}
 						bind:selectedAssets
 						viewFrom="search-page"
 						showArchiveIcon={true}

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -157,7 +157,9 @@
 
 				for (const asset of deletedAssets) {
 					if (asset.status == 'SUCCESS') {
-						data.results.assets.items = data.results.assets.items.filter((a) => a.id != asset.id);
+						data.results.assets.items = data.results.assets.items.filter(
+							(a: AssetResponseDto) => a.id != asset.id
+						);
 					}
 				}
 


### PR DESCRIPTION
Resolved #2307 #2308

* Add archive icon to thumbnail - only displayed on the search page
* Favorite and archive icon shows on the thumbnail on the search page
* Bulk toggle archive/favorite - if one of the selected assets is not in the archive/favorite, the action would be to archive/favorite all - if all the selected assets are archived/favorite or not-archived/not-favorite, the option would be unarchived/unfavorite and archived/favorite, respectively