### PR TITLE
fix(ml): better model unloading

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -186,10 +186,10 @@ Typesense URL example JSON before encoding:
 
 ## Machine Learning
 
-| Variable                                         | Description                                                                         | Default             | Services         |
+| Variable                                         | Description                                                                         |       Default       | Services         |
 | :----------------------------------------------- | :---------------------------------------------------------------------------------- | :-----------------: | :--------------- |
 | `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0)                   |        `300`        | machine learning |
-| `MACHINE_LEARNING_TTL_POLL_S`                    | The frequency with which the model TTL is checked for inactivity (disabled if <= 0) |         `10`        | machine learning |
+| `MACHINE_LEARNING_TTL_POLL_S`                    | The frequency with which the model TTL is checked for inactivity (disabled if <= 0) |        `10`         | machine learning |
 | `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                                               |      `/cache`       | machine learning |
 | `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)                          | number of CPU cores | machine learning |
 | `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                                                 |         `1`         | machine learning |

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -186,21 +186,20 @@ Typesense URL example JSON before encoding:
 
 ## Machine Learning
 
-| Variable                                         | Description                                                       |       Default       | Services         |
-| :----------------------------------------------- | :---------------------------------------------------------------- | :-----------------: | :--------------- |
-| `MACHINE_LEARNING_MODEL_TTL`<sup>\*1</sup>       | Inactivity time (s) before a model is unloaded (disabled if <= 0) |         `0`         | machine learning |
-| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                             |      `/cache`       | machine learning |
-| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*2</sup> | Thread count of the request thread pool (disabled if <= 0)        | number of CPU cores | machine learning |
-| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                               |         `1`         | machine learning |
-| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                        |         `2`         | machine learning |
-| `MACHINE_LEARNING_WORKERS`<sup>\*3</sup>         | Number of worker processes to spawn                               |         `1`         | machine learning |
-| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed    |        `120`        | machine learning |
+| Variable                                         | Description                                                                         | Default             | Services         |
+| :----------------------------------------------- | :---------------------------------------------------------------------------------- | :-----------------: | :--------------- |
+| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0)                   |        `300`        | machine learning |
+| `MACHINE_LEARNING_TTL_POLL_S`                    | The frequency with which the model TTL is checked for inactivity (disabled if <= 0) |         `10`        | machine learning |
+| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                                               |      `/cache`       | machine learning |
+| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)                          | number of CPU cores | machine learning |
+| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                                                 |         `1`         | machine learning |
+| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                                          |         `2`         | machine learning |
+| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                                                 |         `1`         | machine learning |
+| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed                      |        `120`        | machine learning |
 
-\*1: This is an experimental feature. It may result in increased memory use over time when loading models repeatedly.
+\*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 
-\*2: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
-
-\*3: Since each process duplicates models in memory, changing this is not recommended unless you have abundant memory to go around.
+\*2: Since each process duplicates models in memory, changing this is not recommended unless you have abundant memory to go around.
 
 :::info
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -186,16 +186,16 @@ Typesense URL example JSON before encoding:
 
 ## Machine Learning
 
-| Variable                                         | Description                                                                         |       Default       | Services         |
-| :----------------------------------------------- | :---------------------------------------------------------------------------------- | :-----------------: | :--------------- |
-| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0)                   |        `300`        | machine learning |
-| `MACHINE_LEARNING_TTL_POLL_S`                    | The frequency with which the model TTL is checked for inactivity (disabled if <= 0) |        `10`         | machine learning |
-| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                                               |      `/cache`       | machine learning |
-| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)                          | number of CPU cores | machine learning |
-| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                                                 |         `1`         | machine learning |
-| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                                          |         `2`         | machine learning |
-| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                                                 |         `1`         | machine learning |
-| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed                      |        `120`        | machine learning |
+| Variable                                         | Description                                                       |       Default       | Services         |
+| :----------------------------------------------- | :---------------------------------------------------------------- | :-----------------: | :--------------- |
+| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0) |        `300`        | machine learning |
+| `MACHINE_LEARNING_MODEL_TTL_POLL_S`              | Interval (s) between checks for the model TTL (disabled if <= 0)  |        `10`         | machine learning |
+| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                             |      `/cache`       | machine learning |
+| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)        | number of CPU cores | machine learning |
+| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                               |         `1`         | machine learning |
+| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                        |         `2`         | machine learning |
+| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                               |         `1`         | machine learning |
+| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed    |        `120`        | machine learning |
 
 \*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 

--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -13,7 +13,7 @@ from .schemas import ModelType
 
 class Settings(BaseSettings):
     cache_folder: str = "/cache"
-    model_ttl: int = 0
+    model_ttl: int = 300
     host: str = "0.0.0.0"
     port: int = 3003
     workers: int = 1
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     request_threads: int = os.cpu_count() or 4
     model_inter_op_threads: int = 1
     model_intra_op_threads: int = 2
+    shutdown_poll_s: int = 10
 
     class Config:
         env_prefix = "MACHINE_LEARNING_"

--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -14,6 +14,7 @@ from .schemas import ModelType
 class Settings(BaseSettings):
     cache_folder: str = "/cache"
     model_ttl: int = 300
+    model_ttl_poll_s: int = 10
     host: str = "0.0.0.0"
     port: int = 3003
     workers: int = 1
@@ -21,7 +22,6 @@ class Settings(BaseSettings):
     request_threads: int = os.cpu_count() or 4
     model_inter_op_threads: int = 1
     model_intra_op_threads: int = 2
-    ttl_poll_s: int = 10
 
     class Config:
         env_prefix = "MACHINE_LEARNING_"

--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     request_threads: int = os.cpu_count() or 4
     model_inter_op_threads: int = 1
     model_intra_op_threads: int = 2
-    shutdown_poll_s: int = 10
+    ttl_poll_s: int = 10
 
     class Config:
         env_prefix = "MACHINE_LEARNING_"

--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -3,8 +3,8 @@ import gc
 import os
 import sys
 import threading
-from concurrent.futures import ThreadPoolExecutor
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from zipfile import BadZipFile
 
@@ -120,10 +120,6 @@ async def load(model: InferenceModel) -> InferenceModel:
         else:
             await loop.run_in_executor(app.state.thread_pool, _load)
         return model
-
-
-def predict(model: InferenceModel, inputs: Any) -> Any:
-    return model.predict(inputs)
 
 
 async def idle_shutdown_task() -> None:

--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -40,7 +40,7 @@ def init_state() -> None:
     app.state.thread_pool = ThreadPoolExecutor(settings.request_threads) if settings.request_threads > 0 else None
     app.state.lock = threading.Lock()
     app.state.last_called = None
-    if settings.model_ttl > 0 and settings.ttl_poll_s > 0:
+    if settings.model_ttl > 0 and settings.model_ttl_poll_s > 0:
         asyncio.ensure_future(idle_shutdown_task())
     log.info(f"Initialized request thread pool with {settings.request_threads} threads.")
 
@@ -143,4 +143,4 @@ async def idle_shutdown_task() -> None:
                 loop.stop()
             except asyncio.CancelledError:
                 pass
-        await asyncio.sleep(settings.ttl_poll_s)
+        await asyncio.sleep(settings.model_ttl_poll_s)

--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -40,7 +40,7 @@ def init_state() -> None:
     app.state.thread_pool = ThreadPoolExecutor(settings.request_threads) if settings.request_threads > 0 else None
     app.state.lock = threading.Lock()
     app.state.last_called = None
-    if settings.model_ttl > 0 and settings.shutdown_poll_s > 0:
+    if settings.model_ttl > 0 and settings.ttl_poll_s > 0:
         asyncio.ensure_future(idle_shutdown_task())
     log.info(f"Initialized request thread pool with {settings.request_threads} threads.")
 
@@ -143,4 +143,4 @@ async def idle_shutdown_task() -> None:
                 loop.stop()
             except asyncio.CancelledError:
                 pass
-        await asyncio.sleep(settings.shutdown_poll_s)
+        await asyncio.sleep(settings.ttl_poll_s)

--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -86,9 +86,9 @@ async def predict(
 
 
 async def run(model: InferenceModel, inputs: Any) -> Any:
+    app.state.last_called = time.time()
     if app.state.thread_pool is None:
         return model.predict(inputs)
-    app.state.last_called = time.time()
     return await asyncio.get_running_loop().run_in_executor(app.state.thread_pool, model.predict, inputs)
 
 


### PR DESCRIPTION
## Description

This adds a more effective way to reduce the ML container's memory consumption when idle. 

The current approach is to remove the model objects and let Python garbage collect them. However, much of the memory remains allocated after this as the underlying runtimes are not affected by Python's garbage collection and manage their memory independently.

The approach here is to run the app with gunicorn as a process scheduler. The app periodically checks if there have been any requests in a certain period of time and gracefully shuts down if not. gunicorn then terminates the app process, freeing its memory, and restarts the app with a new process. This is admittedly not the most elegant solution, but it is the most effective one that I've found and the results should speak for themselves.

This is a similar approach to #2758, but is much more lightweight and results in lower memory consumption at both peak and idle.

Fixes #2074

## How Has This Been Tested?

1. Start the container with `MACHINE_LEARNING_MODEL_TTL=30` or a similarly low number for faster testing
2. Run `docker stats --no-stream` on startup to see its initial RAM usage
3. Run the `tag objects`, `encode clip` and `recognize faces` jobs to load each model and process some requests
4. Wait for the model TTL duration (it may take a bit longer as it's only polled every 10s)
5. Run `docker stats --no-stream` again to see its current usage

![Compared memory usage](https://i.imgur.com/H3fRmc7.png)