### PR TITLE
fix(mobile): Backup album select search displays incorrect count

### DIFF
--- a/mobile/lib/modules/backup/ui/album_info_list_tile.dart
+++ b/mobile/lib/modules/backup/ui/album_info_list_tile.dart
@@ -41,7 +41,7 @@ class AlbumInfoListTile extends HookConsumerWidget {
         albumInfo.assetCount.then((value) => assetCount.value = value);
         return null;
       },
-      [],
+      [albumInfo],
     );
 
     buildImageFilter() {


### PR DESCRIPTION
This change fixes the issue reported in [here](https://github.com/immich-app/immich/issues/2050#issue-1636601451)
The fix is very simple and the bug reported was due to the use of the useEffect hook in the AlbumInfoListTile had an empty dependency list which caused the useEffect to only run once at the start of the widget creation/rendering.

Adding the correct dependency item to the hook will now make it so any change that is detected on the album file count -- in this case when performing a search -- will update this count in the view reflecting the correct album count

here is what the issue currently looks like in main
![before](https://github.com/immich-app/immich/assets/20519640/648085ad-fdde-463d-9f2d-627a090466e0)
 and here is the result of the update 
![after](https://github.com/immich-app/immich/assets/20519640/37f4ef52-1671-438f-928a-a86e38ea0a16)

Testing:
I did not see any unit of integration test that covered this and I did try to add one but my lack of familiarity with the codebase made it extremely difficult to make it work.
I tested this on both android and ios simulators as well as my own iPhone to make sure the change works as expected.

if i have missed something to test please let me know.
