### PR TITLE
feat(server): "{album}" in storage template

### DIFF
--- a/server/src/domain/storage-template/storage-template.service.spec.ts
+++ b/server/src/domain/storage-template/storage-template.service.spec.ts
@@ -1,6 +1,7 @@
 import { AssetPathType } from '@app/infra/entities';
 import {
   assetStub,
+  newAlbumRepositoryMock,
   newAssetRepositoryMock,
   newMoveRepositoryMock,
   newPersonRepositoryMock,
@@ -11,6 +12,7 @@ import {
 } from '@test';
 import { when } from 'jest-when';
 import {
+  IAlbumRepository,
   IAssetRepository,
   IMoveRepository,
   IPersonRepository,
@@ -23,6 +25,7 @@ import { StorageTemplateService } from './storage-template.service';
 
 describe(StorageTemplateService.name, () => {
   let sut: StorageTemplateService;
+  let albumMock: jest.Mocked<IAlbumRepository>;
   let assetMock: jest.Mocked<IAssetRepository>;
   let configMock: jest.Mocked<ISystemConfigRepository>;
   let moveMock: jest.Mocked<IMoveRepository>;
@@ -36,13 +39,23 @@ describe(StorageTemplateService.name, () => {
 
   beforeEach(async () => {
     assetMock = newAssetRepositoryMock();
+    albumMock = newAlbumRepositoryMock();
     configMock = newSystemConfigRepositoryMock();
     moveMock = newMoveRepositoryMock();
     personMock = newPersonRepositoryMock();
     storageMock = newStorageRepositoryMock();
     userMock = newUserRepositoryMock();
 
-    sut = new StorageTemplateService(assetMock, configMock, defaults, moveMock, personMock, storageMock, userMock);
+    sut = new StorageTemplateService(
+      albumMock,
+      assetMock,
+      configMock,
+      defaults,
+      moveMock,
+      personMock,
+      storageMock,
+      userMock,
+    );
   });
 
   describe('handleMigrationSingle', () => {

--- a/server/src/domain/system-config/system-config.constants.ts
+++ b/server/src/domain/system-config/system-config.constants.ts
@@ -23,6 +23,7 @@ export const supportedPresetTokens = [
   '{{y}}/{{y}}-{{MM}}-{{dd}}/{{assetId}}',
   '{{y}}/{{y}}-{{MM}}/{{assetId}}',
   '{{y}}/{{y}}-{{WW}}/{{assetId}}',
+  '{{album}}/{{filename}}',
 ];
 
 export const INITIAL_SYSTEM_CONFIG = 'INITIAL_SYSTEM_CONFIG';

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -242,6 +242,7 @@ describe(SystemConfigService.name, () => {
           '{{y}}/{{y}}-{{MM}}-{{dd}}/{{assetId}}',
           '{{y}}/{{y}}-{{MM}}/{{assetId}}',
           '{{y}}/{{y}}-{{WW}}/{{assetId}}',
+          '{{album}}/{{filename}}',
         ],
         secondOptions: ['s', 'ss'],
         weekOptions: ['W', 'WW'],

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -57,7 +57,7 @@
       filetype: 'IMG',
       filetypefull: 'IMAGE',
       assetId: 'a8312960-e277-447d-b4ea-56717ccba856',
-      album: 'Immich Adventures',
+      album: 'Album Name',
     };
 
     const dt = luxon.DateTime.fromISO(new Date('2022-02-03T04:56:05.250').toISOString());

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -57,6 +57,7 @@
       filetype: 'IMG',
       filetypefull: 'IMAGE',
       assetId: 'a8312960-e277-447d-b4ea-56717ccba856',
+      album: 'Immich Adventures',
     };
 
     const dt = luxon.DateTime.fromISO(new Date('2022-02-03T04:56:05.250').toISOString());
@@ -208,13 +209,26 @@
             </div>
           </div>
 
-          <div id="migration-info" class="mt-4 text-sm">
-            <p>
-              Template changes will only apply to new assets. To retroactively apply the template to previously uploaded
-              assets, run the <a href="/admin/jobs-status" class="text-immich-primary dark:text-immich-dark-primary"
-                >Storage Migration Job</a
-              >
-            </p>
+          <div id="migration-info" class="mt-2 text-sm">
+            <h3 class="text-base font-medium text-immich-primary dark:text-immich-dark-primary">Notes</h3>
+            <section class="flex flex-col gap-2">
+              <p>
+                Template changes will only apply to new assets. To retroactively apply the template to previously
+                uploaded assets, run the
+                <a href="/admin/jobs-status" class="text-immich-primary dark:text-immich-dark-primary"
+                  >Storage Migration Job</a
+                >.
+              </p>
+              <p>
+                The template variable <span class="font-mono">{`{{album}}`}</span> will always be empty for new assets,
+                so manually running the
+
+                <a href="/admin/jobs-status" class="text-immich-primary dark:text-immich-dark-primary"
+                  >Storage Migration Job</a
+                >
+                is required in order to successfully use the variable.
+              </p>
+            </section>
           </div>
 
           <SettingButtonsRow

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
@@ -5,31 +5,25 @@
 <div class="p-4 mt-2 text-xs bg-gray-200 rounded-lg dark:bg-gray-700 dark:text-immich-dark-fg">
   <div class="flex gap-[50px]">
     <div>
-      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILE NAME</p>
+      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILENAME</p>
       <ul>
-        <li>{`{{filename}}`}</li>
+        <li>{`{{filename}}`} - IMG_123</li>
+        <li>{`{{ext}}`} - jpg</li>
       </ul>
     </div>
 
     <div>
-      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILE EXTENSION</p>
-      <ul>
-        <li>{`{{ext}}`}</li>
-      </ul>
-    </div>
-
-    <div>
-      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILE TYPE</p>
+      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILETYPE</p>
       <ul>
         <li>{`{{filetype}}`} - VID or IMG</li>
         <li>{`{{filetypefull}}`} - VIDEO or IMAGE</li>
       </ul>
     </div>
-
     <div>
-      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">FILE TYPE</p>
+      <p class="font-medium text-immich-primary dark:text-immich-dark-primary uppercase">OTHER</p>
       <ul>
         <li>{`{{assetId}}`} - Asset ID</li>
+        <li>{`{{album}}`} - Album Name</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
See #2933 

![image](https://github.com/immich-app/immich/assets/4334196/9fe67d39-8938-49d3-8cbb-e72df77b592a)
![image](https://github.com/immich-app/immich/assets/4334196/da28188e-b845-43b5-affd-118995af1e00)


This allows for using {album} as a storage-template token

If an asset belongs to one or more albums, the name of the first album will be taken. If an asset doesn't belong to an album, the token will be skipped, so it will be placed in the root of the path where the folder would be created ({album} will be evaluated to ".")

If Assets are added to Albums, a storage migration job must be run. Otherwise if one uploads an asset directly into an album, it will be saved at the correct location without having to run it afterwards.

~~The only issue I see here, is the perfomance impact due to the changes in `album.repository.ts`. Right now, the albums of every asset will be queried when getById() or getAll() are called, even if they are currently not needed except for this case.~~
