### PR TITLE
fix(mobile): Widget overflow due to exception on logout

### DIFF
--- a/mobile/lib/modules/home/ui/home_page_app_bar.dart
+++ b/mobile/lib/modules/home/ui/home_page_app_bar.dart
@@ -30,9 +30,9 @@ class HomePageAppBar extends ConsumerWidget implements PreferredSizeWidget {
         backupState.backgroundBackup || backupState.autoBackup;
     final ServerInfoState serverInfoState = ref.watch(serverInfoProvider);
     AuthenticationState authState = ref.watch(authenticationProvider);
-    final user = Store.get(StoreKey.currentUser);
+    final user = Store.tryGet(StoreKey.currentUser);
     buildProfilePhoto() {
-      if (authState.profileImagePath.isEmpty) {
+      if (authState.profileImagePath.isEmpty || user == null) {
         return IconButton(
           splashRadius: 25,
           icon: const Icon(

--- a/mobile/lib/modules/home/ui/profile_drawer/profile_drawer_header.dart
+++ b/mobile/lib/modules/home/ui/profile_drawer/profile_drawer_header.dart
@@ -20,22 +20,22 @@ class ProfileDrawerHeader extends HookConsumerWidget {
     final uploadProfileImageStatus =
         ref.watch(uploadProfileImageProvider).status;
     final isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    final user = Store.get(StoreKey.currentUser);
+    final user = Store.tryGet(StoreKey.currentUser);
 
     buildUserProfileImage() {
-      var userImage = UserCircleAvatar(
-        radius: 35,
-        size: 66,
-        user: user,
-      );
-
-      if (authState.profileImagePath.isEmpty) {
+      if (authState.profileImagePath.isEmpty || user == null) {
         return const CircleAvatar(
           radius: 35,
           backgroundImage: AssetImage('assets/immich-logo-no-outline.png'),
           backgroundColor: Colors.transparent,
         );
       }
+
+      var userImage = UserCircleAvatar(
+        radius: 35,
+        size: 66,
+        user: user,
+      );
 
       if (uploadProfileImageStatus == UploadProfileStatus.idle) {
         if (authState.profileImagePath.isNotEmpty) {


### PR DESCRIPTION
### Changes made in the PR:

During the mobile app logout, the `currentUser` key is removed from the Store. However, the home page and profile drawer both tries to fetch the key during logout, resulting it an exception. This has been fixed in this PR by handling the unavailability of the key

<img alt="exception" src="https://github.com/immich-app/immich/assets/139912620/981f5454-5c60-4b15-ade4-5615bf921ccb" height=300>


### How was this tested?

- Logout and see no exception in the logs view
- Ensure that profile picture is properly loaded in profile header and home page