### PR TITLE
feat: disk stats for library folder

### DIFF
--- a/server/libs/domain/src/server-info/server-info.service.spec.ts
+++ b/server/libs/domain/src/server-info/server-info.service.spec.ts
@@ -34,7 +34,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
 
     it('should return the disk space as KiB', async () => {
@@ -50,7 +50,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300000,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
 
     it('should return the disk space as MiB', async () => {
@@ -66,7 +66,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300000000,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
 
     it('should return the disk space as GiB', async () => {
@@ -86,7 +86,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300000000000,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
 
     it('should return the disk space as TiB', async () => {
@@ -106,7 +106,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300000000000000,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
 
     it('should return the disk space as PiB', async () => {
@@ -126,7 +126,7 @@ describe(ServerInfoService.name, () => {
         diskUseRaw: 300000000000000000,
       });
 
-      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('./upload');
+      expect(storageMock.checkDiskUsage).toHaveBeenCalledWith('upload/library');
     });
   });
 

--- a/server/libs/domain/src/server-info/server-info.service.ts
+++ b/server/libs/domain/src/server-info/server-info.service.ts
@@ -1,19 +1,22 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { APP_MEDIA_LOCATION, serverVersion } from '../domain.constant';
+import { serverVersion } from '../domain.constant';
 import { asHumanReadable } from '../domain.util';
-import { IStorageRepository } from '../storage';
+import { IStorageRepository, StorageCore, StorageFolder } from '../storage';
 import { IUserRepository, UserStatsQueryResponse } from '../user';
 import { ServerInfoResponseDto, ServerPingResponse, ServerStatsResponseDto, UsageByUserDto } from './response-dto';
 
 @Injectable()
 export class ServerInfoService {
+  private storageCore = new StorageCore();
+
   constructor(
     @Inject(IUserRepository) private userRepository: IUserRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
   ) {}
 
   async getInfo(): Promise<ServerInfoResponseDto> {
-    const diskInfo = await this.storageRepository.checkDiskUsage(APP_MEDIA_LOCATION);
+    const libraryBase = this.storageCore.getBaseFolder(StorageFolder.LIBRARY);
+    const diskInfo = await this.storageRepository.checkDiskUsage(libraryBase);
 
     const usagePercentage = (((diskInfo.total - diskInfo.free) / diskInfo.total) * 100).toFixed(2);
 

--- a/server/libs/domain/src/storage/storage.core.ts
+++ b/server/libs/domain/src/storage/storage.core.ts
@@ -14,10 +14,14 @@ export class StorageCore {
     folder: StorageFolder.ENCODED_VIDEO | StorageFolder.UPLOAD | StorageFolder.PROFILE | StorageFolder.THUMBNAILS,
     userId: string,
   ) {
-    return join(APP_MEDIA_LOCATION, folder, userId);
+    return join(this.getBaseFolder(folder), userId);
   }
 
   getLibraryFolder(user: { storageLabel: string | null; id: string }) {
-    return join(APP_MEDIA_LOCATION, StorageFolder.LIBRARY, user.storageLabel || user.id);
+    return join(this.getBaseFolder(StorageFolder.LIBRARY), user.storageLabel || user.id);
+  }
+
+  getBaseFolder(folder: StorageFolder) {
+    return join(APP_MEDIA_LOCATION, folder);
   }
 }


### PR DESCRIPTION
Change the disk statistics folder from `UPLOAD_LOCATION` to `UPLOAD_LOCATION/library`

This should only impact users mounting separate volumes for library, thumbs, etc. In the case that each folder is a separate mount, I think it makes sense to show the disk statistics for library.