### PR TITLE
fix(server): compile libraw

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,14 +4,17 @@ WORKDIR /usr/src/app
 
 COPY bin/install-ffmpeg.sh build-lock.json ./
 RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
-RUN apt-get update && apt-get install -yqq build-essential ninja-build meson pkg-config jq \
+RUN apt-get update && apt-get install -yqq build-essential ninja-build meson pkg-config jq zlib1g autoconf \
 libglib2.0-dev libexpat1-dev librsvg2-dev libexif-dev libwebp-dev liborc-0.4-dev libtiff5-dev \
-libjpeg62-turbo-dev libgsf-1-dev libspng-dev libraw-dev libjxl-dev libheif-dev \
+libjpeg62-turbo-dev libgsf-1-dev libspng-dev libjxl-dev libheif-dev \
 mesa-va-drivers libmimalloc2.0 $(if [ $(arch) = "x86_64" ]; then echo "intel-media-va-driver-non-free"; fi) \
 && ./install-ffmpeg.sh && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # debian build for imagemagick has broken RAW support, so build manually
-COPY bin/build-imagemagick.sh bin/build-libvips.sh ./
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV LD_RUN_PATH=/usr/local/lib:$LD_RUN_PATH
+COPY bin/build-libraw.sh bin/build-imagemagick.sh bin/build-libvips.sh ./
+RUN ./build-libraw.sh
 RUN ./build-imagemagick.sh
 RUN ./build-libvips.sh
 
@@ -35,20 +38,13 @@ WORKDIR /usr/src/app
 COPY bin/install-ffmpeg.sh build-lock.json ./
 RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && apt-get install -yqq tini libheif1 libwebp7 libwebpdemux2 libwebpmux3 mesa-va-drivers \
-libjpeg62-turbo libexpat1 librsvg2-2 libjxl0.7 libraw20 libtiff6 libspng0 libexif12 libgcc-s1 libglib2.0-0 \
-libgsf-1-114 libopenjp2-7 liblcms2-2 liborc-0.4-0 libopenexr-3-1-30 liblqr-1-0 libltdl7 zlib1g \
+libjpeg62-turbo libexpat1 librsvg2-2 libjxl0.7 libtiff6 libspng0 libexif12 libgcc-s1 libglib2.0-0 \
+libgsf-1-114 libopenjp2-7 liblcms2-2 liborc-0.4-0 libopenexr-3-1-30 liblqr-1-0 libltdl7 zlib1g libgomp1 \
 mesa-va-drivers libmimalloc2.0 $(if [ $(arch) = "x86_64" ]; then echo "intel-media-va-driver-non-free"; fi) jq wget \
 && ./install-ffmpeg.sh && apt-get remove -yqq jq wget && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* \
 && rm install-ffmpeg.sh && rm build-lock.json
 
-COPY --from=prod /usr/local/bin/magick /usr/local/bin/magick
-COPY --from=prod /usr/local/include/ImageMagick-7 /usr/local/include/ImageMagick-7
-
-COPY --from=prod /usr/local/bin/vips /usr/local/bin/vips
-COPY --from=prod /usr/local/include/vips/ /usr/local/include/vips/
-
 COPY --from=prod /usr/local/lib/ /usr/local/lib/
-
 RUN ldconfig /usr/local/lib
 
 COPY --from=prod /usr/src/app/node_modules ./node_modules

--- a/server/bin/build-libraw.sh
+++ b/server/bin/build-libraw.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+LOCK=$(jq -c '.packages[] | select(.name == "libraw")' build-lock.json)
+LIBRAW_VERSION=${LIBRAW_VERSION:=$(echo $LOCK | jq -r '.version')}
+LIBRAW_SHA256=${LIBRAW_SHA256:=$(echo $LOCK | jq -r '.sha256')}
+
+echo "$LIBRAW_SHA256  $LIBRAW_VERSION.tar.gz" > libraw.sha256
+mkdir -p libraw
+wget -nv https://github.com/libraw/libraw/archive/${LIBRAW_VERSION}.tar.gz
+sha256sum -c libraw.sha256
+tar -xvf ${LIBRAW_VERSION}.tar.gz -C libraw --strip-components=1
+rm ${LIBRAW_VERSION}.tar.gz
+rm libraw.sha256
+cd libraw
+autoreconf --install
+./configure
+make -j$(nproc)
+make install
+cd .. && rm -rf libraw
+ldconfig /usr/local/lib

--- a/server/build-lock.json
+++ b/server/build-lock.json
@@ -6,6 +6,11 @@
       "sha256": "8e3ce1aaad19da9f2ca444072bcc631d193a219e3ee11c13ad6d3c895044142c"
     },
     {
+      "name": "libraw",
+      "version": "0.21.1",
+      "sha256": "b63d7ffa43463f74afcc02f9083048c231349b41cc9255dec0840cf8a67b52e0"
+    },
+    {
       "name": "libvips",
       "version": "8.14.2",
       "sha256": "27dad021f0835a5ab14e541d02abd41e4c3bd012d2196438df5a9e754984f7ce"


### PR DESCRIPTION
## Description

The version of libraw used in the image has a bug with CR3 images per [this](https://github.com/ImageMagick/ImageMagick/issues/5508) issue. This PR compiles a newer version to avoid this problem.

Fixes #3584

## How Has This Been Tested?

The sample image provided in #3584 has a normal thumbnail generated with this PR.

![out](https://github.com/immich-app/immich/assets/101130780/37bca389-a8be-425c-bea0-d9e5c1629eff)
