### PR TITLE
fix(mobile): clip and change background for asset selection

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -37,11 +37,21 @@ class ThumbnailImage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isDarkTheme = Theme.of(context).brightness == Brightness.dark;
+    final assetContainerColor =
+        isDarkTheme ? Colors.blueGrey : Theme.of(context).primaryColorLight;
+
     Widget buildSelectionIcon(Asset asset) {
       if (isSelected) {
-        return Icon(
-          Icons.check_circle,
-          color: Theme.of(context).primaryColor,
+        return Container(
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: assetContainerColor,
+          ),
+          child: Icon(
+            Icons.check_circle_rounded,
+            color: Theme.of(context).primaryColor,
+          ),
         );
       } else {
         return const Icon(
@@ -49,6 +59,36 @@ class ThumbnailImage extends HookConsumerWidget {
           color: Colors.white,
         );
       }
+    }
+
+    Widget buildImage(Asset asset) {
+      var image = ImmichImage(
+        asset,
+        width: 300,
+        height: 300,
+        useGrayBoxPlaceholder: useGrayBoxPlaceholder,
+      );
+      if (!multiselectEnabled || !isSelected) {
+        return image;
+      }
+      return Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            width: 0,
+            color: assetContainerColor,
+          ),
+          color: assetContainerColor,
+        ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.only(
+            topRight: Radius.circular(15.0),
+            bottomRight: Radius.circular(15.0),
+            bottomLeft: Radius.circular(15.0),
+            topLeft: Radius.zero,
+          ),
+          child: image,
+        ),
+      );
     }
 
     return GestureDetector(
@@ -84,17 +124,12 @@ class ThumbnailImage extends HookConsumerWidget {
                     ? Border.all(
                         color: onDeselect == null
                             ? Colors.grey
-                            : Theme.of(context).primaryColorLight,
-                        width: 10,
+                            : assetContainerColor,
+                        width: 8,
                       )
                     : const Border(),
               ),
-              child: ImmichImage(
-                asset,
-                width: 300,
-                height: 300,
-                useGrayBoxPlaceholder: useGrayBoxPlaceholder,
-              ),
+              child: buildImage(asset),
             ),
             if (multiselectEnabled)
               Padding(


### PR DESCRIPTION
### Changes made
Added a background color to the selection indicator to make it prominent and clipped the Thumbnail when it is selected to make it more appealing

Before | After
:-: | :-:
![Before-Dark](https://github.com/immich-app/immich/assets/139912620/e38ba945-549a-44f2-b064-21a7c9004c5d) | ![After-Dark](https://github.com/immich-app/immich/assets/139912620/d2414af8-2374-47a1-9b79-d57994ddcee2)
![Before-Light](https://github.com/immich-app/immich/assets/139912620/3024e551-b093-4fd6-b3ba-70c7aa139c3b) | ![After-Light](https://github.com/immich-app/immich/assets/139912620/8bb21897-fe58-4b86-acc4-95b231b5f392)
