### PR TITLE
chore(deps): change compose service dependencies to use alpine variants

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -106,11 +106,11 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2
+    image: redis:6.2-alpine
 
   database:
     container_name: immich_postgres
-    image: postgres:14
+    image: postgres:14-alpine
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -95,7 +95,7 @@ services:
 
   typesense:
     container_name: immich_typesense
-    image: typesense/typesense:0.24.1
+    image: typesense/typesense:0.24.1@sha256:9bcff2b829f12074426ca044b56160ca9d777a0c488303469143dd9f8259d4dd
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
@@ -106,11 +106,11 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2-alpine
+    image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
 
   database:
     container_name: immich_postgres
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -25,12 +25,12 @@ services:
       - immich-test-network
   immich-redis-test:
     container_name: immich-redis-test
-    image: redis:6.2
+    image: redis:6.2-alpine
     networks:
       - immich-test-network
   immich-database-test:
     container_name: immich-database-test
-    image: postgres:14
+    image: postgres:14-alpine
     env_file:
       - .env.test
     environment:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -25,12 +25,12 @@ services:
       - immich-test-network
   immich-redis-test:
     container_name: immich-redis-test
-    image: redis:6.2-alpine
+    image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
     networks:
       - immich-test-network
   immich-database-test:
     container_name: immich-database-test
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
     env_file:
       - .env.test
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   typesense:
     container_name: immich_typesense
-    image: typesense/typesense:0.24.1
+    image: typesense/typesense:0.24.1@sha256:9bcff2b829f12074426ca044b56160ca9d777a0c488303469143dd9f8259d4dd
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
@@ -60,12 +60,12 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2-alpine
+    image: redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3
     restart: always
 
   database:
     container_name: immich_postgres
-    image: postgres:14-alpine
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,12 +60,12 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2
+    image: redis:6.2-alpine
     restart: always
 
   database:
     container_name: immich_postgres
-    image: postgres:14
+    image: postgres:14-alpine
     env_file:
       - .env
     environment:


### PR DESCRIPTION
Immich already uses alpine in its base image.

This is a quality-of-life tweak to update the dependencies in the default dockerfiles to also use leaner container images.