### PR TITLE
fix(server): update asset with tagged people

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -149,7 +149,9 @@ export class AssetRepository implements IAssetRepository {
         owner: true,
         smartInfo: true,
         tags: true,
-        faces: true,
+        faces: {
+          person: true,
+        },
       },
     });
   }


### PR DESCRIPTION
Updating an asset was failing because the returned entity had faces, but no people. This led to a `TypeError` in the mapper. This has been resolved by loading the people relation and verified in the web. I also reproduced this with a new e2e test, which now passes as well.