### PR TITLE
fix (mobile): Fix slow album thumbnail generation for album picker

### DIFF
--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -218,22 +218,18 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       final assetCountInAlbum = await album.assetCountAsync;
       if (assetCountInAlbum > 0) {
         final assetList = await album.getAssetListPaged(page: 0, size: 1);
-
-        if (assetList.isNotEmpty) {
-          final thumbnailAsset = assetList.first;
-
-          try {
-            final thumbnailData = await thumbnailAsset
-                .thumbnailDataWithSize(const ThumbnailSize(512, 512));
-            availableAlbum =
-                availableAlbum.copyWith(thumbnailData: thumbnailData);
-          } catch (e, stack) {
-            log.severe(
-              "Failed to get thumbnail for album ${album.name}",
-              e.toString(),
-              stack,
-            );
-          }
+        final thumbnailAsset = assetList.first;
+        try {
+          final thumbnailData = await thumbnailAsset
+              .thumbnailDataWithSize(const ThumbnailSize(512, 512));
+          availableAlbum =
+              availableAlbum.copyWith(thumbnailData: thumbnailData);
+        } catch (e, stack) {
+          log.severe(
+            "Failed to get thumbnail for album ${album.name}",
+            e.toString(),
+            stack,
+          );
         }
 
         availableAlbums.add(availableAlbum);

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -217,8 +217,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
 
       final assetCountInAlbum = await album.assetCountAsync;
       if (assetCountInAlbum > 0) {
-        final assetList =
-            await album.getAssetListRange(start: 0, end: assetCountInAlbum);
+        final assetList = await album.getAssetListPaged(page: 0, size: 1);
 
         if (assetList.isNotEmpty) {
           final thumbnailAsset = assetList.first;


### PR DESCRIPTION
When generating the thumbnail of an album, all of the pictures of the album are retrieved but only the first picture of the album is used.

Retrieving all of the pictures of the album at once can cause huge performance issues on large albums.

Since only the first picture is used to generate the thumbnail, this commit uses the getAssetListPaged method instead of getAssetListRange, effectively retrieving only the first picture of the album.

Note that this issue has been observed on Android but may also happen on iOS devices.