### PR TITLE
fix(web): broken search-bar during page load

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -64,7 +64,7 @@
   };
 </script>
 
-<button class="w-full" use:clickOutside on:outclick={onFocusOut}>
+<div role="button" class="w-full" use:clickOutside on:outclick={onFocusOut}>
   <form
     draggable="false"
     autocomplete="off"
@@ -160,4 +160,4 @@
       </div>
     {/if}
   </form>
-</button>
+</div>

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -3,7 +3,7 @@
   import Magnify from 'svelte-material-icons/Magnify.svelte';
   import Close from 'svelte-material-icons/Close.svelte';
   import { goto } from '$app/navigation';
-  import { isSearchEnabled, savedSearchTerms } from '$lib/stores/search.store';
+  import { isSearchEnabled, preventRaceConditionSearchBar, savedSearchTerms } from '$lib/stores/search.store';
   import { fly } from 'svelte/transition';
   import { clickOutside } from '$lib/utils/click-outside';
   export let value = '';
@@ -23,8 +23,8 @@
       searchValue = value.slice(2);
     }
 
-    $savedSearchTerms = $savedSearchTerms.filter((item) => item !== searchValue);
-    saveSearchTerm(searchValue);
+    $savedSearchTerms = $savedSearchTerms.filter((item) => item !== value);
+    saveSearchTerm(value);
 
     const params = new URLSearchParams({
       q: searchValue,
@@ -59,6 +59,10 @@
   };
 
   const onFocusOut = () => {
+    if ($isSearchEnabled) {
+      $preventRaceConditionSearchBar = true;
+    }
+
     showBigSearchBar = false;
     $isSearchEnabled = false;
   };

--- a/web/src/lib/stores/search.store.ts
+++ b/web/src/lib/stores/search.store.ts
@@ -3,3 +3,4 @@ import { writable } from 'svelte/store';
 
 export const savedSearchTerms = persisted<string[]>('search-terms', [], {});
 export const isSearchEnabled = writable<boolean>(false);
+export const preventRaceConditionSearchBar = writable<boolean>(false);

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -26,6 +26,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { preventRaceConditionSearchBar } from '$lib/stores/search.store';
 
   export let data: PageData;
 
@@ -53,7 +54,10 @@
     if (!$showAssetViewer) {
       switch (event.key) {
         case 'Escape':
-          goto(previousRoute);
+          if (!$preventRaceConditionSearchBar) {
+            goto(previousRoute);
+          }
+          $preventRaceConditionSearchBar = false;
           return;
       }
     }


### PR DESCRIPTION
This PR fixes :
- The search bar  not properly displayed during the page load.
- Save in the search history `m:` too. Before, if the user searched `m:word`, only `word` was saved

| Before | After |
| --- | --- | 
| <video src="https://github.com/immich-app/immich/assets/74269598/5cb095cf-bdc3-4361-9b4b-2fb547f8fe2b"> | <video src="https://github.com/immich-app/immich/assets/74269598/4589c6ef-5f9b-4bb2-a62d-ddef39012301"> |

