### PR TITLE
fix(web,server): album share performance

### DIFF
--- a/server/src/domain/album/album.repository.ts
+++ b/server/src/domain/album/album.repository.ts
@@ -7,8 +7,12 @@ export interface AlbumAssetCount {
   assetCount: number;
 }
 
+export interface AlbumInfoOptions {
+  withAssets: boolean;
+}
+
 export interface IAlbumRepository {
-  getById(id: string): Promise<AlbumEntity | null>;
+  getById(id: string, options: AlbumInfoOptions): Promise<AlbumEntity | null>;
   getByIds(ids: string[]): Promise<AlbumEntity[]>;
   getByAssetId(ownerId: string, assetId: string): Promise<AlbumEntity[]>;
   hasAsset(id: string, assetId: string): Promise<boolean>;

--- a/server/src/domain/album/album.service.spec.ts
+++ b/server/src/domain/album/album.service.spec.ts
@@ -364,6 +364,7 @@ describe(AlbumService.name, () => {
         updatedAt: expect.any(Date),
         sharedUsers: [],
       });
+      expect(albumMock.getById).toHaveBeenCalledWith(albumStub.sharedWithUser.id, { withAssets: false });
     });
 
     it('should prevent removing a shared user from a not-owned album (shared with auth user)', async () => {
@@ -432,7 +433,7 @@ describe(AlbumService.name, () => {
 
       await sut.get(authStub.admin, albumStub.oneAsset.id, {});
 
-      expect(albumMock.getById).toHaveBeenCalledWith(albumStub.oneAsset.id);
+      expect(albumMock.getById).toHaveBeenCalledWith(albumStub.oneAsset.id, { withAssets: true });
       expect(accessMock.album.hasOwnerAccess).toHaveBeenCalledWith(authStub.admin.id, albumStub.oneAsset.id);
     });
 
@@ -442,7 +443,7 @@ describe(AlbumService.name, () => {
 
       await sut.get(authStub.adminSharedLink, 'album-123', {});
 
-      expect(albumMock.getById).toHaveBeenCalledWith('album-123');
+      expect(albumMock.getById).toHaveBeenCalledWith('album-123', { withAssets: true });
       expect(accessMock.album.hasSharedLinkAccess).toHaveBeenCalledWith(
         authStub.adminSharedLink.sharedLinkId,
         'album-123',
@@ -455,7 +456,7 @@ describe(AlbumService.name, () => {
 
       await sut.get(authStub.user1, 'album-123', {});
 
-      expect(albumMock.getById).toHaveBeenCalledWith('album-123');
+      expect(albumMock.getById).toHaveBeenCalledWith('album-123', { withAssets: true });
       expect(accessMock.album.hasSharedAlbumAccess).toHaveBeenCalledWith(authStub.user1.id, 'album-123');
     });
 

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -100,7 +100,7 @@
   });
 
   const refreshAlbum = async () => {
-    const { data } = await api.albumApi.getAlbumInfo({ id: album.id, withoutAssets: false });
+    const { data } = await api.albumApi.getAlbumInfo({ id: album.id, withoutAssets: true });
     album = data;
   };
 
@@ -261,9 +261,9 @@
     }
   };
 
-  const handleUpdateDescription = (description: string) => {
+  const handleUpdateDescription = async (description: string) => {
     try {
-      api.albumApi.updateAlbumInfo({
+      await api.albumApi.updateAlbumInfo({
         id: album.id,
         updateAlbumDto: {
           description,


### PR DESCRIPTION
Fixes #3177

Improve performance while sharing (adding and removing a user from) an album.

In this PR:
- Don't return assets on the update album endpoint response
- Don't return assets on the add album user endpoint response
- Don't load assets from the database when removing a user (mobile app needs changes before assets can be skipping when adding a new user)
- Don't ask for assets when refreshing the album info (web)

Before vs After Tests (on an album with 10k assets)

1.9 seconds to add a user (before) vs 800ms to add a user (after)
1.7 seconds to remove a user (before) vs 600ms to remove a user (after)

![image](https://github.com/immich-app/immich/assets/4334196/e522ee80-5389-4a95-9d07-892eed7b85c9)

Future Improvements:
- Adding/removing assets to an album should be done without loading all the assets into memory
- Loading all the assets into memory is currently required to get the album asset count. This can be avoided, but may require using query builder or running two selects.

Tested Scenarios:
- Add a user to an album
- Remove a user from an album
- Leaving a shared album
- Creating a new album