### PR TITLE
chore(server): remove refactored controllers from unit test coverage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -138,7 +138,8 @@
     },
     "collectCoverageFrom": [
       "<rootDir>/src/**/*.(t|j)s",
-      "!<rootDir>/src/infra/**/*"
+      "!<rootDir>/src/infra/**/*",
+      "!<rootDir>/src/immich/controllers/**/*"
     ],
     "coverageDirectory": "./coverage",
     "coverageThreshold": {


### PR DESCRIPTION
The controllers don't have any business logic in them, so they don't need to be included in unit test coverage. In the future we can generate test coverage for e2e tests, which should execute the controllers, including the decorator logic, etc.