### PR TITLE
fix(mobile): change password page not navigation properly after password change

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -193,6 +193,8 @@
   "login_form_save_login": "Stay logged in",
   "login_form_server_empty": "Enter a server URL.",
   "login_form_server_error": "Could not connect to server.",
+  "login_password_changed_success": "Password updated successfully",
+  "login_password_changed_error": "There was an error updating your password",
   "monthly_title_text_date_format": "MMMM y",
   "motion_photos_page_title": "Motion Photos",
   "notification_permission_dialog_cancel": "Cancel",

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -113,7 +113,17 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         Store.delete(StoreKey.accessToken),
       ]);
 
-      state = state.copyWith(isAuthenticated: false);
+      state = state.copyWith(
+        deviceId: "",
+        userId: "",
+        userEmail: "",
+        firstName: '',
+        lastName: '',
+        profileImagePath: '',
+        isAdmin: false,
+        shouldChangePassword: false,
+        isAuthenticated: false,
+      );
     } catch (e) {
       log.severe("Error logging out $e");
     }

--- a/mobile/lib/modules/login/ui/change_password_form.dart
+++ b/mobile/lib/modules/login/ui/change_password_form.dart
@@ -2,13 +2,14 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/backup/providers/backup.provider.dart';
 import 'package:immich_mobile/modules/backup/providers/manual_upload.provider.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
-import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/websocket.provider.dart';
+import 'package:immich_mobile/shared/ui/immich_toast.dart';
 
 class ChangePasswordForm extends HookConsumerWidget {
   const ChangePasswordForm({Key? key}) : super(key: key);
@@ -84,13 +85,34 @@ class ChangePasswordForm extends HookConsumerWidget {
                                 .read(manualUploadProvider.notifier)
                                 .cancelBackup();
                             ref.read(backupProvider.notifier).cancelBackup();
-                            ref.read(assetProvider.notifier).clearAllAsset();
+                            await ref
+                                .read(assetProvider.notifier)
+                                .clearAllAsset();
                             ref.read(websocketProvider.notifier).disconnect();
 
-                            AutoRouter.of(context).replace(const LoginRoute());
+                            AutoRouter.of(context).navigateBack();
+
+                            ImmichToast.show(
+                              context: context,
+                              msg: "login_password_changed_success".tr(),
+                              toastType: ToastType.success,
+                              gravity: ToastGravity.TOP,
+                            );
+                          } else {
+                            ImmichToast.show(
+                              context: context,
+                              msg: "login_password_changed_error".tr(),
+                              toastType: ToastType.error,
+                              gravity: ToastGravity.TOP,
+                            );
                           }
                         }
                       },
+                    ),
+                    TextButton.icon(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: () => AutoRouter.of(context).navigateBack(),
+                      label: const Text('Back'),
                     ),
                   ],
                 ),


### PR DESCRIPTION
- Fixes bug where the change password page would not navigate the user back after the password was changed
- Added translation supported notifications when the password was/wasn't successfully reset
- Added back button for user to be able to go back to the login page without changing password

How this was tested:
- Login with user with required password reset, update password, observe app properly sending user back to login page and showing success message
- Login with user with required password reset, disable internet, update password, observe app showing error message
- Login with user with required password reset, observe app showing back button and allowing user to go back

![image](https://github.com/immich-app/immich/assets/17243132/feeb069c-938e-4222-b0c0-90fc1aef667c)