### PR TITLE
feat(web): support uploading Insta360 file format

### DIFF
--- a/mobile/lib/utils/files_helper.dart
+++ b/mobile/lib/utils/files_helper.dart
@@ -47,6 +47,12 @@ class FileHelper {
       case 'webm':
         return {"type": "video", "subType": "webm"};
 
+      case 'insp':
+        return {"type": "image", "subType": "jpeg"};
+
+      case 'insv':
+        return {"type": "video", "subType": "mp4"};
+
       default:
         return {"type": "unsupport", "subType": "unsupport"};
     }

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -146,6 +146,10 @@ export function getFileMimeType(file: File): string {
 			return 'image/x-fuji-raf';
 		case 'srw':
 			return 'image/x-samsung-srw';
+		case 'insp':
+			return 'image/jpeg';
+		case 'insv':
+			return 'video/mp4';
 		default:
 			return '';
 	}

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -22,7 +22,7 @@ export const openFileUploadDialog = async (
 
 			// When adding a content type that is unsupported by browsers, make sure
 			// to also add it to getFileMimeType() otherwise the upload will fail.
-			fileSelector.accept = 'image/*,video/*,.heic,.heif,.dng,.3gp,.nef,.srw,.raf';
+			fileSelector.accept = 'image/*,video/*,.heic,.heif,.dng,.3gp,.nef,.srw,.raf,.insp,.insv';
 
 			fileSelector.onchange = async (e: Event) => {
 				const target = e.target as HTMLInputElement;


### PR DESCRIPTION
Insta360 "raw" formats `insv` and `insp` are actually mp4 (video) and jpeg (picture) respectively.
However, we don't want user to rename the original files, because they follow Insta360 convention, which is required by Insta360 Studio.