### PR TITLE
fix(web): use id instead of assetId

### DIFF
--- a/web/src/lib/stores/asset-interaction.store.ts
+++ b/web/src/lib/stores/asset-interaction.store.ts
@@ -57,7 +57,7 @@ function createAssetInteractionStore() {
 	};
 
 	const setViewingAssetId = async (id: string) => {
-		const { data } = await api.assetApi.getAssetById({ assetId: id });
+		const { data } = await api.assetApi.getAssetById({ id });
 		viewingAssetStoreState.set(data);
 		isViewingAssetStoreState.set(true);
 	};

--- a/web/src/routes/(user)/share/[key]/photos/[assetId]/+page.server.ts
+++ b/web/src/routes/(user)/share/[key]/photos/[assetId]/+page.server.ts
@@ -1,18 +1,19 @@
-export const prerender = false;
-
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load = (async ({ params, locals: { api } }) => {
-	try {
-		const { key, assetId } = params;
-		const { data: asset } = await api.assetApi.getAssetById({ assetId, key });
+	const { key, assetId } = params;
+	const { data: asset } = await api.assetApi.getAssetById({ id: assetId, key });
 
-		if (!asset) {
-			return error(404, 'Asset not found');
-		}
-		return { asset, key };
-	} catch (e) {
-		console.log('Error', e);
+	if (!asset) {
+		throw error(404, 'Asset not found');
 	}
+
+	return {
+		asset,
+		key,
+		meta: {
+			title: 'Public Share'
+		}
+	};
 }) satisfies PageServerLoad;


### PR DESCRIPTION
#2641 changed `assetId` to `id` but some places on web didn't get changed, leading to an error when making API calls. Also fixed invalid types in `+page.server.ts`.

These type of errors should get caught automatically, I'll create a separate PR to add that.