### PR TITLE
fix(server): transcodes failing due to storage migration happening simultaneously

### DIFF
--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -128,7 +128,7 @@ export class MediaService {
 
   async handleVideoConversion({ id }: IEntityJob) {
     const [asset] = await this.assetRepository.getByIds([id]);
-    if (!asset) {
+    if (!asset || asset.type !== AssetType.VIDEO) {
       return false;
     }
 

--- a/server/src/immich/api-v1/asset/asset.core.ts
+++ b/server/src/immich/api-v1/asset/asset.core.ts
@@ -1,5 +1,5 @@
 import { AuthUserDto, IJobRepository, JobName } from '@app/domain';
-import { AssetEntity, AssetType, UserEntity } from '@app/infra/entities';
+import { AssetEntity, UserEntity } from '@app/infra/entities';
 import { parse } from 'node:path';
 import { IAssetRepository } from './asset-repository';
 import { CreateAssetDto, ImportAssetDto, UploadFile } from './dto/create-asset.dto';
@@ -46,9 +46,6 @@ export class AssetCore {
     });
 
     await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: asset.id, source: 'upload' } });
-    if (asset.type === AssetType.VIDEO) {
-      await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id: asset.id } });
-    }
 
     return asset;
   }

--- a/server/src/immich/api-v1/asset/asset.service.spec.ts
+++ b/server/src/immich/api-v1/asset/asset.service.spec.ts
@@ -228,7 +228,6 @@ describe('AssetService', () => {
             data: { id: assetEntityStub.livePhotoMotionAsset.id, source: 'upload' },
           },
         ],
-        [{ name: JobName.VIDEO_CONVERSION, data: { id: assetEntityStub.livePhotoMotionAsset.id } }],
         [{ name: JobName.METADATA_EXTRACTION, data: { id: assetEntityStub.livePhotoStillAsset.id, source: 'upload' } }],
       ]);
     });


### PR DESCRIPTION
## Description

Schedules the video conversion job to be enqueued only after storage migration to avoid a `File not found` error while transcoding. Specifically, it's queued after JPEG thumbnail generation is complete. The reason why this particular job is chosen as a prerequisite is mainly because it already queries for the asset itself on completion, which means the result of this query can be used to check if the asset is a video and only queue for transcoding if so.

An earlier iteration queued all uploaded assets after the storage migration job, but this was misleading from a UX perspective as the number of queued assets for transcoding could be much higher than the number actually transcoded.

Fixes #3047

## How Has This Been Tested?

I made a new account and uploaded about a thousand assets. Where before there would sometimes be a "file not found" error in the past, I never got this error with this PR; all videos were encoded successfully.