### PR TITLE
feat(cli): add build script and unify tests

### DIFF
--- a/cli/jest.config.ts
+++ b/cli/jest.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'jest';
-
-const config: Config = {
-  preset: 'ts-jest',
-  setupFilesAfterEnv: ['jest-extended/all'],
-};
-
-export default config;

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,10 +40,29 @@
     "yaml": "^2.3.1"
   },
   "scripts": {
+    "build": "tsc --project tsconfig.build.json",
     "lint": "eslint \"src/**/*.ts\" --max-warnings 0",
     "prepack": "yarn build ",
     "test": "jest",
     "test:cov": "jest --coverage",
     "format": "prettier --check ."
+  },
+  "jest": {
+    "clearMocks": true,
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "<rootDir>/src/**/*.(t|j)s"
+    ],
+    "coverageDirectory": "./coverage",
+    "testEnvironment": "node"
   }
 }

--- a/cli/test/tsconfig.json
+++ b/cli/test/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "compilerOptions": {
-    "noEmit": true
-  },
-  "references": [{ "path": ".." }]
-}

--- a/cli/tsconfig.build.json
+++ b/cli/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "upload", "test", "**/*spec.ts"]
+}


### PR DESCRIPTION
This makes the new cli buildable (so it can be packaged properly) and integrates the jest config into `package.json`, similar to how it is done for the server.