### PR TITLE
fix(mobile): Fixes hide controls when zoomed and shows them when not zoomed

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -499,6 +499,7 @@ class GalleryViewerPage extends HookConsumerWidget {
             PhotoViewGallery.builder(
               scaleStateChangedCallback: (state) {
                 isZoomed.value = state != PhotoViewScaleState.initial;
+                ref.read(showControlsProvider.notifier).show = !isZoomed.value;
               },
               pageController: controller,
               scrollPhysics: isZoomed.value


### PR DESCRIPTION
Fixes a regression. Hides the controls while zoomed in now. 

![image](https://github.com/immich-app/immich/assets/100457/e2f2d858-803d-416f-a947-da633b0c9914)

Tap still toggles the controls state.