### PR TITLE
Add TZ variable to example env file and installation documentation

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -114,3 +114,16 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 ###################################################################################
 
 #IMMICH_VERSION=
+
+###################################################################################
+# Timezone
+#
+# This allows timestamps to be shown with the correct local time.
+# Use your timezone's TZ identifier for this field.
+# TZ identifiers are listed in this table:
+# - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+#
+# Examples: America/Los_Angeles, Europe/Amsterdam, Asia/Tokyo
+###################################################################################
+
+#TZ=America/Los_Angeles

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -153,6 +153,7 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 - Populate `UPLOAD_LOCATION` with your preferred location for storing backup assets.
 - Consider changing `DB_PASSWORD` to something randomly generated
 - Consider changing `TYPESENSE_API_KEY` to something randomly generated
+- Consider changing `TZ` to your [timezone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).
 
 ### Step 3 - Start the containers
 


### PR DESCRIPTION
I saw in the FAQ that setting the TZ environment variable will help immich display timestamp metadata correctly, so I added it to the example `.env` file and updated the docker-compose installation steps to mention it.