### PR TITLE
fix(ml): set higher default worker timeout

### DIFF
--- a/machine-learning/start.sh
+++ b/machine-learning/start.sh
@@ -5,9 +5,11 @@ export LD_PRELOAD="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 : "${MACHINE_LEARNING_HOST:=0.0.0.0}"
 : "${MACHINE_LEARNING_PORT:=3003}"
 : "${MACHINE_LEARNING_WORKERS:=1}"
+: "${MACHINE_LEARNING_WORKER_TIMEOUT:=120}"
 
 gunicorn app.main:app \
 	-k uvicorn.workers.UvicornWorker \
 	-w $MACHINE_LEARNING_WORKERS \
 	-b $MACHINE_LEARNING_HOST:$MACHINE_LEARNING_PORT \
+	-t $MACHINE_LEARNING_WORKER_TIMEOUT \
 	--log-config-json log_conf.json


### PR DESCRIPTION
## Description

Gunicorn allows 30s for workers to start up by default, killing them and trying again if they exceed this time. It's possible for very slow CPUs to take longer than this to boot up, leading to many repeated attempts to start a worker until one happens to start quickly enough. This PR increases the timeout duration to 120s, which should be enough time for slower CPUs.

Fixes #4002

## Testing

I'm unable to reproduce this error, but the ML service boots up as normal with this change.