### PR TITLE
fix(web): aspect ratio for videos with 90 CW and 270 CW orientation

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -181,6 +181,14 @@ export function getFileMimeType(file: File): string {
 	return file.type || (mimeTypes[getFilenameExtension(file.name)] ?? '');
 }
 
+function isRotated90CW(orientation: number) {
+	return orientation == 6 || orientation == 90;
+}
+
+function isRotated270CW(orientation: number) {
+	return orientation == 8 || orientation == -90;
+}
+
 /**
  * Returns aspect ratio for the asset
  */
@@ -189,8 +197,7 @@ export function getAssetRatio(asset: AssetResponseDto) {
 	let width = asset.exifInfo?.exifImageWidth || 235;
 	const orientation = Number(asset.exifInfo?.orientation);
 	if (orientation) {
-		// 6 - Rotate 90 CW, 8 - Rotate 270 CW
-		if (orientation == 6 || orientation == 8) {
+		if (isRotated90CW(orientation) || isRotated270CW(orientation)) {
 			[width, height] = [height, width];
 		}
 	}


### PR DESCRIPTION
This is a follow up PR for #3003.

#3003 fixed the aspect ratio calculation for photos. Since `ffprobe` returns other values for the orientation tag (`-90`, `90`, etc.), `getAspectRatio` should handle both `exiftool-vendored` range (`1-8`) and `ffprobe` values (`-90`, `90`, `180`, etc.)