### PR TITLE
fix: hide album context menu

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -405,7 +405,7 @@
 						/>
 					{/if}
 
-					{#if !isPublicShared}
+					{#if !isPublicShared && isOwned}
 						<div use:clickOutside on:outclick={() => (isShowAlbumOptions = false)}>
 							<CircleIconButton
 								title="Album options"
@@ -413,15 +413,13 @@
 								logo={DotsVertical}
 								>{#if isShowAlbumOptions}
 									<ContextMenu {...contextMenuPosition}>
-										{#if isOwned}
-											<MenuOption
-												on:click={() => {
-													isShowThumbnailSelection = true;
-													isShowAlbumOptions = false;
-												}}
-												text="Set album cover"
-											/>
-										{/if}
+										<MenuOption
+											on:click={() => {
+												isShowThumbnailSelection = true;
+												isShowAlbumOptions = false;
+											}}
+											text="Set album cover"
+										/>
 									</ContextMenu>
 								{/if}
 							</CircleIconButton>


### PR DESCRIPTION
This PR removes the album action overflow menu icon when viewing as a shared user.

Owner
![image](https://github.com/immich-app/immich/assets/4334196/ac513338-4fd2-4837-bf8f-54216e6a74bc)

Shared User (before - clicking does nothing)
![image](https://github.com/immich-app/immich/assets/4334196/d22bad0b-c43f-4da5-a027-e3c90751c0d2)


Shared User (after - hidden)
![image](https://github.com/immich-app/immich/assets/4334196/db45acae-3716-4326-8d16-b542a4e8d171)

