### PR TITLE
chore(server): add Canon CR3 mime type

### DIFF
--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -30,6 +30,7 @@ export function assertMachineLearningEnabled() {
 
 const validMimeTypes = [
   'image/avif',
+  'image/cr3',
   'image/gif',
   'image/heic',
   'image/heif',


### PR DESCRIPTION
Allows for successful upload for Canon CR3 format as it reports `image/cr3`

I will note that full support for all Canon cameras will depend on ImageMagick support, for example my Canon EOS RP does work, but my more recent Canon EOS R5C does not work as of yet.