### PR TITLE
refactor(web,server): use feature flags for oauth

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -1864,6 +1864,19 @@ export type ModelType = typeof ModelType[keyof typeof ModelType];
 /**
  * 
  * @export
+ * @interface OAuthAuthorizeResponseDto
+ */
+export interface OAuthAuthorizeResponseDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof OAuthAuthorizeResponseDto
+     */
+    'url': string;
+}
+/**
+ * 
+ * @export
  * @interface OAuthCallbackDto
  */
 export interface OAuthCallbackDto {
@@ -8892,6 +8905,41 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
     return {
         /**
          * 
+         * @param {OAuthConfigDto} oAuthConfigDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authorizeOAuth: async (oAuthConfigDto: OAuthConfigDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'oAuthConfigDto' is not null or undefined
+            assertParamExists('authorizeOAuth', 'oAuthConfigDto', oAuthConfigDto)
+            const localVarPath = `/oauth/authorize`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(oAuthConfigDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {OAuthCallbackDto} oAuthCallbackDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -8926,9 +8974,10 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthConfigDto} oAuthConfigDto 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         generateConfig: async (oAuthConfigDto: OAuthConfigDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -9083,6 +9132,16 @@ export const OAuthApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
+         * @param {OAuthConfigDto} oAuthConfigDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async authorizeOAuth(oAuthConfigDto: OAuthConfigDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OAuthAuthorizeResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.authorizeOAuth(oAuthConfigDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {OAuthCallbackDto} oAuthCallbackDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9092,9 +9151,10 @@ export const OAuthApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthConfigDto} oAuthConfigDto 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async generateConfig(oAuthConfigDto: OAuthConfigDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OAuthConfigResponseDto>> {
@@ -9141,6 +9201,15 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
     return {
         /**
          * 
+         * @param {OAuthApiAuthorizeOAuthRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authorizeOAuth(requestParameters: OAuthApiAuthorizeOAuthRequest, options?: AxiosRequestConfig): AxiosPromise<OAuthAuthorizeResponseDto> {
+            return localVarFp.authorizeOAuth(requestParameters.oAuthConfigDto, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {OAuthApiCallbackRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9149,9 +9218,10 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.callback(requestParameters.oAuthCallbackDto, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthApiGenerateConfigRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         generateConfig(requestParameters: OAuthApiGenerateConfigRequest, options?: AxiosRequestConfig): AxiosPromise<OAuthConfigResponseDto> {
@@ -9184,6 +9254,20 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
         },
     };
 };
+
+/**
+ * Request parameters for authorizeOAuth operation in OAuthApi.
+ * @export
+ * @interface OAuthApiAuthorizeOAuthRequest
+ */
+export interface OAuthApiAuthorizeOAuthRequest {
+    /**
+     * 
+     * @type {OAuthConfigDto}
+     * @memberof OAuthApiAuthorizeOAuth
+     */
+    readonly oAuthConfigDto: OAuthConfigDto
+}
 
 /**
  * Request parameters for callback operation in OAuthApi.
@@ -9236,6 +9320,17 @@ export interface OAuthApiLinkRequest {
 export class OAuthApi extends BaseAPI {
     /**
      * 
+     * @param {OAuthApiAuthorizeOAuthRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OAuthApi
+     */
+    public authorizeOAuth(requestParameters: OAuthApiAuthorizeOAuthRequest, options?: AxiosRequestConfig) {
+        return OAuthApiFp(this.configuration).authorizeOAuth(requestParameters.oAuthConfigDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
      * @param {OAuthApiCallbackRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9246,9 +9341,10 @@ export class OAuthApi extends BaseAPI {
     }
 
     /**
-     * 
+     * @deprecated use feature flags and /oauth/authorize
      * @param {OAuthApiGenerateConfigRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      * @memberof OAuthApi
      */

--- a/mobile/openapi/.openapi-generator/FILES
+++ b/mobile/openapi/.openapi-generator/FILES
@@ -73,6 +73,7 @@ doc/MemoryLaneResponseDto.md
 doc/MergePersonDto.md
 doc/ModelType.md
 doc/OAuthApi.md
+doc/OAuthAuthorizeResponseDto.md
 doc/OAuthCallbackDto.md
 doc/OAuthConfigDto.md
 doc/OAuthConfigResponseDto.md
@@ -225,6 +226,7 @@ lib/model/map_marker_response_dto.dart
 lib/model/memory_lane_response_dto.dart
 lib/model/merge_person_dto.dart
 lib/model/model_type.dart
+lib/model/o_auth_authorize_response_dto.dart
 lib/model/o_auth_callback_dto.dart
 lib/model/o_auth_config_dto.dart
 lib/model/o_auth_config_response_dto.dart
@@ -352,6 +354,7 @@ test/memory_lane_response_dto_test.dart
 test/merge_person_dto_test.dart
 test/model_type_test.dart
 test/o_auth_api_test.dart
+test/o_auth_authorize_response_dto_test.dart
 test/o_auth_callback_dto_test.dart
 test/o_auth_config_dto_test.dart
 test/o_auth_config_response_dto_test.dart

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -124,6 +124,7 @@ Class | Method | HTTP request | Description
 *AuthenticationApi* | [**validateAccessToken**](doc//AuthenticationApi.md#validateaccesstoken) | **POST** /auth/validateToken | 
 *JobApi* | [**getAllJobsStatus**](doc//JobApi.md#getalljobsstatus) | **GET** /jobs | 
 *JobApi* | [**sendJobCommand**](doc//JobApi.md#sendjobcommand) | **PUT** /jobs/{id} | 
+*OAuthApi* | [**authorizeOAuth**](doc//OAuthApi.md#authorizeoauth) | **POST** /oauth/authorize | 
 *OAuthApi* | [**callback**](doc//OAuthApi.md#callback) | **POST** /oauth/callback | 
 *OAuthApi* | [**generateConfig**](doc//OAuthApi.md#generateconfig) | **POST** /oauth/config | 
 *OAuthApi* | [**link**](doc//OAuthApi.md#link) | **POST** /oauth/link | 
@@ -244,6 +245,7 @@ Class | Method | HTTP request | Description
  - [MemoryLaneResponseDto](doc//MemoryLaneResponseDto.md)
  - [MergePersonDto](doc//MergePersonDto.md)
  - [ModelType](doc//ModelType.md)
+ - [OAuthAuthorizeResponseDto](doc//OAuthAuthorizeResponseDto.md)
  - [OAuthCallbackDto](doc//OAuthCallbackDto.md)
  - [OAuthConfigDto](doc//OAuthConfigDto.md)
  - [OAuthConfigResponseDto](doc//OAuthConfigResponseDto.md)

--- a/mobile/openapi/doc/OAuthApi.md
+++ b/mobile/openapi/doc/OAuthApi.md
@@ -9,12 +9,54 @@ All URIs are relative to */api*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**authorizeOAuth**](OAuthApi.md#authorizeoauth) | **POST** /oauth/authorize | 
 [**callback**](OAuthApi.md#callback) | **POST** /oauth/callback | 
 [**generateConfig**](OAuthApi.md#generateconfig) | **POST** /oauth/config | 
 [**link**](OAuthApi.md#link) | **POST** /oauth/link | 
 [**mobileRedirect**](OAuthApi.md#mobileredirect) | **GET** /oauth/mobile-redirect | 
 [**unlink**](OAuthApi.md#unlink) | **POST** /oauth/unlink | 
 
+
+# **authorizeOAuth**
+> OAuthAuthorizeResponseDto authorizeOAuth(oAuthConfigDto)
+
+
+
+### Example
+```dart
+import 'package:openapi/api.dart';
+
+final api_instance = OAuthApi();
+final oAuthConfigDto = OAuthConfigDto(); // OAuthConfigDto | 
+
+try {
+    final result = api_instance.authorizeOAuth(oAuthConfigDto);
+    print(result);
+} catch (e) {
+    print('Exception when calling OAuthApi->authorizeOAuth: $e\n');
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **oAuthConfigDto** | [**OAuthConfigDto**](OAuthConfigDto.md)|  | 
+
+### Return type
+
+[**OAuthAuthorizeResponseDto**](OAuthAuthorizeResponseDto.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **callback**
 > LoginResponseDto callback(oAuthCallbackDto)
@@ -61,6 +103,8 @@ No authorization required
 > OAuthConfigResponseDto generateConfig(oAuthConfigDto)
 
 
+
+@deprecated use feature flags and /oauth/authorize
 
 ### Example
 ```dart

--- a/mobile/openapi/doc/OAuthAuthorizeResponseDto.md
+++ b/mobile/openapi/doc/OAuthAuthorizeResponseDto.md
@@ -1,0 +1,15 @@
+# openapi.model.OAuthAuthorizeResponseDto
+
+## Load the model package
+```dart
+import 'package:openapi/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**url** | **String** |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -107,6 +107,7 @@ part 'model/map_marker_response_dto.dart';
 part 'model/memory_lane_response_dto.dart';
 part 'model/merge_person_dto.dart';
 part 'model/model_type.dart';
+part 'model/o_auth_authorize_response_dto.dart';
 part 'model/o_auth_callback_dto.dart';
 part 'model/o_auth_config_dto.dart';
 part 'model/o_auth_config_response_dto.dart';

--- a/mobile/openapi/lib/api/o_auth_api.dart
+++ b/mobile/openapi/lib/api/o_auth_api.dart
@@ -16,6 +16,53 @@ class OAuthApi {
 
   final ApiClient apiClient;
 
+  /// Performs an HTTP 'POST /oauth/authorize' operation and returns the [Response].
+  /// Parameters:
+  ///
+  /// * [OAuthConfigDto] oAuthConfigDto (required):
+  Future<Response> authorizeOAuthWithHttpInfo(OAuthConfigDto oAuthConfigDto,) async {
+    // ignore: prefer_const_declarations
+    final path = r'/oauth/authorize';
+
+    // ignore: prefer_final_locals
+    Object? postBody = oAuthConfigDto;
+
+    final queryParams = <QueryParam>[];
+    final headerParams = <String, String>{};
+    final formParams = <String, String>{};
+
+    const contentTypes = <String>['application/json'];
+
+
+    return apiClient.invokeAPI(
+      path,
+      'POST',
+      queryParams,
+      postBody,
+      headerParams,
+      formParams,
+      contentTypes.isEmpty ? null : contentTypes.first,
+    );
+  }
+
+  /// Parameters:
+  ///
+  /// * [OAuthConfigDto] oAuthConfigDto (required):
+  Future<OAuthAuthorizeResponseDto?> authorizeOAuth(OAuthConfigDto oAuthConfigDto,) async {
+    final response = await authorizeOAuthWithHttpInfo(oAuthConfigDto,);
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    }
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'OAuthAuthorizeResponseDto',) as OAuthAuthorizeResponseDto;
+    
+    }
+    return null;
+  }
+
   /// Performs an HTTP 'POST /oauth/callback' operation and returns the [Response].
   /// Parameters:
   ///
@@ -63,7 +110,10 @@ class OAuthApi {
     return null;
   }
 
-  /// Performs an HTTP 'POST /oauth/config' operation and returns the [Response].
+  /// @deprecated use feature flags and /oauth/authorize
+  ///
+  /// Note: This method returns the HTTP [Response].
+  ///
   /// Parameters:
   ///
   /// * [OAuthConfigDto] oAuthConfigDto (required):
@@ -92,6 +142,8 @@ class OAuthApi {
     );
   }
 
+  /// @deprecated use feature flags and /oauth/authorize
+  ///
   /// Parameters:
   ///
   /// * [OAuthConfigDto] oAuthConfigDto (required):

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -307,6 +307,8 @@ class ApiClient {
           return MergePersonDto.fromJson(value);
         case 'ModelType':
           return ModelTypeTypeTransformer().decode(value);
+        case 'OAuthAuthorizeResponseDto':
+          return OAuthAuthorizeResponseDto.fromJson(value);
         case 'OAuthCallbackDto':
           return OAuthCallbackDto.fromJson(value);
         case 'OAuthConfigDto':

--- a/mobile/openapi/lib/model/o_auth_authorize_response_dto.dart
+++ b/mobile/openapi/lib/model/o_auth_authorize_response_dto.dart
@@ -1,0 +1,98 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class OAuthAuthorizeResponseDto {
+  /// Returns a new [OAuthAuthorizeResponseDto] instance.
+  OAuthAuthorizeResponseDto({
+    required this.url,
+  });
+
+  String url;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OAuthAuthorizeResponseDto &&
+     other.url == url;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (url.hashCode);
+
+  @override
+  String toString() => 'OAuthAuthorizeResponseDto[url=$url]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'url'] = this.url;
+    return json;
+  }
+
+  /// Returns a new [OAuthAuthorizeResponseDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static OAuthAuthorizeResponseDto? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return OAuthAuthorizeResponseDto(
+        url: mapValueOfType<String>(json, r'url')!,
+      );
+    }
+    return null;
+  }
+
+  static List<OAuthAuthorizeResponseDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <OAuthAuthorizeResponseDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = OAuthAuthorizeResponseDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, OAuthAuthorizeResponseDto> mapFromJson(dynamic json) {
+    final map = <String, OAuthAuthorizeResponseDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = OAuthAuthorizeResponseDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of OAuthAuthorizeResponseDto-objects as value to a dart map
+  static Map<String, List<OAuthAuthorizeResponseDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<OAuthAuthorizeResponseDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = OAuthAuthorizeResponseDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'url',
+  };
+}
+

--- a/mobile/openapi/test/o_auth_api_test.dart
+++ b/mobile/openapi/test/o_auth_api_test.dart
@@ -17,11 +17,18 @@ void main() {
   // final instance = OAuthApi();
 
   group('tests for OAuthApi', () {
+    //Future<OAuthAuthorizeResponseDto> authorizeOAuth(OAuthConfigDto oAuthConfigDto) async
+    test('test authorizeOAuth', () async {
+      // TODO
+    });
+
     //Future<LoginResponseDto> callback(OAuthCallbackDto oAuthCallbackDto) async
     test('test callback', () async {
       // TODO
     });
 
+    // @deprecated use feature flags and /oauth/authorize
+    //
     //Future<OAuthConfigResponseDto> generateConfig(OAuthConfigDto oAuthConfigDto) async
     test('test generateConfig', () async {
       // TODO

--- a/mobile/openapi/test/o_auth_authorize_response_dto_test.dart
+++ b/mobile/openapi/test/o_auth_authorize_response_dto_test.dart
@@ -1,0 +1,27 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.12
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:openapi/api.dart';
+import 'package:test/test.dart';
+
+// tests for OAuthAuthorizeResponseDto
+void main() {
+  // final instance = OAuthAuthorizeResponseDto();
+
+  group('test OAuthAuthorizeResponseDto', () {
+    // String url
+    test('to test the property `url`', () async {
+      // TODO
+    });
+
+
+  });
+
+}

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -2477,6 +2477,37 @@
         ]
       }
     },
+    "/oauth/authorize": {
+      "post": {
+        "operationId": "authorizeOAuth",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OAuthConfigDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthAuthorizeResponseDto"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "OAuth"
+        ]
+      }
+    },
     "/oauth/callback": {
       "post": {
         "operationId": "callback",
@@ -2510,6 +2541,8 @@
     },
     "/oauth/config": {
       "post": {
+        "deprecated": true,
+        "description": "@deprecated use feature flags and /oauth/authorize",
         "operationId": "generateConfig",
         "parameters": [],
         "requestBody": {
@@ -6201,6 +6234,17 @@
           "clip"
         ],
         "type": "string"
+      },
+      "OAuthAuthorizeResponseDto": {
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
       },
       "OAuthCallbackDto": {
         "properties": {

--- a/server/src/domain/auth/dto/oauth-config.dto.ts
+++ b/server/src/domain/auth/dto/oauth-config.dto.ts
@@ -1,9 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class OAuthConfigDto {
   @IsNotEmpty()
   @IsString()
-  @ApiProperty()
   redirectUri!: string;
 }

--- a/server/src/domain/auth/response-dto/oauth-config-response.dto.ts
+++ b/server/src/domain/auth/response-dto/oauth-config-response.dto.ts
@@ -5,3 +5,7 @@ export class OAuthConfigResponseDto {
   buttonText?: string;
   autoLaunch?: boolean;
 }
+
+export class OAuthAuthorizeResponseDto {
+  url!: string;
+}

--- a/server/src/immich/controllers/oauth.controller.ts
+++ b/server/src/immich/controllers/oauth.controller.ts
@@ -3,6 +3,7 @@ import {
   AuthUserDto,
   LoginDetails,
   LoginResponseDto,
+  OAuthAuthorizeResponseDto,
   OAuthCallbackDto,
   OAuthConfigDto,
   OAuthConfigResponseDto,
@@ -31,10 +32,17 @@ export class OAuthController {
     };
   }
 
+  /** @deprecated use feature flags and /oauth/authorize */
   @PublicRoute()
   @Post('config')
   generateConfig(@Body() dto: OAuthConfigDto): Promise<OAuthConfigResponseDto> {
     return this.service.generateConfig(dto);
+  }
+
+  @PublicRoute()
+  @Post('authorize')
+  authorizeOAuth(@Body() dto: OAuthConfigDto): Promise<OAuthAuthorizeResponseDto> {
+    return this.service.authorize(dto);
   }
 
   @PublicRoute()

--- a/server/test/e2e/oauth.e2e-spec.ts
+++ b/server/test/e2e/oauth.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { AppModule, OAuthController } from '@app/immich';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { errorStub } from '../fixtures';
+import { api, db } from '../test-utils';
+
+describe(`${OAuthController.name} (e2e)`, () => {
+  let app: INestApplication;
+  let server: any;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = await moduleFixture.createNestApplication().init();
+    server = app.getHttpServer();
+  });
+
+  beforeEach(async () => {
+    await db.reset();
+    await api.adminSignUp(server);
+  });
+
+  afterAll(async () => {
+    await db.disconnect();
+    await app.close();
+  });
+
+  describe('POST /oauth/authorize', () => {
+    beforeEach(async () => {
+      await db.reset();
+    });
+
+    it(`should throw an error if a redirect uri is not provided`, async () => {
+      const { status, body } = await request(server).post('/oauth/authorize').send({});
+      expect(status).toBe(400);
+      expect(body).toEqual(errorStub.badRequest);
+    });
+  });
+});

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1864,6 +1864,19 @@ export type ModelType = typeof ModelType[keyof typeof ModelType];
 /**
  * 
  * @export
+ * @interface OAuthAuthorizeResponseDto
+ */
+export interface OAuthAuthorizeResponseDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof OAuthAuthorizeResponseDto
+     */
+    'url': string;
+}
+/**
+ * 
+ * @export
  * @interface OAuthCallbackDto
  */
 export interface OAuthCallbackDto {
@@ -8892,6 +8905,41 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
     return {
         /**
          * 
+         * @param {OAuthConfigDto} oAuthConfigDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authorizeOAuth: async (oAuthConfigDto: OAuthConfigDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'oAuthConfigDto' is not null or undefined
+            assertParamExists('authorizeOAuth', 'oAuthConfigDto', oAuthConfigDto)
+            const localVarPath = `/oauth/authorize`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(oAuthConfigDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {OAuthCallbackDto} oAuthCallbackDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -8926,9 +8974,10 @@ export const OAuthApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthConfigDto} oAuthConfigDto 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         generateConfig: async (oAuthConfigDto: OAuthConfigDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -9083,6 +9132,16 @@ export const OAuthApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
+         * @param {OAuthConfigDto} oAuthConfigDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async authorizeOAuth(oAuthConfigDto: OAuthConfigDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OAuthAuthorizeResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.authorizeOAuth(oAuthConfigDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @param {OAuthCallbackDto} oAuthCallbackDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9092,9 +9151,10 @@ export const OAuthApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthConfigDto} oAuthConfigDto 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async generateConfig(oAuthConfigDto: OAuthConfigDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<OAuthConfigResponseDto>> {
@@ -9141,6 +9201,15 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
     return {
         /**
          * 
+         * @param {OAuthApiAuthorizeOAuthRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        authorizeOAuth(requestParameters: OAuthApiAuthorizeOAuthRequest, options?: AxiosRequestConfig): AxiosPromise<OAuthAuthorizeResponseDto> {
+            return localVarFp.authorizeOAuth(requestParameters.oAuthConfigDto, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {OAuthApiCallbackRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9149,9 +9218,10 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.callback(requestParameters.oAuthCallbackDto, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * @deprecated use feature flags and /oauth/authorize
          * @param {OAuthApiGenerateConfigRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         generateConfig(requestParameters: OAuthApiGenerateConfigRequest, options?: AxiosRequestConfig): AxiosPromise<OAuthConfigResponseDto> {
@@ -9184,6 +9254,20 @@ export const OAuthApiFactory = function (configuration?: Configuration, basePath
         },
     };
 };
+
+/**
+ * Request parameters for authorizeOAuth operation in OAuthApi.
+ * @export
+ * @interface OAuthApiAuthorizeOAuthRequest
+ */
+export interface OAuthApiAuthorizeOAuthRequest {
+    /**
+     * 
+     * @type {OAuthConfigDto}
+     * @memberof OAuthApiAuthorizeOAuth
+     */
+    readonly oAuthConfigDto: OAuthConfigDto
+}
 
 /**
  * Request parameters for callback operation in OAuthApi.
@@ -9236,6 +9320,17 @@ export interface OAuthApiLinkRequest {
 export class OAuthApi extends BaseAPI {
     /**
      * 
+     * @param {OAuthApiAuthorizeOAuthRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OAuthApi
+     */
+    public authorizeOAuth(requestParameters: OAuthApiAuthorizeOAuthRequest, options?: AxiosRequestConfig) {
+        return OAuthApiFp(this.configuration).authorizeOAuth(requestParameters.oAuthConfigDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
      * @param {OAuthApiCallbackRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9246,9 +9341,10 @@ export class OAuthApi extends BaseAPI {
     }
 
     /**
-     * 
+     * @deprecated use feature flags and /oauth/authorize
      * @param {OAuthApiGenerateConfigRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      * @memberof OAuthApi
      */

--- a/web/src/api/utils.ts
+++ b/web/src/api/utils.ts
@@ -1,3 +1,4 @@
+import { goto } from '$app/navigation';
 import type { AxiosError, AxiosPromise } from 'axios';
 import {
   notificationController,
@@ -32,9 +33,17 @@ export const oauth = {
     }
     return false;
   },
+  authorize: async (location: Location) => {
+    try {
+      const redirectUri = location.href.split('?')[0];
+      const { data } = await api.oauthApi.authorizeOAuth({ oAuthConfigDto: { redirectUri } });
+      goto(data.url);
+    } catch (error) {
+      handleError(error, 'Unable to login with OAuth');
+    }
+  },
   getConfig: (location: Location) => {
     const redirectUri = location.href.split('?')[0];
-    console.log(`OAuth Redirect URI: ${redirectUri}`);
     return api.oauthApi.generateConfig({ oAuthConfigDto: { redirectUri } });
   },
   login: (location: Location) => {

--- a/web/src/lib/components/shared-components/fullscreen-container.svelte
+++ b/web/src/lib/components/shared-components/fullscreen-container.svelte
@@ -5,7 +5,7 @@
   export let showMessage = $$slots.message;
 </script>
 
-<section class="flex min-h-screen w-screen place-content-center place-items-center p-4">
+<section class="min-w-screen flex min-h-screen place-content-center place-items-center p-4">
   <div
     class="flex w-full max-w-lg flex-col gap-4 rounded-3xl border bg-white p-8 shadow-sm dark:border-immich-dark-gray dark:bg-immich-dark-gray"
   >

--- a/web/src/lib/components/user-settings-page/oauth-settings.svelte
+++ b/web/src/lib/components/user-settings-page/oauth-settings.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { oauth, OAuthConfigResponseDto, UserResponseDto } from '@api';
+  import { featureFlags } from '$lib/stores/feature-flags.store';
+  import { oauth, UserResponseDto } from '@api';
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { handleError } from '../../utils/handle-error';
+  import Button from '../elements/buttons/button.svelte';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { notificationController, NotificationType } from '../shared-components/notification/notification';
-  import Button from '../elements/buttons/button.svelte';
 
   export let user: UserResponseDto;
 
-  let config: OAuthConfigResponseDto = { enabled: false, passwordLoginEnabled: true };
   let loading = true;
 
   onMount(async () => {
@@ -30,13 +30,6 @@
       } finally {
         goto('?open=oauth');
       }
-    }
-
-    try {
-      const { data } = await oauth.getConfig(window.location);
-      config = data;
-    } catch (error) {
-      handleError(error, 'Unable to load OAuth config');
     }
 
     loading = false;
@@ -63,13 +56,11 @@
         <div class="flex place-content-center place-items-center">
           <LoadingSpinner />
         </div>
-      {:else if config.enabled}
+      {:else if $featureFlags.oauth}
         {#if user.oauthId}
           <Button size="sm" on:click={() => handleUnlink()}>Unlink Oauth</Button>
         {:else}
-          <a href={config.url}>
-            <Button size="sm" on:click={() => handleUnlink()}>Link to OAuth</Button>
-          </a>
+          <Button size="sm" on:click={() => oauth.authorize(window.location)}>Link to OAuth</Button>
         {/if}
       {/if}
     </div>

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { page } from '$app/stores';
+  import { featureFlags } from '$lib/stores/feature-flags.store';
   import { APIKeyResponseDto, AuthDeviceResponseDto, oauth, UserResponseDto } from '@api';
   import SettingAccordion from '../admin-page/settings/setting-accordion.svelte';
   import ChangePasswordSettings from './change-password-settings.svelte';
@@ -9,7 +11,6 @@
   import PartnerSettings from './partner-settings.svelte';
   import UserAPIKeyList from './user-api-key-list.svelte';
   import UserProfileSettings from './user-profile-settings.svelte';
-  import { onMount } from 'svelte';
 
   export let user: UserResponseDto;
 
@@ -17,18 +18,10 @@
   export let devices: AuthDeviceResponseDto[] = [];
   export let partners: UserResponseDto[] = [];
 
-  let oauthEnabled = false;
   let oauthOpen = false;
-
-  onMount(async () => {
+  if (browser) {
     oauthOpen = oauth.isCallback(window.location);
-    try {
-      const { data } = await oauth.getConfig(window.location);
-      oauthEnabled = data.enabled;
-    } catch {
-      // noop
-    }
-  });
+  }
 </script>
 
 <SettingAccordion title="Account" subtitle="Manage your account">
@@ -47,7 +40,7 @@
   <MemoriesSettings {user} />
 </SettingAccordion>
 
-{#if oauthEnabled}
+{#if $featureFlags.loaded && $featureFlags.oauth}
   <SettingAccordion
     title="OAuth"
     subtitle="Manage your OAuth connection"

--- a/web/src/lib/stores/feature-flags.store.ts
+++ b/web/src/lib/stores/feature-flags.store.ts
@@ -1,21 +1,22 @@
 import { api, ServerFeaturesDto } from '@api';
 import { writable } from 'svelte/store';
 
-export type FeatureFlags = ServerFeaturesDto;
+export type FeatureFlags = ServerFeaturesDto & { loaded: boolean };
 
 export const featureFlags = writable<FeatureFlags>({
+  loaded: false,
   clipEncode: true,
   facialRecognition: true,
   sidecar: true,
   tagImage: true,
   search: true,
-  oauth: true,
-  oauthAutoLaunch: true,
+  oauth: false,
+  oauthAutoLaunch: false,
   passwordLogin: true,
   configFile: false,
 });
 
 export const loadFeatureFlags = async () => {
   const { data } = await api.serverInfoApi.getServerFeatures();
-  featureFlags.update(() => data);
+  featureFlags.update(() => ({ ...data, loaded: true }));
 };

--- a/web/src/routes/auth/login/+page.server.ts
+++ b/web/src/routes/auth/login/+page.server.ts
@@ -1,5 +1,4 @@
 import { AppRoute } from '$lib/constants';
-import type { OAuthConfigResponseDto } from '@api';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -10,23 +9,7 @@ export const load = (async ({ locals: { api } }) => {
     throw redirect(302, AppRoute.AUTH_REGISTER);
   }
 
-  let authConfig: OAuthConfigResponseDto = {
-    passwordLoginEnabled: true,
-    enabled: false,
-  };
-
-  try {
-    // TODO: Figure out how to get correct redirect URI server-side.
-    const { data } = await api.oauthApi.generateConfig({ oAuthConfigDto: { redirectUri: '/' } });
-    data.url = undefined;
-
-    authConfig = data;
-  } catch (err) {
-    console.error('[ERROR] login/+page.server.ts:', err);
-  }
-
   return {
-    authConfig,
     meta: {
       title: 'Login',
     },

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -4,20 +4,22 @@
   import FullscreenContainer from '$lib/components/shared-components/fullscreen-container.svelte';
   import { AppRoute } from '$lib/constants';
   import { loginPageMessage } from '$lib/constants';
+  import { featureFlags } from '$lib/stores/feature-flags.store';
   import type { PageData } from './$types';
 
   export let data: PageData;
 </script>
 
-<FullscreenContainer title={data.meta.title} showMessage={!!loginPageMessage}>
-  <p slot="message">
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    {@html loginPageMessage}
-  </p>
+{#if $featureFlags.loaded}
+  <FullscreenContainer title={data.meta.title} showMessage={!!loginPageMessage}>
+    <p slot="message">
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html loginPageMessage}
+    </p>
 
-  <LoginForm
-    authConfig={data.authConfig}
-    on:success={() => goto(AppRoute.PHOTOS, { invalidateAll: true })}
-    on:first-login={() => goto(AppRoute.AUTH_CHANGE_PASSWORD)}
-  />
-</FullscreenContainer>
+    <LoginForm
+      on:success={() => goto(AppRoute.PHOTOS, { invalidateAll: true })}
+      on:first-login={() => goto(AppRoute.AUTH_CHANGE_PASSWORD)}
+    />
+  </FullscreenContainer>
+{/if}


### PR DESCRIPTION
In this PR:
- Use feature flags for OAuth
- Remove calls to `generateConfig`
- Add a new endpoint to get an authorization url (`POST /api/oauth/authorize`)
- Remove custom OAuth button text usage
- Lazily get the authorize url with a request to `POST /api/oauth/authorize`

Tested Scenarios:
- Password and OAuth disabled =  no login
- Password enabled = login button
- OAuth enabled = "Login" button, which triggers oauth and works
- OAuth and Password enabled = "Login" + "Login with OAuth" separated with a vertical line, both work
- User settings link and unlink OAuth account
- AutoLaunch=true auto logs the user in when navigating to `/auth/login`