### PR TITLE
fix(ml): setting different clip

### DIFF
--- a/machine-learning/app/models/__init__.py
+++ b/machine-learning/app/models/__init__.py
@@ -1,3 +1,3 @@
-from .clip import CLIPSTTextEncoder, CLIPSTVisionEncoder
+from .clip import CLIPSTEncoder
 from .facial_recognition import FaceRecognizer
 from .image_classification import ImageClassifier

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 

--- a/machine-learning/app/models/clip.py
+++ b/machine-learning/app/models/clip.py
@@ -25,13 +25,3 @@ class CLIPSTEncoder(InferenceModel):
 
     def predict(self, image_or_text: Image | str) -> list[float]:
         return self.model.encode(image_or_text).tolist()
-
-
-# stubs to allow different behavior between the two in the future
-# and handle loading different image and text clip models
-class CLIPSTVisionEncoder(CLIPSTEncoder):
-    _model_type = ModelType.CLIP_VISION
-
-
-class CLIPSTTextEncoder(CLIPSTEncoder):
-    _model_type = ModelType.CLIP_TEXT

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -61,6 +61,4 @@ class FaceResponse(BaseModel):
 class ModelType(Enum):
     IMAGE_CLASSIFICATION = "image-classification"
     CLIP = "clip"
-    CLIP_VISION = "clip-vision"
-    CLIP_TEXT = "clip-text"
     FACIAL_RECOGNITION = "facial-recognition"


### PR DESCRIPTION
## Description

Fixes #2979 by removing the stub classes for image-only or text-only CLIP models. 

The source of this bug was that `__subclasses__` only shows direct subclasses, so it doesn't include the stubs for using different clip image/text models. This could also have been resolved in other ways, like by recursing subclasses or by moving the mapping into a constant. However, these stubs are proving to be unnecessary, so it's cleaner to just remove them.


## Testing

Set the following env variables in the environment in which the app will run:

```
MACHINE_LEARNING_CLIP_IMAGE_MODEL=clip-ViT-B-32
MACHINE_LEARNING_CLIP_TEXT_MODEL=clip-ViT-B-32-multilingual-v1
```

It should start up and handle requests without errors.