### PR TITLE
refactor(server): android motion photos

### DIFF
--- a/server/src/domain/asset/asset.repository.ts
+++ b/server/src/domain/asset/asset.repository.ts
@@ -71,6 +71,7 @@ export const IAssetRepository = 'IAssetRepository';
 export interface IAssetRepository {
   getByDate(ownerId: string, date: Date): Promise<AssetEntity[]>;
   getByIds(ids: string[]): Promise<AssetEntity[]>;
+  getByChecksum(userId: string, checksum: Buffer): Promise<AssetEntity | null>;
   getByAlbumId(pagination: PaginationOptions, albumId: string): Paginated<AssetEntity>;
   getByUserId(pagination: PaginationOptions, userId: string): Paginated<AssetEntity>;
   getWithout(pagination: PaginationOptions, property: WithoutProperty): Paginated<AssetEntity>;

--- a/server/src/domain/crypto/crypto.repository.ts
+++ b/server/src/domain/crypto/crypto.repository.ts
@@ -3,8 +3,9 @@ export const ICryptoRepository = 'ICryptoRepository';
 export interface ICryptoRepository {
   randomBytes(size: number): Buffer;
   randomUUID(): string;
-  hashFile(filePath: string): Promise<Buffer>;
+  hashFile(filePath: string | Buffer): Promise<Buffer>;
   hashSha256(data: string): string;
+  hashSha1(data: string | Buffer): Buffer;
   hashBcrypt(data: string | Buffer, saltOrRounds: string | number): Promise<string>;
   compareBcrypt(data: string | Buffer, encrypted: string): boolean;
 }

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -156,6 +156,10 @@ export class AssetRepository implements IAssetRepository {
     });
   }
 
+  getByChecksum(userId: string, checksum: Buffer): Promise<AssetEntity | null> {
+    return this.repository.findOne({ where: { ownerId: userId, checksum } });
+  }
+
   findLivePhotoMatch(options: LivePhotoSearchOptions): Promise<AssetEntity | null> {
     const { ownerId, otherAssetId, livePhotoCID, type } = options;
 

--- a/server/src/infra/repositories/crypto.repository.ts
+++ b/server/src/infra/repositories/crypto.repository.ts
@@ -16,7 +16,11 @@ export class CryptoRepository implements ICryptoRepository {
     return createHash('sha256').update(value).digest('base64');
   }
 
-  hashFile(filepath: string): Promise<Buffer> {
+  hashSha1(value: string | Buffer): Buffer {
+    return createHash('sha1').update(value).digest();
+  }
+
+  hashFile(filepath: string | Buffer): Promise<Buffer> {
     return new Promise<Buffer>((resolve, reject) => {
       const hash = createHash('sha1');
       const stream = createReadStream(filepath);

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -8,6 +8,7 @@ export const newAssetRepositoryMock = (): jest.Mocked<IAssetRepository> => {
     getByAlbumId: jest.fn(),
     getByUserId: jest.fn(),
     getWithout: jest.fn(),
+    getByChecksum: jest.fn(),
     getWith: jest.fn(),
     getFirstAssetForAlbumId: jest.fn(),
     getLastUpdatedAssetForAlbumId: jest.fn(),

--- a/server/test/repositories/crypto.repository.mock.ts
+++ b/server/test/repositories/crypto.repository.mock.ts
@@ -7,6 +7,7 @@ export const newCryptoRepositoryMock = (): jest.Mocked<ICryptoRepository> => {
     compareBcrypt: jest.fn().mockReturnValue(true),
     hashBcrypt: jest.fn().mockImplementation((input) => Promise.resolve(`${input} (hashed)`)),
     hashSha256: jest.fn().mockImplementation((input) => `${input} (hashed)`),
+    hashSha1: jest.fn().mockImplementation((input) => Buffer.from(`${input.toString()} (hashed)`)),
     hashFile: jest.fn().mockImplementation((input) => `${input} (file-hashed)`),
   };
 };


### PR DESCRIPTION
A little bit easier to read.

- Handle duplicates (duplicate extracted videos)
- Hash the video portion without writing it to disk
- Only write the video to disk when it is unique and a new asset is being created
- Run video metadata extraction as a separate job, which can pass/fail independently

Tested by uploading a android motion photo and verifying the extracted video is linked and plays correctly.