### PR TITLE
fix(web): play videos on safari

### DIFF
--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { api } from '@api';
+  import { ThumbnailFormat, api } from '@api';
   import { fade } from 'svelte/transition';
   import { createEventDispatcher } from 'svelte';
   import { videoViewerVolume } from '$lib/stores/preferences.store';
@@ -29,11 +29,13 @@
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   <video
     autoplay
+    playsinline
     controls
     class="h-full object-contain"
     on:canplay={handleCanPlay}
     on:ended={() => dispatch('onVideoEnded')}
     bind:volume={$videoViewerVolume}
+    poster={api.getAssetThumbnailUrl(assetId, ThumbnailFormat.Jpeg)}
   >
     <source src={api.getAssetFileUrl(assetId, false, true, publicSharedKey)} type="video/mp4" />
     <track kind="captions" />

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -18,16 +18,17 @@
       video.muted = true;
       await video.play();
       video.muted = false;
-
-      isVideoLoading = false;
     } catch (error) {
       handleError(error, 'Unable to play video');
+    } finally {
+      isVideoLoading = false;
     }
   };
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   <video
+    autoplay
     controls
     class="h-full object-contain"
     on:canplay={handleCanPlay}


### PR DESCRIPTION
Fix #3387 

Safari does not fire `canplay` unless the video element has `autoplay`.