### PR TITLE
refactor(web): move memory lane to photos page

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -10,7 +10,6 @@
   import Portal from '../shared-components/portal/portal.svelte';
   import Scrollbar from '../shared-components/scrollbar/scrollbar.svelte';
   import AssetDateGroup from './asset-date-group.svelte';
-  import MemoryLane from './memory-lane.svelte';
 
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
@@ -21,8 +20,6 @@
   import ShowShortcuts from '../shared-components/show-shortcuts.svelte';
 
   export let isAlbumSelectionMode = false;
-  export let showMemoryLane = false;
-
   export let assetStore: AssetStore;
   export let assetInteractionStore: AssetInteractionStore;
 
@@ -284,9 +281,7 @@
   on:scroll={handleTimelineScroll}
 >
   {#if element}
-    {#if showMemoryLane}
-      <MemoryLane />
-    {/if}
+    <slot />
     <section id="virtual-timeline" style:height={$assetStore.timelineHeight + 'px'}>
       {#each $assetStore.buckets as bucket, bucketIndex (bucketIndex)}
         <IntersectionObserver

--- a/web/src/routes/(user)/photos/+page.svelte
+++ b/web/src/routes/(user)/photos/+page.svelte
@@ -10,9 +10,10 @@
   import AssetGrid from '$lib/components/photos-page/asset-grid.svelte';
   import AssetSelectContextMenu from '$lib/components/photos-page/asset-select-context-menu.svelte';
   import AssetSelectControlBar from '$lib/components/photos-page/asset-select-control-bar.svelte';
+  import MemoryLane from '$lib/components/photos-page/memory-lane.svelte';
   import EmptyPlaceholder from '$lib/components/shared-components/empty-placeholder.svelte';
-  import { AssetStore } from '$lib/stores/assets.store';
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
+  import { AssetStore } from '$lib/stores/assets.store';
   import { openFileUploadDialog } from '$lib/utils/file-uploader';
   import { TimeGroupEnum, api } from '@api';
   import { onDestroy, onMount } from 'svelte';
@@ -64,7 +65,9 @@
   </svelte:fragment>
   <svelte:fragment slot="content">
     {#if assetCount}
-      <AssetGrid {assetStore} {assetInteractionStore} showMemoryLane />
+      <AssetGrid {assetStore} {assetInteractionStore}>
+        <MemoryLane />
+      </AssetGrid>
     {:else}
       <EmptyPlaceholder text="CLICK TO UPLOAD YOUR FIRST PHOTO" actionHandler={handleUpload} />
     {/if}


### PR DESCRIPTION
Move `MemoryLane` component to the photos page, the only place it is used and should show up.

- Tested with and without a memory for today
- Tested with partner sharing, asset grid renders correctly.