### PR TITLE
feat(web): new shortcuts

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -81,7 +81,7 @@
         if (shiftKey) downloadFile(asset, publicSharedKey);
         return;
       case 'Delete':
-        deleteAsset();
+        isShowDeleteConfirmation = true;
         return;
       case 'Escape':
         closeViewer();

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -18,6 +18,7 @@
   import { isShowDetail } from '$lib/stores/preferences.store';
   import { addAssetsToAlbum, downloadFile } from '$lib/utils/asset-utils';
   import { browser } from '$app/environment';
+  import { handleError } from '$lib/utils/handle-error';
 
   export let asset: AssetResponseDto;
   export let publicSharedKey = '';
@@ -161,11 +162,7 @@
         message: asset.isFavorite ? `Added to favorites` : `Removed from favorites`,
       });
     } catch (error) {
-      console.error(error);
-      notificationController.show({
-        type: NotificationType.Error,
-        message: `Error ${asset.isFavorite ? 'favoriting' : 'unfavoriting'} asset, check console for more details`,
-      });
+      handleError(error, `Unable to ${asset.isArchived ? `add asset to` : `remove asset from`} favorites`);
     }
   };
 
@@ -229,11 +226,7 @@
         message: asset.isArchived ? `Added to archive` : `Removed from archive`,
       });
     } catch (error) {
-      console.error(error);
-      notificationController.show({
-        type: NotificationType.Error,
-        message: `Error ${asset.isArchived ? 'archiving' : 'unarchiving'} asset, check console for more details`,
-      });
+      handleError(error, `Unable to ${asset.isArchived ? `add asset to` : `remove asset from`} archive`);
     }
   };
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -145,15 +145,28 @@
   };
 
   const toggleFavorite = async () => {
-    const { data } = await api.assetApi.updateAsset({
-      id: asset.id,
-      updateAssetDto: {
-        isFavorite: !asset.isFavorite,
-      },
-    });
+    try {
+      const { data } = await api.assetApi.updateAsset({
+        id: asset.id,
+        updateAssetDto: {
+          isFavorite: !asset.isFavorite,
+        },
+      });
 
-    asset.isFavorite = data.isFavorite;
-    assetStore.updateAsset(asset.id, data.isFavorite);
+      asset.isFavorite = data.isFavorite;
+      assetStore.updateAsset(asset.id, data.isFavorite);
+
+      notificationController.show({
+        type: NotificationType.Info,
+        message: asset.isFavorite ? `Added to favorites` : `Removed from favorites`,
+      });
+    } catch (error) {
+      console.error(error);
+      notificationController.show({
+        type: NotificationType.Error,
+        message: `Error ${asset.isFavorite ? 'favoriting' : 'unfavoriting'} asset, check console for more details`,
+      });
+    }
   };
 
   const openAlbumPicker = (shared: boolean) => {

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -34,7 +34,7 @@
   let shouldPlayMotionPhoto = false;
   let shouldShowDownloadButton = sharedLink ? sharedLink.allowDownload : true;
   let canCopyImagesToClipboard: boolean;
-  const onKeyboardPress = (keyInfo: KeyboardEvent) => handleKeyboardPress(keyInfo.key);
+  const onKeyboardPress = (keyInfo: KeyboardEvent) => handleKeyboardPress(keyInfo.key, keyInfo.shiftKey);
 
   onMount(async () => {
     document.addEventListener('keydown', onKeyboardPress);
@@ -64,22 +64,33 @@
     }
   };
 
-  const handleKeyboardPress = (key: string) => {
+  const handleKeyboardPress = (key: string, shiftKey: boolean) => {
     switch (key) {
-      case 'Escape':
-        closeViewer();
-        return;
-      case 'Delete':
-        isShowDeleteConfirmation = true;
-        return;
-      case 'i':
-        $isShowDetail = !$isShowDetail;
+      case 'a':
+      case 'A':
+        if (shiftKey) toggleArchive();
         return;
       case 'ArrowLeft':
         navigateAssetBackward();
         return;
       case 'ArrowRight':
         navigateAssetForward();
+        return;
+      case 'd':
+      case 'D':
+        if (shiftKey) downloadFile(asset, publicSharedKey);
+        return;
+      case 'Delete':
+        deleteAsset();
+        return;
+      case 'Escape':
+        closeViewer();
+        return;
+      case 'f':
+        toggleFavorite();
+        return;
+      case 'i':
+        $isShowDetail = !$isShowDetail;
         return;
     }
   };

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -21,6 +21,9 @@
   import AssetDateGroup from './asset-date-group.svelte';
   import MemoryLane from './memory-lane.svelte';
 
+  import { AppRoute } from '$lib/constants';
+  import { goto } from '$app/navigation';
+
   export let user: UserResponseDto | undefined = undefined;
   export let isAlbumSelectionMode = false;
   export let showMemoryLane = false;
@@ -30,7 +33,10 @@
   let assetGridElement: HTMLElement;
   let bucketInfo: AssetCountByTimeBucketResponseDto;
 
+  const onKeyboardPress = (event: KeyboardEvent) => handleKeyboardPress(event);
+
   onMount(async () => {
+    document.addEventListener('keydown', onKeyboardPress);
     const { data: assetCountByTimebucket } = await api.assetApi.getAssetCountByTimeBucket({
       getAssetCountByTimeBucketDto: {
         timeGroup: TimeGroupEnum.Month,
@@ -64,6 +70,17 @@
   onDestroy(() => {
     assetStore.setInitialState(0, 0, { totalCount: 0, buckets: [] }, undefined);
   });
+
+  const handleKeyboardPress = (event: KeyboardEvent) => {
+    if (event.key === '/') event.preventDefault();
+    if (!$isViewingAssetStoreState) {
+      switch (event.key) {
+        case '/':
+          goto(AppRoute.EXPLORE);
+          return;
+      }
+    }
+  };
 
   function intersectedHandler(event: CustomEvent) {
     const el = event.detail.container as HTMLElement;
@@ -123,14 +140,14 @@
   let shiftKeyIsDown = false;
 
   const onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Shift') {
+    if (e.shiftKey && e.key !== '/') {
       e.preventDefault();
       shiftKeyIsDown = true;
     }
   };
 
   const onKeyUp = (e: KeyboardEvent) => {
-    if (e.key === 'Shift') {
+    if (e.shiftKey && e.key !== '/') {
       e.preventDefault();
       shiftKeyIsDown = false;
     }

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -23,6 +23,7 @@
 
   import { AppRoute } from '$lib/constants';
   import { goto } from '$app/navigation';
+  import { browser } from '$app/environment';
 
   export let user: UserResponseDto | undefined = undefined;
   export let isAlbumSelectionMode = false;
@@ -68,6 +69,7 @@
   });
 
   onDestroy(() => {
+    if (browser) document.removeEventListener('keydown', handleKeyboardPress);
     assetStore.setInitialState(0, 0, { totalCount: 0, buckets: [] }, undefined);
   });
 

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -109,6 +109,11 @@ export const downloadFile = async (asset: AssetResponseDto, key?: string) => {
         },
       );
 
+      notificationController.show({
+        type: NotificationType.Info,
+        message: `Downloading asset ${asset.originalFileName}`,
+      });
+
       downloadBlob(data, filename);
     } catch (e) {
       handleError(e, `Error downloading ${filename}`);


### PR DESCRIPTION
This PR implements the following shortcuts when viewing assets individually:
- `f` to mark the current viewing asset as favorite
- `Shift` + `a` to archive it
- `Shift` + `d` to download it

and while viewing the asset grid:
- `/` to go to the explore page

This is the same behavior as Google Photos even when caps lock is activated.