### PR TITLE
feat(ml): batched model inference

### DIFF
--- a/machine-learning/app/cache.py
+++ b/machine-learning/app/cache.py
@@ -2,6 +2,7 @@ from aiocache.plugins import TimingPlugin, BasePlugin
 from aiocache.backends.memory import SimpleMemoryCache
 from aiocache.lock import OptimisticLock
 from typing import Any
+from schemas import ModelType
 from models import get_model
 
 
@@ -36,7 +37,7 @@ class ModelCache:
         )
 
     async def get_cached_model(
-        self, model_name: str, model_type: str, **model_kwargs
+        self, model_name: str, model_type: ModelType, **model_kwargs
     ) -> Any:
         """
         Args:

--- a/machine-learning/app/models.py
+++ b/machine-learning/app/models.py
@@ -30,11 +30,11 @@ def get_model(model_name: str, model_type: ModelType, **model_kwargs):
 
     cache_dir = _get_cache_dir(model_name, model_type)
     match model_type:
-        case "facial-recognition":
+        case ModelType.FACIAL_RECOGNITION:
             model = _load_facial_recognition(
                 model_name, cache_dir=cache_dir, **model_kwargs
             )
-        case "clip":
+        case ModelType.CLIP:
             model = SentenceTransformer(
                 model_name, cache_folder=cache_dir.as_posix(), **model_kwargs
             )
@@ -50,7 +50,7 @@ def get_model(model_name: str, model_type: ModelType, **model_kwargs):
 
 def run_classification(
     model: Pipeline, images: list[Image], min_score: float | None = None
-) -> list[str] | list[list[str]]:
+) -> list[list[str]]:
 
     batch_predictions: list[list[dict[str, Any]]] = model(images)  # type: ignore
     results = [
@@ -127,7 +127,7 @@ def _load_facial_recognition(
     **model_kwargs,
 ):
     if cache_dir is None:
-        cache_dir = _get_cache_dir(model_name, "facial-recognition")
+        cache_dir = _get_cache_dir(model_name, ModelType.FACIAL_RECOGNITION)
     if isinstance(cache_dir, Path):
         cache_dir = cache_dir.as_posix()
     if min_face_score is None:
@@ -143,5 +143,5 @@ def _load_facial_recognition(
     return model
 
 
-def _get_cache_dir(model_name: str, model_type: str) -> Path:
+def _get_cache_dir(model_name: str, model_type: ModelType) -> Path:
     return Path(cache_folder) / device / model_type / model_name

--- a/machine-learning/app/models.py
+++ b/machine-learning/app/models.py
@@ -1,3 +1,4 @@
+from schemas import ModelType
 import torch
 from insightface.app import FaceAnalysis
 from pathlib import Path
@@ -7,13 +8,14 @@ from transformers import pipeline, Pipeline
 from sentence_transformers import SentenceTransformer
 from typing import Any
 import cv2 as cv
+from PIL.Image import Image
 import numpy as np
 from insightface.utils.face_align import norm_crop
 cache_folder = os.getenv("MACHINE_LEARNING_CACHE_FOLDER", "/cache")
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
 
-def get_model(model_name: str, model_type: str, **model_kwargs):
+def get_model(model_name: str, model_type: ModelType, **model_kwargs):
     """
     Instantiates the specified model.
 
@@ -21,9 +23,6 @@ def get_model(model_name: str, model_type: str, **model_kwargs):
         model_name: Name of model in the model hub used for the task.
         model_type: Model type or task, which determines which model zoo is used.
             `facial-recognition` uses Insightface, while all other models use the HF Model Hub.
-
-            Options:
-                `image-classification`, `clip`,`facial-recognition`, `tokenizer`, `processor`
 
     Returns:
         model: The requested model.
@@ -37,7 +36,7 @@ def get_model(model_name: str, model_type: str, **model_kwargs):
             )
         case "clip":
             model = SentenceTransformer(
-                model_name, cache_folder=cache_dir, **model_kwargs
+                model_name, cache_folder=cache_dir.as_posix(), **model_kwargs
             )
         case _:
             model = pipeline(
@@ -50,13 +49,10 @@ def get_model(model_name: str, model_type: str, **model_kwargs):
 
 
 def run_classification(
-    model: Pipeline, image_paths: str | list[str], min_score: float | None = None
+    model: Pipeline, images: list[Image], min_score: float | None = None
 ) -> list[str] | list[list[str]]:
 
-    batch_predictions = model(image_paths)  # type: ignore
-    if not (batched := isinstance(batch_predictions[0], list)):
-        batch_predictions = [batch_predictions]
-
+    batch_predictions: list[list[dict[str, Any]]] = model(images)  # type: ignore
     results = [
         list({
             tag
@@ -67,51 +63,49 @@ def run_classification(
         for predictions in batch_predictions
     ]
 
-    return results[0] if not batched else results
+    return results
 
 
-def run_facial_recognition(
-    model: FaceAnalysis, image_paths: str | list[str]
-) -> list[dict[str, Any]] | list[list[dict[str, Any]]]:
-    if not (batched := isinstance(image_paths, list)):
-        images = [cv.imread(image_paths)]
-    else:
-        images = [cv.imread(image_path) for image_path in image_paths]
+def run_facial_recognition(model: FaceAnalysis, images: list[cv.Mat]) -> list[dict[str, Any]]:
+    batch_det: list[np.ndarray[int, np.dtype[np.float32]]] = []
+    image_offsets: list[int] = []
+    batch_cropped_images: list[cv.Mat] = []
+    results: list[dict[str, Any]] = []
 
-    batch_det = []
-    face_counts = []
-    batch_cropped_images = []
+    total_faces = 0
     for image in images:
         # detection model doesn't support batching, but recognition model does
         bboxes, kpss = model.det_model.detect(image)
         face_count = bboxes.shape[0]
-        face_counts.append(face_count)
-        if face_count == 0:
-            continue
-
+        total_faces += face_count
+        image_offsets.append(total_faces)
+        height, width, _ = image.shape
+        image_faces = {
+            "imageWidth": width,
+            "imageHeight": height,
+            "faces": []
+        }
+        results.append(image_faces)
         batch_det.append(bboxes)
         for kps in kpss:
             batch_cropped_images.append(norm_crop(image, kps))
-    if not batch_cropped_images:
-        return [] if not batched else [[]] * len(image_paths)
-    
-    embeddings = model.models['recognition'].get_feat(batch_cropped_images).tolist()
-    batch_det_np = np.stack(batch_det)
-    batch_bboxes = batch_det_np[:, :4].round().tolist()
-    det_scores = batch_det_np[:, 4].tolist()
 
-    results = []
-    images_with_faces = [image for i, image in enumerate(images) for _ in range(face_counts[i])]
-    for i, image in enumerate(images_with_faces):
-        height, width, _ = image.shape
-        image_faces = []
-        for j in face_counts[i]:
-            embedding = embeddings[i][j]
-            x1, y1, x2, y2 = batch_bboxes[i][j]
-            det_score = det_scores[i][j]
+    if not batch_cropped_images:
+        return results
+
+    embeddings = model.models['recognition'].get_feat(batch_cropped_images)
+    image_embeddings = np.array_split(embeddings, image_offsets)
+
+    for i, image_faces in enumerate(results):
+        if image_embeddings[i].shape[0] == 0:
+            continue
+
+        embeddings = image_embeddings[i].tolist()
+        bboxes = batch_det[i][:, :4].round().tolist()
+        det_scores = batch_det[i][:, 4].tolist()
+        for embedding, bbox, det_score in zip(embeddings, bboxes, det_scores):
+            x1, y1, x2, y2 = bbox
             face = {
-                "imageWidth": width,
-                "imageHeight": height,
                 "boundingBox": {
                     "x1": x1,
                     "y1": y1,
@@ -121,10 +115,9 @@ def run_facial_recognition(
                 "score": det_score,
                 "embedding": embedding,
             }
-            image_faces.append(face)
-        results.append(image_faces)
 
-    return results[0] if not batched else results
+            image_faces["faces"].append(face)
+    return results
 
 
 def _load_facial_recognition(
@@ -151,4 +144,4 @@ def _load_facial_recognition(
 
 
 def _get_cache_dir(model_name: str, model_type: str) -> Path:
-    return Path(cache_folder, device, model_type, model_name)
+    return Path(cache_folder) / device / model_type / model_name

--- a/machine-learning/app/models.py
+++ b/machine-learning/app/models.py
@@ -40,7 +40,7 @@ def get_model(model_name: str, model_type: ModelType, **model_kwargs):
             )
         case _:
             model = pipeline(
-                model_type,
+                model_type.value,
                 model_name,
                 model_kwargs={"cache_dir": cache_dir, **model_kwargs},
             )

--- a/machine-learning/app/models.py
+++ b/machine-learning/app/models.py
@@ -54,7 +54,7 @@ def run_classification(
 ) -> list[str] | list[list[str]]:
 
     batch_predictions = model(image_paths)  # type: ignore
-    if (batched := isinstance(batch_predictions[0], dict)):
+    if not (batched := isinstance(batch_predictions[0], list)):
         batch_predictions = [batch_predictions]
 
     results = [

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import ParamSpec, TypeAlias, Literal, TypeVar
 from pydantic import BaseModel
 
@@ -77,6 +78,13 @@ class FaceResponse(BaseModel):
     __root__: ImageFaces | list[ImageFaces]
 
 
-ModelType: TypeAlias = Literal['image-classification', 'clip', 'facial-recognition', 'tokenizer', 'processor']
+class ModelType(StrEnum):
+    IMAGE_CLASSIFICATION = 'image-classification'
+    CLIP = 'clip'
+    FACIAL_RECOGNITION = 'facial-recognition'
+    TOKENIZER = 'tokenizer'
+    PROCESSOR = 'processor'
+
+
 R = TypeVar("R")
 P = ParamSpec("P")

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -1,3 +1,4 @@
+from typing import TypeVar
 from pydantic import BaseModel
 
 
@@ -10,7 +11,7 @@ def to_lower_camel(string: str) -> str:
 
 
 class VisionModelRequest(BaseModel):
-    image_path: str
+    image_paths: str | list[str]
 
     class Config:
         alias_generator = to_lower_camel
@@ -18,7 +19,7 @@ class VisionModelRequest(BaseModel):
 
 
 class TextModelRequest(BaseModel):
-    text: str
+    text: str | list[str]
 
 
 class TextResponse(BaseModel):
@@ -29,8 +30,12 @@ class MessageResponse(BaseModel):
     message: str
 
 
-class TagResponse(BaseModel):
+class Tags(BaseModel):
     __root__: list[str]
+
+
+class TagResponse(BaseModel):
+    __root__: Tags | list[Tags]
 
 
 class Embedding(BaseModel):
@@ -38,7 +43,7 @@ class Embedding(BaseModel):
 
 
 class EmbeddingResponse(BaseModel):
-    __root__: Embedding
+    __root__: Embedding | list[Embedding]
 
 
 class BoundingBox(BaseModel):
@@ -60,5 +65,9 @@ class Face(BaseModel):
         allow_population_by_field_name = True
 
 
-class FaceResponse(BaseModel):
+class Faces(BaseModel):
     __root__: list[Face]
+
+
+class FaceResponse(BaseModel):
+    __root__: Faces | list[Faces]

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import ParamSpec, TypeAlias, Literal, TypeVar
+from typing import ParamSpec, TypeVar
 from pydantic import BaseModel
 
 
@@ -12,7 +12,7 @@ def to_lower_camel(string: str) -> str:
 
 
 class VisionModelRequest(BaseModel):
-    image_paths: str | list[str]
+    image_paths: list[str]
 
     class Config:
         alias_generator = to_lower_camel
@@ -20,7 +20,7 @@ class VisionModelRequest(BaseModel):
 
 
 class TextModelRequest(BaseModel):
-    text: str | list[str]
+    text: list[str]
 
 
 class TextResponse(BaseModel):
@@ -36,7 +36,7 @@ class Tags(BaseModel):
 
 
 class TagResponse(BaseModel):
-    __root__: Tags | list[Tags]
+    __root__: list[Tags]
 
 
 class Embedding(BaseModel):
@@ -44,7 +44,7 @@ class Embedding(BaseModel):
 
 
 class EmbeddingResponse(BaseModel):
-    __root__: Embedding | list[Embedding]
+    __root__: list[Embedding]
 
 
 class BoundingBox(BaseModel):
@@ -75,7 +75,7 @@ class ImageFaces(BaseModel):
 
 
 class FaceResponse(BaseModel):
-    __root__: ImageFaces | list[ImageFaces]
+    __root__: list[ImageFaces]
 
 
 class ModelType(StrEnum):

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import TypeVar
+from typing import ParamSpec, TypeAlias, Literal, TypeVar
 from pydantic import BaseModel
 
 
@@ -54,8 +54,6 @@ class BoundingBox(BaseModel):
 
 
 class Face(BaseModel):
-    image_width: int
-    image_height: int
     bounding_box: BoundingBox
     score: float
     embedding: Embedding
@@ -65,9 +63,20 @@ class Face(BaseModel):
         allow_population_by_field_name = True
 
 
-class Faces(BaseModel):
-    __root__: list[Face]
+class ImageFaces(BaseModel):
+    image_width: int
+    image_height: int
+    faces: list[Face]
+
+    class Config:
+        alias_generator = to_lower_camel
+        allow_population_by_field_name = True
 
 
 class FaceResponse(BaseModel):
-    __root__: Faces | list[Faces]
+    __root__: ImageFaces | list[ImageFaces]
+
+
+ModelType: TypeAlias = Literal['image-classification', 'clip', 'facial-recognition', 'tokenizer', 'processor']
+R = TypeVar("R")
+P = ParamSpec("P")

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -21,7 +21,7 @@ export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload
 
 export const MACHINE_LEARNING_URL = process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003';
 export const MACHINE_LEARNING_ENABLED = MACHINE_LEARNING_URL !== 'false';
-export const MACHINE_LEARNING_BATCH_SIZE = 4;
+export const MACHINE_LEARNING_BATCH_SIZE = 8;
 
 export function assertMachineLearningEnabled() {
   if (!MACHINE_LEARNING_ENABLED) {

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -21,6 +21,7 @@ export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload
 
 export const MACHINE_LEARNING_URL = process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003';
 export const MACHINE_LEARNING_ENABLED = MACHINE_LEARNING_URL !== 'false';
+export const MACHINE_LEARNING_BATCH_SIZE = 4;
 
 export function assertMachineLearningEnabled() {
   if (!MACHINE_LEARNING_ENABLED) {

--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -33,6 +33,18 @@ export function asHumanReadable(bytes: number, precision = 1): string {
   return `${remainder.toFixed(magnitude == 0 ? 0 : precision)} ${units[magnitude]}`;
 }
 
+export function batched<T>(items: T[], batchSize: number): T[][] {
+  const batchedItems = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    batchedItems.push(items.slice(i, i + batchSize));
+  }
+  return batchedItems;
+}
+
+export function notNull<T>(value: T): value is NonNullable<T> {
+  return value != null && value != undefined;
+}
+
 export interface PaginationOptions {
   take: number;
   skip?: number;

--- a/server/src/domain/job/job.repository.ts
+++ b/server/src/domain/job/job.repository.ts
@@ -52,16 +52,16 @@ export type JobItem =
 
   // Object Tagging
   | { name: JobName.QUEUE_OBJECT_TAGGING; data: IBaseJob }
-  | { name: JobName.CLASSIFY_IMAGE; data: IEntityJob }
+  | { name: JobName.CLASSIFY_IMAGE; data: IBulkEntityJob }
 
   // Recognize Faces
   | { name: JobName.QUEUE_RECOGNIZE_FACES; data: IBaseJob }
-  | { name: JobName.RECOGNIZE_FACES; data: IEntityJob }
+  | { name: JobName.RECOGNIZE_FACES; data: IBulkEntityJob }
   | { name: JobName.GENERATE_FACE_THUMBNAIL; data: IFaceThumbnailJob }
 
   // Clip Embedding
   | { name: JobName.QUEUE_ENCODE_CLIP; data: IBaseJob }
-  | { name: JobName.ENCODE_CLIP; data: IEntityJob }
+  | { name: JobName.ENCODE_CLIP; data: IBulkEntityJob }
 
   // Filesystem
   | { name: JobName.DELETE_FILES; data: IDeleteFilesJob }

--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -264,15 +264,15 @@ describe(JobService.name, () => {
         jobs: [JobName.GENERATE_WEBP_THUMBNAIL, JobName.CLASSIFY_IMAGE, JobName.ENCODE_CLIP, JobName.RECOGNIZE_FACES],
       },
       {
-        item: { name: JobName.CLASSIFY_IMAGE, data: { id: 'asset-1' } },
+        item: { name: JobName.CLASSIFY_IMAGE, data: { ids: ['asset-1'] } },
         jobs: [JobName.SEARCH_INDEX_ASSET],
       },
       {
-        item: { name: JobName.ENCODE_CLIP, data: { id: 'asset-1' } },
+        item: { name: JobName.ENCODE_CLIP, data: { ids: ['asset-1'] } },
         jobs: [JobName.SEARCH_INDEX_ASSET],
       },
       {
-        item: { name: JobName.RECOGNIZE_FACES, data: { id: 'asset-1' } },
+        item: { name: JobName.RECOGNIZE_FACES, data: { ids: ['asset-1'] } },
         jobs: [JobName.SEARCH_INDEX_ASSET],
       },
     ];

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -135,8 +135,8 @@ export class SearchService {
     let assets: SearchResult<AssetEntity>;
     switch (strategy) {
       case SearchStrategy.CLIP:
-        const clip = await this.machineLearning.encodeText(query);
-        assets = await this.searchRepository.vectorSearch(clip, filters);
+        const clip = await this.machineLearning.encodeText([query]);
+        assets = await this.searchRepository.vectorSearch(clip[0], filters);
         break;
       case SearchStrategy.TEXT:
       default:

--- a/server/src/domain/smart-info/machine-learning.interface.ts
+++ b/server/src/domain/smart-info/machine-learning.interface.ts
@@ -11,17 +11,21 @@ export interface BoundingBox {
   y2: number;
 }
 
-export interface DetectFaceResult {
-  imageWidth: number;
-  imageHeight: number;
+export interface Face {
   boundingBox: BoundingBox;
   score: number;
   embedding: number[];
+}
+
+export interface DetectFaceResult {
+  imageWidth: number;
+  imageHeight: number;
+  faces: Face[]
 }
 
 export interface IMachineLearningRepository {
   classifyImage(input: MachineLearningInput): Promise<string[][]>;
   encodeImage(input: MachineLearningInput): Promise<number[][]>;
   encodeText(input: string[]): Promise<number[][]>;
-  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[][]>;
+  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[]>;
 }

--- a/server/src/domain/smart-info/machine-learning.interface.ts
+++ b/server/src/domain/smart-info/machine-learning.interface.ts
@@ -1,7 +1,7 @@
 export const IMachineLearningRepository = 'IMachineLearningRepository';
 
 export interface MachineLearningInput {
-  imagePath: string;
+  imagePaths: string[];
 }
 
 export interface BoundingBox {
@@ -20,8 +20,8 @@ export interface DetectFaceResult {
 }
 
 export interface IMachineLearningRepository {
-  classifyImage(input: MachineLearningInput): Promise<string[]>;
-  encodeImage(input: MachineLearningInput): Promise<number[]>;
-  encodeText(input: string): Promise<number[]>;
-  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[]>;
+  classifyImage(input: MachineLearningInput): Promise<string[][]>;
+  encodeImage(input: MachineLearningInput): Promise<number[][]>;
+  encodeText(input: string[]): Promise<number[][]>;
+  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[][]>;
 }

--- a/server/src/domain/smart-info/machine-learning.interface.ts
+++ b/server/src/domain/smart-info/machine-learning.interface.ts
@@ -20,7 +20,7 @@ export interface Face {
 export interface DetectFaceResult {
   imageWidth: number;
   imageHeight: number;
-  faces: Face[]
+  faces: Face[];
 }
 
 export interface IMachineLearningRepository {

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -48,7 +48,7 @@ describe(SmartInfoService.name, () => {
       await sut.handleQueueObjectTagging({ force: false });
 
       expect(jobMock.queue.mock.calls).toEqual([
-        [{ name: JobName.CLASSIFY_IMAGE, data: { id: assetEntityStub.image.id } }],
+        [{ name: JobName.CLASSIFY_IMAGE, data: { ids: [assetEntityStub.image.id] } }],
       ]);
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.OBJECT_TAGS);
     });
@@ -62,7 +62,7 @@ describe(SmartInfoService.name, () => {
       await sut.handleQueueObjectTagging({ force: true });
 
       expect(jobMock.queue.mock.calls).toEqual([
-        [{ name: JobName.CLASSIFY_IMAGE, data: { id: assetEntityStub.image.id } }],
+        [{ name: JobName.CLASSIFY_IMAGE, data: { ids: [assetEntityStub.image.id] } }],
       ]);
       expect(assetMock.getAll).toHaveBeenCalled();
     });
@@ -73,18 +73,18 @@ describe(SmartInfoService.name, () => {
       const asset = { resizePath: '' } as AssetEntity;
       assetMock.getByIds.mockResolvedValue([asset]);
 
-      await sut.handleClassifyImage({ id: asset.id });
+      await sut.handleClassifyImage({ ids: [asset.id] });
 
       expect(smartMock.upsert).not.toHaveBeenCalled();
       expect(machineMock.classifyImage).not.toHaveBeenCalled();
     });
 
     it('should save the returned tags', async () => {
-      machineMock.classifyImage.mockResolvedValue(['tag1', 'tag2', 'tag3']);
+      machineMock.classifyImage.mockResolvedValue([['tag1', 'tag2', 'tag3']]);
 
-      await sut.handleClassifyImage({ id: asset.id });
+      await sut.handleClassifyImage({ ids: [asset.id] });
 
-      expect(machineMock.classifyImage).toHaveBeenCalledWith({ imagePath: 'path/to/resize.ext' });
+      expect(machineMock.classifyImage).toHaveBeenCalledWith({ imagePaths: ['path/to/resize.ext'] });
       expect(smartMock.upsert).toHaveBeenCalledWith({
         assetId: 'asset-1',
         tags: ['tag1', 'tag2', 'tag3'],
@@ -94,7 +94,7 @@ describe(SmartInfoService.name, () => {
     it('should no update the smart info if no tags were returned', async () => {
       machineMock.classifyImage.mockResolvedValue([]);
 
-      await sut.handleClassifyImage({ id: asset.id });
+      await sut.handleClassifyImage({ ids: [asset.id] });
 
       expect(machineMock.classifyImage).toHaveBeenCalled();
       expect(smartMock.upsert).not.toHaveBeenCalled();
@@ -110,7 +110,10 @@ describe(SmartInfoService.name, () => {
 
       await sut.handleQueueEncodeClip({ force: false });
 
-      expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.ENCODE_CLIP, data: { id: assetEntityStub.image.id } });
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.ENCODE_CLIP,
+        data: { ids: [assetEntityStub.image.id] },
+      });
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.CLIP_ENCODING);
     });
 
@@ -122,7 +125,10 @@ describe(SmartInfoService.name, () => {
 
       await sut.handleQueueEncodeClip({ force: true });
 
-      expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.ENCODE_CLIP, data: { id: assetEntityStub.image.id } });
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.ENCODE_CLIP,
+        data: { ids: [assetEntityStub.image.id] },
+      });
       expect(assetMock.getAll).toHaveBeenCalled();
     });
   });
@@ -132,18 +138,18 @@ describe(SmartInfoService.name, () => {
       const asset = { resizePath: '' } as AssetEntity;
       assetMock.getByIds.mockResolvedValue([asset]);
 
-      await sut.handleEncodeClip({ id: asset.id });
+      await sut.handleEncodeClip({ ids: [asset.id] });
 
       expect(smartMock.upsert).not.toHaveBeenCalled();
       expect(machineMock.encodeImage).not.toHaveBeenCalled();
     });
 
     it('should save the returned objects', async () => {
-      machineMock.encodeImage.mockResolvedValue([0.01, 0.02, 0.03]);
+      machineMock.encodeImage.mockResolvedValue([[0.01, 0.02, 0.03]]);
 
-      await sut.handleEncodeClip({ id: asset.id });
+      await sut.handleEncodeClip({ ids: [asset.id] });
 
-      expect(machineMock.encodeImage).toHaveBeenCalledWith({ imagePath: 'path/to/resize.ext' });
+      expect(machineMock.encodeImage).toHaveBeenCalledWith({ imagePaths: ['path/to/resize.ext'] });
       expect(smartMock.upsert).toHaveBeenCalledWith({
         assetId: 'asset-1',
         clipEmbedding: [0.01, 0.02, 0.03],

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -6,19 +6,19 @@ const client = axios.create({ baseURL: MACHINE_LEARNING_URL });
 
 @Injectable()
 export class MachineLearningRepository implements IMachineLearningRepository {
-  classifyImage(input: MachineLearningInput): Promise<string[]> {
-    return client.post<string[]>('/image-classifier/tag-image', input).then((res) => res.data);
+  classifyImage(input: MachineLearningInput): Promise<string[][]> {
+    return client.post<string[][]>('/image-classifier/tag-image', input).then((res) => res.data);
   }
 
-  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[]> {
-    return client.post<DetectFaceResult[]>('/facial-recognition/detect-faces', input).then((res) => res.data);
+  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[][]> {
+    return client.post<DetectFaceResult[][]>('/facial-recognition/detect-faces', input).then((res) => res.data);
   }
 
-  encodeImage(input: MachineLearningInput): Promise<number[]> {
-    return client.post<number[]>('/sentence-transformer/encode-image', input).then((res) => res.data);
+  encodeImage(input: MachineLearningInput): Promise<number[][]> {
+    return client.post<number[][]>('/sentence-transformer/encode-image', input).then((res) => res.data);
   }
 
-  encodeText(input: string): Promise<number[]> {
-    return client.post<number[]>('/sentence-transformer/encode-text', { text: input }).then((res) => res.data);
+  encodeText(input: string[]): Promise<number[][]> {
+    return client.post<number[][]>('/sentence-transformer/encode-text', { text: input }).then((res) => res.data);
   }
 }

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -10,8 +10,8 @@ export class MachineLearningRepository implements IMachineLearningRepository {
     return client.post<string[][]>('/image-classifier/tag-image', input).then((res) => res.data);
   }
 
-  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[][]> {
-    return client.post<DetectFaceResult[][]>('/facial-recognition/detect-faces', input).then((res) => res.data);
+  detectFaces(input: MachineLearningInput): Promise<DetectFaceResult[]> {
+    return client.post<DetectFaceResult[]>('/facial-recognition/detect-faces', input).then((res) => res.data);
   }
 
   encodeImage(input: MachineLearningInput): Promise<number[][]> {


### PR DESCRIPTION
This is a draft PR that makes ML inference requests and responses support a batch dimension. Models are optimized to run inference in batches for a number of reasons. However, until now, every model input had to be sent as a separate request and handled alone. This adds considerable overhead and is a major performance bottleneck for GPUs from testing.

While this PR (seems to) work, it's not quite ready for merging yet. 

- Only explicitly started jobs are batched; jobs that happen after thumbnail generation aren't affected since they're handled separately. 
- The batch size is currently a hardcoded constant and separate from the models' job concurrencies. This means with a batch size of 4 and a concurrency of 2, 2 requests are sent with 4 images each. 
  - It's possible to instead have the job concurrency act as the batch size and send 1 request at a time, but I don't know which is better.
- I also want to test it a bit more to make sure the batching logic is completely sound.