### PR TITLE
feat(mobile): stop asset grid rebuilds

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -37,12 +37,14 @@ class GalleryViewerPage extends HookConsumerWidget {
   final Asset Function(int index) loadAsset;
   final int totalAssets;
   final int initialIndex;
+  final int heroOffset;
 
   GalleryViewerPage({
     super.key,
     required this.initialIndex,
     required this.loadAsset,
     required this.totalAssets,
+    this.heroOffset = 0,
   }) : controller = PageController(initialPage: initialIndex);
 
   final PageController controller;
@@ -589,7 +591,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                     },
                     imageProvider: provider,
                     heroAttributes: PhotoViewHeroAttributes(
-                      tag: asset.id,
+                      tag: asset.id + heroOffset,
                     ),
                     filterQuality: FilterQuality.high,
                     tightMode: true,
@@ -606,7 +608,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                     onDragUpdate: (_, details, __) =>
                         handleSwipeUpDown(details),
                     heroAttributes: PhotoViewHeroAttributes(
-                      tag: asset.id,
+                      tag: asset.id + heroOffset,
                     ),
                     filterQuality: FilterQuality.high,
                     maxScale: 1.0,

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -34,6 +34,7 @@ class ImmichAssetGridView extends StatefulWidget {
   final void Function(ItemPosition start, ItemPosition end)?
       visibleItemsListener;
   final Widget? topWidget;
+  final int heroOffset;
 
   const ImmichAssetGridView({
     super.key,
@@ -50,6 +51,7 @@ class ImmichAssetGridView extends StatefulWidget {
     this.showMultiSelectIndicator = true,
     this.visibleItemsListener,
     this.topWidget,
+    this.heroOffset = 0,
   });
 
   @override
@@ -122,6 +124,7 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
           : null,
       useGrayBoxPlaceholder: true,
       showStorageIndicator: widget.showStorageIndicator,
+      heroOffset: widget.heroOffset,
     );
   }
 

--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -18,6 +18,7 @@ class ThumbnailImage extends HookConsumerWidget {
   final bool multiselectEnabled;
   final Function? onSelect;
   final Function? onDeselect;
+  final int heroOffset;
 
   const ThumbnailImage({
     Key? key,
@@ -31,6 +32,7 @@ class ThumbnailImage extends HookConsumerWidget {
     this.multiselectEnabled = false,
     this.onDeselect,
     this.onSelect,
+    this.heroOffset = 0,
   }) : super(key: key);
 
   @override
@@ -63,6 +65,7 @@ class ThumbnailImage extends HookConsumerWidget {
               initialIndex: index,
               loadAsset: loadAsset,
               totalAssets: totalAssets,
+              heroOffset: heroOffset,
             ),
           );
         }
@@ -72,32 +75,7 @@ class ThumbnailImage extends HookConsumerWidget {
         HapticFeedback.heavyImpact();
       },
       child: Hero(
-        createRectTween: (begin, end) {
-          double? top;
-          // Uses the [BoxFit.contain] algorithm
-          if (asset.width != null && asset.height != null) {
-            final assetAR = asset.width! / asset.height!;
-            final w = MediaQuery.of(context).size.width;
-            final deviceAR = MediaQuery.of(context).size.aspectRatio;
-            if (deviceAR < assetAR) {
-              top = asset.height! * w / asset.width!;
-            } else {
-              top = 0;
-            }
-            // get the height offset
-          }
-
-          return MaterialRectCenterArcTween(
-            begin: Rect.fromLTRB(
-              0,
-              top ?? 0.0,
-              MediaQuery.of(context).size.width,
-              MediaQuery.of(context).size.height,
-            ),
-            end: end,
-          );
-        },
-        tag: asset.id,
+        tag: asset.id + heroOffset,
         child: Stack(
           children: [
             Container(

--- a/mobile/lib/modules/memories/ui/memory_lane.dart
+++ b/mobile/lib/modules/memories/ui/memory_lane.dart
@@ -31,7 +31,7 @@ class MemoryLane extends HookConsumerWidget {
                           onTap: () {
                             HapticFeedback.heavyImpact();
                             AutoRouter.of(context).push(
-                              VerticalRouteView(
+                              MemoryRoute(
                                 memories: memories,
                                 memoryIndex: index,
                               ),

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -106,7 +106,11 @@ part 'router.gr.dart';
       guards: [AuthGuard, DuplicateGuard],
       transitionsBuilder: TransitionsBuilders.slideBottom,
     ),
-    AutoRoute(page: AlbumViewerPage, guards: [AuthGuard, DuplicateGuard]),
+    AutoRoute(
+      page: AlbumViewerPage,
+      guards: [AuthGuard, DuplicateGuard],
+      initial: true,
+    ),
     CustomRoute<List<String>?>(
       page: SelectAdditionalUserForSharingPage,
       guards: [AuthGuard, DuplicateGuard],

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -106,11 +106,7 @@ part 'router.gr.dart';
       guards: [AuthGuard, DuplicateGuard],
       transitionsBuilder: TransitionsBuilders.slideBottom,
     ),
-    AutoRoute(
-      page: AlbumViewerPage,
-      guards: [AuthGuard, DuplicateGuard],
-      initial: true,
-    ),
+    AutoRoute(page: AlbumViewerPage, guards: [AuthGuard, DuplicateGuard]),
     CustomRoute<List<String>?>(
       page: SelectAdditionalUserForSharingPage,
       guards: [AuthGuard, DuplicateGuard],

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -70,6 +70,7 @@ class _$AppRouter extends RootStackRouter {
           initialIndex: args.initialIndex,
           loadAsset: args.loadAsset,
           totalAssets: args.totalAssets,
+          heroOffset: args.heroOffset,
         ),
       );
     },
@@ -290,8 +291,8 @@ class _$AppRouter extends RootStackRouter {
         child: const AllPeoplePage(),
       );
     },
-    VerticalRouteView.name: (routeData) {
-      final args = routeData.argsAs<VerticalRouteViewArgs>();
+    MemoryRoute.name: (routeData) {
+      final args = routeData.argsAs<MemoryRouteArgs>();
       return MaterialPageX<dynamic>(
         routeData: routeData,
         child: MemoryPage(
@@ -506,7 +507,7 @@ class _$AppRouter extends RootStackRouter {
         ),
         RouteConfig(
           AlbumViewerRoute.name,
-          path: '/album-viewer-page',
+          path: '/',
           guards: [
             authGuard,
             duplicateGuard,
@@ -601,8 +602,8 @@ class _$AppRouter extends RootStackRouter {
           ],
         ),
         RouteConfig(
-          VerticalRouteView.name,
-          path: '/vertical-page-view',
+          MemoryRoute.name,
+          path: '/memory-page',
           guards: [
             authGuard,
             duplicateGuard,
@@ -680,6 +681,7 @@ class GalleryViewerRoute extends PageRouteInfo<GalleryViewerRouteArgs> {
     required int initialIndex,
     required Asset Function(int) loadAsset,
     required int totalAssets,
+    int heroOffset = 0,
   }) : super(
           GalleryViewerRoute.name,
           path: '/gallery-viewer-page',
@@ -688,6 +690,7 @@ class GalleryViewerRoute extends PageRouteInfo<GalleryViewerRouteArgs> {
             initialIndex: initialIndex,
             loadAsset: loadAsset,
             totalAssets: totalAssets,
+            heroOffset: heroOffset,
           ),
         );
 
@@ -700,6 +703,7 @@ class GalleryViewerRouteArgs {
     required this.initialIndex,
     required this.loadAsset,
     required this.totalAssets,
+    this.heroOffset = 0,
   });
 
   final Key? key;
@@ -710,9 +714,11 @@ class GalleryViewerRouteArgs {
 
   final int totalAssets;
 
+  final int heroOffset;
+
   @override
   String toString() {
-    return 'GalleryViewerRouteArgs{key: $key, initialIndex: $initialIndex, loadAsset: $loadAsset, totalAssets: $totalAssets}';
+    return 'GalleryViewerRouteArgs{key: $key, initialIndex: $initialIndex, loadAsset: $loadAsset, totalAssets: $totalAssets, heroOffset: $heroOffset}';
   }
 }
 
@@ -1014,7 +1020,7 @@ class AlbumViewerRoute extends PageRouteInfo<AlbumViewerRouteArgs> {
     required int albumId,
   }) : super(
           AlbumViewerRoute.name,
-          path: '/album-viewer-page',
+          path: '/',
           args: AlbumViewerRouteArgs(
             key: key,
             albumId: albumId,
@@ -1302,26 +1308,26 @@ class AllPeopleRoute extends PageRouteInfo<void> {
 
 /// generated route for
 /// [MemoryPage]
-class VerticalRouteView extends PageRouteInfo<VerticalRouteViewArgs> {
-  VerticalRouteView({
+class MemoryRoute extends PageRouteInfo<MemoryRouteArgs> {
+  MemoryRoute({
     required List<Memory> memories,
     required int memoryIndex,
     Key? key,
   }) : super(
-          VerticalRouteView.name,
-          path: '/vertical-page-view',
-          args: VerticalRouteViewArgs(
+          MemoryRoute.name,
+          path: '/memory-page',
+          args: MemoryRouteArgs(
             memories: memories,
             memoryIndex: memoryIndex,
             key: key,
           ),
         );
 
-  static const String name = 'VerticalRouteView';
+  static const String name = 'MemoryRoute';
 }
 
-class VerticalRouteViewArgs {
-  const VerticalRouteViewArgs({
+class MemoryRouteArgs {
+  const MemoryRouteArgs({
     required this.memories,
     required this.memoryIndex,
     this.key,
@@ -1335,7 +1341,7 @@ class VerticalRouteViewArgs {
 
   @override
   String toString() {
-    return 'VerticalRouteViewArgs{memories: $memories, memoryIndex: $memoryIndex, key: $key}';
+    return 'MemoryRouteArgs{memories: $memories, memoryIndex: $memoryIndex, key: $key}';
   }
 }
 


### PR DESCRIPTION
another try like #3129 
This time, hero animations  behave ok. 

What is the issue? Each asset used the asset id for its Hero tag. The different tabs are active at the same time. When an asset is loaded on the main timeline and also rendered in the album view, a hero animation is performed because they have the same Hero tag! This PR fixes this by adding a different offset to the hero id depending on the currently active tab (or if outside of the tabs)