### PR TITLE
chore(mobile): build split APKs

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -64,10 +64,10 @@ jobs:
           ALIAS: ${{ secrets.ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
-        run: flutter build apk --release
+        run: flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
 
       - name: Publish Android Artifact
         uses: actions/upload-artifact@v3
         with:
           name: release-apk-signed
-          path: mobile/build/app/outputs/flutter-apk/app-release.apk
+          path: mobile/build/app/outputs/flutter-apk/*.apk

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -64,7 +64,9 @@ jobs:
           ALIAS: ${{ secrets.ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
-        run: flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
+        run: |
+          flutter build apk --release
+          flutter build apk --release --split-per-abi --target-platform android-arm,android-arm64,android-x64
 
       - name: Publish Android Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
A [fat APK](https://docs.flutter.dev/deployment/android#what-is-a-fat-apk) that contains binaries for multiple ABIs embedded within it, but it has the drawback that its file size is much larger.
So, build split APKs, as described in [build an APK](https://docs.flutter.dev/deployment/android#build-an-apk) using the --split-per-abi flag.