### PR TITLE
Document OAuth config env variables for docker

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -114,3 +114,21 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 ###################################################################################
 
 #IMMICH_VERSION=
+
+###################################################################################
+# OAuth configuration - Optional
+#
+# This allows users to login with external credentials from an OAuth / OIDC provider
+# like Authentik or Keycloak instead of having a local account.  This sort of SSO
+# is useful if immich is installed as part of a community or managed group.
+#
+# For more info see https://immich.app/docs/administration/oauth
+###################################################################################
+#OAUTH_ENABLED=true
+#OAUTH_ISSUER_URL=https://login.example.com/realms/realm-name
+#OAUTH_CLIENT_ID=immich
+#OAUTH_CLIENT_SECRET=client-secret
+##OAUTH_REDIRECT_URI=https://immich.example.com/auth/login
+##OAUTH_TOKEN_RESPONSE_ALG=HS256
+#OAUTH_AUTO_REGISTER=true
+#OAUTH_BUTTON_TEXT=Login with OIDC

--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -14,6 +14,7 @@ Immich supports 3rd party authentication via [OpenID Connect][oidc] (OIDC), an i
 - [Authelia](https://www.authelia.com/configuration/identity-providers/open-id-connect/)
 - [Okta](https://www.okta.com/openid-connect/)
 - [Google](https://developers.google.com/identity/openid-connect/openid-connect)
+- [Keycloak](https://www.keycloak.org/)
 
 ## Prerequisites
 
@@ -103,5 +104,22 @@ Immich has a route (`/api/oauth/mobile-redirect`) that is already configured to 
 Here's an example of OAuth configured for Authentik:
 
 ![OAuth Settings](./img/oauth-settings.png)
+
+## Docker environment configuration for OAuth
+
+It is also possible to configure OAuth through the Docker `.env` or `docker-compse.yaml` file. A possible configuration for Authentik or Keycloak would be:
+
+```
+
+OAUTH_ENABLED=true
+OAUTH_ISSUER_URL=https://authentik.example.com/application/o/immich/.well-known/openid-configuration
+OAUTH_ISSUER_URL=https://keycloak.example.com/realms/realm-name
+OAUTH_CLIENT_ID=immich
+OAUTH_CLIENT_SECRET=shared-client-secret
+#OAUTH_REDIRECT_URI=https://immich.example.com/auth/login
+OAUTH_TOKEN_RESPONSE_ALG=HS256
+OAUTH_AUTO_REGISTER=true
+OAUTH_BUTTON_TEXT=Login with OpenID
+```
 
 [oidc]: https://openid.net/connect/

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -153,6 +153,7 @@ IMMICH_MACHINE_LEARNING_URL=http://immich-machine-learning:3003
 - Populate `UPLOAD_LOCATION` with your preferred location for storing backup assets.
 - Consider changing `DB_PASSWORD` to something randomly generated
 - Consider changing `TYPESENSE_API_KEY` to something randomly generated
+- Configure OAuth environment variables if you're using SSO. See [Administration - OAuth](/docs/administration/oauth) for more details
 
 ### Step 3 - Start the containers
 


### PR DESCRIPTION
This patch adds documentation to Administration - OAuth for setting the docker-compose environment to include the OIDC provider information and also adds a sample configuration to the example.env file.