### PR TITLE
chore(web): switch to eslint-plugin-svelte package

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,23 +1,43 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
 	root: true,
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:svelte/recommended'
+	],
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-	plugins: ['svelte3', '@typescript-eslint'],
-	ignorePatterns: ['*.cjs'],
-	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
-	settings: {
-		'svelte3/typescript': () => require('typescript')
-	},
+	plugins: ['@typescript-eslint'],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020
+		ecmaVersion: 2020,
+		extraFileExtensions: ['.svelte']
 	},
 	env: {
 		browser: true,
 		es2017: true,
 		node: true
 	},
+	overrides: [
+		{
+			files: ['*.svelte'],
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser'
+			}
+		}
+	],
 	globals: {
 		NodeJS: true
+	},
+	rules: {
+		'@typescript-eslint/no-unused-vars': [
+			'warn',
+			{
+				// Allow underscore (_) variables
+				argsIgnorePattern: '^_$',
+				varsIgnorePattern: '^_$'
+			}
+		]
 	}
 };

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,7 +41,7 @@
 				"babel-jest": "^29.4.3",
 				"eslint": "^8.34.0",
 				"eslint-config-prettier": "^8.6.0",
-				"eslint-plugin-svelte3": "^4.0.0",
+				"eslint-plugin-svelte": "^2.28.0",
 				"factory.ts": "^1.3.0",
 				"identity-obj-proxy": "^3.0.0",
 				"jest": "^29.4.3",
@@ -5440,14 +5440,36 @@
 				"eslint": ">=7.0.0"
 			}
 		},
-		"node_modules/eslint-plugin-svelte3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-4.0.0.tgz",
-			"integrity": "sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==",
+		"node_modules/eslint-plugin-svelte": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.28.0.tgz",
+			"integrity": "sha512-bXPXKnjq5uKoVAQtC2E0L1Vp+mmJ3nlC9jyz8zwfZ99pQROL2h7Hes01QdYil1vxgh6tLXl5YVpZ2wwyAbBz5g==",
 			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14",
+				"debug": "^4.3.1",
+				"esutils": "^2.0.3",
+				"known-css-properties": "^0.27.0",
+				"postcss": "^8.4.5",
+				"postcss-load-config": "^3.1.4",
+				"postcss-safe-parser": "^6.0.0",
+				"svelte-eslint-parser": "^0.28.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
 			"peerDependencies": {
-				"eslint": ">=8.0.0",
-				"svelte": "^3.2.0"
+				"eslint": "^7.0.0 || ^8.0.0-0",
+				"svelte": "^3.37.0"
+			},
+			"peerDependenciesMeta": {
+				"svelte": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -9053,6 +9075,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/known-css-properties": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+			"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
+			"dev": true
+		},
 		"node_modules/leaflet": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
@@ -9810,6 +9838,22 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.14"
+			}
+		},
+		"node_modules/postcss-safe-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/postcss-selector-parser": {
@@ -10700,6 +10744,56 @@
 			},
 			"engines": {
 				"node": ">=12.20"
+			}
+		},
+		"node_modules/svelte-eslint-parser": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.28.0.tgz",
+			"integrity": "sha512-qWg5M3CIp7LkcdG5bpn44QEd48UxvgxG5L+Sbl701EG8Wujht7EqJuJhqgzvO3bbI9ENbWCXK49eCcwiNnpMzw==",
+			"dev": true,
+			"dependencies": {
+				"eslint-scope": "^7.0.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
+			"peerDependencies": {
+				"svelte": "^3.37.0"
+			},
+			"peerDependenciesMeta": {
+				"svelte": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/svelte-eslint-parser/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/svelte-hmr": {
@@ -15541,12 +15635,22 @@
 			"dev": true,
 			"requires": {}
 		},
-		"eslint-plugin-svelte3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-4.0.0.tgz",
-			"integrity": "sha512-OIx9lgaNzD02+MDFNLw0GEUbuovNcglg+wnd/UY0fbZmlQSz7GlQiQ1f+yX0XvC07XPcDOnFcichqI3xCwp71g==",
+		"eslint-plugin-svelte": {
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-2.28.0.tgz",
+			"integrity": "sha512-bXPXKnjq5uKoVAQtC2E0L1Vp+mmJ3nlC9jyz8zwfZ99pQROL2h7Hes01QdYil1vxgh6tLXl5YVpZ2wwyAbBz5g==",
 			"dev": true,
-			"requires": {}
+			"requires": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14",
+				"debug": "^4.3.1",
+				"esutils": "^2.0.3",
+				"known-css-properties": "^0.27.0",
+				"postcss": "^8.4.5",
+				"postcss-load-config": "^3.1.4",
+				"postcss-safe-parser": "^6.0.0",
+				"svelte-eslint-parser": "^0.28.0"
+			}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -18067,6 +18171,12 @@
 			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"dev": true
 		},
+		"known-css-properties": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+			"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
+			"dev": true
+		},
 		"leaflet": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
@@ -18589,6 +18699,13 @@
 			"requires": {
 				"postcss-selector-parser": "^6.0.10"
 			}
+		},
+		"postcss-safe-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+			"dev": true,
+			"requires": {}
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.11",
@@ -19237,6 +19354,35 @@
 					"version": "5.0.3",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
 					"integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+					"dev": true
+				}
+			}
+		},
+		"svelte-eslint-parser": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.28.0.tgz",
+			"integrity": "sha512-qWg5M3CIp7LkcdG5bpn44QEd48UxvgxG5L+Sbl701EG8Wujht7EqJuJhqgzvO3bbI9ENbWCXK49eCcwiNnpMzw==",
+			"dev": true,
+			"requires": {
+				"eslint-scope": "^7.0.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+					"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^5.2.0"
+					}
+				},
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				}
 			}

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
 		"babel-jest": "^29.4.3",
 		"eslint": "^8.34.0",
 		"eslint-config-prettier": "^8.6.0",
-		"eslint-plugin-svelte3": "^4.0.0",
+		"eslint-plugin-svelte": "^2.28.0",
 		"factory.ts": "^1.3.0",
 		"identity-obj-proxy": "^3.0.0",
 		"jest": "^29.4.3",

--- a/web/src/lib/components/admin-page/jobs/job-tile.svelte
+++ b/web/src/lib/components/admin-page/jobs/job-tile.svelte
@@ -91,12 +91,11 @@
 				</JobTileButton>
 			{/if}
 			{#if queueStatus.isPaused}
+				{@const size = waitingCount > 0 ? '24' : '48'}
 				<JobTileButton
 					color="light-gray"
 					on:click={() => dispatch('command', { command: JobCommand.Resume, force: false })}
 				>
-					{@const size = waitingCount > 0 ? '24' : '48'}
-
 					<!-- size property is not reactive, so have to use width and height -->
 					<FastForward width={size} height={size} /> RESUME
 				</JobTileButton>

--- a/web/src/lib/components/elements/buttons/circle-icon-button.svelte
+++ b/web/src/lib/components/elements/buttons/circle-icon-button.svelte
@@ -11,7 +11,7 @@
 
 <button
 	{title}
-	style:backgroundColor
+	style:background-color={backgroundColor}
 	style:--immich-icon-button-hover-color={hoverColor}
 	class="dark:text-immich-dark-fg rounded-full p-3 flex place-items-center place-content-center transition-all
 	{isOpacity

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -91,6 +91,6 @@
 	</div>
 
 	<p class="whitespace-pre-wrap text-sm pl-[28px] pr-[16px]" data-testid="message">
-		{@html notificationInfo.message}
+		{notificationInfo.message}
 	</p>
 </div>

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -11,6 +11,7 @@
 
 <FullscreenContainer title={data.meta.title} showMessage={!!loginPageMessage}>
 	<p slot="message">
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html loginPageMessage}
 	</p>
 


### PR DESCRIPTION
`eslint-plugin-svelte3` is [deprecated](https://github.com/sveltejs/eslint-plugin-svelte3#readme) and has been replaced by the recommended `eslint-plugin-svelte`. There were some errors and warnings as a result, which have been handled. The `@html` directive in `NotificationCard` is removed because it's no longer needed and poses an XSS risk.