### PR TITLE
chore(mobile): Capitalize Places cities in app

### DIFF
--- a/mobile/lib/modules/search/ui/thumbnail_with_info.dart
+++ b/mobile/lib/modules/search/ui/thumbnail_with_info.dart
@@ -1,7 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/shared/models/store.dart';
-import 'package:immich_mobile/utils/capitalize_first_letter.dart';
+import 'package:immich_mobile/utils/capitalize.dart';
 
 // ignore: must_be_immutable
 class ThumbnailWithInfo extends StatelessWidget {
@@ -80,7 +80,7 @@ class ThumbnailWithInfo extends StatelessWidget {
             bottom: 12,
             left: 14,
             child: Text(
-              textInfo == '' ? textInfo : textInfo.capitalizeFirstLetter(),
+              textInfo == '' ? textInfo : textInfo.capitalize(),
               style: const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.bold,

--- a/mobile/lib/modules/search/views/curated_object_page.dart
+++ b/mobile/lib/modules/search/views/curated_object_page.dart
@@ -6,7 +6,7 @@ import 'package:immich_mobile/modules/search/models/curated_content.dart';
 import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
 import 'package:immich_mobile/modules/search/ui/explore_grid.dart';
 import 'package:immich_mobile/shared/ui/immich_loading_indicator.dart';
-import 'package:immich_mobile/utils/capitalize_first_letter.dart';
+import 'package:immich_mobile/utils/capitalize.dart';
 import 'package:openapi/api.dart';
 
 class CuratedObjectPage extends HookConsumerWidget {
@@ -43,7 +43,7 @@ class CuratedObjectPage extends HookConsumerWidget {
           curatedContent: curatedLocations
               .map(
                 (l) => CuratedContent(
-                  label: l.object.capitalizeFirstLetter(),
+                  label: l.object.capitalize(),
                   id: l.id,
                 ),
               )

--- a/mobile/lib/utils/capitalize.dart
+++ b/mobile/lib/utils/capitalize.dart
@@ -1,0 +1,9 @@
+extension StringExtension on String {
+  String capitalize() {
+    return this
+        .split(" ")
+        .map((str) =>
+            str.isEmpty ? str : str[0].toUpperCase() + str.substring(1))
+        .join(" ");
+  }
+}


### PR DESCRIPTION
Currently, Places cities are capitalized on the web via `text-transform: capitalize` (by way of the `capitalize` tailwind class). In the app, Places cities are capitalized only on the first letter. This pull request brings these into parity with both having the first letter of each word in the city being capitalized.