### PR TITLE
Add filesize to backup asset info and improve allignment.

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -74,6 +74,7 @@
   "backup_controller_page_failed": "Failed ({})",
   "backup_controller_page_filename": "File name: {} [{}]",
   "backup_controller_page_id": "ID: {}",
+  "backup_controller_page_filesize": "Size: {}",
   "backup_controller_page_info": "Backup Information",
   "backup_controller_page_none_selected": "None selected",
   "backup_controller_page_remainder": "Remainder",

--- a/mobile/lib/modules/backup/models/current_upload_asset.model.dart
+++ b/mobile/lib/modules/backup/models/current_upload_asset.model.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 class CurrentUploadAsset {
   final String id;
   final DateTime fileCreatedAt;
+  final int fileSize;
   final String fileName;
   final String fileType;
 
@@ -11,6 +12,7 @@ class CurrentUploadAsset {
     required this.fileCreatedAt,
     required this.fileName,
     required this.fileType,
+    required this.fileSize,
   });
 
   CurrentUploadAsset copyWith({
@@ -18,12 +20,14 @@ class CurrentUploadAsset {
     DateTime? fileCreatedAt,
     String? fileName,
     String? fileType,
+    int? fileSize,
   }) {
     return CurrentUploadAsset(
       id: id ?? this.id,
       fileCreatedAt: fileCreatedAt ?? this.fileCreatedAt,
       fileName: fileName ?? this.fileName,
       fileType: fileType ?? this.fileType,
+      fileSize: fileSize ?? this.fileSize,
     );
   }
 
@@ -34,6 +38,7 @@ class CurrentUploadAsset {
     result.addAll({'fileCreatedAt': fileCreatedAt.millisecondsSinceEpoch});
     result.addAll({'fileName': fileName});
     result.addAll({'fileType': fileType});
+    result.addAll({'fileSize': fileSize});
 
     return result;
   }
@@ -44,6 +49,7 @@ class CurrentUploadAsset {
       fileCreatedAt: DateTime.fromMillisecondsSinceEpoch(map['fileCreatedAt']),
       fileName: map['fileName'] ?? '',
       fileType: map['fileType'] ?? '',
+      fileSize: map['fileSize'] ?? '',
     );
   }
 
@@ -54,7 +60,7 @@ class CurrentUploadAsset {
 
   @override
   String toString() {
-    return 'CurrentUploadAsset(id: $id, fileCreatedAt: $fileCreatedAt, fileName: $fileName, fileType: $fileType)';
+    return 'CurrentUploadAsset(id: $id, fileCreatedAt: $fileCreatedAt, fileName: $fileName, fileType: $fileType, fileSize: $fileSize)';
   }
 
   @override
@@ -65,7 +71,8 @@ class CurrentUploadAsset {
         other.id == id &&
         other.fileCreatedAt == fileCreatedAt &&
         other.fileName == fileName &&
-        other.fileType == fileType;
+        other.fileType == fileType &&
+        other.fileSize == fileSize;
   }
 
   @override
@@ -73,6 +80,7 @@ class CurrentUploadAsset {
     return id.hashCode ^
         fileCreatedAt.hashCode ^
         fileName.hashCode ^
-        fileType.hashCode;
+        fileType.hashCode ^
+        fileSize.hashCode;
   }
 }

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -64,6 +64,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
               fileCreatedAt: DateTime.parse('2020-10-04'),
               fileName: '...',
               fileType: '...',
+              fileSize: 0,
             ),
           ),
         );

--- a/mobile/lib/modules/backup/providers/manual_upload.provider.dart
+++ b/mobile/lib/modules/backup/providers/manual_upload.provider.dart
@@ -32,6 +32,14 @@ final manualUploadProvider =
   );
 });
 
+final CurrentUploadAsset defaultCurrentUploadAsset = CurrentUploadAsset(
+              id: '...',
+              fileCreatedAt: DateTime.parse('2020-10-04'),
+              fileName: '...',
+              fileType: '...',
+              fileSize: 0,
+            );
+
 class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
   final Logger _log = Logger("ManualUploadNotifier");
   final LocalNotificationService _localNotificationService;
@@ -46,12 +54,7 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
           ManualUploadState(
             progressInPercentage: 0,
             cancelToken: CancellationToken(),
-            currentUploadAsset: CurrentUploadAsset(
-              id: '...',
-              fileCreatedAt: DateTime.parse('2020-10-04'),
-              fileName: '...',
-              fileType: '...',
-            ),
+            currentUploadAsset: defaultCurrentUploadAsset,
             totalAssetsToUpload: 0,
             successfulUploads: 0,
             currentAssetIndex: 0,
@@ -185,12 +188,7 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
           totalAssetsToUpload: allUploadAssets.length,
           successfulUploads: 0,
           currentAssetIndex: 0,
-          currentUploadAsset: CurrentUploadAsset(
-            id: '...',
-            fileCreatedAt: DateTime.parse('2020-10-04'),
-            fileName: '...',
-            fileType: '...',
-          ),
+          currentUploadAsset: defaultCurrentUploadAsset,
           cancelToken: CancellationToken(),
         );
         // Reset Error List

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -229,10 +229,12 @@ class BackupService {
         if (file != null) {
           String originalFileName = await entity.titleAsync;
           var fileStream = file.openRead();
+          var fileSize = file.lengthSync();
+
           var assetRawUploadData = http.MultipartFile(
             "assetData",
             fileStream,
-            file.lengthSync(),
+            fileSize,
             filename: originalFileName,
           );
 
@@ -271,6 +273,7 @@ class BackupService {
                   : entity.createDateTime,
               fileName: originalFileName,
               fileType: _getAssetType(entity.type),
+              fileSize: fileSize,
             ),
           );
 

--- a/mobile/lib/modules/backup/ui/current_backup_asset_info_box.dart
+++ b/mobile/lib/modules/backup/ui/current_backup_asset_info_box.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
@@ -10,6 +12,7 @@ import 'package:immich_mobile/modules/backup/providers/error_backup_list.provide
 import 'package:immich_mobile/modules/backup/providers/manual_upload.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:immich_mobile/utils/bytes_units.dart';
 
 class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
   const CurrentUploadingAssetInfoBox({super.key});
@@ -67,7 +70,6 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
         children: [
           TableRow(
             decoration: const BoxDecoration(
-                // color: Colors.grey[100],
                 ),
             children: [
               TableCell(
@@ -89,7 +91,24 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
           ),
           TableRow(
             decoration: const BoxDecoration(
-                // color: Colors.grey[200],
+                ),
+            children: [
+              TableCell(
+                child: Padding(
+                  padding: const EdgeInsets.all(6.0),
+                  child: const Text(
+                    "backup_controller_page_filesize",
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 10.0,
+                    ),
+                  ).tr(args: [formatBytes(asset.fileSize)]),
+                ),
+              ),
+            ],
+          ),
+          TableRow(
+            decoration: const BoxDecoration(
                 ),
             children: [
               TableCell(
@@ -111,7 +130,6 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
           ),
           TableRow(
             decoration: const BoxDecoration(
-                // color: Colors.grey[100],
                 ),
             children: [
               TableCell(
@@ -177,7 +195,6 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
             child: Icon(
               Icons.image_outlined,
               color: Theme.of(context).primaryColor,
-              size: 30,
             ),
           ),
           crossFadeState: isShowThumbnail.value
@@ -211,7 +228,12 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
                   ),
                   Text(
                     " ${uploadProgress.toStringAsFixed(0)}%",
-                    style: const TextStyle(fontSize: 12),
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontFeatures: [
+                        FontFeature.tabularFigures()
+                      ],
+                      ),
                   ),
                 ],
               ),

--- a/mobile/lib/modules/backup/ui/current_backup_asset_info_box.dart
+++ b/mobile/lib/modules/backup/ui/current_backup_asset_info_box.dart
@@ -231,7 +231,7 @@ class CurrentUploadingAssetInfoBox extends HookConsumerWidget {
                     style: const TextStyle(
                       fontSize: 12,
                       fontFeatures: [
-                        FontFeature.tabularFigures()
+                        FontFeature.tabularFigures(),
                       ],
                       ),
                   ),

--- a/mobile/lib/modules/backup/views/backup_controller_page.dart
+++ b/mobile/lib/modules/backup/views/backup_controller_page.dart
@@ -774,7 +774,9 @@ class BackupControllerPage extends HookConsumerWidget {
             const Divider(),
             buildStorageInformation(),
             const Divider(),
-            const CurrentUploadingAssetInfoBox(),
+            if (backupState.backupProgress == BackUpProgressEnum.inProgress ||
+                  backupState.backupProgress ==
+                      BackUpProgressEnum.manualInProgress) const CurrentUploadingAssetInfoBox(),
             if (!hasExclusiveAccess) buildBackgroundBackupInfo(),
             buildBackupButton(),
           ],


### PR DESCRIPTION
A few improvements related to the current backup asset info box in the mobile app

1. Only show this tile when an backup is running
2. Align the icon of this tile to the other items in the list
3. Add the file size to the backup asset info
4. I also changed the upload percentage in this tile. Every digit uses the same amount of space, so the percentage bar changes size less often

Edit: added point 4 