### PR TITLE
docker: use default entrypoint and command where applicable

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   immich-server:
     container_name: immich_server
     image: ghcr.io/immich-app/immich-server:release
-    entrypoint: ["/bin/sh", "./start-server.sh"]
+    command: ["start-server.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
@@ -18,7 +18,7 @@ services:
   immich-microservices:
     container_name: immich_microservices
     image: ghcr.io/immich-app/immich-server:release
-    entrypoint: ["/bin/sh", "./start-microservices.sh"]
+    command: ["start-microservices.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
     env_file:
@@ -42,7 +42,6 @@ services:
   immich-web:
     container_name: immich_web
     image: ghcr.io/immich-app/immich-web:release
-    entrypoint: ["/bin/sh", "./entrypoint.sh"]
     env_file:
       - .env
     restart: always

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -39,3 +39,5 @@ RUN npm link && npm cache clean --force
 VOLUME /usr/src/app/upload
 
 EXPOSE 3001
+
+ENTRYPOINT ["/bin/sh"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -38,3 +38,7 @@ COPY --from=prod /usr/src/app/build ./build
 
 COPY package.json package-lock.json ./
 COPY entrypoint.sh ./
+
+ENTRYPOINT ["/bin/sh"]
+
+CMD ["entrypoint.sh"]


### PR DESCRIPTION
A default entrypoint and command make it just a bit easier to use the images as there is no longer a need for an explicit entrypoint. The exception is the server image, which still requires the shell script to be specified.