### PR TITLE
Allow docker image version pinning

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   immich-server:
     container_name: immich_server
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     command: ["start-server.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
@@ -17,7 +17,7 @@ services:
 
   immich-microservices:
     container_name: immich_microservices
-    image: ghcr.io/immich-app/immich-server:release
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     command: ["start-microservices.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
@@ -31,7 +31,7 @@ services:
 
   immich-machine-learning:
     container_name: immich_machine_learning
-    image: ghcr.io/immich-app/immich-machine-learning:release
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - model-cache:/cache
@@ -41,7 +41,7 @@ services:
 
   immich-web:
     container_name: immich_web
-    image: ghcr.io/immich-app/immich-web:release
+    image: ghcr.io/immich-app/immich-web:${IMMICH_VERSION:-release}
     env_file:
       - .env
     restart: always
@@ -79,7 +79,7 @@ services:
 
   immich-proxy:
     container_name: immich_proxy
-    image: ghcr.io/immich-app/immich-proxy:release
+    image: ghcr.io/immich-app/immich-proxy:${IMMICH_VERSION:-release}
     environment:
       # Make sure these values get passed through from the env file
       - IMMICH_SERVER_URL

--- a/docker/example.env
+++ b/docker/example.env
@@ -105,3 +105,12 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 ####################################################################################
 
 #IMMICH_API_URL_EXTERNAL=http://localhost:3001
+
+###################################################################################
+# Immich Version
+#
+# This allows all immich docker images to be pinned to a specific version. By default, 
+# the version is "release" but could be a specific version, like "v1.59.0".
+###################################################################################
+
+#IMMICH_VERSION=

--- a/docker/example.env
+++ b/docker/example.env
@@ -107,7 +107,7 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 #IMMICH_API_URL_EXTERNAL=http://localhost:3001
 
 ###################################################################################
-# Immich Version
+# Immich Version - Optional
 #
 # This allows all immich docker images to be pinned to a specific version. By default, 
 # the version is "release" but could be a specific version, like "v1.59.0".

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -138,7 +138,7 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 #IMMICH_API_URL_EXTERNAL=http://localhost:3001
 
 ###################################################################################
-# Immich Version
+# Immich Version - Optional
 #
 # This allows all immich docker images to be pinned to a specific version. By default,
 # the version is "release" but could be a specific version, like "v1.59.0".

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -140,7 +140,7 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 ###################################################################################
 # Immich Version
 #
-# This allows all immich docker images to be pinned to a specific version. By default, 
+# This allows all immich docker images to be pinned to a specific version. By default,
 # the version is "release" but could be a specific version, like "v1.59.0".
 ###################################################################################
 

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -136,6 +136,15 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 ####################################################################################
 
 #IMMICH_API_URL_EXTERNAL=http://localhost:3001
+
+###################################################################################
+# Immich Version
+#
+# This allows all immich docker images to be pinned to a specific version. By default, 
+# the version is "release" but could be a specific version, like "v1.59.0".
+###################################################################################
+
+#IMMICH_VERSION=
 ```
 
 </details>
@@ -158,6 +167,8 @@ For more information on how to use the application, please refer to the [Post In
 :::
 
 ### Step 4 - Upgrading
+
+If `IMMICH_VERSION` is set, it will need to be updated to the latest or desired version.
 
 When a new version of Immich is [released](https://github.com/immich-app/immich/releases), the application can be upgraded with the following commands, run in the directory with the `docker-compose.yml` file:
 


### PR DESCRIPTION
Those of us _on the bleeding edge of the bleeding edge_ may try to update our docker deployment within just a few minutes of the release notification. With the tag of `release`, I tend to get some updated images and some not updated, and it makes the app act very funny, especially when there are breaking changes from one version to the next.

The idea here is to continue to default to `release` but allow version "pinning" so that a user can manually increment their local desired version, run `docker-compose pull`, and receive an error if not all images are ready/available. This also forces all images to be on the same version, but this requires all immich images to increment at the same pace. 