### PR TITLE
fix(server): invalid exif date string

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -116,13 +116,16 @@ export class MetadataExtractionProcessor {
       : {};
 
     const exifToDate = (exifDate: string | ExifDateTime | undefined) => {
-      if (!exifDate) return null;
-
-      if (typeof exifDate === 'string') {
-        return new Date(exifDate);
+      if (!exifDate) {
+        return null;
       }
 
-      return exifDate.toDate();
+      const date = typeof exifDate === 'string' ? new Date(exifDate) : exifDate.toDate();
+      if (isNaN(date.valueOf())) {
+        return null;
+      }
+
+      return date;
     };
 
     const exifTimeZone = (exifDate: string | ExifDateTime | undefined) => {


### PR DESCRIPTION
The date string `0000:00:00 00:00:00` results in an invalid date, and then converting it to a string resulted in `NaN:NaN...`, etc., triggering a database error.

This PR detects an invalid date object and returns `null` instead, allow the field to use an alternative, valid value.