### PR TITLE
fix: explore tags

### DIFF
--- a/server/src/infra/repositories/typesense.repository.ts
+++ b/server/src/infra/repositories/typesense.repository.ts
@@ -159,7 +159,7 @@ export class TypesenseRepository implements ISearchRepository {
     const { facet_counts: facets } = await asset$.search({
       ...common,
       query_by: 'originalFileName',
-      facet_by: 'exifInfo.city,smartInfo.objects',
+      facet_by: 'exifInfo.city,smartInfo.tags',
       max_facet_values: 12,
     });
 

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -16,7 +16,6 @@
   enum Field {
     CITY = 'exifInfo.city',
     TAGS = 'smartInfo.tags',
-    OBJECTS = 'smartInfo.objects',
   }
 
   const MAX_ITEMS = 12;
@@ -25,7 +24,7 @@
     return targetField?.items || [];
   };
 
-  $: things = getFieldItems(data.items, Field.OBJECTS);
+  $: things = getFieldItems(data.items, Field.TAGS);
   $: places = getFieldItems(data.items, Field.CITY);
   $: people = data.response.people.slice(0, MAX_ITEMS);
   $: hasPeople = data.response.total > 0;
@@ -90,7 +89,7 @@
       </div>
       <div class="flex flex-row flex-wrap gap-4">
         {#each things as item}
-          <a class="relative" href="/search?{Field.OBJECTS}={item.value}" draggable="false">
+          <a class="relative" href="/search?{Field.TAGS}={item.value}" draggable="false">
             <div
               class="flex w-[calc((100vw-(72px+5rem))/2)] max-w-[156px] justify-center overflow-hidden rounded-xl brightness-75 filter"
             >


### PR DESCRIPTION
Originally we had two machine learning models:
1.  Object tagging (saved in `smartInfo.objects`)
2. Image classification (saved in `smartInfo.tags`)

We removed the object one awhile ago, but never updated the explore page and endpoint to use `tags` instead. This PR switches to using `tags` in favor of `objects`, since that is always empty on new installs. It's possible some people may have old data in that column still, in which case they will see those results disappear from the explore page.