### PR TITLE
chore(web): better explain what the thumbnails type are for

### DIFF
--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -79,8 +79,8 @@
       <form autocomplete="off" on:submit|preventDefault>
         <div class="ml-4 mt-4 flex flex-col gap-4">
           <SettingSelect
-            label="WEBP RESOLUTION"
-            desc="Higher resolutions can preserve more detail but take longer to encode, have larger file sizes, and can reduce app responsiveness."
+            label="SMALL THUMBNAIL RESOLUTION"
+            desc="Used when viewing groups of photos (main timeline, album view, etc.). Higher resolutions can preserve more detail but take longer to encode, have larger file sizes, and can reduce app responsiveness."
             number
             bind:value={thumbnailConfig.webpSize}
             options={[
@@ -94,8 +94,8 @@
           />
 
           <SettingSelect
-            label="JPEG RESOLUTION"
-            desc="Higher resolutions can preserve more detail but take longer to encode, have larger file sizes, and can reduce app responsiveness."
+            label="LARGE THUMBNAIL RESOLUTION"
+            desc="Used when viewing a single photo and for machine learning. Higher resolutions can preserve more detail but take longer to encode, have larger file sizes, and can reduce app responsiveness."
             number
             bind:value={thumbnailConfig.jpegSize}
             options={[


### PR DESCRIPTION
I also changed the title of the settings (for some users WEBP and JPG might make little sense). I don't know if it's correct to spell "small thumbnails resolution" with or without the trailing "S" in the word "thumbnails" - sorry, not a native speaker.

I rewrote the helper text several times trying to find the best way to explain thumbnails usage; this is the best I could come up with. Feel free to suggest anything else of course.