### PR TITLE
fix(server): build vips without tiff

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /usr/src/app
 COPY bin/install-ffmpeg.sh build-lock.json ./
 RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && apt-get install -yqq build-essential ninja-build meson pkg-config jq zlib1g autoconf \
-libglib2.0-dev libexpat1-dev librsvg2-dev libexif-dev libwebp-dev liborc-0.4-dev libtiff5-dev \
-libjpeg62-turbo-dev libgsf-1-dev libspng-dev libjxl-dev libheif-dev \
+libglib2.0-dev libexpat1-dev librsvg2-dev libexif-dev libwebp-dev liborc-0.4-dev \
+libjpeg62-turbo-dev libgsf-1-dev libspng-dev libjxl-dev libheif-dev liblcms2-2 \
 mesa-va-drivers libmimalloc2.0 $(if [ $(arch) = "x86_64" ]; then echo "intel-media-va-driver-non-free"; fi) \
 && ./install-ffmpeg.sh && apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -38,7 +38,7 @@ WORKDIR /usr/src/app
 COPY bin/install-ffmpeg.sh build-lock.json ./
 RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
 RUN apt-get update && apt-get install -yqq tini libheif1 libwebp7 libwebpdemux2 libwebpmux3 mesa-va-drivers \
-libjpeg62-turbo libexpat1 librsvg2-2 libjxl0.7 libtiff6 libspng0 libexif12 libgcc-s1 libglib2.0-0 \
+libjpeg62-turbo libexpat1 librsvg2-2 libjxl0.7 libspng0 libexif12 libgcc-s1 libglib2.0-0 \
 libgsf-1-114 libopenjp2-7 liblcms2-2 liborc-0.4-0 libopenexr-3-1-30 liblqr-1-0 libltdl7 zlib1g libgomp1 \
 mesa-va-drivers libmimalloc2.0 $(if [ $(arch) = "x86_64" ]; then echo "intel-media-va-driver-non-free"; fi) jq wget \
 && ./install-ffmpeg.sh && apt-get remove -yqq jq wget && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* \

--- a/server/bin/build-libvips.sh
+++ b/server/bin/build-libvips.sh
@@ -14,7 +14,7 @@ tar -xvf vips-${LIBVIPS_VERSION}.tar.xz -C libvips --strip-components=1
 rm vips-${LIBVIPS_VERSION}.tar.xz
 rm libvips.sha256
 cd libvips
-meson setup build --buildtype=release --libdir=lib -Dintrospection=false
+meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled
 cd build
 # ninja test  # tests set concurrency too high for arm/v7
 ninja install

--- a/server/build-lock.json
+++ b/server/build-lock.json
@@ -12,8 +12,8 @@
     },
     {
       "name": "libvips",
-      "version": "8.14.2",
-      "sha256": "27dad021f0835a5ab14e541d02abd41e4c3bd012d2196438df5a9e754984f7ce"
+      "version": "8.14.3",
+      "sha256": "f884d61a6b54c99cdae855001c8b9523e13b4982be7e76cac03faccb91be105c"
     },
     {
       "name": "ffmpeg",


### PR DESCRIPTION
## Description

While libvips now supports CR2 images, NEF images are still processed incorrectly as it only converts the embedded thumbnail in these formats instead of the full image. Until this is fixed, it's better to rely on Imagemagick for these files as it's more reliable.

This PR is similar to #3648, but doesn't require manually handling this in code. Once NEF images are processed correctly, switching back to libvips for these files will be similarly seamless.


Fixes #3068


## How Has This Been Tested?

The sample image in #3068 is processed correctly with this fix.

![blackbird](https://github.com/immich-app/immich/assets/101130780/fed4a176-d4f9-4b09-b39d-9ddf627f0684)