### PR TITLE
fix(mobile): setting to always display remote assets

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -5,6 +5,8 @@
   "advanced_settings_tile_title": "Advanced",
   "advanced_settings_troubleshooting_subtitle": "Enable additional features for troubleshooting",
   "advanced_settings_troubleshooting_title": "Troubleshooting",
+  "advanced_settings_prefer_remote_title": "Prefer remote images",
+  "advanced_settings_prefer_remote_subtitle": "Some devices are painfully slow to load thumbnails from assets on the device. Activate this setting to load remote images instead.",
   "album_info_card_backup_album_excluded": "EXCLUDED",
   "album_info_card_backup_album_included": "INCLUDED",
   "album_thumbnail_card_item": "1 item",

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -131,7 +131,8 @@ class GalleryViewerPage extends HookConsumerWidget {
       if (index < totalAssets && index >= 0) {
         final asset = loadAsset(index);
 
-        if (asset.isLocal) {
+        if (!asset.isRemote ||
+            asset.isLocal && !Store.get(StoreKey.preferRemoteImage, false)) {
           // Preload the local asset
           precacheImage(localImageProvider(asset), context);
         } else {
@@ -459,7 +460,8 @@ class GalleryViewerPage extends HookConsumerWidget {
     });
 
     ImageProvider imageProvider(Asset asset) {
-      if (asset.isLocal) {
+      if (!asset.isRemote ||
+          asset.isLocal && !Store.get(StoreKey.preferRemoteImage, false)) {
         return localImageProvider(asset);
       } else {
         if (isLoadOriginal.value) {
@@ -518,7 +520,9 @@ class GalleryViewerPage extends HookConsumerWidget {
               loadingBuilder: isLoadPreview.value
                   ? (context, event) {
                       final a = asset();
-                      if (!a.isLocal) {
+                      if (!a.isLocal ||
+                          (a.isRemote &&
+                              Store.get(StoreKey.preferRemoteImage, false))) {
                         // Use the WEBP Thumbnail as a placeholder for the JPEG thumbnail to achieve
                         // Three-Stage Loading (WEBP -> JPEG -> Original)
                         final webPThumbnail = CachedNetworkImage(

--- a/mobile/lib/modules/settings/services/app_settings.service.dart
+++ b/mobile/lib/modules/settings/services/app_settings.service.dart
@@ -44,7 +44,8 @@ enum AppSettingsEnum<T> {
     0,
   ),
   advancedTroubleshooting<bool>(StoreKey.advancedTroubleshooting, null, false),
-  logLevel<int>(StoreKey.logLevel, null, 5) // Level.INFO = 5
+  logLevel<int>(StoreKey.logLevel, null, 5), // Level.INFO = 5
+  preferRemoteImage<bool>(StoreKey.preferRemoteImage, null, false),
   ;
 
   const AppSettingsEnum(this.storeKey, this.hiveKey, this.defaultValue);

--- a/mobile/lib/modules/settings/ui/advanced_settings/advanced_settings.dart
+++ b/mobile/lib/modules/settings/ui/advanced_settings/advanced_settings.dart
@@ -16,6 +16,8 @@ class AdvancedSettings extends HookConsumerWidget {
     final isEnabled =
         useState(AppSettingsEnum.advancedTroubleshooting.defaultValue);
     final levelId = useState(AppSettingsEnum.logLevel.defaultValue);
+    final preferRemote =
+        useState(AppSettingsEnum.preferRemoteImage.defaultValue);
 
     useEffect(
       () {
@@ -23,6 +25,8 @@ class AdvancedSettings extends HookConsumerWidget {
           AppSettingsEnum.advancedTroubleshooting,
         );
         levelId.value = appSettingService.getSetting(AppSettingsEnum.logLevel);
+        preferRemote.value =
+            appSettingService.getSetting(AppSettingsEnum.preferRemoteImage);
         return null;
       },
       [],
@@ -76,6 +80,13 @@ class AdvancedSettings extends HookConsumerWidget {
             label: logLevel,
             activeColor: Theme.of(context).primaryColor,
           ),
+        ),
+        SettingsSwitchListTile(
+          appSettingService: appSettingService,
+          valueNotifier: preferRemote,
+          settingsEnum: AppSettingsEnum.preferRemoteImage,
+          title: "advanced_settings_prefer_remote_title".tr(),
+          subtitle: "advanced_settings_prefer_remote_subtitle".tr(),
         ),
       ],
     );

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -173,6 +173,7 @@ enum StoreKey<T> {
   selectedAlbumSortOrder<int>(113, type: int),
   advancedTroubleshooting<bool>(114, type: bool),
   logLevel<int>(115, type: int),
+  preferRemoteImage<bool>(116, type: bool),
   ;
 
   const StoreKey(

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -43,7 +43,8 @@ class ImmichImage extends StatelessWidget {
       );
     }
     final Asset asset = this.asset!;
-    if (asset.isLocal) {
+    if (!asset.isRemote ||
+        (asset.isLocal && !Store.get(StoreKey.preferRemoteImage, false))) {
       return Image(
         image: AssetEntityImageProvider(
           asset.local!,


### PR DESCRIPTION
workaround for #2128

Users can opt-in (in advanced settings) to always display remote versions of assets. This helps users who's device is dead slow to load local thumbnails (usually from heic/heif files)

![image](https://github.com/immich-app/immich/assets/10599762/bd21881f-6876-4a26-903a-e15c2a33bdd1)
