### PR TITLE
refactor(server): use better algorithm for dupe filenames

### DIFF
--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -96,19 +96,17 @@ export class AssetService {
 
     const zip = this.storageRepository.createZipStream();
     const assets = await this.assetRepository.getByIds(dto.assetIds);
-    const paths: Record<string, boolean> = {};
+    const paths: Record<string, number> = {};
 
     for (const { originalPath, originalFileName } of assets) {
       const ext = extname(originalPath);
       let filename = `${originalFileName}${ext}`;
-      for (let i = 0; i < 10_000; i++) {
-        if (!paths[filename]) {
-          break;
-        }
-        filename = `${originalFileName}+${i + 1}${ext}`;
+      const count = paths[filename] || 0;
+      paths[filename] = count + 1;
+      if (count !== 0) {
+        filename = `${originalFileName}+${count}${ext}`;
       }
 
-      paths[filename] = true;
       zip.addFile(originalPath, filename);
     }
 


### PR DESCRIPTION
Tested Scenarios:
- Upload two different files with the same name
- Download three assets, including the two with the same name (observe +1)

(also the test case for this code still passes :smile:)

![image](https://github.com/immich-app/immich/assets/4334196/00308994-c97b-43ff-9b7a-3b8365f19681)
