### PR TITLE
fix(server): await thumbnail generation before returning

### DIFF
--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -200,12 +200,6 @@ describe(MediaService.name, () => {
       expect(assetMock.save).not.toHaveBeenCalledWith();
     });
 
-    it('should skip thumbnail generate if resize path is missing', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.noResizePath]);
-      await sut.handleGenerateWebpThumbnail({ id: assetStub.noResizePath.id });
-      expect(mediaMock.resize).not.toHaveBeenCalled();
-    });
-
     it('should generate a thumbnail', async () => {
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
       await sut.handleGenerateWebpThumbnail({ id: assetStub.image.id });

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -109,7 +109,7 @@ export class MediaService {
 
   async handleGenerateWebpThumbnail({ id }: IEntityJob) {
     const [asset] = await this.assetRepository.getByIds([id]);
-    if (!asset || !asset.resizePath) {
+    if (!asset) {
       return false;
     }
 

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -15,6 +15,7 @@ export class MediaRepository implements IMediaRepository {
 
   crop(input: string | Buffer, options: CropOptions): Promise<Buffer> {
     return sharp(input, { failOn: 'none' })
+      .pipelineColorspace('rgb16')
       .extract({
         left: options.left,
         top: options.top,
@@ -38,7 +39,7 @@ export class MediaRepository implements IMediaRepository {
       }
     }
     const chromaSubsampling = options.quality >= 80 ? '4:4:4' : '4:2:0'; // this is default in libvips (except the threshold is 90), but we need to set it manually in sharp
-    sharp(input, { failOn: 'none' })
+    await sharp(input, { failOn: 'none' })
       .pipelineColorspace('rgb16')
       .resize(options.size, options.size, { fit: 'outside', withoutEnlargement: true })
       .rotate()


### PR DESCRIPTION
## Description

This is a fix to ensure that the `resize` method finishes generating the thumbnail before returning. The current behavior returns before sharp finishes the thumbnail, which means there's a race condition where downstream jobs that expect the JPEG to be completed may or may not fail.

## How Has This Been Tested?

With this change, I don't see any `ENOENT` errors and uploaded images have JPEG and WebP thumbnails as well as thumbhashes working as expected.