### PR TITLE
fix(server): exif time extraction

### DIFF
--- a/server/apps/microservices/src/processors/metadata-extraction.processor.ts
+++ b/server/apps/microservices/src/processors/metadata-extraction.processor.ts
@@ -115,12 +115,12 @@ export class MetadataExtractionProcessor {
         })
       : {};
 
-    const exifToDate = (exifDate: string | ExifDateTime | undefined) => {
+    const exifToDate = (exifDate: string | Date | ExifDateTime | undefined) => {
       if (!exifDate) {
         return null;
       }
 
-      const date = typeof exifDate === 'string' ? new Date(exifDate) : exifDate.toDate();
+      const date = exifDate instanceof ExifDateTime ? exifDate.toDate() : new Date(exifDate);
       if (isNaN(date.valueOf())) {
         return null;
       }
@@ -128,10 +128,9 @@ export class MetadataExtractionProcessor {
       return date;
     };
 
-    const exifTimeZone = (exifDate: string | ExifDateTime | undefined) => {
-      if (!exifDate) return null;
-
-      if (typeof exifDate === 'string') {
+    const exifTimeZone = (exifDate: string | Date | ExifDateTime | undefined) => {
+      const isExifDate = exifDate instanceof ExifDateTime;
+      if (!isExifDate) {
         return null;
       }
 


### PR DESCRIPTION
TypeORM entities with timestamp columns are of type `Date`, but we are incorrectly using `string` in a lot of places. This case isn't being handled properly in the metadata extraction and can lead to errors when any timestamp of the asset entity is used.

I'm keeping it to a simple fix for now. However, the timestamp columns of all entities should be corrected which requires quite some refactoring
