### PR TITLE
fix(server): handle failed ML responses

### DIFF
--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -19,7 +19,11 @@ export class MachineLearningRepository implements IMachineLearningRepository {
     const formData = await this.getFormData(input, config);
     const res = await fetch(`${url}/predict`, { method: 'POST', body: formData });
     if (res.status >= 400) {
-      throw new Error(`Request ${config.modelType ? `for ${config.modelType.replace('-', ' ')} ` : ''}failed with status ${res.status}: ${res.statusText}`);
+      throw new Error(
+        `Request ${config.modelType ? `for ${config.modelType.replace('-', ' ')} ` : ''}failed with status ${
+          res.status
+        }: ${res.statusText}`,
+      );
     }
     return res.json();
   }

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -18,6 +18,9 @@ export class MachineLearningRepository implements IMachineLearningRepository {
   private async post<T>(url: string, input: TextModelInput | VisionModelInput, config: ModelConfig): Promise<T> {
     const formData = await this.getFormData(input, config);
     const res = await fetch(`${url}/predict`, { method: 'POST', body: formData });
+    if (res.status >= 400) {
+      throw new Error(`Request failed with status ${res.status}: ${res.statusText}`);
+    }
     return res.json();
   }
 

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -20,9 +20,8 @@ export class MachineLearningRepository implements IMachineLearningRepository {
     const res = await fetch(`${url}/predict`, { method: 'POST', body: formData });
     if (res.status >= 400) {
       throw new Error(
-        `Request ${config.modelType ? `for ${config.modelType.replace('-', ' ')} ` : ''}failed with status ${
-          res.status
-        }: ${res.statusText}`,
+        `Request ${config.modelType ? `for ${config.modelType.replace('-', ' ')} ` : ''}` +
+          `failed with status ${res.status}: ${res.statusText}`,
       );
     }
     return res.json();

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -19,7 +19,7 @@ export class MachineLearningRepository implements IMachineLearningRepository {
     const formData = await this.getFormData(input, config);
     const res = await fetch(`${url}/predict`, { method: 'POST', body: formData });
     if (res.status >= 400) {
-      throw new Error(`Request failed with status ${res.status}: ${res.statusText}`);
+      throw new Error(`Request ${config.modelType ? `for ${config.modelType.replace('-', ' ')} ` : ''}failed with status ${res.status}: ${res.statusText}`);
     }
     return res.json();
   }


### PR DESCRIPTION
## Description

Currently, the ML repository does not handle failed requests well as it calls `.json()` on the response even when there's an error and no JSON to parse. This results in useless errors from not being able to parse the response as JSON. This PR checks the status code and throws a formatted error instead.

## How Has This Been Tested?

I tested it by setting the classification model name to an invalid model.

Before: 

```
ERROR [JobService] SyntaxError: Unexpected token I in JSON at position 0
immich_microservices | at JSON.parse ()
immich_microservices | at parseJSONFromBytes (node:internal/deps/undici/undici:6662:19)
immich_microservices | at successSteps (node:internal/deps/undici/undici:6636:27)
immich_microservices | at node:internal/deps/undici/undici:1236:60
immich_microservices | at node:internal/process/task_queues:140:7
immich_microservices | at AsyncResource.runInAsyncScope (node:async_hooks:203:9)
immich_microservices | at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
immich_microservices | at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

After: 

```
ERROR [JobService] Error: Request for image classification failed with status 500: Internal Server Error
immich_microservices | at MachineLearningRepository.post (/usr/src/app/dist/infra/repositories/machine-learning.repository.js:29:19)
immich_microservices | at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
immich_microservices | at async SmartInfoService.handleClassifyImage (/usr/src/app/dist/domain/smart-info/smart-info.service.js:77:22)
immich_microservices | at async /usr/src/app/dist/domain/job/job.service.js:105:37
immich_microservices | at async Worker.processJob (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:346:28)
immich_microservices | at async Worker.retryIfFailed (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:531:24)
```