### PR TITLE
fix(mobile): Uses ImageFiltered for performance

### DIFF
--- a/mobile/lib/modules/memories/ui/memory_card.dart
+++ b/mobile/lib/modules/memories/ui/memory_card.dart
@@ -55,7 +55,7 @@ class MemoryCard extends HookConsumerWidget {
       child: Stack(
         children: [
           ImageFiltered(
-            imageFilter: ImageFilter.blur(sigmaX: 60, sigmaY: 60),
+            imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
             child: Container(
               decoration: BoxDecoration(
                 image: DecorationImage(
@@ -71,7 +71,7 @@ class MemoryCard extends HookConsumerWidget {
                   fit: BoxFit.cover,
                 ),
               ),
-              child: Container(color: Colors.black.withOpacity(0.4)),
+              child: Container(color: Colors.black.withOpacity(0.2)),
             ),
           ),
           GestureDetector(

--- a/mobile/lib/modules/memories/ui/memory_card.dart
+++ b/mobile/lib/modules/memories/ui/memory_card.dart
@@ -54,27 +54,24 @@ class MemoryCard extends HookConsumerWidget {
       clipBehavior: Clip.hardEdge,
       child: Stack(
         children: [
-          Container(
-            decoration: BoxDecoration(
-              image: DecorationImage(
-                image: CachedNetworkImageProvider(
-                  getThumbnailUrl(
-                    asset,
+          ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: 60, sigmaY: 60),
+            child: Container(
+              decoration: BoxDecoration(
+                image: DecorationImage(
+                  image: CachedNetworkImageProvider(
+                    getThumbnailUrl(
+                      asset,
+                    ),
+                    cacheKey: getThumbnailCacheKey(
+                      asset,
+                    ),
+                    headers: {"Authorization": authToken},
                   ),
-                  cacheKey: getThumbnailCacheKey(
-                    asset,
-                  ),
-                  headers: {"Authorization": authToken},
+                  fit: BoxFit.cover,
                 ),
-                fit: BoxFit.cover,
               ),
-            ),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 60, sigmaY: 60),
-              child: Container(
-                decoration:
-                    BoxDecoration(color: Colors.black.withOpacity(0.25)),
-              ),
+              child: Container(color: Colors.black.withOpacity(0.4)),
             ),
           ),
           GestureDetector(


### PR DESCRIPTION
![image](https://github.com/immich-app/immich/assets/100457/fc751646-72b8-4c7e-acc4-2e2acea1c33c)

Changes `BackdropFilter` out for `ImageFiltered`.

From the documentation for `BackdropFilter`:

>  This effect is relatively expensive, especially if the filter is non-local,
> such as a blur.
>
> If all you want to do is apply an [ImageFilter] to a single widget
> (as opposed to applying the filter to everything _beneath_ a widget), use
> [ImageFiltered] instead. For that scenario, [ImageFiltered] is both
> easier to use and less expensive than [BackdropFilter].

It looks a little different, though. You can play around with the child container opacity to change the look, but I found something I thought looked appropriate. 

It's much more performant and doesn't have the strange flicker I was seeing while paging through my memories on my Android phone with the the `BackdropFilter`.