### PR TITLE
fix(web): back button on person page

### DIFF
--- a/web/src/routes/(user)/people/[personId]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import ImageThumbnail from '$lib/components/assets/thumbnail/image-thumbnail.svelte';
 	import EditNameInput from '$lib/components/faces-page/edit-name-input.svelte';
 	import CreateSharedLink from '$lib/components/photos-page/actions/create-shared-link.svelte';
@@ -22,9 +23,16 @@
 	export let data: PageData;
 
 	let isEditName = false;
-
 	let multiSelectAsset: Set<AssetResponseDto> = new Set();
+	let previousRoute: string = AppRoute.EXPLORE;
 	$: isMultiSelectionMode = multiSelectAsset.size > 0;
+
+	afterNavigate(({ from }) => {
+		// Prevent setting previousRoute to the current page.
+		if (from && from.route.id !== $page.route.id) {
+			previousRoute = from.url.href;
+		}
+	});
 
 	const handleNameChange = async (name: string) => {
 		try {
@@ -60,7 +68,7 @@
 	<ControlAppBar
 		showBackButton
 		backIcon={ArrowLeft}
-		on:close-button-click={() => goto(AppRoute.EXPLORE)}
+		on:close-button-click={() => goto(previousRoute)}
 	/>
 {/if}
 


### PR DESCRIPTION
Set default route of the back button on the `people/[personId]` page to the previous route, with a fallback to `/explore` instead of always going to that page