### PR TITLE
feat(ml): env variables for tags, faces and eager startup

### DIFF
--- a/machine-learning/src/main.py
+++ b/machine-learning/src/main.py
@@ -35,6 +35,11 @@ eager_startup = (
 
 cache_folder = os.getenv("MACHINE_LEARNING_CACHE_FOLDER", "/cache")
 
+model_type_to_name = {
+    "image-classification": classification_model,
+    "clip": clip_model,
+    "facial-recognition": facial_recognition_model,
+}
 _model_cache = {}
 
 app = FastAPI()
@@ -42,13 +47,12 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def startup_event():
-    if not eager_startup:
-        return
-
     # Get all models
-    _get_model(classification_model, "image-classification")
-    _get_model(clip_model)
-    _get_model(facial_recognition_model, "facial-recognition")
+    for model_type, model_name in model_type_to_name.items():
+        if eager_startup:
+            get_cached_model(model_name, model_type)
+        else:
+            _get_model(model_name, model_type)
 
 
 @app.get("/")
@@ -63,28 +67,28 @@ def ping():
 
 @app.post("/image-classifier/tag-image", status_code=200)
 def image_classification(payload: MlRequestBody):
-    model = _get_model(classification_model, "image-classification")
+    model = get_cached_model(classification_model, "image-classification")
     assetPath = payload.thumbnailPath
     return run_engine(model, assetPath)
 
 
 @app.post("/sentence-transformer/encode-image", status_code=200)
 def clip_encode_image(payload: MlRequestBody):
-    model = _get_model(clip_model)
+    model = get_cached_model(clip_model, "clip")
     assetPath = payload.thumbnailPath
     return model.encode(Image.open(assetPath)).tolist()
 
 
 @app.post("/sentence-transformer/encode-text", status_code=200)
 def clip_encode_text(payload: ClipRequestBody):
-    model = _get_model(clip_model)
+    model = get_cached_model(clip_model, "clip")
     text = payload.text
     return model.encode(text).tolist()
 
 
 @app.post("/facial-recognition/detect-faces", status_code=200)
 def facial_recognition(payload: MlRequestBody):
-    model = _get_model(facial_recognition_model, "facial-recognition")
+    model = get_cached_model(facial_recognition_model, "facial-recognition")
     assetPath = payload.thumbnailPath
     img = cv.imread(assetPath)
     height, width, _ = img.shape
@@ -128,24 +132,32 @@ def run_engine(engine, path):
     return result
 
 
-def _get_model(model, task=None):
+def get_cached_model(model, task):
     global _model_cache
     key = "|".join([model, str(task)])
-    if key not in _model_cache:
-        if task:
-            if task == "facial-recognition":
-                face_model = FaceAnalysis(
-                    name=model,
-                    root=cache_folder,
-                    allowed_modules=["detection", "recognition"],
-                )
-                face_model.prepare(ctx_id=0, det_size=(640, 640))
-                _model_cache[key] = face_model
-            else:
-                _model_cache[key] = pipeline(model=model, task=task)
-        else:
-            _model_cache[key] = SentenceTransformer(model, cache_folder=cache_folder)
-    return _model_cache[key]
+    if key in _model_cache:
+        return _model_cache[key]
+    else:
+        model = _get_model(model, task)
+        _model_cache[key] = model
+
+    return model
+
+
+def _get_model(model, task):
+    match task:
+        case "facial-recognition":
+            model = FaceAnalysis(
+                name=model,
+                root=cache_folder,
+                allowed_modules=["detection", "recognition"],
+            )
+            model.prepare(ctx_id=0, det_size=(640, 640))
+        case "clip":
+            model = SentenceTransformer(model, cache_folder=cache_folder)
+        case _:
+            model = pipeline(model=model, task=task)
+    return model
 
 
 if __name__ == "__main__":

--- a/machine-learning/src/main.py
+++ b/machine-learning/src/main.py
@@ -135,13 +135,11 @@ def run_engine(engine, path):
 def get_cached_model(model, task):
     global _model_cache
     key = "|".join([model, str(task)])
-    if key in _model_cache:
-        return _model_cache[key]
-    else:
+    if key not in _model_cache:
         model = _get_model(model, task)
         _model_cache[key] = model
 
-    return model
+    return _model_cache[key]
 
 
 def _get_model(model, task):


### PR DESCRIPTION
This PR adds three environmental variables: 

- `MACHINE_LEARNING_MIN_FACE_SCORE` (float, default 0.7)
  * Score threshold for facial recognition.
- `MACHINE_LEARNING_MIN_TAG_SCORE` (float, default 0.9)
  * Score threshold for image classification.
- `MACHINE_LEARNING_EAGER_STARTUP` (bool, default "true")
  * Whether to load all models at startup. If disabled, models are downloaded but not kept in memory at startup.

Additionally, it changes the behavior for MACHINE_LEARNING_CLIP_IMAGE_MODEL: it will now be used to determine both image and text models. This is because the text and image models have to be the same, so exposing both can lead to unexpected behavior.

Edit: this no longer changes the above behavior in light of the use-case of multilingual models.