### PR TITLE
fix(web,server): disable partner's archive access

### DIFF
--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -19,6 +19,8 @@ export enum Permission {
   ALBUM_SHARE = 'album.share',
   ALBUM_DOWNLOAD = 'album.download',
 
+  ARCHIVE_READ = 'archive.read',
+
   LIBRARY_READ = 'library.read',
   LIBRARY_DOWNLOAD = 'library.download',
 }
@@ -155,6 +157,9 @@ export class AccessCore {
 
       case Permission.ALBUM_REMOVE_ASSET:
         return this.repository.album.hasOwnerAccess(authUser.id, id);
+
+      case Permission.ARCHIVE_READ:
+        return authUser.id === id;
 
       case Permission.LIBRARY_READ:
         return authUser.id === id || (await this.repository.library.hasPartnerAccess(authUser.id, id));

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -148,6 +148,9 @@ export class AssetService {
     if (dto.albumId) {
       await this.access.requirePermission(authUser, Permission.ALBUM_READ, [dto.albumId]);
     } else if (dto.userId) {
+      if (dto.isArchived !== false) {
+        await this.access.requirePermission(authUser, Permission.ARCHIVE_READ, [dto.userId]);
+      }
       await this.access.requirePermission(authUser, Permission.LIBRARY_READ, [dto.userId]);
     } else {
       dto.userId = authUser.id;

--- a/web/src/routes/(user)/partners/[userId]/+page.svelte
+++ b/web/src/routes/(user)/partners/[userId]/+page.svelte
@@ -18,7 +18,7 @@
 
   export let data: PageData;
 
-  const assetStore = new AssetStore({ size: TimeBucketSize.Month, userId: data.partner.id });
+  const assetStore = new AssetStore({ size: TimeBucketSize.Month, userId: data.partner.id, isArchived: false });
   const assetInteractionStore = createAssetInteractionStore();
   const { isMultiSelectState, selectedAssets } = assetInteractionStore;
 


### PR DESCRIPTION
## Description
Before 1.72.0 user didn't have access to partner's archived assets. This PR fixes the regression by introducing the new permission `ARCHIVE_READ`

## How Has This Been Tested?
 - Partner's timeline now doesn't include archived assets
 - `getTimeBuckets` and `getByTimeBucket` with `userId` specified and `isArchived` other than `false` throws an error now