### PR TITLE
fix(web): remove processing key events in photo viewer window

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -45,6 +45,9 @@
   };
 
   const handleKeypress = async ({ metaKey, ctrlKey, key }: KeyboardEvent) => {
+    if (window.getSelection()?.type === 'Range') {
+      return;
+    }
     if ((metaKey || ctrlKey) && key === 'c') {
       await doCopy();
     }


### PR DESCRIPTION
Resolves #3165 

Currently processing key events are always executed. Update this to allow only when range selection is not active