### PR TITLE
fix(server): use camera white balance for raw images

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,7 +13,7 @@ mesa-va-drivers libmimalloc2.0 $(if [ $(arch) = "x86_64" ]; then echo "intel-med
 # debian build for imagemagick has broken RAW support, so build manually
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV LD_RUN_PATH=/usr/local/lib:$LD_RUN_PATH
-COPY bin/build-libraw.sh bin/build-imagemagick.sh bin/build-libvips.sh ./
+COPY bin/build-libraw.sh bin/build-imagemagick.sh bin/build-libvips.sh bin/use-camera-wb.patch ./
 RUN ./build-libraw.sh
 RUN ./build-imagemagick.sh
 RUN ./build-libvips.sh

--- a/server/bin/build-imagemagick.sh
+++ b/server/bin/build-imagemagick.sh
@@ -13,6 +13,7 @@ sha256sum -c imagemagick.sha256
 tar -xvf ${IMAGEMAGICK_VERSION}.tar.gz -C ImageMagick --strip-components=1
 rm ${IMAGEMAGICK_VERSION}.tar.gz
 rm imagemagick.sha256
+patch -u ImageMagick/coders/dng.c -i use-camera-wb.patch
 cd ImageMagick
 ./configure --with-modules
 make -j$(nproc)

--- a/server/bin/use-camera-wb.patch
+++ b/server/bin/use-camera-wb.patch
@@ -1,0 +1,9 @@
+@@ -339,6 +339,8 @@
+     option=GetImageOption(image_info,"dng:use_camera_wb");
+   if (option != (const char *) NULL)
+     raw_info->params.use_camera_wb=IsStringTrue(option);
++  else
++    raw_info->params.use_camera_wb=MagickTrue;
+   option=GetImageOption(image_info,"dng:use-auto-wb");
+   if (option == (const char *) NULL)
+     option=GetImageOption(image_info,"dng:use_auto_wb");


### PR DESCRIPTION
## Description

Currently, libraw seems to ignore the white balance metadata provided by the camera, leading to images that are much warmer than the original. The ImageMagick flag `-define dng:use-camera-wb=true` fixes this. 

However, there's no way for us to set this flag ourselves as ImageMagick is called internally in libvips, and there's currently no way to configure this to be a global behavior in ImageMagick (see [this](https://github.com/ImageMagick/ImageMagick/discussions/6571) discussion). As a result, this PR patches Imagemagick to default the `use-camera-wb` flag to `true` unless overridden.

Fixes the issue described [here](https://github.com/immich-app/immich/pull/3658#issuecomment-1680787853)


## How Has This Been Tested?

In a production build, I uploaded a few images to confirm that thumbnails generated successfully with normal white balance.

Before:

![_DSC2642_disabled_1440](https://github.com/immich-app/immich/assets/101130780/fa94121b-9c09-4cd7-942c-124c1f21b378)

After:

![_DSC2642_enabled_1440](https://github.com/immich-app/immich/assets/101130780/e24cd0dc-a70a-4e8c-8369-ed2a7dd4da35)

