### PR TITLE
feat(web): allow closing asset viewer by clicking on background

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -279,33 +279,36 @@
     </div>
   {/if}
 
-  <div class="col-span-4 col-start-1 row-span-full row-start-1">
-    {#key asset.id}
-      {#if !asset.resized}
-        <div class="flex h-full w-full justify-center">
-          <div
-            class="px-auto flex aspect-square h-full items-center justify-center bg-gray-100 dark:bg-immich-dark-gray"
-          >
-            <ImageBrokenVariant size="25%" />
+  <div class="col-span-4 col-start-1 row-span-full row-start-1 flex place-items-center">
+    <div class="absolute inset-0 cursor-pointer" on:click={closeViewer}></div>
+    <div class="relative">
+      {#key asset.id}
+        {#if !asset.resized}
+          <div class="flex h-full w-full justify-center">
+            <div
+              class="px-auto flex aspect-square h-full items-center justify-center bg-gray-100 dark:bg-immich-dark-gray"
+            >
+              <ImageBrokenVariant size="25%" />
+            </div>
           </div>
-        </div>
-      {:else if asset.type === AssetTypeEnum.Image}
-        {#if shouldPlayMotionPhoto && asset.livePhotoVideoId}
-          <VideoViewer
-            {publicSharedKey}
-            assetId={asset.livePhotoVideoId}
-            on:close={closeViewer}
-            on:onVideoEnded={() => (shouldPlayMotionPhoto = false)}
-          />
-        {:else if asset.exifInfo?.projectionType === ProjectionType.EQUIRECTANGULAR}
-          <PanoramaViewer {publicSharedKey} {asset} />
+        {:else if asset.type === AssetTypeEnum.Image}
+          {#if shouldPlayMotionPhoto && asset.livePhotoVideoId}
+            <VideoViewer
+              {publicSharedKey}
+              assetId={asset.livePhotoVideoId}
+              on:close={closeViewer}
+              on:onVideoEnded={() => (shouldPlayMotionPhoto = false)}
+            />
+          {:else if asset.exifInfo?.projectionType === ProjectionType.EQUIRECTANGULAR}
+            <PanoramaViewer {publicSharedKey} {asset} />
+          {:else}
+            <PhotoViewer {publicSharedKey} {asset} on:close={closeViewer} />
+          {/if}
         {:else}
-          <PhotoViewer {publicSharedKey} {asset} on:close={closeViewer} />
+          <VideoViewer {publicSharedKey} assetId={asset.id} on:close={closeViewer} />
         {/if}
-      {:else}
-        <VideoViewer {publicSharedKey} assetId={asset.id} on:close={closeViewer} />
-      {/if}
-    {/key}
+      {/key}
+    </div>
   </div>
 
   {#if showNavigation}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -279,36 +279,35 @@
     </div>
   {/if}
 
-  <div class="col-span-4 col-start-1 row-span-full row-start-1 flex place-items-center">
-    <div class="absolute inset-0 cursor-pointer" on:click={closeViewer}></div>
-    <div class="relative">
-      {#key asset.id}
-        {#if !asset.resized}
-          <div class="flex h-full w-full justify-center">
-            <div
-              class="px-auto flex aspect-square h-full items-center justify-center bg-gray-100 dark:bg-immich-dark-gray"
-            >
-              <ImageBrokenVariant size="25%" />
-            </div>
+  <div class="relative col-span-4 col-start-1 row-span-full row-start-1 cursor-pointer" on:click={closeViewer}></div>
+
+  <div class="col-span-4 col-start-1 row-span-full row-start-1 flex place-content-center place-items-center">
+    {#key asset.id}
+      {#if !asset.resized}
+        <div class="flex h-full w-full justify-center">
+          <div
+            class="px-auto flex aspect-square h-full items-center justify-center bg-gray-100 dark:bg-immich-dark-gray"
+          >
+            <ImageBrokenVariant class="relative" size="25%" />
           </div>
-        {:else if asset.type === AssetTypeEnum.Image}
-          {#if shouldPlayMotionPhoto && asset.livePhotoVideoId}
-            <VideoViewer
-              {publicSharedKey}
-              assetId={asset.livePhotoVideoId}
-              on:close={closeViewer}
-              on:onVideoEnded={() => (shouldPlayMotionPhoto = false)}
-            />
-          {:else if asset.exifInfo?.projectionType === ProjectionType.EQUIRECTANGULAR}
-            <PanoramaViewer {publicSharedKey} {asset} />
-          {:else}
-            <PhotoViewer {publicSharedKey} {asset} on:close={closeViewer} />
-          {/if}
+        </div>
+      {:else if asset.type === AssetTypeEnum.Image}
+        {#if shouldPlayMotionPhoto && asset.livePhotoVideoId}
+          <VideoViewer
+            {publicSharedKey}
+            assetId={asset.livePhotoVideoId}
+            on:close={closeViewer}
+            on:onVideoEnded={() => (shouldPlayMotionPhoto = false)}
+          />
+        {:else if asset.exifInfo?.projectionType === ProjectionType.EQUIRECTANGULAR}
+          <PanoramaViewer {publicSharedKey} {asset} />
         {:else}
-          <VideoViewer {publicSharedKey} assetId={asset.id} on:close={closeViewer} />
+          <PhotoViewer {publicSharedKey} {asset} on:close={closeViewer} />
         {/if}
-      {/key}
-    </div>
+      {:else}
+        <VideoViewer {publicSharedKey} assetId={asset.id} on:close={closeViewer} />
+      {/if}
+    {/key}
   </div>
 
   {#if showNavigation}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -279,7 +279,7 @@
     </div>
   {/if}
 
-  <div class="relative col-span-4 col-start-1 row-span-full row-start-1 cursor-pointer" on:click={closeViewer}></div>
+  <div class="z-10 col-span-4 col-start-1 row-span-full row-start-1 cursor-pointer" on:click={closeViewer}></div>
 
   <div class="col-span-4 col-start-1 row-span-full row-start-1 flex place-content-center place-items-center">
     {#key asset.id}
@@ -288,7 +288,7 @@
           <div
             class="px-auto flex aspect-square h-full items-center justify-center bg-gray-100 dark:bg-immich-dark-gray"
           >
-            <ImageBrokenVariant class="relative" size="25%" />
+            <ImageBrokenVariant class="relative z-10" size="25%" />
           </div>
         </div>
       {:else if asset.type === AssetTypeEnum.Image}

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -27,7 +27,7 @@
   };
 </script>
 
-<div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
+<div transition:fade={{ duration: 150 }} class="select-none">
   {#await loadAssetData()}
     <LoadingSpinner />
   {:then assetData}

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -27,12 +27,12 @@
   };
 </script>
 
-<div transition:fade={{ duration: 150 }} class="select-none">
+<div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   {#await loadAssetData()}
     <LoadingSpinner />
   {:then assetData}
     {#if assetData}
-      <View360 autoResize={true} initialZoom={0.5} projection={new EquirectProjection({ src: assetData })} />
+      <View360 class="relative" autoResize={true} initialZoom={0.5} projection={new EquirectProjection({ src: assetData })} />
     {:else}
       <p>{errorMessage}</p>
     {/if}

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -32,7 +32,7 @@
     <LoadingSpinner />
   {:then assetData}
     {#if assetData}
-      <View360 class="relative" autoResize={true} initialZoom={0.5} projection={new EquirectProjection({ src: assetData })} />
+      <View360 class="relative z-10" autoResize={true} initialZoom={0.5} projection={new EquirectProjection({ src: assetData })} />
     {:else}
       <p>{errorMessage}</p>
     {/if}

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -113,7 +113,7 @@
         transition:fade={{ duration: 150 }}
         src={assetData}
         alt={asset.id}
-        class="object-contain"
+        class="relative object-contain"
         draggable="false"
       />
     </div>

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -103,17 +103,17 @@
 <div
   bind:this={element}
   transition:fade={{ duration: 150 }}
-  class="flex h-full select-none place-content-center place-items-center"
+  class="select-none"
 >
   {#await loadAssetData()}
     <LoadingSpinner />
   {:then assetData}
-    <div bind:this={imgElement} class="h-full w-full">
+    <div bind:this={imgElement}>
       <img
         transition:fade={{ duration: 150 }}
         src={assetData}
         alt={asset.id}
-        class="h-full w-full object-contain"
+        class="object-contain"
         draggable="false"
       />
     </div>

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -113,7 +113,7 @@
         transition:fade={{ duration: 150 }}
         src={assetData}
         alt={asset.id}
-        class="relative object-contain"
+        class="relative z-10 object-contain"
         draggable="false"
       />
     </div>

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -24,6 +24,7 @@
 
 <div transition:fade={{ duration: 150 }} class="select-none">
   <video
+    class="relative"
     controls
     on:canplay={handleCanPlay}
     on:ended={() => dispatch('onVideoEnded')}

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -22,10 +22,9 @@
   };
 </script>
 
-<div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
+<div transition:fade={{ duration: 150 }} class="select-none">
   <video
     controls
-    class="h-full object-contain"
     on:canplay={handleCanPlay}
     on:ended={() => dispatch('onVideoEnded')}
     bind:volume={$videoViewerVolume}

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -24,7 +24,7 @@
 
 <div transition:fade={{ duration: 150 }} class="select-none">
   <video
-    class="relative"
+    class="relative z-10"
     controls
     on:canplay={handleCanPlay}
     on:ended={() => dispatch('onVideoEnded')}


### PR DESCRIPTION
## Description
Currently, the only ways to close the asset viewer in the web application is by clicking the arrow in the top left or by using the keyboard. This adds another way, that may be convenient when using the web application using primarily a mouse, by clicking outside the region of the asset, but not over any of the overlays (navigation, etc).

This is done is by creating another element covering the screen solely to capture clicks, and then raising the assets above this. Styles for centering the assets are moved upwards, so that the assets can take only their needed space so as to not block the cursor capturing.

We also make sure that only the actual assets are raised high enough in the stacking context and not loading spinners so that we can still click through loading spinners to close the viewer (to me this makes sense, loading spinners seem like they should be "transparent" and not block this, not sure if others agree)


## How Has This Been Tested?

This has just been manually tested, making sure that the functionality works, and that all of the different types of viewers (Photo, Video, Panorama) still work correctly.

## Screenshots (if appropriate):

https://github.com/immich-app/immich/assets/25019123/3f35221d-9faf-4a38-868d-945902412995


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable