### PR TITLE
fix(web): Assigns description text area with asset description if it exists #4073

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -25,6 +25,10 @@
   $: isOwner = $page?.data?.user?.id === asset.ownerId;
 
   $: {
+    if (textarea) {
+      textarea.value = asset?.exifInfo?.description || '';
+    }
+
     // Get latest description from server
     if (asset.id && !api.isSharedLink) {
       api.assetApi.getAssetById({ id: asset.id }).then((res) => {


### PR DESCRIPTION
## Description
  - Attempts to use the current `asset`'s exifInfo.description in the textArea (When it exists)

Fixes #4073


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Upload image -> Add description -> Add to shared album -> Open image as photo owner -> Open shared link as photo owner -> open shared link in incognito tab(anon user) -> Verify photo description is visible across all viewing methods

## Screenshots (if appropriate):
Left: As Photo Middle: As photo owner through shared link Right: As anon user in incognito
![Screenshot from 2023-09-17 11-55-40](https://github.com/immich-app/immich/assets/3691245/e117b687-9174-4fce-8b3b-da1c30277de2)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable