### PR TITLE
fix(deployment) Add dependency on immich-web to immich-proxy

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -136,6 +136,7 @@ services:
       - 2283:8080
     depends_on:
       - immich-server
+      - immich-web
     restart: always
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - 2283:8080
     depends_on:
       - immich-server
+      - immich-web
     restart: always
 
 volumes:


### PR DESCRIPTION
In some cases I've seen immich-proxy start before immich-web, which results in dns errors as docker can't resolve the "immich-web" hostname before immich-web is started. The resulting error is similar to:

`immich-proxy_1             | nginx: [emerg] host not found in upstream "immich-web:3000" in /etc/nginx/conf.d/default.conf:20
`

which results in immich not being reachable. This PR adds a dependency on immich-web to start before immich-proxy which fixes the issue.