### PR TITLE
fix(server): sort un-named faces in query

### DIFF
--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -27,10 +27,8 @@ export class PersonService {
 
   async getAll(authUser: AuthUserDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
     const people = await this.repository.getAll(authUser.id, { minimumFaceCount: 1 });
-    const named = people.filter((person) => !!person.name);
-    const unnamed = people.filter((person) => !person.name);
 
-    const persons: PersonResponseDto[] = [...named, ...unnamed]
+    const persons: PersonResponseDto[] = people
       // with thumbnails
       .filter((person) => !!person.thumbnailPath)
       .map((person) => mapPerson(person));

--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -56,6 +56,7 @@ export class PersonRepository implements IPersonRepository {
       .leftJoin('person.faces', 'face')
       .where('person.ownerId = :userId', { userId })
       .orderBy('COUNT(face.assetId)', 'DESC')
+      .addOrderBy("NULLIF(person.name, '')", 'ASC', 'NULLS LAST')
       .having('COUNT(face.assetId) >= :faces', { faces: options?.minimumFaceCount || 1 })
       .groupBy('person.id')
       .limit(500)


### PR DESCRIPTION
### Changes made in this PR
Named and un-named persons are sorted directly using the query rather than fetching the results and filtering them in the server. The existing approach was incorrect since we are limiting the results to be 500 in the query which might result in named persons not getting returned within the first 500 results.

### How was this tested
- A named person who was not getting displayed in my people section started showing up
- All the persons are sorted by their asset count, followed by their name

Fixes #3660 