### PR TITLE
fix(cli): read-only and sidecar support for import

### DIFF
--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -70,11 +70,13 @@ export default class Upload extends BaseCommand {
         if (options.import) {
           const importData = {
             assetPath: asset.path,
+            sidecarPath: asset.sidecarPath,
             deviceAssetId: asset.deviceAssetId,
             deviceId: this.deviceId,
             fileCreatedAt: asset.fileCreatedAt,
             fileModifiedAt: asset.fileModifiedAt,
             isFavorite: false,
+            isReadOnly: options.readOnly,
           };
 
           if (!this.dryRun) {

--- a/cli/src/cores/dto/upload-options-dto.ts
+++ b/cli/src/cores/dto/upload-options-dto.ts
@@ -5,4 +5,5 @@ export class UploadOptionsDto {
   skipHash = false;
   delete = false;
   import = false;
+  readOnly = true;
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -35,7 +35,7 @@ program
       .default(false),
   )
   .addOption(new Option('-i, --ignore [paths...]', 'Paths to ignore').env('IMMICH_IGNORE_PATHS').default(false))
-  .addOption(new Option('--no-read-only', 'Import files without read-only protection, allowing Immich to manage them').default(true))
+  .addOption(new Option('--no-read-only', 'Import files without read-only protection, allowing Immich to manage them'))
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => {
     options.import = true;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -35,9 +35,11 @@ program
       .default(false),
   )
   .addOption(new Option('-i, --ignore [paths...]', 'Paths to ignore').env('IMMICH_IGNORE_PATHS').default(false))
+  .addOption(new Option('--no-read-only', 'Import files without read-only protection, allowing Immich to manage them').default(true))
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => {
     options.import = true;
+    options.excludePatterns = options.ignore;
     new Upload().run(paths, options);
   });
 


### PR DESCRIPTION
added flag to support toggling read-only mode (read-only true by default), added sidecarPath to import request payload