### PR TITLE
fix(web): ContextMenu unsatisfying UI behaviors

### DIFF
--- a/web/src/lib/components/photos-page/asset-select-context-menu.svelte
+++ b/web/src/lib/components/photos-page/asset-select-context-menu.svelte
@@ -17,7 +17,7 @@
   let showContextMenu = false;
   let contextMenuPosition = { x: 0, y: 0 };
 
-  const handleShowMenu = ({ x, y }: MouseEvent) => {
+  const handleShowMenu = ({ x }: MouseEvent) => {
     const navigationBarHeight = 75;
     contextMenuPosition = { x: x, y: navigationBarHeight };
     showContextMenu = !showContextMenu;

--- a/web/src/lib/components/photos-page/asset-select-context-menu.svelte
+++ b/web/src/lib/components/photos-page/asset-select-context-menu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" context="module">
+  import { clickOutside } from '$lib/utils/click-outside';
   import { createContext } from '$lib/utils/context';
 
   const { get: getMenuContext, set: setContext } = createContext<() => void>();
@@ -25,12 +26,13 @@
   setContext(() => (showContextMenu = false));
 </script>
 
-<CircleIconButton {title} logo={icon} on:click={handleShowMenu} />
-
-{#if showContextMenu}
-  <ContextMenu {...contextMenuPosition} on:outclick={() => (showContextMenu = false)}>
-    <div class="flex flex-col rounded-lg">
-      <slot />
-    </div>
-  </ContextMenu>
-{/if}
+<div use:clickOutside on:outclick={() => (showContextMenu = false)}>
+  <CircleIconButton {title} logo={icon} on:click={handleShowMenu} />
+  {#if showContextMenu}
+    <ContextMenu {...contextMenuPosition}>
+      <div class="flex flex-col rounded-lg">
+        <slot />
+      </div>
+    </ContextMenu>
+  {/if}
+</div>

--- a/web/src/lib/components/photos-page/asset-select-context-menu.svelte
+++ b/web/src/lib/components/photos-page/asset-select-context-menu.svelte
@@ -17,7 +17,8 @@
   let contextMenuPosition = { x: 0, y: 0 };
 
   const handleShowMenu = ({ x, y }: MouseEvent) => {
-    contextMenuPosition = { x, y };
+    const navigationBarHeight = 75;
+    contextMenuPosition = { x: x, y: navigationBarHeight };
     showContextMenu = !showContextMenu;
   };
 

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -44,6 +44,7 @@
   import Plus from 'svelte-material-icons/Plus.svelte';
   import ShareVariantOutline from 'svelte-material-icons/ShareVariantOutline.svelte';
   import type { PageData } from './$types';
+  import { clickOutside } from '$lib/utils/click-outside';
 
   export let data: PageData;
 
@@ -169,6 +170,7 @@
   const handleOpenAlbumOptions = ({ x, y }: MouseEvent) => {
     const navigationBarHeight = 75;
     contextMenuPosition = { x: x, y: navigationBarHeight };
+    viewMode = viewMode === ViewMode.VIEW ? ViewMode.ALBUM_OPTIONS : ViewMode.VIEW;
   };
 
   const handleSelectFromComputer = async () => {
@@ -330,13 +332,15 @@
             <CircleIconButton title="Download" on:click={handleDownloadAlbum} logo={FolderDownloadOutline} />
 
             {#if isOwned}
-              <CircleIconButton title="Album options" on:click={handleOpenAlbumOptions} logo={DotsVertical}>
-                {#if viewMode === ViewMode.ALBUM_OPTIONS}
-                  <ContextMenu {...contextMenuPosition} on:outclick={() => (viewMode = ViewMode.VIEW)}>
-                    <MenuOption on:click={() => (viewMode = ViewMode.SELECT_THUMBNAIL)} text="Set album cover" />
-                  </ContextMenu>
-                {/if}
-              </CircleIconButton>
+              <div use:clickOutside on:outclick={() => (viewMode = ViewMode.VIEW)}>
+                <CircleIconButton title="Album options" on:click={handleOpenAlbumOptions} logo={DotsVertical}>
+                  {#if viewMode === ViewMode.ALBUM_OPTIONS}
+                    <ContextMenu {...contextMenuPosition}>
+                      <MenuOption on:click={() => (viewMode = ViewMode.SELECT_THUMBNAIL)} text="Set album cover" />
+                    </ContextMenu>
+                  {/if}
+                </CircleIconButton>
+              </div>
             {/if}
           {/if}
 

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -167,7 +167,7 @@
     timelineInteractionStore.clearMultiselect();
   };
 
-  const handleOpenAlbumOptions = ({ x, y }: MouseEvent) => {
+  const handleOpenAlbumOptions = ({ x }: MouseEvent) => {
     const navigationBarHeight = 75;
     contextMenuPosition = { x: x, y: navigationBarHeight };
     viewMode = viewMode === ViewMode.VIEW ? ViewMode.ALBUM_OPTIONS : ViewMode.VIEW;

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -167,8 +167,8 @@
   };
 
   const handleOpenAlbumOptions = ({ x, y }: MouseEvent) => {
-    contextMenuPosition = { x, y };
-    viewMode = ViewMode.ALBUM_OPTIONS;
+    const navigationBarHeight = 75;
+    contextMenuPosition = { x: x, y: navigationBarHeight };
   };
 
   const handleSelectFromComputer = async () => {


### PR DESCRIPTION
# Changes made in this PR
Related Issue #3735
## 1. Fix opened `ContextMenu` blocks navigation bar
Like the issue mentioned `ContextMenu` blocks. I surveyed similar `AccountInfoPanel`, and found it is also a absolute panel with fixed **75px** top value, so I chose to fix it this way.

## 2. Both double-click on the button and click outside does close `ContextMenu`
As I was fixing the first bug, I found double-click on the button doesn't close `ContextMenu`, which doesn't match with the behavior of `AccountInfoPanel`'s button. So I coded a fix as well.

# How has it been tested
Run `npm run check:all` locally for web.

# Demo
https://github.com/immich-app/immich/assets/54995766/66bfaa05-a430-426a-8fb8-02fcc93dd503

