### PR TITLE
feat(mobile): sync remote assets without thumbs

### DIFF
--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -66,8 +66,11 @@ class AssetService {
     try {
       final etag = hasCache ? _db.eTags.getByIdSync(user.id)?.value : null;
       final (List<AssetResponseDto>? assets, String? newETag) =
-          await _apiService.assetApi
-              .getAllAssetsWithETag(eTag: etag, userId: user.id);
+          await _apiService.assetApi.getAllAssetsWithETag(
+        eTag: etag,
+        userId: user.id,
+        withoutThumbs: true,
+      );
       if (assets == null) {
         return null;
       } else if (assets.isNotEmpty && assets.first.ownerId != user.id) {

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
@@ -110,8 +111,12 @@ class ImmichImage extends StatelessWidget {
         );
       },
       errorWidget: (context, url, error) {
-        debugPrint("Error getting thumbnail $url = $error");
-        CachedNetworkImage.evictFromCache(thumbnailRequestUrl);
+        if (error is HttpExceptionWithStatus &&
+            error.statusCode >= 400 &&
+            error.statusCode < 500) {
+          debugPrint("Evicting thumbnail '$url' from cache: $error");
+          CachedNetworkImage.evictFromCache(url);
+        }
         return Icon(
           Icons.image_not_supported_outlined,
           color: Theme.of(context).primaryColor,

--- a/mobile/lib/utils/openapi_extensions.dart
+++ b/mobile/lib/utils/openapi_extensions.dart
@@ -15,10 +15,16 @@ extension WithETag on AssetApi {
   Future<(List<AssetResponseDto>? assets, String? eTag)> getAllAssetsWithETag({
     String? eTag,
     String? userId,
+    bool? isFavorite,
+    bool? isArchived,
+    bool? withoutThumbs,
   }) async {
     final response = await getAllAssetsWithHttpInfo(
       ifNoneMatch: eTag,
       userId: userId,
+      isFavorite: isFavorite,
+      isArchived: isArchived,
+      withoutThumbs: withoutThumbs,
     );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -367,7 +367,7 @@ packages:
     source: hosted
     version: "0.7.0"
   flutter_cache_manager:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_cache_manager
       sha256: "32cd900555219333326a2d0653aaaf8671264c29befa65bbd9856d204a4c9fb3"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_hooks: ^0.18.6
   hooks_riverpod: ^2.2.0
   cached_network_image: ^3.2.2
+  flutter_cache_manager: ^3.3.0
   intl: ^0.18.0
   auto_route: ^5.0.1
   fluttertoast: ^8.0.8


### PR DESCRIPTION
syncs all remote assets to the app - even if the assets do not yet have a thumbnail image on the server.

This prevents users from thinking their backup or sync is not working properly (while only the server has not yet produced a thumbnail image for whatever reason)