### PR TITLE
fix(server): use current schema for search/explore

### DIFF
--- a/server/libs/infra/src/repositories/typesense.repository.ts
+++ b/server/libs/infra/src/repositories/typesense.repository.ts
@@ -132,15 +132,13 @@ export class TypesenseRepository implements ISearchRepository {
   }
 
   async explore(userId: string): Promise<SearchExploreItem<AssetEntity>[]> {
-    const alias = await this.client.aliases(SearchCollection.ASSETS).retrieve();
-
     const common = {
       q: '*',
       filter_by: this.buildFilterBy('ownerId', userId, true),
       per_page: 100,
     };
 
-    const asset$ = this.client.collections<AssetEntity>(alias.collection_name).documents();
+    const asset$ = this.client.collections<AssetEntity>(assetSchema.name).documents();
 
     const { facet_counts: facets } = await asset$.search({
       ...common,
@@ -208,10 +206,8 @@ export class TypesenseRepository implements ISearchRepository {
   }
 
   async searchAlbums(query: string, filters: SearchFilter): Promise<SearchResult<AlbumEntity>> {
-    const alias = await this.client.aliases(SearchCollection.ALBUMS).retrieve();
-
     const results = await this.client
-      .collections<AlbumEntity>(alias.collection_name)
+      .collections<AlbumEntity>(albumSchema.name)
       .documents()
       .search({
         q: query,
@@ -223,9 +219,8 @@ export class TypesenseRepository implements ISearchRepository {
   }
 
   async searchAssets(query: string, filters: SearchFilter): Promise<SearchResult<AssetEntity>> {
-    const alias = await this.client.aliases(SearchCollection.ASSETS).retrieve();
     const results = await this.client
-      .collections<AssetEntity>(alias.collection_name)
+      .collections<AssetEntity>(assetSchema.name)
       .documents()
       .search({
         q: query,
@@ -248,12 +243,10 @@ export class TypesenseRepository implements ISearchRepository {
   }
 
   async vectorSearch(input: number[], filters: SearchFilter): Promise<SearchResult<AssetEntity>> {
-    const alias = await this.client.aliases(SearchCollection.ASSETS).retrieve();
-
     const { results } = await this.client.multiSearch.perform({
       searches: [
         {
-          collection: alias.collection_name,
+          collection: assetSchema.name,
           q: '*',
           vector_query: `smartInfo.clipEmbedding:([${input.join(',')}], k:100)`,
           per_page: 250,


### PR DESCRIPTION
Previously, typesense would only uses fully-indexed collections. This changes that to always use the most recent collection, regardless of index status. The results of this change should be:

1. Explore/search functionality is available sooner on new installs (searchable as they're being indexed)
2. Migrations won't break search/explore with 400 Bad Request errors while indexing is happening (if explore references a new field, that doesn't exist in the old schema, it would lead to this situation)

Related to:
- #2330