### PR TITLE
fix(web): Timeline narrow date groups style

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -66,7 +66,7 @@
 	<div
 		style:width="{width}px"
 		style:height="{height}px"
-		class="relative group {disabled
+		class="relative group overflow-hidden {disabled
 			? 'bg-gray-300'
 			: 'bg-immich-primary/20 dark:bg-immich-dark-primary/20'}"
 		class:cursor-not-allowed={disabled}

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -201,7 +201,7 @@
 					</div>
 				{/if}
 
-				<span class="truncate">
+				<span class="truncate" title={dateGroupTitle}>
 					{dateGroupTitle}
 				</span>
 			</p>

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -182,6 +182,7 @@
 			<!-- Date group title -->
 			<p
 				class="font-medium text-xs md:text-sm text-immich-fg dark:text-immich-dark-fg mb-2 flex place-items-center h-6"
+				style="width: {calculateWidth(geometry[groupIndex].boxes)}px"
 			>
 				{#if (hoveredDateGroup == dateGroupTitle && isMouseOverGroup) || $selectedGroup.has(dateGroupTitle)}
 					<div
@@ -198,7 +199,7 @@
 					</div>
 				{/if}
 
-				<span>
+				<span class="truncate">
 					{dateGroupTitle}
 				</span>
 			</p>

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -52,15 +52,17 @@
 	$: geometry = (() => {
 		const geometry = [];
 		for (let group of assetsGroupByDate) {
-			geometry.push(
-				justifiedLayout(group.map(getAssetRatio), {
-					boxSpacing: 2,
-					containerWidth: Math.floor(viewportWidth),
-					containerPadding: 0,
-					targetRowHeightTolerance: 0.15,
-					targetRowHeight: 235
-				})
-			);
+			const justifiedLayoutResult = justifiedLayout(group.map(getAssetRatio), {
+				boxSpacing: 2,
+				containerWidth: Math.floor(viewportWidth),
+				containerPadding: 0,
+				targetRowHeightTolerance: 0.15,
+				targetRowHeight: 235
+			});
+			geometry.push({
+				...justifiedLayoutResult,
+				containerWidth: calculateWidth(justifiedLayoutResult.boxes)
+			});
 		}
 		return geometry;
 	})();
@@ -182,7 +184,7 @@
 			<!-- Date group title -->
 			<p
 				class="font-medium text-xs md:text-sm text-immich-fg dark:text-immich-dark-fg mb-2 flex place-items-center h-6"
-				style="width: {calculateWidth(geometry[groupIndex].boxes)}px"
+				style="width: {geometry[groupIndex].containerWidth}px"
 			>
 				{#if (hoveredDateGroup == dateGroupTitle && isMouseOverGroup) || $selectedGroup.has(dateGroupTitle)}
 					<div
@@ -207,9 +209,8 @@
 			<!-- Image grid -->
 			<div
 				class="relative"
-				style="height: {geometry[groupIndex].containerHeight}px;width: {calculateWidth(
-					geometry[groupIndex].boxes
-				)}px"
+				style="height: {geometry[groupIndex].containerHeight}px;width: {geometry[groupIndex]
+					.containerWidth}px"
 			>
 				{#each assetsInDateGroup as asset, index (asset.id)}
 					{@const box = geometry[groupIndex].boxes[index]}


### PR DESCRIPTION
Date group's title is now truncated with ellipsis similar to Google Photos behavior:

![3](https://github.com/immich-app/immich/assets/71479/7bc8aacc-e6d7-4a2f-aec1-1cfee7deb40f)
