### PR TITLE
chore: Enable logging on typesense container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,8 +51,6 @@ services:
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
-    logging:
-      driver: none
     volumes:
       - tsdata:/data
     restart: always


### PR DESCRIPTION
Leaving the logging disabled on typesense has no particular value, and it regularly causes a hiccup in troubleshooting if typesense is acting up for people.