### PR TITLE
fix(server): transcode live photos on upload

### DIFF
--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -172,6 +172,8 @@ export class JobService {
         if (asset) {
           if (asset.type === AssetType.VIDEO) {
             await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: item.data });
+          } else if (asset.livePhotoVideoId) {
+            await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
           }
           this.communicationRepository.send(CommunicationEvent.UPLOAD_SUCCESS, asset.ownerId, mapAsset(asset));
         }


### PR DESCRIPTION
## Description

Currently, the check to transcode assets on uploads misses live photos since it only checks the image portion of these images. This change adds a check for the `livePhotoVideoId` of assets so it can transcode live photos as well.


## How Has This Been Tested?

I took a live photo and uploaded it from the mobile app. The logs showed "Encoding success" for this asset without running any jobs explicitly.