### PR TITLE
fix: hide faces

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -1805,6 +1805,50 @@ export interface PeopleResponseDto {
 /**
  * 
  * @export
+ * @interface PeopleUpdateDto
+ */
+export interface PeopleUpdateDto {
+    /**
+     * 
+     * @type {Array<PeopleUpdateItem>}
+     * @memberof PeopleUpdateDto
+     */
+    'people': Array<PeopleUpdateItem>;
+}
+/**
+ * 
+ * @export
+ * @interface PeopleUpdateItem
+ */
+export interface PeopleUpdateItem {
+    /**
+     * Person id.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'id': string;
+    /**
+     * Person name.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'name'?: string;
+    /**
+     * Asset is used to get the feature face thumbnail.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'featureFaceAssetId'?: string;
+    /**
+     * Person visibility
+     * @type {boolean}
+     * @memberof PeopleUpdateItem
+     */
+    'isHidden'?: boolean;
+}
+/**
+ * 
+ * @export
  * @interface PersonResponseDto
  */
 export interface PersonResponseDto {
@@ -8898,6 +8942,50 @@ export const PersonApiAxiosParamCreator = function (configuration?: Configuratio
         },
         /**
          * 
+         * @param {PeopleUpdateDto} peopleUpdateDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePeople: async (peopleUpdateDto: PeopleUpdateDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'peopleUpdateDto' is not null or undefined
+            assertParamExists('updatePeople', 'peopleUpdateDto', peopleUpdateDto)
+            const localVarPath = `/person`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication cookie required
+
+            // authentication api_key required
+            await setApiKeyToObject(localVarHeaderParameter, "x-api-key", configuration)
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(peopleUpdateDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {PersonUpdateDto} personUpdateDto 
          * @param {*} [options] Override http request option.
@@ -9007,6 +9095,16 @@ export const PersonApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {PeopleUpdateDto} peopleUpdateDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PersonResponseDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePeople(peopleUpdateDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {PersonUpdateDto} personUpdateDto 
          * @param {*} [options] Override http request option.
@@ -9070,6 +9168,15 @@ export const PersonApiFactory = function (configuration?: Configuration, basePat
          */
         mergePerson(requestParameters: PersonApiMergePersonRequest, options?: AxiosRequestConfig): AxiosPromise<Array<BulkIdResponseDto>> {
             return localVarFp.mergePerson(requestParameters.id, requestParameters.mergePersonDto, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {PersonApiUpdatePeopleRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePeople(requestParameters: PersonApiUpdatePeopleRequest, options?: AxiosRequestConfig): AxiosPromise<Array<PersonResponseDto>> {
+            return localVarFp.updatePeople(requestParameters.peopleUpdateDto, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -9161,6 +9268,20 @@ export interface PersonApiMergePersonRequest {
 }
 
 /**
+ * Request parameters for updatePeople operation in PersonApi.
+ * @export
+ * @interface PersonApiUpdatePeopleRequest
+ */
+export interface PersonApiUpdatePeopleRequest {
+    /**
+     * 
+     * @type {PeopleUpdateDto}
+     * @memberof PersonApiUpdatePeople
+     */
+    readonly peopleUpdateDto: PeopleUpdateDto
+}
+
+/**
  * Request parameters for updatePerson operation in PersonApi.
  * @export
  * @interface PersonApiUpdatePersonRequest
@@ -9241,6 +9362,17 @@ export class PersonApi extends BaseAPI {
      */
     public mergePerson(requestParameters: PersonApiMergePersonRequest, options?: AxiosRequestConfig) {
         return PersonApiFp(this.configuration).mergePerson(requestParameters.id, requestParameters.mergePersonDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {PersonApiUpdatePeopleRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PersonApi
+     */
+    public updatePeople(requestParameters: PersonApiUpdatePeopleRequest, options?: AxiosRequestConfig) {
+        return PersonApiFp(this.configuration).updatePeople(requestParameters.peopleUpdateDto, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -9099,7 +9099,7 @@ export const PersonApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PersonResponseDto>>> {
+        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<BulkIdResponseDto>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updatePeople(peopleUpdateDto, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -9175,7 +9175,7 @@ export const PersonApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePeople(requestParameters: PersonApiUpdatePeopleRequest, options?: AxiosRequestConfig): AxiosPromise<Array<PersonResponseDto>> {
+        updatePeople(requestParameters: PersonApiUpdatePeopleRequest, options?: AxiosRequestConfig): AxiosPromise<Array<BulkIdResponseDto>> {
             return localVarFp.updatePeople(requestParameters.peopleUpdateDto, options).then((request) => request(axios, basePath));
         },
         /**

--- a/mobile/openapi/.openapi-generator/FILES
+++ b/mobile/openapi/.openapi-generator/FILES
@@ -72,6 +72,8 @@ doc/OAuthConfigDto.md
 doc/OAuthConfigResponseDto.md
 doc/PartnerApi.md
 doc/PeopleResponseDto.md
+doc/PeopleUpdateDto.md
+doc/PeopleUpdateItem.md
 doc/PersonApi.md
 doc/PersonResponseDto.md
 doc/PersonUpdateDto.md
@@ -210,6 +212,8 @@ lib/model/o_auth_callback_dto.dart
 lib/model/o_auth_config_dto.dart
 lib/model/o_auth_config_response_dto.dart
 lib/model/people_response_dto.dart
+lib/model/people_update_dto.dart
+lib/model/people_update_item.dart
 lib/model/person_response_dto.dart
 lib/model/person_update_dto.dart
 lib/model/queue_status_dto.dart
@@ -325,6 +329,8 @@ test/o_auth_config_dto_test.dart
 test/o_auth_config_response_dto_test.dart
 test/partner_api_test.dart
 test/people_response_dto_test.dart
+test/people_update_dto_test.dart
+test/people_update_item_test.dart
 test/person_api_test.dart
 test/person_response_dto_test.dart
 test/person_update_dto_test.dart

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -134,6 +134,7 @@ Class | Method | HTTP request | Description
 *PersonApi* | [**getPersonAssets**](doc//PersonApi.md#getpersonassets) | **GET** /person/{id}/assets | 
 *PersonApi* | [**getPersonThumbnail**](doc//PersonApi.md#getpersonthumbnail) | **GET** /person/{id}/thumbnail | 
 *PersonApi* | [**mergePerson**](doc//PersonApi.md#mergeperson) | **POST** /person/{id}/merge | 
+*PersonApi* | [**updatePeople**](doc//PersonApi.md#updatepeople) | **PUT** /person | 
 *PersonApi* | [**updatePerson**](doc//PersonApi.md#updateperson) | **PUT** /person/{id} | 
 *SearchApi* | [**getExploreData**](doc//SearchApi.md#getexploredata) | **GET** /search/explore | 
 *SearchApi* | [**getSearchConfig**](doc//SearchApi.md#getsearchconfig) | **GET** /search/config | 
@@ -239,6 +240,8 @@ Class | Method | HTTP request | Description
  - [OAuthConfigDto](doc//OAuthConfigDto.md)
  - [OAuthConfigResponseDto](doc//OAuthConfigResponseDto.md)
  - [PeopleResponseDto](doc//PeopleResponseDto.md)
+ - [PeopleUpdateDto](doc//PeopleUpdateDto.md)
+ - [PeopleUpdateItem](doc//PeopleUpdateItem.md)
  - [PersonResponseDto](doc//PersonResponseDto.md)
  - [PersonUpdateDto](doc//PersonUpdateDto.md)
  - [QueueStatusDto](doc//QueueStatusDto.md)

--- a/mobile/openapi/doc/PeopleUpdateDto.md
+++ b/mobile/openapi/doc/PeopleUpdateDto.md
@@ -1,0 +1,15 @@
+# openapi.model.PeopleUpdateDto
+
+## Load the model package
+```dart
+import 'package:openapi/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**people** | [**List<PeopleUpdateItem>**](PeopleUpdateItem.md) |  | [default to const []]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/mobile/openapi/doc/PeopleUpdateItem.md
+++ b/mobile/openapi/doc/PeopleUpdateItem.md
@@ -1,0 +1,18 @@
+# openapi.model.PeopleUpdateItem
+
+## Load the model package
+```dart
+import 'package:openapi/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **String** | Person id. | 
+**name** | **String** | Person name. | [optional] 
+**featureFaceAssetId** | **String** | Asset is used to get the feature face thumbnail. | [optional] 
+**isHidden** | **bool** | Person visibility | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/mobile/openapi/doc/PersonApi.md
+++ b/mobile/openapi/doc/PersonApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**getPersonAssets**](PersonApi.md#getpersonassets) | **GET** /person/{id}/assets | 
 [**getPersonThumbnail**](PersonApi.md#getpersonthumbnail) | **GET** /person/{id}/thumbnail | 
 [**mergePerson**](PersonApi.md#mergeperson) | **POST** /person/{id}/merge | 
+[**updatePeople**](PersonApi.md#updatepeople) | **PUT** /person | 
 [**updatePerson**](PersonApi.md#updateperson) | **PUT** /person/{id} | 
 
 
@@ -282,6 +283,61 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**List<BulkIdResponseDto>**](BulkIdResponseDto.md)
+
+### Authorization
+
+[cookie](../README.md#cookie), [api_key](../README.md#api_key), [bearer](../README.md#bearer)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **updatePeople**
+> List<PersonResponseDto> updatePeople(peopleUpdateDto)
+
+
+
+### Example
+```dart
+import 'package:openapi/api.dart';
+// TODO Configure API key authorization: cookie
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
+// TODO Configure API key authorization: api_key
+//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKey = 'YOUR_API_KEY';
+// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
+// TODO Configure HTTP Bearer authorization: bearer
+// Case 1. Use String Token
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
+// Case 2. Use Function which generate token.
+// String yourTokenGeneratorFunction() { ... }
+//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
+
+final api_instance = PersonApi();
+final peopleUpdateDto = PeopleUpdateDto(); // PeopleUpdateDto | 
+
+try {
+    final result = api_instance.updatePeople(peopleUpdateDto);
+    print(result);
+} catch (e) {
+    print('Exception when calling PersonApi->updatePeople: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **peopleUpdateDto** | [**PeopleUpdateDto**](PeopleUpdateDto.md)|  | 
+
+### Return type
+
+[**List<PersonResponseDto>**](PersonResponseDto.md)
 
 ### Authorization
 

--- a/mobile/openapi/doc/PersonApi.md
+++ b/mobile/openapi/doc/PersonApi.md
@@ -296,7 +296,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updatePeople**
-> List<PersonResponseDto> updatePeople(peopleUpdateDto)
+> List<BulkIdResponseDto> updatePeople(peopleUpdateDto)
 
 
 
@@ -337,7 +337,7 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-[**List<PersonResponseDto>**](PersonResponseDto.md)
+[**List<BulkIdResponseDto>**](BulkIdResponseDto.md)
 
 ### Authorization
 

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -105,6 +105,8 @@ part 'model/o_auth_callback_dto.dart';
 part 'model/o_auth_config_dto.dart';
 part 'model/o_auth_config_response_dto.dart';
 part 'model/people_response_dto.dart';
+part 'model/people_update_dto.dart';
+part 'model/people_update_item.dart';
 part 'model/person_response_dto.dart';
 part 'model/person_update_dto.dart';
 part 'model/queue_status_dto.dart';

--- a/mobile/openapi/lib/api/person_api.dart
+++ b/mobile/openapi/lib/api/person_api.dart
@@ -269,6 +269,56 @@ class PersonApi {
     return null;
   }
 
+  /// Performs an HTTP 'PUT /person' operation and returns the [Response].
+  /// Parameters:
+  ///
+  /// * [PeopleUpdateDto] peopleUpdateDto (required):
+  Future<Response> updatePeopleWithHttpInfo(PeopleUpdateDto peopleUpdateDto,) async {
+    // ignore: prefer_const_declarations
+    final path = r'/person';
+
+    // ignore: prefer_final_locals
+    Object? postBody = peopleUpdateDto;
+
+    final queryParams = <QueryParam>[];
+    final headerParams = <String, String>{};
+    final formParams = <String, String>{};
+
+    const contentTypes = <String>['application/json'];
+
+
+    return apiClient.invokeAPI(
+      path,
+      'PUT',
+      queryParams,
+      postBody,
+      headerParams,
+      formParams,
+      contentTypes.isEmpty ? null : contentTypes.first,
+    );
+  }
+
+  /// Parameters:
+  ///
+  /// * [PeopleUpdateDto] peopleUpdateDto (required):
+  Future<List<PersonResponseDto>?> updatePeople(PeopleUpdateDto peopleUpdateDto,) async {
+    final response = await updatePeopleWithHttpInfo(peopleUpdateDto,);
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    }
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+      final responseBody = await _decodeBodyBytes(response);
+      return (await apiClient.deserializeAsync(responseBody, 'List<PersonResponseDto>') as List)
+        .cast<PersonResponseDto>()
+        .toList();
+
+    }
+    return null;
+  }
+
   /// Performs an HTTP 'PUT /person/{id}' operation and returns the [Response].
   /// Parameters:
   ///

--- a/mobile/openapi/lib/api/person_api.dart
+++ b/mobile/openapi/lib/api/person_api.dart
@@ -301,7 +301,7 @@ class PersonApi {
   /// Parameters:
   ///
   /// * [PeopleUpdateDto] peopleUpdateDto (required):
-  Future<List<PersonResponseDto>?> updatePeople(PeopleUpdateDto peopleUpdateDto,) async {
+  Future<List<BulkIdResponseDto>?> updatePeople(PeopleUpdateDto peopleUpdateDto,) async {
     final response = await updatePeopleWithHttpInfo(peopleUpdateDto,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
@@ -311,8 +311,8 @@ class PersonApi {
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
       final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<PersonResponseDto>') as List)
-        .cast<PersonResponseDto>()
+      return (await apiClient.deserializeAsync(responseBody, 'List<BulkIdResponseDto>') as List)
+        .cast<BulkIdResponseDto>()
         .toList();
 
     }

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -305,6 +305,10 @@ class ApiClient {
           return OAuthConfigResponseDto.fromJson(value);
         case 'PeopleResponseDto':
           return PeopleResponseDto.fromJson(value);
+        case 'PeopleUpdateDto':
+          return PeopleUpdateDto.fromJson(value);
+        case 'PeopleUpdateItem':
+          return PeopleUpdateItem.fromJson(value);
         case 'PersonResponseDto':
           return PersonResponseDto.fromJson(value);
         case 'PersonUpdateDto':

--- a/mobile/openapi/lib/model/people_update_dto.dart
+++ b/mobile/openapi/lib/model/people_update_dto.dart
@@ -1,0 +1,98 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class PeopleUpdateDto {
+  /// Returns a new [PeopleUpdateDto] instance.
+  PeopleUpdateDto({
+    this.people = const [],
+  });
+
+  List<PeopleUpdateItem> people;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PeopleUpdateDto &&
+     other.people == people;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (people.hashCode);
+
+  @override
+  String toString() => 'PeopleUpdateDto[people=$people]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'people'] = this.people;
+    return json;
+  }
+
+  /// Returns a new [PeopleUpdateDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static PeopleUpdateDto? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return PeopleUpdateDto(
+        people: PeopleUpdateItem.listFromJson(json[r'people']),
+      );
+    }
+    return null;
+  }
+
+  static List<PeopleUpdateDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <PeopleUpdateDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = PeopleUpdateDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, PeopleUpdateDto> mapFromJson(dynamic json) {
+    final map = <String, PeopleUpdateDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = PeopleUpdateDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of PeopleUpdateDto-objects as value to a dart map
+  static Map<String, List<PeopleUpdateDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<PeopleUpdateDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = PeopleUpdateDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'people',
+  };
+}
+

--- a/mobile/openapi/lib/model/people_update_item.dart
+++ b/mobile/openapi/lib/model/people_update_item.dart
@@ -1,0 +1,153 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class PeopleUpdateItem {
+  /// Returns a new [PeopleUpdateItem] instance.
+  PeopleUpdateItem({
+    required this.id,
+    this.name,
+    this.featureFaceAssetId,
+    this.isHidden,
+  });
+
+  /// Person id.
+  String id;
+
+  /// Person name.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? name;
+
+  /// Asset is used to get the feature face thumbnail.
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? featureFaceAssetId;
+
+  /// Person visibility
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isHidden;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PeopleUpdateItem &&
+     other.id == id &&
+     other.name == name &&
+     other.featureFaceAssetId == featureFaceAssetId &&
+     other.isHidden == isHidden;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (id.hashCode) +
+    (name == null ? 0 : name!.hashCode) +
+    (featureFaceAssetId == null ? 0 : featureFaceAssetId!.hashCode) +
+    (isHidden == null ? 0 : isHidden!.hashCode);
+
+  @override
+  String toString() => 'PeopleUpdateItem[id=$id, name=$name, featureFaceAssetId=$featureFaceAssetId, isHidden=$isHidden]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'id'] = this.id;
+    if (this.name != null) {
+      json[r'name'] = this.name;
+    } else {
+    //  json[r'name'] = null;
+    }
+    if (this.featureFaceAssetId != null) {
+      json[r'featureFaceAssetId'] = this.featureFaceAssetId;
+    } else {
+    //  json[r'featureFaceAssetId'] = null;
+    }
+    if (this.isHidden != null) {
+      json[r'isHidden'] = this.isHidden;
+    } else {
+    //  json[r'isHidden'] = null;
+    }
+    return json;
+  }
+
+  /// Returns a new [PeopleUpdateItem] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static PeopleUpdateItem? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return PeopleUpdateItem(
+        id: mapValueOfType<String>(json, r'id')!,
+        name: mapValueOfType<String>(json, r'name'),
+        featureFaceAssetId: mapValueOfType<String>(json, r'featureFaceAssetId'),
+        isHidden: mapValueOfType<bool>(json, r'isHidden'),
+      );
+    }
+    return null;
+  }
+
+  static List<PeopleUpdateItem> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <PeopleUpdateItem>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = PeopleUpdateItem.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, PeopleUpdateItem> mapFromJson(dynamic json) {
+    final map = <String, PeopleUpdateItem>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = PeopleUpdateItem.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of PeopleUpdateItem-objects as value to a dart map
+  static Map<String, List<PeopleUpdateItem>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<PeopleUpdateItem>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = PeopleUpdateItem.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'id',
+  };
+}
+

--- a/mobile/openapi/test/people_update_dto_test.dart
+++ b/mobile/openapi/test/people_update_dto_test.dart
@@ -1,0 +1,27 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:openapi/api.dart';
+import 'package:test/test.dart';
+
+// tests for PeopleUpdateDto
+void main() {
+  // final instance = PeopleUpdateDto();
+
+  group('test PeopleUpdateDto', () {
+    // List<PeopleUpdateItem> people (default value: const [])
+    test('to test the property `people`', () async {
+      // TODO
+    });
+
+
+  });
+
+}

--- a/mobile/openapi/test/people_update_item_test.dart
+++ b/mobile/openapi/test/people_update_item_test.dart
@@ -1,0 +1,46 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:openapi/api.dart';
+import 'package:test/test.dart';
+
+// tests for PeopleUpdateItem
+void main() {
+  // final instance = PeopleUpdateItem();
+
+  group('test PeopleUpdateItem', () {
+    // Person id.
+    // String id
+    test('to test the property `id`', () async {
+      // TODO
+    });
+
+    // Person name.
+    // String name
+    test('to test the property `name`', () async {
+      // TODO
+    });
+
+    // Asset is used to get the feature face thumbnail.
+    // String featureFaceAssetId
+    test('to test the property `featureFaceAssetId`', () async {
+      // TODO
+    });
+
+    // Person visibility
+    // bool isHidden
+    test('to test the property `isHidden`', () async {
+      // TODO
+    });
+
+
+  });
+
+}

--- a/mobile/openapi/test/person_api_test.dart
+++ b/mobile/openapi/test/person_api_test.dart
@@ -42,7 +42,7 @@ void main() {
       // TODO
     });
 
-    //Future<List<PersonResponseDto>> updatePeople(PeopleUpdateDto peopleUpdateDto) async
+    //Future<List<BulkIdResponseDto>> updatePeople(PeopleUpdateDto peopleUpdateDto) async
     test('test updatePeople', () async {
       // TODO
     });

--- a/mobile/openapi/test/person_api_test.dart
+++ b/mobile/openapi/test/person_api_test.dart
@@ -42,6 +42,11 @@ void main() {
       // TODO
     });
 
+    //Future<List<PersonResponseDto>> updatePeople(PeopleUpdateDto peopleUpdateDto) async
+    test('test updatePeople', () async {
+      // TODO
+    });
+
     //Future<PersonResponseDto> updatePerson(String id, PersonUpdateDto personUpdateDto) async
     test('test updatePerson', () async {
       // TODO

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -2546,6 +2546,49 @@
             "api_key": []
           }
         ]
+      },
+      "put": {
+        "operationId": "updatePeople",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PeopleUpdateDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PersonResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Person"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ]
       }
     },
     "/person/{id}": {
@@ -5904,6 +5947,44 @@
           "total",
           "visible",
           "people"
+        ]
+      },
+      "PeopleUpdateDto": {
+        "type": "object",
+        "properties": {
+          "people": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PeopleUpdateItem"
+            }
+          }
+        },
+        "required": [
+          "people"
+        ]
+      },
+      "PeopleUpdateItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Person id."
+          },
+          "name": {
+            "type": "string",
+            "description": "Person name."
+          },
+          "featureFaceAssetId": {
+            "type": "string",
+            "description": "Asset is used to get the feature face thumbnail."
+          },
+          "isHidden": {
+            "type": "boolean",
+            "description": "Person visibility"
+          }
+        },
+        "required": [
+          "id"
         ]
       },
       "PersonResponseDto": {

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -2568,7 +2568,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PersonResponseDto"
+                    "$ref": "#/components/schemas/BulkIdResponseDto"
                   }
                 }
               }
@@ -5071,13 +5071,13 @@
             "type": "boolean"
           },
           "error": {
-            "type": "string",
             "enum": [
               "duplicate",
               "no_permission",
               "not_found",
               "unknown"
-            ]
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/server/src/domain/person/person.dto.ts
+++ b/server/src/domain/person/person.dto.ts
@@ -1,9 +1,46 @@
 import { AssetFaceEntity, PersonEntity } from '@app/infra/entities';
-import { Transform } from 'class-transformer';
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { toBoolean, ValidateUUID } from '../domain.util';
 
 export class PersonUpdateDto {
+  /**
+   * Person name.
+   */
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  /**
+   * Asset is used to get the feature face thumbnail.
+   */
+  @IsOptional()
+  @IsString()
+  featureFaceAssetId?: string;
+
+  /**
+   * Person visibility
+   */
+  @IsOptional()
+  @IsBoolean()
+  isHidden?: boolean;
+}
+
+export class PeopleUpdateDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PeopleUpdateItem)
+  people!: PeopleUpdateItem[];
+}
+
+export class PeopleUpdateItem {
+  /**
+   * Person id.
+   */
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
   /**
    * Person name.
    */

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -188,6 +188,16 @@ describe(PersonService.name, () => {
     });
   });
 
+  describe('updateAll', () => {
+    it('should throw an error when personId is invalid', async () => {
+      personMock.getById.mockResolvedValue(null);
+      await expect(
+        sut.updatePeople(authStub.admin, { people: [{ id: 'person-1', name: 'Person 1' }] }),
+      ).resolves.toEqual([{ error: BulkIdErrorReason.UNKNOWN, id: 'person-1', success: false }]);
+      expect(personMock.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('handlePersonCleanup', () => {
     it('should delete people without faces', async () => {
       personMock.getAllWithoutFaces.mockResolvedValue([personStub.noName]);

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -97,22 +97,22 @@ export class PersonService {
     return mapPerson(person);
   }
 
-  async updatePeople(authUser: AuthUserDto, dto: PeopleUpdateDto): Promise<PersonResponseDto[]> {
-    const peopleReponse: PersonResponseDto[] = [];
+  async updatePeople(authUser: AuthUserDto, dto: PeopleUpdateDto): Promise<BulkIdResponseDto[]> {
+    const results: BulkIdResponseDto[] = [];
     for (const person of dto.people) {
       try {
-        peopleReponse.push(
-          await this.update(authUser, person.id, {
-            isHidden: person.isHidden,
-            name: person.name,
-            featureFaceAssetId: person.featureFaceAssetId,
-          }),
-        );
+        await this.update(authUser, person.id, {
+          isHidden: person.isHidden,
+          name: person.name,
+          featureFaceAssetId: person.featureFaceAssetId,
+        }),
+          results.push({ id: person.id, success: true });
       } catch (error: Error | any) {
-        this.logger.error(`Unable to update ${person.id}: ${error}`, error?.stack);
+        this.logger.error(`Unable to update ${person.id} : ${error}`, error?.stack);
+        results.push({ id: person.id, success: false, error: BulkIdErrorReason.UNKNOWN });
       }
     }
-    return peopleReponse;
+    return results;
   }
 
   async handlePersonCleanup() {

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -8,6 +8,7 @@ import {
   mapPerson,
   MergePersonDto,
   PeopleResponseDto,
+  PeopleUpdateDto,
   PersonResponseDto,
   PersonSearchDto,
   PersonUpdateDto,
@@ -94,6 +95,20 @@ export class PersonService {
     }
 
     return mapPerson(person);
+  }
+
+  async updatePeople(authUser: AuthUserDto, dto: PeopleUpdateDto): Promise<PersonResponseDto[]> {
+    const peopleReponse: PersonResponseDto[] = [];
+    for (const person of dto.people) {
+      peopleReponse.push(
+        await this.update(authUser, person.id, {
+          isHidden: person.isHidden,
+          name: person.name,
+          featureFaceAssetId: person.featureFaceAssetId,
+        }),
+      );
+    }
+    return peopleReponse;
   }
 
   async handlePersonCleanup() {

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -100,13 +100,17 @@ export class PersonService {
   async updatePeople(authUser: AuthUserDto, dto: PeopleUpdateDto): Promise<PersonResponseDto[]> {
     const peopleReponse: PersonResponseDto[] = [];
     for (const person of dto.people) {
-      peopleReponse.push(
-        await this.update(authUser, person.id, {
-          isHidden: person.isHidden,
-          name: person.name,
-          featureFaceAssetId: person.featureFaceAssetId,
-        }),
-      );
+      try {
+        peopleReponse.push(
+          await this.update(authUser, person.id, {
+            isHidden: person.isHidden,
+            name: person.name,
+            featureFaceAssetId: person.featureFaceAssetId,
+          }),
+        );
+      } catch (error: Error | any) {
+        this.logger.error(`Unable to update ${person.id}: ${error}`, error?.stack);
+      }
     }
     return peopleReponse;
   }

--- a/server/src/immich/controllers/person.controller.ts
+++ b/server/src/immich/controllers/person.controller.ts
@@ -34,7 +34,7 @@ export class PersonController {
   }
 
   @Put()
-  updatePeople(@AuthUser() authUser: AuthUserDto, @Body() dto: PeopleUpdateDto): Promise<PersonResponseDto[]> {
+  updatePeople(@AuthUser() authUser: AuthUserDto, @Body() dto: PeopleUpdateDto): Promise<BulkIdResponseDto[]> {
     return this.service.updatePeople(authUser, dto);
   }
 

--- a/server/src/immich/controllers/person.controller.ts
+++ b/server/src/immich/controllers/person.controller.ts
@@ -5,6 +5,7 @@ import {
   ImmichReadStream,
   MergePersonDto,
   PeopleResponseDto,
+  PeopleUpdateDto,
   PersonResponseDto,
   PersonSearchDto,
   PersonService,
@@ -30,6 +31,11 @@ export class PersonController {
   @Get()
   getAllPeople(@AuthUser() authUser: AuthUserDto, @Query() withHidden: PersonSearchDto): Promise<PeopleResponseDto> {
     return this.service.getAll(authUser, withHidden);
+  }
+
+  @Put()
+  updatePeople(@AuthUser() authUser: AuthUserDto, @Body() dto: PeopleUpdateDto): Promise<PersonResponseDto[]> {
+    return this.service.updatePeople(authUser, dto);
   }
 
   @Get(':id')

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1805,6 +1805,50 @@ export interface PeopleResponseDto {
 /**
  * 
  * @export
+ * @interface PeopleUpdateDto
+ */
+export interface PeopleUpdateDto {
+    /**
+     * 
+     * @type {Array<PeopleUpdateItem>}
+     * @memberof PeopleUpdateDto
+     */
+    'people': Array<PeopleUpdateItem>;
+}
+/**
+ * 
+ * @export
+ * @interface PeopleUpdateItem
+ */
+export interface PeopleUpdateItem {
+    /**
+     * Person id.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'id': string;
+    /**
+     * Person name.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'name'?: string;
+    /**
+     * Asset is used to get the feature face thumbnail.
+     * @type {string}
+     * @memberof PeopleUpdateItem
+     */
+    'featureFaceAssetId'?: string;
+    /**
+     * Person visibility
+     * @type {boolean}
+     * @memberof PeopleUpdateItem
+     */
+    'isHidden'?: boolean;
+}
+/**
+ * 
+ * @export
  * @interface PersonResponseDto
  */
 export interface PersonResponseDto {
@@ -8942,6 +8986,50 @@ export const PersonApiAxiosParamCreator = function (configuration?: Configuratio
         },
         /**
          * 
+         * @param {PeopleUpdateDto} peopleUpdateDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePeople: async (peopleUpdateDto: PeopleUpdateDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'peopleUpdateDto' is not null or undefined
+            assertParamExists('updatePeople', 'peopleUpdateDto', peopleUpdateDto)
+            const localVarPath = `/person`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication cookie required
+
+            // authentication api_key required
+            await setApiKeyToObject(localVarHeaderParameter, "x-api-key", configuration)
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(peopleUpdateDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {PersonUpdateDto} personUpdateDto 
          * @param {*} [options] Override http request option.
@@ -9051,6 +9139,16 @@ export const PersonApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {PeopleUpdateDto} peopleUpdateDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PersonResponseDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePeople(peopleUpdateDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {string} id 
          * @param {PersonUpdateDto} personUpdateDto 
          * @param {*} [options] Override http request option.
@@ -9115,6 +9213,15 @@ export const PersonApiFactory = function (configuration?: Configuration, basePat
          */
         mergePerson(id: string, mergePersonDto: MergePersonDto, options?: any): AxiosPromise<Array<BulkIdResponseDto>> {
             return localVarFp.mergePerson(id, mergePersonDto, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {PeopleUpdateDto} peopleUpdateDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: any): AxiosPromise<Array<PersonResponseDto>> {
+            return localVarFp.updatePeople(peopleUpdateDto, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -9207,6 +9314,20 @@ export interface PersonApiMergePersonRequest {
 }
 
 /**
+ * Request parameters for updatePeople operation in PersonApi.
+ * @export
+ * @interface PersonApiUpdatePeopleRequest
+ */
+export interface PersonApiUpdatePeopleRequest {
+    /**
+     * 
+     * @type {PeopleUpdateDto}
+     * @memberof PersonApiUpdatePeople
+     */
+    readonly peopleUpdateDto: PeopleUpdateDto
+}
+
+/**
  * Request parameters for updatePerson operation in PersonApi.
  * @export
  * @interface PersonApiUpdatePersonRequest
@@ -9287,6 +9408,17 @@ export class PersonApi extends BaseAPI {
      */
     public mergePerson(requestParameters: PersonApiMergePersonRequest, options?: AxiosRequestConfig) {
         return PersonApiFp(this.configuration).mergePerson(requestParameters.id, requestParameters.mergePersonDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {PersonApiUpdatePeopleRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PersonApi
+     */
+    public updatePeople(requestParameters: PersonApiUpdatePeopleRequest, options?: AxiosRequestConfig) {
+        return PersonApiFp(this.configuration).updatePeople(requestParameters.peopleUpdateDto, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -9143,7 +9143,7 @@ export const PersonApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PersonResponseDto>>> {
+        async updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<BulkIdResponseDto>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updatePeople(peopleUpdateDto, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -9220,7 +9220,7 @@ export const PersonApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: any): AxiosPromise<Array<PersonResponseDto>> {
+        updatePeople(peopleUpdateDto: PeopleUpdateDto, options?: any): AxiosPromise<Array<BulkIdResponseDto>> {
             return localVarFp.updatePeople(peopleUpdateDto, options).then((request) => request(axios, basePath));
         },
         /**

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -16,32 +16,32 @@
   export let hidden = false;
   let complete = false;
 
-  let eyeColor = 'white';
+  export let eyeColor = 'white';
 </script>
 
-<button class="w-full" on:mouseenter={() => (eyeColor = 'black')} on:mouseleave={() => (eyeColor = 'white')}>
-  <img
-    style:width={widthStyle}
-    style:height={heightStyle}
-    style:filter={hidden ? 'grayscale(50%)' : 'none'}
-    style:opacity={hidden ? '0.5' : '1'}
-    src={url}
-    alt={altText}
-    class="object-cover transition duration-300"
-    class:rounded-lg={curve}
-    class:shadow-lg={shadow}
-    class:rounded-full={circle}
-    class:opacity-0={!thumbhash && !complete}
-    draggable="false"
-    use:imageLoad
-    on:image-load|once={() => (complete = true)}
-  />
-  {#if hidden}
-    <div class="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
-      <EyeOffOutline size="2em" color={eyeColor} />
-    </div>
-  {/if}
-</button>
+<img
+  style:width={widthStyle}
+  style:height={heightStyle}
+  style:filter={hidden ? 'grayscale(50%)' : 'none'}
+  style:opacity={hidden ? '0.5' : '1'}
+  src={url}
+  alt={altText}
+  class="object-cover transition duration-300"
+  class:rounded-lg={curve}
+  class:shadow-lg={shadow}
+  class:rounded-full={circle}
+  class:opacity-0={!thumbhash && !complete}
+  draggable="false"
+  use:imageLoad
+  on:image-load|once={() => (complete = true)}
+/>
+
+{#if hidden}
+  <div class="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
+    <EyeOffOutline size="2em" color={eyeColor} />
+  </div>
+{/if}
+
 {#if thumbhash && !complete}
   <img
     style:width={widthStyle}

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -15,29 +15,33 @@
   export let circle = false;
   export let hidden = false;
   let complete = false;
+
+  let color = 'white';
 </script>
 
-<img
-  style:width={widthStyle}
-  style:height={heightStyle}
-  style:filter={hidden ? 'grayscale(75%)' : 'none'}
-  src={url}
-  alt={altText}
-  class="object-cover transition duration-300"
-  class:rounded-lg={curve}
-  class:shadow-lg={shadow}
-  class:rounded-full={circle}
-  class:opacity-0={!thumbhash && !complete}
-  draggable="false"
-  use:imageLoad
-  on:image-load|once={() => (complete = true)}
-/>
-{#if hidden}
-  <div class="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
-    <EyeOffOutline size="2em" />
-  </div>
-{/if}
-
+<button on:mouseenter={() => (color = 'black')} on:mouseleave={() => (color = 'white')}>
+  <img
+    style:width={widthStyle}
+    style:height={heightStyle}
+    style:filter={hidden ? 'grayscale(50%)' : 'none'}
+    style:opacity={hidden ? '0.5' : '1'}
+    src={url}
+    alt={altText}
+    class="object-cover transition duration-300"
+    class:rounded-lg={curve}
+    class:shadow-lg={shadow}
+    class:rounded-full={circle}
+    class:opacity-0={!thumbhash && !complete}
+    draggable="false"
+    use:imageLoad
+    on:image-load|once={() => (complete = true)}
+  />
+  {#if hidden}
+    <div class="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
+      <EyeOffOutline size="2em" {color} />
+    </div>
+  {/if}
+</button>
 {#if thumbhash && !complete}
   <img
     style:width={widthStyle}

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -19,7 +19,7 @@
   let color = 'white';
 </script>
 
-<button on:mouseenter={() => (color = 'black')} on:mouseleave={() => (color = 'white')}>
+<button class="h-full w-full" on:mouseenter={() => (color = 'black')} on:mouseleave={() => (color = 'white')}>
   <img
     style:width={widthStyle}
     style:height={heightStyle}

--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -16,10 +16,10 @@
   export let hidden = false;
   let complete = false;
 
-  let color = 'white';
+  let eyeColor = 'white';
 </script>
 
-<button class="h-full w-full" on:mouseenter={() => (color = 'black')} on:mouseleave={() => (color = 'white')}>
+<button class="w-full" on:mouseenter={() => (eyeColor = 'black')} on:mouseleave={() => (eyeColor = 'white')}>
   <img
     style:width={widthStyle}
     style:height={heightStyle}
@@ -38,7 +38,7 @@
   />
   {#if hidden}
     <div class="absolute left-1/2 top-1/2 translate-x-[-50%] translate-y-[-50%] transform">
-      <EyeOffOutline size="2em" {color} />
+      <EyeOffOutline size="2em" color={eyeColor} />
     </div>
   {/if}
 </button>

--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -25,7 +25,7 @@
   $: unselectedPeople = people.filter((source) => !selectedPeople.includes(source) && source.id !== person.id);
 
   onMount(async () => {
-    const { data } = await api.personApi.getAllPeople({ withHidden: true });
+    const { data } = await api.personApi.getAllPeople({ withHidden: false });
     people = data.people;
   });
 

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -31,6 +31,11 @@
     <div class="h-48 w-48 rounded-xl brightness-95 filter">
       <ImageThumbnail shadow url={api.getPeopleThumbnailUrl(person.id)} altText={person.name} widthStyle="100%" />
     </div>
+    {#if person.name}
+      <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
+        {person.name}
+      </span>
+    {/if}
   </a>
 
   <button

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -20,6 +20,10 @@
   const onMergeFacesClicked = () => {
     dispatch('merge-faces', person);
   };
+
+  const onHideFaceClicked = () => {
+    dispatch('hide-face', person);
+  };
 </script>
 
 <div id="people-card" class="relative">
@@ -50,6 +54,7 @@
 
     {#if showContextMenu}
       <ContextMenu on:outclick={() => (showContextMenu = false)}>
+        <MenuOption on:click={() => onHideFaceClicked()} text="Hide face" />
         <MenuOption on:click={() => onChangeNameClicked()} text="Change name" />
         <MenuOption on:click={() => onMergeFacesClicked()} text="Merge faces" />
       </ContextMenu>

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -28,16 +28,9 @@
 
 <div id="people-card" class="relative">
   <a href="/people/{person.id}" draggable="false">
-    <div class="w-48 rounded-xl brightness-95 filter">
+    <div class="h-48 w-48 rounded-xl brightness-95 filter">
       <ImageThumbnail shadow url={api.getPeopleThumbnailUrl(person.id)} altText={person.name} widthStyle="100%" />
     </div>
-    {#if person.name}
-      <span
-        class="w-100 absolute bottom-2 w-full text-ellipsis px-1 text-center font-medium text-white backdrop-blur-[1px] hover:cursor-pointer"
-      >
-        {person.name}
-      </span>
-    {/if}
   </a>
 
   <button

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -6,10 +6,14 @@
   import IconButton from '../elements/buttons/icon-button.svelte';
   import { createEventDispatcher } from 'svelte';
   import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
+  import Restart from 'svelte-material-icons/Restart.svelte';
+  import Eye from 'svelte-material-icons/Eye.svelte';
+  import EyeOff from 'svelte-material-icons/EyeOff.svelte';
 
   const dispatch = createEventDispatcher();
 
   export let showLoadingSpinner: boolean;
+  export let toggleVisibility: boolean;
 </script>
 
 <section
@@ -24,11 +28,25 @@
         <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
         <p class="ml-4">Show & hide faces</p>
       </div>
-      {#if !showLoadingSpinner}
-        <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
-      {:else}
-        <LoadingSpinner />
-      {/if}
+      <div class="flex items-center justify-end">
+        <div class="mr-8 flex items-center">
+          <CircleIconButton
+            title="Reset faces visibility"
+            logo={Restart}
+            on:click={() => dispatch('reset-visibility')}
+          />
+          <CircleIconButton
+            title="Toggle visibility"
+            logo={toggleVisibility ? Eye : EyeOff}
+            on:click={() => dispatch('toggle-visibility')}
+          />
+        </div>
+        {#if !showLoadingSpinner}
+          <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
+        {:else}
+          <LoadingSpinner />
+        {/if}
+      </div>
     </div>
     <div class="immich-scrollbar absolute top-16 bg-immich-bg p-4 pb-8 dark:bg-immich-dark-bg">
       <slot />

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -21,35 +21,30 @@
   class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg dark:bg-immich-dark-bg"
 >
   <div
-    class="absolute flex h-16 w-full place-items-center justify-between border-b dark:border-immich-dark-gray dark:text-immich-dark-fg"
+    class="flex h-16 w-full items-center justify-between border-b p-1 dark:border-immich-dark-gray dark:text-immich-dark-fg md:p-8"
   >
-    <div class="flex w-full items-center justify-between p-8">
-      <div class="flex items-center">
-        <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
-        <p class="ml-4">Show & hide faces</p>
-      </div>
-      <div class="flex items-center justify-end">
-        <div class="mr-8 flex items-center">
-          <CircleIconButton
-            title="Reset faces visibility"
-            logo={Restart}
-            on:click={() => dispatch('reset-visibility')}
-          />
-          <CircleIconButton
-            title="Toggle visibility"
-            logo={toggleVisibility ? Eye : EyeOff}
-            on:click={() => dispatch('toggle-visibility')}
-          />
-        </div>
-        {#if !showLoadingSpinner}
-          <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
-        {:else}
-          <LoadingSpinner />
-        {/if}
-      </div>
+    <div class="flex items-center">
+      <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
+      <p class="ml-4 hidden sm:block">Show & hide faces</p>
     </div>
-    <div class="immich-scrollbar absolute top-16 bg-immich-bg p-4 pb-8 dark:bg-immich-dark-bg">
-      <slot />
+    <div class="flex items-center justify-end">
+      <div class="flex items-center md:mr-8">
+        <CircleIconButton title="Reset faces visibility" logo={Restart} on:click={() => dispatch('reset-visibility')} />
+        <CircleIconButton
+          title="Toggle visibility"
+          logo={toggleVisibility ? Eye : EyeOff}
+          on:click={() => dispatch('toggle-visibility')}
+        />
+      </div>
+      {#if !showLoadingSpinner}
+        <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
+      {:else}
+        <LoadingSpinner />
+      {/if}
     </div>
+  </div>
+
+  <div class="flex w-full flex-wrap gap-1 bg-immich-bg p-2 pb-8 dark:bg-immich-dark-bg md:px-8 md:pt-4">
+    <slot />
   </div>
 </section>

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -1,17 +1,20 @@
-<script>
+<script lang="ts">
   import { fly } from 'svelte/transition';
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import { quintOut } from 'svelte/easing';
   import Close from 'svelte-material-icons/Close.svelte';
   import IconButton from '../elements/buttons/icon-button.svelte';
   import { createEventDispatcher } from 'svelte';
+  import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
 
   const dispatch = createEventDispatcher();
+
+  export let showLoadingSpinner: boolean;
 </script>
 
 <section
   transition:fly={{ y: 500, duration: 100, easing: quintOut }}
-  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg dark:bg-immich-dark-bg"
+  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg bg-scroll dark:bg-immich-dark-bg"
 >
   <div
     class="absolute flex h-16 w-full place-items-center justify-between border-b dark:border-immich-dark-gray dark:text-immich-dark-fg"
@@ -21,9 +24,13 @@
         <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
         <p class="ml-4">Show & hide faces</p>
       </div>
-      <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
+      {#if !showLoadingSpinner}
+        <IconButton on:click={() => dispatch('doneClick')}>Done</IconButton>
+      {:else}
+        <LoadingSpinner />
+      {/if}
     </div>
-    <div class="immich-scrollbar absolute top-16 h-[calc(100%-theme(spacing.16))] w-full p-4 pb-8">
+    <div class="immich-scrollbar absolute top-16 bg-immich-bg p-4 pb-8 dark:bg-immich-dark-bg">
       <slot />
     </div>
   </div>

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -18,10 +18,10 @@
 
 <section
   transition:fly={{ y: 500, duration: 100, easing: quintOut }}
-  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg dark:bg-immich-dark-bg"
+  class="bg-immich-bg dark:bg-immich-dark-bg absolute left-0 top-0 z-[9999] h-full w-full"
 >
   <div
-    class="flex h-16 w-full items-center justify-between border-b p-1 dark:border-immich-dark-gray dark:text-immich-dark-fg md:p-8"
+    class="dark:border-immich-dark-gray dark:text-immich-dark-fg sticky top-0 z-10 flex h-16 w-full items-center justify-between border-b bg-white p-1 dark:bg-black md:p-8"
   >
     <div class="flex items-center">
       <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class="flex w-full flex-wrap gap-1 bg-immich-bg p-2 pb-8 dark:bg-immich-dark-bg md:px-8 md:pt-4">
+  <div class="bg-immich-bg dark:bg-immich-dark-bg flex w-full flex-wrap gap-1 p-2 pb-8 md:px-8 md:pt-4">
     <slot />
   </div>
 </section>

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -14,7 +14,7 @@
 
 <section
   transition:fly={{ y: 500, duration: 100, easing: quintOut }}
-  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg bg-scroll dark:bg-immich-dark-bg"
+  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg dark:bg-immich-dark-bg"
 >
   <div
     class="absolute flex h-16 w-full place-items-center justify-between border-b dark:border-immich-dark-gray dark:text-immich-dark-fg"

--- a/web/src/lib/components/faces-page/show-hide.svelte
+++ b/web/src/lib/components/faces-page/show-hide.svelte
@@ -18,10 +18,10 @@
 
 <section
   transition:fly={{ y: 500, duration: 100, easing: quintOut }}
-  class="bg-immich-bg dark:bg-immich-dark-bg absolute left-0 top-0 z-[9999] h-full w-full"
+  class="absolute left-0 top-0 z-[9999] h-full w-full bg-immich-bg dark:bg-immich-dark-bg"
 >
   <div
-    class="dark:border-immich-dark-gray dark:text-immich-dark-fg sticky top-0 z-10 flex h-16 w-full items-center justify-between border-b bg-white p-1 dark:bg-black md:p-8"
+    class="sticky top-0 z-10 flex h-16 w-full items-center justify-between border-b bg-white p-1 dark:border-immich-dark-gray dark:bg-black dark:text-immich-dark-fg md:p-8"
   >
     <div class="flex items-center">
       <CircleIconButton logo={Close} on:click={() => dispatch('closeClick')} />
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  <div class="bg-immich-bg dark:bg-immich-dark-bg flex w-full flex-wrap gap-1 p-2 pb-8 md:px-8 md:pt-4">
+  <div class="flex w-full flex-wrap gap-1 bg-immich-bg p-2 pb-8 dark:bg-immich-dark-bg md:px-8 md:pt-4">
     <slot />
   </div>
 </section>

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -27,6 +27,7 @@
   let countVisiblePeople = data.people.visible;
 
   let showLoadingSpinner = false;
+  let toggleVisibility = false;
 
   people.forEach((person: PersonResponseDto) => {
     initialHiddenValues[person.id] = person.isHidden;
@@ -36,8 +37,33 @@
     for (const person of people) {
       person.isHidden = initialHiddenValues[person.id];
     }
+    // trigger reactivity
+    people = people;
+
+    // Reset variables used on the "Show & hide faces"   modal
     showLoadingSpinner = false;
     selectHidden = false;
+    toggleVisibility = false;
+  };
+
+  const handleResetVisibility = () => {
+    for (const person of people) {
+      person.isHidden = initialHiddenValues[person.id];
+    }
+
+    // trigger reactivity
+    people = people;
+  };
+
+  const handleToggleVisibility = () => {
+    toggleVisibility = !toggleVisibility;
+    console.log(toggleVisibility);
+    for (const person of people) {
+      person.isHidden = toggleVisibility;
+    }
+
+    // trigger reactivity
+    people = people;
   };
 
   const handleDoneClick = async () => {
@@ -80,8 +106,10 @@
         `Unable to change the visibility for ${changed.length} ${changed.length <= 1 ? 'person' : 'people'}`,
       );
     }
+    // Reset variables used on the "Show & hide faces"   modal
     showLoadingSpinner = false;
     selectHidden = false;
+    toggleVisibility = false;
   };
 
   let showChangeNameModal = false;
@@ -107,6 +135,12 @@
         }
         return person;
       });
+
+      people.forEach((person: PersonResponseDto) => {
+        initialHiddenValues[person.id] = person.isHidden;
+      });
+
+      countVisiblePeople--;
 
       showChangeNameModal = false;
 
@@ -166,18 +200,16 @@
   {#if countVisiblePeople > 0}
     <div class="pl-4">
       <div class="flex flex-row flex-wrap gap-1">
-        {#key selectHidden}
-          {#each people as person (person.id)}
-            {#if !person.isHidden}
-              <PeopleCard
-                {person}
-                on:change-name={handleChangeName}
-                on:merge-faces={handleMergeFaces}
-                on:hide-face={handleHideFace}
-              />
-            {/if}
-          {/each}
-        {/key}
+        {#each people as person (person.id)}
+          {#if !person.isHidden}
+            <PeopleCard
+              {person}
+              on:change-name={handleChangeName}
+              on:merge-faces={handleMergeFaces}
+              on:hide-face={handleHideFace}
+            />
+          {/if}
+        {/each}
       </div>
     </div>
   {:else}
@@ -223,7 +255,14 @@
   {/if}
 </UserPageLayout>
 {#if selectHidden}
-  <ShowHide on:doneClick={handleDoneClick} on:closeClick={handleCloseClick} bind:showLoadingSpinner>
+  <ShowHide
+    on:doneClick={handleDoneClick}
+    on:closeClick={handleCloseClick}
+    on:reset-visibility={handleResetVisibility}
+    on:toggle-visibility={handleToggleVisibility}
+    bind:showLoadingSpinner
+    bind:toggleVisibility
+  >
     <div class="pl-4">
       <div class="flex flex-row flex-wrap gap-1">
         {#each people as person (person.id)}

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -56,15 +56,22 @@
           countVisiblePeople += person.isHidden ? -1 : 1;
         }
       }
-      if (changed.length > 0)
-        await api.personApi.updatePeople({
+      if (changed.length > 0) {
+        const { data: results } = await api.personApi.updatePeople({
           peopleUpdateDto: { people: changed },
         });
-
-      if (changed.length > 0) {
+        const count = results.filter(({ success }) => success).length;
+        if (results.length - count > 0) {
+          notificationController.show({
+            type: NotificationType.Error,
+            message: `Unable to change the visibility for ${results.length - count} ${
+              results.length - count <= 1 ? 'person' : 'people'
+            }`,
+          });
+        }
         notificationController.show({
           type: NotificationType.Info,
-          message: `Visibility changed for ${changed.length} ${changed.length <= 1 ? 'person' : 'people'}`,
+          message: `Visibility changed for ${count} ${count <= 1 ? 'person' : 'people'}`,
         });
       }
     } catch (error) {

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -24,6 +24,8 @@
   let selectHidden = false;
   let initialHiddenValues: Record<string, boolean> = {};
 
+  let eyeColorMap: Record<string, string> = {};
+
   let people = data.people.people;
   let countTotalPeople = data.people.total;
   let countVisiblePeople = data.people.visible;
@@ -103,6 +105,7 @@
           countVisiblePeople += person.isHidden ? -1 : 1;
         }
       }
+
       if (changed.length > 0) {
         const { data: results } = await api.personApi.updatePeople({
           peopleUpdateDto: { people: changed },
@@ -289,23 +292,27 @@
         {#each people as person (person.id)}
           <div class="relative">
             <div class="h-48 w-48 rounded-xl brightness-95 filter">
-              <button class="h-full w-full" on:click={() => (person.isHidden = !person.isHidden)}>
+              <button
+                class="h-full w-full"
+                on:click={() => (person.isHidden = !person.isHidden)}
+                on:mouseenter={() => (eyeColorMap[person.id] = 'black')}
+                on:mouseleave={() => (eyeColorMap[person.id] = 'white')}
+              >
                 <ImageThumbnail
                   bind:hidden={person.isHidden}
                   shadow
                   url={api.getPeopleThumbnailUrl(person.id)}
                   altText={person.name}
                   widthStyle="100%"
+                  bind:eyeColor={eyeColorMap[person.id]}
                 />
+                {#if person.name}
+                  <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
+                    {person.name}
+                  </span>
+                {/if}
               </button>
             </div>
-            {#if person.name}
-              <span
-                class="w-100 absolute bottom-2 w-full text-ellipsis px-1 text-center font-medium text-white backdrop-blur-[1px] hover:cursor-pointer"
-              >
-                {person.name}
-              </span>
-            {/if}
           </div>
         {/each}
       </div>

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -20,7 +20,6 @@
 
   export let data: PageData;
   let selectHidden = false;
-  let changeCounter = 0;
   let initialHiddenValues: Record<string, boolean> = {};
 
   let people = data.people.people;

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -94,6 +94,31 @@
     edittingPerson = detail;
   };
 
+  const handleHideFace = async (event: CustomEvent<PersonResponseDto>) => {
+    try {
+      const { data: updatedPerson } = await api.personApi.updatePerson({
+        id: event.detail.id,
+        personUpdateDto: { isHidden: true },
+      });
+
+      people = people.map((person: PersonResponseDto) => {
+        if (person.id === updatedPerson.id) {
+          return updatedPerson;
+        }
+        return person;
+      });
+
+      showChangeNameModal = false;
+
+      notificationController.show({
+        message: 'Changed visibility succesfully',
+        type: NotificationType.Info,
+      });
+    } catch (error) {
+      handleError(error, 'Unable to hide person');
+    }
+  };
+
   const handleMergeFaces = (event: CustomEvent<PersonResponseDto>) => {
     goto(`${AppRoute.PEOPLE}/${event.detail.id}?action=merge`);
   };
@@ -144,7 +169,12 @@
         {#key selectHidden}
           {#each people as person (person.id)}
             {#if !person.isHidden}
-              <PeopleCard {person} on:change-name={handleChangeName} on:merge-faces={handleMergeFaces} />
+              <PeopleCard
+                {person}
+                on:change-name={handleChangeName}
+                on:merge-faces={handleMergeFaces}
+                on:hide-face={handleHideFace}
+              />
             {/if}
           {/each}
         {/key}

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -287,35 +287,27 @@
     bind:showLoadingSpinner
     bind:toggleVisibility
   >
-    <div class="pl-4">
-      <div class="flex flex-row flex-wrap gap-1">
-        {#each people as person (person.id)}
-          <div class="relative">
-            <div class="h-48 w-48 rounded-xl brightness-95 filter">
-              <button
-                class="h-full w-full"
-                on:click={() => (person.isHidden = !person.isHidden)}
-                on:mouseenter={() => (eyeColorMap[person.id] = 'black')}
-                on:mouseleave={() => (eyeColorMap[person.id] = 'white')}
-              >
-                <ImageThumbnail
-                  bind:hidden={person.isHidden}
-                  shadow
-                  url={api.getPeopleThumbnailUrl(person.id)}
-                  altText={person.name}
-                  widthStyle="100%"
-                  bind:eyeColor={eyeColorMap[person.id]}
-                />
-                {#if person.name}
-                  <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
-                    {person.name}
-                  </span>
-                {/if}
-              </button>
-            </div>
-          </div>
-        {/each}
-      </div>
-    </div>
+    {#each people as person (person.id)}
+      <button
+        class="relative h-36 w-36 md:h-48 md:w-48"
+        on:click={() => (person.isHidden = !person.isHidden)}
+        on:mouseenter={() => (eyeColorMap[person.id] = 'black')}
+        on:mouseleave={() => (eyeColorMap[person.id] = 'white')}
+      >
+        <ImageThumbnail
+          bind:hidden={person.isHidden}
+          shadow
+          url={api.getPeopleThumbnailUrl(person.id)}
+          altText={person.name}
+          widthStyle="100%"
+          bind:eyeColor={eyeColorMap[person.id]}
+        />
+        {#if person.name}
+          <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
+            {person.name}
+          </span>
+        {/if}
+      </button>
+    {/each}
   </ShowHide>
 {/if}

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -57,7 +57,6 @@
 
   const handleToggleVisibility = () => {
     toggleVisibility = !toggleVisibility;
-    console.log(toggleVisibility);
     for (const person of people) {
       person.isHidden = toggleVisibility;
     }
@@ -106,7 +105,7 @@
         `Unable to change the visibility for ${changed.length} ${changed.length <= 1 ? 'person' : 'people'}`,
       );
     }
-    // Reset variables used on the "Show & hide faces"   modal
+    // Reset variables used on the "Show & hide faces" modal
     showLoadingSpinner = false;
     selectHidden = false;
     toggleVisibility = false;

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -17,6 +17,8 @@
   import IconButton from '$lib/components/elements/buttons/icon-button.svelte';
   import EyeOutline from 'svelte-material-icons/EyeOutline.svelte';
   import ImageThumbnail from '$lib/components/assets/thumbnail/image-thumbnail.svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import { browser } from '$app/environment';
 
   export let data: PageData;
   let selectHidden = false;
@@ -32,6 +34,26 @@
   people.forEach((person: PersonResponseDto) => {
     initialHiddenValues[person.id] = person.isHidden;
   });
+
+  const onKeyboardPress = (event: KeyboardEvent) => handleKeyboardPress(event);
+
+  onMount(() => {
+    document.addEventListener('keydown', onKeyboardPress);
+  });
+
+  onDestroy(() => {
+    if (browser) {
+      document.removeEventListener('keydown', onKeyboardPress);
+    }
+  });
+
+  const handleKeyboardPress = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case 'Escape':
+        handleCloseClick();
+        return;
+    }
+  };
 
   const handleCloseClick = () => {
     for (const person of people) {


### PR DESCRIPTION
This PR brings multiple fixes and optimizations:
- Fix the background issue when scrolling through the faces on the `Show & hide faces` modal (you can take a look at the picture posted [here](https://github.com/immich-app/immich/issues/3349))
- The `Show & hide faces` modal disappear only when the request is done.
- Once `Done` is clicked, the button is replaced by a loading spinner
- A single API request is used which reduces the delay by 50% (tested with 50 faces)
- Merging people shows only visible people as suggested [here](https://github.com/immich-app/immich/discussions/2472#discussioncomment-6495979)
- Hidden people appear with a grey filter and with opacity to better differentiate hidden / visible people as suggested [here](https://github.com/immich-app/immich/discussions/2472#discussioncomment-6507895)
- Add "hide face" option in the dropdown menu
- Add button to toggle and reset the visibility of all faces on the `Show & hide faces` modal. 
- Escape key closes the `Show & hide faces` modal

https://github.com/immich-app/immich/assets/74269598/97d6e798-803a-432e-9c06-797b4aca256f

