### PR TITLE
fix(server): set stream index for ffmpeg command

### DIFF
--- a/server/src/domain/media/media.repository.ts
+++ b/server/src/domain/media/media.repository.ts
@@ -8,6 +8,7 @@ export interface ResizeOptions {
 }
 
 export interface VideoStreamInfo {
+  index: number;
   height: number;
   width: number;
   rotation: number;
@@ -18,8 +19,10 @@ export interface VideoStreamInfo {
 }
 
 export interface AudioStreamInfo {
+  index: number;
   codecName?: string;
   codecType?: string;
+  frameCount: number;
 }
 
 export interface VideoFormat {
@@ -55,7 +58,7 @@ export interface BitrateDistribution {
 }
 
 export interface VideoCodecSWConfig {
-  getOptions(stream: VideoStreamInfo): TranscodeOptions;
+  getOptions(videoStream: VideoStreamInfo, audioStream: AudioStreamInfo): TranscodeOptions;
 }
 
 export interface VideoCodecHWConfig extends VideoCodecSWConfig {

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -311,8 +311,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -350,8 +350,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -374,8 +374,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -401,8 +401,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -426,8 +426,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -451,8 +451,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -476,8 +476,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -525,8 +525,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -555,8 +555,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -582,8 +582,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -611,8 +611,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec vp9',
-            '-acodec aac',
+            '-c:v:0 vp9',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -642,8 +642,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec vp9',
-            '-acodec aac',
+            '-c:v:0 vp9',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -672,8 +672,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec vp9',
-            '-acodec aac',
+            '-c:v:0 vp9',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -701,8 +701,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec vp9',
-            '-acodec aac',
+            '-c:v:0 vp9',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -729,8 +729,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -757,8 +757,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -785,8 +785,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec hevc',
-            '-acodec aac',
+            '-c:v:0 hevc',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -816,8 +816,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec hevc',
-            '-acodec aac',
+            '-c:v:0 hevc',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -876,7 +876,6 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
           outputOptions: [
-            `-vcodec h264_nvenc`,
             '-tune hq',
             '-qmin 0',
             '-g 250',
@@ -886,7 +885,8 @@ describe(MediaService.name, () => {
             '-rc-lookahead 20',
             '-i_qfactor 0.75',
             '-b_qfactor 1.1',
-            '-acodec aac',
+            `-c:v:0 h264_nvenc`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -916,7 +916,6 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
           outputOptions: [
-            `-vcodec h264_nvenc`,
             '-tune hq',
             '-qmin 0',
             '-g 250',
@@ -926,7 +925,8 @@ describe(MediaService.name, () => {
             '-rc-lookahead 20',
             '-i_qfactor 0.75',
             '-b_qfactor 1.1',
-            '-acodec aac',
+            `-c:v:0 h264_nvenc`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -952,7 +952,6 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
           outputOptions: [
-            `-vcodec h264_nvenc`,
             '-tune hq',
             '-qmin 0',
             '-g 250',
@@ -962,7 +961,8 @@ describe(MediaService.name, () => {
             '-rc-lookahead 20',
             '-i_qfactor 0.75',
             '-b_qfactor 1.1',
-            '-acodec aac',
+            `-c:v:0 h264_nvenc`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -989,7 +989,6 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
           outputOptions: [
-            `-vcodec h264_nvenc`,
             '-tune hq',
             '-qmin 0',
             '-g 250',
@@ -999,7 +998,8 @@ describe(MediaService.name, () => {
             '-rc-lookahead 20',
             '-i_qfactor 0.75',
             '-b_qfactor 1.1',
-            '-acodec aac',
+            `-c:v:0 h264_nvenc`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1022,7 +1022,6 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
           outputOptions: [
-            `-vcodec h264_nvenc`,
             '-tune hq',
             '-qmin 0',
             '-g 250',
@@ -1032,7 +1031,8 @@ describe(MediaService.name, () => {
             '-rc-lookahead 20',
             '-i_qfactor 0.75',
             '-b_qfactor 1.1',
-            '-acodec aac',
+            `-c:v:0 h264_nvenc`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1060,12 +1060,12 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
           outputOptions: [
-            `-vcodec h264_qsv`,
             '-g 256',
             '-extbrc 1',
             '-refs 5',
             '-bf 7',
-            '-acodec aac',
+            `-c:v:0 h264_qsv`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1095,12 +1095,12 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
           outputOptions: [
-            `-vcodec h264_qsv`,
             '-g 256',
             '-extbrc 1',
             '-refs 5',
             '-bf 7',
-            '-acodec aac',
+            `-c:v:0 h264_qsv`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1127,12 +1127,12 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
           outputOptions: [
-            `-vcodec vp9_qsv`,
             '-g 256',
             '-extbrc 1',
             '-refs 5',
             '-bf 7',
-            '-acodec aac',
+            `-c:v:0 vp9_qsv`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-low_power 1',
@@ -1170,8 +1170,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
           outputOptions: [
-            `-vcodec h264_vaapi`,
-            '-acodec aac',
+            `-c:v:0 h264_vaapi`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1199,8 +1199,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
           outputOptions: [
-            `-vcodec h264_vaapi`,
-            '-acodec aac',
+            `-c:v:0 h264_vaapi`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1230,8 +1230,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
           outputOptions: [
-            `-vcodec h264_vaapi`,
-            '-acodec aac',
+            `-c:v:0 h264_vaapi`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1257,8 +1257,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/card1', '-filter_hw_device accel'],
           outputOptions: [
-            `-vcodec h264_vaapi`,
-            '-acodec aac',
+            `-c:v:0 h264_vaapi`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1280,8 +1280,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD129', '-filter_hw_device accel'],
           outputOptions: [
-            `-vcodec h264_vaapi`,
-            '-acodec aac',
+            `-c:v:0 h264_vaapi`,
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1310,8 +1310,8 @@ describe(MediaService.name, () => {
         {
           inputOptions: [],
           outputOptions: [
-            '-vcodec h264',
-            '-acodec aac',
+            '-c:v:0 h264',
+            '-c:a:0 aac',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-v verbose',
@@ -1345,8 +1345,8 @@ describe(MediaService.name, () => {
       {
         inputOptions: [],
         outputOptions: [
-          '-vcodec h264',
-          '-acodec aac',
+          '-c:v:0 h264',
+          '-c:a:0 aac',
           '-movflags faststart',
           '-fps_mode passthrough',
           '-v verbose',
@@ -1370,8 +1370,8 @@ describe(MediaService.name, () => {
       {
         inputOptions: [],
         outputOptions: [
-          '-vcodec h264',
-          '-acodec aac',
+          '-c:v:0 h264',
+          '-c:a:0 aac',
           '-movflags faststart',
           '-fps_mode passthrough',
           '-v verbose',
@@ -1395,8 +1395,8 @@ describe(MediaService.name, () => {
       {
         inputOptions: [],
         outputOptions: [
-          '-vcodec h264',
-          '-acodec aac',
+          '-c:v:0 h264',
+          '-c:a:0 aac',
           '-movflags faststart',
           '-fps_mode passthrough',
           '-v verbose',

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -42,6 +42,7 @@ export class MediaRepository implements IMediaRepository {
       videoStreams: results.streams
         .filter((stream) => stream.codec_type === 'video')
         .map((stream) => ({
+          index: stream.index,
           height: stream.height || 0,
           width: stream.width || 0,
           codecName: stream.codec_name === 'h265' ? 'hevc' : stream.codec_name,
@@ -53,8 +54,10 @@ export class MediaRepository implements IMediaRepository {
       audioStreams: results.streams
         .filter((stream) => stream.codec_type === 'audio')
         .map((stream) => ({
+          index: stream.index,
           codecType: stream.codec_type,
           codecName: stream.codec_name,
+          frameCount: Number.parseInt(stream.nb_frames ?? '0'),
         })),
     };
   }

--- a/server/test/e2e/setup.ts
+++ b/server/test/e2e/setup.ts
@@ -1,5 +1,5 @@
-import { GenericContainer } from 'testcontainers';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { GenericContainer } from 'testcontainers';
 export default async () => {
   process.env.NODE_ENV = 'development';
   process.env.TYPESENSE_API_KEY = 'abc123';

--- a/server/test/fixtures/media.stub.ts
+++ b/server/test/fixtures/media.stub.ts
@@ -7,10 +7,21 @@ const probeStubDefaultFormat: VideoFormat = {
 };
 
 const probeStubDefaultVideoStream: VideoStreamInfo[] = [
-  { height: 1080, width: 1920, codecName: 'hevc', codecType: 'video', frameCount: 100, rotation: 0, isHDR: false },
+  {
+    index: 0,
+    height: 1080,
+    width: 1920,
+    codecName: 'hevc',
+    codecType: 'video',
+    frameCount: 100,
+    rotation: 0,
+    isHDR: false,
+  },
 ];
 
-const probeStubDefaultAudioStream: AudioStreamInfo[] = [{ codecName: 'aac', codecType: 'audio' }];
+const probeStubDefaultAudioStream: AudioStreamInfo[] = [
+  { index: 0, codecName: 'aac', codecType: 'audio', frameCount: 100 },
+];
 
 const probeStubDefault: VideoInfo = {
   format: probeStubDefaultFormat,
@@ -25,6 +36,7 @@ export const probeStub = {
     ...probeStubDefault,
     videoStreams: [
       {
+        index: 0,
         height: 1080,
         width: 400,
         codecName: 'hevc',
@@ -34,6 +46,7 @@ export const probeStub = {
         isHDR: false,
       },
       {
+        index: 1,
         height: 1080,
         width: 400,
         codecName: 'h7000',
@@ -48,6 +61,7 @@ export const probeStub = {
     ...probeStubDefault,
     videoStreams: [
       {
+        index: 0,
         height: 0,
         width: 400,
         codecName: 'hevc',
@@ -62,6 +76,7 @@ export const probeStub = {
     ...probeStubDefault,
     videoStreams: [
       {
+        index: 0,
         height: 2160,
         width: 3840,
         codecName: 'h264',
@@ -76,6 +91,7 @@ export const probeStub = {
     ...probeStubDefault,
     videoStreams: [
       {
+        index: 0,
         height: 480,
         width: 480,
         codecName: 'h264',
@@ -90,6 +106,7 @@ export const probeStub = {
     ...probeStubDefault,
     videoStreams: [
       {
+        index: 0,
         height: 2160,
         width: 3840,
         codecName: 'h264',
@@ -102,7 +119,7 @@ export const probeStub = {
   }),
   audioStreamMp3: Object.freeze<VideoInfo>({
     ...probeStubDefault,
-    audioStreams: [{ codecType: 'audio', codecName: 'aac' }],
+    audioStreams: [{ index: 0, codecType: 'audio', codecName: 'aac', frameCount: 100 }],
   }),
   matroskaContainer: Object.freeze<VideoInfo>({
     ...probeStubDefault,


### PR DESCRIPTION
## Description

This PR explicitly sets the video and audio streams to be used for transcoding. FFmpeg has heuristics for which stream to use if left unspecified, but it can select the wrong stream in some cases, particularly with Motion Photos on Android.

Fixes #3421

## Testing

All tests pass, but the specific issue described has not been tested yet.