### PR TITLE
update node images

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.17 as builder
+FROM node:18.16.0-alpine3.18@sha256:f41850f74ff16a33daff988e2ea06ef8f5daeb6fb84913c7df09552a98caba09 as builder
 
 WORKDIR /usr/src/app
 
@@ -17,7 +17,7 @@ RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 
 
-FROM node:18-alpine3.17
+FROM node:18.16.0-alpine3.18@sha256:f41850f74ff16a33daff988e2ea06ef8f5daeb6fb84913c7df09552a98caba09
 
 ENV NODE_ENV=production
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Our Node base image
-FROM node:18-alpine3.17 as base
+FROM node:18.16.0-alpine3.18@sha256:f41850f74ff16a33daff988e2ea06ef8f5daeb6fb84913c7df09552a98caba09 as base
 
 WORKDIR /usr/src/app
 EXPOSE 3000


### PR DESCRIPTION
This is required to support raw images as Alpine 3.18 included fixes to imagemagick.

Related: #2156

In addtion, the images have stricter tags and are pinned with a digest. The manifest list digest can be found using:

```sh
❯ docker buildx imagetools inspect node:18.16.0-alpine3.18
```