### PR TITLE
fix the grammar for albums to be backed up

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -84,7 +84,7 @@
   "backup_controller_page_status_off": "Automatic foreground backup is off",
   "backup_controller_page_status_on": "Automatic foreground backup is on",
   "backup_controller_page_storage_format": "{} of {} used",
-  "backup_controller_page_to_backup": "Albums to be backup",
+  "backup_controller_page_to_backup": "Albums to be backed up",
   "backup_controller_page_total": "Total",
   "backup_controller_page_total_sub": "All unique photos and videos from selected albums",
   "backup_controller_page_turn_off": "Turn off foreground backup",


### PR DESCRIPTION
It looks like this is managed in a 3rd party service like lokalise or something. But this sounds better in English