### PR TITLE
fix(web+server): showing assets without thumbnail

### DIFF
--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -553,7 +553,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getAllAssets**
-> List<AssetResponseDto> getAllAssets(userId, isFavorite, isArchived, skip, ifNoneMatch)
+> List<AssetResponseDto> getAllAssets(userId, isFavorite, isArchived, withoutThumbs, skip, ifNoneMatch)
 
 
 
@@ -581,11 +581,12 @@ final api_instance = AssetApi();
 final userId = 38400000-8cf0-11bd-b23e-10b96e4ef00d; // String | 
 final isFavorite = true; // bool | 
 final isArchived = true; // bool | 
+final withoutThumbs = true; // bool | Include assets without thumbnails
 final skip = 8.14; // num | 
 final ifNoneMatch = ifNoneMatch_example; // String | ETag of data already cached on the client
 
 try {
-    final result = api_instance.getAllAssets(userId, isFavorite, isArchived, skip, ifNoneMatch);
+    final result = api_instance.getAllAssets(userId, isFavorite, isArchived, withoutThumbs, skip, ifNoneMatch);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->getAllAssets: $e\n');
@@ -599,6 +600,7 @@ Name | Type | Description  | Notes
  **userId** | **String**|  | [optional] 
  **isFavorite** | **bool**|  | [optional] 
  **isArchived** | **bool**|  | [optional] 
+ **withoutThumbs** | **bool**| Include assets without thumbnails | [optional] 
  **skip** | **num**|  | [optional] 
  **ifNoneMatch** | **String**| ETag of data already cached on the client | [optional] 
 

--- a/mobile/openapi/doc/GetAssetCountByTimeBucketDto.md
+++ b/mobile/openapi/doc/GetAssetCountByTimeBucketDto.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **timeGroup** | [**TimeGroupEnum**](TimeGroupEnum.md) |  | 
 **userId** | **String** |  | [optional] 
+**withoutThumbs** | **bool** | Include assets without thumbnails | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/api/asset_api.dart
+++ b/mobile/openapi/lib/api/asset_api.dart
@@ -525,11 +525,14 @@ class AssetApi {
   ///
   /// * [bool] isArchived:
   ///
+  /// * [bool] withoutThumbs:
+  ///   Include assets without thumbnails
+  ///
   /// * [num] skip:
   ///
   /// * [String] ifNoneMatch:
   ///   ETag of data already cached on the client
-  Future<Response> getAllAssetsWithHttpInfo({ String? userId, bool? isFavorite, bool? isArchived, num? skip, String? ifNoneMatch, }) async {
+  Future<Response> getAllAssetsWithHttpInfo({ String? userId, bool? isFavorite, bool? isArchived, bool? withoutThumbs, num? skip, String? ifNoneMatch, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset';
 
@@ -548,6 +551,9 @@ class AssetApi {
     }
     if (isArchived != null) {
       queryParams.addAll(_queryParams('', 'isArchived', isArchived));
+    }
+    if (withoutThumbs != null) {
+      queryParams.addAll(_queryParams('', 'withoutThumbs', withoutThumbs));
     }
     if (skip != null) {
       queryParams.addAll(_queryParams('', 'skip', skip));
@@ -581,12 +587,15 @@ class AssetApi {
   ///
   /// * [bool] isArchived:
   ///
+  /// * [bool] withoutThumbs:
+  ///   Include assets without thumbnails
+  ///
   /// * [num] skip:
   ///
   /// * [String] ifNoneMatch:
   ///   ETag of data already cached on the client
-  Future<List<AssetResponseDto>?> getAllAssets({ String? userId, bool? isFavorite, bool? isArchived, num? skip, String? ifNoneMatch, }) async {
-    final response = await getAllAssetsWithHttpInfo( userId: userId, isFavorite: isFavorite, isArchived: isArchived, skip: skip, ifNoneMatch: ifNoneMatch, );
+  Future<List<AssetResponseDto>?> getAllAssets({ String? userId, bool? isFavorite, bool? isArchived, bool? withoutThumbs, num? skip, String? ifNoneMatch, }) async {
+    final response = await getAllAssetsWithHttpInfo( userId: userId, isFavorite: isFavorite, isArchived: isArchived, withoutThumbs: withoutThumbs, skip: skip, ifNoneMatch: ifNoneMatch, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/get_asset_count_by_time_bucket_dto.dart
+++ b/mobile/openapi/lib/model/get_asset_count_by_time_bucket_dto.dart
@@ -15,6 +15,7 @@ class GetAssetCountByTimeBucketDto {
   GetAssetCountByTimeBucketDto({
     required this.timeGroup,
     this.userId,
+    this.withoutThumbs,
   });
 
   TimeGroupEnum timeGroup;
@@ -27,19 +28,30 @@ class GetAssetCountByTimeBucketDto {
   ///
   String? userId;
 
+  /// Include assets without thumbnails
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? withoutThumbs;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is GetAssetCountByTimeBucketDto &&
      other.timeGroup == timeGroup &&
-     other.userId == userId;
+     other.userId == userId &&
+     other.withoutThumbs == withoutThumbs;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (timeGroup.hashCode) +
-    (userId == null ? 0 : userId!.hashCode);
+    (userId == null ? 0 : userId!.hashCode) +
+    (withoutThumbs == null ? 0 : withoutThumbs!.hashCode);
 
   @override
-  String toString() => 'GetAssetCountByTimeBucketDto[timeGroup=$timeGroup, userId=$userId]';
+  String toString() => 'GetAssetCountByTimeBucketDto[timeGroup=$timeGroup, userId=$userId, withoutThumbs=$withoutThumbs]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -48,6 +60,11 @@ class GetAssetCountByTimeBucketDto {
       json[r'userId'] = this.userId;
     } else {
       // json[r'userId'] = null;
+    }
+    if (this.withoutThumbs != null) {
+      json[r'withoutThumbs'] = this.withoutThumbs;
+    } else {
+      // json[r'withoutThumbs'] = null;
     }
     return json;
   }
@@ -73,6 +90,7 @@ class GetAssetCountByTimeBucketDto {
       return GetAssetCountByTimeBucketDto(
         timeGroup: TimeGroupEnum.fromJson(json[r'timeGroup'])!,
         userId: mapValueOfType<String>(json, r'userId'),
+        withoutThumbs: mapValueOfType<bool>(json, r'withoutThumbs'),
       );
     }
     return null;

--- a/mobile/openapi/test/asset_api_test.dart
+++ b/mobile/openapi/test/asset_api_test.dart
@@ -72,7 +72,7 @@ void main() {
 
     // Get all AssetEntity belong to the user
     //
-    //Future<List<AssetResponseDto>> getAllAssets({ String userId, bool isFavorite, bool isArchived, num skip, String ifNoneMatch }) async
+    //Future<List<AssetResponseDto>> getAllAssets({ String userId, bool isFavorite, bool isArchived, bool withoutThumbs, num skip, String ifNoneMatch }) async
     test('test getAllAssets', () async {
       // TODO
     });

--- a/mobile/openapi/test/get_asset_count_by_time_bucket_dto_test.dart
+++ b/mobile/openapi/test/get_asset_count_by_time_bucket_dto_test.dart
@@ -26,6 +26,12 @@ void main() {
       // TODO
     });
 
+    // Include assets without thumbnails
+    // bool withoutThumbs
+    test('to test the property `withoutThumbs`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/server/apps/immich/src/api-v1/asset/asset.service.ts
+++ b/server/apps/immich/src/api-v1/asset/asset.service.ts
@@ -533,7 +533,7 @@ export class AssetService {
 
     const result = await this._assetRepository.getAssetCountByTimeBucket(
       getAssetCountByTimeBucketDto.userId || authUser.id,
-      getAssetCountByTimeBucketDto.timeGroup,
+      getAssetCountByTimeBucketDto,
     );
 
     return mapAssetCountByTimeBucket(result);

--- a/server/apps/immich/src/api-v1/asset/dto/asset-search.dto.ts
+++ b/server/apps/immich/src/api-v1/asset/dto/asset-search.dto.ts
@@ -16,6 +16,14 @@ export class AssetSearchDto {
   @Transform(toBoolean)
   isArchived?: boolean;
 
+  /**
+   * Include assets without thumbnails
+   */
+  @IsOptional()
+  @IsBoolean()
+  @Transform(toBoolean)
+  withoutThumbs?: boolean;
+
   @IsOptional()
   @IsNumber()
   skip?: number;

--- a/server/apps/immich/src/api-v1/asset/dto/get-asset-count-by-time-bucket.dto.ts
+++ b/server/apps/immich/src/api-v1/asset/dto/get-asset-count-by-time-bucket.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { toBoolean } from '../../../utils/transform.util';
 
 export enum TimeGroupEnum {
   Day = 'day',
@@ -19,4 +21,12 @@ export class GetAssetCountByTimeBucketDto {
   @IsUUID('4')
   @ApiProperty({ format: 'uuid' })
   userId?: string;
+
+  /**
+   * Include assets without thumbnails
+   */
+  @IsOptional()
+  @IsBoolean()
+  @Transform(toBoolean)
+  withoutThumbs?: boolean;
 }

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -3381,6 +3381,15 @@
             }
           },
           {
+            "name": "withoutThumbs",
+            "required": false,
+            "in": "query",
+            "description": "Include assets without thumbnails",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "skip",
             "required": false,
             "in": "query",
@@ -6221,6 +6230,10 @@
           "userId": {
             "type": "string",
             "format": "uuid"
+          },
+          "withoutThumbs": {
+            "type": "boolean",
+            "description": "Include assets without thumbnails"
           }
         },
         "required": [

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1396,6 +1396,12 @@ export interface GetAssetCountByTimeBucketDto {
      * @memberof GetAssetCountByTimeBucketDto
      */
     'userId'?: string;
+    /**
+     * Include assets without thumbnails
+     * @type {boolean}
+     * @memberof GetAssetCountByTimeBucketDto
+     */
+    'withoutThumbs'?: boolean;
 }
 
 
@@ -4999,12 +5005,13 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * @param {string} [userId] 
          * @param {boolean} [isFavorite] 
          * @param {boolean} [isArchived] 
+         * @param {boolean} [withoutThumbs] Include assets without thumbnails
          * @param {number} [skip] 
          * @param {string} [ifNoneMatch] ETag of data already cached on the client
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAllAssets: async (userId?: string, isFavorite?: boolean, isArchived?: boolean, skip?: number, ifNoneMatch?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getAllAssets: async (userId?: string, isFavorite?: boolean, isArchived?: boolean, withoutThumbs?: boolean, skip?: number, ifNoneMatch?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/asset`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -5036,6 +5043,10 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
 
             if (isArchived !== undefined) {
                 localVarQueryParameter['isArchived'] = isArchived;
+            }
+
+            if (withoutThumbs !== undefined) {
+                localVarQueryParameter['withoutThumbs'] = withoutThumbs;
             }
 
             if (skip !== undefined) {
@@ -5970,13 +5981,14 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * @param {string} [userId] 
          * @param {boolean} [isFavorite] 
          * @param {boolean} [isArchived] 
+         * @param {boolean} [withoutThumbs] Include assets without thumbnails
          * @param {number} [skip] 
          * @param {string} [ifNoneMatch] ETag of data already cached on the client
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAllAssets(userId?: string, isFavorite?: boolean, isArchived?: boolean, skip?: number, ifNoneMatch?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<AssetResponseDto>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllAssets(userId, isFavorite, isArchived, skip, ifNoneMatch, options);
+        async getAllAssets(userId?: string, isFavorite?: boolean, isArchived?: boolean, withoutThumbs?: boolean, skip?: number, ifNoneMatch?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<AssetResponseDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllAssets(userId, isFavorite, isArchived, withoutThumbs, skip, ifNoneMatch, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -6259,13 +6271,14 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * @param {string} [userId] 
          * @param {boolean} [isFavorite] 
          * @param {boolean} [isArchived] 
+         * @param {boolean} [withoutThumbs] Include assets without thumbnails
          * @param {number} [skip] 
          * @param {string} [ifNoneMatch] ETag of data already cached on the client
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAllAssets(userId?: string, isFavorite?: boolean, isArchived?: boolean, skip?: number, ifNoneMatch?: string, options?: any): AxiosPromise<Array<AssetResponseDto>> {
-            return localVarFp.getAllAssets(userId, isFavorite, isArchived, skip, ifNoneMatch, options).then((request) => request(axios, basePath));
+        getAllAssets(userId?: string, isFavorite?: boolean, isArchived?: boolean, withoutThumbs?: boolean, skip?: number, ifNoneMatch?: string, options?: any): AxiosPromise<Array<AssetResponseDto>> {
+            return localVarFp.getAllAssets(userId, isFavorite, isArchived, withoutThumbs, skip, ifNoneMatch, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -6626,6 +6639,13 @@ export interface AssetApiGetAllAssetsRequest {
      * @memberof AssetApiGetAllAssets
      */
     readonly isArchived?: boolean
+
+    /**
+     * Include assets without thumbnails
+     * @type {boolean}
+     * @memberof AssetApiGetAllAssets
+     */
+    readonly withoutThumbs?: boolean
 
     /**
      * 
@@ -7071,7 +7091,7 @@ export class AssetApi extends BaseAPI {
      * @memberof AssetApi
      */
     public getAllAssets(requestParameters: AssetApiGetAllAssetsRequest = {}, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getAllAssets(requestParameters.userId, requestParameters.isFavorite, requestParameters.isArchived, requestParameters.skip, requestParameters.ifNoneMatch, options).then((request) => request(this.axios, this.basePath));
+        return AssetApiFp(this.configuration).getAllAssets(requestParameters.userId, requestParameters.isFavorite, requestParameters.isArchived, requestParameters.withoutThumbs, requestParameters.skip, requestParameters.ifNoneMatch, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -29,7 +29,8 @@
 		const { data: assetCountByTimebucket } = await api.assetApi.getAssetCountByTimeBucket({
 			getAssetCountByTimeBucketDto: {
 				timeGroup: TimeGroupEnum.Month,
-				userId: user?.id
+				userId: user?.id,
+				withoutThumbs: true
 			}
 		});
 		bucketInfo = assetCountByTimebucket;

--- a/web/src/lib/components/shared-components/side-bar/side-bar.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar.svelte
@@ -30,7 +30,10 @@
 
 	const getFavoriteCount = async () => {
 		try {
-			const { data: assets } = await api.assetApi.getAllAssets({ isFavorite: true });
+			const { data: assets } = await api.assetApi.getAllAssets({
+				isFavorite: true,
+				withoutThumbs: true
+			});
 
 			return {
 				favorites: assets.length

--- a/web/src/routes/(user)/archive/+page.svelte
+++ b/web/src/routes/(user)/archive/+page.svelte
@@ -26,7 +26,10 @@
 
 	onMount(async () => {
 		try {
-			const { data: assets } = await api.assetApi.getAllAssets({ isArchived: true });
+			const { data: assets } = await api.assetApi.getAllAssets({
+				isArchived: true,
+				withoutThumbs: true
+			});
 			$archivedAsset = assets;
 		} catch {
 			handleError(Error, 'Unable to load archived assets');

--- a/web/src/routes/(user)/favorites/+page.svelte
+++ b/web/src/routes/(user)/favorites/+page.svelte
@@ -28,7 +28,10 @@
 
 	onMount(async () => {
 		try {
-			const { data: assets } = await api.assetApi.getAllAssets({ isFavorite: true });
+			const { data: assets } = await api.assetApi.getAllAssets({
+				isFavorite: true,
+				withoutThumbs: true
+			});
 			favorites = assets;
 		} catch {
 			handleError(Error, 'Unable to load favorites');


### PR DESCRIPTION
#2561 added support for showing assets without thumbnails, but some edge cases were missed:
1. When a bucket only contains assets without thumbnails, the bucket won't be returned by `/asset/count-by-time-bucket` and won't show up in the timeline
2. If you archive an asset without thumbnail, the asset will be become hidden

Fixed by adding `withoutThumbnails` to these endpoints and showing assets without thumbnails on the archive and favorites page 