### PR TITLE
fix(web): remove dependency on rxjs 

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,6 @@
         "leaflet.markercluster": "^1.5.3",
         "lodash-es": "^4.17.21",
         "luxon": "^3.2.1",
-        "rxjs": "^7.8.0",
         "socket.io-client": "^4.6.1",
         "svelte-local-storage-store": "^0.5.0",
         "svelte-material-icons": "^3.0.5",
@@ -10526,14 +10525,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -11447,7 +11438,8 @@
     "node_modules/tslib": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19522,14 +19514,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      }
-    },
     "sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -20184,7 +20168,8 @@
     "tslib": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/web/package.json
+++ b/web/package.json
@@ -70,7 +70,6 @@
     "leaflet.markercluster": "^1.5.3",
     "lodash-es": "^4.17.21",
     "luxon": "^3.2.1",
-    "rxjs": "^7.8.0",
     "socket.io-client": "^4.6.1",
     "svelte-local-storage-store": "^0.5.0",
     "svelte-material-icons": "^3.0.5",


### PR DESCRIPTION
The dependency on rxjs has been removed in favour of iterators as it's clearer and the nature of the workload is inherently non-reactive. The uncaught error when the list of files is empty has also been implicitly fixed by this change.

Fixes: https://github.com/immich-app/immich/issues/3300