### PR TITLE
fix(ml): model downloading improvements

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -57,7 +57,7 @@ class InferenceModel(ABC):
 
         try:
             loader(**model_kwargs)
-        except (BadZipFile, OSError, InvalidProtobuf, NoSuchFile):
+        except (OSError, InvalidProtobuf, BadZipFile, NoSuchFile):
             log.warn(
                 (
                     f"Failed to load {self.model_type.replace('_', ' ')} model '{self.model_name}'."

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -8,7 +8,7 @@ from typing import Any
 from zipfile import BadZipFile
 
 import onnxruntime as ort
-from onnxruntime.capi.onnxruntime_pybind11_state import InvalidProtobuf  # type: ignore
+from onnxruntime.capi.onnxruntime_pybind11_state import InvalidProtobuf, NoSuchFile  # type: ignore
 
 from ..config import get_cache_dir, log, settings
 from ..schemas import ModelType
@@ -57,7 +57,7 @@ class InferenceModel(ABC):
 
         try:
             loader(**model_kwargs)
-        except (OSError, InvalidProtobuf, BadZipFile):
+        except (BadZipFile, OSError, InvalidProtobuf, NoSuchFile):
             log.warn(
                 (
                     f"Failed to load {self.model_type.replace('_', ' ')} model '{self.model_name}'."

--- a/machine-learning/app/models/clip.py
+++ b/machine-learning/app/models/clip.py
@@ -131,6 +131,10 @@ class CLIPEncoder(InferenceModel):
             os.remove(file)
         return True
 
+    @property
+    def cached(self) -> bool:
+        return (self.cache_dir / "textual.onnx").is_file() and (self.cache_dir / "visual.onnx").is_file()
+
 
 # same as `_transform_blob` without `_blob2image`
 def _transform_pil_image(n_px: int) -> Compose:


### PR DESCRIPTION
## Description

ONNX Runtime can throw a custom `NoSuchFile` exception that isn't caught like other IO exceptions, resulting in the model cache not being cleared when it should be. 

Additionally, the check for whether CLIP models are downloaded only checks that the folder exists and isn't empty, so it doesn't catch cases where there's a missing file. This isn't as critical since it clears the cache and redownloads on error, but it's better if the missing file can be downloaded without deleting other files.
