### PR TITLE
feat(web): people sidebar link

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/side-bar.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar.svelte
@@ -9,13 +9,14 @@
   import ArchiveArrowDownOutline from 'svelte-material-icons/ArchiveArrowDownOutline.svelte';
   import Magnify from 'svelte-material-icons/Magnify.svelte';
   import Map from 'svelte-material-icons/Map.svelte';
+  import Account from 'svelte-material-icons/Account.svelte';
   import HeartMultipleOutline from 'svelte-material-icons/HeartMultipleOutline.svelte';
   import HeartMultiple from 'svelte-material-icons/HeartMultiple.svelte';
   import { AppRoute } from '../../../constants';
   import LoadingSpinner from '../loading-spinner.svelte';
   import StatusBox from '../status-box.svelte';
   import SideBarButton from './side-bar-button.svelte';
-  import { locale } from '$lib/stores/preferences.store';
+  import { locale, sidebarSettings } from '$lib/stores/preferences.store';
   import SideBarSection from './side-bar-section.svelte';
   import { featureFlags } from '$lib/stores/server-config.store';
 
@@ -65,6 +66,11 @@
   {#if $featureFlags.map}
     <a data-sveltekit-preload-data="hover" href={AppRoute.MAP} draggable="false">
       <SideBarButton title="Map" logo={Map} isSelected={$page.route.id === '/(user)/map'} />
+    </a>
+  {/if}
+  {#if $sidebarSettings.people}
+    <a data-sveltekit-preload-data="hover" href={AppRoute.PEOPLE} draggable="false">
+      <SideBarButton title="People" logo={Account} isSelected={$page.route.id === '/(user)/people'} />
     </a>
   {/if}
   <a data-sveltekit-preload-data="hover" href={AppRoute.SHARING} draggable="false">

--- a/web/src/lib/components/user-settings-page/sidebar-settings.svelte
+++ b/web/src/lib/components/user-settings-page/sidebar-settings.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition';
+  import { sidebarSettings } from '../../stores/preferences.store';
+  import SettingSwitch from '../admin-page/settings/setting-switch.svelte';
+</script>
+
+<section class="my-4">
+  <div in:fade={{ duration: 500 }}>
+    <div class="ml-4 mt-4 flex flex-col gap-4">
+      <div class="ml-4">
+        <SettingSwitch title="People" subtitle="Display a link to People" bind:checked={$sidebarSettings.people} />
+      </div>
+    </div>
+  </div>
+</section>

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -6,12 +6,13 @@
   import SettingAccordion from '../admin-page/settings/setting-accordion.svelte';
   import ChangePasswordSettings from './change-password-settings.svelte';
   import DeviceList from './device-list.svelte';
+  import LibraryList from './library-list.svelte';
   import MemoriesSettings from './memories-settings.svelte';
   import OAuthSettings from './oauth-settings.svelte';
   import PartnerSettings from './partner-settings.svelte';
+  import SidebarSettings from './sidebar-settings.svelte';
   import UserAPIKeyList from './user-api-key-list.svelte';
   import UserProfileSettings from './user-profile-settings.svelte';
-  import LibraryList from './library-list.svelte';
 
   export let user: UserResponseDto;
 
@@ -61,4 +62,8 @@
 
 <SettingAccordion title="Sharing" subtitle="Manage sharing with partners">
   <PartnerSettings {user} bind:partners />
+</SettingAccordion>
+
+<SettingAccordion title="Sidebar" subtitle="Manage sidebar settings">
+  <SidebarSettings />
 </SettingAccordion>

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -44,6 +44,14 @@ export interface AlbumViewSettings {
   view: string;
 }
 
+export interface SidebarSettings {
+  people: boolean;
+}
+
+export const sidebarSettings = persisted<SidebarSettings>('sidebar-settings', {
+  people: false,
+});
+
 export enum AlbumViewMode {
   Cover = 'Cover',
   List = 'List',


### PR DESCRIPTION
Add a new account preference (Account Settings > Sidebar Settings), which allows a user to enable a sidebar link to "People" (/people). Defaults to false. Requested in https://github.com/immich-app/immich/discussions/2472 (number 8)

| Light | Dark
| - | - |
| ![image](https://github.com/immich-app/immich/assets/4334196/0d1ae058-6af2-461b-a449-ee8d41545f50) | ![image](https://github.com/immich-app/immich/assets/4334196/13e0a0d6-f31e-464d-af2d-edbe872708cc) | 

![image](https://github.com/immich-app/immich/assets/4334196/86470458-aa18-4fb2-b920-a7868f08d3f2)
![image](https://github.com/immich-app/immich/assets/4334196/4f5a0e80-a907-403a-a9df-0aa73f160d7c)
