### PR TITLE
feat(web): smaller album title

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -96,7 +96,7 @@
 
   <div class="mt-4">
     <p
-      class="w-full truncate text-xl font-semibold text-immich-primary dark:text-immich-dark-primary"
+      class="w-full truncate text-lg font-semibold text-immich-primary dark:text-immich-dark-primary"
       data-testid="album-name"
       title={album.albumName}
     >


### PR DESCRIPTION
Album titles are huge curently and longer titles are cut to early...

before:
![obrazek](https://github.com/immich-app/immich/assets/15554561/c6cd220b-cd21-48a5-9aea-a47c7e12f93a)

after:
![obrazek](https://github.com/immich-app/immich/assets/15554561/fff9a808-3dcf-441e-9dae-b4d5aebe9e85)
