### PR TITLE
fix(server): add video capability for nvenc

### DIFF
--- a/docker/hwaccel.yml
+++ b/docker/hwaccel.yml
@@ -20,4 +20,4 @@ services:
     #       devices:
     #         - driver: nvidia
     #           count: 1
-    #           capabilities: [gpu]
+    #           capabilities: [gpu,video]


### PR DESCRIPTION
## Description

On Linux servers, it may be necessary to pass `video` to the list of capabilities for NVIDIA GPUs in `hwaccel.yml`. Otherwise, it may not expose the Video Codec SDK regardless of the value of `NVIDIA_DRIVER_CAPABILITIES`, leading transcoding to fail with `CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected`.

Related: https://stackoverflow.com/a/75809584


## How Has This Been Tested?

This fixed an issue a user was facing while trying to use NVENC. It should not be necessary on WSL, but from my testing it's harmless to add it.