### PR TITLE
feat(server): pagination for asset queries in jobs

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -8,10 +8,10 @@ import {
   JobName,
   JOBS_ASSET_PAGINATION_SIZE,
   QueueName,
+  usePagination,
   WithoutProperty,
 } from '@app/domain';
 import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { Process, Processor } from '@nestjs/bull';
 import { Inject, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';

--- a/server/libs/domain/src/asset/asset.core.ts
+++ b/server/libs/domain/src/asset/asset.core.ts
@@ -1,13 +1,9 @@
 import { AssetEntity } from '@app/infra/entities';
 import { IJobRepository, JobName } from '../job';
-import { AssetSearchOptions, IAssetRepository, LivePhotoSearchOptions } from './asset.repository';
+import { IAssetRepository, LivePhotoSearchOptions } from './asset.repository';
 
 export class AssetCore {
   constructor(private assetRepository: IAssetRepository, private jobRepository: IJobRepository) {}
-
-  getAll(options: AssetSearchOptions) {
-    return this.assetRepository.getAll(options);
-  }
 
   async save(asset: Partial<AssetEntity>) {
     const _asset = await this.assetRepository.save(asset);

--- a/server/libs/domain/src/asset/asset.repository.ts
+++ b/server/libs/domain/src/asset/asset.repository.ts
@@ -1,5 +1,5 @@
 import { AssetEntity, AssetType } from '@app/infra/entities';
-import { Paginated, PaginationOptions } from '@app/infra/utils/pagination.util';
+import { Paginated, PaginationOptions } from '../domain.util';
 
 export interface AssetSearchOptions {
   isVisible?: boolean;

--- a/server/libs/domain/src/asset/asset.repository.ts
+++ b/server/libs/domain/src/asset/asset.repository.ts
@@ -1,4 +1,5 @@
 import { AssetEntity, AssetType } from '@app/infra/entities';
+import { Paginated, PaginationOptions } from '@app/infra/utils/pagination.util';
 
 export interface AssetSearchOptions {
   isVisible?: boolean;
@@ -35,10 +36,10 @@ export const IAssetRepository = 'IAssetRepository';
 
 export interface IAssetRepository {
   getByIds(ids: string[]): Promise<AssetEntity[]>;
-  getWithout(property: WithoutProperty): Promise<AssetEntity[]>;
+  getWithout(pagination: PaginationOptions, property: WithoutProperty): Paginated<AssetEntity>;
   getFirstAssetForAlbumId(albumId: string): Promise<AssetEntity | null>;
   deleteAll(ownerId: string): Promise<void>;
-  getAll(options?: AssetSearchOptions): Promise<AssetEntity[]>;
+  getAll(pagination: PaginationOptions, options?: AssetSearchOptions): Paginated<AssetEntity>;
   save(asset: Partial<AssetEntity>): Promise<AssetEntity>;
   findLivePhotoMatch(options: LivePhotoSearchOptions): Promise<AssetEntity | null>;
   getMapMarkers(ownerId: string, options?: MapMarkerSearchOptions): Promise<MapMarker[]>;

--- a/server/libs/domain/src/domain.util.ts
+++ b/server/libs/domain/src/domain.util.ts
@@ -32,3 +32,28 @@ export function asHumanReadable(bytes: number, precision = 1): string {
 
   return `${remainder.toFixed(magnitude == 0 ? 0 : precision)} ${units[magnitude]}`;
 }
+
+export interface PaginationOptions {
+  take: number;
+  skip?: number;
+}
+
+export interface PaginationResult<T> {
+  items: T[];
+  hasNextPage: boolean;
+}
+
+export type Paginated<T> = Promise<PaginationResult<T>>;
+
+export async function* usePagination<T>(
+  pageSize: number,
+  getNextPage: (pagination: PaginationOptions) => Paginated<T>,
+) {
+  let hasNextPage = true;
+
+  for (let skip = 0; hasNextPage; skip += pageSize) {
+    const result = await getNextPage({ take: pageSize, skip });
+    hasNextPage = result.hasNextPage;
+    yield result.items;
+  }
+}

--- a/server/libs/domain/src/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/libs/domain/src/facial-recognition/facial-recognition.service.spec.ts
@@ -132,10 +132,13 @@ describe(FacialRecognitionService.name, () => {
 
   describe('handleQueueRecognizeFaces', () => {
     it('should queue missing assets', async () => {
-      assetMock.getWithout.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getWithout.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       await sut.handleQueueRecognizeFaces({});
 
-      expect(assetMock.getWithout).toHaveBeenCalledWith(WithoutProperty.FACES);
+      expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.FACES);
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.RECOGNIZE_FACES,
         data: { asset: assetEntityStub.image },
@@ -143,7 +146,10 @@ describe(FacialRecognitionService.name, () => {
     });
 
     it('should queue all assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       personMock.deleteAll.mockResolvedValue(5);
       searchMock.deleteAllFaces.mockResolvedValue(100);
 

--- a/server/libs/domain/src/facial-recognition/facial-recognition.services.ts
+++ b/server/libs/domain/src/facial-recognition/facial-recognition.services.ts
@@ -1,8 +1,8 @@
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Logger } from '@nestjs/common';
 import { join } from 'path';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { MACHINE_LEARNING_ENABLED } from '../domain.constant';
+import { usePagination } from '../domain.util';
 import { IAssetJob, IBaseJob, IFaceThumbnailJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { CropOptions, FACE_THUMBNAIL_SIZE, IMediaRepository } from '../media';
 import { IPersonRepository } from '../person/person.repository';

--- a/server/libs/domain/src/facial-recognition/facial-recognition.services.ts
+++ b/server/libs/domain/src/facial-recognition/facial-recognition.services.ts
@@ -1,8 +1,9 @@
+import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Logger } from '@nestjs/common';
 import { join } from 'path';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { MACHINE_LEARNING_ENABLED } from '../domain.constant';
-import { IAssetJob, IBaseJob, IFaceThumbnailJob, IJobRepository, JobName } from '../job';
+import { IAssetJob, IBaseJob, IFaceThumbnailJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { CropOptions, FACE_THUMBNAIL_SIZE, IMediaRepository } from '../media';
 import { IPersonRepository } from '../person/person.repository';
 import { ISearchRepository } from '../search/search.repository';
@@ -27,17 +28,21 @@ export class FacialRecognitionService {
 
   async handleQueueRecognizeFaces({ force }: IBaseJob) {
     try {
-      const assets = force
-        ? await this.assetRepository.getAll()
-        : await this.assetRepository.getWithout(WithoutProperty.FACES);
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
+        return force
+          ? this.assetRepository.getAll(pagination)
+          : this.assetRepository.getWithout(pagination, WithoutProperty.FACES);
+      });
 
       if (force) {
         const people = await this.personRepository.deleteAll();
         const faces = await this.searchRepository.deleteAllFaces();
         this.logger.debug(`Deleted ${people} people and ${faces} faces`);
       }
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.RECOGNIZE_FACES, data: { asset } });
+      for await (const assets of assetPagination) {
+        for (const asset of assets) {
+          await this.jobRepository.queue({ name: JobName.RECOGNIZE_FACES, data: { asset } });
+        }
       }
     } catch (error: any) {
       this.logger.error(`Unable to queue recognize faces`, error?.stack);

--- a/server/libs/domain/src/job/job.constants.ts
+++ b/server/libs/domain/src/job/job.constants.ts
@@ -73,3 +73,5 @@ export enum JobName {
   QUEUE_ENCODE_CLIP = 'queue-clip-encode',
   ENCODE_CLIP = 'clip-encode',
 }
+
+export const JOBS_ASSET_PAGINATION_SIZE = 1000;

--- a/server/libs/domain/src/media/media.service.spec.ts
+++ b/server/libs/domain/src/media/media.service.spec.ts
@@ -44,7 +44,10 @@ describe(MediaService.name, () => {
 
   describe('handleQueueGenerateThumbnails', () => {
     it('should queue all assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueGenerateThumbnails({ force: true });
 
@@ -57,12 +60,15 @@ describe(MediaService.name, () => {
     });
 
     it('should queue all assets with missing thumbnails', async () => {
-      assetMock.getWithout.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getWithout.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueGenerateThumbnails({ force: false });
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
-      expect(assetMock.getWithout).toHaveBeenCalledWith(WithoutProperty.THUMBNAIL);
+      expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.THUMBNAIL);
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.GENERATE_JPEG_THUMBNAIL,
         data: { asset: assetEntityStub.image },
@@ -183,11 +189,14 @@ describe(MediaService.name, () => {
 
   describe('handleQueueVideoConversion', () => {
     it('should queue all video assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.video]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.video],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueVideoConversion({ force: true });
 
-      expect(assetMock.getAll).toHaveBeenCalledWith({ type: AssetType.VIDEO });
+      expect(assetMock.getAll).toHaveBeenCalledWith({ skip: 0, take: 1000 }, { type: AssetType.VIDEO });
       expect(assetMock.getWithout).not.toHaveBeenCalled();
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.VIDEO_CONVERSION,
@@ -196,12 +205,15 @@ describe(MediaService.name, () => {
     });
 
     it('should queue all video assets without encoded videos', async () => {
-      assetMock.getWithout.mockResolvedValue([assetEntityStub.video]);
+      assetMock.getWithout.mockResolvedValue({
+        items: [assetEntityStub.video],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueVideoConversion({});
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
-      expect(assetMock.getWithout).toHaveBeenCalledWith(WithoutProperty.ENCODED_VIDEO);
+      expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.ENCODED_VIDEO);
       expect(jobMock.queue).toHaveBeenCalledWith({
         name: JobName.VIDEO_CONVERSION,
         data: { asset: assetEntityStub.video },

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -1,9 +1,9 @@
 import { AssetEntity, AssetType, TranscodePreset } from '@app/infra/entities';
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { join } from 'path';
 import { IAssetRepository, mapAsset, WithoutProperty } from '../asset';
 import { CommunicationEvent, ICommunicationRepository } from '../communication';
+import { usePagination } from '../domain.util';
 import { IAssetJob, IBaseJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IStorageRepository, StorageCore, StorageFolder } from '../storage';
 import { ISystemConfigRepository, SystemConfigFFmpegDto } from '../system-config';

--- a/server/libs/domain/src/media/media.service.ts
+++ b/server/libs/domain/src/media/media.service.ts
@@ -1,9 +1,10 @@
 import { AssetEntity, AssetType, TranscodePreset } from '@app/infra/entities';
+import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { join } from 'path';
 import { IAssetRepository, mapAsset, WithoutProperty } from '../asset';
 import { CommunicationEvent, ICommunicationRepository } from '../communication';
-import { IAssetJob, IBaseJob, IJobRepository, JobName } from '../job';
+import { IAssetJob, IBaseJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IStorageRepository, StorageCore, StorageFolder } from '../storage';
 import { ISystemConfigRepository, SystemConfigFFmpegDto } from '../system-config';
 import { SystemConfigCore } from '../system-config/system-config.core';
@@ -31,12 +32,16 @@ export class MediaService {
     try {
       const { force } = job;
 
-      const assets = force
-        ? await this.assetRepository.getAll()
-        : await this.assetRepository.getWithout(WithoutProperty.THUMBNAIL);
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
+        return force
+          ? this.assetRepository.getAll(pagination)
+          : this.assetRepository.getWithout(pagination, WithoutProperty.THUMBNAIL);
+      });
 
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.GENERATE_JPEG_THUMBNAIL, data: { asset } });
+      for await (const assets of assetPagination) {
+        for (const asset of assets) {
+          await this.jobRepository.queue({ name: JobName.GENERATE_JPEG_THUMBNAIL, data: { asset } });
+        }
       }
     } catch (error: any) {
       this.logger.error('Failed to queue generate thumbnail jobs', error.stack);
@@ -115,11 +120,16 @@ export class MediaService {
     const { force } = job;
 
     try {
-      const assets = force
-        ? await this.assetRepository.getAll({ type: AssetType.VIDEO })
-        : await this.assetRepository.getWithout(WithoutProperty.ENCODED_VIDEO);
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { asset } });
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
+        return force
+          ? this.assetRepository.getAll(pagination, { type: AssetType.VIDEO })
+          : this.assetRepository.getWithout(pagination, WithoutProperty.ENCODED_VIDEO);
+      });
+
+      for await (const assets of assetPagination) {
+        for (const asset of assets) {
+          await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { asset } });
+        }
       }
     } catch (error: any) {
       this.logger.error('Failed to queue video conversions', error.stack);

--- a/server/libs/domain/src/search/search.service.spec.ts
+++ b/server/libs/domain/src/search/search.service.spec.ts
@@ -185,11 +185,6 @@ describe(SearchService.name, () => {
 
   describe('handleIndexAssets', () => {
     it('should call done, even when there are no assets', async () => {
-      assetMock.getAll.mockResolvedValue({
-        items: [],
-        hasNextPage: false,
-      });
-
       await sut.handleIndexAssets();
 
       expect(searchMock.importAssets).toHaveBeenCalledWith([], true);

--- a/server/libs/domain/src/search/search.service.spec.ts
+++ b/server/libs/domain/src/search/search.service.spec.ts
@@ -185,7 +185,10 @@ describe(SearchService.name, () => {
 
   describe('handleIndexAssets', () => {
     it('should call done, even when there are no assets', async () => {
-      assetMock.getAll.mockResolvedValue([]);
+      assetMock.getAll.mockResolvedValue({
+        items: [],
+        hasNextPage: false,
+      });
 
       await sut.handleIndexAssets();
 
@@ -193,7 +196,10 @@ describe(SearchService.name, () => {
     });
 
     it('should index all the assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleIndexAssets();
 
@@ -204,7 +210,10 @@ describe(SearchService.name, () => {
     });
 
     it('should log an error', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       searchMock.importAssets.mockRejectedValue(new Error('import failed'));
 
       await sut.handleIndexAssets();

--- a/server/libs/domain/src/search/search.service.ts
+++ b/server/libs/domain/src/search/search.service.ts
@@ -161,7 +161,7 @@ export class SearchService {
       );
 
       for await (const assets of assetPagination) {
-        this.logger.log(`Indexing ${assets.length} assets`);
+        this.logger.debug(`Indexing ${assets.length} assets`);
 
         const patchedAssets = this.patchAssets(assets);
         await this.searchRepository.importAssets(patchedAssets, false);

--- a/server/libs/domain/src/search/search.service.ts
+++ b/server/libs/domain/src/search/search.service.ts
@@ -1,5 +1,4 @@
 import { AlbumEntity, AssetEntity, AssetFaceEntity } from '@app/infra/entities';
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { mapAlbum } from '../album';
@@ -8,6 +7,7 @@ import { mapAsset } from '../asset';
 import { IAssetRepository } from '../asset/asset.repository';
 import { AuthUserDto } from '../auth';
 import { MACHINE_LEARNING_ENABLED } from '../domain.constant';
+import { usePagination } from '../domain.util';
 import { AssetFaceId, IFaceRepository } from '../facial-recognition';
 import { IAssetFaceJob, IBulkEntityJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IMachineLearningRepository } from '../smart-info';

--- a/server/libs/domain/src/smart-info/smart-info.service.spec.ts
+++ b/server/libs/domain/src/smart-info/smart-info.service.spec.ts
@@ -38,7 +38,10 @@ describe(SmartInfoService.name, () => {
 
   describe('handleQueueObjectTagging', () => {
     it('should queue the assets without tags', async () => {
-      assetMock.getWithout.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getWithout.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueObjectTagging({ force: false });
 
@@ -46,11 +49,14 @@ describe(SmartInfoService.name, () => {
         [{ name: JobName.CLASSIFY_IMAGE, data: { asset: assetEntityStub.image } }],
         [{ name: JobName.DETECT_OBJECTS, data: { asset: assetEntityStub.image } }],
       ]);
-      expect(assetMock.getWithout).toHaveBeenCalledWith(WithoutProperty.OBJECT_TAGS);
+      expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.OBJECT_TAGS);
     });
 
     it('should queue all the assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueObjectTagging({ force: true });
 
@@ -140,16 +146,22 @@ describe(SmartInfoService.name, () => {
 
   describe('handleQueueEncodeClip', () => {
     it('should queue the assets without clip embeddings', async () => {
-      assetMock.getWithout.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getWithout.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueEncodeClip({ force: false });
 
       expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.ENCODE_CLIP, data: { asset: assetEntityStub.image } });
-      expect(assetMock.getWithout).toHaveBeenCalledWith(WithoutProperty.CLIP_ENCODING);
+      expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.CLIP_ENCODING);
     });
 
     it('should queue all the assets', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
 
       await sut.handleQueueEncodeClip({ force: true });
 

--- a/server/libs/domain/src/smart-info/smart-info.service.ts
+++ b/server/libs/domain/src/smart-info/smart-info.service.ts
@@ -1,7 +1,7 @@
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { MACHINE_LEARNING_ENABLED } from '../domain.constant';
+import { usePagination } from '../domain.util';
 import { IAssetJob, IBaseJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IMachineLearningRepository } from './machine-learning.interface';
 import { ISmartInfoRepository } from './smart-info.repository';

--- a/server/libs/domain/src/smart-info/smart-info.service.ts
+++ b/server/libs/domain/src/smart-info/smart-info.service.ts
@@ -1,7 +1,8 @@
+import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { MACHINE_LEARNING_ENABLED } from '../domain.constant';
-import { IAssetJob, IBaseJob, IJobRepository, JobName } from '../job';
+import { IAssetJob, IBaseJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IMachineLearningRepository } from './machine-learning.interface';
 import { ISmartInfoRepository } from './smart-info.repository';
 
@@ -18,13 +19,17 @@ export class SmartInfoService {
 
   async handleQueueObjectTagging({ force }: IBaseJob) {
     try {
-      const assets = force
-        ? await this.assetRepository.getAll()
-        : await this.assetRepository.getWithout(WithoutProperty.OBJECT_TAGS);
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
+        return force
+          ? this.assetRepository.getAll(pagination)
+          : this.assetRepository.getWithout(pagination, WithoutProperty.OBJECT_TAGS);
+      });
 
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.CLASSIFY_IMAGE, data: { asset } });
-        await this.jobRepository.queue({ name: JobName.DETECT_OBJECTS, data: { asset } });
+      for await (const assets of assetPagination) {
+        for (const asset of assets) {
+          await this.jobRepository.queue({ name: JobName.CLASSIFY_IMAGE, data: { asset } });
+          await this.jobRepository.queue({ name: JobName.DETECT_OBJECTS, data: { asset } });
+        }
       }
     } catch (error: any) {
       this.logger.error(`Unable to queue object tagging`, error?.stack);
@@ -69,12 +74,16 @@ export class SmartInfoService {
 
   async handleQueueEncodeClip({ force }: IBaseJob) {
     try {
-      const assets = force
-        ? await this.assetRepository.getAll()
-        : await this.assetRepository.getWithout(WithoutProperty.CLIP_ENCODING);
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
+        return force
+          ? this.assetRepository.getAll(pagination)
+          : this.assetRepository.getWithout(pagination, WithoutProperty.CLIP_ENCODING);
+      });
 
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.ENCODE_CLIP, data: { asset } });
+      for await (const assets of assetPagination) {
+        for (const asset of assets) {
+          await this.jobRepository.queue({ name: JobName.ENCODE_CLIP, data: { asset } });
+        }
       }
     } catch (error: any) {
       this.logger.error(`Unable to queue clip encoding`, error?.stack);

--- a/server/libs/domain/src/storage-template/storage-template.service.spec.ts
+++ b/server/libs/domain/src/storage-template/storage-template.service.spec.ts
@@ -197,10 +197,6 @@ describe(StorageTemplateService.name, () => {
   });
 
   it('should handle an error', async () => {
-    assetMock.getAll.mockResolvedValue({
-      items: [],
-      hasNextPage: false,
-    });
     storageMock.removeEmptyDirs.mockRejectedValue(new Error('Read only filesystem'));
     userMock.getList.mockResolvedValue([]);
 

--- a/server/libs/domain/src/storage-template/storage-template.service.spec.ts
+++ b/server/libs/domain/src/storage-template/storage-template.service.spec.ts
@@ -36,7 +36,10 @@ describe(StorageTemplateService.name, () => {
 
   describe('handle template migration', () => {
     it('should handle no assets', async () => {
-      assetMock.getAll.mockResolvedValue([]);
+      assetMock.getAll.mockResolvedValue({
+        items: [],
+        hasNextPage: false,
+      });
       userMock.getList.mockResolvedValue([]);
 
       await sut.handleTemplateMigration();
@@ -45,7 +48,10 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should handle an asset with a duplicate destination', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       assetMock.save.mockResolvedValue(assetEntityStub.image);
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
@@ -69,12 +75,15 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should skip when an asset already matches the template', async () => {
-      assetMock.getAll.mockResolvedValue([
-        {
-          ...assetEntityStub.image,
-          originalPath: 'upload/library/user-id/2023/2023-02-23/asset-id.ext',
-        },
-      ]);
+      assetMock.getAll.mockResolvedValue({
+        items: [
+          {
+            ...assetEntityStub.image,
+            originalPath: 'upload/library/user-id/2023/2023-02-23/asset-id.ext',
+          },
+        ],
+        hasNextPage: false,
+      });
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
       await sut.handleTemplateMigration();
@@ -86,12 +95,15 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should skip when an asset is probably a duplicate', async () => {
-      assetMock.getAll.mockResolvedValue([
-        {
-          ...assetEntityStub.image,
-          originalPath: 'upload/library/user-id/2023/2023-02-23/asset-id+1.ext',
-        },
-      ]);
+      assetMock.getAll.mockResolvedValue({
+        items: [
+          {
+            ...assetEntityStub.image,
+            originalPath: 'upload/library/user-id/2023/2023-02-23/asset-id+1.ext',
+          },
+        ],
+        hasNextPage: false,
+      });
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
       await sut.handleTemplateMigration();
@@ -103,7 +115,10 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should move an asset', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       assetMock.save.mockResolvedValue(assetEntityStub.image);
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
@@ -121,7 +136,10 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should use the user storage label', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       assetMock.save.mockResolvedValue(assetEntityStub.image);
       userMock.getList.mockResolvedValue([userEntityStub.storageLabel]);
 
@@ -139,7 +157,10 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should not update the database if the move fails', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       storageMock.moveFile.mockRejectedValue(new Error('Read only system'));
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
@@ -154,7 +175,10 @@ describe(StorageTemplateService.name, () => {
     });
 
     it('should move the asset back if the database fails', async () => {
-      assetMock.getAll.mockResolvedValue([assetEntityStub.image]);
+      assetMock.getAll.mockResolvedValue({
+        items: [assetEntityStub.image],
+        hasNextPage: false,
+      });
       assetMock.save.mockRejectedValue('Connection Error!');
       userMock.getList.mockResolvedValue([userEntityStub.user1]);
 
@@ -173,7 +197,10 @@ describe(StorageTemplateService.name, () => {
   });
 
   it('should handle an error', async () => {
-    assetMock.getAll.mockResolvedValue([]);
+    assetMock.getAll.mockResolvedValue({
+      items: [],
+      hasNextPage: false,
+    });
     storageMock.removeEmptyDirs.mockRejectedValue(new Error('Read only filesystem'));
     userMock.getList.mockResolvedValue([]);
 

--- a/server/libs/domain/src/storage-template/storage-template.service.ts
+++ b/server/libs/domain/src/storage-template/storage-template.service.ts
@@ -1,9 +1,8 @@
 import { AssetEntity, SystemConfig } from '@app/infra/entities';
-import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IAssetRepository } from '../asset/asset.repository';
 import { APP_MEDIA_LOCATION } from '../domain.constant';
-import { getLivePhotoMotionFilename } from '../domain.util';
+import { getLivePhotoMotionFilename, usePagination } from '../domain.util';
 import { IAssetJob, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IStorageRepository } from '../storage/storage.repository';
 import { INITIAL_SYSTEM_CONFIG, ISystemConfigRepository } from '../system-config';

--- a/server/libs/domain/src/storage-template/storage-template.service.ts
+++ b/server/libs/domain/src/storage-template/storage-template.service.ts
@@ -1,9 +1,10 @@
 import { AssetEntity, SystemConfig } from '@app/infra/entities';
+import { usePagination } from '@app/infra/utils/pagination.util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { IAssetRepository } from '../asset/asset.repository';
 import { APP_MEDIA_LOCATION } from '../domain.constant';
 import { getLivePhotoMotionFilename } from '../domain.util';
-import { IAssetJob } from '../job';
+import { IAssetJob, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import { IStorageRepository } from '../storage/storage.repository';
 import { INITIAL_SYSTEM_CONFIG, ISystemConfigRepository } from '../system-config';
 import { IUserRepository } from '../user/user.repository';
@@ -52,24 +53,29 @@ export class StorageTemplateService {
   async handleTemplateMigration() {
     try {
       console.time('migrating-time');
-      const assets = await this.assetRepository.getAll();
+
+      const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
+        this.assetRepository.getAll(pagination),
+      );
       const users = await this.userRepository.getList();
 
-      const livePhotoMap: Record<string, AssetEntity> = {};
+      for await (const assets of assetPagination) {
+        const livePhotoMap: Record<string, AssetEntity> = {};
 
-      for (const asset of assets) {
-        if (asset.livePhotoVideoId) {
-          livePhotoMap[asset.livePhotoVideoId] = asset;
+        for (const asset of assets) {
+          if (asset.livePhotoVideoId) {
+            livePhotoMap[asset.livePhotoVideoId] = asset;
+          }
         }
-      }
 
-      for (const asset of assets) {
-        const livePhotoParentAsset = livePhotoMap[asset.id];
-        // TODO: remove livePhoto specific stuff once upload is fixed
-        const user = users.find((user) => user.id === asset.ownerId);
-        const storageLabel = user?.storageLabel || null;
-        const filename = asset.originalFileName || livePhotoParentAsset?.originalFileName || asset.id;
-        await this.moveAsset(asset, { storageLabel, filename });
+        for (const asset of assets) {
+          const livePhotoParentAsset = livePhotoMap[asset.id];
+          // TODO: remove livePhoto specific stuff once upload is fixed
+          const user = users.find((user) => user.id === asset.ownerId);
+          const storageLabel = user?.storageLabel || null;
+          const filename = asset.originalFileName || livePhotoParentAsset?.originalFileName || asset.id;
+          await this.moveAsset(asset, { storageLabel, filename });
+        }
       }
 
       this.logger.debug('Cleaning up empty directories...');

--- a/server/libs/domain/src/storage-template/storage-template.service.ts
+++ b/server/libs/domain/src/storage-template/storage-template.service.ts
@@ -60,20 +60,10 @@ export class StorageTemplateService {
       const users = await this.userRepository.getList();
 
       for await (const assets of assetPagination) {
-        const livePhotoMap: Record<string, AssetEntity> = {};
-
         for (const asset of assets) {
-          if (asset.livePhotoVideoId) {
-            livePhotoMap[asset.livePhotoVideoId] = asset;
-          }
-        }
-
-        for (const asset of assets) {
-          const livePhotoParentAsset = livePhotoMap[asset.id];
-          // TODO: remove livePhoto specific stuff once upload is fixed
           const user = users.find((user) => user.id === asset.ownerId);
           const storageLabel = user?.storageLabel || null;
-          const filename = asset.originalFileName || livePhotoParentAsset?.originalFileName || asset.id;
+          const filename = asset.originalFileName || asset.id;
           await this.moveAsset(asset, { storageLabel, filename });
         }
       }

--- a/server/libs/domain/test/asset.repository.mock.ts
+++ b/server/libs/domain/test/asset.repository.mock.ts
@@ -5,7 +5,10 @@ export const newAssetRepositoryMock = (): jest.Mocked<IAssetRepository> => {
     getByIds: jest.fn(),
     getWithout: jest.fn(),
     getFirstAssetForAlbumId: jest.fn(),
-    getAll: jest.fn(),
+    getAll: jest.fn().mockResolvedValue({
+      items: [],
+      hasNextPage: false,
+    }),
     deleteAll: jest.fn(),
     save: jest.fn(),
     findLivePhotoMatch: jest.fn(),

--- a/server/libs/infra/src/repositories/asset.repository.ts
+++ b/server/libs/infra/src/repositories/asset.repository.ts
@@ -47,6 +47,10 @@ export class AssetRepository implements IAssetRepository {
           person: true,
         },
       },
+      order: {
+        // Ensures correct order when paginating
+        createdAt: 'ASC',
+      },
     });
   }
 
@@ -162,6 +166,10 @@ export class AssetRepository implements IAssetRepository {
     return paginate(this.repository, pagination, {
       relations,
       where,
+      order: {
+        // Ensures correct order when paginating
+        createdAt: 'ASC',
+      },
     });
   }
 

--- a/server/libs/infra/src/repositories/asset.repository.ts
+++ b/server/libs/infra/src/repositories/asset.repository.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsRelations, FindOptionsWhere, In, IsNull, Not, Repository } from 'typeorm';
 import { AssetEntity, AssetType } from '../entities';
+import { paginate, Paginated, PaginationOptions } from '../utils/pagination.util';
 
 @Injectable()
 export class AssetRepository implements IAssetRepository {
@@ -32,10 +33,8 @@ export class AssetRepository implements IAssetRepository {
     await this.repository.delete({ ownerId });
   }
 
-  getAll(options?: AssetSearchOptions | undefined): Promise<AssetEntity[]> {
-    options = options || {};
-
-    return this.repository.find({
+  getAll(pagination: PaginationOptions, options: AssetSearchOptions = {}): Paginated<AssetEntity> {
+    return paginate(this.repository, pagination, {
       where: {
         isVisible: options.isVisible,
         type: options.type,
@@ -83,7 +82,7 @@ export class AssetRepository implements IAssetRepository {
     });
   }
 
-  getWithout(property: WithoutProperty): Promise<AssetEntity[]> {
+  getWithout(pagination: PaginationOptions, property: WithoutProperty): Paginated<AssetEntity> {
     let relations: FindOptionsRelations<AssetEntity> = {};
     let where: FindOptionsWhere<AssetEntity> | FindOptionsWhere<AssetEntity>[] = {};
 
@@ -160,7 +159,7 @@ export class AssetRepository implements IAssetRepository {
         throw new Error(`Invalid getWithout property: ${property}`);
     }
 
-    return this.repository.find({
+    return paginate(this.repository, pagination, {
       relations,
       where,
     });

--- a/server/libs/infra/src/repositories/asset.repository.ts
+++ b/server/libs/infra/src/repositories/asset.repository.ts
@@ -4,13 +4,15 @@ import {
   LivePhotoSearchOptions,
   MapMarker,
   MapMarkerSearchOptions,
+  Paginated,
+  PaginationOptions,
   WithoutProperty,
 } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsRelations, FindOptionsWhere, In, IsNull, Not, Repository } from 'typeorm';
 import { AssetEntity, AssetType } from '../entities';
-import { paginate, Paginated, PaginationOptions } from '../utils/pagination.util';
+import { paginate } from '../utils/pagination.util';
 
 @Injectable()
 export class AssetRepository implements IAssetRepository {

--- a/server/libs/infra/src/utils/pagination.util.ts
+++ b/server/libs/infra/src/utils/pagination.util.ts
@@ -1,0 +1,44 @@
+import { FindOneOptions, ObjectLiteral, Repository } from 'typeorm';
+
+export interface PaginationOptions {
+  take: number;
+  skip?: number;
+}
+
+export interface PaginationResult<T> {
+  items: T[];
+  hasNextPage: boolean;
+}
+
+export type Paginated<T> = Promise<PaginationResult<T>>;
+
+export async function paginate<Entity extends ObjectLiteral>(
+  repository: Repository<Entity>,
+  paginationOptions: PaginationOptions,
+  searchOptions?: FindOneOptions<Entity>,
+): Paginated<Entity> {
+  const items = await repository.find({
+    ...searchOptions,
+    // Take one more item to check if there's a next page
+    take: paginationOptions.take + 1,
+    skip: paginationOptions.skip,
+  });
+
+  const hasNextPage = items.length > paginationOptions.take;
+  items.splice(paginationOptions.take);
+
+  return { items, hasNextPage };
+}
+
+export async function* usePagination<T>(
+  pageSize: number,
+  getNextPage: (pagination: PaginationOptions) => Paginated<T>,
+) {
+  let hasNextPage = true;
+
+  for (let skip = 0; hasNextPage; skip += pageSize) {
+    const result = await getNextPage({ take: pageSize, skip });
+    hasNextPage = result.hasNextPage;
+    yield result.items;
+  }
+}

--- a/server/libs/infra/src/utils/pagination.util.ts
+++ b/server/libs/infra/src/utils/pagination.util.ts
@@ -1,16 +1,5 @@
+import { Paginated, PaginationOptions } from '@app/domain';
 import { FindOneOptions, ObjectLiteral, Repository } from 'typeorm';
-
-export interface PaginationOptions {
-  take: number;
-  skip?: number;
-}
-
-export interface PaginationResult<T> {
-  items: T[];
-  hasNextPage: boolean;
-}
-
-export type Paginated<T> = Promise<PaginationResult<T>>;
 
 export async function paginate<Entity extends ObjectLiteral>(
   repository: Repository<Entity>,
@@ -28,17 +17,4 @@ export async function paginate<Entity extends ObjectLiteral>(
   items.splice(paginationOptions.take);
 
   return { items, hasNextPage };
-}
-
-export async function* usePagination<T>(
-  pageSize: number,
-  getNextPage: (pagination: PaginationOptions) => Paginated<T>,
-) {
-  let hasNextPage = true;
-
-  for (let skip = 0; hasNextPage; skip += pageSize) {
-    const result = await getNextPage({ take: pageSize, skip });
-    hasNextPage = result.hasNextPage;
-    yield result.items;
-  }
 }


### PR DESCRIPTION
Jobs need to iterate through all assets to queue them. The current implementation queries all assets at once and holds them in memory until they are queued. With a large library, this uses a lot of memory and can cause the microservices container to crash.

The solution is to use pagination which limits the amount of assets that are kept in memory. For the `paginate` function I've used a generic approach to accomodate future usage in controller or other repositories. The `usePagination` utility can be used to iterate through all pages using a `for await...of` loop. Should fix #2505