### PR TITLE
feat(server): support rclone as storage backend

### DIFF
--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -19,7 +19,11 @@ export class FilesystemProvider implements IStorageRepository {
   }
 
   async moveFile(source: string, destination: string): Promise<void> {
-    await moveFile(source, destination, { mkdirp: true, clobber: false });
+    if (await this.checkFileExists(destination)) {
+      throw new Error(`Destination file already exists: ${destination}`);
+    }
+
+    await moveFile(source, destination, { mkdirp: true, clobber: true });
   }
 
   async checkFileExists(filepath: string, mode = constants.F_OK): Promise<boolean> {


### PR DESCRIPTION
Closes #2831, ref #1899, #1683. 

I'm not entirely sure about the minimal approach taken here, but it does work: remote filesystems such as `rclone` FUSE mounts can now handle the file operation that was blocking support.