### PR TITLE
fix(web): show warning if upload completed with errors #2531

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -10,6 +10,7 @@
   let showDetail = true;
   let uploadLength = 0;
   let duplicateCount = 0;
+  let errorCount = 0;
   let isUploading = false;
 
   // Reactive action to update asset uploadLength whenever there is a new one added to the list
@@ -26,6 +27,10 @@
   uploadAssetsStore.duplicateCounter.subscribe((value) => {
     duplicateCount = value;
   });
+
+  uploadAssetsStore.errorCounter.subscribe((value) => {
+    errorCount = value;
+  });
 </script>
 
 {#if isUploading}
@@ -33,10 +38,17 @@
     in:fade={{ duration: 250 }}
     out:fade={{ duration: 250, delay: 1000 }}
     on:outroend={() => {
+      const errorInfo =
+        errorCount > 0 ? `Upload completed with ${errorCount} error${errorCount > 1 ? 's' : ''}` : 'Upload success';
+      const type = errorCount > 0 ? NotificationType.Warning : NotificationType.Info;
+
       notificationController.show({
-        message: 'Upload success, refresh the page to see new upload assets',
-        type: NotificationType.Info,
+        message: `${errorInfo}, refresh the page to see new upload assets`,
+        type,
       });
+
+      uploadAssetsStore.errorCounter.set(0);
+
       if (duplicateCount > 0) {
         notificationController.show({
           message: `Skipped ${duplicateCount} duplicate picture${duplicateCount > 1 ? 's' : ''}`,

--- a/web/src/lib/stores/upload.ts
+++ b/web/src/lib/stores/upload.ts
@@ -4,6 +4,7 @@ import type { UploadAsset } from '../models/upload-asset';
 function createUploadStore() {
   const uploadAssets = writable<Array<UploadAsset>>([]);
   const duplicateCounter = writable(0);
+  const errorCounter = writable(0);
 
   const { subscribe } = uploadAssets;
 
@@ -36,6 +37,7 @@ function createUploadStore() {
 
   return {
     subscribe,
+    errorCounter,
     duplicateCounter,
     isUploading,
     addNewUploadAsset,

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -173,6 +173,8 @@ async function fileUploader(
 }
 
 function handleUploadError(asset: File, respBody = '{}', extraMessage?: string) {
+  uploadAssetsStore.errorCounter.update((count) => count + 1);
+
   try {
     const res = JSON.parse(respBody);
 


### PR DESCRIPTION
## Description
  - Increments an `errorCounter` for all errors during upload
  - Uses the new warning notification if upload encountered errors during upload

Fixes #2531 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Upload picture -> simulate error -> verify warning notification with correct error count and only reports `error` instead of `errors`
- [x] Upload many pictures -> simulate multiple errors -> verify warning notification with correct count and reports `errors` instead of `error`
- [x] Upload many pictures without simulated errors -> verify standard success info notification pops up

## Screenshots (if appropriate):
![Screenshot from 2023-08-09 20-43-45](https://github.com/immich-app/immich/assets/3691245/bbdac983-39a9-4dfc-8a0f-452b248cb91b)
![Screenshot from 2023-08-09 20-49-15](https://github.com/immich-app/immich/assets/3691245/ebe73ebf-093a-4fd0-b1ae-e72f8cfabd38)
![Screenshot from 2023-08-09 20-52-16](https://github.com/immich-app/immich/assets/3691245/53f55666-4925-4537-b117-953c256cff29)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable