### PR TITLE
fix(web): leave assets selected after creating a shared link

### DIFF
--- a/web/src/lib/components/photos-page/actions/create-shared-link.svelte
+++ b/web/src/lib/components/photos-page/actions/create-shared-link.svelte
@@ -6,7 +6,7 @@
   import { getAssetControlContext } from '../asset-select-control-bar.svelte';
 
   let showModal = false;
-  const { getAssets, clearSelect } = getAssetControlContext();
+  const { getAssets } = getAssetControlContext();
 </script>
 
 <CircleIconButton title="Share" logo={ShareVariantOutline} on:click={() => (showModal = true)} />
@@ -15,9 +15,6 @@
   <CreateSharedLinkModal
     sharedAssets={Array.from(getAssets())}
     shareType={SharedLinkType.Individual}
-    on:close={() => {
-      showModal = false;
-      clearSelect();
-    }}
+    on:close={() => (showModal = false)}
   />
 {/if}


### PR DESCRIPTION
Fixes #3280

Tested Scenarios:
- Select photos from timeline and create a shared link. Photos are still selected after closing the modal.