### PR TITLE
fix(server): use thumbnail content type instead of application/octet-stream

### DIFF
--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -822,7 +822,7 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/octet-stream
+ - **Accept**: image/jpeg, image/webp
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/mobile/openapi/doc/PersonApi.md
+++ b/mobile/openapi/doc/PersonApi.md
@@ -228,7 +228,7 @@ Name | Type | Description  | Notes
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: application/octet-stream
+ - **Accept**: image/jpeg
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -1673,7 +1673,13 @@
         "responses": {
           "200": {
             "content": {
-              "application/octet-stream": {
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/webp": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
@@ -2704,7 +2710,7 @@
         "responses": {
           "200": {
             "content": {
-              "application/octet-stream": {
+              "image/jpeg": {
                 "schema": {
                   "type": "string",
                   "format": "binary"

--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -19,7 +19,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
-import { ApiBody, ApiConsumes, ApiHeader, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiHeader, ApiTags } from '@nestjs/swagger';
 import { Response as Res } from 'express';
 import { Authenticated, AuthUser, SharedLinkRoute } from '../../app.guard';
 import { assetUploadOption, ImmichFile } from '../../config/asset-upload.config';
@@ -122,7 +122,6 @@ export class AssetController {
   @SharedLinkRoute()
   @Get('/file/:id')
   @Header('Cache-Control', 'private, max-age=86400, no-transform')
-  @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
   serveFile(
     @AuthUser() authUser: AuthUserDto,
     @Headers() headers: Record<string, string>,
@@ -136,7 +135,6 @@ export class AssetController {
   @SharedLinkRoute()
   @Get('/thumbnail/:id')
   @Header('Cache-Control', 'private, max-age=86400, no-transform')
-  @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
   getAssetThumbnail(
     @AuthUser() authUser: AuthUserDto,
     @Headers() headers: Record<string, string>,

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -260,8 +260,8 @@ export class AssetService {
     }
 
     try {
-      const [thumbnailPath, format] = this.getThumbnailPath(asset, query.format);
-      return this.streamFile(thumbnailPath, res, headers, `image/${format.toLowerCase()}`);
+      const [thumbnailPath, contentType] = this.getThumbnailPath(asset, query.format);
+      return this.streamFile(thumbnailPath, res, headers, contentType);
     } catch (e) {
       res.header('Cache-Control', 'none');
       Logger.error(`Cannot create read stream for asset ${asset.id}`, 'getAssetThumbnail');
@@ -579,7 +579,7 @@ export class AssetService {
     switch (format) {
       case GetAssetThumbnailFormatEnum.WEBP:
         if (asset.webpPath) {
-          return [asset.webpPath, GetAssetThumbnailFormatEnum.WEBP];
+          return [asset.webpPath, 'image/webp'];
         }
 
       case GetAssetThumbnailFormatEnum.JPEG:
@@ -590,7 +590,7 @@ export class AssetService {
         if (format != GetAssetThumbnailFormatEnum.JPEG) {
           this.logger.warn(`${format} thumbnail requested but not found for asset ${asset.id}, falling back to JPEG`);
         }
-        return [asset.resizePath, GetAssetThumbnailFormatEnum.JPEG];
+        return [asset.resizePath, 'image/jpeg'];
     }
   }
 

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -572,10 +572,6 @@ export class AssetService {
   }
 
   private getThumbnailPath(asset: AssetEntity, format: GetAssetThumbnailFormatEnum) {
-    if (!Object.values(GetAssetThumbnailFormatEnum).includes(format)) {
-      throw new UnsupportedMediaTypeException(`Unsupported thumbnail format requested: ${format}`);
-    }
-
     switch (format) {
       case GetAssetThumbnailFormatEnum.WEBP:
         if (asset.webpPath) {

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -22,7 +22,6 @@ import {
   Logger,
   NotFoundException,
   StreamableFile,
-  UnsupportedMediaTypeException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Response as Res } from 'express';

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -260,7 +260,7 @@ export class AssetService {
 
     try {
       const thumbnailPath = this.getThumbnailPath(asset, query.format);
-      return this.streamFile(thumbnailPath, res, headers, asset.mimeType);
+      return this.streamFile(thumbnailPath, res, headers, `image/${query.format.toLowerCase()}`);
     } catch (e) {
       res.header('Cache-Control', 'none');
       Logger.error(`Cannot create read stream for asset ${asset.id}`, 'getAssetThumbnail');

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -22,6 +22,7 @@ import {
   Logger,
   NotFoundException,
   StreamableFile,
+  UnsupportedMediaTypeException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Response as Res } from 'express';
@@ -573,16 +574,18 @@ export class AssetService {
   private getThumbnailPath(asset: AssetEntity, format: GetAssetThumbnailFormatEnum) {
     switch (format) {
       case GetAssetThumbnailFormatEnum.WEBP:
-        if (asset.webpPath && asset.webpPath.length > 0) {
-          return asset.webpPath;
+        if (!asset.webpPath) {
+          throw new NotFoundException(`No ${format} thumbnail found for asset ${asset.id}`);
         }
+        return asset.webpPath;
 
       case GetAssetThumbnailFormatEnum.JPEG:
-      default:
         if (!asset.resizePath) {
-          throw new NotFoundException('resizePath not set');
+          throw new NotFoundException(`No ${format} thumbnail found for asset ${asset.id}`);
         }
         return asset.resizePath;
+      default:
+        throw new UnsupportedMediaTypeException(`Unsupported thumbnail format requested: ${format}`);
     }
   }
 

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -260,7 +260,7 @@ export class AssetService {
 
     try {
       const thumbnailPath = this.getThumbnailPath(asset, query.format);
-      return this.streamFile(thumbnailPath, res, headers);
+      return this.streamFile(thumbnailPath, res, headers, asset.mimeType);
     } catch (e) {
       res.header('Cache-Control', 'none');
       Logger.error(`Cannot create read stream for asset ${asset.id}`, 'getAssetThumbnail');

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -260,8 +260,8 @@ export class AssetService {
     }
 
     try {
-      const thumbnailPath = this.getThumbnailPath(asset, query.format);
-      return this.streamFile(thumbnailPath, res, headers, `image/${query.format.toLowerCase()}`);
+      const [thumbnailPath, format] = this.getThumbnailPath(asset, query.format);
+      return this.streamFile(thumbnailPath, res, headers, `image/${format.toLowerCase()}`);
     } catch (e) {
       res.header('Cache-Control', 'none');
       Logger.error(`Cannot create read stream for asset ${asset.id}`, 'getAssetThumbnail');
@@ -572,20 +572,25 @@ export class AssetService {
   }
 
   private getThumbnailPath(asset: AssetEntity, format: GetAssetThumbnailFormatEnum) {
+    if (!Object.values(GetAssetThumbnailFormatEnum).includes(format)) {
+      throw new UnsupportedMediaTypeException(`Unsupported thumbnail format requested: ${format}`);
+    }
+
     switch (format) {
       case GetAssetThumbnailFormatEnum.WEBP:
-        if (!asset.webpPath) {
-          throw new NotFoundException(`No ${format} thumbnail found for asset ${asset.id}`);
+        if (asset.webpPath) {
+          return [asset.webpPath, GetAssetThumbnailFormatEnum.WEBP];
         }
-        return asset.webpPath;
 
       case GetAssetThumbnailFormatEnum.JPEG:
-        if (!asset.resizePath) {
-          throw new NotFoundException(`No ${format} thumbnail found for asset ${asset.id}`);
-        }
-        return asset.resizePath;
       default:
-        throw new UnsupportedMediaTypeException(`Unsupported thumbnail format requested: ${format}`);
+        if (!asset.resizePath) {
+          throw new NotFoundException(`No thumbnail found for asset ${asset.id}`);
+        }
+        if (format != GetAssetThumbnailFormatEnum.JPEG) {
+          this.logger.warn(`${format} thumbnail requested but not found for asset ${asset.id}, falling back to JPEG`);
+        }
+        return [asset.resizePath, GetAssetThumbnailFormatEnum.JPEG];
     }
   }
 

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -576,14 +576,12 @@ export class AssetService {
         if (asset.webpPath) {
           return [asset.webpPath, 'image/webp'];
         }
+        this.logger.warn(`WebP thumbnail requested but not found for asset ${asset.id}, falling back to JPEG`);
 
       case GetAssetThumbnailFormatEnum.JPEG:
       default:
         if (!asset.resizePath) {
           throw new NotFoundException(`No thumbnail found for asset ${asset.id}`);
-        }
-        if (format != GetAssetThumbnailFormatEnum.JPEG) {
-          this.logger.warn(`${format} thumbnail requested but not found for asset ${asset.id}, falling back to JPEG`);
         }
         return [asset.resizePath, 'image/jpeg'];
     }

--- a/server/src/immich/api-v1/asset/dto/get-asset-thumbnail.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/get-asset-thumbnail.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional } from 'class-validator';
+import { IsEnum, IsOptional } from 'class-validator';
 
 export enum GetAssetThumbnailFormatEnum {
   JPEG = 'JPEG',
@@ -8,6 +8,7 @@ export enum GetAssetThumbnailFormatEnum {
 
 export class GetAssetThumbnailDto {
   @IsOptional()
+  @IsEnum(GetAssetThumbnailFormatEnum)
   @ApiProperty({
     type: String,
     enum: GetAssetThumbnailFormatEnum,

--- a/server/src/immich/controllers/person.controller.ts
+++ b/server/src/immich/controllers/person.controller.ts
@@ -7,7 +7,7 @@ import {
   PersonUpdateDto,
 } from '@app/domain';
 import { Body, Controller, Get, Param, Put, StreamableFile } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 import { Authenticated, AuthUser } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
@@ -43,7 +43,6 @@ export class PersonController {
   }
 
   @Get(':id/thumbnail')
-  @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
   getPersonThumbnail(@AuthUser() authUser: AuthUserDto, @Param() { id }: UUIDParamDto) {
     return this.service.getThumbnail(authUser, id).then(asStreamableFile);
   }


### PR DESCRIPTION
## Description
Fixes a bug where all thumbnails would have the `application/octet-stream` mime type. This was caused by the content type not being set in `getAssetThumbnail`, which meant that the default for streams was used instead.

Fixes #3018


## How Has This Been Tested?

Thumbnails in the main gallery view now have `image/jpeg` or `image/webp` mime types as expected.