### PR TITLE
chore(ci): versions the Docker cleaning action to latest released

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -38,11 +38,12 @@ jobs:
       -
         name: Clean temporary images
         if: "${{ env.TOKEN != '' }}"
-        uses: stumpylog/image-cleaner-action/ephemeral@develop
+        uses: stumpylog/image-cleaner-action/ephemeral@v0.1.0
         with:
           token: "${{ env.TOKEN }}"
           owner: "immich-app"
           is_org: "true"
+          do_delete: "true"
           package_name: "${{ matrix.primary-name }}"
           scheme: "pull_request"
           repo_name: "immich"
@@ -69,9 +70,10 @@ jobs:
       -
         name: Clean untagged images
         if: "${{ env.TOKEN != '' }}"
-        uses: stumpylog/image-cleaner-action/untagged@develop
+        uses: stumpylog/image-cleaner-action/untagged@v0.1.0
         with:
           token: "${{ env.TOKEN }}"
           owner: "immich-app"
+          do_delete: "true"
           is_org: "true"
           package_name: "${{ matrix.primary-name }}"


### PR DESCRIPTION
This is a follow up to #2302.  

I've versioned my action, and set that latest release as the version for immich to use.  This also lets me continue to develop the action without affecting users.  This version [has been running over here](https://github.com/paperless-ngx/paperless-ngx/actions/workflows/cleanup-tags.yml) without issue.

This also enables the actual deletion.  I've been watching the dry runs and the images which would be removed all look correct, so I feel confident in enabling the actual deletion at this point.