### PR TITLE
feat(web): album list options

### DIFF
--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import SwapVertical from 'svelte-material-icons/SwapVertical.svelte';
   import Check from 'svelte-material-icons/Check.svelte';
   import LinkButton from './buttons/link-button.svelte';
   import { clickOutside } from '$lib/utils/click-outside';
@@ -7,6 +6,7 @@
 
   export let options: string[] = [];
   export let value = options[0];
+  export let icons: any[] = undefined;
 
   let showMenu = false;
 
@@ -18,13 +18,18 @@
     value = options[index];
     showMenu = false;
   };
+
+  $: index = options.findIndex(option => option === value)
+  $: icon = icons?.[index]
 </script>
 
 <div id="dropdown-button" use:clickOutside on:outclick={handleClickOutside}>
   <!-- BUTTON TITLE -->
   <LinkButton on:click={() => (showMenu = true)}>
     <div class="flex place-items-center gap-2 text-sm">
-      <SwapVertical size="18" />
+      {#if icon}
+        <svelte:component this={icon} size="18" />
+      {/if}
       {value}
     </div>
   </LinkButton>

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -4,9 +4,14 @@
   import { clickOutside } from '$lib/utils/click-outside';
   import { fly } from 'svelte/transition';
 
-  export let options: string[] = [];
+  interface DropdownOption {
+    value: string;
+    icon?: typeof LinkButton;
+  }
+
+  export let options: DropdownOption[] = [];
   export let value = options[0];
-  export let icons: any[] = undefined;
+  export let icons: typeof LinkButton[] | undefined = undefined;
 
   let showMenu = false;
 

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -3,15 +3,16 @@
   import LinkButton from './buttons/link-button.svelte';
   import { clickOutside } from '$lib/utils/click-outside';
   import { fly } from 'svelte/transition';
+  import type Icon from 'svelte-material-icons/DotsVertical.svelte';
 
   interface DropdownOption {
     value: string;
-    icon?: typeof LinkButton;
+    icon?: Icon;
   }
 
-  export let options: DropdownOption[] = [];
+  export let options: DropdownOption[] | string[] = [];
   export let value = options[0];
-  export let icons: (typeof LinkButton)[] | undefined = undefined;
+  export let icons: (typeof Icon)[] | undefined = undefined;
 
   let showMenu = false;
 
@@ -51,10 +52,10 @@
           on:click={() => handleSelectOption(index)}
         >
           {#if value == option}
-            <div class="font-medium text-immich-primary dark:text-immich-dark-primary">
+            <div class="text-immich-primary dark:text-immich-dark-primary font-medium">
               <Check size="18" />
             </div>
-            <p class="justify-self-start font-medium text-immich-primary dark:text-immich-dark-primary">
+            <p class="text-immich-primary dark:text-immich-dark-primary justify-self-start font-medium">
               {option}
             </p>
           {:else}

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -52,10 +52,10 @@
           on:click={() => handleSelectOption(index)}
         >
           {#if value == option}
-            <div class="text-immich-primary dark:text-immich-dark-primary font-medium">
+            <div class="font-medium text-immich-primary dark:text-immich-dark-primary">
               <Check size="18" />
             </div>
-            <p class="text-immich-primary dark:text-immich-dark-primary justify-self-start font-medium">
+            <p class="justify-self-start font-medium text-immich-primary dark:text-immich-dark-primary">
               {option}
             </p>
           {:else}

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -11,7 +11,7 @@
 
   export let options: DropdownOption[] = [];
   export let value = options[0];
-  export let icons: typeof LinkButton[] | undefined = undefined;
+  export let icons: (typeof LinkButton)[] | undefined = undefined;
 
   let showMenu = false;
 
@@ -24,8 +24,8 @@
     showMenu = false;
   };
 
-  $: index = options.findIndex(option => option === value)
-  $: icon = icons?.[index]
+  $: index = options.findIndex((option) => option === value);
+  $: icon = icons?.[index];
 </script>
 
 <div id="dropdown-button" use:clickOutside on:outclick={handleClickOutside}>

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -44,7 +44,12 @@ export interface AlbumViewSettings {
   view: string;
 }
 
+export enum AlbumViewMode {
+  Cover = 'Cover',
+  List = 'List'
+}
+
 export const albumViewSettings = persisted<AlbumViewSettings>('album-view-settings', {
   sortBy: 'Most recent photo',
-  view: 'Cover'
+  view: AlbumViewMode.Cover
 });

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -41,8 +41,10 @@ export const isShowDetail = persisted<boolean>('info-opened', false, {});
 
 export interface AlbumViewSettings {
   sortBy: string;
+  view: string;
 }
 
 export const albumViewSettings = persisted<AlbumViewSettings>('album-view-settings', {
   sortBy: 'Most recent photo',
+  view: 'Cover'
 });

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -46,10 +46,10 @@ export interface AlbumViewSettings {
 
 export enum AlbumViewMode {
   Cover = 'Cover',
-  List = 'List'
+  List = 'List',
 }
 
 export const albumViewSettings = persisted<AlbumViewSettings>('album-view-settings', {
   sortBy: 'Most recent photo',
-  view: AlbumViewMode.Cover
+  view: AlbumViewMode.Cover,
 });

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -19,7 +19,7 @@
   import Dropdown from '$lib/components/elements/dropdown.svelte';
   import ConfirmDialogue from '$lib/components/shared-components/confirm-dialogue.svelte';
   import { dateFormats } from '$lib/constants';
-  import { locale } from '$lib/stores/preferences.store';
+  import { locale, AlbumViewMode } from '$lib/stores/preferences.store';
   import {
     notificationController,
     NotificationType,
@@ -30,10 +30,10 @@
 
   const sortByOptions = ['Most recent photo', 'Last modified', 'Album title'];
   const viewOptions = [{
-    name: 'Cover',
+    name: AlbumViewMode.Cover,
     icon: ViewGridOutline
   }, {
-    name: 'List',
+    name: AlbumViewMode.List,
     icon: FormatListBulletedSquare
   }]
   const viewOptionNames = viewOptions.map(option => option.name)
@@ -137,7 +137,7 @@
   </div>
 
   <!-- Album Card -->
-  {#if $albumViewSettings.view === 'Cover'}
+  {#if $albumViewSettings.view === AlbumViewMode.Cover}
     <div class="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]">
       {#each $albums as album (album.id)}
         <a data-sveltekit-preload-data="hover" href={`albums/${album.id}`} animate:flip={{ duration: 200 }}>
@@ -145,7 +145,7 @@
         </a>
       {/each}
     </div>
-  {:else if $albumViewSettings.view === 'List'}
+  {:else if $albumViewSettings.view === AlbumViewMode.List}
     <table class="mt-5 w-full text-left">
       <thead
         class="mb-4 flex h-12 w-full rounded-md border bg-gray-50 text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary"

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -162,7 +162,8 @@
       >
         {#each $albums as album (album.id)}
             <tr
-              class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50"
+              class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
+              on:click={() => goto(`albums/${album.id}`)}
             >
               <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
               <td class="w-1/4 text-ellipsis px-2 text-md">

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -102,6 +102,10 @@
     }
   };
 
+  const dateLocaleString = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString($locale, dateFormats.album)
+  }
+
   onMount(() => {
     removeAlbumsIfEmpty();
   });
@@ -142,34 +146,35 @@
       {/each}
     </div>
   {:else if $albumViewSettings.view === 'List'}
-    <div class="grid grid-cols-4 text-white mb-2">
-      <span>Album title</span>
-      <span>Assets</span>
-      <span>Updated date</span>
-      <span>Created date</span>
-    </div>
-
-    {#each $albums as album (album.id)}
-      <a class="grid grid-cols-4" data-sveltekit-preload-data="hover" href={`albums/${album.id}`}>
-         <span
-          class="w-full truncate text-xl font-semibold text-immich-primary dark:text-immich-dark-primary"
-          data-testid="album-name"
-          title={album.albumName}
-        >
-          {album.albumName}
-        </span>
-
-        <span>
-          {album.assetCount}
-          {album.assetCount == 1 ? `item` : `items`}
-        </span>
-
-        <span>{new Date(album.updatedAt).toLocaleDateString($locale, dateFormats.album)}</span>
-        <span>{new Date(album.createdAt).toLocaleDateString($locale, dateFormats.album)}</span>
-
-        <!-- <span>{album.startDate} - {album.endDate}</span> -->
-      </a>
-    {/each}
+    <table class="mt-5 w-full text-left">
+      <thead
+        class="mb-4 flex h-12 w-full rounded-md border bg-gray-50 text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary"
+      >
+        <tr class="flex w-full place-items-center">
+          <th class="w-1/4 text-center text-sm font-medium">Album title</th>
+          <th class="w-1/4 text-center text-sm font-medium">Assets</th>
+          <th class="w-1/4 text-center text-sm font-medium">Updated date</th>
+          <th class="w-1/4 text-center text-sm font-medium">Created date</th>
+        </tr>
+      </thead>
+      <tbody
+        class="block max-h-[320px] w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
+      >
+        {#each $albums as album (album.id)}
+            <tr
+              class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50"
+            >
+              <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
+              <td class="w-1/4 text-ellipsis px-2 text-md">
+                 {album.assetCount}
+                 {album.assetCount == 1 ? `item` : `items`}
+              </td>
+              <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.updatedAt)}</td>
+              <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.createdAt)}</td>
+            </tr>
+        {/each}
+      </tbody>
+    </table>
   {/if}
 
   <!-- Empty Message -->

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -152,7 +152,7 @@
   {:else if $albumViewSettings.view === AlbumViewMode.List}
     <table class="mt-5 w-full text-left">
       <thead
-        class="text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary mb-4 flex h-12 w-full rounded-md border bg-gray-50"
+        class="mb-4 flex h-12 w-full rounded-md border bg-gray-50 text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary"
       >
         <tr class="flex w-full place-items-center">
           <th class="w-1/4 text-center text-sm font-medium">Album title</th>
@@ -162,11 +162,11 @@
         </tr>
       </thead>
       <tbody
-        class="dark:border-immich-dark-gray dark:text-immich-dark-fg block max-h-[320px] w-full overflow-y-auto rounded-md border"
+        class="block max-h-[320px] w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
       >
         {#each $albums as album (album.id)}
           <tr
-            class="odd:bg-immich-gray even:bg-immich-bg hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75 flex h-[50px] w-full place-items-center border-[3px] border-transparent p-5 text-center hover:cursor-pointer"
+            class="flex h-[50px] w-full place-items-center border-[3px] border-transparent p-5 text-center odd:bg-immich-gray even:bg-immich-bg hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75"
             on:click={() => goto(`albums/${album.id}`)}
             on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
             tabindex="0"

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -161,20 +161,20 @@
         class="block max-h-[320px] w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
       >
         {#each $albums as album (album.id)}
-            <tr
-              class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
-              on:click={() => goto(`albums/${album.id}`)}
-              on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
-              tabindex="0"
-            >
-              <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
-              <td class="w-1/4 text-ellipsis px-2 text-md">
-                 {album.assetCount}
-                 {album.assetCount == 1 ? `item` : `items`}
-              </td>
-              <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.updatedAt)}</td>
-              <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.createdAt)}</td>
-            </tr>
+          <tr
+            class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
+            on:click={() => goto(`albums/${album.id}`)}
+            on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
+            tabindex="0"
+          >
+            <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
+            <td class="w-1/4 text-ellipsis px-2 text-md">
+               {album.assetCount}
+               {album.assetCount == 1 ? `item` : `items`}
+            </td>
+            <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.updatedAt)}</td>
+            <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.createdAt)}</td>
+          </tr>
         {/each}
       </tbody>
     </table>

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -164,6 +164,8 @@
             <tr
               class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
               on:click={() => goto(`albums/${album.id}`)}
+              on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
+              tabindex="0"
             >
               <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
               <td class="w-1/4 text-ellipsis px-2 text-md">

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -5,6 +5,9 @@
   import ContextMenu from '$lib/components/shared-components/context-menu/context-menu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import DeleteOutline from 'svelte-material-icons/DeleteOutline.svelte';
+  import SwapVertical from 'svelte-material-icons/SwapVertical.svelte';
+  import FormatListBulletedSquare from 'svelte-material-icons/FormatListBulletedSquare.svelte';
+  import ViewGridOutline from 'svelte-material-icons/ViewGridOutline.svelte';
   import type { PageData } from './$types';
   import PlusBoxOutline from 'svelte-material-icons/PlusBoxOutline.svelte';
   import { useAlbums } from './albums.bloc';

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -29,15 +29,18 @@
   export let data: PageData;
 
   const sortByOptions = ['Most recent photo', 'Last modified', 'Album title'];
-  const viewOptions = [{
-    name: AlbumViewMode.Cover,
-    icon: ViewGridOutline
-  }, {
-    name: AlbumViewMode.List,
-    icon: FormatListBulletedSquare
-  }]
-  const viewOptionNames = viewOptions.map(option => option.name)
-  const viewOptionIcons = viewOptions.map(option => option.icon)
+  const viewOptions = [
+    {
+      name: AlbumViewMode.Cover,
+      icon: ViewGridOutline,
+    },
+    {
+      name: AlbumViewMode.List,
+      icon: FormatListBulletedSquare,
+    },
+  ];
+  const viewOptionNames = viewOptions.map((option) => option.name);
+  const viewOptionIcons = viewOptions.map((option) => option.icon);
 
   const {
     albums: unsortedAlbums,
@@ -103,8 +106,8 @@
   };
 
   const dateLocaleString = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString($locale, dateFormats.album)
-  }
+    return new Date(dateString).toLocaleDateString($locale, dateFormats.album);
+  };
 
   onMount(() => {
     removeAlbumsIfEmpty();
@@ -162,18 +165,18 @@
       >
         {#each $albums as album (album.id)}
           <tr
-            class="flex h-[50px] w-full place-items-center text-center odd:bg-immich-gray even:bg-immich-bg odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
+            class="flex h-[50px] w-full place-items-center border-[3px] border-transparent p-5 text-center odd:bg-immich-gray even:bg-immich-bg hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75"
             on:click={() => goto(`albums/${album.id}`)}
             on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
             tabindex="0"
           >
-            <td class="w-1/4 text-ellipsis px-2 text-md">{album.albumName}</td>
-            <td class="w-1/4 text-ellipsis px-2 text-md">
-               {album.assetCount}
-               {album.assetCount == 1 ? `item` : `items`}
+            <td class="text-md w-1/4 text-ellipsis px-2">{album.albumName}</td>
+            <td class="text-md w-1/4 text-ellipsis px-2">
+              {album.assetCount}
+              {album.assetCount == 1 ? `item` : `items`}
             </td>
-            <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.updatedAt)}</td>
-            <td class="w-1/4 text-ellipsis px-2 text-md">{dateLocaleString(album.createdAt)}</td>
+            <td class="text-md w-1/4 text-ellipsis px-2">{dateLocaleString(album.updatedAt)}</td>
+            <td class="text-md w-1/4 text-ellipsis px-2">{dateLocaleString(album.createdAt)}</td>
           </tr>
         {/each}
       </tbody>

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -25,6 +25,7 @@
     NotificationType,
   } from '$lib/components/shared-components/notification/notification';
   import type { AlbumResponseDto } from '@api';
+  import type Icon from 'svelte-material-icons/DotsVertical.svelte';
 
   export let data: PageData;
 
@@ -40,7 +41,7 @@
     },
   ];
   const viewOptionNames = viewOptions.map((option) => option.name);
-  const viewOptionIcons = viewOptions.map((option) => option.icon);
+  const viewOptionIcons: (typeof Icon)[] = viewOptions.map((option) => option.icon);
 
   const {
     albums: unsortedAlbums,
@@ -151,7 +152,7 @@
   {:else if $albumViewSettings.view === AlbumViewMode.List}
     <table class="mt-5 w-full text-left">
       <thead
-        class="mb-4 flex h-12 w-full rounded-md border bg-gray-50 text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary"
+        class="text-immich-primary dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-primary mb-4 flex h-12 w-full rounded-md border bg-gray-50"
       >
         <tr class="flex w-full place-items-center">
           <th class="w-1/4 text-center text-sm font-medium">Album title</th>
@@ -161,11 +162,11 @@
         </tr>
       </thead>
       <tbody
-        class="block max-h-[320px] w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
+        class="dark:border-immich-dark-gray dark:text-immich-dark-fg block max-h-[320px] w-full overflow-y-auto rounded-md border"
       >
         {#each $albums as album (album.id)}
           <tr
-            class="flex h-[50px] w-full place-items-center border-[3px] border-transparent p-5 text-center odd:bg-immich-gray even:bg-immich-bg hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75"
+            class="odd:bg-immich-gray even:bg-immich-bg hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75 flex h-[50px] w-full place-items-center border-[3px] border-transparent p-5 text-center hover:cursor-pointer"
             on:click={() => goto(`albums/${album.id}`)}
             on:keydown={(event) => event.key === 'Enter' && goto(`albums/${album.id}`)}
             tabindex="0"

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -159,15 +159,15 @@
           {album.albumName}
         </span>
 
-         <span>
-            {album.assetCount}
-            {album.assetCount == 1 ? `item` : `items`}
-         </span>
+        <span>
+          {album.assetCount}
+          {album.assetCount == 1 ? `item` : `items`}
+        </span>
 
-         <span>{new Date(album.updatedAt).toLocaleDateString($locale, dateFormats.album)}</span>
-         <span>{new Date(album.createdAt).toLocaleDateString($locale, dateFormats.album)}</span>
+        <span>{new Date(album.updatedAt).toLocaleDateString($locale, dateFormats.album)}</span>
+        <span>{new Date(album.createdAt).toLocaleDateString($locale, dateFormats.album)}</span>
 
-         <!-- <span>{album.startDate} - {album.endDate}</span> -->
+        <!-- <span>{album.startDate} - {album.endDate}</span> -->
       </a>
     {/each}
   {/if}


### PR DESCRIPTION
View all albums as cover/card or list view.
Found it hard to find albums with long album names when cover/card view, give more space by listing each album as list rows.

> [!NOTE] 
> Please suggest other names for options or additional views.


### Desktop list view:
![Screenshot 2023-08-14 at 7 23 01 PM](https://github.com/immich-app/immich/assets/2287769/79229bed-de4e-4538-a0d9-35b6f8ca9703)

### View options:
![Screenshot 2023-08-13 at 10 27 23 PM](https://github.com/immich-app/immich/assets/2287769/dedd6916-0b0e-4df4-80e1-c4f6eb281c36)
![Screenshot 2023-08-13 at 10 27 17 PM](https://github.com/immich-app/immich/assets/2287769/51ef1405-e1d2-4614-b287-d82f570f6dc9)

TODO:
 - [x] Implement List view
 - [x] Better use of space
 - [ ] Responsive design for desktop & mobile
 - [ ] Update APP