### PR TITLE
feat(server): Add endpoint to set an asset as profile image

### DIFF
--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -112,6 +112,16 @@ export class UserService {
     return mapCreateProfileImageResponse(updatedUser.id, updatedUser.profileImagePath);
   }
 
+  async createProfileImageByAssetId(authUser: AuthUserDto, assetId: string): Promise<CreateProfileImageResponseDto> {
+    const asset = await this.assetRepository.getByIds([assetId]);
+    if (!asset[0]) {
+      throw new BadRequestException('Asset not found');
+    }
+
+    const updatedUser = await this.userCore.createProfileImage(authUser, asset[0].originalPath);
+    return mapCreateProfileImageResponse(updatedUser.id, updatedUser.profileImagePath);
+  }
+
   async getUserProfileImage(userId: string): Promise<ReadStream> {
     const user = await this.userCore.get(userId);
     if (!user) {

--- a/server/src/immich/controllers/user.controller.ts
+++ b/server/src/immich/controllers/user.controller.ts
@@ -97,6 +97,14 @@ export class UserController {
     return this.service.createProfileImage(authUser, fileInfo);
   }
 
+  @Post('/profile-image-by-assetid')
+  createProfileImageByAssetId(
+    @AuthUser() authUser: AuthUserDto,
+    assetId: string,
+  ): Promise<CreateProfileImageResponseDto> {
+    return this.service.createProfileImageByAssetId(authUser, assetId);
+  }
+
   @Get('/profile-image/:userId')
   @Header('Cache-Control', 'private, max-age=86400, no-transform')
   async getProfileImage(@Param() { userId }: UserIdDto, @Response({ passthrough: true }) res: Res): Promise<any> {


### PR DESCRIPTION
Add endpoint to set an asset as profile image, so that users can simply select an asset as profile image.

#3079

As this is just an draft for now, i want to express some ideas:

- add the ability to crop an existing asset and set it as profile image (could be done via the existing endpoint)
- set an asset as profile image from within the asset viewer via the dots menu
