### PR TITLE
fix(web): album selection modal overflow and alignment

### DIFF
--- a/web/src/lib/components/asset-viewer/album-list-item.svelte
+++ b/web/src/lib/components/asset-viewer/album-list-item.svelte
@@ -25,21 +25,23 @@
 
 <button
   on:click={() => dispatcher('album')}
-  class="flex w-full gap-4 px-6 py-2 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+  class="flex w-full gap-4 px-6 py-2 text-left transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
 >
-  <div class="h-12 w-12 rounded-xl bg-slate-300">
+  <div class="h-12 w-12 shrink-0 rounded-xl bg-slate-300">
     {#if album.albumThumbnailAssetId}
       <img
         src={api.getAssetThumbnailUrl(album.albumThumbnailAssetId, ThumbnailFormat.Webp)}
         alt={album.albumName}
-        class={`z-0 h-full w-full rounded-xl object-cover transition-all duration-300 hover:shadow-lg`}
+        class="z-0 h-full w-full rounded-xl object-cover transition-all duration-300 hover:shadow-lg"
         data-testid="album-image"
         draggable="false"
       />
     {/if}
   </div>
-  <div class="flex h-12 flex-col items-start justify-center">
-    <span>{albumNameArray[0]}<b>{albumNameArray[1]}</b>{albumNameArray[2]}</span>
+  <div class="flex h-12 flex-col items-start justify-center overflow-hidden">
+    <span class="w-full shrink overflow-hidden text-ellipsis whitespace-nowrap"
+      >{albumNameArray[0]}<b>{albumNameArray[1]}</b>{albumNameArray[2]}</span
+    >
     <span class="flex gap-1 text-sm">
       {#if variant === 'simple'}
         <span


### PR DESCRIPTION
Fixes #4058.

- Image is always square
- Title overflows with ellipsis.
- Button text is left-aligned

![image](https://github.com/immich-app/immich/assets/4334196/712dae84-e624-4e79-b05c-06078b1f8fa5)
