### PR TITLE
fix(ml): `minScore` not being set correctly

### DIFF
--- a/machine-learning/app/models/facial_recognition.py
+++ b/machine-learning/app/models/facial_recognition.py
@@ -105,4 +105,4 @@ class FaceRecognizer(InferenceModel):
         return self.cache_dir.is_dir() and any(self.cache_dir.glob("*.onnx"))
 
     def configure(self, **model_kwargs: Any) -> None:
-        self.det_model.det_thresh = model_kwargs.get("min_score", self.det_model.det_thresh)
+        self.det_model.det_thresh = model_kwargs.pop("minScore", self.det_model.det_thresh)

--- a/machine-learning/app/models/facial_recognition.py
+++ b/machine-learning/app/models/facial_recognition.py
@@ -23,7 +23,7 @@ class FaceRecognizer(InferenceModel):
         cache_dir: Path | str | None = None,
         **model_kwargs: Any,
     ) -> None:
-        self.min_score = min_score
+        self.min_score = model_kwargs.pop("minScore", min_score)
         super().__init__(model_name, cache_dir, **model_kwargs)
 
     def _download(self, **model_kwargs: Any) -> None:

--- a/machine-learning/app/models/image_classification.py
+++ b/machine-learning/app/models/image_classification.py
@@ -65,4 +65,4 @@ class ImageClassifier(InferenceModel):
         return tags
 
     def configure(self, **model_kwargs: Any) -> None:
-        self.min_score = model_kwargs.get("min_score", self.min_score)
+        self.min_score = model_kwargs.pop("minScore", self.min_score)

--- a/machine-learning/app/models/image_classification.py
+++ b/machine-learning/app/models/image_classification.py
@@ -22,7 +22,7 @@ class ImageClassifier(InferenceModel):
         cache_dir: Path | str | None = None,
         **model_kwargs: Any,
     ) -> None:
-        self.min_score = min_score
+        self.min_score = model_kwargs.pop("minScore", min_score)
         super().__init__(model_name, cache_dir, **model_kwargs)
 
     def _download(self, **model_kwargs: Any) -> None:

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -44,6 +44,9 @@ export class MachineLearningRepository implements IMachineLearningRepository {
   async getFormData(input: TextModelInput | VisionModelInput, config: ModelConfig): Promise<FormData> {
     const formData = new FormData();
     const { enabled, modelName, modelType, ...options } = config;
+    if (!enabled) {
+      throw new Error('Model not enabled');
+    }
 
     formData.append('modelName', modelName);
     if (modelType) {

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -43,7 +43,7 @@ export class MachineLearningRepository implements IMachineLearningRepository {
 
   async getFormData(input: TextModelInput | VisionModelInput, config: ModelConfig): Promise<FormData> {
     const formData = new FormData();
-    const { modelName, modelType, ...options } = config;
+    const { enabled, modelName, modelType, ...options } = config;
 
     formData.append('modelName', modelName);
     if (modelType) {

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -45,7 +45,7 @@ export class MachineLearningRepository implements IMachineLearningRepository {
     const formData = new FormData();
     const { enabled, modelName, modelType, ...options } = config;
     if (!enabled) {
-      throw new Error('Model not enabled');
+      throw new Error(`${modelType} is not enabled`);
     }
 
     formData.append('modelName', modelName);


### PR DESCRIPTION
## Description

This is a hot-fix in two respects: fixing the image classification model erroring if the model is not downloaded, and correctly setting the `minScore` config in image classification and facial recognition. If the model is not already downloaded and exported to ONNX, the `pipeline` function used for the first load validates the kwargs passed while the other code path does not. Additionally, the options sent are in camelCase while the check is currently for snake_case. 

Fixes #3915


## How Has This Been Tested?

I deleted the image classification model from the cache, restarted the containers and confirmed that each job runs without errors.