### PR TITLE
feat(web,server): shared link album time buckets

### DIFF
--- a/server/src/infra/repositories/shared-link.repository.ts
+++ b/server/src/infra/repositories/shared-link.repository.ts
@@ -62,14 +62,7 @@ export class SharedLinkRepository implements ISharedLinkRepository {
         key,
       },
       relations: {
-        assets: true,
-        album: {
-          assets: true,
-        },
         user: true,
-      },
-      order: {
-        createdAt: 'DESC',
       },
     });
   }

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -21,6 +21,7 @@
   export let isSelectionMode = false;
   export let viewport: Viewport;
   export let singleSelect = false;
+  export let publicSharedKey: string | undefined = undefined;
 
   export let assetStore: AssetStore;
   export let assetInteractionStore: AssetInteractionStore;
@@ -189,6 +190,7 @@
               disabled={$assetStore.albumAssets.has(asset.id)}
               thumbnailWidth={box.width}
               thumbnailHeight={box.height}
+              {publicSharedKey}
             />
           </div>
         {/each}

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -23,6 +23,7 @@
   export let assetStore: AssetStore;
   export let assetInteractionStore: AssetInteractionStore;
   export let removeAction: AssetAction | null = null;
+  export let publicSharedKey: string | undefined = undefined;
 
   const { assetSelectionCandidates, assetSelectionStart, selectedGroup, selectedAssets, isMultiSelectState } =
     assetInteractionStore;
@@ -349,6 +350,7 @@
                 bucketDate={bucket.bucketDate}
                 bucketHeight={bucket.bucketHeight}
                 {viewport}
+                {publicSharedKey}
               />
             {/if}
           </div>

--- a/web/src/routes/(user)/share/[key]/+page.svelte
+++ b/web/src/routes/(user)/share/[key]/+page.svelte
@@ -1,23 +1,17 @@
 <script lang="ts">
   import AlbumViewer from '$lib/components/album-page/album-viewer.svelte';
   import IndividualSharedViewer from '$lib/components/share-page/individual-shared-viewer.svelte';
-  import { AlbumResponseDto, SharedLinkType } from '@api';
+  import { SharedLinkType } from '@api';
   import type { PageData } from './$types';
 
   export let data: PageData;
   const { sharedLink } = data;
 
-  let album: AlbumResponseDto | null = null;
   let isOwned = data.user ? data.user.id === sharedLink.userId : false;
-  if (sharedLink.album) {
-    album = { ...sharedLink.album, assets: sharedLink.assets };
-  }
 </script>
 
-{#if sharedLink.type == SharedLinkType.Album && album}
-  <div class="immich-scrollbar">
-    <AlbumViewer {album} {sharedLink} />
-  </div>
+{#if sharedLink.type == SharedLinkType.Album}
+  <AlbumViewer {sharedLink} />
 {/if}
 
 {#if sharedLink.type == SharedLinkType.Individual}


### PR DESCRIPTION
Fixes #2030

In this PR:
- Use time buckets for shared album links
- Don't load all the assets for every shared link auth request (!!!)

Tested scenarios:
- Create an album shared link, view album correctly (faster)
