### PR TITLE
feat(server): add support for the tif extension

### DIFF
--- a/server/src/domain/domain.constant.spec.ts
+++ b/server/src/domain/domain.constant.spec.ts
@@ -37,6 +37,7 @@ describe('mimeTypes', () => {
     { mimetype: 'image/sr2', extension: '.sr2' },
     { mimetype: 'image/srf', extension: '.srf' },
     { mimetype: 'image/srw', extension: '.srw' },
+    { mimetype: 'image/tiff', extension: '.tif' },
     { mimetype: 'image/tiff', extension: '.tiff' },
     { mimetype: 'image/webp', extension: '.webp' },
     { mimetype: 'image/x-adobe-dng', extension: '.dng' },
@@ -82,7 +83,7 @@ describe('mimeTypes', () => {
     { mimetype: 'video/x-ms-wmv', extension: '.wmv' },
     { mimetype: 'video/x-msvideo', extension: '.avi' },
   ]) {
-    it(`should map ${extension} to ${mimetype}`, async () => {
+    it(`should map ${extension} to ${mimetype}`, () => {
       expect({ ...mimeTypes.image, ...mimeTypes.video }[extension]).toContain(mimetype);
     });
   }

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -66,6 +66,7 @@ const image: Record<string, string[]> = {
   '.sr2': ['image/sr2', 'image/x-sony-sr2'],
   '.srf': ['image/srf', 'image/x-sony-srf'],
   '.srw': ['image/srw', 'image/x-samsung-srw'],
+  '.tif': ['image/tiff'],
   '.tiff': ['image/tiff'],
   '.webp': ['image/webp'],
   '.x3f': ['image/x3f', 'image/x-sigma-x3f'],


### PR DESCRIPTION
Closes #3429
Closes #3744

Add support for the `.tif` extension. Successfully uploaded a `.tif` file (and it generated a thumbnail).