### PR TITLE
fix(web): update style of rows in user administration table

### DIFF
--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -187,10 +187,10 @@
                 : 'bg-immich-bg dark:bg-immich-dark-gray/50'
             }`}
           >
-            <td class="text-sm px-4 w-1/4 text-ellipsis">{user.email}</td>
-            <td class="text-sm px-4 w-1/4 text-ellipsis">{user.firstName}</td>
-            <td class="text-sm px-4 w-1/4 text-ellipsis">{user.lastName}</td>
-            <td class="text-sm px-4 w-1/4 text-ellipsis">
+            <td class="text-sm px-4 w-1/4 text-ellipsis break-all">{user.email}</td>
+            <td class="text-sm px-4 w-1/4 text-ellipsis break-all">{user.firstName}</td>
+            <td class="text-sm px-4 w-1/4 text-ellipsis break-all">{user.lastName}</td>
+            <td class="text-sm px-4 w-1/4 text-ellipsis break-all">
               <div class="container flex flex-wrap mx-auto justify-center">
                 {#if user.externalPath}
                   <Check size="16" />
@@ -199,7 +199,7 @@
                 {/if}
               </div>
             </td>
-            <td class="text-sm px-4 w-1/4 text-ellipsis">
+            <td class="text-sm px-4 w-1/4 text-ellipsis break-all">
               {#if !isDeleted(user)}
                 <button
                   on:click={() => editUserHandler(user)}


### PR DESCRIPTION
Resolves #3141 

Wrapping text in multiple lines using `break-all` in Tailwind

Before 

<img width="1009" alt="image" src="https://github.com/immich-app/immich/assets/29462498/4ae8f788-f705-41e1-a804-7e29710dd845">

After

<img width="1093" alt="image" src="https://github.com/immich-app/immich/assets/29462498/313c1401-5f94-4eaa-88e3-a51d64c14b74">
