### PR TITLE
fix(server): libvips meson flag

### DIFF
--- a/server/bin/build-libvips.sh
+++ b/server/bin/build-libvips.sh
@@ -14,7 +14,7 @@ tar -xvf vips-${LIBVIPS_VERSION}.tar.xz -C libvips --strip-components=1
 rm vips-${LIBVIPS_VERSION}.tar.xz
 rm libvips.sha256
 cd libvips
-meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled
+meson setup build --buildtype=release --libdir=lib -Dintrospection=false -Dtiff=disabled
 cd build
 # ninja test  # tests set concurrency too high for arm/v7
 ninja install


### PR DESCRIPTION
## Description

Minor fix to use `false` instead of `disabled` for `-Dintrospection`. I think this worked locally because it reused an earlier build configuration instead of making it from scratch.


## How Has This Been Tested?

It builds without any errors, and thumbnail generation works as expected.