### PR TITLE
fix(web): layout spacing when zooming

### DIFF
--- a/web/src/lib/components/layouts/user-page-layout.svelte
+++ b/web/src/lib/components/layouts/user-page-layout.svelte
@@ -22,7 +22,7 @@
 </header>
 
 <main
-	class="grid md:grid-cols-[250px_auto] grid-cols-[70px_auto] relative pt-[4.25rem] h-screen bg-immich-bg dark:bg-immich-dark-bg immich-scrollbar"
+	class="grid md:grid-cols-[theme(spacing.64)_auto] grid-cols-[theme(spacing.18)_auto] relative pt-[var(--navbar-height)] h-screen bg-immich-bg dark:bg-immich-dark-bg immich-scrollbar"
 >
 	<SideBar />
 	<slot name="content">

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -40,9 +40,9 @@
 	};
 </script>
 
-<section id="dashboard-navbar" class="fixed h-[4.25rem] w-screen z-[900] text-sm">
+<section id="dashboard-navbar" class="fixed h-[var(--navbar-height)] w-screen z-[900] text-sm">
 	<div
-		class="grid md:grid-cols-[250px_auto] grid-cols-[70px_auto] border-b dark:border-b-immich-dark-gray items-center py-2 bg-immich-bg dark:bg-immich-dark-bg"
+		class="grid h-full md:grid-cols-[theme(spacing.64)_auto] grid-cols-[theme(spacing.18)_auto] border-b dark:border-b-immich-dark-gray items-center py-2 bg-immich-bg dark:bg-immich-dark-bg"
 	>
 		<a
 			data-sveltekit-preload-data="hover"
@@ -76,7 +76,7 @@
 					<div in:fly={{ x: 50, duration: 250 }}>
 						<LinkButton on:click={() => dispatch('uploadClicked')}>
 							<div class="flex gap-2">
-								<TrayArrowUp size="20" />
+								<TrayArrowUp size="1.5em" />
 								<span class="md:block hidden">Upload</span>
 							</div>
 						</LinkButton>
@@ -158,3 +158,10 @@
 		</div>
 	</div>
 </section>
+
+<style>
+	:root {
+		/* Used by layouts to ensure proper spacing between navbar and content */
+		--navbar-height: calc(theme(spacing.18) + 4px);
+	}
+</style>

--- a/web/src/lib/components/shared-components/side-bar/side-bar-section.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar-section.svelte
@@ -3,7 +3,7 @@
 
 <section
 	id="sidebar"
-	class="group flex flex-col gap-1 pt-8 bg-immich-bg dark:bg-immich-dark-bg transition-all duration-200 z-10 w-[72px] md:w-64 hover:sm:pr-6 md:pr-6 hover:sm:w-64 hover:sm:shadow-2xl hover:md:shadow-none hover:md:border-none hover:sm:border-r hover:sm:dark:border-r-immich-dark-gray"
+	class="group flex flex-col gap-1 pt-8 bg-immich-bg dark:bg-immich-dark-bg transition-all duration-200 z-10 w-18 md:w-64 hover:sm:pr-6 md:pr-6 hover:sm:w-64 hover:sm:shadow-2xl hover:md:shadow-none hover:md:border-none hover:sm:border-r hover:sm:dark:border-r-immich-dark-gray"
 >
 	<slot />
 </section>

--- a/web/src/routes/(user)/partners/[userId]/+page.svelte
+++ b/web/src/routes/(user)/partners/[userId]/+page.svelte
@@ -21,7 +21,7 @@
 	});
 </script>
 
-<main class="grid h-screen pt-[4.25rem] bg-immich-bg dark:bg-immich-dark-bg">
+<main class="grid h-screen pt-18 bg-immich-bg dark:bg-immich-dark-bg">
 	{#if $isMultiSelectStoreState}
 		<AssetSelectControlBar
 			assets={$selectedAssets}

--- a/web/src/routes/admin/+layout.svelte
+++ b/web/src/routes/admin/+layout.svelte
@@ -41,7 +41,9 @@
 <NavigationBar user={data.user} />
 
 <main>
-	<section class="grid md:grid-cols-[250px_auto] grid-cols-[70px_auto] pt-[72px] h-screen">
+	<section
+		class="grid md:grid-cols-[theme(spacing.64)_auto] grid-cols-[theme(spacing.18)_auto] pt-[var(--navbar-height)] h-screen"
+	>
 		<SideBarSection>
 			<SideBarButton
 				title="Users"

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	darkMode: 'class',
@@ -18,6 +19,9 @@ module.exports = {
 			},
 			fontFamily: {
 				'immich-title': ['Snowburst One', 'cursive']
+			},
+			spacing: {
+				18: '4.5rem'
 			}
 		}
 	},


### PR DESCRIPTION
The spacing for navbar, sidebar and main content were using a mix of pixels and rem causing inconsistent spacing when zooming. This has been fixed by using the appropriate units and values.

**Before - After with 150% zoom**

![before-150](https://github.com/immich-app/immich/assets/59014050/6217b22c-acd7-47d6-a4b9-c07287fd1fb3)
![after-150](https://github.com/immich-app/immich/assets/59014050/a960e06c-78fd-4fbc-aa11-2eebf9a88540)


