### PR TITLE
fix(server): h264 and hevc not respecting max bitrate

### DIFF
--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -396,6 +396,7 @@ describe(MediaService.name, () => {
             '-preset ultrafast',
             '-crf 23',
             '-maxrate 4500k',
+            '-bufsize 9000k',
           ],
           twoPass: false,
         },

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -284,7 +284,14 @@ export class MediaService {
     } else if (constrainMaximumBitrate || isVP9) {
       // for vp9, these flags work for both one-pass and two-pass
       options.push(`-crf ${ffmpeg.crf}`);
-      options.push(`${isVP9 ? '-b:v' : '-maxrate'} ${maxBitrateValue}${bitrateUnit}`);
+      if (isVP9) {
+        options.push(`-b:v ${maxBitrateValue}${bitrateUnit}`);
+      } else {
+        options.push(`-maxrate ${maxBitrateValue}${bitrateUnit}`);
+        // -bufsize is the peak possible bitrate at any moment, while -maxrate is the max rolling average bitrate
+        // needed for -maxrate to be enforced
+        options.push(`-bufsize ${maxBitrateValue * 2}${bitrateUnit}`);
+      }
     } else {
       options.push(`-crf ${ffmpeg.crf}`);
     }


### PR DESCRIPTION
## Description
H.264 and HEVC ignore `-maxrate`  unless `-bufsize` is also specified. This PR adds `-bufsize` to the command when constraining bitrate with these codecs. The common suggestion is to set `-bufsize` to twice the max bitrate to allow budgeting more bandwidth for difficult frames. The max bitrate is then the max rolling average over any 2 second period.

Fixes #3050

## Testing

1. Set the target codec to `h264` and set the max bitrate to a positive number.
2. Transcode a video.
3. Inspect the bitrate of this transcode. It should be very similar to the max bitrate or below it.