### PR TITLE
feat(mobile): auto close memories on scrolling beyond first / last memory

### DIFF
--- a/mobile/lib/modules/memories/views/memory_page.dart
+++ b/mobile/lib/modules/memories/views/memory_page.dart
@@ -165,28 +165,30 @@ class MemoryPage extends HookConsumerWidget {
      */
     return NotificationListener<ScrollNotification>(
       onNotification: (ScrollNotification notification) {
-        // Calculate OverScroll manually using the number of pixels away from minScrollExtent and maxScrollExtent
+        // Calculate OverScroll manually using the number of pixels away from maxScrollExtent
         // maxScrollExtend contains the sum of horizontal pixels of all assets for depth = 1
         // or sum of vertical pixels of all memories for depth = 0
         if (notification is ScrollUpdateNotification) {
           final offset = notification.metrics.pixels;
-          // Vertical scroll handling
-          if (notification.depth == 0) {
-            if (offset < notification.metrics.minScrollExtent - 150 ||
-                offset > notification.metrics.maxScrollExtent + 150) {
-              AutoRouter.of(context).pop();
-              return true;
+          final isLastMemory =
+              (memories.indexOf(currentMemory.value) + 1) >= memories.length;
+          if (isLastMemory) {
+            // Vertical scroll handling only at the last asset.
+            // Tapping on the last asset instead of swiping will trigger the scroll
+            // implicitly which will trigger the below handling and thereby closes the
+            // memory lane as well
+            if (notification.depth == 0) {
+              final isLastAsset = (currentAssetPage.value + 1) ==
+                  currentMemory.value.assets.length;
+              if (isLastAsset &&
+                  (offset > notification.metrics.maxScrollExtent + 150)) {
+                AutoRouter.of(context).pop();
+                return true;
+              }
             }
-          }
-          // Horizontal scroll handling
-          if (notification.depth == 1) {
-            final currentMemoryIndex = memories.indexOf(currentMemory.value);
-            final beyondFirstMemory = ((currentMemoryIndex - 1) < 0) &&
-                (offset < notification.metrics.minScrollExtent - 100);
-            final beyondLastMemory =
-                ((currentMemoryIndex + 1) >= memories.length) &&
-                    (offset > notification.metrics.maxScrollExtent + 100);
-            if (beyondFirstMemory || beyondLastMemory) {
+            // Horizontal scroll handling
+            if (notification.depth == 1 &&
+                (offset > notification.metrics.maxScrollExtent + 100)) {
               AutoRouter.of(context).pop();
               return true;
             }

--- a/mobile/lib/modules/memories/views/memory_page.dart
+++ b/mobile/lib/modules/memories/views/memory_page.dart
@@ -64,6 +64,11 @@ class MemoryPage extends HookConsumerWidget {
         return;
       }
 
+      // Context might be removed due to popping out of Memory Lane during Scroll handling
+      if (!context.mounted) {
+        return;
+      }
+
       late Asset asset;
       if (index < currentMemory.value.assets.length) {
         // Uses the next asset in this current memory
@@ -160,18 +165,49 @@ class MemoryPage extends HookConsumerWidget {
      */
     return NotificationListener<ScrollNotification>(
       onNotification: (ScrollNotification notification) {
+        // Calculate OverScroll manually using the number of pixels away from minScrollExtent and maxScrollExtent
+        // maxScrollExtend contains the sum of horizontal pixels of all assets for depth = 1
+        // or sum of vertical pixels of all memories for depth = 0
+        if (notification is ScrollUpdateNotification) {
+          final offset = notification.metrics.pixels;
+          // Vertical scroll handling
+          if (notification.depth == 0) {
+            if (offset < notification.metrics.minScrollExtent - 150 ||
+                offset > notification.metrics.maxScrollExtent + 150) {
+              AutoRouter.of(context).pop();
+              return true;
+            }
+          }
+          // Horizontal scroll handling
+          if (notification.depth == 1) {
+            final currentMemoryIndex = memories.indexOf(currentMemory.value);
+            final beyondFirstMemory = ((currentMemoryIndex - 1) < 0) &&
+                (offset < notification.metrics.minScrollExtent - 100);
+            final beyondLastMemory =
+                ((currentMemoryIndex + 1) >= memories.length) &&
+                    (offset > notification.metrics.maxScrollExtent + 100);
+            if (beyondFirstMemory || beyondLastMemory) {
+              AutoRouter.of(context).pop();
+              return true;
+            }
+          }
+        }
+
         if (notification.depth == 0) {
-          var currentPageNumber = memoryPageController.page!.toInt();
-          currentMemory.value = memories[currentPageNumber];
           if (notification is ScrollStartNotification) {
             assetProgress.value = "";
-          } else if (notification is ScrollEndNotification) {
+            return true;
+          }
+          var currentPageNumber = memoryPageController.page!.toInt();
+          currentMemory.value = memories[currentPageNumber];
+          if (notification is ScrollEndNotification) {
             HapticFeedback.mediumImpact();
             if (currentPageNumber != previousMemoryIndex.value) {
               currentAssetPage.value = 0;
               previousMemoryIndex.value = currentPageNumber;
             }
             updateProgressText();
+            return true;
           }
         }
         return false;
@@ -180,6 +216,9 @@ class MemoryPage extends HookConsumerWidget {
         backgroundColor: bgColor,
         body: SafeArea(
           child: PageView.builder(
+            physics: const BouncingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics(),
+            ),
             scrollDirection: Axis.vertical,
             controller: memoryPageController,
             itemCount: memories.length,
@@ -189,6 +228,9 @@ class MemoryPage extends HookConsumerWidget {
                 children: [
                   Expanded(
                     child: PageView.builder(
+                      physics: const BouncingScrollPhysics(
+                        parent: AlwaysScrollableScrollPhysics(),
+                      ),
                       controller: memoryAssetPageController,
                       onPageChanged: onAssetChanged,
                       scrollDirection: Axis.horizontal,


### PR DESCRIPTION
### Changes made

- Scroll Physics for Android in Memory lane is made similar to the one used in iOS. It looks visually better and also fixes the jarring animation when a user tries to scroll past the last asset / memory.
- When a user tries to scroll above the first memory or scroll past the last memory, the memory lane is closed and the user is brought back to the timeline view. The same behavior is used if the user tries to scroll to the previous asset from the very first asset of the first memory or if a user tries to scroll past the last asset of the last memory


Before | After
:-: | :-:
<video src='https://github.com/immich-app/immich/assets/139912620/ee03cd99-573c-4b2d-8570-cadeef521e0a' width=180/> | <video src='https://github.com/immich-app/immich/assets/139912620/5eec7d35-7ee1-4ef6-8aa3-402835eb4953' width=180/>

### How Has This Been Tested?
- Made sure that the scrolling physics is used for both horizontal and vertical scrolls in Single asset memory as well as Multi asset memories
- Made sure that the user is brought back to the timeline view only when scrolling past the first and last memory. Scrolling in all the other memories takes the user to the previous or next asset accordingly