### PR TITLE
fix(server): Does not assign lat/lon if they are at 0,0 #2991

### DIFF
--- a/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
+++ b/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class FixGPSNullIsland1692057328660 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE "exif" SET latitude = NULL, longitude = NULL WHERE latitude = 0 AND longitude = 0;`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE "exif" SET latitude = 0, longitude = 0 WHERE latitude = NULL AND longitude = NULL;`);
+    }
+
+}

--- a/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
+++ b/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
@@ -6,7 +6,8 @@ export class FixGPSNullIsland1692057328660 implements MigrationInterface {
         await queryRunner.query(`UPDATE "exif" SET latitude = NULL, longitude = NULL WHERE latitude = 0 AND longitude = 0;`);
     }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
+    public async down(): Promise<void> {
+        // Setting lat,lon to 0 not necessary
     }
 
 }

--- a/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
+++ b/server/src/infra/migrations/1692057328660-fixGPSNullIsland.ts
@@ -7,7 +7,6 @@ export class FixGPSNullIsland1692057328660 implements MigrationInterface {
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`UPDATE "exif" SET latitude = 0, longitude = 0 WHERE latitude = NULL AND longitude = NULL;`);
     }
 
 }

--- a/server/src/microservices/processors/metadata-extraction.processor.ts
+++ b/server/src/microservices/processors/metadata-extraction.processor.ts
@@ -308,8 +308,16 @@ export class MetadataExtractionProcessor {
 
     const latitude = getExifProperty('GPSLatitude');
     const longitude = getExifProperty('GPSLongitude');
-    newExif.latitude = latitude !== null ? parseLatitude(latitude) : null;
-    newExif.longitude = longitude !== null ? parseLongitude(longitude) : null;
+    const lat = parseLatitude(latitude);
+    const lon = parseLongitude(longitude);
+
+    if (lat === 0 && lon === 0) {
+      this.logger.warn(`Latitude & Longitude were on Null Island (${lat},${lon}), not assigning coordinates`);
+    } else {
+      newExif.latitude = lat;
+      newExif.longitude = lon;
+    }
+
     if (getExifProperty('MotionPhoto')) {
       // Seen on more recent Pixel phones: starting as early as Pixel 4a, possibly earlier.
       const rawDirectory = getExifProperty('Directory');

--- a/server/src/microservices/utils/exif/coordinates.spec.ts
+++ b/server/src/microservices/utils/exif/coordinates.spec.ts
@@ -23,6 +23,12 @@ describe('parsing latitude from string input', () => {
   });
 });
 
+describe('parsing latitude from null input', () => {
+  it('returns null for null input', () => {
+    expect(parseLatitude(null)).toBeNull();
+  });
+});
+
 describe('parsing longitude from string input', () => {
   it('returns null for invalid inputs', () => {
     expect(parseLongitude('')).toBeNull();
@@ -42,5 +48,11 @@ describe('parsing longitude from string input', () => {
     expect(parseLongitude(-179.9)).toBeCloseTo(-179.9);
     expect(parseLongitude('0')).toBeCloseTo(0);
     expect(parseLongitude('-0.0')).toBeCloseTo(-0.0);
+  });
+});
+
+describe('parsing longitude from null input', () => {
+  it('returns null for null input', () => {
+    expect(parseLongitude(null)).toBeNull();
   });
 });

--- a/server/src/microservices/utils/exif/coordinates.ts
+++ b/server/src/microservices/utils/exif/coordinates.ts
@@ -1,6 +1,9 @@
 import { isNumberInRange } from '../numbers';
 
-export function parseLatitude(input: string | number): number | null {
+export function parseLatitude(input: string | number | null): number | null {
+  if (input === null) {
+    return null;
+  }
   const latitude = typeof input === 'string' ? Number.parseFloat(input) : input;
 
   if (isNumberInRange(latitude, -90, 90)) {
@@ -9,7 +12,11 @@ export function parseLatitude(input: string | number): number | null {
   return null;
 }
 
-export function parseLongitude(input: string | number): number | null {
+export function parseLongitude(input: string | number | null): number | null {
+  if (input === null) {
+    return null;
+  }
+
   const longitude = typeof input === 'string' ? Number.parseFloat(input) : input;
 
   if (isNumberInRange(longitude, -180, 180)) {


### PR DESCRIPTION
## Description
  - Allows null input to `parseLatitude` and `parseLongitude`
    - Returns null
  - If the latitude AND longitude are both 0, their exif coordinates are not set

Fixes #2991
Closes #3665 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Edit picture metadata to have lat,lon (0,0) -> open map with default settings -> verify null island is empty

## Screenshots (if appropriate):


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable