### PR TITLE
fix(web): Context menu underflowing

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/context-menu.svelte
@@ -23,7 +23,7 @@
 <div
   transition:slide={{ duration: 200, easing: quintOut }}
   bind:this={menuElement}
-  class="absolute w-[200px] overflow-hidden rounded-lg shadow-lg"
+  class="absolute z-10 w-[200px] overflow-hidden rounded-lg shadow-lg"
   style="left: {left}px; top: {top}px;"
   role="menu"
   use:clickOutside


### PR DESCRIPTION
Fixes an issue that has been introduced in #4071 as described by https://github.com/immich-app/immich/pull/4071#issuecomment-1722430395.

I've verified that the fix in #4071 still applies.