### PR TITLE
fix: increase request timeout from 5 minutes to 30 minutes

### DIFF
--- a/server/src/immich/main.ts
+++ b/server/src/immich/main.ts
@@ -29,7 +29,7 @@ export async function bootstrap() {
 
   await app.get(AppService).init();
   const server = await app.listen(port);
-  server.setTimeout(1800000);
+  server.requestTimeout = 30 * 60 * 1000;
 
   logger.log(`Immich Server is listening on ${port} [v${SERVER_VERSION}] [${envName}] `);
 }


### PR DESCRIPTION
since node 18 the default request timeout was changed from unlimited to 5 minutes, causing large uploads to fail on slow connections