### PR TITLE
Local merged videos should now play locally instead of loading remote

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -34,7 +34,7 @@ class VideoViewerPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (asset.storage == AssetState.local && asset.livePhotoVideoId == null) {
+    if (asset.isLocal && asset.livePhotoVideoId == null) {
       final AsyncValue<File> videoFile = ref.watch(_fileFamily(asset.local!));
       return videoFile.when(
         data: (data) => VideoPlayer(


### PR DESCRIPTION
Fixes a bug where an `AssetState.merged` video asset would prefer to play the remote video rather than the local one.

Fixes #3523 