### PR TITLE
fix(web): Uses asset exif info for desc in asset viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -65,6 +65,12 @@
     }
   }
 
+  const handleNewAsset = (newAsset: AssetResponseDto) => {
+    description = newAsset?.exifInfo?.description || '';
+  };
+
+  $: handleNewAsset(asset);
+
   $: latlng = (() => {
     const lat = asset.exifInfo?.latitude;
     const lng = asset.exifInfo?.longitude;

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -54,19 +54,17 @@
 
   $: isOwner = $user?.id === asset.ownerId;
 
-  $: {
-    // Get latest description from server
-    if (asset.id && !api.isSharedLink) {
-      api.assetApi.getAssetById({ id: asset.id }).then((res) => {
-        people = res.data?.people || [];
-        textarea.value = res.data?.exifInfo?.description || '';
-        autoGrowHeight();
-      });
-    }
-  }
-
-  const handleNewAsset = (newAsset: AssetResponseDto) => {
+  const handleNewAsset = async (newAsset: AssetResponseDto) => {
     description = newAsset?.exifInfo?.description || '';
+
+    // Get latest description from server
+    if (newAsset.id && !api.isSharedLink) {
+      const { data } = await api.assetApi.getAssetById({ id: asset.id });
+      people = data?.people || [];
+      description = data.exifInfo?.description || '';
+      textarea.value = description;
+      autoGrowHeight();
+    }
   };
 
   $: handleNewAsset(asset);
@@ -198,18 +196,21 @@
     </section>
   {/if}
 
-  <section class="mx-4 mt-10" style:display={!isOwner && textarea?.value == '' ? 'none' : 'block'}>
-    <textarea
-      bind:this={textarea}
-      class="max-h-[500px]
+  <section class="mx-4 mt-10" style:display={!isOwner && description === '' ? 'none' : 'block'}>
+    {#if !isOwner || api.isSharedLink}
+      <span>{description}</span>
+    {:else}
+      <textarea
+        bind:this={textarea}
+        class="max-h-[500px]
       w-full resize-none overflow-hidden border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary"
-      placeholder={!isOwner ? '' : 'Add a description'}
-      on:focusin={handleFocusIn}
-      on:focusout={handleFocusOut}
-      on:input={autoGrowHeight}
-      bind:value={description}
-      disabled={!isOwner}
-    />
+        placeholder={!isOwner ? '' : 'Add a description'}
+        on:focusin={handleFocusIn}
+        on:focusout={handleFocusOut}
+        on:input={autoGrowHeight}
+        bind:value={description}
+      />
+    {/if}
   </section>
 
   {#if !api.isSharedLink && people.length > 0}


### PR DESCRIPTION
## Description
  - Attempts to use the current `asset`'s exifInfo.description in the bound description (When it exists)
  - This approach will set a default value for the description if we have it and differs from the previous approach of trying to set the value of the text area

Fixes #4073
Fixes #6244

## How Has This Been Tested? 
sorry for the buggy PR @waclaw66 Any other test paths you want me to exercise?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Upload image -> Add description -> Add to shared album -> Open image as photo owner -> Open shared link as photo owner -> open shared link in incognito tab(anon user) -> Verify photo description is visible across all viewing methods
- [x] Upload image AFTER testing above ^ -> Verify existing descriptions are maintained and web doesnt crash
- [x] Add image without description to shared album -> Verify asset detail is correct
- [x] Modify image description after upload -> Verify description is maintained in standard view + album views 

## Screenshots (if appropriate):
Left: As Photo Middle: As photo owner through shared link Right: As anon user in incognito
![banana_test](https://github.com/immich-app/immich/assets/3691245/3ce03613-fc56-4b63-ae84-37ccff3b0e04)
Tested the photo detail when people are present to exercise the code within the if statement
![with_people](https://github.com/immich-app/immich/assets/3691245/410cd602-d9a2-44bc-8002-7abea23cc01b)
After editing description just to make sure the detail is updated properly
![post_edit](https://github.com/immich-app/immich/assets/3691245/f1143c6a-15b1-4cbe-a595-258da8b1ff3e)



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable