### PR TITLE
chore: Enable logging, but reduce verboseness of typesense container

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -100,8 +100,8 @@ services:
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
-    logging:
-      driver: none
+      # remove this to get debug messages
+      - GLOG_minloglevel=1
     volumes:
       - tsdata:/data
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -68,8 +68,8 @@ services:
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
-    logging:
-      driver: none
+      # remove this to get debug messages
+      - GLOG_minloglevel=1
     volumes:
       - tsdata:/data
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,6 +54,8 @@ services:
     environment:
       - TYPESENSE_API_KEY=${TYPESENSE_API_KEY}
       - TYPESENSE_DATA_DIR=/data
+      # remove this to get debug messages
+      - GLOG_minloglevel=1
     volumes:
       - tsdata:/data
     restart: always


### PR DESCRIPTION
This PR builds on #3326 to enable logs of typesense container, but:
- reduce verboseness by default by removing INFO messages
- makes it consistent: enable logging in prod and dev

Idea comes from:
https://github.com/typesense/typesense/issues/475#issuecomment-1597713929

Definition of `GLOG_minloglevel` is here:
https://github.com/google/glog/tree/3a0d4d22c5ae0b9a2216988411cfa6bf860cc372#setting-flags