### PR TITLE
don't fallback to exiftool for embedded image previews

### DIFF
--- a/server/src/domain/media/media.repository.ts
+++ b/server/src/domain/media/media.repository.ts
@@ -45,7 +45,6 @@ export interface TranscodeOptions {
 
 export interface IMediaRepository {
   // image
-  extractThumbnailFromExif(input: string, output: string): Promise<void>;
   resize(input: string | Buffer, output: string, options: ResizeOptions): Promise<void>;
   crop(input: string, options: CropOptions): Promise<Buffer>;
 

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -81,28 +81,6 @@ describe(MediaService.name, () => {
         size: 1440,
         format: 'jpeg',
       });
-      expect(mediaMock.extractThumbnailFromExif).not.toHaveBeenCalled();
-      expect(assetMock.save).toHaveBeenCalledWith({
-        id: 'asset-id',
-        resizePath: 'upload/thumbs/user-id/asset-id.jpeg',
-      });
-    });
-
-    it('should generate a thumbnail for an image from exif', async () => {
-      assetMock.getByIds.mockResolvedValue([assetEntityStub.image]);
-      mediaMock.resize.mockRejectedValue(new Error('unsupported format'));
-
-      await sut.handleGenerateJpegThumbnail({ id: assetEntityStub.image.id });
-
-      expect(storageMock.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id');
-      expect(mediaMock.resize).toHaveBeenCalledWith('/original/path.ext', 'upload/thumbs/user-id/asset-id.jpeg', {
-        size: 1440,
-        format: 'jpeg',
-      });
-      expect(mediaMock.extractThumbnailFromExif).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/thumbs/user-id/asset-id.jpeg',
-      );
       expect(assetMock.save).toHaveBeenCalledWith({
         id: 'asset-id',
         resizePath: 'upload/thumbs/user-id/asset-id.jpeg',

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -54,24 +54,18 @@ export class MediaService {
     this.storageRepository.mkdirSync(resizePath);
     const jpegThumbnailPath = join(resizePath, `${asset.id}.jpeg`);
 
-    if (asset.type == AssetType.IMAGE) {
-      try {
+    switch (asset.type) {
+      case AssetType.IMAGE:
         await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, {
           size: JPEG_THUMBNAIL_SIZE,
           format: 'jpeg',
         });
-      } catch (error: any) {
-        this.logger.warn(
-          `Failed to generate jpeg thumbnail using sharp, trying with exiftool-vendored (asset=${asset.id}): ${error.message}`,
-        );
-        await this.mediaRepository.extractThumbnailFromExif(asset.originalPath, jpegThumbnailPath);
-      }
-    }
-
-    if (asset.type == AssetType.VIDEO) {
-      this.logger.log('Start Generating Video Thumbnail');
-      await this.mediaRepository.extractVideoThumbnail(asset.originalPath, jpegThumbnailPath, JPEG_THUMBNAIL_SIZE);
-      this.logger.log(`Generating Video Thumbnail Success ${asset.id}`);
+        break;
+      case AssetType.VIDEO:
+        this.logger.log('Generating video thumbnail');
+        await this.mediaRepository.extractVideoThumbnail(asset.originalPath, jpegThumbnailPath, JPEG_THUMBNAIL_SIZE);
+        this.logger.log(`Successfully generated video thumbnail ${asset.id}`);
+        break;
     }
 
     await this.assetRepository.save({ id: asset.id, resizePath: jpegThumbnailPath });

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -1,5 +1,4 @@
 import { CropOptions, IMediaRepository, ResizeOptions, TranscodeOptions, VideoInfo } from '@app/domain';
-import { exiftool } from 'exiftool-vendored';
 import ffmpeg, { FfprobeData } from 'fluent-ffmpeg';
 import sharp from 'sharp';
 import { promisify } from 'util';
@@ -17,10 +16,6 @@ export class MediaRepository implements IMediaRepository {
         height: options.height,
       })
       .toBuffer();
-  }
-
-  extractThumbnailFromExif(input: string, output: string): Promise<void> {
-    return exiftool.extractThumbnail(input, output);
   }
 
   async resize(input: string | Buffer, output: string, options: ResizeOptions): Promise<void> {

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -2,7 +2,6 @@ import { IMediaRepository } from '@app/domain';
 
 export const newMediaRepositoryMock = (): jest.Mocked<IMediaRepository> => {
   return {
-    extractThumbnailFromExif: jest.fn(),
     extractVideoThumbnail: jest.fn(),
     resize: jest.fn(),
     crop: jest.fn(),


### PR DESCRIPTION
Given #2668 introduced support for imagemagick and libraw, this should no longer be necessary which allow for reduced code footprint and complexity.

Fixes: #2744