### PR TITLE
fix(web): fixes previous pull request: set asset as profile image

### DIFF
--- a/web/src/lib/components/shared-components/profile-image-cropper.svelte
+++ b/web/src/lib/components/shared-components/profile-image-cropper.svelte
@@ -75,7 +75,7 @@
   </svelte:fragment>
   <div class="flex place-items-center items-center justify-center">
     <div
-      class="border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4"
+      class="relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4 border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary"
     >
       <PhotoViewer bind:element={imgElement} {asset} />
     </div>

--- a/web/src/lib/components/shared-components/profile-image-cropper.svelte
+++ b/web/src/lib/components/shared-components/profile-image-cropper.svelte
@@ -75,7 +75,7 @@
   </svelte:fragment>
   <div class="flex place-items-center items-center justify-center">
     <div
-      class="photoviewer-wrapper border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4"
+      class="border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4"
     >
       <PhotoViewer bind:element={imgElement} {asset} />
     </div>

--- a/web/src/lib/components/shared-components/profile-image-cropper.svelte
+++ b/web/src/lib/components/shared-components/profile-image-cropper.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { AssetResponseDto, api } from '@api';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import { notificationController, NotificationType } from './notification/notification';
   import { handleError } from '$lib/utils/handle-error';
   import domtoimage from 'dom-to-image';
@@ -12,6 +12,10 @@
 
   const dispatch = createEventDispatcher();
   let imgElement: HTMLDivElement;
+
+  onMount(() => {
+    imgElement.style.width = '100%';
+  });
 
   const hasTransparentPixels = async (blob: Blob) => {
     const img = new Image();
@@ -71,7 +75,7 @@
   </svelte:fragment>
   <div class="flex place-items-center items-center justify-center">
     <div
-      class="relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4 border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary"
+      class="photoviewer-wrapper border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary relative flex aspect-square w-1/2 overflow-hidden rounded-full border-4"
     >
       <PhotoViewer bind:element={imgElement} {asset} />
     </div>


### PR DESCRIPTION
set photoviewer 100% width, fixes transparent ede
![grafik](https://github.com/immich-app/immich/assets/22776173/5cb11b0c-b417-4329-8d18-9ff1be0803fe)
![grafik](https://github.com/immich-app/immich/assets/22776173/38af9a77-505e-4ec9-b345-d0eb3327bcc5)
