### PR TITLE
feat(web): album and face menu dots visible on hover only

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -12,6 +12,7 @@
   export let user: UserResponseDto;
   export let showItemCount = true;
   export let showContextMenu = true;
+  let showVerticalDots = false;
 
   $: imageData = album.albumThumbnailAssetId
     ? api.getAssetThumbnailUrl(album.albumThumbnailAssetId, ThumbnailFormat.Webp)
@@ -63,6 +64,8 @@
   class="group relative mt-4 rounded-3xl border-[3px] border-transparent p-5 hover:cursor-pointer hover:border-immich-primary/75 dark:hover:border-immich-dark-primary/75"
   on:click={() => dispatchClick('click', album)}
   on:keydown={() => dispatchClick('click', album)}
+  on:mouseenter={() => (showVerticalDots = true)}
+  on:mouseleave={() => (showVerticalDots = false)}
   data-testid="album-card"
 >
   <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -71,9 +74,10 @@
       id={`icon-${album.id}`}
       class="absolute right-6 top-6 z-10"
       on:click|stopPropagation|preventDefault={showAlbumContextMenu}
+      class:hidden={!showVerticalDots}
       data-testid="context-button-parent"
     >
-      <IconButton color="overlay-primary">
+      <IconButton color="transparent-primary">
         <DotsVertical size="20" class="icon-white-drop-shadow" color="white" />
       </IconButton>
     </div>


### PR DESCRIPTION
Currently all albums and faces have context menu dots visible, that is very disruptive. Proposed change show them only when mouse hovers over album or face.
![menu-dots](https://github.com/immich-app/immich/assets/15554561/5a89da73-80ae-4851-aa75-8542019c4ab9)
![album-dark](https://github.com/immich-app/immich/assets/15554561/ea0619e9-f9b4-4eb7-b2c3-cc5581498e02)
![faces-dark](https://github.com/immich-app/immich/assets/15554561/80481359-d55f-4b72-92c9-0ed54fc9b9bd)

