### PR TITLE
feat(server): wide gamut thumbnails

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -1049,6 +1049,20 @@ export interface ClassificationConfig {
 /**
  * 
  * @export
+ * @enum {string}
+ */
+
+export const Colorspace = {
+    Srgb: 'srgb',
+    P3: 'p3'
+} as const;
+
+export type Colorspace = typeof Colorspace[keyof typeof Colorspace];
+
+
+/**
+ * 
+ * @export
  * @interface CreateAlbumDto
  */
 export interface CreateAlbumDto {
@@ -3186,6 +3200,12 @@ export interface SystemConfigTemplateStorageOptionDto {
 export interface SystemConfigThumbnailDto {
     /**
      * 
+     * @type {Colorspace}
+     * @memberof SystemConfigThumbnailDto
+     */
+    'colorspace': Colorspace;
+    /**
+     * 
      * @type {number}
      * @memberof SystemConfigThumbnailDto
      */
@@ -3202,13 +3222,9 @@ export interface SystemConfigThumbnailDto {
      * @memberof SystemConfigThumbnailDto
      */
     'webpSize': number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SystemConfigThumbnailDto
-     */
-    'wideGamut': boolean;
 }
+
+
 /**
  * 
  * @export

--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -3195,7 +3195,19 @@ export interface SystemConfigThumbnailDto {
      * @type {number}
      * @memberof SystemConfigThumbnailDto
      */
+    'quality': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof SystemConfigThumbnailDto
+     */
     'webpSize': number;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SystemConfigThumbnailDto
+     */
+    'wideGamut': boolean;
 }
 /**
  * 

--- a/mobile/openapi/.openapi-generator/FILES
+++ b/mobile/openapi/.openapi-generator/FILES
@@ -44,6 +44,7 @@ doc/CheckDuplicateAssetResponseDto.md
 doc/CheckExistingAssetsDto.md
 doc/CheckExistingAssetsResponseDto.md
 doc/ClassificationConfig.md
+doc/Colorspace.md
 doc/CreateAlbumDto.md
 doc/CreateProfileImageResponseDto.md
 doc/CreateTagDto.md
@@ -199,6 +200,7 @@ lib/model/check_existing_assets_response_dto.dart
 lib/model/classification_config.dart
 lib/model/clip_config.dart
 lib/model/clip_mode.dart
+lib/model/colorspace.dart
 lib/model/cq_mode.dart
 lib/model/create_album_dto.dart
 lib/model/create_profile_image_response_dto.dart
@@ -326,6 +328,7 @@ test/check_existing_assets_response_dto_test.dart
 test/classification_config_test.dart
 test/clip_config_test.dart
 test/clip_mode_test.dart
+test/colorspace_test.dart
 test/cq_mode_test.dart
 test/create_album_dto_test.dart
 test/create_profile_image_response_dto_test.dart

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -218,6 +218,7 @@ Class | Method | HTTP request | Description
  - [CheckExistingAssetsDto](doc//CheckExistingAssetsDto.md)
  - [CheckExistingAssetsResponseDto](doc//CheckExistingAssetsResponseDto.md)
  - [ClassificationConfig](doc//ClassificationConfig.md)
+ - [Colorspace](doc//Colorspace.md)
  - [CreateAlbumDto](doc//CreateAlbumDto.md)
  - [CreateProfileImageResponseDto](doc//CreateProfileImageResponseDto.md)
  - [CreateTagDto](doc//CreateTagDto.md)

--- a/mobile/openapi/doc/Colorspace.md
+++ b/mobile/openapi/doc/Colorspace.md
@@ -1,0 +1,14 @@
+# openapi.model.Colorspace
+
+## Load the model package
+```dart
+import 'package:openapi/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/mobile/openapi/doc/SystemConfigThumbnailDto.md
+++ b/mobile/openapi/doc/SystemConfigThumbnailDto.md
@@ -9,7 +9,9 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **jpegSize** | **int** |  | 
+**quality** | **int** |  | 
 **webpSize** | **int** |  | 
+**wideGamut** | **bool** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/doc/SystemConfigThumbnailDto.md
+++ b/mobile/openapi/doc/SystemConfigThumbnailDto.md
@@ -8,10 +8,10 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**colorspace** | [**Colorspace**](Colorspace.md) |  | 
 **jpegSize** | **int** |  | 
 **quality** | **int** |  | 
 **webpSize** | **int** |  | 
-**wideGamut** | **bool** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -80,6 +80,7 @@ part 'model/check_duplicate_asset_response_dto.dart';
 part 'model/check_existing_assets_dto.dart';
 part 'model/check_existing_assets_response_dto.dart';
 part 'model/classification_config.dart';
+part 'model/colorspace.dart';
 part 'model/create_album_dto.dart';
 part 'model/create_profile_image_response_dto.dart';
 part 'model/create_tag_dto.dart';

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -253,6 +253,8 @@ class ApiClient {
           return CheckExistingAssetsResponseDto.fromJson(value);
         case 'ClassificationConfig':
           return ClassificationConfig.fromJson(value);
+        case 'Colorspace':
+          return ColorspaceTypeTransformer().decode(value);
         case 'CreateAlbumDto':
           return CreateAlbumDto.fromJson(value);
         case 'CreateProfileImageResponseDto':

--- a/mobile/openapi/lib/api_helper.dart
+++ b/mobile/openapi/lib/api_helper.dart
@@ -70,6 +70,9 @@ String parameterToString(dynamic value) {
   if (value is CQMode) {
     return CQModeTypeTransformer().encode(value).toString();
   }
+  if (value is Colorspace) {
+    return ColorspaceTypeTransformer().encode(value).toString();
+  }
   if (value is DeleteAssetStatus) {
     return DeleteAssetStatusTypeTransformer().encode(value).toString();
   }

--- a/mobile/openapi/lib/model/colorspace.dart
+++ b/mobile/openapi/lib/model/colorspace.dart
@@ -1,0 +1,85 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+
+class Colorspace {
+  /// Instantiate a new enum with the provided [value].
+  const Colorspace._(this.value);
+
+  /// The underlying value of this enum member.
+  final String value;
+
+  @override
+  String toString() => value;
+
+  String toJson() => value;
+
+  static const srgb = Colorspace._(r'srgb');
+  static const p3 = Colorspace._(r'p3');
+
+  /// List of all possible values in this [enum][Colorspace].
+  static const values = <Colorspace>[
+    srgb,
+    p3,
+  ];
+
+  static Colorspace? fromJson(dynamic value) => ColorspaceTypeTransformer().decode(value);
+
+  static List<Colorspace>? listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <Colorspace>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = Colorspace.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+}
+
+/// Transformation class that can [encode] an instance of [Colorspace] to String,
+/// and [decode] dynamic data back to [Colorspace].
+class ColorspaceTypeTransformer {
+  factory ColorspaceTypeTransformer() => _instance ??= const ColorspaceTypeTransformer._();
+
+  const ColorspaceTypeTransformer._();
+
+  String encode(Colorspace data) => data.value;
+
+  /// Decodes a [dynamic value][data] to a Colorspace.
+  ///
+  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
+  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
+  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
+  ///
+  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
+  /// and users are still using an old app with the old code.
+  Colorspace? decode(dynamic data, {bool allowNull = true}) {
+    if (data != null) {
+      switch (data) {
+        case r'srgb': return Colorspace.srgb;
+        case r'p3': return Colorspace.p3;
+        default:
+          if (!allowNull) {
+            throw ArgumentError('Unknown enum value to decode: $data');
+          }
+      }
+    }
+    return null;
+  }
+
+  /// Singleton [ColorspaceTypeTransformer] instance.
+  static ColorspaceTypeTransformer? _instance;
+}
+

--- a/mobile/openapi/lib/model/system_config_thumbnail_dto.dart
+++ b/mobile/openapi/lib/model/system_config_thumbnail_dto.dart
@@ -14,31 +14,43 @@ class SystemConfigThumbnailDto {
   /// Returns a new [SystemConfigThumbnailDto] instance.
   SystemConfigThumbnailDto({
     required this.jpegSize,
+    required this.quality,
     required this.webpSize,
+    required this.wideGamut,
   });
 
   int jpegSize;
 
+  int quality;
+
   int webpSize;
+
+  bool wideGamut;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigThumbnailDto &&
      other.jpegSize == jpegSize &&
-     other.webpSize == webpSize;
+     other.quality == quality &&
+     other.webpSize == webpSize &&
+     other.wideGamut == wideGamut;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (jpegSize.hashCode) +
-    (webpSize.hashCode);
+    (quality.hashCode) +
+    (webpSize.hashCode) +
+    (wideGamut.hashCode);
 
   @override
-  String toString() => 'SystemConfigThumbnailDto[jpegSize=$jpegSize, webpSize=$webpSize]';
+  String toString() => 'SystemConfigThumbnailDto[jpegSize=$jpegSize, quality=$quality, webpSize=$webpSize, wideGamut=$wideGamut]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'jpegSize'] = this.jpegSize;
+      json[r'quality'] = this.quality;
       json[r'webpSize'] = this.webpSize;
+      json[r'wideGamut'] = this.wideGamut;
     return json;
   }
 
@@ -51,7 +63,9 @@ class SystemConfigThumbnailDto {
 
       return SystemConfigThumbnailDto(
         jpegSize: mapValueOfType<int>(json, r'jpegSize')!,
+        quality: mapValueOfType<int>(json, r'quality')!,
         webpSize: mapValueOfType<int>(json, r'webpSize')!,
+        wideGamut: mapValueOfType<bool>(json, r'wideGamut')!,
       );
     }
     return null;
@@ -100,7 +114,9 @@ class SystemConfigThumbnailDto {
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
     'jpegSize',
+    'quality',
     'webpSize',
+    'wideGamut',
   };
 }
 

--- a/mobile/openapi/lib/model/system_config_thumbnail_dto.dart
+++ b/mobile/openapi/lib/model/system_config_thumbnail_dto.dart
@@ -13,11 +13,13 @@ part of openapi.api;
 class SystemConfigThumbnailDto {
   /// Returns a new [SystemConfigThumbnailDto] instance.
   SystemConfigThumbnailDto({
+    required this.colorspace,
     required this.jpegSize,
     required this.quality,
     required this.webpSize,
-    required this.wideGamut,
   });
+
+  Colorspace colorspace;
 
   int jpegSize;
 
@@ -25,32 +27,30 @@ class SystemConfigThumbnailDto {
 
   int webpSize;
 
-  bool wideGamut;
-
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigThumbnailDto &&
+     other.colorspace == colorspace &&
      other.jpegSize == jpegSize &&
      other.quality == quality &&
-     other.webpSize == webpSize &&
-     other.wideGamut == wideGamut;
+     other.webpSize == webpSize;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (colorspace.hashCode) +
     (jpegSize.hashCode) +
     (quality.hashCode) +
-    (webpSize.hashCode) +
-    (wideGamut.hashCode);
+    (webpSize.hashCode);
 
   @override
-  String toString() => 'SystemConfigThumbnailDto[jpegSize=$jpegSize, quality=$quality, webpSize=$webpSize, wideGamut=$wideGamut]';
+  String toString() => 'SystemConfigThumbnailDto[colorspace=$colorspace, jpegSize=$jpegSize, quality=$quality, webpSize=$webpSize]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+      json[r'colorspace'] = this.colorspace;
       json[r'jpegSize'] = this.jpegSize;
       json[r'quality'] = this.quality;
       json[r'webpSize'] = this.webpSize;
-      json[r'wideGamut'] = this.wideGamut;
     return json;
   }
 
@@ -62,10 +62,10 @@ class SystemConfigThumbnailDto {
       final json = value.cast<String, dynamic>();
 
       return SystemConfigThumbnailDto(
+        colorspace: Colorspace.fromJson(json[r'colorspace'])!,
         jpegSize: mapValueOfType<int>(json, r'jpegSize')!,
         quality: mapValueOfType<int>(json, r'quality')!,
         webpSize: mapValueOfType<int>(json, r'webpSize')!,
-        wideGamut: mapValueOfType<bool>(json, r'wideGamut')!,
       );
     }
     return null;
@@ -113,10 +113,10 @@ class SystemConfigThumbnailDto {
 
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
+    'colorspace',
     'jpegSize',
     'quality',
     'webpSize',
-    'wideGamut',
   };
 }
 

--- a/mobile/openapi/test/colorspace_test.dart
+++ b/mobile/openapi/test/colorspace_test.dart
@@ -1,0 +1,21 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:openapi/api.dart';
+import 'package:test/test.dart';
+
+// tests for Colorspace
+void main() {
+
+  group('test Colorspace', () {
+
+  });
+
+}

--- a/mobile/openapi/test/system_config_thumbnail_dto_test.dart
+++ b/mobile/openapi/test/system_config_thumbnail_dto_test.dart
@@ -16,6 +16,11 @@ void main() {
   // final instance = SystemConfigThumbnailDto();
 
   group('test SystemConfigThumbnailDto', () {
+    // Colorspace colorspace
+    test('to test the property `colorspace`', () async {
+      // TODO
+    });
+
     // int jpegSize
     test('to test the property `jpegSize`', () async {
       // TODO
@@ -28,11 +33,6 @@ void main() {
 
     // int webpSize
     test('to test the property `webpSize`', () async {
-      // TODO
-    });
-
-    // bool wideGamut
-    test('to test the property `wideGamut`', () async {
       // TODO
     });
 

--- a/mobile/openapi/test/system_config_thumbnail_dto_test.dart
+++ b/mobile/openapi/test/system_config_thumbnail_dto_test.dart
@@ -21,8 +21,18 @@ void main() {
       // TODO
     });
 
+    // int quality
+    test('to test the property `quality`', () async {
+      // TODO
+    });
+
     // int webpSize
     test('to test the property `webpSize`', () async {
+      // TODO
+    });
+
+    // bool wideGamut
+    test('to test the property `wideGamut`', () async {
       // TODO
     });
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -7287,13 +7287,21 @@
           "jpegSize": {
             "type": "integer"
           },
+          "quality": {
+            "type": "integer"
+          },
           "webpSize": {
             "type": "integer"
+          },
+          "wideGamut": {
+            "type": "boolean"
           }
         },
         "required": [
           "webpSize",
-          "jpegSize"
+          "jpegSize",
+          "quality",
+          "wideGamut"
         ],
         "type": "object"
       },

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -5523,6 +5523,13 @@
         ],
         "type": "object"
       },
+      "Colorspace": {
+        "enum": [
+          "srgb",
+          "p3"
+        ],
+        "type": "string"
+      },
       "CreateAlbumDto": {
         "properties": {
           "albumName": {
@@ -7284,6 +7291,9 @@
       },
       "SystemConfigThumbnailDto": {
         "properties": {
+          "colorspace": {
+            "$ref": "#/components/schemas/Colorspace"
+          },
           "jpegSize": {
             "type": "integer"
           },
@@ -7292,16 +7302,13 @@
           },
           "webpSize": {
             "type": "integer"
-          },
-          "wideGamut": {
-            "type": "boolean"
           }
         },
         "required": [
           "webpSize",
           "jpegSize",
           "quality",
-          "wideGamut"
+          "colorspace"
         ],
         "type": "object"
       },

--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsNotEmpty, IsOptional, IsString, IsUUID, ValidationOptions, ValidateIf } from 'class-validator';
 import { basename, extname } from 'node:path';
 import sanitize from 'sanitize-filename';
+import { Stream } from 'stream';
 
 export type Options = {
   optional?: boolean;

--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -3,7 +3,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsNotEmpty, IsOptional, IsString, IsUUID, ValidationOptions, ValidateIf } from 'class-validator';
 import { basename, extname } from 'node:path';
 import sanitize from 'sanitize-filename';
-import { Stream } from 'stream';
 
 export type Options = {
   optional?: boolean;

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -97,7 +97,6 @@ const faceSearch = {
 describe(FacialRecognitionService.name, () => {
   let sut: FacialRecognitionService;
   let assetMock: jest.Mocked<IAssetRepository>;
-  let configMock: jest.Mocked<ISystemConfigRepository>;
   let faceMock: jest.Mocked<IFaceRepository>;
   let jobMock: jest.Mocked<IJobRepository>;
   let machineLearningMock: jest.Mocked<IMachineLearningRepository>;
@@ -109,7 +108,6 @@ describe(FacialRecognitionService.name, () => {
 
   beforeEach(async () => {
     assetMock = newAssetRepositoryMock();
-    configMock = newSystemConfigRepositoryMock();
     faceMock = newFaceRepositoryMock();
     jobMock = newJobRepositoryMock();
     machineLearningMock = newMachineLearningRepositoryMock();
@@ -123,7 +121,6 @@ describe(FacialRecognitionService.name, () => {
 
     sut = new FacialRecognitionService(
       assetMock,
-      configMock,
       faceMock,
       jobMock,
       machineLearningMock,

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -96,6 +96,7 @@ const faceSearch = {
 
 describe(FacialRecognitionService.name, () => {
   let sut: FacialRecognitionService;
+  let configMock: jest.Mocked<ISystemConfigRepository>;
   let assetMock: jest.Mocked<IAssetRepository>;
   let faceMock: jest.Mocked<IFaceRepository>;
   let jobMock: jest.Mocked<IJobRepository>;
@@ -104,10 +105,10 @@ describe(FacialRecognitionService.name, () => {
   let personMock: jest.Mocked<IPersonRepository>;
   let searchMock: jest.Mocked<ISearchRepository>;
   let storageMock: jest.Mocked<IStorageRepository>;
-  let configMock: jest.Mocked<ISystemConfigRepository>;
 
   beforeEach(async () => {
     assetMock = newAssetRepositoryMock();
+    configMock = newSystemConfigRepositoryMock();
     faceMock = newFaceRepositoryMock();
     jobMock = newJobRepositoryMock();
     machineLearningMock = newMachineLearningRepositoryMock();
@@ -115,12 +116,12 @@ describe(FacialRecognitionService.name, () => {
     personMock = newPersonRepositoryMock();
     searchMock = newSearchRepositoryMock();
     storageMock = newStorageRepositoryMock();
-    configMock = newSystemConfigRepositoryMock();
 
     mediaMock.crop.mockResolvedValue(croppedFace);
 
     sut = new FacialRecognitionService(
       assetMock,
+      configMock,
       faceMock,
       jobMock,
       machineLearningMock,
@@ -128,7 +129,6 @@ describe(FacialRecognitionService.name, () => {
       personMock,
       searchMock,
       storageMock,
-      configMock,
     );
   });
 

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -96,8 +96,8 @@ const faceSearch = {
 
 describe(FacialRecognitionService.name, () => {
   let sut: FacialRecognitionService;
-  let configMock: jest.Mocked<ISystemConfigRepository>;
   let assetMock: jest.Mocked<IAssetRepository>;
+  let configMock: jest.Mocked<ISystemConfigRepository>;
   let faceMock: jest.Mocked<IFaceRepository>;
   let jobMock: jest.Mocked<IJobRepository>;
   let machineLearningMock: jest.Mocked<IMachineLearningRepository>;

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -1,3 +1,4 @@
+import { Colorspace } from '@app/infra/entities';
 import {
   assetStub,
   faceStub,
@@ -22,7 +23,6 @@ import { IStorageRepository } from '../storage';
 import { ISystemConfigRepository } from '../system-config';
 import { IFaceRepository } from './face.repository';
 import { FacialRecognitionService } from './facial-recognition.services';
-import { Colorspace } from '@app/infra/entities';
 
 const croppedFace = Buffer.from('Cropped Face');
 

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -104,6 +104,7 @@ describe(FacialRecognitionService.name, () => {
   let personMock: jest.Mocked<IPersonRepository>;
   let searchMock: jest.Mocked<ISearchRepository>;
   let storageMock: jest.Mocked<IStorageRepository>;
+  let configMock: jest.Mocked<ISystemConfigRepository>;
 
   beforeEach(async () => {
     assetMock = newAssetRepositoryMock();
@@ -129,6 +130,7 @@ describe(FacialRecognitionService.name, () => {
       personMock,
       searchMock,
       storageMock,
+      configMock,
     );
   });
 
@@ -292,6 +294,8 @@ describe(FacialRecognitionService.name, () => {
       expect(mediaMock.resize).toHaveBeenCalledWith(croppedFace, 'upload/thumbs/user-id/person-1.jpeg', {
         format: 'jpeg',
         size: 250,
+        quality: 80,
+        wideGamut: true,
       });
       expect(personMock.update).toHaveBeenCalledWith({
         id: 'person-1',
@@ -313,6 +317,8 @@ describe(FacialRecognitionService.name, () => {
       expect(mediaMock.resize).toHaveBeenCalledWith(croppedFace, 'upload/thumbs/user-id/person-1.jpeg', {
         format: 'jpeg',
         size: 250,
+        quality: 80,
+        wideGamut: true,
       });
     });
 
@@ -330,6 +336,8 @@ describe(FacialRecognitionService.name, () => {
       expect(mediaMock.resize).toHaveBeenCalledWith(croppedFace, 'upload/thumbs/user-id/person-1.jpeg', {
         format: 'jpeg',
         size: 250,
+        quality: 80,
+        wideGamut: true,
       });
     });
   });

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -295,7 +295,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        wideGamut: true,
+        colorspace: 'p3',
       });
       expect(personMock.update).toHaveBeenCalledWith({
         id: 'person-1',
@@ -318,7 +318,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        wideGamut: true,
+        colorspace: 'p3',
       });
     });
 
@@ -337,7 +337,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        wideGamut: true,
+        colorspace: 'p3',
       });
     });
   });

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -295,7 +295,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        colorspace: 'p3',
+        colorspace: Colorspace.P3,
       });
       expect(personMock.update).toHaveBeenCalledWith({
         id: 'person-1',
@@ -318,7 +318,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        colorspace: 'p3',
+        colorspace: Colorspace.P3,
       });
     });
 
@@ -337,7 +337,7 @@ describe(FacialRecognitionService.name, () => {
         format: 'jpeg',
         size: 250,
         quality: 80,
-        colorspace: 'p3',
+        colorspace: Colorspace.P3,
       });
     });
   });

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -22,6 +22,7 @@ import { IStorageRepository } from '../storage';
 import { ISystemConfigRepository } from '../system-config';
 import { IFaceRepository } from './face.repository';
 import { FacialRecognitionService } from './facial-recognition.services';
+import { Colorspace } from '@app/infra/entities';
 
 const croppedFace = Buffer.from('Cropped Face');
 

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -18,6 +18,7 @@ export class FacialRecognitionService {
 
   constructor(
     @Inject(IAssetRepository) private assetRepository: IAssetRepository,
+    @Inject(ISystemConfigRepository) systemConfig: ISystemConfigRepository,
     @Inject(IFaceRepository) private faceRepository: IFaceRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(IMachineLearningRepository) private machineLearning: IMachineLearningRepository,
@@ -25,7 +26,6 @@ export class FacialRecognitionService {
     @Inject(IPersonRepository) private personRepository: IPersonRepository,
     @Inject(ISearchRepository) private searchRepository: ISearchRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
-    @Inject(ISystemConfigRepository) systemConfig: ISystemConfigRepository,
   ) {
     this.configCore = new SystemConfigCore(systemConfig);
   }

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -167,7 +167,7 @@ export class FacialRecognitionService {
     const thumbnailOptions = {
       format: 'jpeg',
       size: FACE_THUMBNAIL_SIZE,
-      wideGamut: thumbnail.wideGamut,
+      colorspace: thumbnail.colorspace,
       quality: thumbnail.quality,
     } as const;
     await this.mediaRepository.resize(croppedOutput, output, thumbnailOptions);

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -163,7 +163,8 @@ export class FacialRecognitionService {
     };
 
     const croppedOutput = await this.mediaRepository.crop(asset.resizePath, cropOptions);
-    await this.mediaRepository.resize(croppedOutput, output, { size: FACE_THUMBNAIL_SIZE, format: 'jpeg' });
+    await this.mediaRepository.resize(croppedOutput, { size: FACE_THUMBNAIL_SIZE });
+    await this.mediaRepository.saveThumbnail(croppedOutput, output, { format: 'jpeg' });
     await this.personRepository.update({ id: personId, thumbnailPath: output });
 
     return true;

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -18,7 +18,7 @@ export class FacialRecognitionService {
 
   constructor(
     @Inject(IAssetRepository) private assetRepository: IAssetRepository,
-    @Inject(ISystemConfigRepository) systemConfig: ISystemConfigRepository,
+    @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
     @Inject(IFaceRepository) private faceRepository: IFaceRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(IMachineLearningRepository) private machineLearning: IMachineLearningRepository,
@@ -27,7 +27,7 @@ export class FacialRecognitionService {
     @Inject(ISearchRepository) private searchRepository: ISearchRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
   ) {
-    this.configCore = new SystemConfigCore(systemConfig);
+    this.configCore = new SystemConfigCore(configRepository);
   }
 
   async handleQueueRecognizeFaces({ force }: IBaseJob) {

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -162,9 +162,15 @@ export class FacialRecognitionService {
       height: newHalfSize * 2,
     };
 
+    const { thumbnail } = await this.configCore.getConfig();
     const croppedOutput = await this.mediaRepository.crop(asset.resizePath, cropOptions);
-    await this.mediaRepository.resize(croppedOutput, { size: FACE_THUMBNAIL_SIZE });
-    await this.mediaRepository.saveThumbnail(croppedOutput, output, { format: 'jpeg' });
+    const thumbnailOptions = {
+      format: 'jpeg',
+      size: FACE_THUMBNAIL_SIZE,
+      wideGamut: thumbnail.wideGamut,
+      quality: thumbnail.quality,
+    } as const;
+    await this.mediaRepository.resize(croppedOutput, output, thumbnailOptions);
     await this.personRepository.update({ id: personId, thumbnailPath: output });
 
     return true;

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -18,7 +18,6 @@ export class FacialRecognitionService {
 
   constructor(
     @Inject(IAssetRepository) private assetRepository: IAssetRepository,
-    @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
     @Inject(IFaceRepository) private faceRepository: IFaceRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(IMachineLearningRepository) private machineLearning: IMachineLearningRepository,
@@ -26,8 +25,9 @@ export class FacialRecognitionService {
     @Inject(IPersonRepository) private personRepository: IPersonRepository,
     @Inject(ISearchRepository) private searchRepository: ISearchRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
+    @Inject(ISystemConfigRepository) systemConfig: ISystemConfigRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = new SystemConfigCore(systemConfig);
   }
 
   async handleQueueRecognizeFaces({ force }: IBaseJob) {

--- a/server/src/domain/media/media.repository.ts
+++ b/server/src/domain/media/media.repository.ts
@@ -5,9 +5,6 @@ export const IMediaRepository = 'IMediaRepository';
 
 export interface ResizeOptions {
   size: number;
-}
-
-export interface ThumbnailOptions {
   format: 'webp' | 'jpeg';
   wideGamut: boolean;
   quality: number;
@@ -73,10 +70,9 @@ export interface VideoCodecHWConfig extends VideoCodecSWConfig {
 
 export interface IMediaRepository {
   // image
-  resize(input: string | Buffer, options: ResizeOptions): Promise<Buffer>;
-  crop(input: string | Buffer, options: CropOptions): Promise<Buffer>;
-  generateThumbhash(imagePath: string | Buffer): Promise<Buffer>;
-  saveThumbnail(imagePath: string | Buffer, output: string, options: ThumbnailOptions): Promise<void>;
+  resize(input: string | Buffer, output: string, options: ResizeOptions): Promise<void>;
+  crop(input: string, options: CropOptions): Promise<Buffer>;
+  generateThumbhash(imagePath: string): Promise<Buffer>;
 
   // video
   probe(input: string): Promise<VideoInfo>;

--- a/server/src/domain/media/media.repository.ts
+++ b/server/src/domain/media/media.repository.ts
@@ -6,7 +6,7 @@ export const IMediaRepository = 'IMediaRepository';
 export interface ResizeOptions {
   size: number;
   format: 'webp' | 'jpeg';
-  wideGamut: boolean;
+  colorspace: string;
   quality: number;
 }
 

--- a/server/src/domain/media/media.repository.ts
+++ b/server/src/domain/media/media.repository.ts
@@ -1,10 +1,16 @@
 import { VideoCodec } from '@app/infra/entities';
+import { Writable } from 'stream';
 
 export const IMediaRepository = 'IMediaRepository';
 
 export interface ResizeOptions {
   size: number;
+}
+
+export interface ThumbnailOptions {
   format: 'webp' | 'jpeg';
+  wideGamut: boolean;
+  quality: number;
 }
 
 export interface VideoStreamInfo {
@@ -67,11 +73,12 @@ export interface VideoCodecHWConfig extends VideoCodecSWConfig {
 
 export interface IMediaRepository {
   // image
-  resize(input: string | Buffer, output: string, options: ResizeOptions): Promise<void>;
-  crop(input: string, options: CropOptions): Promise<Buffer>;
-  generateThumbhash(imagePath: string): Promise<Buffer>;
+  resize(input: string | Buffer, options: ResizeOptions): Promise<Buffer>;
+  crop(input: string | Buffer, options: CropOptions): Promise<Buffer>;
+  generateThumbhash(imagePath: string | Buffer): Promise<Buffer>;
+  saveThumbnail(imagePath: string | Buffer, output: string, options: ThumbnailOptions): Promise<void>;
 
   // video
   probe(input: string): Promise<VideoInfo>;
-  transcode(input: string, output: string, options: TranscodeOptions): Promise<void>;
+  transcode(input: string, output: string | Writable, options: TranscodeOptions): Promise<void>;
 }

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -134,6 +134,8 @@ describe(MediaService.name, () => {
       expect(mediaMock.resize).toHaveBeenCalledWith('/original/path.jpg', 'upload/thumbs/user-id/asset-id.jpeg', {
         size: 1440,
         format: 'jpeg',
+        quality: 80,
+        wideGamut: true,
       });
       expect(assetMock.save).toHaveBeenCalledWith({
         id: 'asset-id',
@@ -148,12 +150,11 @@ describe(MediaService.name, () => {
 
       expect(storageMock.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id');
       expect(mediaMock.transcode).toHaveBeenCalledWith('/original/path.ext', 'upload/thumbs/user-id/asset-id.jpeg', {
-        inputOptions: [],
+        inputOptions: ['-ss 00:00:00', '-sws_flags accurate_rnd+bitexact+full_chroma_int'],
         outputOptions: [
-          '-ss 00:00:00.000',
           '-frames:v 1',
           '-v verbose',
-          '-vf scale=-2:1440:out_color_matrix=bt601:out_range=pc,format=yuv420p',
+          '-vf scale=-2:1440:flags=lanczos+accurate_rnd+bitexact+full_chroma_int:out_color_matrix=601:out_range=pc,format=yuv420p',
         ],
         twoPass: false,
       });
@@ -170,12 +171,11 @@ describe(MediaService.name, () => {
 
       expect(storageMock.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id');
       expect(mediaMock.transcode).toHaveBeenCalledWith('/original/path.ext', 'upload/thumbs/user-id/asset-id.jpeg', {
-        inputOptions: [],
+        inputOptions: ['-ss 00:00:00', '-sws_flags accurate_rnd+bitexact+full_chroma_int'],
         outputOptions: [
-          '-ss 00:00:00.000',
           '-frames:v 1',
           '-v verbose',
-          '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt470bg:t=601:m=bt470bg:range=pc,format=yuv420p',
+          '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=601:m=bt470bg:range=pc,format=yuv420p',
         ],
         twoPass: false,
       });
@@ -209,12 +209,13 @@ describe(MediaService.name, () => {
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
       await sut.handleGenerateWebpThumbnail({ id: assetStub.image.id });
 
-      expect(mediaMock.resize).toHaveBeenCalledWith(
-        '/uploads/user-id/thumbs/path.jpg',
-        '/uploads/user-id/thumbs/path.webp',
-        { format: 'webp', size: 250 },
-      );
-      expect(assetMock.save).toHaveBeenCalledWith({ id: 'asset-id', webpPath: '/uploads/user-id/thumbs/path.webp' });
+      expect(mediaMock.resize).toHaveBeenCalledWith('/original/path.jpg', 'upload/thumbs/user-id/asset-id.webp', {
+        format: 'webp',
+        size: 250,
+        quality: 80,
+        wideGamut: true,
+      });
+      expect(assetMock.save).toHaveBeenCalledWith({ id: 'asset-id', webpPath: 'upload/thumbs/user-id/asset-id.webp' });
     });
   });
 

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   AssetType,
+  Colorspace,
   SystemConfigKey,
   ToneMapping,
   TranscodeHWAccel,
@@ -21,7 +22,6 @@ import { IStorageRepository } from '../storage';
 import { ISystemConfigRepository } from '../system-config';
 import { IMediaRepository } from './media.repository';
 import { MediaService } from './media.service';
-import { Colorspace } from '@app/infra/entities';
 
 describe(MediaService.name, () => {
   let sut: MediaService;

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -135,7 +135,7 @@ describe(MediaService.name, () => {
         size: 1440,
         format: 'jpeg',
         quality: 80,
-        colorspace: 'p3',
+        colorspace: Colorspace.P3,
       });
       expect(assetMock.save).toHaveBeenCalledWith({
         id: 'asset-id',
@@ -213,7 +213,7 @@ describe(MediaService.name, () => {
         format: 'webp',
         size: 250,
         quality: 80,
-        colorspace: 'p3',
+        colorspace: Colorspace.P3,
       });
       expect(assetMock.save).toHaveBeenCalledWith({ id: 'asset-id', webpPath: 'upload/thumbs/user-id/asset-id.webp' });
     });

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -135,7 +135,7 @@ describe(MediaService.name, () => {
         size: 1440,
         format: 'jpeg',
         quality: 80,
-        wideGamut: true,
+        colorspace: 'p3',
       });
       expect(assetMock.save).toHaveBeenCalledWith({
         id: 'asset-id',
@@ -213,7 +213,7 @@ describe(MediaService.name, () => {
         format: 'webp',
         size: 250,
         quality: 80,
-        wideGamut: true,
+        colorspace: 'p3',
       });
       expect(assetMock.save).toHaveBeenCalledWith({ id: 'asset-id', webpPath: 'upload/thumbs/user-id/asset-id.webp' });
     });

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -21,6 +21,7 @@ import { IStorageRepository } from '../storage';
 import { ISystemConfigRepository } from '../system-config';
 import { IMediaRepository } from './media.repository';
 import { MediaService } from './media.service';
+import { Colorspace } from '@app/infra/entities';
 
 describe(MediaService.name, () => {
   let sut: MediaService;

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -78,8 +78,8 @@ export class MediaService {
     const { thumbnail } = await this.configCore.getConfig();
     const size = format === 'jpeg' ? thumbnail.jpegSize : thumbnail.webpSize;
     const thumbnailOptions = { format, size, colorspace: thumbnail.colorspace, quality: thumbnail.quality };
-    const thumbnailPath = this.getPath(asset, format);
-    await this.mediaRepository.resize(asset.originalPath, thumbnailPath, thumbnailOptions);
+    const path = this.ensureThumbnailPath(asset, format);
+    await this.mediaRepository.resize(asset.originalPath, path, thumbnailOptions);
   }
 
   async generateVideoThumbnail(asset: AssetEntity, format: 'jpeg' | 'webp') {
@@ -93,10 +93,10 @@ export class MediaService {
       );
     }
     const mainAudioStream = this.getMainStream(audioStreams);
-    const thumbnailPath = this.getPath(asset, format);
+    const path = this.ensureThumbnailPath(asset, format);
     const config = { ...ffmpeg, targetResolution: size.toString() };
     const options = new ThumbnailConfig(config).getOptions(mainVideoStream, mainAudioStream);
-    await this.mediaRepository.transcode(asset.originalPath, thumbnailPath, options);
+    await this.mediaRepository.transcode(asset.originalPath, path, options);
   }
 
   async handleGenerateWebpThumbnail({ id }: IEntityJob) {
@@ -302,7 +302,7 @@ export class MediaService {
     return handler;
   }
 
-  getPath(asset: AssetEntity, extension: string): string {
+  ensureThumbnailPath(asset: AssetEntity, extension: string): string {
     const folderPath = this.storageCore.getFolderLocation(StorageFolder.THUMBNAILS, asset.ownerId);
     this.storageRepository.mkdirSync(folderPath);
     return join(folderPath, `${asset.id}.${extension}`);

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -58,39 +58,55 @@ export class MediaService {
       return false;
     }
 
-    const jpegThumbnailPath = this.getPath(asset, 'jpeg');
-    const { ffmpeg, thumbnail } = await this.configCore.getConfig();
     switch (asset.type) {
       case AssetType.IMAGE:
-        const thumbnailOptions = {
-          format: 'jpeg',
-          size: thumbnail.jpegSize,
-          wideGamut: thumbnail.wideGamut,
-          quality: thumbnail.quality,
-        } as const;
-        await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, thumbnailOptions);
-        this.logger.log(`Successfully generated image thumbnail ${asset.id}`);
-        break;
-      case AssetType.VIDEO:
-        const { audioStreams, videoStreams } = await this.mediaRepository.probe(asset.originalPath);
-        const mainVideoStream = this.getMainStream(videoStreams);
-        if (!mainVideoStream) {
-          this.logger.error(`Could not extract thumbnail for asset ${asset.id}: no video streams found`);
+        try {
+          await this.generateImageThumbnail(asset, 'jpeg');
+          this.logger.log(`Successfully generated JPEG image thumbnail ${asset.id}`);
+        } catch (err) {
+          this.logger.error(`Could not generate JPEG image thumbnail for asset ${asset.id}: ${err}`);
           return false;
         }
-        const mainAudioStream = this.getMainStream(audioStreams);
-        const config = { ...ffmpeg, targetResolution: thumbnail.jpegSize.toString() };
-        const options = new ThumbnailConfig(config).getOptions(mainVideoStream, mainAudioStream);
-        await this.mediaRepository.transcode(asset.originalPath, jpegThumbnailPath, options);
-        this.logger.log(`Successfully generated video thumbnail ${asset.id}`);
+        break;
+      case AssetType.VIDEO:
+        try {
+          await this.generateVideoThumbnail(asset, 'jpeg');
+          this.logger.log(`Successfully generated JPEG video thumbnail ${asset.id}`);
+        } catch (err) {
+          this.logger.error(`Could not generate JPEG video thumbnail for asset ${asset.id}: ${err}`);
+          return false;
+        }
         break;
       default:
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
     }
 
-    await this.assetRepository.save({ id: asset.id, resizePath: jpegThumbnailPath });
-
     return true;
+  }
+
+  async generateImageThumbnail(asset: AssetEntity, format: 'jpeg' | 'webp') {
+    const { thumbnail } = await this.configCore.getConfig();
+    const size = format === 'jpeg' ? thumbnail.jpegSize : thumbnail.webpSize;
+    const thumbnailOptions = { format, size, wideGamut: thumbnail.wideGamut, quality: thumbnail.quality };
+    const thumbnailPath = this.getPath(asset, format);
+    await this.mediaRepository.resize(asset.originalPath, thumbnailPath, thumbnailOptions);
+    await this.assetRepository.save({ id: asset.id, resizePath: thumbnailPath });
+  }
+
+  async generateVideoThumbnail(asset: AssetEntity, format: 'jpeg' | 'webp') {
+    const { ffmpeg, thumbnail } = await this.configCore.getConfig();
+    const size = format === 'jpeg' ? thumbnail.jpegSize : thumbnail.webpSize;
+    const { audioStreams, videoStreams } = await this.mediaRepository.probe(asset.originalPath);
+    const mainVideoStream = this.getMainStream(videoStreams);
+    if (!mainVideoStream) {
+      throw new UnsupportedMediaTypeException(`Could not extract thumbnail for asset ${asset.id}: no video streams found`);
+    }
+    const mainAudioStream = this.getMainStream(audioStreams);
+    const thumbnailPath = this.getPath(asset, format);
+    const config = { ...ffmpeg, targetResolution: size.toString() };
+    const options = new ThumbnailConfig(config).getOptions(mainVideoStream, mainAudioStream);
+    await this.mediaRepository.transcode(asset.originalPath, thumbnailPath, options);
+    await this.assetRepository.save({ id: asset.id, resizePath: thumbnailPath });
   }
 
   async handleGenerateWebpThumbnail({ id }: IEntityJob) {
@@ -99,16 +115,28 @@ export class MediaService {
       return false;
     }
 
-    const webpPath = this.getPath(asset, 'webp');
-    const { thumbnail } = await this.configCore.getConfig();
-    const thumbnailOptions = {
-      format: 'webp',
-      size: thumbnail.webpSize,
-      wideGamut: thumbnail.wideGamut,
-      quality: thumbnail.quality,
-    } as const;
-    await this.mediaRepository.resize(asset.originalPath, webpPath, thumbnailOptions);
-    await this.assetRepository.save({ id: asset.id, webpPath });
+    switch (asset.type) {
+      case AssetType.IMAGE:
+        try {
+          await this.generateImageThumbnail(asset, 'webp');
+          this.logger.log(`Successfully generated WebP image thumbnail ${asset.id}`);
+        } catch (err) {
+          this.logger.error(`Could not generate WebP image thumbnail for asset ${asset.id}: ${err}`);
+          return false;
+        }
+        break;
+      case AssetType.VIDEO:
+        try {
+          await this.generateVideoThumbnail(asset, 'webp');
+          this.logger.log(`Successfully generated WebP video thumbnail ${asset.id}`);
+        } catch (err) {
+          this.logger.error(`Could not generate WebP video thumbnail for asset ${asset.id}: ${err}`);
+          return false;
+        }
+        break;
+      default:
+        throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
+    }
 
     return true;
   }

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -62,7 +62,13 @@ export class MediaService {
     const { ffmpeg, thumbnail } = await this.configCore.getConfig();
     switch (asset.type) {
       case AssetType.IMAGE:
-        await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, { format: 'jpeg', size: thumbnail.jpegSize, ...thumbnail });
+        const thumbnailOptions = {
+          format: 'jpeg',
+          size: thumbnail.jpegSize,
+          wideGamut: thumbnail.wideGamut,
+          quality: thumbnail.quality,
+        } as const;
+        await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, thumbnailOptions);
         this.logger.log(`Successfully generated image thumbnail ${asset.id}`);
         break;
       case AssetType.VIDEO:
@@ -74,7 +80,7 @@ export class MediaService {
         }
         const mainAudioStream = this.getMainStream(audioStreams);
         const config = { ...ffmpeg, targetResolution: thumbnail.jpegSize.toString() };
-        const options = new ThumbnailConfig(config, { format: 'jpeg', size: thumbnail.jpegSize, ...thumbnail }).getOptions(mainVideoStream, mainAudioStream);
+        const options = new ThumbnailConfig(config).getOptions(mainVideoStream, mainAudioStream);
         await this.mediaRepository.transcode(asset.originalPath, jpegThumbnailPath, options);
         this.logger.log(`Successfully generated video thumbnail ${asset.id}`);
         break;
@@ -95,7 +101,13 @@ export class MediaService {
 
     const webpPath = this.getPath(asset, 'webp');
     const { thumbnail } = await this.configCore.getConfig();
-    await this.mediaRepository.resize(asset.resizePath, webpPath, { format: 'webp', size: thumbnail.webpSize, ...thumbnail });
+    const thumbnailOptions = {
+      format: 'webp',
+      size: thumbnail.webpSize,
+      wideGamut: thumbnail.wideGamut,
+      quality: thumbnail.quality,
+    } as const;
+    await this.mediaRepository.resize(asset.originalPath, webpPath, thumbnailOptions);
     await this.assetRepository.save({ id: asset.id, webpPath });
 
     return true;

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -88,7 +88,7 @@ export class MediaService {
     const { audioStreams, videoStreams } = await this.mediaRepository.probe(asset.originalPath);
     const mainVideoStream = this.getMainStream(videoStreams);
     if (!mainVideoStream) {
-      this.logger.warn(`Skipped thumbnail generation for asset ${asset.id}: no video streams found`)
+      this.logger.warn(`Skipped thumbnail generation for asset ${asset.id}: no video streams found`);
       return;
     }
     const mainAudioStream = this.getMainStream(audioStreams);
@@ -227,7 +227,8 @@ export class MediaService {
     const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${audioStream?.codecType ?? 'None'
+      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${
+        audioStream?.codecType ?? 'None'
       }, containerExtension ${containerExtension}`,
     );
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -69,7 +69,7 @@ export class MediaService {
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
     }
 
-    const resizePath = this.getPath(asset, 'jpeg');
+    const resizePath = this.ensureThumbnailPath(asset, 'jpeg');
     await this.assetRepository.save({ id: asset.id, resizePath });
     return true;
   }
@@ -88,9 +88,8 @@ export class MediaService {
     const { audioStreams, videoStreams } = await this.mediaRepository.probe(asset.originalPath);
     const mainVideoStream = this.getMainStream(videoStreams);
     if (!mainVideoStream) {
-      throw new UnsupportedMediaTypeException(
-        `Could not extract thumbnail for asset ${asset.id}: no video streams found`,
-      );
+      this.logger.warn(`Skipped thumbnail generation for asset ${asset.id}: no video streams found`)
+      return;
     }
     const mainAudioStream = this.getMainStream(audioStreams);
     const path = this.ensureThumbnailPath(asset, format);
@@ -116,7 +115,7 @@ export class MediaService {
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
     }
 
-    const webpPath = this.getPath(asset, 'webp');
+    const webpPath = this.ensureThumbnailPath(asset, 'webp');
     await this.assetRepository.save({ id: asset.id, webpPath });
     return true;
   }

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -75,7 +75,9 @@ export class MediaService {
       default:
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
     }
-    this.logger.log(`Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} thumbnail for asset ${asset.id}`);
+    this.logger.log(
+      `Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} thumbnail for asset ${asset.id}`,
+    );
     return path;
   }
 
@@ -223,7 +225,8 @@ export class MediaService {
     const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${audioStream?.codecType ?? 'None'
+      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${
+        audioStream?.codecType ?? 'None'
       }, containerExtension ${containerExtension}`,
     );
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -20,9 +20,9 @@ export class MediaService {
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(IMediaRepository) private mediaRepository: IMediaRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
-    @Inject(ISystemConfigRepository) systemConfig: ISystemConfigRepository,
+    @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
-    this.configCore = new SystemConfigCore(systemConfig);
+    this.configCore = new SystemConfigCore(configRepository);
   }
 
   async handleQueueGenerateThumbnails(job: IBaseJob) {

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -60,11 +60,9 @@ export class MediaService {
 
     const jpegThumbnailPath = this.getPath(asset, 'jpeg');
     const { ffmpeg, thumbnail } = await this.configCore.getConfig();
-
     switch (asset.type) {
       case AssetType.IMAGE:
-        const imageBuffer = await this.mediaRepository.resize(asset.originalPath, { size: thumbnail.jpegSize });
-        await this.mediaRepository.saveThumbnail(imageBuffer, jpegThumbnailPath, { format: 'jpeg', ...thumbnail });
+        await this.mediaRepository.resize(asset.originalPath, jpegThumbnailPath, { format: 'jpeg', size: thumbnail.jpegSize, ...thumbnail });
         this.logger.log(`Successfully generated image thumbnail ${asset.id}`);
         break;
       case AssetType.VIDEO:
@@ -76,7 +74,7 @@ export class MediaService {
         }
         const mainAudioStream = this.getMainStream(audioStreams);
         const config = { ...ffmpeg, targetResolution: thumbnail.jpegSize.toString() };
-        const options = new ThumbnailConfig(config, { format: 'jpeg', ...thumbnail }).getOptions(mainVideoStream, mainAudioStream);
+        const options = new ThumbnailConfig(config, { format: 'jpeg', size: thumbnail.jpegSize, ...thumbnail }).getOptions(mainVideoStream, mainAudioStream);
         await this.mediaRepository.transcode(asset.originalPath, jpegThumbnailPath, options);
         this.logger.log(`Successfully generated video thumbnail ${asset.id}`);
         break;
@@ -97,8 +95,7 @@ export class MediaService {
 
     const webpPath = this.getPath(asset, 'webp');
     const { thumbnail } = await this.configCore.getConfig();
-    const imageBuffer = await this.mediaRepository.resize(asset.originalPath, { size: thumbnail.webpSize });
-    await this.mediaRepository.saveThumbnail(imageBuffer, webpPath, { format: 'webp', ...thumbnail });
+    await this.mediaRepository.resize(asset.resizePath, webpPath, { format: 'webp', size: thumbnail.webpSize, ...thumbnail });
     await this.assetRepository.save({ id: asset.id, webpPath });
 
     return true;

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -80,6 +80,7 @@ export class MediaService {
     const thumbnailOptions = { format, size, colorspace: thumbnail.colorspace, quality: thumbnail.quality };
     const path = this.ensureThumbnailPath(asset, format);
     await this.mediaRepository.resize(asset.originalPath, path, thumbnailOptions);
+    this.logger.log(`Successfully generated ${format.toUpperCase()} thumbnail for asset ${asset.id}`);
   }
 
   async generateVideoThumbnail(asset: AssetEntity, format: 'jpeg' | 'webp') {
@@ -227,8 +228,7 @@ export class MediaService {
     const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${
-        audioStream?.codecType ?? 'None'
+      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${audioStream?.codecType ?? 'None'
       }, containerExtension ${containerExtension}`,
     );
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -60,22 +60,10 @@ export class MediaService {
 
     switch (asset.type) {
       case AssetType.IMAGE:
-        try {
-          await this.generateImageThumbnail(asset, 'jpeg');
-          this.logger.log(`Successfully generated JPEG image thumbnail ${asset.id}`);
-        } catch (err) {
-          this.logger.error(`Could not generate JPEG image thumbnail for asset ${asset.id}: ${err}`);
-          return false;
-        }
+        await this.generateImageThumbnail(asset, 'jpeg');
         break;
       case AssetType.VIDEO:
-        try {
-          await this.generateVideoThumbnail(asset, 'jpeg');
-          this.logger.log(`Successfully generated JPEG video thumbnail ${asset.id}`);
-        } catch (err) {
-          this.logger.error(`Could not generate JPEG video thumbnail for asset ${asset.id}: ${err}`);
-          return false;
-        }
+        await this.generateVideoThumbnail(asset, 'jpeg');
         break;
       default:
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
@@ -89,7 +77,7 @@ export class MediaService {
   async generateImageThumbnail(asset: AssetEntity, format: 'jpeg' | 'webp') {
     const { thumbnail } = await this.configCore.getConfig();
     const size = format === 'jpeg' ? thumbnail.jpegSize : thumbnail.webpSize;
-    const thumbnailOptions = { format, size, wideGamut: thumbnail.wideGamut, quality: thumbnail.quality };
+    const thumbnailOptions = { format, size, colorspace: thumbnail.colorspace, quality: thumbnail.quality };
     const thumbnailPath = this.getPath(asset, format);
     await this.mediaRepository.resize(asset.originalPath, thumbnailPath, thumbnailOptions);
   }
@@ -119,22 +107,10 @@ export class MediaService {
 
     switch (asset.type) {
       case AssetType.IMAGE:
-        try {
-          await this.generateImageThumbnail(asset, 'webp');
-          this.logger.log(`Successfully generated WebP image thumbnail ${asset.id}`);
-        } catch (err) {
-          this.logger.error(`Could not generate WebP image thumbnail for asset ${asset.id}: ${err}`);
-          return false;
-        }
+        await this.generateImageThumbnail(asset, 'webp');
         break;
       case AssetType.VIDEO:
-        try {
-          await this.generateVideoThumbnail(asset, 'webp');
-          this.logger.log(`Successfully generated WebP video thumbnail ${asset.id}`);
-        } catch (err) {
-          this.logger.error(`Could not generate WebP video thumbnail for asset ${asset.id}: ${err}`);
-          return false;
-        }
+        await this.generateVideoThumbnail(asset, 'webp');
         break;
       default:
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
@@ -252,8 +228,7 @@ export class MediaService {
     const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${
-        audioStream?.codecType ?? 'None'
+      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${audioStream?.codecType ?? 'None'
       }, containerExtension ${containerExtension}`,
     );
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -228,7 +228,8 @@ export class MediaService {
     const isTargetAudioCodec = audioStream == null || audioStream.codecName === ffmpegConfig.targetAudioCodec;
 
     this.logger.verbose(
-      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${audioStream?.codecType ?? 'None'
+      `${asset.id}: AudioCodecName ${audioStream?.codecName ?? 'None'}, AudioStreamCodecType ${
+        audioStream?.codecType ?? 'None'
       }, containerExtension ${containerExtension}`,
     );
 

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -281,7 +281,10 @@ export class ThumbnailConfig extends BaseConfig {
   }
 
   getBitrateOptions() {
-    return [`-q:v ${this.thumbnailOptions.quality}`];
+    // -q:v is a range from 1-31 rather than 1-100
+    let quality = 32 - Math.round(this.thumbnailOptions.quality / 100 * 31);
+    quality = Math.min(31, Math.max(1, quality));
+    return ['-qmin 1', `-q:v ${quality}`];
   }
 
   getScaling(videoStream: VideoStreamInfo) {

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -68,7 +68,7 @@ class BaseConfig implements VideoCodecSWConfig {
     if (this.shouldToneMap(videoStream)) {
       options.push(...this.getToneMapping());
     }
-    options.push(`format=yuv420p`);
+    options.push('format=yuv420p');
 
     return options;
   }

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -69,7 +69,7 @@ class BaseConfig implements VideoCodecSWConfig {
     if (this.shouldToneMap(videoStream)) {
       options.push(...this.getToneMapping());
     }
-    options.push(this.getFormat());
+    options.push(`format=yuv420p`);
 
     return options;
   }
@@ -186,10 +186,6 @@ class BaseConfig implements VideoCodecSWConfig {
     }
   }
 
-  getFormat() {
-    return 'yuv420p';
-  }
-
   getToneMapping() {
     const colors = this.getColors();
 
@@ -281,10 +277,7 @@ export class ThumbnailConfig extends BaseConfig {
   }
 
   getBitrateOptions() {
-    // -q:v is a range from 1-31 rather than 1-100
-    let quality = 32 - Math.round(this.thumbnailOptions.quality / 100 * 31);
-    quality = Math.min(31, Math.max(1, quality));
-    return ['-qmin 1', `-q:v ${quality}`];
+    return []
   }
 
   getScaling(videoStream: VideoStreamInfo) {
@@ -298,17 +291,10 @@ export class ThumbnailConfig extends BaseConfig {
 
   getColors() {
     return {
-      primaries: this.thumbnailOptions.wideGamut ? 'smpte432' : 'bt709',
+      primaries: 'bt709',
       transfer: '601',
       matrix: 'bt470bg',
     };
-  }
-
-  getFormat() {
-    if (this.thumbnailOptions.quality >= 80) {
-      return 'yuv444p';
-    }
-    return 'yuv420p';
   }
 }
 

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -3,7 +3,7 @@ import { SystemConfigFFmpegDto } from '../system-config/dto';
 import {
   AudioStreamInfo,
   BitrateDistribution,
-  ThumbnailOptions,
+  ResizeOptions,
   TranscodeOptions,
   VideoCodecHWConfig,
   VideoCodecSWConfig,
@@ -268,7 +268,7 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
 }
 
 export class ThumbnailConfig extends BaseConfig {
-  constructor(protected config: SystemConfigFFmpegDto, protected thumbnailOptions: ThumbnailOptions) { super(config) }
+  constructor(protected config: SystemConfigFFmpegDto, protected thumbnailOptions: ResizeOptions) { super(config) }
   getBaseInputOptions(): string[] {
     return ['-sws_flags accurate_rnd+bitexact+full_chroma_int']
   }

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -3,7 +3,6 @@ import { SystemConfigFFmpegDto } from '../system-config/dto';
 import {
   AudioStreamInfo,
   BitrateDistribution,
-  ResizeOptions,
   TranscodeOptions,
   VideoCodecHWConfig,
   VideoCodecSWConfig,
@@ -264,12 +263,11 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
 }
 
 export class ThumbnailConfig extends BaseConfig {
-  constructor(protected config: SystemConfigFFmpegDto, protected thumbnailOptions: ResizeOptions) { super(config) }
   getBaseInputOptions(): string[] {
-    return ['-sws_flags accurate_rnd+bitexact+full_chroma_int']
+    return ['-ss 00:00:00', '-sws_flags accurate_rnd+bitexact+full_chroma_int'];
   }
   getBaseOutputOptions() {
-    return ['-ss 00:00:00.000', '-frames:v 1'];
+    return ['-frames:v 1'];
   }
 
   getPresetOptions() {
@@ -277,7 +275,7 @@ export class ThumbnailConfig extends BaseConfig {
   }
 
   getBitrateOptions() {
-    return []
+    return [];
   }
 
   getScaling(videoStream: VideoStreamInfo) {

--- a/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
@@ -1,20 +1,24 @@
 import { toBoolean } from '@app/domain/domain.util';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
-import { IsBoolean, IsInt } from 'class-validator';
+import { IsBoolean, IsInt, Max, Min } from 'class-validator';
 
 export class SystemConfigThumbnailDto {
   @IsInt()
+  @Min(1)
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   webpSize!: number;
 
   @IsInt()
+  @Min(1)
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   jpegSize!: number;
 
   @IsInt()
+  @Min(1)
+  @Max(100)
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   quality!: number;

--- a/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
@@ -1,7 +1,7 @@
-import { toBoolean } from '@app/domain/domain.util';
+import { Colorspace } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
-import { IsBoolean, IsInt, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, Max, Min } from 'class-validator';
 
 export class SystemConfigThumbnailDto {
   @IsInt()
@@ -23,8 +23,7 @@ export class SystemConfigThumbnailDto {
   @ApiProperty({ type: 'integer' })
   quality!: number;
 
-  @IsBoolean()
-  @Transform(toBoolean)
-  @ApiProperty({ type: 'boolean' })
-  wideGamut!: boolean;
+  @IsEnum(Colorspace)
+  @ApiProperty({ enumName: 'Colorspace', enum: Colorspace })
+  colorspace!: Colorspace;
 }

--- a/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
@@ -1,6 +1,7 @@
+import { toBoolean } from '@app/domain/domain.util';
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsInt } from 'class-validator';
 
 export class SystemConfigThumbnailDto {
   @IsInt()
@@ -12,4 +13,14 @@ export class SystemConfigThumbnailDto {
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   jpegSize!: number;
+
+  @IsInt()
+  @Type(() => Number)
+  @ApiProperty({ type: 'integer' })
+  quality!: number;
+
+  @IsBoolean()
+  @Transform(toBoolean)
+  @ApiProperty({ type: 'boolean' })
+  wideGamut!: boolean;
 }

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -128,7 +128,7 @@ export class SystemConfigCore {
 
   public config$ = singleton;
 
-  constructor(private repository: ISystemConfigRepository) { }
+  constructor(private repository: ISystemConfigRepository) {}
 
   async requireFeature(feature: FeatureFlag) {
     const hasFeature = await this.hasFeature(feature);

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -1,6 +1,7 @@
 import {
   AudioCodec,
   CQMode,
+  Colorspace,
   SystemConfig,
   SystemConfigEntity,
   SystemConfigKey,
@@ -99,7 +100,7 @@ export const defaults = Object.freeze<SystemConfig>({
     webpSize: 250,
     jpegSize: 1440,
     quality: 80,
-    wideGamut: true,
+    colorspace: Colorspace.P3,
   },
 });
 
@@ -127,7 +128,7 @@ export class SystemConfigCore {
 
   public config$ = singleton;
 
-  constructor(private repository: ISystemConfigRepository) {}
+  constructor(private repository: ISystemConfigRepository) { }
 
   async requireFeature(feature: FeatureFlag) {
     const hasFeature = await this.hasFeature(feature);

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -99,7 +99,7 @@ export const defaults = Object.freeze<SystemConfig>({
     webpSize: 250,
     jpegSize: 1440,
     quality: 80,
-    wideGamut: true
+    wideGamut: true,
   },
 });
 
@@ -127,7 +127,7 @@ export class SystemConfigCore {
 
   public config$ = singleton;
 
-  constructor(private repository: ISystemConfigRepository) { }
+  constructor(private repository: ISystemConfigRepository) {}
 
   async requireFeature(feature: FeatureFlag) {
     const hasFeature = await this.hasFeature(feature);

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -98,6 +98,8 @@ export const defaults = Object.freeze<SystemConfig>({
   thumbnail: {
     webpSize: 250,
     jpegSize: 1440,
+    quality: 80,
+    wideGamut: true
   },
 });
 
@@ -125,7 +127,7 @@ export class SystemConfigCore {
 
   public config$ = singleton;
 
-  constructor(private repository: ISystemConfigRepository) {}
+  constructor(private repository: ISystemConfigRepository) { }
 
   async requireFeature(feature: FeatureFlag) {
     const hasFeature = await this.hasFeature(feature);

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -15,6 +15,7 @@ import { IJobRepository, JobName, QueueName } from '../job';
 import { defaults, SystemConfigValidator } from './system-config.core';
 import { ISystemConfigRepository } from './system-config.repository';
 import { SystemConfigService } from './system-config.service';
+import { Colorspace } from '@app/infra/entities';
 
 const updates: SystemConfigEntity[] = [
   { key: SystemConfigKey.FFMPEG_CRF, value: 30 },

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -1,6 +1,7 @@
 import {
   AudioCodec,
   CQMode,
+  Colorspace,
   SystemConfig,
   SystemConfigEntity,
   SystemConfigKey,
@@ -15,7 +16,6 @@ import { IJobRepository, JobName, QueueName } from '../job';
 import { defaults, SystemConfigValidator } from './system-config.core';
 import { ISystemConfigRepository } from './system-config.repository';
 import { SystemConfigService } from './system-config.service';
-import { Colorspace } from '@app/infra/entities';
 
 const updates: SystemConfigEntity[] = [
   { key: SystemConfigKey.FFMPEG_CRF, value: 30 },

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -95,7 +95,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     webpSize: 250,
     jpegSize: 1440,
     quality: 80,
-    wideGamut: false
+    wideGamut: true,
   },
 });
 

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -95,7 +95,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     webpSize: 250,
     jpegSize: 1440,
     quality: 80,
-    colorspace: 'p3',
+    colorspace: Colorspace.P3,
   },
 });
 

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -95,7 +95,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     webpSize: 250,
     jpegSize: 1440,
     quality: 80,
-    wideGamut: true,
+    colorspace: 'p3',
   },
 });
 

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -94,6 +94,8 @@ const updatedConfig = Object.freeze<SystemConfig>({
   thumbnail: {
     webpSize: 250,
     jpegSize: 1440,
+    quality: 80,
+    wideGamut: false
   },
 });
 

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -76,6 +76,8 @@ export enum SystemConfigKey {
 
   THUMBNAIL_WEBP_SIZE = 'thumbnail.webpSize',
   THUMBNAIL_JPEG_SIZE = 'thumbnail.jpegSize',
+  THUMBNAIL_QUALITY = 'thumbnail.quality',
+  THUMBNAIL_WIDE_GAMUT = 'thumbnail.wideGamut',
 }
 
 export enum TranscodePolicy {
@@ -179,5 +181,7 @@ export interface SystemConfig {
   thumbnail: {
     webpSize: number;
     jpegSize: number;
+    quality: number;
+    wideGamut: boolean;
   };
 }

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -77,7 +77,7 @@ export enum SystemConfigKey {
   THUMBNAIL_WEBP_SIZE = 'thumbnail.webpSize',
   THUMBNAIL_JPEG_SIZE = 'thumbnail.jpegSize',
   THUMBNAIL_QUALITY = 'thumbnail.quality',
-  THUMBNAIL_WIDE_GAMUT = 'thumbnail.wideGamut',
+  THUMBNAIL_COLORSPACE = 'thumbnail.colorspace',
 }
 
 export enum TranscodePolicy {
@@ -117,6 +117,11 @@ export enum CQMode {
   AUTO = 'auto',
   CQP = 'cqp',
   ICQ = 'icq',
+}
+
+export enum Colorspace {
+  SRGB = 'srgb',
+  P3 = 'p3',
 }
 
 export interface SystemConfig {
@@ -182,6 +187,6 @@ export interface SystemConfig {
     webpSize: number;
     jpegSize: number;
     quality: number;
-    wideGamut: boolean;
+    colorspace: Colorspace;
   };
 }

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -38,6 +38,7 @@ export class MediaRepository implements IMediaRepository {
     }
     const chromaSubsampling = options.quality >= 80 ? '4:4:4' : '4:2:0'; // this is default in libvips (except the threshold is 90), but we need to set it manually in sharp
     sharp(input, { failOn: 'none' })
+      .pipelineColorspace('rgb16')
       .resize(options.size, options.size, { fit: 'outside', withoutEnlargement: true })
       .rotate()
       .withMetadata({ icc: colorspace })

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -25,16 +25,16 @@ export class MediaRepository implements IMediaRepository {
   }
 
   async resize(input: string | Buffer, output: string, options: ResizeOptions): Promise<void> {
-    let colorspace = options.colorspace;
+    let colorProfile = options.colorspace;
     if (options.colorspace !== Colorspace.SRGB) {
       try {
         const { space } = await sharp(input).metadata();
         // if the image is already in srgb, keep it that way
         if (space && space === Colorspace.SRGB) {
-          colorspace = Colorspace.SRGB;
+          colorProfile = Colorspace.SRGB;
         }
       } catch (err) {
-        this.logger.warn(`Could not determine colorspace of image, defaulting to ${colorspace}`);
+        this.logger.warn(`Could not determine colorspace of image, defaulting to ${colorProfile} profile`);
       }
     }
     const chromaSubsampling = options.quality >= 80 ? '4:4:4' : '4:2:0'; // this is default in libvips (except the threshold is 90), but we need to set it manually in sharp
@@ -42,7 +42,7 @@ export class MediaRepository implements IMediaRepository {
       .pipelineColorspace('rgb16')
       .resize(options.size, options.size, { fit: 'outside', withoutEnlargement: true })
       .rotate()
-      .withMetadata({ icc: colorspace })
+      .withMetadata({ icc: colorProfile })
       .toFormat(options.format, { quality: options.quality, chromaSubsampling })
       .toFile(output);
   }

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -27,13 +27,13 @@ export class MediaRepository implements IMediaRepository {
     let colorspace = options.wideGamut ? 'p3' : 'srgb';
     if (options.wideGamut) {
       try {
-        const { space } = await sharp(input, { failOn: 'none' }).metadata()
+        const { space } = await sharp(input, { failOn: 'none' }).metadata();
         // if the image is already in srgb, keep it that way
         if (space && (space as string) === 'srgb') {
           colorspace = 'srgb';
         }
       } catch (err) {
-        this.logger.warn(`Could not determine colorspace of image, defaulting to ${colorspace}`)
+        this.logger.warn(`Could not determine colorspace of image, defaulting to ${colorspace}`);
       }
     }
     const chromaSubsampling = options.quality >= 80 ? '4:4:4' : '4:2:0'; // this is default in libvips (except the threshold is 90), but we need to set it manually in sharp

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -30,7 +30,7 @@ export class MediaRepository implements IMediaRepository {
       try {
         const { space } = await sharp(input).metadata();
         // if the image is already in srgb, keep it that way
-        if (space === Colorspace.SRGB) {
+        if (space === "srgb") {
           colorProfile = Colorspace.SRGB;
         }
       } catch (err) {

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -30,7 +30,7 @@ export class MediaRepository implements IMediaRepository {
       try {
         const { space } = await sharp(input).metadata();
         // if the image is already in srgb, keep it that way
-        if (space && space === Colorspace.SRGB) {
+        if (space === Colorspace.SRGB) {
           colorProfile = Colorspace.SRGB;
         }
       } catch (err) {

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -5,6 +5,7 @@ import fs from 'fs/promises';
 import sharp from 'sharp';
 import { Writable } from 'typeorm/platform/PlatformTools.js';
 import { promisify } from 'util';
+import { Colorspace } from '@app/infra/entities';
 
 const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);
 sharp.concurrency(0);

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -5,7 +5,6 @@ import fs from 'fs/promises';
 import sharp from 'sharp';
 import { Writable } from 'typeorm/platform/PlatformTools.js';
 import { promisify } from 'util';
-import { Colorspace } from '../entities';
 
 const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);
 sharp.concurrency(0);

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -4,7 +4,7 @@ import { Logger } from '@nestjs/common';
 import ffmpeg, { FfprobeData } from 'fluent-ffmpeg';
 import fs from 'fs/promises';
 import sharp from 'sharp';
-import { Writable } from 'typeorm/platform/PlatformTools.js';
+import { Writable } from 'stream';
 import { promisify } from 'util';
 
 const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -27,7 +27,7 @@ export class MediaRepository implements IMediaRepository {
     let colorspace = options.wideGamut ? 'p3' : 'srgb';
     if (options.wideGamut) {
       try {
-        const { space } = await sharp(input, { failOn: 'none' }).metadata();
+        const { space } = await sharp(input).metadata();
         // if the image is already in srgb, keep it that way
         if (space && (space as string) === 'srgb') {
           colorspace = 'srgb';

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -1,11 +1,11 @@
 import { CropOptions, IMediaRepository, ResizeOptions, TranscodeOptions, VideoInfo } from '@app/domain';
+import { Colorspace } from '@app/infra/entities';
 import { Logger } from '@nestjs/common';
 import ffmpeg, { FfprobeData } from 'fluent-ffmpeg';
 import fs from 'fs/promises';
 import sharp from 'sharp';
 import { Writable } from 'typeorm/platform/PlatformTools.js';
 import { promisify } from 'util';
-import { Colorspace } from '@app/infra/entities';
 
 const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);
 sharp.concurrency(0);

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -30,7 +30,7 @@ export class MediaRepository implements IMediaRepository {
       try {
         const { space } = await sharp(input).metadata();
         // if the image is already in srgb, keep it that way
-        if (space === "srgb") {
+        if (space === 'srgb') {
           colorProfile = Colorspace.SRGB;
         }
       } catch (err) {

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1049,6 +1049,20 @@ export interface ClassificationConfig {
 /**
  * 
  * @export
+ * @enum {string}
+ */
+
+export const Colorspace = {
+    Srgb: 'srgb',
+    P3: 'p3'
+} as const;
+
+export type Colorspace = typeof Colorspace[keyof typeof Colorspace];
+
+
+/**
+ * 
+ * @export
  * @interface CreateAlbumDto
  */
 export interface CreateAlbumDto {
@@ -3186,6 +3200,12 @@ export interface SystemConfigTemplateStorageOptionDto {
 export interface SystemConfigThumbnailDto {
     /**
      * 
+     * @type {Colorspace}
+     * @memberof SystemConfigThumbnailDto
+     */
+    'colorspace': Colorspace;
+    /**
+     * 
      * @type {number}
      * @memberof SystemConfigThumbnailDto
      */
@@ -3202,13 +3222,9 @@ export interface SystemConfigThumbnailDto {
      * @memberof SystemConfigThumbnailDto
      */
     'webpSize': number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SystemConfigThumbnailDto
-     */
-    'wideGamut': boolean;
 }
+
+
 /**
  * 
  * @export

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -3195,7 +3195,19 @@ export interface SystemConfigThumbnailDto {
      * @type {number}
      * @memberof SystemConfigThumbnailDto
      */
+    'quality': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof SystemConfigThumbnailDto
+     */
     'webpSize': number;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SystemConfigThumbnailDto
+     */
+    'wideGamut': boolean;
 }
 /**
  * 

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -7,7 +7,9 @@
   export let checked = false;
   export let disabled = false;
   export let isEdited = false;
-  export let onToggle: (checked: boolean) => void;
+  export let onToggle: (checked: boolean) => void = () => {
+    return;
+  };
   export const handler = (e: Event) => {
     const target = e.target as HTMLInputElement;
     onToggle(target.checked);
@@ -30,7 +32,7 @@
       {/if}
     </div>
 
-    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
+    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -32,7 +32,7 @@
       {/if}
     </div>
 
-    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
+    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -9,7 +9,7 @@
   export let disabled = false;
   export let isEdited = false;
 
-  const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher<{ toggle: boolean }>();
 
   function onToggle(event: Event) {
     dispatch('toggle', (event.target as HTMLInputElement).checked);

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -10,10 +10,7 @@
   export let isEdited = false;
 
   const dispatch = createEventDispatcher<{ toggle: boolean }>();
-
-  function onToggle(event: Event) {
-    dispatch('toggle', (event.target as HTMLInputElement).checked);
-  }
+  const onToggle = (event: Event) => dispatch('toggle', (event.target as HTMLInputElement).checked);
 </script>
 
 <div class="flex place-items-center justify-between">

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -7,6 +7,11 @@
   export let checked = false;
   export let disabled = false;
   export let isEdited = false;
+  export let onToggle: (checked: boolean) => void;
+  export const handler = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    onToggle(target.checked);
+  };
 </script>
 
 <div class="flex place-items-center justify-between">
@@ -25,11 +30,17 @@
       {/if}
     </div>
 
-    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
+    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">
-    <input class="disabled::cursor-not-allowed h-0 w-0 opacity-0" type="checkbox" bind:checked on:click {disabled} />
+    <input
+      class="disabled::cursor-not-allowed h-0 w-0 opacity-0"
+      type="checkbox"
+      bind:checked
+      on:click={handler}
+      {disabled}
+    />
 
     {#if disabled}
       <span class="slider-disable cursor-not-allowed" />

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -11,8 +11,8 @@
 
   const dispatch = createEventDispatcher();
 
-  function onToggle() {
-    dispatch('toggle', checked);
+  function onToggle(event: Event) {
+    dispatch('toggle', (event.target as HTMLInputElement).checked);
   }
 </script>
 
@@ -32,7 +32,7 @@
       {/if}
     </div>
 
-    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
+    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
   import { quintOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
+  import { createEventDispatcher } from 'svelte';
 
   export let title: string;
   export let subtitle = '';
   export let checked = false;
   export let disabled = false;
   export let isEdited = false;
-  export let onToggle: (checked: boolean) => void = () => {
-    return;
-  };
-  export const handler = (e: Event) => {
-    const target = e.target as HTMLInputElement;
-    onToggle(target.checked);
-  };
+
+  const dispatch = createEventDispatcher();
+
+  function onToggle() {
+    dispatch('toggle', checked);
+  }
 </script>
 
 <div class="flex place-items-center justify-between">
@@ -32,7 +32,7 @@
       {/if}
     </div>
 
-    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
+    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">
@@ -40,7 +40,7 @@
       class="disabled::cursor-not-allowed h-0 w-0 opacity-0"
       type="checkbox"
       bind:checked
-      on:click={handler}
+      on:click={onToggle}
       {disabled}
     />
 

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -30,7 +30,7 @@
       {/if}
     </div>
 
-    <p class="dark:text-immich-dark-fg text-sm">{subtitle}</p>
+    <p class="text-sm dark:text-immich-dark-fg">{subtitle}</p>
   </div>
 
   <label class="relative inline-block h-[10px] w-[36px] flex-none">

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SettingSelect from '$lib/components/admin-page/settings/setting-select.svelte';
-  import { api, SystemConfigThumbnailDto } from '@api';
+  import { api, Colorspace, SystemConfigThumbnailDto } from '@api';
   import { fade } from 'svelte/transition';
   import { isEqual } from 'lodash-es';
   import SettingButtonsRow from '$lib/components/admin-page/settings/setting-buttons-row.svelte';
@@ -93,7 +93,7 @@
               { value: 250, text: '250p' },
             ]}
             name="resolution"
-            isEdited={!(thumbnailConfig.webpSize === savedConfig.webpSize)}
+            isEdited={thumbnailConfig.webpSize !== savedConfig.webpSize}
             {disabled}
           />
 
@@ -107,7 +107,7 @@
               { value: 1440, text: '1440p' },
             ]}
             name="resolution"
-            isEdited={!(thumbnailConfig.jpegSize === savedConfig.jpegSize)}
+            isEdited={thumbnailConfig.jpegSize !== savedConfig.jpegSize}
             {disabled}
           />
 
@@ -116,14 +116,14 @@
             label="QUALITY"
             desc="Thumbnail quality from 1-100. Higher is better for quality but produces larger files."
             bind:value={thumbnailConfig.quality}
-            isEdited={!(thumbnailConfig.quality === savedConfig.quality)}
+            isEdited={thumbnailConfig.quality !== savedConfig.quality}
           />
 
           <SettingSwitch
             title="PREFER WIDE GAMUT"
-            subtitle="Use the Display P3 colorspace for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
-            bind:checked={thumbnailConfig.wideGamut}
-            isEdited={!(thumbnailConfig.wideGamut === savedConfig.wideGamut)}
+            subtitle="Use Display P3 for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
+            onToggle={(enabled) => (thumbnailConfig.colorspace = enabled ? Colorspace.P3 : Colorspace.Srgb)}
+            isEdited={thumbnailConfig.colorspace !== savedConfig.colorspace}
           />
         </div>
 

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -123,7 +123,7 @@
             title="PREFER WIDE GAMUT"
             subtitle="Use Display P3 for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
             checked={thumbnailConfig.colorspace === Colorspace.P3}
-            on:toggle={(enabled) => (thumbnailConfig.colorspace = enabled ? Colorspace.P3 : Colorspace.Srgb)}
+            on:toggle={(e) => (thumbnailConfig.colorspace = e.detail ? Colorspace.P3 : Colorspace.Srgb)}
             isEdited={thumbnailConfig.colorspace !== savedConfig.colorspace}
           />
         </div>

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -123,7 +123,7 @@
             title="PREFER WIDE GAMUT"
             subtitle="Use Display P3 for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
             checked={thumbnailConfig.colorspace === Colorspace.P3}
-            onToggle={(enabled) => (thumbnailConfig.colorspace = enabled ? Colorspace.P3 : Colorspace.Srgb)}
+            on:toggle={(enabled) => (thumbnailConfig.colorspace = enabled ? Colorspace.P3 : Colorspace.Srgb)}
             isEdited={thumbnailConfig.colorspace !== savedConfig.colorspace}
           />
         </div>

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -8,6 +8,8 @@
     notificationController,
     NotificationType,
   } from '$lib/components/shared-components/notification/notification';
+  import SettingInputField, { SettingInputFieldType } from '../setting-input-field.svelte';
+  import SettingSwitch from '../setting-switch.svelte';
 
   export let thumbnailConfig: SystemConfigThumbnailDto; // this is the config that is being edited
   export let disabled = false;
@@ -107,6 +109,21 @@
             name="resolution"
             isEdited={!(thumbnailConfig.jpegSize === savedConfig.jpegSize)}
             {disabled}
+          />
+
+          <SettingInputField
+            inputType={SettingInputFieldType.NUMBER}
+            label="QUALITY"
+            desc="Thumbnail quality from 1-100. Higher is better for quality but produces larger files."
+            bind:value={thumbnailConfig.quality}
+            isEdited={!(thumbnailConfig.quality === savedConfig.quality)}
+          />
+
+          <SettingSwitch
+            title="PREFER WIDE GAMUT"
+            subtitle="Use the Display P3 colorspace for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
+            bind:checked={thumbnailConfig.wideGamut}
+            isEdited={!(thumbnailConfig.wideGamut === savedConfig.wideGamut)}
           />
         </div>
 

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -122,6 +122,7 @@
           <SettingSwitch
             title="PREFER WIDE GAMUT"
             subtitle="Use Display P3 for thumbnails. This better preserves the vibrance of images with wide colorspaces, but images may appear differently on old devices with an old browser version. sRGB images are kept as sRGB to avoid color shifts."
+            checked={thumbnailConfig.colorspace === Colorspace.P3}
             onToggle={(enabled) => (thumbnailConfig.colorspace = enabled ? Colorspace.P3 : Colorspace.Srgb)}
             isEdited={thumbnailConfig.colorspace !== savedConfig.colorspace}
           />


### PR DESCRIPTION
## Description

As requested in #3623, this PR allows for targeting Display P3 instead of sRGB for thumbnails, allowing for more vibrant images that better capture the colors of the original. Additionally, it adds a quality setting so users can customize thumbnail generation to their preference.

This only applies to image thumbnails for now, not video thumbnails. I tried several approaches for adding the same features for video thumbnails but wasn't satisfied with any of them:

* FFmpeg does not tag the resulting image with an ICC profile even with `-flags2 iccprofiles` (added with [this](https://trac.ffmpeg.org/ticket/9672) issue), so colors do not appear correctly

* JPEG quality in FFmpeg ranges 1-31 (lower is better) instead of 1-100, and even the highest quality setting is notably worse than what sharp or Imagemagick produces

* It is possible to extract a lossless thumbnail from FFmpeg and process it in sharp, but the resulting thumbnail naturally has different colors than the transcoded video

* It is possible to target `smpte432` for videos as well, but they don't seem to be processed correctly in Firefox (and applying a thumbnail setting to transcoding is confusing)


Fixes #3136


## How Has This Been Tested?

I ran thumbnail generation on a library of a few thousand images, some of which are HDR images. Inspecting the thumbnails produced for these images with exiftool shows that they have the expected ICC profile. Comparing them to older thumbnails likewise shows the expected difference in color.

Before:

![before](https://github.com/immich-app/immich/assets/101130780/fe7e9532-058d-4b50-bdef-7355a3a636ec)

After:

![after](https://github.com/immich-app/immich/assets/101130780/ab3fef15-438a-4a68-9b5a-fbb7f34cd64f)

(Credits to @adambeck7 for the image)