### PR TITLE
fix(web): refresh job page render incorrect job buttons

### DIFF
--- a/web/src/routes/admin/jobs-status/+page.svelte
+++ b/web/src/routes/admin/jobs-status/+page.svelte
@@ -2,7 +2,6 @@
   import JobsPanel from '$lib/components/admin-page/jobs/jobs-panel.svelte';
   import { AllJobStatusResponseDto, api } from '@api';
   import { onDestroy, onMount } from 'svelte';
-  import type { PageData } from './$types';
 
   let timer: NodeJS.Timer;
 

--- a/web/src/routes/admin/jobs-status/+page.svelte
+++ b/web/src/routes/admin/jobs-status/+page.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import JobsPanel from '$lib/components/admin-page/jobs/jobs-panel.svelte';
-  import { api } from '@api';
+  import { AllJobStatusResponseDto, api } from '@api';
   import { onDestroy, onMount } from 'svelte';
   import type { PageData } from './$types';
 
-  export let data: PageData;
   let timer: NodeJS.Timer;
 
-  $: jobs = data.jobs;
+  let jobs: AllJobStatusResponseDto;
 
   const load = async () => {
     const { data } = await api.jobApi.getAllJobsStatus();
@@ -24,4 +23,6 @@
   });
 </script>
 
-<JobsPanel {jobs} />
+{#if jobs}
+  <JobsPanel {jobs} />
+{/if}


### PR DESCRIPTION
Fix issue with (ctrl + R) or refresh jobs page on the web will not receive up-to-date payload for the job, therefore render all job options with "Start" instead of the corresponding "Missing", or "All"