### PR TITLE
fix(web): small style issues

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -172,7 +172,9 @@
 				<div><ImageOutline size="24" /></div>
 
 				<div>
-					<p>{`${asset.originalFileName}.${asset.originalPath.split('.')[1]}` || ''}</p>
+					<p class="break-all">
+						{`${asset.originalFileName}.${asset.originalPath.split('.')[1]}` || ''}
+					</p>
 					<div class="flex text-sm gap-2">
 						{#if asset.exifInfo.exifImageHeight && asset.exifInfo.exifImageWidth}
 							{#if getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)}

--- a/web/src/lib/components/shared-components/context-menu/menu-option.svelte
+++ b/web/src/lib/components/shared-components/context-menu/menu-option.svelte
@@ -4,7 +4,7 @@
 
 <button
 	on:click
-	class="bg-slate-100 hover:bg-gray-200 dark:text-immich-dark-bg p-4 w-full text-left text-sm font-medium focus:outline-none focus:ring-inset focus:ring-2"
+	class="bg-slate-100 hover:bg-gray-200 text-immich-fg dark:text-immich-dark-bg p-4 w-full text-left text-sm font-medium focus:outline-none focus:ring-inset focus:ring-2"
 	role="menuitem"
 >
 	{#if text}


### PR DESCRIPTION
- Filename without spaces in detail panel could overflow
- Context menu for asset viewer had wrong text color in light mode

![detail-panel-before](https://github.com/immich-app/immich/assets/59014050/d1d548c1-7c3f-4bcf-89bb-0ddaac56bde1)![detail-panel-after](https://github.com/immich-app/immich/assets/59014050/b68f7ae3-4eed-484e-b8e0-ea23ec4fa672)
![asset-viewer-context-before](https://github.com/immich-app/immich/assets/59014050/f97f7800-ae4c-478b-9f18-852b4a9f69af)![asset-viewer-context-after](https://github.com/immich-app/immich/assets/59014050/6c89d1e4-4091-4f4f-b1a3-b33d18363336)

