### PR TITLE
chore: adjust loglevel of reverse geocoding intializer to LOG

### DIFF
--- a/server/src/microservices/processors/metadata-extraction.processor.ts
+++ b/server/src/microservices/processors/metadata-extraction.processor.ts
@@ -49,7 +49,7 @@ export class MetadataExtractionProcessor {
   }
 
   async init(deleteCache = false) {
-    this.logger.warn(`Reverse geocoding is ${this.reverseGeocodingEnabled ? 'enabled' : 'disabled'}`);
+    this.logger.log(`Reverse geocoding is ${this.reverseGeocodingEnabled ? 'enabled' : 'disabled'}`);
     if (!this.reverseGeocodingEnabled) {
       return;
     }


### PR DESCRIPTION
I believe this log is purely informational so I think it would be preferable if it was a LOG instead to avoid getting a warning on every startup.