### PR TITLE
feat(web): hide face from detail page

### DIFF
--- a/web/src/routes/(user)/people/[personId]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/+page.svelte
@@ -76,6 +76,24 @@
     }
   });
 
+  const hideFace = async () => {
+    try {
+      await api.personApi.updatePerson({
+        id: data.person.id,
+        personUpdateDto: { isHidden: true },
+      });
+
+      notificationController.show({
+        message: 'Changed visibility succesfully',
+        type: NotificationType.Info,
+      });
+
+      goto(AppRoute.EXPLORE, { replaceState: true });
+    } catch (error) {
+      handleError(error, 'Unable to hide person');
+    }
+  };
+
   const handleSelectFeaturePhoto = async (asset: AssetResponseDto) => {
     if (viewMode !== ViewMode.SELECT_FACE) {
       return;
@@ -246,6 +264,7 @@
             <MenuOption text="Change feature photo" on:click={() => (viewMode = ViewMode.SELECT_FACE)} />
             <MenuOption text="Set date of birth" on:click={() => (viewMode = ViewMode.BIRTH_DATE)} />
             <MenuOption text="Merge face" on:click={() => (viewMode = ViewMode.MERGE_FACES)} />
+            <MenuOption text="Hide face" on:click={() => hideFace()} />
           </AssetSelectContextMenu>
         </svelte:fragment>
       </ControlAppBar>


### PR DESCRIPTION
## Changes made in this PR

This PR adds the ability to hide a face from the detail page. Once the face is hidden, the user is redirected to the Explore page.

Closes #4099

## Screenshots

![Screenshot from 2023-09-14 16-42-38](https://github.com/immich-app/immich/assets/74269598/2fad5393-654a-4cca-b312-835e56c5274f)



