### PR TITLE
fix(cli): fix wording in usage guide

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -36,7 +36,7 @@ program
   )
   .addOption(new Option('-i, --ignore [paths...]', 'Paths to ignore').env('IMMICH_IGNORE_PATHS').default(false))
   .addOption(new Option('--no-read-only', 'Import files without read-only protection, allowing Immich to manage them'))
-  .argument('[paths...]', 'One or more paths to assets to be uploaded')
+  .argument('[paths...]', 'One or more paths to assets to be imported')
   .action((paths, options) => {
     options.import = true;
     options.excludePatterns = options.ignore;


### PR DESCRIPTION
~I believe the original author forgot this line.~

Also includes a small wording fix.

EDIT: someone also fixed the ignore patterns bug in the meantime (c40aa4399b21f768617906ca69958317e194a958) so this is a just a wording fix now :-)