### PR TITLE
chore(mobile): Add debug build type suffix to the applicationId and version

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -72,6 +72,11 @@ android {
    }
 
     buildTypes {
+        debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-DEBUG'
+        }
+
         release {
             signingConfig signingConfigs.release
         }

--- a/mobile/lib/shared/providers/server_info.provider.dart
+++ b/mobile/lib/shared/providers/server_info.provider.dart
@@ -76,7 +76,7 @@ class ServerInfoNotifier extends StateNotifier<ServerInfoState> {
     return {
       "major": int.parse(major),
       "minor": int.parse(minor),
-      "patch": int.parse(patch),
+      "patch": int.parse(patch.replaceAll("-DEBUG", "")),
     };
   }
 }


### PR DESCRIPTION
This PR adds `.debug` suffix to the `applicationId` and `-DEBUG` suffix to the `versionName` for debug builds. So now we can debug the mobile app on Android alongside the production/release version installed.

versionName:
![version](https://github.com/immich-app/immich/assets/71479/a624bd8c-5899-4e17-bf9a-edd67735ede1)

applicationId:
![applicationId](https://github.com/immich-app/immich/assets/71479/ef5fe46b-03aa-443c-a9d8-3d452bc9bf07)
