### PR TITLE
Revert "Bump local-reverse-geocoder to 0.15.2 / Fix Corrupted Reverse Geocoding CSV File"

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -36,7 +36,7 @@
         "i18n-iso-countries": "^7.5.0",
         "ioredis": "^5.3.1",
         "joi": "^17.5.0",
-        "local-reverse-geocoder": "^0.15.2",
+        "local-reverse-geocoder": "0.12.5",
         "lodash": "^4.17.21",
         "luxon": "^3.0.3",
         "mv": "^2.1.1",
@@ -4737,9 +4737,9 @@
       "dev": true
     },
     "node_modules/csv-parse": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.10.tgz",
-      "integrity": "sha512-cTXY6iy0gN5Ha/cGILeDgQE+nKiKDU2m0DjSRdJhr86BN3cM7oefBsTk2aH0LQeaYtL7Z7HvW+jYoadmdhzeDA=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.3.tgz",
+      "integrity": "sha512-kEWkAPleNEdhFNkHQpFHu9RYPogsFj3dx6bCxL847fsiLgidzWg0z/O0B1kVWMJUc5ky64zGp18LX2T3DQrOfw=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -8026,21 +8026,20 @@
       }
     },
     "node_modules/local-reverse-geocoder": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.15.2.tgz",
-      "integrity": "sha512-/YnNZjnjFKiGc8EVeA3qz7iSTbtG437jgPdjrj+8wLw2UVtOLgAyaB7HWDYwut9MVA5lyoYkeJ9XX9dXgsIPMA==",
-      "hasInstallScript": true,
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.5.tgz",
+      "integrity": "sha512-FaH8+T29K9PQRiiqYlt+M9Qvq9GlSnWEnX0FTDXgPrNzQ9SWWYGEvO5uODwAD6sep9z19u/K/+Z3cw4AGVW97Q==",
       "dependencies": {
         "async": "^3.2.4",
-        "csv-parse": "^5.3.10",
+        "csv-parse": "^5.3.0",
         "debug": "^4.3.4",
         "kdt": "^0.1.0",
         "request": "^2.88.2",
         "unzip-stream": "^0.3.1"
       },
       "engines": {
-        "node": ">=11.0.0",
-        "npm": ">=6.4.1"
+        "node": ">=10.15.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -15380,9 +15379,9 @@
       }
     },
     "csv-parse": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.10.tgz",
-      "integrity": "sha512-cTXY6iy0gN5Ha/cGILeDgQE+nKiKDU2m0DjSRdJhr86BN3cM7oefBsTk2aH0LQeaYtL7Z7HvW+jYoadmdhzeDA=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.3.tgz",
+      "integrity": "sha512-kEWkAPleNEdhFNkHQpFHu9RYPogsFj3dx6bCxL847fsiLgidzWg0z/O0B1kVWMJUc5ky64zGp18LX2T3DQrOfw=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -17865,12 +17864,12 @@
       "dev": true
     },
     "local-reverse-geocoder": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.15.2.tgz",
-      "integrity": "sha512-/YnNZjnjFKiGc8EVeA3qz7iSTbtG437jgPdjrj+8wLw2UVtOLgAyaB7HWDYwut9MVA5lyoYkeJ9XX9dXgsIPMA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/local-reverse-geocoder/-/local-reverse-geocoder-0.12.5.tgz",
+      "integrity": "sha512-FaH8+T29K9PQRiiqYlt+M9Qvq9GlSnWEnX0FTDXgPrNzQ9SWWYGEvO5uODwAD6sep9z19u/K/+Z3cw4AGVW97Q==",
       "requires": {
         "async": "^3.2.4",
-        "csv-parse": "^5.3.10",
+        "csv-parse": "^5.3.0",
         "debug": "^4.3.4",
         "kdt": "^0.1.0",
         "request": "^2.88.2",

--- a/server/package.json
+++ b/server/package.json
@@ -67,7 +67,7 @@
     "i18n-iso-countries": "^7.5.0",
     "ioredis": "^5.3.1",
     "joi": "^17.5.0",
-    "local-reverse-geocoder": "^0.15.2",
+    "local-reverse-geocoder": "0.12.5",
     "lodash": "^4.17.21",
     "luxon": "^3.0.3",
     "mv": "^2.1.1",


### PR DESCRIPTION
Reverts immich-app/immich#2396

Unfortunately, the new approach to avoiding corrupted files in the local-reverse-geocoder lib causes a problem with cross-device links, see #2402.