### PR TITLE
chore(server): check file extension for XMP instead of mimetype

### DIFF
--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -6,7 +6,6 @@ import {
   ICryptoRepository,
   IJobRepository,
   ImmichReadStream,
-  isSidecarFileType,
   isSupportedFileType,
   IStorageRepository,
   JobName,

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -149,7 +149,7 @@ export class AssetService {
     }
 
     if (dto.sidecarPath) {
-      if (path.extname(dto.sidecarPath).toLowerCase() !== ".xmp") {
+      if (path.extname(dto.sidecarPath).toLowerCase() !== '.xmp') {
         throw new BadRequestException(`Unsupported sidecar file type`);
       }
     }

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -149,7 +149,7 @@ export class AssetService {
     }
 
     if (dto.sidecarPath) {
-      if (!dto.sidecarPath.toLowerCase().match(/\.xmp$/)) {
+      if (path.extname(dto.sidecarPath).toLowerCase() !== ".xmp") {
         throw new BadRequestException(`Unsupported sidecar file type`);
       }
     }

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -149,9 +149,8 @@ export class AssetService {
     }
 
     if (dto.sidecarPath) {
-      const sidecarType = mime.lookup(dto.sidecarPath) as string;
-      if (!isSidecarFileType(sidecarType)) {
-        throw new BadRequestException(`Unsupported sidecar file type ${assetPathType}`);
+      if (!dto.sidecarPath.toLowerCase().match(/\.xmp$/)) {
+        throw new BadRequestException(`Unsupported sidecar file type`);
       }
     }
 


### PR DESCRIPTION
This fixes an error server-side where a mimetype check for an XMP sidecar returns `false`. When uploading, we manually specify the mime-type in the CLI as XML, but the mime-type package server-side during the import process does not detect this. Currently, importing files with sidecars fails and is broken.