### PR TITLE
feat: make settings accordion click area larger

### DIFF
--- a/web/src/lib/components/admin-page/settings/setting-accordion.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-accordion.svelte
@@ -7,8 +7,12 @@
   const toggle = () => (isOpen = !isOpen);
 </script>
 
-<div class="border-b-[1px] border-gray-200 py-4 dark:border-gray-700">
-  <div class="flex place-items-center justify-between">
+<div
+  class="border-b-[1px] border-gray-200 py-4 dark:border-gray-700"
+>
+  <button
+    on:click={toggle}
+    class="flex place-items-center justify-between cursor-pointer text-left">
     <div>
       <h2 class="font-medium text-immich-primary dark:text-immich-dark-primary">
         {title}
@@ -18,7 +22,6 @@
     </div>
 
     <button
-      on:click={toggle}
       aria-expanded={isOpen}
       class="immich-circle-icon-button flex place-content-center place-items-center rounded-full p-3 transition-all hover:bg-immich-primary/10 dark:text-immich-dark-fg hover:dark:bg-immich-dark-primary/20"
     >
@@ -36,7 +39,7 @@
         <path d="M19 9l-7 7-7-7" />
       </svg>
     </button>
-  </div>
+  </button>
 
   {#if isOpen}
     <ul transition:slide={{ duration: 250 }} class="mb-2 ml-4">

--- a/web/src/lib/components/admin-page/settings/setting-accordion.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-accordion.svelte
@@ -7,12 +7,8 @@
   const toggle = () => (isOpen = !isOpen);
 </script>
 
-<div
-  class="border-b-[1px] border-gray-200 py-4 dark:border-gray-700"
->
-  <button
-    on:click={toggle}
-    class="flex place-items-center justify-between cursor-pointer text-left">
+<div class="border-b-[1px] border-gray-200 py-4 dark:border-gray-700">
+  <button on:click={toggle} class="flex cursor-pointer place-items-center justify-between text-left">
     <div>
       <h2 class="font-medium text-immich-primary dark:text-immich-dark-primary">
         {title}


### PR DESCRIPTION
# Description

Changes the setting-accordion Svelte component to make the click area larger.

Currently the only clickable area to open the accordion is the arrow to the right side.

This PR extends that area to contain the title, description and the space between the text and the arrow.

## Why

I believe this makes clicking the items easier, which helps accessibility on large high res displays and on mobile in my opinion.

## Other info

- This is my first open source PR ever, i hope i'm doing things right
- I've had issues running the dev version locally (couldn't get past the admin registration), so i was not able to test directly on the Settings pages. I built this by creating a SettingAccordion in the registration page.