### PR TITLE
feat(ml): support cuda acceleration

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -46,6 +46,37 @@ services:
       - database
     restart: always
 
+  ## Uncomment `immich-machine-learning-cuda` block to enable gpu acceleration
+  ## and comment `immich-machine-learning` block
+  #
+  # immich-machine-learning-cuda:
+  #   container_name: immich_machine_learning_cuda
+  #   image: immich-machine-learning-cuda-dev:latest
+  #   build:
+  #     context: ../machine-learning
+  #     dockerfile: Dockerfile.cuda
+  #   command: python main.py
+  #   ports:
+  #     - 3003:3003
+  #   volumes:
+  #     - ../machine-learning/src:/usr/src/app
+  #     - ${UPLOAD_LOCATION}:/usr/src/app/upload
+  #     - model-cache:/cache
+  #   env_file:
+  #     - .env
+  #   environment:
+  #     - NODE_ENV=development
+  #   depends_on:
+  #     - database
+  #   restart: always
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             count: 1
+  #             capabilities: [gpu]
+
   immich-microservices:
     container_name: immich_microservices
     image: immich-microservices:latest

--- a/machine-learning/Dockerfile.cuda
+++ b/machine-learning/Dockerfile.cuda
@@ -15,9 +15,8 @@ RUN apt-get update && \
         python3-venv && \
     echo "**** build machine-learning ****" && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install -U --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu117 \
-        torch==1.13.1 \
-        torchvision==0.14.1 && \
+    /opt/venv/bin/pip install -U --no-cache-dir --index-url https://download.pytorch.org/whl/cu117 \
+        torch && \
     /opt/venv/bin/pip install -U --no-cache-dir \
         fastapi \
         insightface \

--- a/machine-learning/Dockerfile.cuda
+++ b/machine-learning/Dockerfile.cuda
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/machine-learning/Dockerfile.cuda
+++ b/machine-learning/Dockerfile.cuda
@@ -6,7 +6,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         g++ \
         make \
-        nvidia-cuda-toolkit \
+        libcublas11 \
+        libcublaslt11 \
+        libcurand10 \
+        libcufft10 \
+        libcudart11.0 \
         python3-dev \
         python3-venv && \
     echo "**** build machine-learning ****" && \

--- a/machine-learning/Dockerfile.cuda
+++ b/machine-learning/Dockerfile.cuda
@@ -1,0 +1,60 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        g++ \
+        make \
+        nvidia-cuda-toolkit \
+        python3-dev \
+        python3-venv && \
+    echo "**** build machine-learning ****" && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install -U --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu117 \
+        torch==1.13.1 \
+        torchvision==0.14.1 && \
+    /opt/venv/bin/pip install -U --no-cache-dir \
+        fastapi \
+        insightface \
+        nltk \
+        numpy \
+        onnxruntime-gpu \
+        packaging \
+        Pillow \
+        scikit-learn \
+        scipy \
+        sentencepiece \
+        sentence-transformers \
+        tqdm \
+        transformers \
+        uvicorn[standard] && \
+    echo "**** cleanup ****" && \
+    for cleanfiles in *.pyc *.pyo; do \
+        find /usr/local/lib/python3.* /usr/lib/python3.* -name "${cleanfiles}" -delete; \
+    done && \
+    apt-get remove -y --purge \
+        g++ \
+        make \
+        python3-dev && \
+    apt-get autoremove -y --purge && \
+    apt-get clean && \
+    rm -rf \
+        /tmp/* \
+        /var/tmp/* \
+        /var/lib/apt/lists/* \
+        /root/.cache
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+ENV NODE_ENV=production \
+    TRANSFORMERS_CACHE=/cache \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CUDA_ACCELERATION=true \
+    PATH="/opt/venv/bin:$PATH" \
+    PYTHONPATH=`pwd`
+
+CMD ["python3", "src/main.py"]


### PR DESCRIPTION
Based on @simone-viozzi work, this PR adds support for gpu acceleration for machine-learning. 
Requirements : 
- A nvidia gpu 
- `nvidia-container-toolkit` installed on your machine

AIO image already have nvidia support, you can find some results [here](https://github.com/imagegenius/docker-immich/issues/88#issuecomment-1556800036). 

This image supports gpu acceleration for tag objects, encode clip and recognize faces jobs. Non-compressed image size is ~12gB.

It's not optimized for now : When all jobs are triggered, it uses ~4gB of VRAM 😨, and vram is not freed after computation.

To do: official documentation
