### PR TITLE
feat(web): add link to external map in leaflet popup

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -36,13 +36,12 @@
     const lng = asset.exifInfo?.longitude;
 
     if (lat && lng) {
-      return [lat, lng] as LatLngTuple;
+      return [Number(lat.toFixed(7)), Number(lng.toFixed(7))] as LatLngTuple;
     }
   })();
 
-  $: disp_lat = latlng?.[0]?.toFixed(7);
-
-  $: disp_lng = latlng?.[1]?.toFixed(7);
+  $: lat = latlng ? latlng[0] : undefined;
+  $: lng = latlng ? latlng[1] : undefined;
 
   $: people = asset.people || [];
 
@@ -264,9 +263,9 @@
         />
         <Marker {latlng}>
           <p>
-            {disp_lat}, {disp_lng}
+            {lat}, {lng}
           </p>
-          <a href={`https://www.openstreetmap.org/?mlat=${disp_lat}&mlon=${disp_lng}&zoom=15#map=15/${disp_lat}/${disp_lng}`}>
+          <a href="https://www.openstreetmap.org/?mlat={lat}&mlon={lng}&zoom=15#map=15/{lat}/{lng}">
             Open in OpenStreetMap
           </a>
         </Marker>

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -40,6 +40,10 @@
     }
   })();
 
+  $: disp_lat = latlng?.[0]?.toFixed(7);
+
+  $: disp_lng = latlng?.[1]?.toFixed(7);
+
   $: people = asset.people || [];
 
   const dispatch = createEventDispatcher();
@@ -258,7 +262,14 @@
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
           }}
         />
-        <Marker {latlng} popupContent="{latlng[0].toFixed(7)},{latlng[1].toFixed(7)}" />
+        <Marker {latlng}>
+          <p>
+            {disp_lat}, {disp_lng}
+          </p>
+          <a href={`https://www.openstreetmap.org/?mlat=${disp_lat}&mlon=${disp_lng}&zoom=15#map=15/${disp_lat}/${disp_lng}`}>
+            Open in OpenStreetMap
+          </a>
+        </Marker>
       </Map>
     {/await}
   </div>

--- a/web/src/lib/components/shared-components/leaflet/marker.svelte
+++ b/web/src/lib/components/shared-components/leaflet/marker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import { Marker, Icon, type LatLngExpression, type Content } from 'leaflet';
+  import { Marker, Icon, type LatLngExpression } from 'leaflet';
   import { getMapContext } from './map.svelte';
   import iconUrl from 'leaflet/dist/images/marker-icon.png';
   import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
@@ -46,5 +46,5 @@
 </script>
 
 <span contenteditable="true" bind:innerHTML={popupHTML} class="hide">
-    <slot/>
+  <slot />
 </span>

--- a/web/src/lib/components/shared-components/leaflet/marker.svelte
+++ b/web/src/lib/components/shared-components/leaflet/marker.svelte
@@ -7,7 +7,7 @@
   import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 
   export let latlng: LatLngExpression;
-  export let popupContent: Content | undefined = undefined;
+  let popupHTML: string;
   let marker: Marker;
 
   const defaultIcon = new Icon({
@@ -37,10 +37,14 @@
   $: if (marker) {
     marker.setLatLng(latlng);
 
-    if (popupContent) {
-      marker.bindPopup(popupContent);
+    if (popupHTML) {
+      marker.bindPopup(popupHTML);
     } else {
       marker.unbindPopup();
     }
   }
 </script>
+
+<span contenteditable="true" bind:innerHTML={popupHTML} class="hide">
+    <slot/>
+</span>


### PR DESCRIPTION
A little life improvement.

Sometimes it's useful to open a geo location to an external map application to not have to copy the coordinates manually. Here I put a link to OpenStreetMap because it's what I personally use. But I known some people would want to use something different. We could instead link to geohacks (eg. https://geohack.toolforge.org/geohack.php?params=048.861085_N_0002.313158_E_globe:Earth) or make it a configurable param.

I'm eager to hear your takes on this.

![image](https://github.com/immich-app/immich/assets/20988163/247a8ea0-64e3-48e0-ab12-1403df7fa39d)
