### PR TITLE
feat(web): slideshow mode

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import { photoZoomState } from '$lib/stores/zoom-image.store';
   import { clickOutside } from '$lib/utils/click-outside';
   import { AssetJobName, AssetResponseDto, AssetTypeEnum, api } from '@api';
   import { createEventDispatcher } from 'svelte';
@@ -11,14 +12,13 @@
   import Heart from 'svelte-material-icons/Heart.svelte';
   import HeartOutline from 'svelte-material-icons/HeartOutline.svelte';
   import InformationOutline from 'svelte-material-icons/InformationOutline.svelte';
-  import MagnifyPlusOutline from 'svelte-material-icons/MagnifyPlusOutline.svelte';
   import MagnifyMinusOutline from 'svelte-material-icons/MagnifyMinusOutline.svelte';
+  import MagnifyPlusOutline from 'svelte-material-icons/MagnifyPlusOutline.svelte';
   import MotionPauseOutline from 'svelte-material-icons/MotionPauseOutline.svelte';
   import MotionPlayOutline from 'svelte-material-icons/MotionPlayOutline.svelte';
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import ContextMenu from '../shared-components/context-menu/context-menu.svelte';
   import MenuOption from '../shared-components/context-menu/menu-option.svelte';
-  import { photoZoomState } from '$lib/stores/zoom-image.store';
 
   export let asset: AssetResponseDto;
   export let showCopyButton: boolean;
@@ -26,6 +26,7 @@
   export let showMotionPlayButton: boolean;
   export let isMotionPhotoPlaying = false;
   export let showDownloadButton: boolean;
+  export let showSlideshow = false;
 
   const isOwner = asset.ownerId === $page.data.user?.id;
 
@@ -138,6 +139,9 @@
         <CircleIconButton isOpacity={true} logo={DotsVertical} on:click={showOptionsMenu} title="More" />
         {#if isShowAssetOptions}
           <ContextMenu {...contextMenuPosition} direction="left">
+            {#if showSlideshow}
+              <MenuOption on:click={() => onMenuClick('playSlideShow')} text="Slideshow" />
+            {/if}
             <MenuOption on:click={() => onMenuClick('addToAlbum')} text="Add to Album" />
             <MenuOption on:click={() => onMenuClick('addToSharedAlbum')} text="Add to Shared Album" />
 
@@ -162,8 +166,6 @@
                 />
               {/if}
             {/if}
-
-            <MenuOption on:click={() => onMenuClick('playSlideShow')} text="Slideshow" />
           </ContextMenu>
         {/if}
       </div>

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -29,7 +29,7 @@
 
   const isOwner = asset.ownerId === $page.data.user?.id;
 
-  type MenuItemEvent = 'addToAlbum' | 'addToSharedAlbum' | 'asProfileImage' | 'runJob';
+  type MenuItemEvent = 'addToAlbum' | 'addToSharedAlbum' | 'asProfileImage' | 'runJob' | 'playSlideShow';
 
   const dispatch = createEventDispatcher<{
     goBack: void;
@@ -44,6 +44,7 @@
     addToSharedAlbum: void;
     asProfileImage: void;
     runJob: AssetJobName;
+    playSlideShow: void;
   }>();
 
   let contextMenuPosition = { x: 0, y: 0 };
@@ -161,6 +162,8 @@
                 />
               {/if}
             {/if}
+
+            <MenuOption on:click={() => onMenuClick('playSlideShow')} text="Slideshow" />
           </ContextMenu>
         {/if}
       </div>

--- a/web/src/lib/components/asset-viewer/video-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-viewer.svelte
@@ -9,7 +9,7 @@
   export let assetId: string;
 
   let isVideoLoading = true;
-  const dispatch = createEventDispatcher<{ onVideoEnded: void }>();
+  const dispatch = createEventDispatcher<{ onVideoEnded: void; onVideoStarted: void }>();
 
   const handleCanPlay = async (event: Event) => {
     try {
@@ -17,6 +17,7 @@
       video.muted = true;
       await video.play();
       video.muted = false;
+      dispatch('onVideoStarted');
     } catch (error) {
       handleError(error, 'Unable to play video');
     } finally {

--- a/web/src/lib/components/shared-components/progress-bar/progress-bar.svelte
+++ b/web/src/lib/components/shared-components/progress-bar/progress-bar.svelte
@@ -1,0 +1,83 @@
+<script context="module" lang="ts">
+  export enum ProgressBarStatus {
+    Playing = 'playing',
+    Paused = 'paused',
+  }
+</script>
+
+<script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { tweened } from 'svelte/motion';
+
+  /**
+   * Autoplay on mount
+   * @default false
+   */
+  export let autoplay = false;
+
+  /**
+   * Duration in milliseconds
+   * @default 5000
+   */
+  export let duration = 5000;
+
+  /**
+   * Progress bar status
+   */
+  export let status: ProgressBarStatus = ProgressBarStatus.Paused;
+
+  let progress = tweened<number>(0, {
+    duration: (from: number, to: number) => (to ? duration * (to - from) : 0),
+  });
+
+  const dispatch = createEventDispatcher<{
+    done: void;
+    playing: void;
+    paused: void;
+  }>();
+
+  onMount(() => {
+    if (autoplay) {
+      play();
+    }
+  });
+
+  export const play = () => {
+    status = ProgressBarStatus.Playing;
+    dispatch('playing');
+    progress.set(1);
+  };
+
+  export const pause = () => {
+    status = ProgressBarStatus.Paused;
+    dispatch('paused');
+    progress.set($progress);
+  };
+
+  export const restart = (autoplay: boolean) => {
+    progress.set(0);
+
+    if (autoplay) {
+      play();
+    }
+  };
+
+  export const reset = () => {
+    status = ProgressBarStatus.Paused;
+    progress.set(0);
+  };
+
+  export const setDuration = (newDuration: number) => {
+    progress = tweened<number>(0, {
+      duration: (from: number, to: number) => (to ? newDuration * (to - from) : 0),
+    });
+  };
+
+  progress.subscribe((value) => {
+    if (value === 1) {
+      dispatch('done');
+    }
+  });
+</script>
+
+<span class="absolute left-0 h-[3px] bg-immich-primary shadow-2xl" style:width={`${$progress * 100}%`} />


### PR DESCRIPTION
This PR implements slideshow mode, which is played from the asset viewer component and it will:
- Entering fullscreen mode
- Autostart progress bar, default is 5 seconds
- Auto transition to next asset
- Stop and exit fullscreen mode at the end of the page. 
- Wait for video to finish playing before advancing in navigation

https://github.com/immich-app/immich/assets/27055614/32371512-bb3a-4d12-8953-c1d2f81c13d1



### Todo
- [x] timeline
- [x] album
- [x] archive
- [x] favorite
- [x] face's assets


