### PR TITLE
fix(server): remove mbtree files after transcoding

### DIFF
--- a/server/libs/infra/src/repositories/media.repository.ts
+++ b/server/libs/infra/src/repositories/media.repository.ts
@@ -117,6 +117,7 @@ export class MediaRepository implements IMediaRepository {
             .output(output)
             .on('error', reject)
             .on('end', () => fs.unlink(`${output}-0.log`))
+            .on('end', () => fs.rm(`${output}-0.log.mbtree`, { force: true }))
             .on('end', resolve)
             .run();
         })


### PR DESCRIPTION
Fixes #2600.

The following trascoding settings result in the creation of the `mbtree` file by `ffmpeg`:
- h264 video codec
- 2-pass transcoding
- constrained quality (i.e. max bitrate != 0)
- veryfast or slower preset

That file remains on the disk after the video encoding is completed. This PR removes mbsync file after the successfull transcoding.