### PR TITLE
fix(server): lint import order

### DIFF
--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "all",
   "printWidth": 120,
   "semi": true,
-  "organizeImportsSkipDestructiveCodeActions": true
+  "organizeImportsSkipDestructiveCodeActions": true,
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/server/src/domain/album/album-response.dto.ts
+++ b/server/src/domain/album/album-response.dto.ts
@@ -1,7 +1,7 @@
 import { AlbumEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { AssetResponseDto, mapAsset } from '../asset';
-import { mapUser, UserResponseDto } from '../user';
+import { UserResponseDto, mapUser } from '../user';
 
 export class AlbumResponseDto {
   id!: string;

--- a/server/src/domain/album/dto/album-update.dto.ts
+++ b/server/src/domain/album/dto/album-update.dto.ts
@@ -1,5 +1,5 @@
 import { IsString } from 'class-validator';
-import { ValidateUUID, Optional } from '../../domain.util';
+import { Optional, ValidateUUID } from '../../domain.util';
 
 export class UpdateAlbumDto {
   @Optional()

--- a/server/src/domain/album/dto/album.dto.ts
+++ b/server/src/domain/album/dto/album.dto.ts
@@ -1,6 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
-import { toBoolean, Optional } from '../../domain.util';
+import { Optional, toBoolean } from '../../domain.util';
 
 export class AlbumInfoDto {
   @Optional()

--- a/server/src/domain/album/dto/get-albums.dto.ts
+++ b/server/src/domain/album/dto/get-albums.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
-import { toBoolean, ValidateUUID, Optional } from '../../domain.util';
+import { Optional, ValidateUUID, toBoolean } from '../../domain.util';
 
 export class GetAlbumsDto {
   @Optional()

--- a/server/src/domain/asset/asset.service.spec.ts
+++ b/server/src/domain/asset/asset.service.spec.ts
@@ -1,9 +1,9 @@
 import { AssetType } from '@app/infra/entities';
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import {
+  IAccessRepositoryMock,
   assetStub,
   authStub,
-  IAccessRepositoryMock,
   newAccessRepositoryMock,
   newAssetRepositoryMock,
   newCryptoRepositoryMock,

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -9,7 +9,7 @@ import { ICryptoRepository } from '../crypto';
 import { mimeTypes } from '../domain.constant';
 import { HumanReadableSize, usePagination } from '../domain.util';
 import { IJobRepository, JobName } from '../job';
-import { ImmichReadStream, IStorageRepository, StorageCore, StorageFolder } from '../storage';
+import { IStorageRepository, ImmichReadStream, StorageCore, StorageFolder } from '../storage';
 import { IAssetRepository } from './asset.repository';
 import {
   AssetBulkUpdateDto,
@@ -21,17 +21,17 @@ import {
   DownloadInfoDto,
   DownloadResponseDto,
   MapMarkerDto,
-  mapStats,
   MemoryLaneDto,
   TimeBucketAssetDto,
   TimeBucketDto,
+  mapStats,
 } from './dto';
 import {
   AssetResponseDto,
-  mapAsset,
   MapMarkerResponseDto,
   MemoryLaneResponseDto,
   TimeBucketResponseDto,
+  mapAsset,
 } from './response-dto';
 
 export enum UploadFieldName {

--- a/server/src/domain/asset/dto/asset-statistics.dto.ts
+++ b/server/src/domain/asset/dto/asset-statistics.dto.ts
@@ -2,7 +2,7 @@ import { AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
-import { toBoolean, Optional } from '../../domain.util';
+import { Optional, toBoolean } from '../../domain.util';
 import { AssetStats } from '../asset.repository';
 
 export class AssetStatsDto {

--- a/server/src/domain/asset/dto/asset.dto.ts
+++ b/server/src/domain/asset/dto/asset.dto.ts
@@ -1,6 +1,6 @@
 import { IsBoolean } from 'class-validator';
-import { BulkIdsDto } from '../response-dto';
 import { Optional } from '../../domain.util';
+import { BulkIdsDto } from '../response-dto';
 
 export class AssetBulkUpdateDto extends BulkIdsDto {
   @Optional()

--- a/server/src/domain/asset/dto/map-marker.dto.ts
+++ b/server/src/domain/asset/dto/map-marker.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsBoolean, IsDate } from 'class-validator';
-import { toBoolean, Optional } from '../../domain.util';
+import { Optional, toBoolean } from '../../domain.util';
 
 export class MapMarkerDto {
   @ApiProperty()

--- a/server/src/domain/asset/dto/time-bucket.dto.ts
+++ b/server/src/domain/asset/dto/time-bucket.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
-import { toBoolean, ValidateUUID, Optional } from '../../domain.util';
+import { Optional, ValidateUUID, toBoolean } from '../../domain.util';
 import { TimeBucketSize } from '../asset.repository';
 
 export class TimeBucketDto {

--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -1,9 +1,9 @@
 import { AssetEntity, AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
-import { mapFace, PersonResponseDto } from '../../person/person.dto';
-import { mapTag, TagResponseDto } from '../../tag';
+import { PersonResponseDto, mapFace } from '../../person/person.dto';
+import { TagResponseDto, mapTag } from '../../tag';
 import { ExifResponseDto, mapExif } from './exif-response.dto';
-import { mapSmartInfo, SmartInfoResponseDto } from './smart-info-response.dto';
+import { SmartInfoResponseDto, mapSmartInfo } from './smart-info-response.dto';
 
 export class AssetResponseDto {
   id!: string;

--- a/server/src/domain/audit/audi.service.spec.ts
+++ b/server/src/domain/audit/audi.service.spec.ts
@@ -1,5 +1,5 @@
 import { DatabaseAction, EntityType } from '@app/infra/entities';
-import { auditStub, authStub, IAccessRepositoryMock, newAccessRepositoryMock, newAuditRepositoryMock } from '@test';
+import { IAccessRepositoryMock, auditStub, authStub, newAccessRepositoryMock, newAuditRepositoryMock } from '@test';
 import { IAuditRepository } from './audit.repository';
 import { AuditService } from './audit.service';
 

--- a/server/src/domain/auth/auth.service.spec.ts
+++ b/server/src/domain/auth/auth.service.spec.ts
@@ -16,7 +16,7 @@ import {
   userTokenStub,
 } from '@test';
 import { IncomingHttpHeaders } from 'http';
-import { generators, Issuer } from 'openid-client';
+import { Issuer, generators } from 'openid-client';
 import { Socket } from 'socket.io';
 import { IKeyRepository } from '../api-key';
 import { ICryptoRepository } from '../crypto/crypto.repository';

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -10,7 +10,7 @@ import {
 import cookieParser from 'cookie';
 import { IncomingHttpHeaders } from 'http';
 import { DateTime } from 'luxon';
-import { ClientMetadata, custom, generators, Issuer, UserinfoResponse } from 'openid-client';
+import { ClientMetadata, Issuer, UserinfoResponse, custom, generators } from 'openid-client';
 import { IKeyRepository } from '../api-key';
 import { ICryptoRepository } from '../crypto/crypto.repository';
 import { ISharedLinkRepository } from '../shared-link';
@@ -31,11 +31,11 @@ import {
   AuthDeviceResponseDto,
   LoginResponseDto,
   LogoutResponseDto,
+  OAuthAuthorizeResponseDto,
+  OAuthConfigResponseDto,
   mapAdminSignupResponse,
   mapLoginResponse,
   mapUserToken,
-  OAuthAuthorizeResponseDto,
-  OAuthConfigResponseDto,
 } from './response-dto';
 import { IUserTokenRepository } from './user-token.repository';
 

--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -1,6 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsNotEmpty, IsOptional, IsString, IsUUID, ValidationOptions, ValidateIf } from 'class-validator';
+import { IsArray, IsNotEmpty, IsOptional, IsString, IsUUID, ValidateIf, ValidationOptions } from 'class-validator';
 import { basename, extname } from 'node:path';
 import sanitize from 'sanitize-filename';
 

--- a/server/src/domain/facial-recognition/facial-recognition.services.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.services.ts
@@ -2,7 +2,7 @@ import { Inject, Logger } from '@nestjs/common';
 import { join } from 'path';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { usePagination } from '../domain.util';
-import { IBaseJob, IEntityJob, IFaceThumbnailJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
+import { IBaseJob, IEntityJob, IFaceThumbnailJob, IJobRepository, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 import { CropOptions, FACE_THUMBNAIL_SIZE, IMediaRepository } from '../media';
 import { IPersonRepository } from '../person/person.repository';
 import { ISearchRepository } from '../search/search.repository';

--- a/server/src/domain/job/job.dto.ts
+++ b/server/src/domain/job/job.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsNotEmpty } from 'class-validator';
-import { JobCommand, QueueName } from './job.constants';
 import { Optional } from '../domain.util';
+import { JobCommand, QueueName } from './job.constants';
 
 export class JobIdParamDto {
   @IsNotEmpty()

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Logger, UnsupportedMediaTypeException } from '@nest
 import { join } from 'path';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { usePagination } from '../domain.util';
-import { IBaseJob, IEntityJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
+import { IBaseJob, IEntityJob, IJobRepository, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 import { IStorageRepository, StorageCore, StorageFolder } from '../storage';
 import { ISystemConfigRepository, SystemConfigFFmpegDto } from '../system-config';
 import { SystemConfigCore } from '../system-config/system-config.core';

--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -1,6 +1,6 @@
 import { assetStub, newAssetRepositoryMock, newJobRepositoryMock, newStorageRepositoryMock } from '@test';
 import { constants } from 'fs/promises';
-import { IAssetRepository, WithoutProperty, WithProperty } from '../asset';
+import { IAssetRepository, WithProperty, WithoutProperty } from '../asset';
 import { IJobRepository, JobName } from '../job';
 import { IStorageRepository } from '../storage';
 import { MetadataService } from './metadata.service';

--- a/server/src/domain/partner/partner.service.ts
+++ b/server/src/domain/partner/partner.service.ts
@@ -2,7 +2,7 @@ import { PartnerEntity } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { IPartnerRepository, PartnerDirection, PartnerIds } from '.';
 import { AuthUserDto } from '../auth';
-import { mapUser, UserResponseDto } from '../user';
+import { UserResponseDto, mapUser } from '../user';
 
 @Injectable()
 export class PartnerService {

--- a/server/src/domain/person/person.dto.ts
+++ b/server/src/domain/person/person.dto.ts
@@ -2,7 +2,7 @@ import { AssetFaceEntity, PersonEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsDate, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
-import { Optional, toBoolean, ValidateUUID } from '../domain.util';
+import { Optional, ValidateUUID, toBoolean } from '../domain.util';
 
 export class PersonUpdateDto {
   /**

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -3,15 +3,15 @@ import { AssetResponseDto, BulkIdErrorReason, BulkIdResponseDto, mapAsset } from
 import { AuthUserDto } from '../auth';
 import { mimeTypes } from '../domain.constant';
 import { IJobRepository, JobName } from '../job';
-import { ImmichReadStream, IStorageRepository } from '../storage';
+import { IStorageRepository, ImmichReadStream } from '../storage';
 import {
-  mapPerson,
   MergePersonDto,
   PeopleResponseDto,
   PeopleUpdateDto,
   PersonResponseDto,
   PersonSearchDto,
   PersonUpdateDto,
+  mapPerson,
 } from './person.dto';
 import { IPersonRepository, UpdateFacesData } from './person.repository';
 

--- a/server/src/domain/search/dto/search.dto.ts
+++ b/server/src/domain/search/dto/search.dto.ts
@@ -1,7 +1,7 @@
 import { AssetType } from '@app/infra/entities';
 import { Transform } from 'class-transformer';
 import { IsArray, IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
-import { toBoolean, Optional } from '../../domain.util';
+import { Optional, toBoolean } from '../../domain.util';
 
 export class SearchDto {
   @IsString()

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -7,7 +7,7 @@ import { IAssetRepository } from '../asset/asset.repository';
 import { AuthUserDto } from '../auth';
 import { usePagination } from '../domain.util';
 import { AssetFaceId, IFaceRepository } from '../facial-recognition';
-import { IAssetFaceJob, IBulkEntityJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
+import { IAssetFaceJob, IBulkEntityJob, IJobRepository, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 import { IMachineLearningRepository } from '../smart-info';
 import { FeatureFlag, ISystemConfigRepository, SystemConfigCore } from '../system-config';
 import { SearchDto } from './dto';

--- a/server/src/domain/shared-link/shared-link.dto.ts
+++ b/server/src/domain/shared-link/shared-link.dto.ts
@@ -2,7 +2,7 @@ import { SharedLinkType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsDate, IsEnum, IsString } from 'class-validator';
-import { ValidateUUID, Optional } from '../domain.util';
+import { Optional, ValidateUUID } from '../domain.util';
 
 export class SharedLinkCreateDto {
   @IsEnum(SharedLinkType)

--- a/server/src/domain/shared-link/shared-link.service.spec.ts
+++ b/server/src/domain/shared-link/shared-link.service.spec.ts
@@ -1,9 +1,9 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import {
+  IAccessRepositoryMock,
   albumStub,
   assetStub,
   authStub,
-  IAccessRepositoryMock,
   newAccessRepositoryMock,
   newCryptoRepositoryMock,
   newSharedLinkRepositoryMock,

--- a/server/src/domain/shared-link/shared-link.service.ts
+++ b/server/src/domain/shared-link/shared-link.service.ts
@@ -4,7 +4,7 @@ import { AccessCore, IAccessRepository, Permission } from '../access';
 import { AssetIdErrorReason, AssetIdsDto, AssetIdsResponseDto } from '../asset';
 import { AuthUserDto } from '../auth';
 import { ICryptoRepository } from '../crypto';
-import { mapSharedLink, mapSharedLinkWithNoExif, SharedLinkResponseDto } from './shared-link-response.dto';
+import { SharedLinkResponseDto, mapSharedLink, mapSharedLinkWithNoExif } from './shared-link-response.dto';
 import { SharedLinkCreateDto, SharedLinkEditDto } from './shared-link.dto';
 import { ISharedLinkRepository } from './shared-link.repository';
 

--- a/server/src/domain/smart-info/dto/model-config.dto.ts
+++ b/server/src/domain/smart-info/dto/model-config.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsEnum, IsNotEmpty, IsNumber, IsString, Max, Min } from 'class-validator';
-import { CLIPMode, ModelType } from '../machine-learning.interface';
 import { Optional } from '../../domain.util';
+import { CLIPMode, ModelType } from '../machine-learning.interface';
 
 export class ModelConfig {
   @IsBoolean()

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IAssetRepository, WithoutProperty } from '../asset';
 import { usePagination } from '../domain.util';
-import { IBaseJob, IEntityJob, IJobRepository, JobName, JOBS_ASSET_PAGINATION_SIZE } from '../job';
+import { IBaseJob, IEntityJob, IJobRepository, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 import { ISystemConfigRepository, SystemConfigCore } from '../system-config';
 import { IMachineLearningRepository } from './machine-learning.interface';
 import { ISmartInfoRepository } from './smart-info.repository';

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -13,7 +13,7 @@ import {
 import { BadRequestException } from '@nestjs/common';
 import { newJobRepositoryMock, newSystemConfigRepositoryMock } from '@test';
 import { IJobRepository, JobName, QueueName } from '../job';
-import { defaults, SystemConfigValidator } from './system-config.core';
+import { SystemConfigValidator, defaults } from './system-config.core';
 import { ISystemConfigRepository } from './system-config.repository';
 import { SystemConfigService } from './system-config.service';
 

--- a/server/src/domain/system-config/system-config.service.ts
+++ b/server/src/domain/system-config/system-config.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ISystemConfigRepository } from '.';
 import { IJobRepository, JobName } from '../job';
-import { mapConfig, SystemConfigDto } from './dto/system-config.dto';
+import { SystemConfigDto, mapConfig } from './dto/system-config.dto';
 import { SystemConfigTemplateStorageOptionDto } from './response-dto/system-config-template-storage-option.dto';
 import {
   supportedDayTokens,

--- a/server/src/domain/tag/tag.service.ts
+++ b/server/src/domain/tag/tag.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { AssetIdErrorReason, AssetIdsDto, AssetIdsResponseDto, AssetResponseDto, mapAsset } from '../asset';
 import { AuthUserDto } from '../auth';
-import { mapTag, TagResponseDto } from './tag-response.dto';
+import { TagResponseDto, mapTag } from './tag-response.dto';
 import { CreateTagDto, UpdateTagDto } from './tag.dto';
 import { ITagRepository } from './tag.repository';
 

--- a/server/src/domain/user/dto/create-user.dto.ts
+++ b/server/src/domain/user/dto/create-user.dto.ts
@@ -1,6 +1,6 @@
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
-import { toEmail, toSanitized, Optional } from '../../domain.util';
+import { Optional, toEmail, toSanitized } from '../../domain.util';
 
 export class CreateUserDto {
   @IsEmail({ require_tld: false })

--- a/server/src/domain/user/dto/update-user.dto.ts
+++ b/server/src/domain/user/dto/update-user.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsEmail, IsNotEmpty, IsString, IsUUID } from 'class-validator';
-import { toEmail, toSanitized, Optional } from '../../domain.util';
+import { Optional, toEmail, toSanitized } from '../../domain.util';
 
 export class UpdateUserDto {
   @Optional()

--- a/server/src/domain/user/dto/user-count.dto.ts
+++ b/server/src/domain/user/dto/user-count.dto.ts
@@ -1,6 +1,6 @@
-import { Optional } from '../../domain.util';
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
+import { Optional } from '../../domain.util';
 
 export class UserCountDto {
   @IsBoolean()

--- a/server/src/domain/user/user.core.ts
+++ b/server/src/domain/user/user.core.ts
@@ -6,7 +6,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { constants, createReadStream, ReadStream } from 'fs';
+import { ReadStream, constants, createReadStream } from 'fs';
 import fs from 'fs/promises';
 import sanitize from 'sanitize-filename';
 import { AuthUserDto } from '../auth';

--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -12,11 +12,11 @@ import { IStorageRepository } from '../storage/storage.repository';
 import { CreateUserDto, UpdateUserDto, UserCountDto } from './dto';
 import {
   CreateProfileImageResponseDto,
+  UserCountResponseDto,
+  UserResponseDto,
   mapCreateProfileImageResponse,
   mapUser,
   mapUserCountResponse,
-  UserCountResponseDto,
-  UserResponseDto,
 } from './response-dto';
 import { UserCore } from './user.core';
 import { IUserRepository } from './user.repository';

--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -18,8 +18,8 @@ import {
 } from '@nestjs/common';
 import { ApiBody, ApiConsumes, ApiHeader, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Response as Res } from 'express';
-import { Authenticated, AuthUser, SharedLinkRoute } from '../../app.guard';
-import { FileUploadInterceptor, ImmichFile, mapToUploadFile, Route } from '../../app.interceptor';
+import { AuthUser, Authenticated, SharedLinkRoute } from '../../app.guard';
+import { FileUploadInterceptor, ImmichFile, Route, mapToUploadFile } from '../../app.interceptor';
 import { UUIDParamDto } from '../../controllers/dto/uuid-param.dto';
 import FileNotEmptyValidator from '../validation/file-not-empty-validator';
 import { AssetService } from './asset.service';

--- a/server/src/immich/api-v1/asset/asset.service.spec.ts
+++ b/server/src/immich/api-v1/asset/asset.service.spec.ts
@@ -2,10 +2,10 @@ import { ICryptoRepository, IJobRepository, IStorageRepository, JobName } from '
 import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
 import {
+  IAccessRepositoryMock,
   assetStub,
   authStub,
   fileStub,
-  IAccessRepositoryMock,
   newAccessRepositoryMock,
   newCryptoRepositoryMock,
   newJobRepositoryMock,

--- a/server/src/immich/app.guard.ts
+++ b/server/src/immich/app.guard.ts
@@ -1,12 +1,12 @@
 import { AuthService, AuthUserDto, IMMICH_API_KEY_NAME, LoginDetails } from '@app/domain';
 import {
-  applyDecorators,
   CanActivate,
-  createParamDecorator,
   ExecutionContext,
   Injectable,
   Logger,
   SetMetadata,
+  applyDecorators,
+  createParamDecorator,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ApiBearerAuth, ApiCookieAuth, ApiQuery, ApiSecurity } from '@nestjs/swagger';

--- a/server/src/immich/app.interceptor.ts
+++ b/server/src/immich/app.interceptor.ts
@@ -5,7 +5,7 @@ import { Reflector } from '@nestjs/core';
 import { transformException } from '@nestjs/platform-express/multer/multer/multer.utils';
 import { createHash } from 'crypto';
 import { NextFunction, RequestHandler } from 'express';
-import multer, { diskStorage, StorageEngine } from 'multer';
+import multer, { StorageEngine, diskStorage } from 'multer';
 import { Observable } from 'rxjs';
 import { AuthRequest } from './app.guard';
 

--- a/server/src/immich/app.module.ts
+++ b/server/src/immich/app.module.ts
@@ -12,8 +12,8 @@ import { AppGuard } from './app.guard';
 import { FileUploadInterceptor } from './app.interceptor';
 import { AppService } from './app.service';
 import {
-  AlbumController,
   APIKeyController,
+  AlbumController,
   AppController,
   AssetController,
   AuditController,

--- a/server/src/immich/app.utils.ts
+++ b/server/src/immich/app.utils.ts
@@ -1,8 +1,8 @@
 import {
-  ImmichReadStream,
   IMMICH_ACCESS_COOKIE,
   IMMICH_API_KEY_HEADER,
   IMMICH_API_KEY_NAME,
+  ImmichReadStream,
   SERVER_VERSION,
 } from '@app/domain';
 import { INestApplication, StreamableFile } from '@nestjs/common';

--- a/server/src/immich/controllers/album.controller.ts
+++ b/server/src/immich/controllers/album.controller.ts
@@ -14,7 +14,7 @@ import {
 import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ParseMeUUIDPipe } from '../api-v1/validation/parse-me-uuid-pipe';
-import { Authenticated, AuthUser, SharedLinkRoute } from '../app.guard';
+import { AuthUser, Authenticated, SharedLinkRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/api-key.controller.ts
+++ b/server/src/immich/controllers/api-key.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@app/domain';
 import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/asset.controller.ts
+++ b/server/src/immich/controllers/asset.controller.ts
@@ -19,8 +19,8 @@ import {
 } from '@app/domain';
 import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Put, Query, StreamableFile } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser, SharedLinkRoute } from '../app.guard';
-import { asStreamableFile, UseValidation } from '../app.utils';
+import { AuthUser, Authenticated, SharedLinkRoute } from '../app.guard';
+import { UseValidation, asStreamableFile } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 
 @ApiTags('Asset')

--- a/server/src/immich/controllers/audit.controller.ts
+++ b/server/src/immich/controllers/audit.controller.ts
@@ -1,7 +1,7 @@
 import { AuditDeletesDto, AuditDeletesResponseDto, AuditService, AuthUserDto } from '@app/domain';
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 
 @ApiTags('Audit')

--- a/server/src/immich/controllers/auth.controller.ts
+++ b/server/src/immich/controllers/auth.controller.ts
@@ -17,7 +17,7 @@ import {
 import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, Res } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
-import { Authenticated, AuthUser, GetLoginDetails, PublicRoute } from '../app.guard';
+import { AuthUser, Authenticated, GetLoginDetails, PublicRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/oauth.controller.ts
+++ b/server/src/immich/controllers/oauth.controller.ts
@@ -12,7 +12,7 @@ import {
 import { Body, Controller, Get, HttpStatus, Post, Redirect, Req, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
-import { Authenticated, AuthUser, GetLoginDetails, PublicRoute } from '../app.guard';
+import { AuthUser, Authenticated, GetLoginDetails, PublicRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 
 @ApiTags('OAuth')

--- a/server/src/immich/controllers/partner.controller.ts
+++ b/server/src/immich/controllers/partner.controller.ts
@@ -1,7 +1,7 @@
 import { AuthUserDto, PartnerDirection, PartnerService, UserResponseDto } from '@app/domain';
 import { Controller, Delete, Get, Param, Post, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/person.controller.ts
+++ b/server/src/immich/controllers/person.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@app/domain';
 import { Body, Controller, Get, Param, Post, Put, Query, StreamableFile } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/search.controller.ts
+++ b/server/src/immich/controllers/search.controller.ts
@@ -1,7 +1,7 @@
 import { AuthUserDto, SearchDto, SearchExploreResponseDto, SearchResponseDto, SearchService } from '@app/domain';
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 
 @ApiTags('Search')

--- a/server/src/immich/controllers/shared-link.controller.ts
+++ b/server/src/immich/controllers/shared-link.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@app/domain';
 import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser, SharedLinkRoute } from '../app.guard';
+import { AuthUser, Authenticated, SharedLinkRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/tag.controller.ts
+++ b/server/src/immich/controllers/tag.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@app/domain';
 import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Authenticated, AuthUser } from '../app.guard';
+import { AuthUser, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';
 

--- a/server/src/immich/controllers/user.controller.ts
+++ b/server/src/immich/controllers/user.controller.ts
@@ -1,10 +1,10 @@
 import {
   AuthUserDto,
+  UserCountDto as CountDto,
+  CreateUserDto as CreateDto,
   CreateProfileImageDto,
   CreateProfileImageResponseDto,
-  CreateUserDto as CreateDto,
   UpdateUserDto as UpdateDto,
-  UserCountDto as CountDto,
   UserCountResponseDto,
   UserResponseDto,
   UserService,
@@ -26,7 +26,7 @@ import {
 } from '@nestjs/common';
 import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { Response as Res } from 'express';
-import { AdminRoute, Authenticated, AuthUser, PublicRoute } from '../app.guard';
+import { AdminRoute, AuthUser, Authenticated, PublicRoute } from '../app.guard';
 import { FileUploadInterceptor, Route } from '../app.interceptor';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/test/e2e/auth.e2e-spec.ts
+++ b/server/test/e2e/auth.e2e-spec.ts
@@ -3,13 +3,13 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 import {
+  adminSignupStub,
   changePasswordStub,
   deviceStub,
   errorStub,
   loginResponseStub,
   loginStub,
   signupResponseStub,
-  adminSignupStub,
   uuidStub,
 } from '../fixtures';
 import { api, db } from '../test-utils';

--- a/server/test/test-utils.ts
+++ b/server/test/test-utils.ts
@@ -14,7 +14,7 @@ import {
 } from '@app/domain';
 import { dataSource } from '@app/infra';
 import request from 'supertest';
-import { loginResponseStub, loginStub, signupResponseStub, adminSignupStub } from './fixtures';
+import { adminSignupStub, loginResponseStub, loginStub, signupResponseStub } from './fixtures';
 
 export const db = {
   reset: async () => {


### PR DESCRIPTION
When we migrated to prettier 3 we lost auto-loaded plugins, which removed this functionality.

https://github.com/simonhaenisch/prettier-plugin-organize-imports#prettier-3