### PR TITLE
Create real anchors around admin sidebar buttons

### DIFF
--- a/web/src/routes/admin/+layout.svelte
+++ b/web/src/routes/admin/+layout.svelte
@@ -12,7 +12,6 @@
   import Cog from 'svelte-material-icons/Cog.svelte';
   import Server from 'svelte-material-icons/Server.svelte';
   import StatusBox from '$lib/components/shared-components/status-box.svelte';
-  import { goto } from '$app/navigation';
   import { AppRoute } from '../../lib/constants';
   import type { LayoutData } from './$types';
   import SideBarSection from '$lib/components/shared-components/side-bar/side-bar-section.svelte';
@@ -40,30 +39,22 @@
 
 <UserPageLayout user={data.user} showUploadButton={false} title={getPageTitle(data.routeId)}>
   <SideBarSection slot="sidebar">
-    <SideBarButton
-      title="Users"
-      logo={AccountMultipleOutline}
-      isSelected={data.routeId === AppRoute.ADMIN_USER_MANAGEMENT}
-      on:selected={() => goto(AppRoute.ADMIN_USER_MANAGEMENT)}
-    />
-    <SideBarButton
-      title="Jobs"
-      logo={Sync}
-      isSelected={data.routeId === AppRoute.ADMIN_JOBS}
-      on:selected={() => goto(AppRoute.ADMIN_JOBS)}
-    />
-    <SideBarButton
-      title="Settings"
-      logo={Cog}
-      isSelected={data.routeId === AppRoute.ADMIN_SETTINGS}
-      on:selected={() => goto(AppRoute.ADMIN_SETTINGS)}
-    />
-    <SideBarButton
-      title="Server Stats"
-      logo={Server}
-      isSelected={data.routeId === AppRoute.ADMIN_STATS}
-      on:selected={() => goto(AppRoute.ADMIN_STATS)}
-    />
+    <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_USER_MANAGEMENT} draggable="false">
+      <SideBarButton
+        title="Users"
+        logo={AccountMultipleOutline}
+        isSelected={data.routeId === AppRoute.ADMIN_USER_MANAGEMENT}
+      />
+    </a>
+    <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_JOBS} draggable="false">
+      <SideBarButton title="Jobs" logo={Sync} isSelected={data.routeId === AppRoute.ADMIN_JOBS} />
+    </a>
+    <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_SETTINGS} draggable="false">
+      <SideBarButton title="Settings" logo={Cog} isSelected={data.routeId === AppRoute.ADMIN_SETTINGS} />
+    </a>
+    <a data-sveltekit-preload-data="hover" href={AppRoute.ADMIN_STATS} draggable="false">
+      <SideBarButton title="Server Stats" logo={Server} isSelected={data.routeId === AppRoute.ADMIN_STATS} />
+    </a>
     <div class="mb-6 mt-auto">
       <StatusBox />
     </div>


### PR DESCRIPTION
This will make possible treating the admin sidebar buttons as links, thus enabling other gestures, e.g. Ctrl+Click.
The main (non-admin) sidebar already works like this (correctly).