### PR TITLE
chore(server): queue handlers shouldn't increase concurrency

### DIFF
--- a/server/apps/microservices/src/processors.ts
+++ b/server/apps/microservices/src/processors.ts
@@ -68,7 +68,7 @@ export class BackgroundTaskProcessor {
 export class ObjectTaggingProcessor {
   constructor(private smartInfoService: SmartInfoService) {}
 
-  @Process({ name: JobName.QUEUE_OBJECT_TAGGING, concurrency: 1 })
+  @Process({ name: JobName.QUEUE_OBJECT_TAGGING, concurrency: 0 })
   async onQueueObjectTagging(job: Job<IBaseJob>) {
     await this.smartInfoService.handleQueueObjectTagging(job.data);
   }
@@ -88,7 +88,7 @@ export class ObjectTaggingProcessor {
 export class FacialRecognitionProcessor {
   constructor(private facialRecognitionService: FacialRecognitionService) {}
 
-  @Process({ name: JobName.QUEUE_RECOGNIZE_FACES, concurrency: 1 })
+  @Process({ name: JobName.QUEUE_RECOGNIZE_FACES, concurrency: 0 })
   async onQueueRecognizeFaces(job: Job<IBaseJob>) {
     await this.facialRecognitionService.handleQueueRecognizeFaces(job.data);
   }
@@ -108,7 +108,7 @@ export class FacialRecognitionProcessor {
 export class ClipEncodingProcessor {
   constructor(private smartInfoService: SmartInfoService) {}
 
-  @Process({ name: JobName.QUEUE_ENCODE_CLIP, concurrency: 1 })
+  @Process({ name: JobName.QUEUE_ENCODE_CLIP, concurrency: 0 })
   async onQueueClipEncoding(job: Job<IBaseJob>) {
     await this.smartInfoService.handleQueueEncodeClip(job.data);
   }
@@ -188,7 +188,7 @@ export class StorageTemplateMigrationProcessor {
 export class ThumbnailGeneratorProcessor {
   constructor(private mediaService: MediaService) {}
 
-  @Process({ name: JobName.QUEUE_GENERATE_THUMBNAILS, concurrency: 1 })
+  @Process({ name: JobName.QUEUE_GENERATE_THUMBNAILS, concurrency: 0 })
   async onQueueGenerateThumbnails(job: Job<IBaseJob>) {
     await this.mediaService.handleQueueGenerateThumbnails(job.data);
   }
@@ -208,7 +208,7 @@ export class ThumbnailGeneratorProcessor {
 export class VideoTranscodeProcessor {
   constructor(private mediaService: MediaService) {}
 
-  @Process({ name: JobName.QUEUE_VIDEO_CONVERSION, concurrency: 1 })
+  @Process({ name: JobName.QUEUE_VIDEO_CONVERSION, concurrency: 0 })
   async onQueueVideoConversion(job: Job<IBaseJob>): Promise<void> {
     await this.mediaService.handleQueueVideoConversion(job.data);
   }


### PR DESCRIPTION
Currently, queue handlers add an additional level of concurrency to each job despite taking up an insignificant amount of time. Once queueing is complete, this results in the remaining slower handlers of each processor to have levels of concurrency higher than intended. For instance, object tagging runs 3 jobs at a time despite object detection and image classification each being assigned a concurrency of 1, and 2 videos are transcoded at a time despite a transcode concurrency of 1.

With this PR, queue handlers will no longer offset concurrency.