### PR TITLE
fix(server): oauth mobile callback url

### DIFF
--- a/server/libs/domain/src/oauth/oauth.core.ts
+++ b/server/libs/domain/src/oauth/oauth.core.ts
@@ -97,7 +97,7 @@ export class OAuthCore {
   }
 
   private normalize(redirectUri: string) {
-    const isMobile = redirectUri === MOBILE_REDIRECT;
+    const isMobile = redirectUri.startsWith(MOBILE_REDIRECT);
     const { mobileRedirectUri, mobileOverrideEnabled } = this.config.oauth;
     if (isMobile && mobileOverrideEnabled && mobileRedirectUri) {
       return mobileRedirectUri;

--- a/server/libs/domain/src/oauth/oauth.service.spec.ts
+++ b/server/libs/domain/src/oauth/oauth.service.spec.ts
@@ -154,6 +154,17 @@ describe('OAuthService', () => {
 
       expect(callbackMock).toHaveBeenCalledWith('http://mobile-redirect', { state: 'state' }, { state: 'state' });
     });
+
+    it('should use the mobile redirect override for ios urls with multiple slashes', async () => {
+      sut = create(systemConfigStub.override);
+
+      userMock.getByOAuthId.mockResolvedValue(userEntityStub.user1);
+      userTokenMock.create.mockResolvedValue(userTokenEntityStub.userToken);
+
+      await sut.login({ url: `app.immich:///?code=abc123` }, loginDetails);
+
+      expect(callbackMock).toHaveBeenCalledWith('http://mobile-redirect', { state: 'state' }, { state: 'state' });
+    });
   });
 
   describe('link', () => {


### PR DESCRIPTION
Fixes #1495, which for some reason would redirect to the app with the url `app.immich:///?code=...`