### PR TITLE
fix(server): Thumbnail migration creating unnecessary directories

### DIFF
--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -98,26 +98,29 @@ export class MediaService {
     if (!asset) {
       return false;
     }
-    const resizePath = this.ensureThumbnailPath(asset, 'jpeg', false);
-    const webpPath = this.ensureThumbnailPath(asset, 'webp', false);
-    const encodedVideoPath = this.ensureEncodedVideoPath(asset, 'mp4', false);
 
-    if (asset.resizePath && asset.resizePath !== resizePath) {
-      this.storageRepository.mkdirSync(this.storageCore.getDirectory(resizePath));
-      await this.storageRepository.moveFile(asset.resizePath, resizePath);
-      await this.assetRepository.save({ id: asset.id, resizePath });
+    if (asset.resizePath) {
+      const resizePath = this.ensureThumbnailPath(asset, 'jpeg');
+      if (asset.resizePath !== resizePath) {
+        await this.storageRepository.moveFile(asset.resizePath, resizePath);
+        await this.assetRepository.save({ id: asset.id, resizePath });
+      }
     }
 
-    if (asset.webpPath && asset.webpPath !== webpPath) {
-      this.storageRepository.mkdirSync(this.storageCore.getDirectory(webpPath));
-      await this.storageRepository.moveFile(asset.webpPath, webpPath);
-      await this.assetRepository.save({ id: asset.id, webpPath });
+    if (asset.webpPath) {
+      const webpPath = this.ensureThumbnailPath(asset, 'webp');
+      if (asset.webpPath !== webpPath) {
+        await this.storageRepository.moveFile(asset.webpPath, webpPath);
+        await this.assetRepository.save({ id: asset.id, webpPath });
+      }
     }
 
-    if (asset.encodedVideoPath && asset.encodedVideoPath !== encodedVideoPath) {
-      this.storageRepository.mkdirSync(this.storageCore.getDirectory(encodedVideoPath));
-      await this.storageRepository.moveFile(asset.encodedVideoPath, encodedVideoPath);
-      await this.assetRepository.save({ id: asset.id, encodedVideoPath });
+    if (asset.encodedVideoPath) {
+      const encodedVideoPath = this.ensureEncodedVideoPath(asset, 'mp4');
+      if (asset.encodedVideoPath !== encodedVideoPath) {
+        await this.storageRepository.moveFile(asset.encodedVideoPath, encodedVideoPath);
+        await this.assetRepository.save({ id: asset.id, encodedVideoPath });
+      }
     }
 
     return true;
@@ -370,12 +373,12 @@ export class MediaService {
     return handler;
   }
 
-  ensureThumbnailPath(asset: AssetEntity, extension: string, create: boolean = true): string {
-    return this.storageCore.ensurePath(StorageFolder.THUMBNAILS, asset.ownerId, `${asset.id}.${extension}`, create);
+  ensureThumbnailPath(asset: AssetEntity, extension: string): string {
+    return this.storageCore.ensurePath(StorageFolder.THUMBNAILS, asset.ownerId, `${asset.id}.${extension}`);
   }
 
-  ensureEncodedVideoPath(asset: AssetEntity, extension: string, create: boolean = true): string {
-    return this.storageCore.ensurePath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}.${extension}`, create);
+  ensureEncodedVideoPath(asset: AssetEntity, extension: string): string {
+    return this.storageCore.ensurePath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}.${extension}`);
   }
 
   isSRGB(asset: AssetEntity): boolean {

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -98,21 +98,24 @@ export class MediaService {
     if (!asset) {
       return false;
     }
-    const resizePath = this.ensureThumbnailPath(asset, 'jpeg');
-    const webpPath = this.ensureThumbnailPath(asset, 'webp');
-    const encodedVideoPath = this.ensureEncodedVideoPath(asset, 'mp4');
+    const resizePath = this.ensureThumbnailPath(asset, 'jpeg', false);
+    const webpPath = this.ensureThumbnailPath(asset, 'webp', false);
+    const encodedVideoPath = this.ensureEncodedVideoPath(asset, 'mp4', false);
 
     if (asset.resizePath && asset.resizePath !== resizePath) {
+      this.storageRepository.mkdirSync(this.storageCore.getDirectory(resizePath));
       await this.storageRepository.moveFile(asset.resizePath, resizePath);
       await this.assetRepository.save({ id: asset.id, resizePath });
     }
 
     if (asset.webpPath && asset.webpPath !== webpPath) {
+      this.storageRepository.mkdirSync(this.storageCore.getDirectory(webpPath));
       await this.storageRepository.moveFile(asset.webpPath, webpPath);
       await this.assetRepository.save({ id: asset.id, webpPath });
     }
 
     if (asset.encodedVideoPath && asset.encodedVideoPath !== encodedVideoPath) {
+      this.storageRepository.mkdirSync(this.storageCore.getDirectory(encodedVideoPath));
       await this.storageRepository.moveFile(asset.encodedVideoPath, encodedVideoPath);
       await this.assetRepository.save({ id: asset.id, encodedVideoPath });
     }
@@ -367,12 +370,12 @@ export class MediaService {
     return handler;
   }
 
-  ensureThumbnailPath(asset: AssetEntity, extension: string): string {
-    return this.storageCore.ensurePath(StorageFolder.THUMBNAILS, asset.ownerId, `${asset.id}.${extension}`);
+  ensureThumbnailPath(asset: AssetEntity, extension: string, create: boolean = true): string {
+    return this.storageCore.ensurePath(StorageFolder.THUMBNAILS, asset.ownerId, `${asset.id}.${extension}`, create);
   }
 
-  ensureEncodedVideoPath(asset: AssetEntity, extension: string): string {
-    return this.storageCore.ensurePath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}.${extension}`);
+  ensureEncodedVideoPath(asset: AssetEntity, extension: string, create: boolean = true): string {
+    return this.storageCore.ensurePath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}.${extension}`, create);
   }
 
   isSRGB(asset: AssetEntity): boolean {

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { APP_MEDIA_LOCATION } from '../domain.constant';
 import { IStorageRepository } from './storage.repository';
 
@@ -28,17 +28,22 @@ export class StorageCore {
     return join(APP_MEDIA_LOCATION, folder);
   }
 
+  getDirectory(filepath: string) {
+    return dirname(filepath);
+  }
+
   ensurePath(
     folder: StorageFolder.ENCODED_VIDEO | StorageFolder.UPLOAD | StorageFolder.PROFILE | StorageFolder.THUMBNAILS,
     ownerId: string,
     fileName: string,
+    create: boolean = true,
   ): string {
     const folderPath = join(
       this.getFolderLocation(folder, ownerId),
       fileName.substring(0, 2),
       fileName.substring(2, 4),
     );
-    this.repository.mkdirSync(folderPath);
+    create && this.repository.mkdirSync(folderPath);
     return join(folderPath, fileName);
   }
 

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { APP_MEDIA_LOCATION } from '../domain.constant';
 import { IStorageRepository } from './storage.repository';
 
@@ -28,22 +28,17 @@ export class StorageCore {
     return join(APP_MEDIA_LOCATION, folder);
   }
 
-  getDirectory(filepath: string) {
-    return dirname(filepath);
-  }
-
   ensurePath(
     folder: StorageFolder.ENCODED_VIDEO | StorageFolder.UPLOAD | StorageFolder.PROFILE | StorageFolder.THUMBNAILS,
     ownerId: string,
     fileName: string,
-    create: boolean = true,
   ): string {
     const folderPath = join(
       this.getFolderLocation(folder, ownerId),
       fileName.substring(0, 2),
       fileName.substring(2, 4),
     );
-    create && this.repository.mkdirSync(folderPath);
+    this.repository.mkdirSync(folderPath);
     return join(folderPath, fileName);
   }
 


### PR DESCRIPTION
As pointed out in https://github.com/immich-app/immich/pull/4112#issuecomment-1736784668, the migration job created all directories for each asset (so `jpeg`, `webp` and `encoded video`) before checking if those folders are actually needed.