### PR TITLE
fix(nginx): enable gzip and show error logs

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -135,8 +135,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - 2283:8080
-    logging:
-      driver: none
     depends_on:
       - immich-server
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,8 +87,6 @@ services:
       - IMMICH_WEB_URL
     ports:
       - 2283:8080
-    logging:
-      driver: none
     depends_on:
       - immich-server
     restart: always

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -28,7 +28,7 @@ server {
   client_max_body_size 50000M;
 
   # Compression
-  gzip off;
+  gzip on;
   gzip_comp_level 2;
   gzip_min_length 1000;
   gzip_proxied any;


### PR DESCRIPTION
Enable gzip for the nginx proxy and show error logs by removing `driver: none` from the docker compose file. This should help troubleshoot any configuration or container startup issues, especially for new users.