### PR TITLE
fix(web): add showHidden toggle for null island on map page #2991

### DIFF
--- a/web/src/lib/components/map-page/map-settings-modal.svelte
+++ b/web/src/lib/components/map-page/map-settings-modal.svelte
@@ -30,6 +30,7 @@
     >
       <SettingSwitch title="Allow dark mode" bind:checked={settings.allowDarkMode} />
       <SettingSwitch title="Only favorites" bind:checked={settings.onlyFavorites} />
+      <SettingSwitch title="Show hidden" bind:checked={settings.showHidden} />
       {#if customDateRange}
         <div in:fly={{ y: 10, duration: 200 }} class="flex flex-col gap-4">
           <div class="flex items-center justify-between gap-8">

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -22,6 +22,7 @@ export const locale = persisted<string | undefined>('locale', undefined, {
 export interface MapSettings {
   allowDarkMode: boolean;
   onlyFavorites: boolean;
+  showHidden: boolean;
   relativeDate: string;
   dateAfter: string;
   dateBefore: string;
@@ -30,6 +31,7 @@ export interface MapSettings {
 export const mapSettings = persisted<MapSettings>('map-settings', {
   allowDarkMode: true,
   onlyFavorites: false,
+  showHidden: false,
   relativeDate: '',
   dateAfter: '',
   dateBefore: '',

--- a/web/src/routes/(user)/map/+page.svelte
+++ b/web/src/routes/(user)/map/+page.svelte
@@ -41,7 +41,7 @@
     }
     abortController = new AbortController();
 
-    const { onlyFavorites } = $mapSettings;
+    const { onlyFavorites, showHidden } = $mapSettings;
     const { fileCreatedAfter, fileCreatedBefore } = getFileCreatedDates();
 
     const { data } = await api.assetApi.getMapMarkers(
@@ -54,7 +54,13 @@
         signal: abortController.signal,
       },
     );
-    return data;
+
+    let markers = data;
+
+    if (!showHidden) {
+      markers = data.filter((marker) => !(marker.lat === 0 && marker.lon === 0));
+    }
+    return markers;
   }
 
   function getFileCreatedDates() {


### PR DESCRIPTION
## Description
  - Adds a `showHidden` toggle to map settings defaulted to `false`
  - Does not render images on the map if lat,lon = (0,0) and `showHidden` is `false`

Fixes #2991


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Edit picture metadata to have lat,lon (0,0) -> open map with default settings -> verify null island is empty
- [x] Edit picture metadata to have lat,lon (0,0) -> open map -> toggle `showHidden` to true -> verify image appears at null island

## Screenshots (if appropriate):
![Screenshot from 2023-08-13 11-30-44](https://github.com/immich-app/immich/assets/3691245/e2fe907a-61f3-4d42-ba0f-63c6346ed915)
![Screenshot from 2023-08-13 11-27-03](https://github.com/immich-app/immich/assets/3691245/8f21cc60-1d95-483c-9c7a-45885b2c5e76)
![Screenshot from 2023-08-13 11-20-06](https://github.com/immich-app/immich/assets/3691245/1a1152d0-49e3-4abf-95b9-13316eac5fca)
![Screenshot from 2023-08-13 11-19-51](https://github.com/immich-app/immich/assets/3691245/5f73f553-2bc6-4be4-9bbb-070eef2cffd0)
![Screenshot from 2023-08-13 11-19-18](https://github.com/immich-app/immich/assets/3691245/eb150aec-4a78-47fd-9849-d23d9989ef16)


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable