### PR TITLE
fix(server): use mtime instead of ctime for fileCreatedAt

### DIFF
--- a/cli/src/cores/models/crawled-asset.ts
+++ b/cli/src/cores/models/crawled-asset.ts
@@ -25,7 +25,7 @@ export class CrawledAsset {
   async process() {
     const stats = await fs.promises.stat(this.path);
     this.deviceAssetId = `${basename(this.path)}-${stats.size}`.replace(/\s+/g, '');
-    this.fileCreatedAt = stats.ctime.toISOString();
+    this.fileCreatedAt = stats.mtime.toISOString();
     this.fileModifiedAt = stats.mtime.toISOString();
     this.fileSize = stats.size;
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -249,7 +249,7 @@ export class LibraryService {
         originalPath: assetPath,
         deviceAssetId: deviceAssetId,
         deviceId: 'Library Import',
-        fileCreatedAt: stats.ctime,
+        fileCreatedAt: stats.mtime,
         fileModifiedAt: stats.mtime,
         type: assetType,
         originalFileName: parse(assetPath).name,
@@ -261,7 +261,7 @@ export class LibraryService {
     } else if (doRefresh && existingAssetEntity) {
       assetId = existingAssetEntity.id;
       await this.assetRepository.updateAll([existingAssetEntity.id], {
-        fileCreatedAt: stats.ctime,
+        fileCreatedAt: stats.mtime,
         fileModifiedAt: stats.mtime,
       });
     } else {


### PR DESCRIPTION
ctime means "change time" and it reflects metadata change in the file system.

There is in theory a `birthtime` that could be used, however:

* it's not supported by every file system
* it can't be changed easily (e.g. using `touch`)
* when you copy a file to a remote server (i.e. your Immich server), the creation time will reflect the time of the copy operation, not the time of the original file