### PR TITLE
fix(web, mobile): camera info

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
@@ -255,7 +255,7 @@ class ExifBottomSheet extends HookConsumerWidget {
                 ),
               ),
               subtitle: Text(
-                "ƒ/${exifInfo.fNumber}   ${exifInfo.exposureTime}   ${exifInfo.focalLength} mm   ISO${exifInfo.iso} ",
+                "ƒ/${exifInfo.fNumber}   ${exifInfo.exposureTime}   ${exifInfo.focalLength} mm   ISO ${exifInfo.iso ?? ''} ",
               ),
             ),
         ],

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -207,7 +207,7 @@
       </div>
     {/if}
 
-    {#if asset.exifInfo.make || asset.exifInfo.model || asset.exifInfo?.fNumber}
+    {#if asset.exifInfo?.make || asset.exifInfo?.model || asset.exifInfo?.fNumber}
       <div class="flex gap-4 py-4">
         <div><CameraIris size="24" /></div>
 

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -207,14 +207,16 @@
       </div>
     {/if}
 
-    {#if asset.exifInfo?.fNumber}
+    {#if asset.exifInfo.make || asset.exifInfo.model || asset.exifInfo?.fNumber}
       <div class="flex gap-4 py-4">
         <div><CameraIris size="24" /></div>
 
         <div>
           <p>{asset.exifInfo.make || ''} {asset.exifInfo.model || ''}</p>
           <div class="flex gap-2 text-sm">
-            <p>{`ƒ/${asset.exifInfo.fNumber.toLocaleString($locale)}` || ''}</p>
+            {#if asset.exifInfo?.fNumber}
+              <p>{`ƒ/${asset.exifInfo.fNumber.toLocaleString($locale)}` || ''}</p>
+            {/if}
 
             {#if asset.exifInfo.exposureTime}
               <p>{`${asset.exifInfo.exposureTime}`}</p>
@@ -226,7 +228,7 @@
 
             {#if asset.exifInfo.iso}
               <p>
-                {`ISO${asset.exifInfo.iso}`}
+                {`ISO ${asset.exifInfo.iso}`}
               </p>
             {/if}
           </div>


### PR DESCRIPTION
Fixed:
- web: completely missing info about camera manufacturer and model when lens info is missing
- mobile: "ISOnull" when ISO information is missing