### PR TITLE
chore(web): update svelte related packages

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,7 +26,7 @@
 				"@babel/preset-typescript": "^7.18.6",
 				"@faker-js/faker": "^7.6.0",
 				"@sveltejs/adapter-node": "^1.2.0",
-				"@sveltejs/kit": "^1.8.5",
+				"@sveltejs/kit": "^1.15.2",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/svelte": "^3.2.2",
 				"@types/cookie": "^0.5.1",
@@ -3159,9 +3159,9 @@
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"node_modules/@sveltejs/adapter-node": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.3.tgz",
-			"integrity": "sha512-Fv6NyVpVWYA63KRaV6dDjcU8ytcWFiUr0siJOoHl+oWy5WHNEuRiJOUdiZzYbZo8MmvFaCoxHkTgPrVQhpqaRA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.4.tgz",
+			"integrity": "sha512-TNnhS+OKRZ9RKnC+ho5mlE2FJquI61i0v7yOXxBUSU3LAoYH2kwVVL8P8ecjefmZ8BOfM1V54pBnDODBU5CEaA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/plugin-commonjs": "^24.0.0",
@@ -3174,13 +3174,13 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
-			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.16.3.tgz",
+			"integrity": "sha512-8uv0udYRpVuE1BweFidcWHfL+u2gAANKmvIal1dN/FWPBl7DJYbt9zYEtr3bNTiXystT8Sn0Wp54RfwpbPqHjQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^2.0.0",
+				"@sveltejs/vite-plugin-svelte": "^2.1.1",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
 				"devalue": "^4.3.0",
@@ -3189,10 +3189,10 @@
 				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.5.1",
+				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.20.0"
+				"undici": "~5.22.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -3218,15 +3218,15 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
-			"integrity": "sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.2.0.tgz",
+			"integrity": "sha512-KDtdva+FZrZlyug15KlbXuubntAPKcBau0K7QhAIqC5SAy0uDbjZwoexDRx0L0J2T4niEfC6FnA9GuQQJKg+Aw==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",
-				"deepmerge": "^4.3.0",
+				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.29.0",
+				"magic-string": "^0.30.0",
 				"svelte-hmr": "^0.15.1",
 				"vitefu": "^0.2.4"
 			},
@@ -3239,9 +3239,9 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
-			"integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
@@ -4954,9 +4954,9 @@
 			"dev": true
 		},
 		"node_modules/deepmerge": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -9330,10 +9330,16 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -9692,9 +9698,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+			"integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
 			"dev": true,
 			"funding": [
 				{
@@ -9704,10 +9710,14 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -10201,9 +10211,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.18.0.tgz",
-			"integrity": "sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==",
+			"version": "3.21.6",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.6.tgz",
+			"integrity": "sha512-SXIICxvxQxR3D4dp/3LDHZIJPC8a4anKMHd4E3Jiz2/JnY+2bEjqrOokAauc5ShGVNFHlEFjBXAXlaxkJqIqSg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -10350,9 +10360,9 @@
 			}
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
 			"dev": true
 		},
 		"node_modules/shallow-clone": {
@@ -10659,17 +10669,17 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.58.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
-			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
+			"version": "3.59.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.1.tgz",
+			"integrity": "sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==",
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
-			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.3.2.tgz",
+			"integrity": "sha512-67j3rI0LDc2DvL0ON/2pvCasVVD3nHDrTkZNr4eITNfo2oFXdw7SIyMOiFj4swu+pjmFQAigytBK1IWyik8dBw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -11058,15 +11068,15 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=12.18"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -13691,9 +13701,9 @@
 			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
 		},
 		"@sveltejs/adapter-node": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.3.tgz",
-			"integrity": "sha512-Fv6NyVpVWYA63KRaV6dDjcU8ytcWFiUr0siJOoHl+oWy5WHNEuRiJOUdiZzYbZo8MmvFaCoxHkTgPrVQhpqaRA==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.2.4.tgz",
+			"integrity": "sha512-TNnhS+OKRZ9RKnC+ho5mlE2FJquI61i0v7yOXxBUSU3LAoYH2kwVVL8P8ecjefmZ8BOfM1V54pBnDODBU5CEaA==",
 			"dev": true,
 			"requires": {
 				"@rollup/plugin-commonjs": "^24.0.0",
@@ -13703,12 +13713,12 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.1.tgz",
-			"integrity": "sha512-Wexy3N+COoClTuRawVJRbLoH5HFxNrXG3uoHt/Yd5IGx8WAcJM9Nj/CcBLw/tjCR9uDDYMnx27HxuPy3YIYQUA==",
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.16.3.tgz",
+			"integrity": "sha512-8uv0udYRpVuE1BweFidcWHfL+u2gAANKmvIal1dN/FWPBl7DJYbt9zYEtr3bNTiXystT8Sn0Wp54RfwpbPqHjQ==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^2.0.0",
+				"@sveltejs/vite-plugin-svelte": "^2.1.1",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
 				"devalue": "^4.3.0",
@@ -13717,10 +13727,10 @@
 				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.5.1",
+				"set-cookie-parser": "^2.6.0",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.20.0"
+				"undici": "~5.22.0"
 			},
 			"dependencies": {
 				"magic-string": {
@@ -13735,23 +13745,23 @@
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
-			"integrity": "sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.2.0.tgz",
+			"integrity": "sha512-KDtdva+FZrZlyug15KlbXuubntAPKcBau0K7QhAIqC5SAy0uDbjZwoexDRx0L0J2T4niEfC6FnA9GuQQJKg+Aw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.3.4",
-				"deepmerge": "^4.3.0",
+				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.29.0",
+				"magic-string": "^0.30.0",
 				"svelte-hmr": "^0.15.1",
 				"vitefu": "^0.2.4"
 			},
 			"dependencies": {
 				"magic-string": {
-					"version": "0.29.0",
-					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
-					"integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+					"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 					"dev": true,
 					"requires": {
 						"@jridgewell/sourcemap-codec": "^1.4.13"
@@ -15050,9 +15060,9 @@
 			"dev": true
 		},
 		"deepmerge": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
-			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true
 		},
 		"define-properties": {
@@ -18280,9 +18290,9 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -18542,12 +18552,12 @@
 			}
 		},
 		"postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+			"integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -18881,9 +18891,9 @@
 			}
 		},
 		"rollup": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.18.0.tgz",
-			"integrity": "sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==",
+			"version": "3.21.6",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.6.tgz",
+			"integrity": "sha512-SXIICxvxQxR3D4dp/3LDHZIJPC8a4anKMHd4E3Jiz2/JnY+2bEjqrOokAauc5ShGVNFHlEFjBXAXlaxkJqIqSg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -18987,9 +18997,9 @@
 			"dev": true
 		},
 		"set-cookie-parser": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
 			"dev": true
 		},
 		"shallow-clone": {
@@ -19220,14 +19230,14 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "3.58.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
-			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A=="
+			"version": "3.59.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.1.tgz",
+			"integrity": "sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ=="
 		},
 		"svelte-check": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
-			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.3.2.tgz",
+			"integrity": "sha512-67j3rI0LDc2DvL0ON/2pvCasVVD3nHDrTkZNr4eITNfo2oFXdw7SIyMOiFj4swu+pjmFQAigytBK1IWyik8dBw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -19479,9 +19489,9 @@
 			"optional": true
 		},
 		"undici": {
-			"version": "5.20.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
 		"@babel/preset-typescript": "^7.18.6",
 		"@faker-js/faker": "^7.6.0",
 		"@sveltejs/adapter-node": "^1.2.0",
-		"@sveltejs/kit": "^1.8.5",
+		"@sveltejs/kit": "^1.15.2",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/svelte": "^3.2.2",
 		"@types/cookie": "^0.5.1",


### PR DESCRIPTION
Updates svelte related packages, I know #2242 exists but that's already outdated and has lots of conflicts.
- `svelte` from 3.58.0 to 3.59.1
- `svelte-check` from 3.2.0 to 3.3.2
- `@sveltejs/adapter-node` from 1.2.3 to 1.2.4
- `@sveltejs/kit` from 1.15.1 to 1.16.3 (also update minimum to ^1.15.2 because earlier versions are vulnerable)

Basic functionality has been tested in both dev and prod mode