### PR TITLE
chore(ml): make lazy loading default

### DIFF
--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
     clip_text_model: str = "clip-ViT-B-32"
     facial_recognition_model: str = "buffalo_l"
     min_tag_score: float = 0.9
-    eager_startup: bool = True
+    eager_startup: bool = False
     model_ttl: int = 0
     host: str = "0.0.0.0"
     port: int = 3003


### PR DESCRIPTION
## Description

This change means a model will only load when the ML service receives a relevant request. This doesn't change unloading behavior, so models will stay loaded by default. Additionally, models will still be downloaded on startup. The benefit of this change is to optimize RAM usage. Notably,  disabling particular ML jobs with #3768 means the corresponding model won't be loaded.

## How Has This Been Tested?

I ran `docker stats --no-stream` after startup, confirming low RAM usage for `immich_machine_learning` at under 300mb. I then started and stopped one ML job at a time and checked `docker stats --no-stream` again for each, confirming the expected increase in RAM with each model.