### PR TITLE
docs: fix Immich internal address while bulk uploading through docker

### DIFF
--- a/docs/docs/features/bulk-upload.md
+++ b/docs/docs/features/bulk-upload.md
@@ -76,10 +76,10 @@ If you are running the CLI container on the same machine as your Immich server, 
 
 1. Find the internal Docker network used by Immich via `docker network ls`.
 2. Adapt the above command to pass the `--network <immich_network>` argument to `docker run`, substituting `<immich_network>` with the result from step 1.
-3. Use `--server http://immich-server:3001/` for the upload command instead of the external address.
+3. Use `--server http://immich-server:3001` for the upload command instead of the external address.
 
 ```bash title="Upload to internal address"
-docker run --network immich_default -it --rm -v "$(pwd):/import" ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://immich-server:3001/
+docker run --network immich_default -it --rm -v "$(pwd):/import" ghcr.io/immich-app/immich-cli:latest upload --key HFEJ38DNSDUEG --server http://immich-server:3001
 ```
 
 :::


### PR DESCRIPTION
With the trailing slash in the internal immich-server address, I get the following error:
```
Checking connectivity with Immich instance...
Error connecting to server - check server address and port
```
Removing the trailing slash completely fixes the issue. 

I haven't tested this extensively, but maybe someone with more docker experience can vouch for this.

PS: I have hardly used Immich for an hour, but looking great so far and I'm really excited! Thanks for this great software.