### PR TITLE
fix(ml): clear model cache on load error

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Any
 
+from onnxruntime.capi.onnxruntime_pybind11_state import InvalidProtobuf
+
 from ..config import get_cache_dir
 from ..schemas import ModelType
 
@@ -24,7 +26,7 @@ class InferenceModel(ABC):
 
         try:
             self.load(**model_kwargs)
-        except RuntimeError:
+        except (OSError, InvalidProtobuf):
             self.clear_cache()
             self.load(**model_kwargs)
 

--- a/machine-learning/app/models/clip.py
+++ b/machine-learning/app/models/clip.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 from PIL.Image import Image
 from sentence_transformers import SentenceTransformer
@@ -10,13 +11,7 @@ from .base import InferenceModel
 class CLIPSTEncoder(InferenceModel):
     _model_type = ModelType.CLIP
 
-    def __init__(
-        self,
-        model_name: str,
-        cache_dir: Path | None = None,
-        **model_kwargs,
-    ):
-        super().__init__(model_name, cache_dir)
+    def load(self, **model_kwargs: Any) -> None:
         self.model = SentenceTransformer(
             self.model_name,
             cache_folder=self.cache_dir.as_posix(),

--- a/machine-learning/app/models/facial_recognition.py
+++ b/machine-learning/app/models/facial_recognition.py
@@ -18,21 +18,22 @@ class FaceRecognizer(InferenceModel):
         min_score: float = settings.min_face_score,
         cache_dir: Path | None = None,
         **model_kwargs,
-    ):
-        super().__init__(model_name, cache_dir)
+    ) -> None:
         self.min_score = min_score
-        model = FaceAnalysis(
+        super().__init__(model_name, cache_dir, **model_kwargs)
+
+    def load(self, **model_kwargs: Any) -> None:
+        self.model = FaceAnalysis(
             name=self.model_name,
             root=self.cache_dir.as_posix(),
             allowed_modules=["detection", "recognition"],
             **model_kwargs,
         )
-        model.prepare(
+        self.model.prepare(
             ctx_id=0,
             det_thresh=self.min_score,
             det_size=(640, 640),
         )
-        self.model = model
 
     def predict(self, image: cv2.Mat) -> list[dict[str, Any]]:
         height, width, _ = image.shape

--- a/machine-learning/app/models/image_classification.py
+++ b/machine-learning/app/models/image_classification.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 from PIL.Image import Image
 from transformers.pipelines import pipeline
@@ -17,10 +18,11 @@ class ImageClassifier(InferenceModel):
         min_score: float = settings.min_tag_score,
         cache_dir: Path | None = None,
         **model_kwargs,
-    ):
-        super().__init__(model_name, cache_dir)
+    ) -> None:
         self.min_score = min_score
+        super().__init__(model_name, cache_dir, **model_kwargs)
 
+    def load(self, **model_kwargs: Any) -> None:
         self.model = pipeline(
             self.model_type.value,
             self.model_name,


### PR DESCRIPTION
## Description

Fixes #2947 by adding error handling when loading models. If a model file fails to load, the folder for that model is deleted and the model is redownloaded. If this fails as well, then it will still error out.

## Testing

This bug was reproduced by corrupting the first byte of both the CLIP model and one of the facial recognition models (commands adapted from [this](https://superuser.com/a/121039)). Adjust the model paths as needed.

```
export CLIP_MODEL_PATH=/cache/clip/clip-ViT-B-32/sentence-transformers_clip-ViT-B-32/0_CLIPModel/pytorch_model.bin
export FACE_MODEL_PATH=/cache/facial-recognition/buffalo_l/models/buffalo_l/1k3d68.onnx
echo -ne \\xFF | dd conv=notrunc bs=1 count=1 of=$CLIP_MODEL_PATH
echo -ne \\xFF | dd conv=notrunc bs=1 count=1 of=$FACE_MODEL_PATH
```

The models should be redownloaded on startup and otherwise load without error.