### PR TITLE
fix(server): time bucket and where

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -398,7 +398,7 @@ export class AssetRepository implements IAssetRepository {
     }
 
     if (userId) {
-      builder = builder.where('asset.ownerId = :userId', { userId });
+      builder = builder.andWhere('asset.ownerId = :userId', { userId });
     }
 
     if (isArchived != undefined) {


### PR DESCRIPTION
`where` vs `andWhere` was overriding the previous (where) `isVisible` condition for the timeline and partner sharing views.

| Before | After
| -| - |
| ![image](https://github.com/immich-app/immich/assets/4334196/b446db5e-11d4-4058-8af8-454e57064d0a) |  ![image](https://github.com/immich-app/immich/assets/4334196/204a3c64-b153-4274-8396-ea4737dcbd94) |

