### PR TITLE
fix(web): Add m: to search query upon loading results.

### DIFF
--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -43,7 +43,14 @@
 		}
 	});
 
-	$: term = $page.url.searchParams.get('q') || data.term || '';
+	$: term = (() => {
+		let term = $page.url.searchParams.get('q') || data.term || '';
+		const isMetadataSearch = $page.url.searchParams.get('clip') === 'false';
+		if (isMetadataSearch && term !== '') {
+			term = `m:${term}`;
+		}
+		return term;
+	})();
 
 	let selectedAssets: Set<AssetResponseDto> = new Set();
 	$: isMultiSelectionMode = selectedAssets.size > 0;


### PR DESCRIPTION
Previously, we'd drop the m: from non-clip searches entirely. This behavior incorrectly represents the page's status (results from non-clip search but query implies a clip search). Also, any follow-up searches change to clip searches, which feels like a jarring UX if you have to add m: every time in a 'search-session'.