### PR TITLE
fix(server): use libopus for transcoding

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -752,7 +752,7 @@ export type AssetTypeEnum = typeof AssetTypeEnum[keyof typeof AssetTypeEnum];
 export const AudioCodec = {
     Mp3: 'mp3',
     Aac: 'aac',
-    Opus: 'opus'
+    Libopus: 'libopus'
 } as const;
 
 export type AudioCodec = typeof AudioCodec[keyof typeof AudioCodec];

--- a/mobile/openapi/lib/model/audio_codec.dart
+++ b/mobile/openapi/lib/model/audio_codec.dart
@@ -25,13 +25,13 @@ class AudioCodec {
 
   static const mp3 = AudioCodec._(r'mp3');
   static const aac = AudioCodec._(r'aac');
-  static const opus = AudioCodec._(r'opus');
+  static const libopus = AudioCodec._(r'libopus');
 
   /// List of all possible values in this [enum][AudioCodec].
   static const values = <AudioCodec>[
     mp3,
     aac,
-    opus,
+    libopus,
   ];
 
   static AudioCodec? fromJson(dynamic value) => AudioCodecTypeTransformer().decode(value);
@@ -72,7 +72,7 @@ class AudioCodecTypeTransformer {
       switch (data) {
         case r'mp3': return AudioCodec.mp3;
         case r'aac': return AudioCodec.aac;
-        case r'opus': return AudioCodec.opus;
+        case r'libopus': return AudioCodec.libopus;
         default:
           if (!allowNull) {
             throw ArgumentError('Unknown enum value to decode: $data');

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -5318,7 +5318,7 @@
         "enum": [
           "mp3",
           "aac",
-          "opus"
+          "libopus"
         ],
         "type": "string"
       },

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -99,7 +99,7 @@ export enum VideoCodec {
 export enum AudioCodec {
   MP3 = 'mp3',
   AAC = 'aac',
-  OPUS = 'libopus',
+  LIBOPUS = 'libopus',
 }
 
 export enum TranscodeHWAccel {

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -99,7 +99,7 @@ export enum VideoCodec {
 export enum AudioCodec {
   MP3 = 'mp3',
   AAC = 'aac',
-  OPUS = 'opus',
+  OPUS = 'libopus',
 }
 
 export enum TranscodeHWAccel {

--- a/server/src/infra/migrations/1694758412194-UpdateOpusCodecToLibopus.ts
+++ b/server/src/infra/migrations/1694758412194-UpdateOpusCodecToLibopus.ts
@@ -1,27 +1,21 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class UpdateOpusCodecToLibopus1694758412194 implements MigrationInterface {
-    name = 'UpdateOpusCodecToLibopus1694758412194'
+  name = 'UpdateOpusCodecToLibopus1694758412194'
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
                 UPDATE system_config
-                SET
-                  key = 'ffmpeg.targetAudioCodec',
-                  value = '"libopus"'
-                WHERE
-                  key = 'ffmpeg.targetAudioCodec' AND value = '"opus"'
+                SET value = '"libopus"'
+                WHERE key = 'ffmpeg.targetAudioCodec' AND value = '"opus"'
             `);
-    }
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
                 UPDATE system_config
-                SET
-                  key = 'ffmpeg.targetAudioCodec',
-                  value = '"opus"'
-                WHERE
-                  key = 'ffmpeg.targetAudioCodec' AND value = '"libopus"'
+                SET value = '"opus"'
+                WHERE key = 'ffmpeg.targetAudioCodec' AND value = '"libopus"'
             `);
-    }
+  }
 }

--- a/server/src/infra/migrations/1694758412194-UpdateOpusCodecToLibopus.ts
+++ b/server/src/infra/migrations/1694758412194-UpdateOpusCodecToLibopus.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateOpusCodecToLibopus1694758412194 implements MigrationInterface {
+    name = 'UpdateOpusCodecToLibopus1694758412194'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+                UPDATE system_config
+                SET
+                  key = 'ffmpeg.targetAudioCodec',
+                  value = '"libopus"'
+                WHERE
+                  key = 'ffmpeg.targetAudioCodec' AND value = '"opus"'
+            `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+                UPDATE system_config
+                SET
+                  key = 'ffmpeg.targetAudioCodec',
+                  value = '"opus"'
+                WHERE
+                  key = 'ffmpeg.targetAudioCodec' AND value = '"libopus"'
+            `);
+    }
+}

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -752,7 +752,7 @@ export type AssetTypeEnum = typeof AssetTypeEnum[keyof typeof AssetTypeEnum];
 export const AudioCodec = {
     Mp3: 'mp3',
     Aac: 'aac',
-    Opus: 'opus'
+    Libopus: 'libopus'
 } as const;
 
 export type AudioCodec = typeof AudioCodec[keyof typeof AudioCodec];

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -92,7 +92,7 @@
     <div in:fade={{ duration: 500 }}>
       <form autocomplete="off" on:submit|preventDefault>
         <div class="ml-4 mt-4 flex flex-col gap-4">
-          <p class="text-sm dark:text-immich-dark-fg">
+          <p class="dark:text-immich-dark-fg text-sm">
             <HelpCircleOutline class="inline" size="15" />
             To learn more about the terminology used here, refer to FFmpeg documentation for
             <a href="https://trac.ffmpeg.org/wiki/Encode/H.264" class="underline" target="_blank" rel="noreferrer"
@@ -145,7 +145,7 @@
             options={[
               { value: AudioCodec.Aac, text: 'aac' },
               { value: AudioCodec.Mp3, text: 'mp3' },
-              { value: AudioCodec.Opus, text: 'opus' },
+              { value: AudioCodec.Libopus, text: 'opus' },
             ]}
             name="acodec"
             isEdited={ffmpegConfig.targetAudioCodec !== savedConfig.targetAudioCodec}

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -92,7 +92,7 @@
     <div in:fade={{ duration: 500 }}>
       <form autocomplete="off" on:submit|preventDefault>
         <div class="ml-4 mt-4 flex flex-col gap-4">
-          <p class="dark:text-immich-dark-fg text-sm">
+          <p class="text-sm dark:text-immich-dark-fg">
             <HelpCircleOutline class="inline" size="15" />
             To learn more about the terminology used here, refer to FFmpeg documentation for
             <a href="https://trac.ffmpeg.org/wiki/Encode/H.264" class="underline" target="_blank" rel="noreferrer"


### PR DESCRIPTION
## Description

The current transcoding command when using opus uses FFmpeg's native Opus codec. This is an experimental codec that generally has lower quality than libopus. Since it fixes #4100, this is an additional reason to make the switch.

## How Has This Been Tested?

Tested by first setting the audio codec to opus using the main branch, then switching to this branch. The migration works as expected and applies the new value. Running a transcoding job confirmed that it uses libopus without errors.