### PR TITLE
fix(server): Random assets endpoint return always n assets if available

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -435,7 +435,7 @@ export class AssetRepository implements IAssetRepository {
       `SELECT *
        FROM assets
        WHERE "ownerId" = $1
-       OFFSET FLOOR(RANDOM() * (SELECT GREATEST(COUNT(*) - 1, 0) FROM ASSETS)) LIMIT $2`,
+       OFFSET FLOOR(RANDOM() * (SELECT GREATEST(COUNT(*) - $2, 0) FROM ASSETS)) LIMIT $2`,
       [ownerId, count],
     );
   }


### PR DESCRIPTION
Before, the query could have started choosing assets at an index > `total - n`, so that it couldn't return all n assets, although there are n assets available in the library