### PR TITLE
feat(web): show asset count in sharing tab and album viewer

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -504,7 +504,7 @@
 
 		{#if album.assetCount > 0}
 			<span
-				class="text-xs flex gap-2 my-4 text-sm text-gray-500 font-medium"
+				class="flex gap-2 my-4 text-sm text-gray-500 font-medium"
 				data-testid="album-details"
 			>
 				<p class="">{getDateRange()}</p>

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -503,7 +503,14 @@
 		/>
 
 		{#if album.assetCount > 0}
-			<p class="my-4 text-sm text-gray-500 font-medium">{getDateRange()}</p>
+			<span
+				class="text-xs flex gap-2 my-4 text-sm text-gray-500 font-medium"
+				data-testid="album-details"
+			>
+				<p class="">{getDateRange()}</p>
+				<p>·</p>
+				<p>{album.assetCount} items</p>
+			</span>
 		{/if}
 		{#if album.shared}
 			<div class="my-6 flex">

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -503,10 +503,7 @@
 		/>
 
 		{#if album.assetCount > 0}
-			<span
-				class="flex gap-2 my-4 text-sm text-gray-500 font-medium"
-				data-testid="album-details"
-			>
+			<span class="flex gap-2 my-4 text-sm text-gray-500 font-medium" data-testid="album-details">
 				<p class="">{getDateRange()}</p>
 				<p>·</p>
 				<p>{album.assetCount} items</p>

--- a/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
+++ b/web/src/lib/components/sharing-page/shared-album-list-tile.svelte
@@ -56,16 +56,19 @@
 		<p class="font-medium text-gray-800 dark:text-immich-dark-primary">
 			{album.albumName}
 		</p>
-
-		{#await getAlbumOwnerInfo() then albumOwner}
-			{#if user.email == albumOwner.email}
-				<p class="text-xs text-gray-600 dark:text-immich-dark-fg">Owned</p>
-			{:else}
-				<p class="text-xs text-gray-600 dark:text-immich-dark-fg">
-					Shared by {albumOwner.firstName}
-					{albumOwner.lastName}
-				</p>
-			{/if}
-		{/await}
+		<span class="text-xs flex gap-2 dark:text-immich-dark-fg" data-testid="album-details"
+			><p>{album.assetCount} items</p>
+			<p>·</p>
+			{#await getAlbumOwnerInfo() then albumOwner}
+				{#if user.email == albumOwner.email}
+					<p class="text-xs text-gray-600 dark:text-immich-dark-fg">Owned</p>
+				{:else}
+					<p class="text-xs text-gray-600 dark:text-immich-dark-fg">
+						Shared by {albumOwner.firstName}
+						{albumOwner.lastName}
+					</p>
+				{/if}
+			{/await}
+		</span>
 	</div>
 </div>


### PR DESCRIPTION
Resolves #2301 partially. Mobile still needs to be done.
<img width="958" alt="sharing-tab-shared" src="https://user-images.githubusercontent.com/22776173/233693898-32f55880-e738-4540-8191-8e7c672833a3.png">
![link-album-viewer](https://user-images.githubusercontent.com/22776173/233693900-83a78801-894c-42f1-b87b-ee21a320fc8a.png)
![album-viewer](https://user-images.githubusercontent.com/22776173/233693904-8c5c1e2c-ce12-4d88-a3d7-3c18f43a1b27.png)
