### PR TITLE
fix(mobile): Truncate log messages on the logs list page

### DIFF
--- a/mobile/lib/shared/views/app_log_page.dart
+++ b/mobile/lib/shared/views/app_log_page.dart
@@ -148,7 +148,7 @@ class AppLogPage extends HookConsumerWidget {
                     ),
                   ),
                   TextSpan(
-                    text: logMessage.message,
+                    text: truncateLogMessage(logMessage.message, 4),
                     style: const TextStyle(
                       fontSize: 14.0,
                     ),
@@ -169,5 +169,15 @@ class AppLogPage extends HookConsumerWidget {
         },
       ),
     );
+  }
+  
+  /// Truncate the log message to a certain number of lines
+  /// @param int maxLines - Max number of lines to truncate
+  String truncateLogMessage(String message, int maxLines) {
+    List<String> messageLines = message.split("\n");
+    if (messageLines.length < maxLines) {
+      return message;
+    }
+    return "${messageLines.sublist(0, maxLines).join("\n")} ...";
   }
 }


### PR DESCRIPTION
In the log list page some logs take up too much vertical space (like multiple dozens of pages).. Truncate the number of lines..

After:
![image](https://github.com/immich-app/immich/assets/17243132/c993aa25-3bfe-4eff-ad54-3e21c607a635)

Before:
![image](https://github.com/immich-app/immich/assets/17243132/0483112b-4881-43cb-af44-9180e6fa3ba1)
