### PR TITLE
fix(server): reverse geocoding delete dump logic

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -50,14 +50,14 @@ export class MetadataExtractionProcessor {
     this.reverseGeocodingEnabled = !configService.get('DISABLE_REVERSE_GEOCODING');
   }
 
-  async init(skipCache = false) {
+  async init(deleteCache = false) {
     this.logger.warn(`Reverse geocoding is ${this.reverseGeocodingEnabled ? 'enabled' : 'disabled'}`);
     if (!this.reverseGeocodingEnabled) {
       return;
     }
 
     try {
-      if (!skipCache) {
+      if (deleteCache) {
         await this.geocodingRepository.deleteCache();
       }
       this.logger.log('Initializing Reverse Geocoding');

--- a/server/libs/infra/src/repositories/geocoding.repository.ts
+++ b/server/libs/infra/src/repositories/geocoding.repository.ts
@@ -1,9 +1,10 @@
 import { GeoPoint, IGeocodingRepository, ReverseGeocodeResult } from '@app/domain';
 import { localGeocodingConfig } from '@app/infra';
 import { Injectable, Logger } from '@nestjs/common';
-import { rm } from 'fs/promises';
+import { readdir, rm } from 'fs/promises';
 import { getName } from 'i18n-iso-countries';
 import geocoder, { AddressObject } from 'local-reverse-geocoder';
+import path from 'path';
 import { promisify } from 'util';
 
 export interface AdminCode {
@@ -31,7 +32,12 @@ export class GeocodingRepository implements IGeocodingRepository {
   async deleteCache() {
     const dumpDirectory = localGeocodingConfig.dumpDirectory;
     if (dumpDirectory) {
-      await rm(dumpDirectory, { recursive: true, force: true });
+      // delete contents
+      const items = await readdir(dumpDirectory, { withFileTypes: true });
+      const folders = items.filter((item) => item.isDirectory());
+      for (const { name } of folders) {
+        await rm(path.join(dumpDirectory, name), { recursive: true, force: true });
+      }
     }
   }
 


### PR DESCRIPTION
Delete the contents of the reverse geocoding dump directory on error. Also, only delete the dump on error, not on start-up.

Fixes #2528
