### PR TITLE
feat(mobile): image caching & viewer improvements

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/modules/backup/models/backup_album.model.dart';
 import 'package:immich_mobile/modules/backup/models/duplicated_asset.model.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/routing/tab_navigation_observer.dart';
+import 'package:immich_mobile/shared/cache/widgets_binding.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/android_device_asset.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
@@ -37,7 +38,7 @@ import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
+  ImmichWidgetsBinding();
 
   final db = await loadDb();
   await initApp();

--- a/mobile/lib/shared/cache/custom_image_cache.dart
+++ b/mobile/lib/shared/cache/custom_image_cache.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/painting.dart';
+
+import 'original_image_provider.dart';
+
+/// [ImageCache] that uses two caches for small and large images
+/// so that a single large image does not evict all small iamges
+final class CustomImageCache implements ImageCache {
+  final _small = ImageCache();
+  final _large = ImageCache();
+
+  @override
+  int get maximumSize => _small.maximumSize + _large.maximumSize;
+
+  @override
+  int get maximumSizeBytes => _small.maximumSizeBytes + _large.maximumSizeBytes;
+
+  @override
+  set maximumSize(int value) => _small.maximumSize = value;
+
+  @override
+  set maximumSizeBytes(int value) => _small.maximumSize = value;
+
+  @override
+  void clear() {
+    _small.clear();
+    _large.clear();
+  }
+
+  @override
+  void clearLiveImages() {
+    _small.clearLiveImages();
+    _large.clearLiveImages();
+  }
+
+  @override
+  bool containsKey(Object key) =>
+      (key is OriginalImageProvider ? _large : _small).containsKey(key);
+
+  @override
+  int get currentSize => _small.currentSize + _large.currentSize;
+
+  @override
+  int get currentSizeBytes => _small.currentSizeBytes + _large.currentSizeBytes;
+
+  @override
+  bool evict(Object key, {bool includeLive = true}) =>
+      (key is OriginalImageProvider ? _large : _small)
+          .evict(key, includeLive: includeLive);
+
+  @override
+  int get liveImageCount => _small.liveImageCount + _large.liveImageCount;
+
+  @override
+  int get pendingImageCount =>
+      _small.pendingImageCount + _large.pendingImageCount;
+
+  @override
+  ImageStreamCompleter? putIfAbsent(
+    Object key,
+    ImageStreamCompleter Function() loader, {
+    ImageErrorListener? onError,
+  }) =>
+      (key is OriginalImageProvider ? _large : _small)
+          .putIfAbsent(key, loader, onError: onError);
+
+  @override
+  ImageCacheStatus statusForKey(Object key) =>
+      (key is OriginalImageProvider ? _large : _small).statusForKey(key);
+}

--- a/mobile/lib/shared/cache/original_image_provider.dart
+++ b/mobile/lib/shared/cache/original_image_provider.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:immich_mobile/shared/models/asset.dart';
+
+/// Loads the original image for local assets
+@immutable
+final class OriginalImageProvider extends ImageProvider<OriginalImageProvider> {
+  final Asset asset;
+
+  const OriginalImageProvider(this.asset);
+
+  @override
+  Future<OriginalImageProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<OriginalImageProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    OriginalImageProvider key,
+    ImageDecoderCallback decode,
+  ) =>
+      MultiFrameImageStreamCompleter(
+        codec: _loadAsync(key, decode),
+        scale: 1.0,
+        informationCollector: () sync* {
+          yield ErrorDescription(asset.fileName);
+        },
+      );
+
+  Future<ui.Codec> _loadAsync(
+    OriginalImageProvider key,
+    ImageDecoderCallback decode,
+  ) async {
+    final ui.ImmutableBuffer buffer;
+    if (asset.isImage) {
+      final File? file = await asset.local?.originFile;
+      if (file == null) {
+        throw StateError("Opening file for asset ${asset.fileName} failed");
+      }
+      try {
+        buffer = await ui.ImmutableBuffer.fromFilePath(file.path);
+      } catch (error) {
+        throw StateError("Loading asset ${asset.fileName} failed");
+      }
+    } else {
+      final thumbBytes = await asset.local?.thumbnailData;
+      if (thumbBytes == null) {
+        throw StateError("Loading thumb for video ${asset.fileName} failed");
+      }
+      buffer = await ui.ImmutableBuffer.fromUint8List(thumbBytes);
+    }
+    try {
+      final codec = await decode(buffer);
+      debugPrint("Decoded image ${asset.fileName}");
+      return codec;
+    } catch (error) {
+      throw StateError("Decoding asset ${asset.fileName} failed");
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! OriginalImageProvider) return false;
+    if (identical(this, other)) return true;
+    return asset == other.asset;
+  }
+
+  @override
+  int get hashCode => asset.hashCode;
+}

--- a/mobile/lib/shared/cache/widgets_binding.dart
+++ b/mobile/lib/shared/cache/widgets_binding.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/widgets.dart';
+
+import 'custom_image_cache.dart';
+
+final class ImmichWidgetsBinding extends WidgetsFlutterBinding {
+  @override
+  ImageCache createImageCache() => CustomImageCache();
+}

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -178,6 +178,7 @@ class Asset {
   @override
   bool operator ==(other) {
     if (other is! Asset) return false;
+    if (identical(this, other)) return true;
     return id == other.id &&
         checksum == other.checksum &&
         remoteId == other.remoteId &&

--- a/mobile/lib/shared/ui/photo_view/photo_view.dart
+++ b/mobile/lib/shared/ui/photo_view/photo_view.dart
@@ -235,6 +235,7 @@ class PhotoView extends StatefulWidget {
   const PhotoView({
     Key? key,
     required this.imageProvider,
+    required this.index,
     this.loadingBuilder,
     this.backgroundDecoration,
     this.wantKeepAlive = false,
@@ -304,6 +305,7 @@ class PhotoView extends StatefulWidget {
         imageProvider = null,
         gaplessPlayback = false,
         loadingBuilder = null,
+        index = 0,
         super(key: key);
 
   /// Given a [imageProvider] it resolves into an zoomable image widget using. It
@@ -418,6 +420,8 @@ class PhotoView extends StatefulWidget {
   /// Enable pan the widget even if it's smaller than the hole parent widget.
   /// Useful when you want to drag a widget without restrictions.
   final bool? enablePanAlways;
+
+  final int index;
 
   bool get _isCustomChild {
     return child != null;
@@ -571,6 +575,7 @@ class _PhotoViewState extends State<PhotoView>
                 disableGestures: widget.disableGestures,
                 errorBuilder: widget.errorBuilder,
                 enablePanAlways: widget.enablePanAlways,
+                index: widget.index,
               );
       },
     );
@@ -625,7 +630,7 @@ typedef PhotoViewImageDragStartCallback = Function(
   PhotoViewControllerValue controllerValue,
 );
 
-/// A type definition for a callback when the user drags 
+/// A type definition for a callback when the user drags
 typedef PhotoViewImageDragUpdateCallback = Function(
   BuildContext context,
   DragUpdateDetails details,
@@ -650,4 +655,5 @@ typedef PhotoViewImageScaleEndCallback = Function(
 typedef LoadingBuilder = Widget Function(
   BuildContext context,
   ImageChunkEvent? event,
+  int index,
 );

--- a/mobile/lib/shared/ui/photo_view/photo_view_gallery.dart
+++ b/mobile/lib/shared/ui/photo_view/photo_view_gallery.dart
@@ -281,6 +281,7 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
           )
         : PhotoView(
             key: ObjectKey(index),
+            index: index,
             imageProvider: pageOption.imageProvider,
             loadingBuilder: widget.loadingBuilder,
             backgroundDecoration: widget.backgroundDecoration,
@@ -315,7 +316,10 @@ class _PhotoViewGalleryState extends State<PhotoViewGallery> {
     );
   }
 
-  PhotoViewGalleryPageOptions _buildPageOption(BuildContext context, int index) {
+  PhotoViewGalleryPageOptions _buildPageOption(
+    BuildContext context,
+    int index,
+  ) {
     if (widget._isBuilder) {
       return widget.builder!(context, index);
     }

--- a/mobile/lib/shared/ui/photo_view/src/photo_view_wrappers.dart
+++ b/mobile/lib/shared/ui/photo_view/src/photo_view_wrappers.dart
@@ -35,6 +35,7 @@ class ImageWrapper extends StatefulWidget {
     required this.disableGestures,
     required this.errorBuilder,
     required this.enablePanAlways,
+    required this.index,
   }) : super(key: key);
 
   final ImageProvider imageProvider;
@@ -64,6 +65,7 @@ class ImageWrapper extends StatefulWidget {
   final FilterQuality? filterQuality;
   final bool? disableGestures;
   final bool? enablePanAlways;
+  final int index;
 
   @override
   createState() => _ImageWrapperState();
@@ -128,6 +130,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
         _lastException = null;
         _lastStack = null;
       }
+
       synchronousCall ? setupCB() : setState(setupCB);
     }
 
@@ -212,7 +215,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
 
   Widget _buildLoading(BuildContext context) {
     if (widget.loadingBuilder != null) {
-      return widget.loadingBuilder!(context, _loadingProgress);
+      return widget.loadingBuilder!(context, _loadingProgress, widget.index);
     }
 
     return PhotoViewDefaultLoading(


### PR DESCRIPTION
# huge UX improvement for viewing images in the app

- smooth swiping between assets in the viewer
- no reloading of thumbnails after returning from viewer
- faster loading of original assets from device

## how

- loadingBuilder in photo view was showing the wrong preview because index was updated only afterwards.
- improved the photo view gallery to include the index in the loadingBuilder callback
- loading original assets from device removed many thumbnails from the cache because originals are huge
- build a custom ImageCache that distinguishes between original images from local device and all other images. it uses two different caches internally (one for large originals, one for all others)
- implemented a custom ImageProvider for faster loading of originals from the device

## required testing

There are some scenarios I cannot test. Somebody else please test 

- iOS
- viewing heic/heif images from device
- viewing LivePhotos from device