### PR TITLE
Refer to FFmpeg documentation

### DIFF
--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -16,6 +16,7 @@
   import SettingInputField, { SettingInputFieldType } from '../setting-input-field.svelte';
   import SettingSelect from '../setting-select.svelte';
   import SettingSwitch from '../setting-switch.svelte';
+  import HelpCircleOutline from 'svelte-material-icons/HelpCircleOutline.svelte';
   import { isEqual } from 'lodash-es';
   import { fade } from 'svelte/transition';
 
@@ -89,6 +90,21 @@
     <div in:fade={{ duration: 500 }}>
       <form autocomplete="off" on:submit|preventDefault>
         <div class="ml-4 mt-4 flex flex-col gap-4">
+          <p class="text-sm dark:text-immich-dark-fg">
+            <HelpCircleOutline class="inline" size="15" />
+            To learn more about the terminology used here, refer to FFmpeg documentation for
+            <a href="https://trac.ffmpeg.org/wiki/Encode/H.264" class="underline" target="_blank" rel="noreferrer"
+              >H.264 codec</a
+            >,
+            <a href="https://trac.ffmpeg.org/wiki/Encode/H.265" class="underline" target="_blank" rel="noreferrer"
+              >HEVC codec</a
+            >
+            and
+            <a href="https://trac.ffmpeg.org/wiki/Encode/VP9" class="underline" target="_blank" rel="noreferrer"
+              >VP9 codec</a
+            >.
+          </p>
+
           <SettingInputField
             inputType={SettingInputFieldType.NUMBER}
             {disabled}

--- a/web/src/lib/components/admin-page/settings/oauth/oauth-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/oauth/oauth-settings.svelte
@@ -111,7 +111,7 @@
       <form autocomplete="off" on:submit|preventDefault class="mx-4 flex flex-col gap-4 py-4">
         <p class="text-sm dark:text-immich-dark-fg">
           For more details about this feature, refer to the <a
-            href="http://immich.app/docs/administration/oauth#mobile-redirect-uri"
+            href="https://immich.app/docs/administration/oauth#mobile-redirect-uri"
             class="underline"
             target="_blank"
             rel="noreferrer">docs</a

--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -62,7 +62,7 @@
     </SettingAccordion>
 
     <SettingAccordion
-      title="FFmpeg Settings"
+      title="Video Transcoding Settings"
       subtitle="Manage the resolution and encoding information of the video files"
     >
       <FFmpegSettings disabled={$featureFlags.configFile} ffmpegConfig={configs.ffmpeg} />


### PR DESCRIPTION
Some opinionated changes. Feel free to not agree with me :-)

* Put some links to the FFmpeg site. I had to put them in an intro text at the beginning because FFmpeg wiki pages are codec-specific and not feature-specific (as in there isn't one page talking about "CRF" only for all codecs)
* Changed **"FFmpeg settings"** to **Video Transcoding Settings**
* Added a little inline "help circle" icon to the transcoding settings intro text - *totally removable if that does not go along with the rest of the UI*

![preview-web](https://github.com/immich-app/immich/assets/3763726/7deeded8-6b6b-48be-b5ef-906b04ad4900)

Unrelated:

* Fixed an insecure URL to the Immich site (I know there is a redirect, still seeing a non-SSL URL seemed weird).