### PR TITLE
fix(mobile): loading indicator position

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -73,8 +73,12 @@ class VideoViewerPage extends HookConsumerWidget {
           placeholder: placeholder,
         ),
         if (downloadAssetStatus == DownloadAssetStatus.loading)
-          const Center(
-            child: ImmichLoadingIndicator(),
+          SizedBox(
+            height: MediaQuery.of(context).size.height,
+            width: MediaQuery.of(context).size.width,
+            child: const Center(
+              child: ImmichLoadingIndicator(),
+            ),
           ),
       ],
     );


### PR DESCRIPTION
This PR fixes the loading indicator position while downloading asset. Fixes #2828 
| Before | After|
|--------|--------|
| ![before](https://github.com/immich-app/immich/assets/71479/759ffdb7-0809-4c01-86c3-586da322299e) | ![after](https://github.com/immich-app/immich/assets/71479/92e86205-8b13-4247-8d3f-1a6bf85d7663) |
