### PR TITLE
fix(mobile): make user.memoryEnable optional

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -3159,7 +3159,7 @@ export interface UserResponseDto {
      * @type {boolean}
      * @memberof UserResponseDto
      */
-    'memoriesEnabled': boolean;
+    'memoriesEnabled'?: boolean;
     /**
      * 
      * @type {string}

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -342,10 +342,11 @@ class HomePage extends HookConsumerWidget {
                           listener: selectionListener,
                           selectionActive: selectionEnabledHook.value,
                           onRefresh: refreshAssets,
-                          topWidget:
-                              (currentUser != null && currentUser.memoryEnabled)
-                                  ? const MemoryLane()
-                                  : const SizedBox(),
+                          topWidget: (currentUser != null &&
+                                  currentUser.memoryEnabled != null &&
+                                  currentUser.memoryEnabled!)
+                              ? const MemoryLane()
+                              : const SizedBox(),
                         ),
                   error: (error, _) => Center(child: Text(error.toString())),
                   loading: buildLoadingIndicator,

--- a/mobile/lib/shared/models/user.dart
+++ b/mobile/lib/shared/models/user.dart
@@ -44,7 +44,7 @@ class User {
   bool isPartnerSharedWith;
   bool isAdmin;
   String profileImagePath;
-  bool memoryEnabled;
+  bool? memoryEnabled;
   @Backlink(to: 'owner')
   final IsarLinks<Album> albums = IsarLinks<Album>();
   @Backlink(to: 'sharedUsers')

--- a/mobile/openapi/doc/UserResponseDto.md
+++ b/mobile/openapi/doc/UserResponseDto.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **id** | **String** |  | 
 **isAdmin** | **bool** |  | 
 **lastName** | **String** |  | 
-**memoriesEnabled** | **bool** |  | 
+**memoriesEnabled** | **bool** |  | [optional] 
 **oauthId** | **String** |  | 
 **profileImagePath** | **String** |  | 
 **shouldChangePassword** | **bool** |  | 

--- a/mobile/openapi/lib/model/user_response_dto.dart
+++ b/mobile/openapi/lib/model/user_response_dto.dart
@@ -21,7 +21,7 @@ class UserResponseDto {
     required this.id,
     required this.isAdmin,
     required this.lastName,
-    required this.memoriesEnabled,
+    this.memoriesEnabled,
     required this.oauthId,
     required this.profileImagePath,
     required this.shouldChangePassword,
@@ -45,7 +45,13 @@ class UserResponseDto {
 
   String lastName;
 
-  bool memoriesEnabled;
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? memoriesEnabled;
 
   String oauthId;
 
@@ -85,7 +91,7 @@ class UserResponseDto {
     (id.hashCode) +
     (isAdmin.hashCode) +
     (lastName.hashCode) +
-    (memoriesEnabled.hashCode) +
+    (memoriesEnabled == null ? 0 : memoriesEnabled!.hashCode) +
     (oauthId.hashCode) +
     (profileImagePath.hashCode) +
     (shouldChangePassword.hashCode) +
@@ -113,7 +119,11 @@ class UserResponseDto {
       json[r'id'] = this.id;
       json[r'isAdmin'] = this.isAdmin;
       json[r'lastName'] = this.lastName;
+    if (this.memoriesEnabled != null) {
       json[r'memoriesEnabled'] = this.memoriesEnabled;
+    } else {
+    //  json[r'memoriesEnabled'] = null;
+    }
       json[r'oauthId'] = this.oauthId;
       json[r'profileImagePath'] = this.profileImagePath;
       json[r'shouldChangePassword'] = this.shouldChangePassword;
@@ -142,7 +152,7 @@ class UserResponseDto {
         id: mapValueOfType<String>(json, r'id')!,
         isAdmin: mapValueOfType<bool>(json, r'isAdmin')!,
         lastName: mapValueOfType<String>(json, r'lastName')!,
-        memoriesEnabled: mapValueOfType<bool>(json, r'memoriesEnabled')!,
+        memoriesEnabled: mapValueOfType<bool>(json, r'memoriesEnabled'),
         oauthId: mapValueOfType<String>(json, r'oauthId')!,
         profileImagePath: mapValueOfType<String>(json, r'profileImagePath')!,
         shouldChangePassword: mapValueOfType<bool>(json, r'shouldChangePassword')!,
@@ -203,7 +213,6 @@ class UserResponseDto {
     'id',
     'isAdmin',
     'lastName',
-    'memoriesEnabled',
     'oauthId',
     'profileImagePath',
     'shouldChangePassword',

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -7152,8 +7152,7 @@
           "createdAt",
           "deletedAt",
           "updatedAt",
-          "oauthId",
-          "memoriesEnabled"
+          "oauthId"
         ],
         "type": "object"
       },

--- a/server/src/domain/user/response-dto/user-response.dto.ts
+++ b/server/src/domain/user/response-dto/user-response.dto.ts
@@ -14,7 +14,7 @@ export class UserResponseDto {
   deletedAt!: Date | null;
   updatedAt!: Date;
   oauthId!: string;
-  memoriesEnabled!: boolean;
+  memoriesEnabled?: boolean;
 }
 
 export function mapUser(entity: UserEntity): UserResponseDto {

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -3159,7 +3159,7 @@ export interface UserResponseDto {
      * @type {boolean}
      * @memberof UserResponseDto
      */
-    'memoriesEnabled': boolean;
+    'memoriesEnabled'?: boolean;
     /**
      * 
      * @type {string}


### PR DESCRIPTION
- Avoid breaking change for upcoming release since older instance doesn't have `memoryEnable` property in `UserRespondDto`, and by making it required, it will prevent logging in when the mobile API trying to get the non-existed property from JSON response.

- We can change this back after a few more releases.