### PR TITLE
fix(web): aspect ratio for photos with Rotate 270 CW orientation

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -39,13 +39,7 @@
 			return [thumbnailWidth, thumbnailHeight];
 		}
 
-		if (asset.exifInfo?.orientation === 'Rotate 90 CW') {
-			return [176, 235];
-		} else if (asset.exifInfo?.orientation === 'Horizontal (normal)') {
-			return [313, 235];
-		} else {
-			return [235, 235];
-		}
+		return [235, 235];
 	})();
 
 	const thumbnailClickedHandler = () => {

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -189,7 +189,7 @@ export function getAssetRatio(asset: AssetResponseDto) {
 	let width = asset.exifInfo?.exifImageWidth || 235;
 	const orientation = Number(asset.exifInfo?.orientation);
 	if (orientation) {
-		if (orientation == 6 || orientation == -90) {
+		if (orientation == 6 || orientation == -90 || orientation == 8) {
 			[width, height] = [height, width];
 		}
 	}

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -189,6 +189,7 @@ export function getAssetRatio(asset: AssetResponseDto) {
 	let width = asset.exifInfo?.exifImageWidth || 235;
 	const orientation = Number(asset.exifInfo?.orientation);
 	if (orientation) {
+		// 6 - Rotate 90 CW, 8 - Rotate 270 CW
 		if (orientation == 6 || orientation == 8) {
 			[width, height] = [height, width];
 		}

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -189,7 +189,7 @@ export function getAssetRatio(asset: AssetResponseDto) {
 	let width = asset.exifInfo?.exifImageWidth || 235;
 	const orientation = Number(asset.exifInfo?.orientation);
 	if (orientation) {
-		if (orientation == 6 || orientation == -90 || orientation == 8) {
+		if (orientation == 6 || orientation == 8) {
 			[width, height] = [height, width];
 		}
 	}


### PR DESCRIPTION
We incorrectly determined the aspect ratio for the photos with `Rotate 270 CW` orientation. This issue is mentioned in [this](https://github.com/immich-app/immich/discussions/3000) discussion. This PR fixes it.