### PR TITLE
feat(web): only log http errors in web container

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -22,7 +22,7 @@ export const handle = (async ({ event, resolve }) => {
       if (apiError.response?.status && apiError.response?.status !== 401) {
         console.error('[ERROR] hooks.server.ts [handle]:', err);
       } else if (!apiError.response?.status) {
-        console.error('[ERROR] hooks.server.ts [handle]:', err.message);
+        console.error('[ERROR] hooks.server.ts [handle]:', apiError.message);
       }
     }
   }

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -3,6 +3,8 @@ import type { Handle, HandleServerError } from '@sveltejs/kit';
 import type { AxiosError, AxiosResponse } from 'axios';
 import { ImmichApi } from './api/api';
 
+const LOG_PREFIX = '[hooks.server.ts]';
+
 export const handle = (async ({ event, resolve }) => {
   const basePath = env.PUBLIC_IMMICH_SERVER_URL || 'http://immich-server:3001';
   const accessToken = event.cookies.get('immich_access_token');
@@ -16,13 +18,14 @@ export const handle = (async ({ event, resolve }) => {
       const { data: user } = await api.userApi.getMyUserInfo();
       event.locals.user = user;
     } catch (err) {
-      const apiError = err as AxiosError;
+      console.log(`${LOG_PREFIX} Unable to get my user`, parseError(err));
 
+      const apiError = err as AxiosError;
       // Ignore 401 unauthorized errors and log all others.
       if (apiError.response?.status && apiError.response?.status !== 401) {
-        console.error('[ERROR] hooks.server.ts [handle]:', err);
+        console.error(`${LOG_PREFIX}:handle`, err);
       } else if (!apiError.response?.status) {
-        console.error('[ERROR] hooks.server.ts [handle]:', err.message);
+        console.error(`${LOG_PREFIX}:handle`, (err as Error)?.message);
       }
     }
   }
@@ -38,8 +41,9 @@ export const handle = (async ({ event, resolve }) => {
 
 const DEFAULT_MESSAGE = 'Hmm, not sure about that. Check the logs or open a ticket?';
 
-export const handleError: HandleServerError = async ({ error }) => {
+const parseError = (error: unknown) => {
   const httpError = error as AxiosError;
+  const request = httpError?.request as Request & { path: string };
   const response = httpError?.response as AxiosResponse<{
     message: string;
     statusCode: number;
@@ -51,9 +55,23 @@ export const handleError: HandleServerError = async ({ error }) => {
     code += ` - ${response.data?.error || response.statusText}`;
   }
 
+  if (request && response) {
+    console.log({
+      status: response.status,
+      url: `${request.method} ${request.path}`,
+      response: response.data || 'No data',
+    });
+  }
+
   return {
     message: response?.data?.message || httpError?.message || DEFAULT_MESSAGE,
     code,
     stack: httpError?.stack,
   };
+};
+
+export const handleError: HandleServerError = ({ error }) => {
+  const result = parseError(error);
+  console.error(`${LOG_PREFIX}:handleError ${result.message}`);
+  return result;
 };

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -19,8 +19,10 @@ export const handle = (async ({ event, resolve }) => {
       const apiError = err as AxiosError;
 
       // Ignore 401 unauthorized errors and log all others.
-      if (apiError.response?.status !== 401) {
+      if (apiError.response?.status && apiError.response?.status !== 401) {
         console.error('[ERROR] hooks.server.ts [handle]:', err);
+      } else if (!apiError.response?.status) {
+        console.error('[ERROR] hooks.server.ts [handle]:', err.message);
       }
     }
   }


### PR DESCRIPTION
This PR changes the error handling log in the web container. Currently, we print the whole axos error object to console which is huge. If there's an error with the immich server and I click refresh on the page the web container prints hundreds of lines, drowing out the actual error message.

In this PR, we only print the full error message for HTTP errors (excluding 401). All other errors, like connection refused, only prints the error _message_ which is one line. For example, if the server has an issue and can't start, the web container will print this line upon page refresh:

`immich-web_1               | [ERROR] hooks.server.ts [handle]: connect ECONNREFUSED 172.31.0.6:3001
` 

This has been tested with the case that the server can't start. Other HTTP errors have been hard to simulate, but the change is so minor it shouldn't be an issue.