### PR TITLE
fix(server): sorting people

### DIFF
--- a/server/src/domain/person/person.repository.ts
+++ b/server/src/domain/person/person.repository.ts
@@ -4,6 +4,7 @@ export const IPersonRepository = 'IPersonRepository';
 
 export interface PersonSearchOptions {
   minimumFaceCount: number;
+  withHidden: boolean;
 }
 
 export interface UpdateFacesData {

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -47,7 +47,7 @@ describe(PersonService.name, () => {
         visible: 1,
         people: [responseDto],
       });
-      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1 });
+      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1, withHidden: false });
     });
     it('should get all visible people with thumbnails', async () => {
       personMock.getAll.mockResolvedValue([personStub.withName, personStub.hidden]);
@@ -56,7 +56,7 @@ describe(PersonService.name, () => {
         visible: 1,
         people: [responseDto],
       });
-      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1 });
+      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1, withHidden: false });
     });
     it('should get all hidden and visible people with thumbnails', async () => {
       personMock.getAll.mockResolvedValue([personStub.withName, personStub.hidden]);
@@ -73,7 +73,7 @@ describe(PersonService.name, () => {
           },
         ],
       });
-      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1 });
+      expect(personMock.getAll).toHaveBeenCalledWith(authStub.admin.id, { minimumFaceCount: 1, withHidden: true });
     });
   });
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -26,8 +26,10 @@ export class PersonService {
   ) {}
 
   async getAll(authUser: AuthUserDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
-    const people = await this.repository.getAll(authUser.id, { minimumFaceCount: 1 });
-
+    const people = await this.repository.getAll(authUser.id, {
+      minimumFaceCount: 1,
+      withHidden: dto.withHidden || false,
+    });
     const persons: PersonResponseDto[] = people
       // with thumbnails
       .filter((person) => !!person.thumbnailPath)


### PR DESCRIPTION
## Changes made in this PR

Currently, the server filters the hidden people after executing the query which can result in less than 500 people sent back to the users.
This PR fixes #3709.

## Screenshots

| Without hidden | With hidden |
| --- | -- |
| ![Screenshot from 2023-08-16 00-18-35](https://github.com/immich-app/immich/assets/74269598/70b5b66c-2aa0-4e47-8355-99dbd5b3505c) |![Screenshot from 2023-08-16 00-18-41](https://github.com/immich-app/immich/assets/74269598/b041c6b6-a70a-4034-aade-b615b608f6ec) |

Number of faces:
- macron: 3
- einstein: 2
- torvalds: 2
- obama: 4
- harris: 2
- wozniak: 2
- stallman: 1
- jobs: 2

Faces with the same number of faces are sorted alphabetically