### PR TITLE
Update example.env to specify REDIS_PASSWORD_FILE

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -28,6 +28,7 @@ REDIS_HOSTNAME=immich_redis
 # Note: these parameters are not automatically passed to the Redis Container
 # to do so, please edit the docker-compose.yml file as well. Redis is not configured
 # via environment variables, only redis.conf or the command line
+# NOTE: REDIS_PASSWORD supports Docker secrets by adding a *_FILE suffix to the variable name (REDIS_PASSWORD_FILE)
 
 # REDIS_PORT=6379
 # REDIS_DBINDEX=0


### PR DESCRIPTION
update to the example .env file to indicate docker secret support for REDIS_PASSWORD