### PR TITLE
fix(mobile) Fix ios map launch & Use OSM as map fallback

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
@@ -16,16 +16,32 @@ class ExifBottomSheet extends HookConsumerWidget {
 
   const ExifBottomSheet({Key? key, required this.asset}) : super(key: key);
 
-  bool get showMap =>
+  bool get hasCoordinates =>
       asset.exifInfo?.latitude != null && asset.exifInfo?.longitude != null;
 
-  Future<Uri> _createCoordinatesUri(double latitude, double longitude) async {
-    const zoomLevel = 5;
+  String get formattedDateTime {
+    final fileCreatedAt = asset.fileCreatedAt.toLocal();
+    final date = DateFormat.yMMMEd().format(fileCreatedAt);
+    final time = DateFormat.jm().format(fileCreatedAt);
+
+    return '$date • $time';
+  }
+
+  Future<Uri?> _createCoordinatesUri() async {
+    if (!hasCoordinates) {
+      return null;
+    }
+
+    double latitude = asset.exifInfo!.latitude!;
+    double longitude = asset.exifInfo!.longitude!;
+
+    const zoomLevel = 16;
+
     if (Platform.isAndroid) {
       Uri uri = Uri(
         scheme: 'geo',
         host: '$latitude,$longitude',
-        queryParameters: {'z': '$zoomLevel', 'q': '$latitude,$longitude'},
+        queryParameters: {'z': '$zoomLevel', 'q': formattedDateTime},
       );
       if (await canLaunchUrl(uri)) {
         return uri;
@@ -33,16 +49,20 @@ class ExifBottomSheet extends HookConsumerWidget {
     } else if (Platform.isIOS) {
       var params = {
         'll': '$latitude,$longitude',
-        'q': '$latitude, $longitude',
+        'q': formattedDateTime,
+        'z': '$zoomLevel',
       };
       Uri uri = Uri.https('maps.apple.com', '/', params);
-      if (!await canLaunchUrl(uri)) {
+      if (await canLaunchUrl(uri)) {
         return uri;
       }
     }
-    return Uri.https(
-      'www.google.com',
-      '/maps/place/$latitude,$longitude/@$latitude,$longitude,${zoomLevel}z',
+
+    return Uri(
+      scheme: 'https',
+      host: 'openstreetmap.org',
+      queryParameters: {'mlat': '$latitude', 'mlon': '$longitude'},
+      fragment: 'map=$zoomLevel/$latitude/$longitude',
     );
   }
 
@@ -72,16 +92,14 @@ class ExifBottomSheet extends HookConsumerWidget {
                   ),
                   zoom: 16.0,
                   onTap: (tapPosition, latLong) async {
-                    if (exifInfo != null &&
-                        exifInfo.latitude != null &&
-                        exifInfo.longitude != null) {
-                      launchUrl(
-                        await _createCoordinatesUri(
-                          exifInfo.latitude!,
-                          exifInfo.longitude!,
-                        ),
-                      );
+                    Uri? uri = await _createCoordinatesUri();
+
+                    if (uri == null) {
+                      return;
                     }
+
+                    debugPrint('Opening Map Uri: $uri');
+                    launchUrl(uri);
                   },
                 ),
                 nonRotatedChildren: [
@@ -151,7 +169,7 @@ class ExifBottomSheet extends HookConsumerWidget {
 
     buildLocation() {
       // Guard no lat/lng
-      if (!showMap) {
+      if (!hasCoordinates) {
         return Container();
       }
 
@@ -207,12 +225,8 @@ class ExifBottomSheet extends HookConsumerWidget {
     }
 
     buildDate() {
-      final fileCreatedAt = asset.fileCreatedAt.toLocal();
-      final date = DateFormat.yMMMEd().format(fileCreatedAt);
-      final time = DateFormat.jm().format(fileCreatedAt);
-
       return Text(
-        '$date • $time',
+        formattedDateTime,
         style: const TextStyle(
           fontWeight: FontWeight.bold,
           fontSize: 14,
@@ -306,7 +320,7 @@ class ExifBottomSheet extends HookConsumerWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Flexible(
-                              flex: showMap ? 5 : 0,
+                              flex: hasCoordinates ? 5 : 0,
                               child: Padding(
                                 padding: const EdgeInsets.only(right: 8.0),
                                 child: buildLocation(),
@@ -336,7 +350,7 @@ class ExifBottomSheet extends HookConsumerWidget {
                     if (asset.isRemote) DescriptionInput(asset: asset),
                     const SizedBox(height: 8.0),
                     buildLocation(),
-                    SizedBox(height: showMap ? 16.0 : 0.0),
+                    SizedBox(height: hasCoordinates ? 16.0 : 0.0),
                     buildDetail(),
                     const SizedBox(height: 50),
                   ],


### PR DESCRIPTION
I saw the new feature to open the Maps app when tapping on the preview map of an image in the new version. Sadly, it always opened Google Maps in the browser and not the Apple Maps App. This PR:
- (imho) fixes that and on iOS now opens the Maps app
   - Following the official docs here: https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html
- Changes the fallback from Google Maps to OSM
   - Following the docs here: https://wiki.openstreetmap.org/wiki/Browsing#Other_URL_tricks
- Changes the "label" that's shown when opening the (Apple/Google) Maps application from the coordinates (which are anyway shown for a pin on the map) to the date & time of the image.

## Screen Recordings
### Opening Apple Maps

https://github.com/immich-app/immich/assets/60623116/f055bea6-5504-407d-811c-41bd882952cb

## Opening OSM

https://github.com/immich-app/immich/assets/60623116/1ccddb39-e04d-4c8f-a215-e250e2ac0857

