### PR TITLE
fix(server): use private cache

### DIFF
--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -162,7 +162,7 @@ export class AssetController {
 
   @SharedLinkRoute()
   @Get('/file/:id')
-  @Header('Cache-Control', 'max-age=31536000')
+  @Header('Cache-Control', 'private, max-age=86400, no-transform')
   @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
   serveFile(
     @AuthUser() authUser: AuthUserDto,
@@ -176,7 +176,7 @@ export class AssetController {
 
   @SharedLinkRoute()
   @Get('/thumbnail/:id')
-  @Header('Cache-Control', 'max-age=31536000')
+  @Header('Cache-Control', 'private, max-age=86400, no-transform')
   @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
   getAssetThumbnail(
     @AuthUser() authUser: AuthUserDto,

--- a/server/src/immich/controllers/user.controller.ts
+++ b/server/src/immich/controllers/user.controller.ts
@@ -98,7 +98,7 @@ export class UserController {
   }
 
   @Get('/profile-image/:userId')
-  @Header('Cache-Control', 'max-age=600')
+  @Header('Cache-Control', 'private, max-age=86400, no-transform')
   async getProfileImage(@Param() { userId }: UserIdDto, @Response({ passthrough: true }) res: Res): Promise<any> {
     const readableStream = await this.service.getUserProfileImage(userId);
     res.header('Content-Type', 'image/jpeg');


### PR DESCRIPTION
The omission of additional cache-control directives implied the resource could be stored in shared/public caches, which is not desirable.

In addition, the no-transform directive will ensure content is not unintentionally mangled.

Fixes: #3014