### PR TITLE
refactor(server): remove invalid exif coordinates

### DIFF
--- a/server/libs/infra/src/migrations/1685731372040-RemoveInvalidCoordinates.ts
+++ b/server/libs/infra/src/migrations/1685731372040-RemoveInvalidCoordinates.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveInvalidCoordinates1685731372040 implements MigrationInterface {
+  name = 'RemoveInvalidCoordinates1685731372040';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE "exif" SET "latitude" = NULL WHERE "latitude" IN ('NaN', 'Infinity', '-Infinity')`);
+    await queryRunner.query(
+      `UPDATE "exif" SET "longitude" = NULL WHERE "longitude" IN ('NaN', 'Infinity', '-Infinity')`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Empty, data cannot be restored
+  }
+}

--- a/server/libs/infra/src/repositories/asset.repository.ts
+++ b/server/libs/infra/src/repositories/asset.repository.ts
@@ -11,7 +11,7 @@ import {
 } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsRelations, FindOptionsWhere, In, IsNull, Not, Raw, Repository } from 'typeorm';
+import { FindOptionsRelations, FindOptionsWhere, In, IsNull, Not, Repository } from 'typeorm';
 import { AssetEntity, AssetType } from '../entities';
 import OptionalBetween from '../utils/optional-between.util';
 import { paginate } from '../utils/pagination.util';
@@ -214,9 +214,6 @@ export class AssetRepository implements IAssetRepository {
 
   async getMapMarkers(ownerId: string, options: MapMarkerSearchOptions = {}): Promise<MapMarker[]> {
     const { isFavorite, fileCreatedAfter, fileCreatedBefore } = options;
-    const coordinateFilter = Raw(
-      (column) => `${column} IS NOT NULL AND ${column} NOT IN ('NaN', 'Infinity', '-Infinity')`,
-    );
 
     const assets = await this.repository.find({
       select: {
@@ -231,8 +228,8 @@ export class AssetRepository implements IAssetRepository {
         isVisible: true,
         isArchived: false,
         exifInfo: {
-          latitude: coordinateFilter,
-          longitude: coordinateFilter,
+          latitude: Not(IsNull()),
+          longitude: Not(IsNull()),
         },
         isFavorite,
         fileCreatedAt: OptionalBetween(fileCreatedAfter, fileCreatedBefore),


### PR DESCRIPTION
Use a migration to remove existing invalid data, instead of filtering invalid data out with a query like I did in #2648