### PR TITLE
feat(web,server): Shared accounts / sharing pictures with family / pictures in timeline / "family space"

### DIFF
--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -5301,6 +5301,10 @@
           "id": {
             "type": "string"
           },
+          "parentAuthId": {
+            "nullable": true,
+            "type": "string"
+          },
           "updatedAt": {
             "type": "string"
           }
@@ -5311,7 +5315,8 @@
           "updatedAt",
           "current",
           "deviceType",
-          "deviceOS"
+          "deviceOS",
+          "parentAuthId"
         ],
         "type": "object"
       },
@@ -5568,6 +5573,9 @@
           },
           "firstName": {
             "type": "string"
+          },
+          "interactiveLoginEnabled": {
+            "type": "boolean"
           },
           "lastName": {
             "type": "string"
@@ -7288,6 +7296,9 @@
             "format": "uuid",
             "type": "string"
           },
+          "interactiveLoginEnabled": {
+            "type": "boolean"
+          },
           "isAdmin": {
             "type": "boolean"
           },
@@ -7298,6 +7309,9 @@
             "type": "boolean"
           },
           "password": {
+            "type": "string"
+          },
+          "sharedAccountId": {
             "type": "string"
           },
           "shouldChangePassword": {
@@ -7379,6 +7393,9 @@
           "id": {
             "type": "string"
           },
+          "interactiveLoginEnabled": {
+            "type": "boolean"
+          },
           "isAdmin": {
             "type": "boolean"
           },
@@ -7392,6 +7409,9 @@
             "type": "string"
           },
           "profileImagePath": {
+            "type": "string"
+          },
+          "sharedAccountId": {
             "type": "string"
           },
           "shouldChangePassword": {

--- a/server/src/domain/auth/response-dto/auth-device-response.dto.ts
+++ b/server/src/domain/auth/response-dto/auth-device-response.dto.ts
@@ -7,6 +7,7 @@ export class AuthDeviceResponseDto {
   current!: boolean;
   deviceType!: string;
   deviceOS!: string;
+  parentAuthId!: string | null;
 }
 
 export const mapUserToken = (entity: UserTokenEntity, currentId?: string): AuthDeviceResponseDto => ({
@@ -16,4 +17,5 @@ export const mapUserToken = (entity: UserTokenEntity, currentId?: string): AuthD
   current: currentId === entity.id,
   deviceOS: entity.deviceOS,
   deviceType: entity.deviceType,
+  parentAuthId: entity.authParentId,
 });

--- a/server/src/domain/user/dto/create-user.dto.ts
+++ b/server/src/domain/user/dto/create-user.dto.ts
@@ -31,6 +31,10 @@ export class CreateUserDto {
   @IsOptional()
   @IsBoolean()
   memoriesEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  interactiveLoginEnabled?: boolean;
 }
 
 export class CreateAdminDto {

--- a/server/src/domain/user/dto/update-user.dto.ts
+++ b/server/src/domain/user/dto/update-user.dto.ts
@@ -49,4 +49,12 @@ export class UpdateUserDto {
   @IsOptional()
   @IsBoolean()
   memoriesEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  interactiveLoginEnabled?: boolean;
+
+  @IsOptional()
+  @IsUUID('4')
+  sharedAccountId?: string;
 }

--- a/server/src/domain/user/response-dto/user-response.dto.ts
+++ b/server/src/domain/user/response-dto/user-response.dto.ts
@@ -15,6 +15,8 @@ export class UserResponseDto {
   updatedAt!: Date;
   oauthId!: string;
   memoriesEnabled?: boolean;
+  interactiveLoginEnabled?: boolean;
+  sharedAccountId?: string;
 }
 
 export function mapUser(entity: UserEntity): UserResponseDto {
@@ -33,5 +35,7 @@ export function mapUser(entity: UserEntity): UserResponseDto {
     updatedAt: entity.updatedAt,
     oauthId: entity.oauthId,
     memoriesEnabled: entity.memoriesEnabled,
+    interactiveLoginEnabled: entity.interactiveLoginEnabled,
+    sharedAccountId: entity.sharedAccountId,
   };
 }

--- a/server/src/domain/user/user.core.ts
+++ b/server/src/domain/user/user.core.ts
@@ -47,6 +47,21 @@ export class UserCore {
       }
     }
 
+    if (dto.sharedAccountId) {
+      const sharedUser = await this.userRepository.get(dto.sharedAccountId);
+      if (!sharedUser) {
+        throw new BadRequestException('Shared account does not exist');
+      }
+
+      if (sharedUser.sharedAccountId === dto.id) {
+        throw new BadRequestException('Shared account cannot be the same as the user');
+      }
+
+      if (sharedUser.interactiveLoginEnabled) {
+        throw new BadRequestException('Shared account cannot have interactive login enabled');
+      }
+    }
+
     try {
       if (dto.password) {
         dto.password = await this.cryptoRepository.hashBcrypt(dto.password, SALT_ROUNDS);

--- a/server/src/immich/app.guard.ts
+++ b/server/src/immich/app.guard.ts
@@ -69,6 +69,7 @@ export const GetLoginDetails = createParamDecorator((data, ctx: ExecutionContext
     isSecure: req.secure,
     deviceType: userAgent.browser.name || userAgent.device.type || (req.headers.devicemodel as string) || '',
     deviceOS: userAgent.os.name || (req.headers.devicetype as string) || '',
+    authParent: null
   };
 });
 

--- a/server/src/infra/entities/user-token.entity.ts
+++ b/server/src/infra/entities/user-token.entity.ts
@@ -26,4 +26,10 @@ export class UserTokenEntity {
 
   @Column({ default: '' })
   deviceOS!: string;
+
+  @ManyToOne(() => UserEntity, { onUpdate: 'CASCADE', onDelete: 'CASCADE' })
+  authParent!: UserEntity | null;
+
+  @Column({ default: null })
+  authParentId!: string | null;
 }

--- a/server/src/infra/entities/user.entity.ts
+++ b/server/src/infra/entities/user.entity.ts
@@ -4,11 +4,13 @@ import {
   DeleteDateColumn,
   Entity,
   OneToMany,
+  ManyToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { AssetEntity } from './asset.entity';
 import { TagEntity } from './tag.entity';
+import { UserTokenEntity } from "./user-token.entity";
 
 @Entity('users')
 export class UserEntity {
@@ -57,9 +59,18 @@ export class UserEntity {
   @Column({ default: true })
   memoriesEnabled!: boolean;
 
+  @Column({ default: false })
+  interactiveLoginEnabled!: boolean;
+
+  @Column({ default: null })
+  sharedAccountId!: string;
+
   @OneToMany(() => TagEntity, (tag) => tag.user)
   tags!: TagEntity[];
 
   @OneToMany(() => AssetEntity, (asset) => asset.owner)
   assets!: AssetEntity[];
+
+  @OneToMany(() => UserTokenEntity, (token) => token.authParent)
+  userTokens!: UserTokenEntity[];
 }

--- a/server/src/infra/migrations/1692880809207-AddSharedAccountCapabilities.ts
+++ b/server/src/infra/migrations/1692880809207-AddSharedAccountCapabilities.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Infra1692880809207 implements MigrationInterface {
+    name = 'Infra1692880809207'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" ADD "interactiveLoginEnabled" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "users" ADD "sharedAccountId" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "sharedAccountId"`);
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "interactiveLoginEnabled"`);
+    }
+
+}

--- a/server/src/infra/migrations/1692906088974-AddContextToUserToken.ts
+++ b/server/src/infra/migrations/1692906088974-AddContextToUserToken.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Infra1692906088974 implements MigrationInterface {
+    name = 'Infra1692906088974'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_token" ADD "authParentId" uuid DEFAULT NULL`);
+        await queryRunner.query(`ALTER TABLE "user_token" ADD CONSTRAINT "FK_b148a32f567215890c16a52d3b8" FOREIGN KEY ("authParentId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_token" DROP CONSTRAINT "FK_b148a32f567215890c16a52d3b8"`);
+        await queryRunner.query(`ALTER TABLE "user_token" DROP COLUMN "authParentId"`);
+    }
+
+}

--- a/web/src/lib/components/admin-page/settings/setting-select.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-select.svelte
@@ -49,7 +49,7 @@
     on:change={handleChange}
   >
     {#each options as option}
-      <option value={option.value}>{option.text}</option>
+      <option value={option.value} disabled={option.disabled}>{option.text}</option>
     {/each}
   </select>
 </div>

--- a/web/src/lib/components/admin-page/settings/setting-switch.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-switch.svelte
@@ -86,4 +86,10 @@
     transform: translateX(18px);
     background-color: #4250af;
   }
+
+  .slider-disable:before {
+    -webkit-transform: translateX(18px);
+    -ms-transform: translateX(18px);
+    transform: translateX(18px);
+  }
 </style>

--- a/web/src/lib/components/forms/create-user-form.svelte
+++ b/web/src/lib/components/forms/create-user-form.svelte
@@ -4,6 +4,7 @@
   import ImmichLogo from '../shared-components/immich-logo.svelte';
   import { notificationController, NotificationType } from '../shared-components/notification/notification';
   import Button from '../elements/buttons/button.svelte';
+  import SettingSwitch from "$lib/components/admin-page/settings/setting-switch.svelte";
 
   let error: string;
   let success: string;
@@ -14,6 +15,7 @@
   let canCreateUser = false;
 
   let isCreatingUser = false;
+  let isInteractiveLoginEnabled = true;
 
   $: {
     if (password !== confirmPassowrd && confirmPassowrd.length > 0) {
@@ -37,14 +39,16 @@
       const form = new FormData(formElement);
 
       const email = form.get('email');
-      const password = form.get('password');
+      const isInteractiveLoginEnabled = form.get('isInteractiveLoginEnabled');
       const firstName = form.get('firstName');
       const lastName = form.get('lastName');
+      const password = form.get('password') || '';
 
       try {
         const { status } = await api.userApi.createUser({
           createUserDto: {
             email: String(email),
+            isInteractiveLoginEnabled: Boolean(isInteractiveLoginEnabled),
             password: String(password),
             firstName: String(firstName),
             lastName: String(lastName),
@@ -84,7 +88,11 @@
     <ImmichLogo class="text-center" height="100" width="100" />
     <h1 class="text-2xl font-medium text-immich-primary dark:text-immich-dark-primary">Create new user</h1>
     <p class="rounded-md border p-4 font-mono text-sm text-gray-600 dark:border-immich-dark-bg dark:text-gray-300">
-      Please provide your user with the password, they will have to change it on their first sign in.
+      {#if isInteractiveLoginEnabled}
+        Please provide your user with the password, they will have to change it on their first sign in.
+      {:else}
+        Please don't forget to connect later a parent account with interactive login enabled to this account.
+      {/if}
     </p>
   </div>
 
@@ -95,21 +103,31 @@
     </div>
 
     <div class="m-4 flex flex-col gap-2">
-      <label class="immich-form-label" for="password">Password</label>
-      <input class="immich-form-input" id="password" name="password" type="password" required bind:value={password} />
-    </div>
-
-    <div class="m-4 flex flex-col gap-2">
-      <label class="immich-form-label" for="confirmPassword">Confirm Password</label>
-      <input
-        class="immich-form-input"
-        id="confirmPassword"
-        name="password"
-        type="password"
-        required
-        bind:value={confirmPassowrd}
+      <SettingSwitch
+        bind:checked={isInteractiveLoginEnabled}
+        title="Account type"
+        subtitle="Enable interactive login on the account"
       />
     </div>
+
+    {#if isInteractiveLoginEnabled}
+      <div class="m-4 flex flex-col gap-2">
+        <label class="immich-form-label" for="password">Password</label>
+        <input class="immich-form-input" id="password" name="password" type="password" required bind:value={password} />
+      </div>
+
+      <div class="m-4 flex flex-col gap-2">
+        <label class="immich-form-label" for="confirmPassword">Confirm Password</label>
+        <input
+          class="immich-form-input"
+          id="confirmPassword"
+          name="password"
+          type="password"
+          required
+          bind:value={confirmPassowrd}
+        />
+      </div>
+    {/if}
 
     <div class="m-4 flex flex-col gap-2">
       <label class="immich-form-label" for="firstName">First Name</label>

--- a/web/src/lib/components/forms/login-form.svelte
+++ b/web/src/lib/components/forms/login-form.svelte
@@ -63,7 +63,7 @@
         },
       });
 
-      if (!data.isAdmin && data.shouldChangePassword) {
+      if (!data.isAdmin && data.interactiveLoginEnabled && data.shouldChangePassword) {
         dispatch('first-login');
         return;
       }

--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -172,6 +172,7 @@
         <th class="w-2/12 text-center text-sm font-medium">First name</th>
         <th class="w-2/12 text-center text-sm font-medium">Last name</th>
         <th class="w-2/12 text-center text-sm font-medium">Can import</th>
+        <th class="w-2/12 text-center text-sm font-medium">Interactive Login</th>
         <th class="w-2/12 text-center text-sm font-medium">Action</th>
       </tr>
     </thead>
@@ -193,6 +194,15 @@
             <td class="w-2/12 text-ellipsis break-all px-2 text-sm">
               <div class="container mx-auto flex flex-wrap justify-center">
                 {#if user.externalPath}
+                  <Check size="16" />
+                {:else}
+                  <Close size="16" />
+                {/if}
+              </div>
+            </td>
+            <td class="w-2/12 text-ellipsis break-all px-2 text-sm">
+              <div class="container mx-auto flex flex-wrap justify-center">
+                {#if user.interactiveLoginEnabled}
                   <Check size="16" />
                 {:else}
                   <Close size="16" />

--- a/web/src/test-data/factories/user-factory.ts
+++ b/web/src/test-data/factories/user-factory.ts
@@ -16,5 +16,6 @@ export const userFactory = Sync.makeFactory<UserResponseDto>({
   deletedAt: null,
   updatedAt: Sync.each(() => faker.date.past().toISOString()),
   memoriesEnabled: true,
+  interactiveLoginEnabled: true,
   oauthId: '',
 });


### PR DESCRIPTION
Hi Immich team,

Thanks for the great project,

As was discussed, I created this PR to collect further feedback and let it wait until libraries functionality gets merged.

**The info and background about this PR**: It works in a way like non interactive login and you can assign other accounts to be logged into this account programmatically once you have performed an interactive login with password/SAML. As as result multiple users ends up into "shared" account where all photos belongs to the same user aka one family group. Family group can also share its own albums to other users in Immich, this way we achieve two-hop sharing (see FAQ below for more info).

Audit log has been patched as well, you can also see you is actually using this meta account.

<img width="300" alt="Screenshot 2023-08-25 at 00 01 50" src="https://github.com/immich-app/immich/assets/104727/8866b3a8-9af3-4850-9381-b0ac73647d6c">

<img width="300" alt="Screenshot 2023-08-24 at 23 55 59" src="https://github.com/immich-app/immich/assets/104727/838ad43e-6fbc-4a6c-9684-8f0b10948745">

This might be not ideal, but amount of effort vs product outcome in my opinion is great:

**This implementation gives us**:
- One shared family space as an virtual account;
- Closes https://github.com/immich-app/immich/discussions/3886
- Closes https://github.com/immich-app/immich/discussions/3781
- Partially closes https://github.com/immich-app/immich/issues/1043
- Closes https://github.com/immich-app/immich/discussions/3843 if belongs to the same family
- Closes https://github.com/immich-app/immich/discussions/3418 if belongs to the same family;
- Display shared photos in main photo feed;
- Search capabilities;
- Facial data can be shared;
- Geo data can be shared;
- Edit/delete functionalities within "family" account;
- **Simple**: does not touch core immich queries for selecting photos, etc because implemented as part of authentication layer.

**FAQ**:
What is "_non-interactive login account_":
- Account has restricted abilities for interactive login: password/SAML is blocked and you can not login into this account directly from the login page.

How do you see managing the change of password with your solution?
- Password change and initial password-set forms are not affected by this functionality for accounts with interactive login capabilities.

What is two-hop sharing?
- Account "A" (with Google OpenID/password credentials) -> ---- does programmatic authentication ----- -> account C (non interactive account "Family Space") - > ----- shares album to other accounts in Immich -> Account E (with Google OpenID/password credentials) 
  - Account "A" - me
  - Account "B" - other person in same household
  - Account "C" - family space (non interactive login account)
  - Account "E" - parent