### PR TITLE
feat(mobile): render login fields/buttons based on server configuration

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -186,7 +186,7 @@
   "login_form_save_login": "Stay logged in",
   "login_form_server_empty": "Enter a server URL.",
   "login_form_server_error": "Could not connect to server.",
-  "login_disabled": "Login has been disabled.",
+  "login_disabled": "Login has been disabled",
   "monthly_title_text_date_format": "MMMM y",
   "motion_photos_page_title": "Motion Photos",
   "notification_permission_dialog_cancel": "Cancel",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -186,6 +186,7 @@
   "login_form_save_login": "Stay logged in",
   "login_form_server_empty": "Enter a server URL.",
   "login_form_server_error": "Could not connect to server.",
+  "login_disabled": "Login has been disabled.",
   "monthly_title_text_date_format": "MMMM y",
   "motion_photos_page_title": "Motion Photos",
   "notification_permission_dialog_cancel": "Cancel",

--- a/mobile/lib/modules/login/ui/login_form.dart
+++ b/mobile/lib/modules/login/ui/login_form.dart
@@ -36,6 +36,7 @@ class LoginForm extends HookConsumerWidget {
     final isLoading = useState<bool>(false);
     final isLoadingServer = useState<bool>(false);
     final isOauthEnable = useState<bool>(false);
+    final isPasswordLoginEnable = useState<bool>(false);
     final oAuthButtonLabel = useState<String>('OAuth');
     final logoAnimationController = useAnimationController(
       duration: const Duration(seconds: 60),
@@ -69,9 +70,11 @@ class LoginForm extends HookConsumerWidget {
 
         if (loginConfig != null) {
           isOauthEnable.value = loginConfig.enabled;
+          isPasswordLoginEnable.value = loginConfig.passwordLoginEnabled;
           oAuthButtonLabel.value = loginConfig.buttonText ?? 'OAuth';
         } else {
           isOauthEnable.value = false;
+          isPasswordLoginEnable.value = true;
         }
 
         serverEndpoint.value = endpoint;
@@ -82,6 +85,7 @@ class LoginForm extends HookConsumerWidget {
           toastType: ToastType.error,
         );
         isOauthEnable.value = false;
+        isPasswordLoginEnable.value = true;
         isLoadingServer.value = false;
         return false;
       } catch (e) {
@@ -91,6 +95,7 @@ class LoginForm extends HookConsumerWidget {
           toastType: ToastType.error,
         );
         isOauthEnable.value = false;
+        isPasswordLoginEnable.value = true;
         isLoadingServer.value = false;
         return false;
       }
@@ -262,18 +267,20 @@ class LoginForm extends HookConsumerWidget {
               style: Theme.of(context).textTheme.displaySmall,
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 18),
-            EmailInput(
-              controller: usernameController,
-              focusNode: emailFocusNode,
-              onSubmit: passwordFocusNode.requestFocus,
-            ),
-            const SizedBox(height: 8),
-            PasswordInput(
-              controller: passwordController,
-              focusNode: passwordFocusNode,
-              onSubmit: login,
-            ),
+            if (isPasswordLoginEnable.value) ...[
+              const SizedBox(height: 18),
+              EmailInput(
+                controller: usernameController,
+                focusNode: emailFocusNode,
+                onSubmit: passwordFocusNode.requestFocus,
+              ),
+              const SizedBox(height: 8),
+              PasswordInput(
+                controller: passwordController,
+                focusNode: passwordFocusNode,
+                onSubmit: login,
+              ),
+            ],
 
             // Note: This used to have an AnimatedSwitcher, but was removed
             // because of https://github.com/flutter/flutter/issues/120874
@@ -295,9 +302,11 @@ class LoginForm extends HookConsumerWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       const SizedBox(height: 18),
-                      LoginButton(onPressed: login),
+                      if (isPasswordLoginEnable.value)
+                        LoginButton(onPressed: login),
                       if (isOauthEnable.value) ...[
-                        Padding(
+                        if (isPasswordLoginEnable.value)
+                          Padding(
                           padding: const EdgeInsets.symmetric(
                             horizontal: 16.0,
                           ),
@@ -317,6 +326,10 @@ class LoginForm extends HookConsumerWidget {
                       ],
                     ],
                   ),
+            if (!isOauthEnable.value && !isPasswordLoginEnable.value)
+              const Center(
+                child: Text("Login has been disabled."),
+              ),
             const SizedBox(height: 12),
             TextButton.icon(
               icon: const Icon(Icons.arrow_back),

--- a/mobile/lib/modules/login/ui/login_form.dart
+++ b/mobile/lib/modules/login/ui/login_form.dart
@@ -328,7 +328,7 @@ class LoginForm extends HookConsumerWidget {
                   ),
             if (!isOauthEnable.value && !isPasswordLoginEnable.value)
               const Center(
-                child: Text("Login has been disabled."),
+                child: Text('login_disabled'),
               ),
             const SizedBox(height: 12),
             TextButton.icon(

--- a/mobile/lib/modules/login/ui/login_form.dart
+++ b/mobile/lib/modules/login/ui/login_form.dart
@@ -307,16 +307,16 @@ class LoginForm extends HookConsumerWidget {
                       if (isOauthEnable.value) ...[
                         if (isPasswordLoginEnable.value)
                           Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 16.0,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16.0,
+                            ),
+                            child: Divider(
+                              color: Brightness.dark ==
+                                      Theme.of(context).brightness
+                                  ? Colors.white
+                                  : Colors.black,
+                            ),
                           ),
-                          child: Divider(
-                            color:
-                                Brightness.dark == Theme.of(context).brightness
-                                    ? Colors.white
-                                    : Colors.black,
-                          ),
-                        ),
                         OAuthLoginButton(
                           serverEndpointController: serverEndpointController,
                           buttonLabel: oAuthButtonLabel.value,
@@ -327,8 +327,8 @@ class LoginForm extends HookConsumerWidget {
                     ],
                   ),
             if (!isOauthEnable.value && !isPasswordLoginEnable.value)
-              const Center(
-                child: Text('login_disabled'),
+              Center(
+                child: const Text('login_disabled').tr(),
               ),
             const SizedBox(height: 12),
             TextButton.icon(


### PR DESCRIPTION
Issue #3337, Discussion #2206 

Shows/hides email/password fields based on config on the server
Shows/hides oauth buttons based on config on the server
Shows error message same as web interface is both are disabled

![Only Password](https://github.com/immich-app/immich/assets/17243132/2625a515-b1e2-4540-bf70-d869d5ff6a4d)
![Both Enabled](https://github.com/immich-app/immich/assets/17243132/740ac181-7619-45cc-af08-5672d7db83c9)
![Only OAuth](https://github.com/immich-app/immich/assets/17243132/cdea0a90-e823-407a-90d9-7a39fff5311d)
![Nothing Enabled](https://github.com/immich-app/immich/assets/17243132/b056b7fd-6766-4b81-9b65-5bdd0ecf8b59)
