### PR TITLE
fix(server): use HTTP status OK instead of CREATED for assets

### DIFF
--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -1066,7 +1066,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "",
             "content": {
               "application/json": {
@@ -1595,7 +1595,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "",
             "content": {
               "application/json": {
@@ -1910,7 +1910,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": "",
             "content": {
               "application/json": {

--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -7,6 +7,7 @@ import {
   Header,
   Headers,
   HttpCode,
+  HttpStatus,
   Param,
   ParseFilePipe,
   Patch,
@@ -111,7 +112,7 @@ export class AssetController {
 
     const responseDto = await this.assetService.uploadFile(authUser, dto, file, livePhotoFile, sidecarFile);
     if (responseDto.duplicate) {
-      res.status(200);
+      res.status(HttpStatus.OK);
     }
 
     return responseDto;
@@ -193,6 +194,7 @@ export class AssetController {
   }
 
   @Post('/search')
+  @HttpCode(HttpStatus.OK)
   searchAsset(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: SearchAssetDto,
@@ -201,6 +203,7 @@ export class AssetController {
   }
 
   @Post('/count-by-time-bucket')
+  @HttpCode(HttpStatus.OK)
   getAssetCountByTimeBucket(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: GetAssetCountByTimeBucketDto,
@@ -235,6 +238,7 @@ export class AssetController {
   }
 
   @Post('/time-bucket')
+  @HttpCode(HttpStatus.OK)
   getAssetByTimeBucket(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: GetAssetByTimeBucketDto,
@@ -284,7 +288,7 @@ export class AssetController {
    */
   @SharedLinkRoute()
   @Post('/check')
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   checkDuplicateAsset(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: CheckDuplicateAssetDto,
@@ -296,7 +300,7 @@ export class AssetController {
    * Checks if multiple assets exist on the server and returns all existing - used by background backup
    */
   @Post('/exist')
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   checkExistingAssets(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: CheckExistingAssetsDto,
@@ -308,7 +312,7 @@ export class AssetController {
    * Checks if assets exist by checksums
    */
   @Post('/bulk-upload-check')
-  @HttpCode(200)
+  @HttpCode(HttpStatus.OK)
   bulkUploadCheck(
     @AuthUser() authUser: AuthUserDto,
     @Body(ValidationPipe) dto: AssetBulkUploadCheckDto,


### PR DESCRIPTION
The NGINX gzip module does not compress responses with a status of 201, which is
a major issue specifically for the /api/asset/time-bucket endpoint where
responses can be upwards of 5Mi. The size of the response is dramatically
reduced with gzip to 500Ki in some cases.

https://trac.nginx.org/nginx/ticket/471
https://trac.nginx.org/nginx/ticket/394

The signature of these endpoints should be GET rather than POST anyway, but that
is a bigger discussion.