### PR TITLE
fix(mobile): Improve vertical swipe detection in gallery viewer

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -239,6 +239,7 @@ class GalleryViewerPage extends HookConsumerWidget {
     void handleSwipeUpDown(DragUpdateDetails details) {
       int sensitivity = 15;
       int dxThreshold = 50;
+      double ratioThreshold = 3.0;
 
       if (isZoomed.value) {
         return;
@@ -256,9 +257,10 @@ class GalleryViewerPage extends HookConsumerWidget {
         return;
       }
 
-      if (details.delta.dy > sensitivity) {
+      double ratio = d.dy / max(d.dx.abs(), 1);
+      if (d.dy > sensitivity && ratio > ratioThreshold) {
         AutoRouter.of(context).pop();
-      } else if (details.delta.dy < -sensitivity) {
+      } else if (d.dy < -sensitivity && ratio < -ratioThreshold) {
         showInfo();
       }
     }

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -257,7 +257,7 @@ class GalleryViewerPage extends HookConsumerWidget {
         return;
       }
 
-      double ratio = d.dy / max(d.dx.abs(), 1);
+      final ratio = d.dy / max(d.dx.abs(), 1);
       if (d.dy > sensitivity && ratio > ratioThreshold) {
         AutoRouter.of(context).pop();
       } else if (d.dy < -sensitivity && ratio < -ratioThreshold) {


### PR DESCRIPTION
On my device, I have had hard times opening up the details section / closing the photo viewer via the swipe-up / -down gesture in the gallery viewer. Either my device reports smaller deltas more frequently or I am generally slow with my gestures^^ How is it on other devices?

This PR changes this behavior by looking at the direction of the gesture (ratio of y/x difference). I could have reduced the existing delta sensitivity, but I wasn't sure if that affects other devices negatively.