### PR TITLE
fix(web): revert assigns description text area with asset description if it exists

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -25,10 +25,6 @@
   $: isOwner = $page?.data?.user?.id === asset.ownerId;
 
   $: {
-    if (textarea) {
-      textarea.value = asset?.exifInfo?.description || '';
-    }
-
     // Get latest description from server
     if (asset.id && !api.isSharedLink) {
       api.assetApi.getAssetById({ id: asset.id }).then((res) => {


### PR DESCRIPTION
This PR reverts #4125.

When an asset is accessed, the browser creates an infinite loop of requests which can crash the browser.