### PR TITLE
fix: increase request timeout from 5 minutes to 30 minutes

### DIFF
--- a/server/src/immich/main.ts
+++ b/server/src/immich/main.ts
@@ -28,7 +28,8 @@ export async function bootstrap() {
   useSwagger(app, isDev);
 
   await app.get(AppService).init();
-  await app.listen(port);
+  const server = await app.listen(port);
+  server.setTimeout(1800000);
 
   logger.log(`Immich Server is listening on ${port} [v${SERVER_VERSION}] [${envName}] `);
 }


### PR DESCRIPTION
Since node 18 the default request timeout was changed from unlimited to 5 minutes, this means large files get timed out and fail to upload