### PR TITLE
fix(server): Set dev restart policy to unless-stopped.

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -43,7 +43,7 @@ services:
       - NODE_ENV=development
     depends_on:
       - database
-    restart: always
+    restart: unless-stopped
 
   immich-microservices:
     container_name: immich_microservices
@@ -88,7 +88,7 @@ services:
     volumes:
       - ../web:/usr/src/app
       - /usr/src/app/node_modules
-    restart: always
+    restart: unless-stopped
     depends_on:
       - immich-server
 
@@ -137,7 +137,7 @@ services:
     depends_on:
       - immich-server
       - immich-web
-    restart: always
+    restart: unless-stopped
 
 volumes:
   pgdata:


### PR DESCRIPTION
Previously, if you'd shut down the `make-dev` command and restart the docker daemon (say, on a system reboot), there would be 3 immich containers already running.

---

Testing:

This is the output on the main branch after ``systemctl restart docker.service`:

```
$ docker ps --format '{{.Names}}'
immich_proxy_dev
immich_web_dev
immich_machine_learning_dev
jellyfin
caddy
pihole
```

And on this branch:

```
$ docker ps --format '{{.Names}}'
jellyfin
caddy
pihole
```
