### PR TITLE
fix(mobile): Sort newest first for asset selection in album

### DIFF
--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -190,7 +190,7 @@ final remoteAssetsProvider =
       .remoteIdIsNotNull()
       .filter()
       .ownerIdEqualTo(userId)
-      .sortByFileCreatedAt();
+      .sortByFileCreatedAtDesc();
   final settings = ref.watch(appSettingsServiceProvider);
   final groupBy =
       GroupAssetsBy.values[settings.getSetting(AppSettingsEnum.groupAssetsBy)];


### PR DESCRIPTION
Fix #2829