### PR TITLE
feat(mobile): launch map app from exif info

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -70,5 +70,9 @@
       <action android:name="android.intent.action.VIEW" />
       <data android:scheme="https" />
     </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="geo" />
+    </intent>
   </queries>
 </manifest>


### PR DESCRIPTION
### Changes made in the PR:
Adds support for the following request:
- #3472 

### How Has This Been Tested?
- (Android) Ensured the map app is opened with marker directly if no other apps are available
- (Android) Ensured that the app list is displayed if multiple apps can handle the Uri
- (Android) Ensured that different map apps can handle the geo uri
- (Android) Ensured that the map is opened in the default WebView if no app can handle the Uri
- (iOS) Ensured that Apple maps are opened with marker to the correct location

### Video

https://github.com/immich-app/immich/assets/139912620/cb2b9262-98fb-4ec1-95b3-7fa598e0201a

⚠️ There is an upstream bug in the map dependency (flutter_map) which results in the attribution text receiving the tap input even when it is invisible resulting in the copyrights page of openstreetmap opening instead of navigating to the map app when the default animation for the attribution pop-up `FadeRAWA` is used.

https://github.com/fleaflet/flutter_map/issues/1589

This has been fixed and is planned for the 6.0.0 release. Switching the animation to `ScaleRAWA` will fix the issue but not sure if this is worth the change in animation for the attribution pop-up.