### PR TITLE
fix(web): remove global style from map marker

### DIFF
--- a/web/src/lib/components/shared-components/leaflet/asset-marker-cluster.svelte
+++ b/web/src/lib/components/shared-components/leaflet/asset-marker-cluster.svelte
@@ -100,18 +100,13 @@
 	<slot />
 {/if}
 
-<style>
-	:global(.leaflet-marker-icon) {
-		border-radius: 50%;
-	}
-
+<style lang="postcss">
 	:global(.marker-cluster) {
 		background-clip: padding-box;
-		border-radius: 20px;
 	}
 
 	:global(.asset-marker-icon) {
-		border-radius: 50%;
+		@apply rounded-full;
 		object-fit: cover;
 		border: 1px solid rgb(69, 80, 169);
 		box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 2px, rgba(0, 0, 0, 0.07) 0px 2px 4px,
@@ -126,7 +121,7 @@
 		margin-top: 5px;
 
 		text-align: center;
-		border-radius: 20px;
+		@apply rounded-full;
 		font-weight: bold;
 
 		background-color: rgb(236, 237, 246);


### PR DESCRIPTION
The `AssetMarkerCluster` component styles the global `leaflet-marker-icon` class, causing the map marker in other components to also get a border radius which is unwanted.

![image](https://github.com/immich-app/immich/assets/59014050/7c6e2430-0cf9-4b93-b0a0-47041c167c43)![image](https://github.com/immich-app/immich/assets/59014050/3e6371ff-0bdc-4964-b35f-b06557efdc72)
