### PR TITLE
feat(mobile): upload image assets before videos

### DIFF
--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -218,7 +218,14 @@ class BackupService {
     bool anyErrors = false;
     final List<String> duplicatedAssetIds = [];
 
-    for (var entity in assetList) {
+    // Upload images before video assets
+    // AssetType::audio is greater than image / video
+    // But since we do not support them, it shouldn't be an issue
+    List<AssetEntity> sortedAssets = assetList.sorted(
+      (a, b) => a.typeInt - b.typeInt,
+    );
+
+    for (var entity in sortedAssets) {
       try {
         if (entity.type == AssetType.video) {
           file = await entity.originFile;
@@ -248,7 +255,8 @@ class BackupService {
 
           req.fields['deviceAssetId'] = entity.id;
           req.fields['deviceId'] = deviceId;
-          req.fields['fileCreatedAt'] = entity.createDateTime.toUtc().toIso8601String();
+          req.fields['fileCreatedAt'] =
+              entity.createDateTime.toUtc().toIso8601String();
           req.fields['fileModifiedAt'] =
               entity.modifiedDateTime.toUtc().toIso8601String();
           req.fields['isFavorite'] = entity.isFavorite.toString();

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -219,10 +219,14 @@ class BackupService {
     final List<String> duplicatedAssetIds = [];
 
     // Upload images before video assets
-    // AssetType::audio is greater than image / video
-    // But since we do not support them, it shouldn't be an issue
+    // these are further sorted by using their creation date so the upload goes as follows
+    // older images -> latest images -> older videos -> latest videos
     List<AssetEntity> sortedAssets = assetList.sorted(
-      (a, b) => a.typeInt - b.typeInt,
+      (a, b) {
+        final cmp = a.typeInt - b.typeInt;
+        if (cmp != 0) return cmp;
+        return a.createDateTime.compareTo(b.createDateTime);
+      },
     );
 
     for (var entity in sortedAssets) {


### PR DESCRIPTION
### Changes made in this PR:
Asset backup flow is updated to always prefer image files before uploading video files. Mobile device uploads are sequential and so, uploading a huge video file might block the other uploads from getting processed faster.  Since most of the times, image assets are smaller than video assets, it makes sense to try to upload them so as to maximize the number of uploads. This is especially useful in iOS if a large video asset gets retried in a loop blocking other smaller image assets from getting uploaded
- #3341 

### How was this tested?
The backup service code is common for both background upload and manual asset upload. I've tested the change only with manual upload. Background upload should work properly as well

- Tried uploading a mix of image and video assets manually and ensured that images are getting uploaded before the video assets are processed.

### Feedback required
- I'm not sure if the current flow of uploading the assets as they come is useful. But if people prefer that, we can have this "image before video" behind a toggle in the backup page?