### PR TITLE
Update read-only-gallery.md

### DIFF
--- a/docs/docs/features/read-only-gallery.md
+++ b/docs/docs/features/read-only-gallery.md
@@ -42,8 +42,8 @@ We will use those values in the steps below.
     command: [ "start.sh", "immich" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-+     - /mnt/media/precious-memory:/mnt/media/precious-memory
-+     - /mnt/media/childhood-memory:/mnt/media/childhood-memory
++     - /mnt/media/precious-memory:/mnt/media/precious-memory:ro
++     - /mnt/media/childhood-memory:/mnt/media/childhood-memory:ro
     env_file:
       - .env
     depends_on:
@@ -58,8 +58,8 @@ We will use those values in the steps below.
     command: [ "start.sh", "microservices" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-+     - /mnt/media/precious-memory:/mnt/media/precious-memory
-+     - /mnt/media/childhood-memory:/mnt/media/childhood-memory
++     - /mnt/media/precious-memory:/mnt/media/precious-memory:ro
++     - /mnt/media/childhood-memory:/mnt/media/childhood-memory:ro
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
A very tiny tweak to the documentation about read only galleries. 

This prevent Immich from having write access to volumes that should only be read. Imho it's good practise to never give more permissions than needed and since it's likely that users will copy what they see in this guide adding the `ro` (read-only) here might increase the likelyhood that others add it as well. 