### PR TITLE
refactor(web): asset grid state

### DIFF
--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -19,7 +19,7 @@
 
       const assetGridState = get(assetStore);
       for (const bucket of assetGridState.buckets) {
-        await assetStore.getAssetsByBucket(bucket.bucketDate, BucketPosition.Unknown);
+        await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
         for (const asset of bucket.assets) {
           assetInteractionStore.addAssetToMultiselectGroup(asset);
         }

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -60,7 +60,7 @@
 
   $: {
     if (actualBucketHeight && actualBucketHeight != 0 && actualBucketHeight != bucketHeight) {
-      const heightDelta = assetStore.updateBucketHeight(bucketDate, actualBucketHeight);
+      const heightDelta = assetStore.updateBucket(bucketDate, actualBucketHeight);
       if (heightDelta !== 0) {
         scrollTimeline(heightDelta);
       }

--- a/web/src/lib/models/asset-grid-state.ts
+++ b/web/src/lib/models/asset-grid-state.ts
@@ -1,10 +1,24 @@
-import type { AssetResponseDto } from '@api';
+import { api, AssetCountByTimeBucket, AssetResponseDto } from '@api';
+import { writable } from 'svelte/store';
+import type { AssetStore } from '../stores/assets.store';
+import { handleError } from '../utils/handle-error';
 
 export enum BucketPosition {
   Above = 'above',
   Below = 'below',
   Visible = 'visible',
   Unknown = 'unknown',
+}
+
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+interface AssetLookup {
+  bucket: AssetBucket;
+  bucketIndex: number;
+  assetIndex: number;
 }
 
 export class AssetBucket {
@@ -15,44 +29,220 @@ export class AssetBucket {
   bucketHeight!: number;
   bucketDate!: string;
   assets!: AssetResponseDto[];
-  cancelToken!: AbortController;
+  cancelToken!: AbortController | null;
   position!: BucketPosition;
 }
 
-export class AssetGridState {
-  /**
-   * The total height of the timeline in pixel
-   * This value is first estimated by the number of asset and later is corrected as the user scroll
-   */
+const THUMBNAIL_HEIGHT = 235;
+
+export class AssetGridState implements AssetStore {
+  private store$ = writable(this);
+  private assetToBucket: Record<string, AssetLookup> = {};
+  private viewport: Viewport = { width: 0, height: 0 };
+  private userId: string | undefined;
+
+  initialized = false;
   timelineHeight = 0;
-
-  /**
-   * The fixed viewport height in pixel
-   */
-  viewportHeight = 0;
-
-  /**
-   * The fixed viewport width in pixel
-   */
-  viewportWidth = 0;
-
-  /**
-   * List of bucket information
-   */
   buckets: AssetBucket[] = [];
-
-  /**
-   * Total assets that have been loaded
-   */
   assets: AssetResponseDto[] = [];
 
-  /**
-   * Total assets that have been loaded along with additional data
-   */
-  loadedAssets: Record<string, number> = {};
+  subscribe = this.store$.subscribe;
 
-  /**
-   * User that owns assets
-   */
-  userId: string | undefined;
+  init(viewport: Viewport, buckets: AssetCountByTimeBucket[], userId: string | undefined) {
+    this.initialized = false;
+    this.assets = [];
+    this.assetToBucket = {};
+    this.buckets = [];
+    this.viewport = viewport;
+    this.userId = userId;
+    this.buckets = buckets.map((bucket) => {
+      const unwrappedWidth = (3 / 2) * bucket.count * THUMBNAIL_HEIGHT * (7 / 10);
+      const rows = Math.ceil(unwrappedWidth / this.viewport.width);
+      const height = rows * THUMBNAIL_HEIGHT;
+
+      return {
+        bucketDate: bucket.timeBucket,
+        bucketHeight: height,
+        assets: [],
+        cancelToken: null,
+        position: BucketPosition.Unknown,
+      };
+    });
+
+    this.timelineHeight = this.buckets.reduce((acc, b) => acc + b.bucketHeight, 0);
+
+    this.emit(false);
+
+    let height = 0;
+    for (const bucket of this.buckets) {
+      if (height < this.viewport.height) {
+        height += bucket.bucketHeight;
+        this.loadBucket(bucket.bucketDate, BucketPosition.Visible);
+        continue;
+      }
+
+      break;
+    }
+
+    this.initialized = true;
+  }
+
+  getBucketByDate(bucketDate: string): AssetBucket | null {
+    return this.buckets.find((bucket) => bucket.bucketDate === bucketDate) || null;
+  }
+
+  getBucketInfoForAssetId(assetId: string) {
+    return this.assetToBucket[assetId] || null;
+  }
+
+  getBucketIndexByAssetId(assetId: string) {
+    return this.assetToBucket[assetId]?.bucketIndex || null;
+  }
+
+  async loadBucket(bucketDate: string, position: BucketPosition): Promise<void> {
+    try {
+      const bucket = this.getBucketByDate(bucketDate);
+      if (!bucket) {
+        return;
+      }
+
+      bucket.position = position;
+
+      if (bucket.assets.length !== 0) {
+        this.emit(false);
+        return;
+      }
+
+      bucket.cancelToken = new AbortController();
+
+      const { data: assets } = await api.assetApi.getAssetByTimeBucket(
+        {
+          getAssetByTimeBucketDto: {
+            timeBucket: [bucketDate],
+            userId: this.userId,
+            withoutThumbs: true,
+          },
+        },
+        { signal: bucket.cancelToken.signal },
+      );
+
+      bucket.assets = assets;
+      this.emit(true);
+    } catch (error) {
+      handleError(error, 'Failed to load assets');
+    }
+  }
+
+  cancelBucket(bucket: AssetBucket) {
+    bucket.cancelToken?.abort();
+  }
+
+  updateBucket(bucketDate: string, height: number) {
+    const bucket = this.getBucketByDate(bucketDate);
+    if (!bucket) {
+      return 0;
+    }
+
+    const delta = height - bucket.bucketHeight;
+    const scrollTimeline = bucket.position == BucketPosition.Above;
+
+    bucket.bucketHeight = height;
+    bucket.position = BucketPosition.Unknown;
+
+    this.timelineHeight += delta;
+
+    this.emit(false);
+
+    return scrollTimeline ? delta : 0;
+  }
+
+  updateAsset(assetId: string, isFavorite: boolean) {
+    const asset = this.assets.find((asset) => asset.id === assetId);
+    if (!asset) {
+      return;
+    }
+
+    asset.isFavorite = isFavorite;
+    this.emit(false);
+  }
+
+  removeAsset(assetId: string) {
+    for (let i = 0; i < this.buckets.length; i++) {
+      const bucket = this.buckets[i];
+      for (let j = 0; j < bucket.assets.length; j++) {
+        const asset = bucket.assets[j];
+        if (asset.id !== assetId) {
+          continue;
+        }
+
+        bucket.assets.splice(j, 1);
+        if (bucket.assets.length === 0) {
+          this.buckets.splice(i, 1);
+        }
+
+        this.emit(true);
+        return;
+      }
+    }
+  }
+
+  async getPreviousAssetId(assetId: string): Promise<string | null> {
+    const info = this.getBucketInfoForAssetId(assetId);
+    if (!info) {
+      return null;
+    }
+
+    const { bucket, assetIndex, bucketIndex } = info;
+
+    if (assetIndex !== 0) {
+      return bucket.assets[assetIndex - 1].id;
+    }
+
+    if (bucketIndex === 0) {
+      return null;
+    }
+
+    const previousBucket = this.buckets[bucketIndex - 1];
+    await this.loadBucket(previousBucket.bucketDate, BucketPosition.Unknown);
+    return previousBucket.assets.at(-1)?.id || null;
+  }
+
+  async getNextAssetId(assetId: string): Promise<string | null> {
+    const info = this.getBucketInfoForAssetId(assetId);
+    if (!info) {
+      return null;
+    }
+
+    const { bucket, assetIndex, bucketIndex } = info;
+
+    if (assetIndex !== bucket.assets.length - 1) {
+      return bucket.assets[assetIndex + 1].id;
+    }
+
+    if (bucketIndex === this.buckets.length - 1) {
+      return null;
+    }
+
+    const nextBucket = this.buckets[bucketIndex + 1];
+    await this.loadBucket(nextBucket.bucketDate, BucketPosition.Unknown);
+    return nextBucket.assets[0]?.id || null;
+  }
+
+  private emit(recalculate: boolean) {
+    if (recalculate) {
+      this.assets = this.buckets.flatMap(({ assets }) => assets);
+
+      const assetToBucket: Record<string, AssetLookup> = {};
+      for (let i = 0; i < this.buckets.length; i++) {
+        const bucket = this.buckets[i];
+        for (let j = 0; j < bucket.assets.length; j++) {
+          const asset = bucket.assets[j];
+          assetToBucket[asset.id] = { bucket, bucketIndex: i, assetIndex: j };
+        }
+      }
+      this.assetToBucket = assetToBucket;
+    }
+
+    this.store$.update(() => this);
+  }
 }

--- a/web/src/lib/models/asset-grid-state.ts
+++ b/web/src/lib/models/asset-grid-state.ts
@@ -96,7 +96,7 @@ export class AssetGridState implements AssetStore {
   }
 
   getBucketIndexByAssetId(assetId: string) {
-    return this.assetToBucket[assetId]?.bucketIndex || null;
+    return this.assetToBucket[assetId]?.bucketIndex ?? null;
   }
 
   async loadBucket(bucketDate: string, position: BucketPosition): Promise<void> {

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -1,268 +1,38 @@
-import { AssetGridState, BucketPosition } from '$lib/models/asset-grid-state';
-import { api, AssetCountByTimeBucketResponseDto, AssetResponseDto } from '@api';
-import { writable } from 'svelte/store';
+import { AssetBucket, AssetGridState, BucketPosition, Viewport } from '$lib/models/asset-grid-state';
+import type { AssetCountByTimeBucket } from '@api';
 
 export interface AssetStore {
-  setInitialState: (
-    viewportHeight: number,
-    viewportWidth: number,
-    data: AssetCountByTimeBucketResponseDto,
-    userId: string | undefined,
-  ) => void;
-  getAssetsByBucket: (bucket: string, position: BucketPosition) => Promise<void>;
-  updateBucketHeight: (bucket: string, actualBucketHeight: number) => number;
-  cancelBucketRequest: (token: AbortController, bucketDate: string) => Promise<void>;
-  getAdjacentAsset: (assetId: string, direction: 'next' | 'previous') => Promise<string | null>;
+  init: (viewport: Viewport, data: AssetCountByTimeBucket[], userId: string | undefined) => void;
+
+  // bucket
+  loadBucket: (bucket: string, position: BucketPosition) => Promise<void>;
+  updateBucket: (bucket: string, actualBucketHeight: number) => number;
+  cancelBucket: (bucket: AssetBucket) => void;
+
+  // asset
   removeAsset: (assetId: string) => void;
   updateAsset: (assetId: string, isFavorite: boolean) => void;
+
+  // asset navigation
+  getNextAssetId: (assetId: string) => Promise<string | null>;
+  getPreviousAssetId: (assetId: string) => Promise<string | null>;
+
+  // store
   subscribe: (run: (value: AssetGridState) => void, invalidate?: (value?: AssetGridState) => void) => () => void;
 }
 
 export function createAssetStore(): AssetStore {
-  let _loadingBuckets: { [key: string]: boolean } = {};
-  let _assetGridState = new AssetGridState();
-
-  const { subscribe, set, update } = writable(new AssetGridState());
-
-  subscribe((state) => {
-    _assetGridState = state;
-  });
-
-  const _estimateViewportHeight = (assetCount: number, viewportWidth: number): number => {
-    // Ideally we would use the average aspect ratio for the photoset, however assume
-    // a normal landscape aspect ratio of 3:2, then discount for the likelihood we
-    // will be scaling down and coalescing.
-    const thumbnailHeight = 235;
-    const unwrappedWidth = (3 / 2) * assetCount * thumbnailHeight * (7 / 10);
-    const rows = Math.ceil(unwrappedWidth / viewportWidth);
-    const height = rows * thumbnailHeight;
-    return height;
-  };
-
-  const refreshLoadedAssets = (state: AssetGridState): void => {
-    state.loadedAssets = {};
-    state.buckets.forEach((bucket, bucketIndex) =>
-      bucket.assets.map((asset) => {
-        state.loadedAssets[asset.id] = bucketIndex;
-      }),
-    );
-  };
-
-  const setInitialState = (
-    viewportHeight: number,
-    viewportWidth: number,
-    data: AssetCountByTimeBucketResponseDto,
-    userId: string | undefined,
-  ) => {
-    set({
-      viewportHeight,
-      viewportWidth,
-      timelineHeight: 0,
-      buckets: data.buckets.map((bucket) => ({
-        bucketDate: bucket.timeBucket,
-        bucketHeight: _estimateViewportHeight(bucket.count, viewportWidth),
-        assets: [],
-        cancelToken: new AbortController(),
-        position: BucketPosition.Unknown,
-      })),
-      assets: [],
-      loadedAssets: {},
-      userId,
-    });
-
-    update((state) => {
-      state.timelineHeight = state.buckets.reduce((acc, b) => acc + b.bucketHeight, 0);
-      return state;
-    });
-  };
-
-  const getAssetsByBucket = async (bucket: string, position: BucketPosition) => {
-    try {
-      const currentBucketData = _assetGridState.buckets.find((b) => b.bucketDate === bucket);
-      if (currentBucketData?.assets && currentBucketData.assets.length > 0) {
-        update((state) => {
-          const bucketIndex = state.buckets.findIndex((b) => b.bucketDate === bucket);
-          state.buckets[bucketIndex].position = position;
-          return state;
-        });
-        return;
-      }
-
-      _loadingBuckets = { ..._loadingBuckets, [bucket]: true };
-      const { data: assets } = await api.assetApi.getAssetByTimeBucket(
-        {
-          getAssetByTimeBucketDto: {
-            timeBucket: [bucket],
-            userId: _assetGridState.userId,
-            withoutThumbs: true,
-          },
-        },
-        { signal: currentBucketData?.cancelToken.signal },
-      );
-      _loadingBuckets = { ..._loadingBuckets, [bucket]: false };
-
-      update((state) => {
-        const bucketIndex = state.buckets.findIndex((b) => b.bucketDate === bucket);
-        state.buckets[bucketIndex].assets = assets;
-        state.buckets[bucketIndex].position = position;
-        state.assets = state.buckets.flatMap((b) => b.assets);
-        refreshLoadedAssets(state);
-        return state;
-      });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
-      if (e.name === 'CanceledError') {
-        return;
-      }
-      console.error('Failed to get asset for bucket ', bucket);
-      console.error(e);
-    }
-  };
-
-  const removeAsset = (assetId: string) => {
-    update((state) => {
-      const bucketIndex = state.buckets.findIndex((b) => b.assets.some((a) => a.id === assetId));
-      const assetIndex = state.buckets[bucketIndex].assets.findIndex((a) => a.id === assetId);
-      state.buckets[bucketIndex].assets.splice(assetIndex, 1);
-
-      if (state.buckets[bucketIndex].assets.length === 0) {
-        _removeBucket(state.buckets[bucketIndex].bucketDate);
-      }
-      state.assets = state.buckets.flatMap((b) => b.assets);
-      refreshLoadedAssets(state);
-      return state;
-    });
-  };
-
-  const _removeBucket = (bucketDate: string) => {
-    update((state) => {
-      const bucketIndex = state.buckets.findIndex((b) => b.bucketDate === bucketDate);
-      state.buckets.splice(bucketIndex, 1);
-      state.assets = state.buckets.flatMap((b) => b.assets);
-      refreshLoadedAssets(state);
-      return state;
-    });
-  };
-
-  const updateBucketHeight = (bucket: string, actualBucketHeight: number): number => {
-    let scrollTimeline = false;
-    let heightDelta = 0;
-
-    update((state) => {
-      const bucketIndex = state.buckets.findIndex((b) => b.bucketDate === bucket);
-      // Update timeline height based on the new bucket height
-      const estimateBucketHeight = state.buckets[bucketIndex].bucketHeight;
-
-      heightDelta = actualBucketHeight - estimateBucketHeight;
-      state.timelineHeight += heightDelta;
-
-      scrollTimeline = state.buckets[bucketIndex].position == BucketPosition.Above;
-
-      state.buckets[bucketIndex].bucketHeight = actualBucketHeight;
-      state.buckets[bucketIndex].position = BucketPosition.Unknown;
-
-      return state;
-    });
-
-    if (scrollTimeline) {
-      return heightDelta;
-    }
-
-    return 0;
-  };
-
-  const cancelBucketRequest = async (token: AbortController, bucketDate: string) => {
-    if (!_loadingBuckets[bucketDate]) {
-      return;
-    }
-
-    token.abort();
-
-    update((state) => {
-      const bucketIndex = state.buckets.findIndex((b) => b.bucketDate === bucketDate);
-      state.buckets[bucketIndex].cancelToken = new AbortController();
-      return state;
-    });
-  };
-
-  const updateAsset = (assetId: string, isFavorite: boolean) => {
-    update((state) => {
-      const bucketIndex = state.buckets.findIndex((b) => b.assets.some((a) => a.id === assetId));
-      const assetIndex = state.buckets[bucketIndex].assets.findIndex((a) => a.id === assetId);
-      state.buckets[bucketIndex].assets[assetIndex].isFavorite = isFavorite;
-
-      state.assets = state.buckets.flatMap((b) => b.assets);
-      refreshLoadedAssets(state);
-      return state;
-    });
-  };
-
-  const _getNextAsset = async (currentBucketIndex: number, assetId: string): Promise<AssetResponseDto | null> => {
-    const currentBucket = _assetGridState.buckets[currentBucketIndex];
-    const assetIndex = currentBucket.assets.findIndex(({ id }) => id == assetId);
-    if (assetIndex === -1) {
-      return null;
-    }
-
-    if (assetIndex + 1 < currentBucket.assets.length) {
-      return currentBucket.assets[assetIndex + 1];
-    }
-
-    const nextBucketIndex = currentBucketIndex + 1;
-    if (nextBucketIndex >= _assetGridState.buckets.length) {
-      return null;
-    }
-
-    const nextBucket = _assetGridState.buckets[nextBucketIndex];
-    await getAssetsByBucket(nextBucket.bucketDate, BucketPosition.Unknown);
-
-    return nextBucket.assets[0] ?? null;
-  };
-
-  const _getPrevAsset = async (currentBucketIndex: number, assetId: string): Promise<AssetResponseDto | null> => {
-    const currentBucket = _assetGridState.buckets[currentBucketIndex];
-    const assetIndex = currentBucket.assets.findIndex(({ id }) => id == assetId);
-    if (assetIndex === -1) {
-      return null;
-    }
-
-    if (assetIndex > 0) {
-      return currentBucket.assets[assetIndex - 1];
-    }
-
-    const prevBucketIndex = currentBucketIndex - 1;
-    if (prevBucketIndex < 0) {
-      return null;
-    }
-
-    const prevBucket = _assetGridState.buckets[prevBucketIndex];
-    await getAssetsByBucket(prevBucket.bucketDate, BucketPosition.Unknown);
-
-    return prevBucket.assets[prevBucket.assets.length - 1] ?? null;
-  };
-
-  const getAdjacentAsset = async (assetId: string, direction: 'next' | 'previous'): Promise<string | null> => {
-    const currentBucketIndex = _assetGridState.loadedAssets[assetId];
-    if (currentBucketIndex < 0 || currentBucketIndex >= _assetGridState.buckets.length) {
-      return null;
-    }
-
-    const asset =
-      direction === 'next'
-        ? await _getNextAsset(currentBucketIndex, assetId)
-        : await _getPrevAsset(currentBucketIndex, assetId);
-
-    return asset?.id ?? null;
-  };
+  const store = new AssetGridState();
 
   return {
-    setInitialState,
-    getAssetsByBucket,
-    removeAsset,
-    updateBucketHeight,
-    cancelBucketRequest,
-    getAdjacentAsset,
-    updateAsset,
-    subscribe,
+    init: store.init.bind(store),
+    loadBucket: store.loadBucket.bind(store),
+    updateBucket: store.updateBucket.bind(store),
+    cancelBucket: store.cancelBucket.bind(store),
+    removeAsset: store.removeAsset.bind(store),
+    updateAsset: store.updateAsset.bind(store),
+    getNextAssetId: store.getNextAssetId.bind(store),
+    getPreviousAssetId: store.getPreviousAssetId.bind(store),
+    subscribe: store.subscribe,
   };
 }


### PR DESCRIPTION
In this PR:
- Refactor asset grid state
- Only create an abort controller before starting an http request
- Track asset lookup map to bucket, bucket index, and asset index

Tested Scenarios:
- View an asset, hit next until the next time bucket loads (observed in the network tab)
- View an asset towards end of timeline, hit previous until a previous time bucket loads (observed in the network tab)
- View first asset in the timeline, observe clicking previous does nothing
- Scrub the timeline and observe relatively quick loading/rendering.
- Add an artificial delay to get asset by time bucket to verify abort controller is firing and cancelling requests when the bucket is no longer intersecting
- Delete photos, make sure they are removed from the grid
- Archive photos, make sure they are removed from the grid
- Select all photos, make sure the count matches the statistics for the user
- Select the first asset, jump a long way down, shift select an asset, then scroll up and observe everything is selected