### PR TITLE
Add typesense_host into example env file

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -48,6 +48,7 @@ UPLOAD_LOCATION=absolute_location_on_your_machine_where_you_want_to_store_the_ba
 # Typesense
 ###################################################################################
 TYPESENSE_API_KEY=some-random-text
+TYPESENSE_HOST=typesense
 # TYPESENSE_ENABLED=false
 # TYPESENSE_URL uses base64 encoding for the nodes json.
 # Example JSON that was used:


### PR DESCRIPTION
When I deployed typesense with another container name, I found the application is not able to connect to typesense.   
I think it's better to put the env name to example file to have a chance to lead user find it when they need to change it.