### PR TITLE
fix(mobile): curated places taking more size on large screens

### DIFF
--- a/mobile/lib/modules/search/views/search_page.dart
+++ b/mobile/lib/modules/search/views/search_page.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -27,7 +28,7 @@ class SearchPage extends HookConsumerWidget {
     final curatedLocation = ref.watch(getCuratedLocationProvider);
     final curatedPeople = ref.watch(getCuratedPeopleProvider);
     var isDarkTheme = Theme.of(context).brightness == Brightness.dark;
-    double imageSize = MediaQuery.of(context).size.width / 3;
+    double imageSize = math.min(MediaQuery.of(context).size.width / 3, 150);
 
     TextStyle categoryTitleStyle = const TextStyle(
       fontWeight: FontWeight.bold,


### PR DESCRIPTION
### Changes made in this PR:

Curated places section in mobile app seems to take huge image size based on the available width. This is now limited to a fixed size for devices with larger screens like the iPad

Before | After
:-: | :-:
![image](https://github.com/immich-app/immich/assets/139912620/89256e71-b49c-4454-b102-ba4c1782196d) | ![image](https://github.com/immich-app/immich/assets/139912620/3fd9cf52-a31c-46f6-b2d8-84ac5bc2b4d0)


### How is this tested
- I've verified the change across multiple simulators such as the iPad Pro, iPhone 14, iPhone SE and Pixel 6 Pro