### PR TITLE
fix(web): Timeline scrollbar shown over menu

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/context-menu.svelte
@@ -23,7 +23,7 @@
 <div
   transition:slide={{ duration: 200, easing: quintOut }}
   bind:this={menuElement}
-  class="absolute z-[99999] w-[200px] overflow-hidden rounded-lg shadow-lg"
+  class="absolute w-[200px] overflow-hidden rounded-lg shadow-lg"
   style="left: {left}px; top: {top}px;"
   role="menu"
   use:clickOutside

--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -59,7 +59,7 @@
 {#if $assetStore.timelineHeight > height}
   <div
     id="immich-scrubbable-scrollbar"
-    class="fixed right-0 z-[100] select-none bg-immich-bg hover:cursor-row-resize"
+    class="fixed right-0 z-[1] select-none bg-immich-bg hover:cursor-row-resize"
     style:width={isDragging ? '100vw' : '60px'}
     style:height={height + 'px'}
     style:background-color={isDragging ? 'transparent' : 'transparent'}


### PR DESCRIPTION
This PR fixes #3735.

### Before
<img width="217" alt="Screenshot 2023-09-12 at 16 26 08" src="https://github.com/immich-app/immich/assets/36593685/7515b098-cf09-4683-9051-5e65d6d23ca3">

### After
Mouse on the button
<img width="208" alt="Screenshot 2023-09-12 at 16 27 30" src="https://github.com/immich-app/immich/assets/36593685/f24353f9-71d2-4d91-9622-54e047eb1df7">

Mose below the button, timeline text not overflowing
<img width="206" alt="Screenshot 2023-09-12 at 16 27 38" src="https://github.com/immich-app/immich/assets/36593685/3ff68e22-2b7f-40f7-8897-d4b7289466f2">
