### PR TITLE
fix(web): show warning on duplicate uploads #2557

### DIFF
--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -29,7 +29,7 @@
     }
 
     if (notificationInfo.type === NotificationType.Warning) {
-      return '#FDE7A3';
+      return '#FFF6DC';
     }
   };
 
@@ -43,7 +43,7 @@
     }
 
     if (notificationInfo.type === NotificationType.Warning) {
-      return '1px solid #D8DDFF';
+      return '1px solid #FFE6A5';
     }
   };
 

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -15,6 +15,7 @@
 
   let infoPrimaryColor = '#4250AF';
   let errorPrimaryColor = '#E64132';
+  let warningPrimaryColor = '#D08613';
 
   $: icon = notificationInfo.type === NotificationType.Error ? CloseCircleOutline : InformationOutline;
 
@@ -26,6 +27,10 @@
     if (notificationInfo.type === NotificationType.Error) {
       return '#FBE8E6';
     }
+
+    if (notificationInfo.type === NotificationType.Warning) {
+      return '#FDE7A3';
+    }
   };
 
   $: borderStyle = () => {
@@ -36,6 +41,10 @@
     if (notificationInfo.type === NotificationType.Error) {
       return '1px solid #F0E8E7';
     }
+
+    if (notificationInfo.type === NotificationType.Warning) {
+      return '1px solid #D8DDFF';
+    }
   };
 
   $: primaryColor = () => {
@@ -45,6 +54,10 @@
 
     if (notificationInfo.type === NotificationType.Error) {
       return errorPrimaryColor;
+    }
+
+    if (notificationInfo.type === NotificationType.Warning) {
+      return warningPrimaryColor;
     }
   };
 

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -3,10 +3,11 @@ import { writable } from 'svelte/store';
 export enum NotificationType {
   Info = 'Info',
   Error = 'Error',
+  Warning = 'Warning',
 }
 
 export class ImmichNotification {
-  id = new Date().getTime();
+  id = new Date().getTime() + Math.random();
   type!: NotificationType;
   message!: string;
   action!: NotificationAction;

--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -9,6 +9,7 @@
 
   let showDetail = true;
   let uploadLength = 0;
+  let duplicateCount = 0;
   let isUploading = false;
 
   // Reactive action to update asset uploadLength whenever there is a new one added to the list
@@ -21,6 +22,10 @@
   uploadAssetsStore.isUploading.subscribe((value) => {
     isUploading = value;
   });
+
+  uploadAssetsStore.duplicateCounter.subscribe((value) => {
+    duplicateCount = value;
+  });
 </script>
 
 {#if isUploading}
@@ -32,6 +37,13 @@
         message: 'Upload success, refresh the page to see new upload assets',
         type: NotificationType.Info,
       });
+      if (duplicateCount > 0) {
+        notificationController.show({
+          message: `Skipped ${duplicateCount} duplicate picture${duplicateCount > 1 ? 's' : ''}`,
+          type: NotificationType.Warning
+        });
+        uploadAssetsStore.duplicateCounter.set(0);
+      }
     }}
     class="absolute bottom-6 right-6 z-[10000]"
   >

--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -40,7 +40,7 @@
       if (duplicateCount > 0) {
         notificationController.show({
           message: `Skipped ${duplicateCount} duplicate picture${duplicateCount > 1 ? 's' : ''}`,
-          type: NotificationType.Warning
+          type: NotificationType.Warning,
         });
         uploadAssetsStore.duplicateCounter.set(0);
       }

--- a/web/src/lib/stores/upload.ts
+++ b/web/src/lib/stores/upload.ts
@@ -3,6 +3,7 @@ import type { UploadAsset } from '../models/upload-asset';
 
 function createUploadStore() {
   const uploadAssets = writable<Array<UploadAsset>>([]);
+  const duplicateCounter = writable(0);
 
   const { subscribe } = uploadAssets;
 
@@ -35,6 +36,7 @@ function createUploadStore() {
 
   return {
     subscribe,
+    duplicateCounter,
     isUploading,
     addNewUploadAsset,
     updateProgress,

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -151,6 +151,10 @@ async function fileUploader(
     if (response.status == 200 || response.status == 201) {
       const res: AssetFileUploadResponseDto = response.data;
 
+      if (res.duplicate) {
+        uploadAssetsStore.duplicateCounter.update((count) => count + 1);
+      }
+
       if (albumId && res.id) {
         await addAssetsToAlbum(albumId, [res.id], sharedKey);
       }


### PR DESCRIPTION
## Description
  - Adds a warning notification
  - Increments a `duplicateCounter` for all duplicates uploaded
  - Displays new duplicate warning notification of total duplicate count after upload 

Fixes #2557


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Upload picture -> upload picture again -> verify warning notification with correct count and only reports `picture` instead of `pictures`
- [x] Upload many picture -> upload same pictures again -> verify warning notification with correct count and reports `pictures` instead of `picture`

## Screenshots (if appropriate):
![1_Duplicate](https://github.com/immich-app/immich/assets/3691245/99544e3c-c340-420f-b90e-9c417bf88f50)
![2_Duplicates](https://github.com/immich-app/immich/assets/3691245/286038c2-d607-4360-844c-0034e773816e)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable

## Credit:
Mostly copied from this [PR](https://github.com/immich-app/immich/pull/2845) but wanted to see the feature made, thank you @KotaUeshima!