### PR TITLE
fix(mobile): assetList is empty

### DIFF
--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -218,6 +218,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       final assetCountInAlbum = await album.assetCountAsync;
       if (assetCountInAlbum > 0) {
         final assetList = await album.getAssetListPaged(page: 0, size: 1);
+        if (assetList.isEmpty) continue;
         final thumbnailAsset = assetList.first;
         try {
           final thumbnailData = await thumbnailAsset

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -218,7 +218,12 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       final assetCountInAlbum = await album.assetCountAsync;
       if (assetCountInAlbum > 0) {
         final assetList = await album.getAssetListPaged(page: 0, size: 1);
-        if (assetList.isEmpty) continue;
+
+        // Even though we check assetCountInAlbum to make sure that there are assets in album
+        // The `getAssetListPaged` method still return empty list and cause not assets get rendered
+        if (assetList.isEmpty) {
+          continue;
+        }
         final thumbnailAsset = assetList.first;
         try {
           final thumbnailData = await thumbnailAsset


### PR DESCRIPTION
On my phone (Andorid 13, Xiaomi 13 Pro), the `assetCountInAlbum` variable in this code has a value of `2`, but the length of `assetList` is `0`. The code of the `main` branch will throw an exception here, causing the entire picture list to fail to load, so I have added a empty judgment logic for `assetList`, which works well on my phone. I hope you can merge this pr, thank you very much.

But I haven't figured out what caused the length of `assetList` to not be 2. I only see that the value of the `name` field of the `album` object here is `"image"`, but I don't know how to get the full path of this album. If you know how to get this full path, please let me know, and I will investigate the specific reason further, thank you!