### PR TITLE
fix(server): enable transcoding of audioless videos

### DIFF
--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -141,7 +141,7 @@ export class MediaService {
     const mainVideoStream = this.getMainVideoStream(videoStreams);
     const mainAudioStream = this.getMainAudioStream(audioStreams);
     const containerExtension = format.formatName;
-    if (!mainVideoStream || !mainAudioStream || !containerExtension) {
+    if (!mainVideoStream || !containerExtension) {
       return false;
     }
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -176,7 +176,7 @@ export class MediaService {
   private isTranscodeRequired(
     asset: AssetEntity,
     videoStream: VideoStreamInfo,
-    audioStream: AudioStreamInfo,
+    audioStream: AudioStreamInfo | null,
     containerExtension: string,
     ffmpegConfig: SystemConfigFFmpegDto,
   ): boolean {
@@ -186,12 +186,18 @@ export class MediaService {
     }
 
     const isTargetVideoCodec = videoStream.codecName === ffmpegConfig.targetVideoCodec;
-    const isTargetAudioCodec = audioStream.codecName === ffmpegConfig.targetAudioCodec;
     const isTargetContainer = ['mov,mp4,m4a,3gp,3g2,mj2', 'mp4', 'mov'].includes(containerExtension);
+    const isTargetAudioCodec = (audioStream != null) && audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
-    this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream.codecName}, AudioStreamCodecType ${audioStream.codecType}, containerExtension ${containerExtension}`,
-    );
+    if (audioStream != null) {
+        this.logger.log(
+            `${asset.id}: AudioCodecName ${audioStream.codecName}, AudioStreamCodecType ${audioStream.codecType}, containerExtension ${containerExtension}`,
+        );
+    } else {
+        this.logger.log(
+            `${asset.id}: AudioCodecName None, AudioStreamCodecType None, containerExtension ${containerExtension}`,
+        );
+    }
 
     const allTargetsMatching = isTargetVideoCodec && isTargetAudioCodec && isTargetContainer;
     const scalingEnabled = ffmpegConfig.targetResolution !== 'original';

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -187,7 +187,7 @@ export class MediaService {
 
     const isTargetVideoCodec = videoStream.codecName === ffmpegConfig.targetVideoCodec;
     const isTargetContainer = ['mov,mp4,m4a,3gp,3g2,mj2', 'mp4', 'mov'].includes(containerExtension);
-    const isTargetAudioCodec = audioStream != null && audioStream.codecName === ffmpegConfig.targetAudioCodec;
+    const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     if (audioStream != null) {
       this.logger.verbose(

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -187,16 +187,16 @@ export class MediaService {
 
     const isTargetVideoCodec = videoStream.codecName === ffmpegConfig.targetVideoCodec;
     const isTargetContainer = ['mov,mp4,m4a,3gp,3g2,mj2', 'mp4', 'mov'].includes(containerExtension);
-    const isTargetAudioCodec = (audioStream != null) && audioStream.codecName === ffmpegConfig.targetAudioCodec;
+    const isTargetAudioCodec = audioStream != null && audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     if (audioStream != null) {
-        this.logger.log(
-            `${asset.id}: AudioCodecName ${audioStream.codecName}, AudioStreamCodecType ${audioStream.codecType}, containerExtension ${containerExtension}`,
-        );
+      this.logger.verbose(
+        `${asset.id}: AudioCodecName ${audioStream.codecName}, AudioStreamCodecType ${audioStream.codecType}, containerExtension ${containerExtension}`,
+      );
     } else {
-        this.logger.log(
-            `${asset.id}: AudioCodecName None, AudioStreamCodecType None, containerExtension ${containerExtension}`,
-        );
+      this.logger.verbose(
+        `${asset.id}: AudioCodecName None, AudioStreamCodecType None, containerExtension ${containerExtension}`,
+      );
     }
 
     const allTargetsMatching = isTargetVideoCodec && isTargetAudioCodec && isTargetContainer;


### PR DESCRIPTION
See https://github.com/immich-app/immich/issues/3146

Uploaded videos that do not contain any audio streams are not transcoded..
This simple change removes the check for the presence of an audio stream, which appears to be currently a prerequisite for video transcoding.