### PR TITLE
feat(server): consider shared albums in getByAssetId

### DIFF
--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -50,7 +50,10 @@ export class AlbumRepository implements IAlbumRepository {
 
   getByAssetId(ownerId: string, assetId: string): Promise<AlbumEntity[]> {
     return this.repository.find({
-      where: { ownerId, assets: { id: assetId } },
+      where: [
+        { ownerId, assets: { id: assetId } },
+        { sharedUsers: { id: ownerId }, assets: { id: assetId } },
+      ],
       relations: { owner: true, sharedUsers: true },
       order: { createdAt: 'DESC' },
     });


### PR DESCRIPTION
This commit changes the `album.getByAssetId` API to also consider albums that have been shared with the current user. This way when the user is browing their timeline and clicks to show the asset details they will see if the asset appears in not only their own albums but also albums shared with them.