### PR TITLE
feat(server): storage label claim

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -2601,6 +2601,12 @@ export interface SystemConfigOAuthDto {
      * @type {string}
      * @memberof SystemConfigOAuthDto
      */
+    'storageLabelClaim': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SystemConfigOAuthDto
+     */
     'buttonText': string;
     /**
      * 

--- a/mobile/openapi/doc/SystemConfigOAuthDto.md
+++ b/mobile/openapi/doc/SystemConfigOAuthDto.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **clientId** | **String** |  | 
 **clientSecret** | **String** |  | 
 **scope** | **String** |  | 
+**storageLabelClaim** | **String** |  | 
 **buttonText** | **String** |  | 
 **autoRegister** | **bool** |  | 
 **autoLaunch** | **bool** |  | 

--- a/mobile/openapi/lib/model/system_config_o_auth_dto.dart
+++ b/mobile/openapi/lib/model/system_config_o_auth_dto.dart
@@ -18,6 +18,7 @@ class SystemConfigOAuthDto {
     required this.clientId,
     required this.clientSecret,
     required this.scope,
+    required this.storageLabelClaim,
     required this.buttonText,
     required this.autoRegister,
     required this.autoLaunch,
@@ -34,6 +35,8 @@ class SystemConfigOAuthDto {
   String clientSecret;
 
   String scope;
+
+  String storageLabelClaim;
 
   String buttonText;
 
@@ -52,6 +55,7 @@ class SystemConfigOAuthDto {
      other.clientId == clientId &&
      other.clientSecret == clientSecret &&
      other.scope == scope &&
+     other.storageLabelClaim == storageLabelClaim &&
      other.buttonText == buttonText &&
      other.autoRegister == autoRegister &&
      other.autoLaunch == autoLaunch &&
@@ -66,6 +70,7 @@ class SystemConfigOAuthDto {
     (clientId.hashCode) +
     (clientSecret.hashCode) +
     (scope.hashCode) +
+    (storageLabelClaim.hashCode) +
     (buttonText.hashCode) +
     (autoRegister.hashCode) +
     (autoLaunch.hashCode) +
@@ -73,7 +78,7 @@ class SystemConfigOAuthDto {
     (mobileRedirectUri.hashCode);
 
   @override
-  String toString() => 'SystemConfigOAuthDto[enabled=$enabled, issuerUrl=$issuerUrl, clientId=$clientId, clientSecret=$clientSecret, scope=$scope, buttonText=$buttonText, autoRegister=$autoRegister, autoLaunch=$autoLaunch, mobileOverrideEnabled=$mobileOverrideEnabled, mobileRedirectUri=$mobileRedirectUri]';
+  String toString() => 'SystemConfigOAuthDto[enabled=$enabled, issuerUrl=$issuerUrl, clientId=$clientId, clientSecret=$clientSecret, scope=$scope, storageLabelClaim=$storageLabelClaim, buttonText=$buttonText, autoRegister=$autoRegister, autoLaunch=$autoLaunch, mobileOverrideEnabled=$mobileOverrideEnabled, mobileRedirectUri=$mobileRedirectUri]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -82,6 +87,7 @@ class SystemConfigOAuthDto {
       json[r'clientId'] = this.clientId;
       json[r'clientSecret'] = this.clientSecret;
       json[r'scope'] = this.scope;
+      json[r'storageLabelClaim'] = this.storageLabelClaim;
       json[r'buttonText'] = this.buttonText;
       json[r'autoRegister'] = this.autoRegister;
       json[r'autoLaunch'] = this.autoLaunch;
@@ -103,6 +109,7 @@ class SystemConfigOAuthDto {
         clientId: mapValueOfType<String>(json, r'clientId')!,
         clientSecret: mapValueOfType<String>(json, r'clientSecret')!,
         scope: mapValueOfType<String>(json, r'scope')!,
+        storageLabelClaim: mapValueOfType<String>(json, r'storageLabelClaim')!,
         buttonText: mapValueOfType<String>(json, r'buttonText')!,
         autoRegister: mapValueOfType<bool>(json, r'autoRegister')!,
         autoLaunch: mapValueOfType<bool>(json, r'autoLaunch')!,
@@ -160,6 +167,7 @@ class SystemConfigOAuthDto {
     'clientId',
     'clientSecret',
     'scope',
+    'storageLabelClaim',
     'buttonText',
     'autoRegister',
     'autoLaunch',

--- a/mobile/openapi/test/system_config_o_auth_dto_test.dart
+++ b/mobile/openapi/test/system_config_o_auth_dto_test.dart
@@ -41,6 +41,11 @@ void main() {
       // TODO
     });
 
+    // String storageLabelClaim
+    test('to test the property `storageLabelClaim`', () async {
+      // TODO
+    });
+
     // String buttonText
     test('to test the property `buttonText`', () async {
       // TODO

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -6503,6 +6503,9 @@
           "scope": {
             "type": "string"
           },
+          "storageLabelClaim": {
+            "type": "string"
+          },
           "buttonText": {
             "type": "string"
           },
@@ -6525,6 +6528,7 @@
           "clientId",
           "clientSecret",
           "scope",
+          "storageLabelClaim",
           "buttonText",
           "autoRegister",
           "autoLaunch",

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -240,11 +240,19 @@ export class AuthService {
       }
 
       this.logger.log(`Registering new user: ${profile.email}/${profile.sub}`);
+      this.logger.verbose(`OAuth Profile: ${JSON.stringify(profile)}`);
+
+      let storageLabel: string | null = profile[config.oauth.storageLabelClaim as keyof OAuthProfile] as string;
+      if (typeof storageLabel !== 'string') {
+        storageLabel = null;
+      }
+
       user = await this.userCore.createUser({
         firstName: profile.given_name || '',
         lastName: profile.family_name || '',
         email: profile.email,
         oauthId: profile.sub,
+        storageLabel,
       });
     }
 

--- a/server/src/domain/system-config/dto/system-config-oauth.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-oauth.dto.ts
@@ -26,6 +26,9 @@ export class SystemConfigOAuthDto {
   scope!: string;
 
   @IsString()
+  storageLabelClaim!: string;
+
+  @IsString()
   buttonText!: string;
 
   @IsBoolean()

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -48,6 +48,7 @@ export const defaults = Object.freeze<SystemConfig>({
     mobileOverrideEnabled: false,
     mobileRedirectUri: '',
     scope: 'openid email profile',
+    storageLabelClaim: 'preferred_username',
     buttonText: 'Login with OAuth',
     autoRegister: true,
     autoLaunch: false,

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -53,6 +53,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     mobileOverrideEnabled: false,
     mobileRedirectUri: '',
     scope: 'openid email profile',
+    storageLabelClaim: 'preferred_username',
   },
   passwordLogin: {
     enabled: true,

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -40,6 +40,7 @@ export enum SystemConfigKey {
   OAUTH_CLIENT_ID = 'oauth.clientId',
   OAUTH_CLIENT_SECRET = 'oauth.clientSecret',
   OAUTH_SCOPE = 'oauth.scope',
+  OAUTH_STORAGE_LABEL_CLAIM = 'oauth.storageLabelClaim',
   OAUTH_AUTO_LAUNCH = 'oauth.autoLaunch',
   OAUTH_BUTTON_TEXT = 'oauth.buttonText',
   OAUTH_AUTO_REGISTER = 'oauth.autoRegister',
@@ -89,6 +90,7 @@ export interface SystemConfig {
     clientId: string;
     clientSecret: string;
     scope: string;
+    storageLabelClaim: string;
     buttonText: string;
     autoRegister: boolean;
     autoLaunch: boolean;

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -2601,6 +2601,12 @@ export interface SystemConfigOAuthDto {
      * @type {string}
      * @memberof SystemConfigOAuthDto
      */
+    'storageLabelClaim': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SystemConfigOAuthDto
+     */
     'buttonText': string;
     /**
      * 

--- a/web/src/lib/components/admin-page/settings/oauth/oauth-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/oauth/oauth-settings.svelte
@@ -157,6 +157,16 @@
 
         <SettingInputField
           inputType={SettingInputFieldType.TEXT}
+          label="STORAGE LABEL CLAIM"
+          desc="Automatically set the user's storage label to the value of this claim."
+          bind:value={oauthConfig.storageLabelClaim}
+          required={true}
+          disabled={!oauthConfig.storageLabelClaim}
+          isEdited={!(oauthConfig.storageLabelClaim == savedConfig.storageLabelClaim)}
+        />
+
+        <SettingInputField
+          inputType={SettingInputFieldType.TEXT}
           label="BUTTON TEXT"
           bind:value={oauthConfig.buttonText}
           required={false}


### PR DESCRIPTION
(merge after #3242)

Resolves #3276 

In this PR:
- Add storage label claim system config setting
- Set `user.storageLabel` to the value of the `oauth.storageLabelClaim` property of the OAuth profile when a user signs in for the first time.
- Default storage label claim to `preferred_username`

![image](https://github.com/immich-app/immich/assets/4334196/dc3bb87b-4059-4ec3-8d67-c845cb558f6c)

Tested Scenarios:
- Reset the setting to the default by clearing it out
- Use an invalid claim (storage label is set to null)
- Use a valid claim (storage label is set to mapped value)

