### PR TITLE
chore: skip mobile app build for dependabot

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -19,7 +19,7 @@ jobs:
   build-sign-android:
     name: Build and sign Android
     # Skip when PR from a fork
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     runs-on: macos-12
 
     steps:


### PR DESCRIPTION
Skip building and signing the mobile app in dependabot PRs.