### PR TITLE
fix(mobile): Decrease ScrollBar Fade timeout to a second

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -341,8 +341,8 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
             backgroundColor: Theme.of(context).hintColor,
             labelTextBuilder: _labelBuilder,
             labelConstraints: const BoxConstraints(maxHeight: 28),
-            scrollbarAnimationDuration: const Duration(seconds: 1),
-            scrollbarTimeToFade: const Duration(seconds: 4),
+            scrollbarAnimationDuration: const Duration(milliseconds: 300),
+            scrollbarTimeToFade: const Duration(milliseconds: 1000),
             child: listWidget,
           )
         : listWidget;


### PR DESCRIPTION
The current timeout of 4 seconds along with the animation duration of 1 second for hiding the scrollbar in the timeline feels way too long in usage. In general, a timeout of 500ms-1second should be good enough for majority of people.

Fixes #3297 