### PR TITLE
chore(server): add limit to people return

### DIFF
--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -28,6 +28,7 @@ export class PersonRepository implements IPersonRepository {
       .orderBy('COUNT(face.assetId)', 'DESC')
       .having('COUNT(face.assetId) >= :faces', { faces: options?.minimumFaceCount || 1 })
       .groupBy('person.id')
+      .limit(500)
       .getMany();
   }
 


### PR DESCRIPTION
Workaround for some reported issues with the unresponsive page when accessing `/people` due to the people view not using the time-bucket rendering. Therefore rendering all the faces, could up to thousand of faces in some case