### PR TITLE
fix: people in shared assets

### DIFF
--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -207,10 +207,10 @@ export class AssetService {
 
     const allowExif = this.getExifPermission(authUser);
     const asset = await this._assetRepository.getById(assetId);
-    let data = allowExif ? mapAsset(asset) : mapAssetWithoutExif(asset);
+    const data = allowExif ? mapAsset(asset) : mapAssetWithoutExif(asset);
 
     if (data.ownerId !== authUser.id) {
-      delete data.people;
+      data.people = [];
     }
 
     return data;

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -207,12 +207,13 @@ export class AssetService {
 
     const allowExif = this.getExifPermission(authUser);
     const asset = await this._assetRepository.getById(assetId);
+    let data = allowExif ? mapAsset(asset) : mapAssetWithoutExif(asset);
 
-    if (allowExif) {
-      return mapAsset(asset);
-    } else {
-      return mapAssetWithoutExif(asset);
+    if (data.ownerId !== authUser.id) {
+      delete data.people;
     }
+
+    return data;
   }
 
   public async updateAsset(authUser: AuthUserDto, assetId: string, dto: UpdateAssetDto): Promise<AssetResponseDto> {


### PR DESCRIPTION
Currently, when assets with people in it are shared in albums, users who don't own the asset fail to load people thumbnails. This PR removes the people information for those who don't own the asset.

Here an example with an account looking at a shared asset with a face in this asset : 
| Before | After |
| --- | --- |
| ![Screenshot from 2023-07-27 00-03-22](https://github.com/immich-app/immich/assets/74269598/4fffadda-4b25-4f54-8898-e5e8be210756) | ![Screenshot from 2023-07-27 00-03-42](https://github.com/immich-app/immich/assets/74269598/5bed53f0-61e3-44a3-b708-f21e6e43dbc7) |
