### PR TITLE
fix(mobile): LivePhoto video not uploaded during manual asset upload

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.73.0+96
 isar_version: &isar_version 3.1.0+1
 
 environment:
-  sdk: ">=3.0.0-0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### Changes made in this PR:

- Asset properties are refreshed from the `photo_manager` before proceeding with manual upload to get platform specific properties such as `subtype` properly updated. This fixes the issue where uploading a LivePhoto manually will not add the LivePhoto video to the upload due to the lack of proper `subtype`
- A state handling error resulting in the state/icon not updating from crossed-cloud to checked-cloud after manual upload is also fixed
https://github.com/immich-app/immich/pull/3611#issuecomment-1676090321
This was due to the app getting disconnected from the websocket listener before receiving the `onUploadSuccess` callback which is used to refresh the state of the asset in local db

### How has this been tested:
- Upload a single LivePhoto and ensure that the video can be played in the web and iOS app after successful upload
- Upload multiple LivePhotos and ensure that all of them are properly playable after upload
- Ensured that the state of the asset is immediately updated after successful upload