### PR TITLE
fix(mobile): fix endless rendering of asset grid when scrolling

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -272,11 +272,7 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
   Widget _buildAssetGrid() {
     final useDragScrolling = widget.renderList.totalAssets >= 20;
 
-    void dragScrolling(bool active) {
-      setState(() {
-        _scrolling = active;
-      });
-    }
+    void dragScrolling(bool active) => _scrolling = active;
 
     final listWidget = ScrollablePositionedList.builder(
       padding: const EdgeInsets.only(
@@ -302,7 +298,6 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
             child: listWidget,
           )
         : listWidget;
-
     return widget.onRefresh == null
         ? child
         : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);


### PR DESCRIPTION
Currently, the entire asset grid is rebuilt multiple per second while scrolling with the draggable scroll bar. This is awful for performance and results in all sorts of issues originating from re-rendering (such as animation flickering).

This PR fixes the issue by not calling `setState` within `build`