### PR TITLE
feat: add setting for minimum face count for face detection

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -2157,6 +2157,12 @@ export interface RecognitionConfig {
      * @type {number}
      * @memberof RecognitionConfig
      */
+    'minFaces': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RecognitionConfig
+     */
     'minScore': number;
     /**
      * 

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -70,7 +70,8 @@ The default configuration looks like this:
       "enabled": true,
       "modelName": "buffalo_l",
       "minScore": 0.7,
-      "maxDistance": 0.6
+      "maxDistance": 0.6,
+      "minFaces": 1,
     }
   },
   "oauth": {

--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -71,7 +71,7 @@ The default configuration looks like this:
       "modelName": "buffalo_l",
       "minScore": 0.7,
       "maxDistance": 0.6,
-      "minFaces": 1,
+      "minFaces": 1
     }
   },
   "oauth": {

--- a/mobile/openapi/doc/RecognitionConfig.md
+++ b/mobile/openapi/doc/RecognitionConfig.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enabled** | **bool** |  | 
 **maxDistance** | **int** |  | 
+**minFaces** | **int** |  | 
 **minScore** | **int** |  | 
 **modelName** | **String** |  | 
 **modelType** | [**ModelType**](ModelType.md) |  | [optional] 

--- a/mobile/openapi/lib/model/recognition_config.dart
+++ b/mobile/openapi/lib/model/recognition_config.dart
@@ -15,6 +15,7 @@ class RecognitionConfig {
   RecognitionConfig({
     required this.enabled,
     required this.maxDistance,
+    required this.minFaces,
     required this.minScore,
     required this.modelName,
     this.modelType,
@@ -23,6 +24,8 @@ class RecognitionConfig {
   bool enabled;
 
   int maxDistance;
+
+  int minFaces;
 
   int minScore;
 
@@ -40,6 +43,7 @@ class RecognitionConfig {
   bool operator ==(Object other) => identical(this, other) || other is RecognitionConfig &&
      other.enabled == enabled &&
      other.maxDistance == maxDistance &&
+     other.minFaces == minFaces &&
      other.minScore == minScore &&
      other.modelName == modelName &&
      other.modelType == modelType;
@@ -49,17 +53,19 @@ class RecognitionConfig {
     // ignore: unnecessary_parenthesis
     (enabled.hashCode) +
     (maxDistance.hashCode) +
+    (minFaces.hashCode) +
     (minScore.hashCode) +
     (modelName.hashCode) +
     (modelType == null ? 0 : modelType!.hashCode);
 
   @override
-  String toString() => 'RecognitionConfig[enabled=$enabled, maxDistance=$maxDistance, minScore=$minScore, modelName=$modelName, modelType=$modelType]';
+  String toString() => 'RecognitionConfig[enabled=$enabled, maxDistance=$maxDistance, minFaces=$minFaces, minScore=$minScore, modelName=$modelName, modelType=$modelType]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'enabled'] = this.enabled;
       json[r'maxDistance'] = this.maxDistance;
+      json[r'minFaces'] = this.minFaces;
       json[r'minScore'] = this.minScore;
       json[r'modelName'] = this.modelName;
     if (this.modelType != null) {
@@ -80,6 +86,7 @@ class RecognitionConfig {
       return RecognitionConfig(
         enabled: mapValueOfType<bool>(json, r'enabled')!,
         maxDistance: mapValueOfType<int>(json, r'maxDistance')!,
+        minFaces: mapValueOfType<int>(json, r'minFaces')!,
         minScore: mapValueOfType<int>(json, r'minScore')!,
         modelName: mapValueOfType<String>(json, r'modelName')!,
         modelType: ModelType.fromJson(json[r'modelType']),
@@ -132,6 +139,7 @@ class RecognitionConfig {
   static const requiredKeys = <String>{
     'enabled',
     'maxDistance',
+    'minFaces',
     'minScore',
     'modelName',
   };

--- a/mobile/openapi/test/recognition_config_test.dart
+++ b/mobile/openapi/test/recognition_config_test.dart
@@ -26,6 +26,11 @@ void main() {
       // TODO
     });
 
+    // int minFaces
+    test('to test the property `minFaces`', () async {
+      // TODO
+    });
+
     // int minScore
     test('to test the property `minScore`', () async {
       // TODO

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -6471,6 +6471,9 @@
           "maxDistance": {
             "type": "integer"
           },
+          "minFaces": {
+            "type": "integer"
+          },
           "minScore": {
             "type": "integer"
           },
@@ -6484,6 +6487,7 @@
         "required": [
           "minScore",
           "maxDistance",
+          "minFaces",
           "enabled",
           "modelName"
         ],

--- a/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
+++ b/server/src/domain/facial-recognition/facial-recognition.service.spec.ts
@@ -205,6 +205,7 @@ describe(FacialRecognitionService.name, () => {
           enabled: true,
           maxDistance: 0.6,
           minScore: 0.7,
+          minFaces: 1,
           modelName: 'buffalo_l',
         },
       );

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -6,11 +6,13 @@ import {
   newJobRepositoryMock,
   newPersonRepositoryMock,
   newStorageRepositoryMock,
+  newSystemConfigRepositoryMock,
   personStub,
 } from '@test';
 import { BulkIdErrorReason } from '../asset';
 import { IJobRepository, JobName } from '../job';
 import { IStorageRepository } from '../storage';
+import { ISystemConfigRepository } from '../system-config';
 import { PersonResponseDto } from './person.dto';
 import { IPersonRepository } from './person.repository';
 import { PersonService } from './person.service';
@@ -26,14 +28,16 @@ const responseDto: PersonResponseDto = {
 describe(PersonService.name, () => {
   let sut: PersonService;
   let personMock: jest.Mocked<IPersonRepository>;
+  let configMock: jest.Mocked<ISystemConfigRepository>;
   let storageMock: jest.Mocked<IStorageRepository>;
   let jobMock: jest.Mocked<IJobRepository>;
 
   beforeEach(async () => {
     personMock = newPersonRepositoryMock();
     storageMock = newStorageRepositoryMock();
+    configMock = newSystemConfigRepositoryMock();
     jobMock = newJobRepositoryMock();
-    sut = new PersonService(personMock, storageMock, jobMock);
+    sut = new PersonService(personMock, configMock, storageMock, jobMock);
   });
 
   it('should be defined', () => {

--- a/server/src/domain/smart-info/dto/model-config.dto.ts
+++ b/server/src/domain/smart-info/dto/model-config.dto.ts
@@ -51,7 +51,6 @@ export class RecognitionConfig extends ModelConfig {
 
   @IsNumber()
   @Min(1)
-  @Max(5)
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   minFaces!: number;

--- a/server/src/domain/smart-info/dto/model-config.dto.ts
+++ b/server/src/domain/smart-info/dto/model-config.dto.ts
@@ -48,4 +48,11 @@ export class RecognitionConfig extends ModelConfig {
   @Type(() => Number)
   @ApiProperty({ type: 'integer' })
   maxDistance!: number;
+
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  @Type(() => Number)
+  @ApiProperty({ type: 'integer' })
+  minFaces!: number;
 }

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -72,6 +72,7 @@ export const defaults = Object.freeze<SystemConfig>({
       modelName: 'buffalo_l',
       minScore: 0.7,
       maxDistance: 0.6,
+      minFaces: 1,
     },
   },
   map: {

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -71,6 +71,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
       modelName: 'buffalo_l',
       minScore: 0.7,
       maxDistance: 0.6,
+      minFaces: 1,
     },
   },
   map: {

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -57,6 +57,7 @@ export enum SystemConfigKey {
   MACHINE_LEARNING_FACIAL_RECOGNITION_MODEL_NAME = 'machineLearning.facialRecognition.modelName',
   MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_SCORE = 'machineLearning.facialRecognition.minScore',
   MACHINE_LEARNING_FACIAL_RECOGNITION_MAX_DISTANCE = 'machineLearning.facialRecognition.maxDistance',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_FACES = 'machineLearning.facialRecognition.minFaces',
 
   MAP_ENABLED = 'map.enabled',
   MAP_TILE_URL = 'map.tileUrl',
@@ -164,6 +165,7 @@ export interface SystemConfig {
       enabled: boolean;
       modelName: string;
       minScore: number;
+      minFaces: number;
       maxDistance: number;
     };
   };

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -2157,6 +2157,12 @@ export interface RecognitionConfig {
      * @type {number}
      * @memberof RecognitionConfig
      */
+    'minFaces': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RecognitionConfig
+     */
     'minScore': number;
     /**
      * 

--- a/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
@@ -196,6 +196,18 @@
               isEdited={machineLearningConfig.facialRecognition.maxDistance !==
                 savedConfig.facialRecognition.maxDistance}
             />
+
+            <SettingInputField
+              inputType={SettingInputFieldType.NUMBER}
+              label="MIN FACES DETECTED"
+              desc="The minimum number of faces of a person that must be detected for them to appear in the People tab. Setting this to a value greater than 1 can prevent strangers or blurry faces that are not the main subject of the image from being displayed."
+              bind:value={machineLearningConfig.facialRecognition.minFaces}
+              step="1"
+              min="1"
+              max="5"
+              disabled={disabled || !machineLearningConfig.enabled || !machineLearningConfig.facialRecognition.enabled}
+              isEdited={machineLearningConfig.facialRecognition.minFaces !== savedConfig.facialRecognition.minFaces}
+            />
           </div>
         </SettingAccordion>
 

--- a/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
@@ -204,7 +204,6 @@
               bind:value={machineLearningConfig.facialRecognition.minFaces}
               step="1"
               min="1"
-              max="5"
               disabled={disabled || !machineLearningConfig.enabled || !machineLearningConfig.facialRecognition.enabled}
               isEdited={machineLearningConfig.facialRecognition.minFaces !== savedConfig.facialRecognition.minFaces}
             />


### PR DESCRIPTION
Adds the minimum face count setting to the web interface to circumvent detection of strangers and random background people if desired by the user. Originally discussed in the PR for face recognition (https://github.com/immich-app/immich/pull/2180#discussion_r1196146598). The default behavior is unchanged (i.e. every match is shown).

I tested it manually by adding multiple pictures of a person and changing the setting around, which worked flawlessly.

![image](https://github.com/immich-app/immich/assets/26469094/7b55839b-fe52-43b2-9628-ee5bb91e3045)
