### PR TITLE
fix(web): not displaying assets in album after adding shared user

### DIFF
--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -159,6 +159,7 @@ export class AlbumRepository implements IAlbumRepository {
       relations: {
         owner: true,
         sharedUsers: true,
+        assets: true,
       },
     });
   }


### PR DESCRIPTION
This PR fixes an issue in the album when adding a new share user; the current assets in the album aren't displayed until navigating out of and back to the album. 

This is due to the assets aren't returned with the update query, so the mapping function doesn't return the assets count, which is used for conditionally displaying the "Add asset" button vs render the assets in the album