### PR TITLE
fix(web): keep video volume

### DIFF
--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -2,7 +2,7 @@
 	import { api } from '@api';
 	import { fade } from 'svelte/transition';
 	import { createEventDispatcher } from 'svelte';
-	import { videoViewerVolume } from '$lib/stores/asset-interaction.store';
+	import { videoViewerVolume } from '$lib/stores/preferences.store';
 	import LoadingSpinner from '../shared-components/loading-spinner.svelte';
 
 	export let assetId: string;
@@ -10,14 +10,6 @@
 
 	let isVideoLoading = true;
 	const dispatch = createEventDispatcher();
-
-	let volume: number = 1;
-
-	//subscribing to the store
-	videoViewerVolume.subscribe((value) => {
-		volume = value;
-	});
-	$: videoViewerVolume.set(volume);
 
 	const handleCanPlay = (ev: Event & { currentTarget: HTMLVideoElement }) => {
 		const playerNode = ev.currentTarget;
@@ -39,7 +31,7 @@
 		class="h-full object-contain"
 		on:canplay={handleCanPlay}
 		on:ended={() => dispatch('onVideoEnded')}
-		bind:volume
+		bind:volume={$videoViewerVolume}
 	>
 		<source src={api.getAssetFileUrl(assetId, false, true, publicSharedKey)} type="video/mp4" />
 		<track kind="captions" />

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -2,6 +2,7 @@
 	import { api } from '@api';
 	import { fade } from 'svelte/transition';
 	import { createEventDispatcher } from 'svelte';
+	import { videoViewerVolume } from '$lib/stores/asset-interaction.store';
 	import LoadingSpinner from '../shared-components/loading-spinner.svelte';
 
 	export let assetId: string;
@@ -9,6 +10,14 @@
 
 	let isVideoLoading = true;
 	const dispatch = createEventDispatcher();
+
+	let volume: number = 1;
+
+	//subscribing to the store
+	videoViewerVolume.subscribe((value) => {
+		volume = value;
+	});
+	$: videoViewerVolume.set(volume);
 
 	const handleCanPlay = (ev: Event & { currentTarget: HTMLVideoElement }) => {
 		const playerNode = ev.currentTarget;
@@ -30,6 +39,7 @@
 		class="h-full object-contain"
 		on:canplay={handleCanPlay}
 		on:ended={() => dispatch('onVideoEnded')}
+		bind:volume
 	>
 		<source src={api.getAssetFileUrl(assetId, false, true, publicSharedKey)} type="video/mp4" />
 		<track kind="captions" />

--- a/web/src/lib/stores/asset-interaction.store.ts
+++ b/web/src/lib/stores/asset-interaction.store.ts
@@ -8,6 +8,8 @@ import { sortBy } from 'lodash-es';
 export const viewingAssetStoreState = writable<AssetResponseDto>();
 export const isViewingAssetStoreState = writable<boolean>(false);
 
+export const videoViewerVolume = writable<number>(1);
+
 // Multi-Selection mode
 export const assetsInAlbumStoreState = writable<AssetResponseDto[]>([]);
 export const selectedAssets = writable<Set<AssetResponseDto>>(new Set());

--- a/web/src/lib/stores/asset-interaction.store.ts
+++ b/web/src/lib/stores/asset-interaction.store.ts
@@ -8,8 +8,6 @@ import { sortBy } from 'lodash-es';
 export const viewingAssetStoreState = writable<AssetResponseDto>();
 export const isViewingAssetStoreState = writable<boolean>(false);
 
-export const videoViewerVolume = writable<number>(1);
-
 // Multi-Selection mode
 export const assetsInAlbumStoreState = writable<AssetResponseDto[]>([]);
 export const selectedAssets = writable<Set<AssetResponseDto>>(new Set());

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -35,3 +35,5 @@ export const mapSettings = persisted<MapSettings>('map-settings', {
 	dateAfter: '',
 	dateBefore: ''
 });
+
+export const videoViewerVolume = persisted<number>('video-viewer-volume', 1, {});


### PR DESCRIPTION
save video volume in asset-interaction.store.ts, fixes #2885
google saves the video volume in localstorage, which i think would be the better implementation?

`yt-player-volume:"{"data":"{\"volume\":37,\"muted\":false}","expiration":1689945428802,"creation":1687353428802}"`