### PR TITLE
fix(server): empty tag responses should be considered valid

### DIFF
--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -91,13 +91,13 @@ describe(SmartInfoService.name, () => {
       });
     });
 
-    it('should no update the smart info if no tags were returned', async () => {
+    it('should update the smart info even if no tags were returned', async () => {
       machineMock.classifyImage.mockResolvedValue([]);
 
       await sut.handleClassifyImage({ id: asset.id });
 
       expect(machineMock.classifyImage).toHaveBeenCalled();
-      expect(smartMock.upsert).not.toHaveBeenCalled();
+      expect(smartMock.upsert).toHaveBeenCalled();
     });
   });
 

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -91,7 +91,7 @@ describe(SmartInfoService.name, () => {
       });
     });
 
-    it('should update the smart info even if no tags were returned', async () => {
+    it('should always overwrite old tags', async () => {
       machineMock.classifyImage.mockResolvedValue([]);
 
       await sut.handleClassifyImage({ id: asset.id });

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -41,10 +41,6 @@ export class SmartInfoService {
     }
 
     const tags = await this.machineLearning.classifyImage({ imagePath: asset.resizePath });
-    if (tags.length === 0) {
-      return false;
-    }
-
     await this.repository.upsert({ assetId: asset.id, tags });
 
     return true;


### PR DESCRIPTION
## Description

This PR changes the handling of empty tag responses so they're treated the same as non-empty responses. 

The current behavior is problematic in two ways:

1. It can lead to the same images being processed whenever a "missing" job is run. This is because if none of the tags pass the score threshold for an image, then the `tags` field of an asset's `smartInfo` always stays null.
2. If the response for an image changes (by raising the score threshold, changing the model, etc.), stale tags are not removed if the new response is an empty tag response. The behavior I would expect is to replace them with the new set of tags, even if this means the image no longer has any tags associated with it.

## Testing

For these steps to be meaningful, they need to be done in an environment where at least some of the images haven't run tagging yet. Otherwise, it's possible for all images to already have tags beforehand.

1. Set `MACHINE_LEARNING_MIN_TAG_SCORE=1.0` in the ML environment. This is to ensure that all responses are empty. 
2. Run "all" for "tag objects" in the job dashboard.
3. Run "without" for "tag objects" in the job dashboard.

Step 3 should not query for any images as all of them should be considered completed.

Fixes #2883, #2888