### PR TITLE
fix(server): apply timezone to storage template

### DIFF
--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -233,7 +233,7 @@ export class StorageTemplateService {
       filetypefull: asset.type == AssetType.IMAGE ? 'IMAGE' : 'VIDEO',
     };
 
-    const dt = luxon.DateTime.fromJSDate(asset.fileCreatedAt);
+    const dt = luxon.DateTime.fromJSDate(asset.fileCreatedAt, { zone: asset.exifInfo?.timeZone || undefined });
 
     const dateTokens = [
       ...supportedYearTokens,


### PR DESCRIPTION
Apply timeZone from exif to date used in the storage template.

Tested by observing file names changed to the correct times for assets with timezones.

Fixes #1519 