### PR TITLE
Clarify immich-admin command usage

### DIFF
--- a/docs/docs/administration/server-commands.md
+++ b/docs/docs/administration/server-commands.md
@@ -12,9 +12,11 @@ The `immich-server` docker image comes preinstalled with an administrative CLI (
 
 ## How to run a command
 
-To run a command, [connect](/docs/guides/docker-help.md#attach-to-a-container) to the `immich_server` container and then execute the command via `immich <command>`.
+To run a command, [connect](/docs/guides/docker-help.md#attach-to-a-container) to the `immich_server` container and then execute the command via `immich-admin <command>`.
 
 ## Examples
+
+Note that the commands below should begin with `immich-admin`.
 
 Reset Admin Password
 


### PR DESCRIPTION
Some parts of the documentation state that administrative tasks like changing the admin password can be done via the `immich` function, but that is incorrect; instead, the `immich-admin` function should be used.