### PR TITLE
feat(mobile): upload image assets before videos

### DIFF
--- a/mobile/lib/modules/backup/background_service/background.service.dart
+++ b/mobile/lib/modules/backup/background_service/background.service.dart
@@ -459,6 +459,7 @@ class BackgroundService {
       notifySingleProgress ? _onProgress : (sent, total) {},
       notifySingleProgress ? _onSetCurrentBackupAsset : (asset) {},
       _onBackupError,
+      sortAssets: true,
     );
     if (!ok && !_cancellationToken!.isCancelled) {
       _showErrorNotification(

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -464,6 +464,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         _onUploadProgress,
         _onSetCurrentBackupAsset,
         _onBackupError,
+        oldestFirst: false,
       );
       await notifyBackgroundServiceCanRun();
     } else {

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -464,7 +464,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         _onUploadProgress,
         _onSetCurrentBackupAsset,
         _onBackupError,
-        oldestFirst: false,
       );
       await notifyBackgroundServiceCanRun();
     } else {

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -221,7 +221,18 @@ class BackupService {
     // DON'T KNOW WHY BUT THIS HELPS BACKGROUND BACKUP TO WORK ON IOS
     await PhotoManager.requestPermissionExtend();
 
-    for (var entity in assetList) {
+    // Upload images before video assets
+    // these are further sorted by using their creation date so the upload goes as follows
+    // older images -> latest images -> older videos -> latest videos
+    List<AssetEntity> sortedAssets = assetList.sorted(
+      (a, b) {
+        final cmp = a.typeInt - b.typeInt;
+        if (cmp != 0) return cmp;
+        return a.createDateTime.compareTo(b.createDateTime);
+      },
+    );
+
+    for (var entity in sortedAssets) {
       try {
         if (entity.type == AssetType.video) {
           file = await entity.originFile;

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -203,7 +203,7 @@ class BackupService {
     Function(int, int) uploadProgressCb,
     Function(CurrentUploadAsset) setCurrentUploadAssetCb,
     Function(ErrorUploadAsset) errorCb, {
-    bool oldestFirst = true,
+    bool sortAssets = false,
   }) async {
     if (Platform.isAndroid &&
         !(await Permission.accessMediaLocation.status).isGranted) {
@@ -222,19 +222,19 @@ class BackupService {
     // DON'T KNOW WHY BUT THIS HELPS BACKGROUND BACKUP TO WORK ON IOS
     await PhotoManager.requestPermissionExtend();
 
-    // Upload images before video assets
-    // these are further sorted by using their creation date
-    List<AssetEntity> sortedAssets = assetList.sorted(
-      (a, b) {
-        final cmp = a.typeInt - b.typeInt;
-        if (cmp != 0) return cmp;
-        return oldestFirst
-            ? a.createDateTime.compareTo(b.createDateTime)
-            : b.createDateTime.compareTo(a.createDateTime);
-      },
-    );
+    List<AssetEntity> assetsToUpload = sortAssets
+        // Upload images before video assets
+        // these are further sorted by using their creation date
+        ? assetList.sorted(
+            (a, b) {
+              final cmp = a.typeInt - b.typeInt;
+              if (cmp != 0) return cmp;
+              return a.createDateTime.compareTo(b.createDateTime);
+            },
+          )
+        : assetList.toList();
 
-    for (var entity in sortedAssets) {
+    for (var entity in assetsToUpload) {
       try {
         if (entity.type == AssetType.video) {
           file = await entity.originFile;

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -202,8 +202,9 @@ class BackupService {
     Function(String, String, bool) uploadSuccessCb,
     Function(int, int) uploadProgressCb,
     Function(CurrentUploadAsset) setCurrentUploadAssetCb,
-    Function(ErrorUploadAsset) errorCb,
-  ) async {
+    Function(ErrorUploadAsset) errorCb, {
+    bool oldestFirst = true,
+  }) async {
     if (Platform.isAndroid &&
         !(await Permission.accessMediaLocation.status).isGranted) {
       // double check that permission is granted here, to guard against
@@ -222,13 +223,14 @@ class BackupService {
     await PhotoManager.requestPermissionExtend();
 
     // Upload images before video assets
-    // these are further sorted by using their creation date so the upload goes as follows
-    // older images -> latest images -> older videos -> latest videos
+    // these are further sorted by using their creation date
     List<AssetEntity> sortedAssets = assetList.sorted(
       (a, b) {
         final cmp = a.typeInt - b.typeInt;
         if (cmp != 0) return cmp;
-        return a.createDateTime.compareTo(b.createDateTime);
+        return oldestFirst
+            ? a.createDateTime.compareTo(b.createDateTime)
+            : b.createDateTime.compareTo(a.createDateTime);
       },
     );
 


### PR DESCRIPTION
### Changes made in this PR:
- Added back assets sorting before upload from #3872 
- Foreground uploads are sorted in the newest assets to oldest assets order and background and manual uploads are sorted from oldest assets to newest assets order
- Image assets are always uploaded before video assets irrespective of the type of upload