### PR TITLE
feat(server): Add week numbers for templating

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -3547,6 +3547,12 @@ export interface SystemConfigTemplateStorageOptionDto {
      * @type {Array<string>}
      * @memberof SystemConfigTemplateStorageOptionDto
      */
+    'weekOptions': Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof SystemConfigTemplateStorageOptionDto
+     */
     'yearOptions': Array<string>;
 }
 /**

--- a/mobile/openapi/doc/SystemConfigTemplateStorageOptionDto.md
+++ b/mobile/openapi/doc/SystemConfigTemplateStorageOptionDto.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **monthOptions** | **List<String>** |  | [default to const []]
 **presetOptions** | **List<String>** |  | [default to const []]
 **secondOptions** | **List<String>** |  | [default to const []]
+**weekOptions** | **List<String>** |  | [default to const []]
 **yearOptions** | **List<String>** |  | [default to const []]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/mobile/openapi/lib/model/system_config_template_storage_option_dto.dart
+++ b/mobile/openapi/lib/model/system_config_template_storage_option_dto.dart
@@ -19,6 +19,7 @@ class SystemConfigTemplateStorageOptionDto {
     this.monthOptions = const [],
     this.presetOptions = const [],
     this.secondOptions = const [],
+    this.weekOptions = const [],
     this.yearOptions = const [],
   });
 
@@ -34,6 +35,8 @@ class SystemConfigTemplateStorageOptionDto {
 
   List<String> secondOptions;
 
+  List<String> weekOptions;
+
   List<String> yearOptions;
 
   @override
@@ -44,6 +47,7 @@ class SystemConfigTemplateStorageOptionDto {
      other.monthOptions == monthOptions &&
      other.presetOptions == presetOptions &&
      other.secondOptions == secondOptions &&
+     other.weekOptions == weekOptions &&
      other.yearOptions == yearOptions;
 
   @override
@@ -55,10 +59,11 @@ class SystemConfigTemplateStorageOptionDto {
     (monthOptions.hashCode) +
     (presetOptions.hashCode) +
     (secondOptions.hashCode) +
+    (weekOptions.hashCode) +
     (yearOptions.hashCode);
 
   @override
-  String toString() => 'SystemConfigTemplateStorageOptionDto[dayOptions=$dayOptions, hourOptions=$hourOptions, minuteOptions=$minuteOptions, monthOptions=$monthOptions, presetOptions=$presetOptions, secondOptions=$secondOptions, yearOptions=$yearOptions]';
+  String toString() => 'SystemConfigTemplateStorageOptionDto[dayOptions=$dayOptions, hourOptions=$hourOptions, minuteOptions=$minuteOptions, monthOptions=$monthOptions, presetOptions=$presetOptions, secondOptions=$secondOptions, weekOptions=$weekOptions, yearOptions=$yearOptions]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -68,6 +73,7 @@ class SystemConfigTemplateStorageOptionDto {
       json[r'monthOptions'] = this.monthOptions;
       json[r'presetOptions'] = this.presetOptions;
       json[r'secondOptions'] = this.secondOptions;
+      json[r'weekOptions'] = this.weekOptions;
       json[r'yearOptions'] = this.yearOptions;
     return json;
   }
@@ -97,6 +103,9 @@ class SystemConfigTemplateStorageOptionDto {
             : const [],
         secondOptions: json[r'secondOptions'] is List
             ? (json[r'secondOptions'] as List).cast<String>()
+            : const [],
+        weekOptions: json[r'weekOptions'] is List
+            ? (json[r'weekOptions'] as List).cast<String>()
             : const [],
         yearOptions: json[r'yearOptions'] is List
             ? (json[r'yearOptions'] as List).cast<String>()
@@ -154,6 +163,7 @@ class SystemConfigTemplateStorageOptionDto {
     'monthOptions',
     'presetOptions',
     'secondOptions',
+    'weekOptions',
     'yearOptions',
   };
 }

--- a/mobile/openapi/test/system_config_template_storage_option_dto_test.dart
+++ b/mobile/openapi/test/system_config_template_storage_option_dto_test.dart
@@ -46,6 +46,11 @@ void main() {
       // TODO
     });
 
+    // List<String> weekOptions (default value: const [])
+    test('to test the property `weekOptions`', () async {
+      // TODO
+    });
+
     // List<String> yearOptions (default value: const [])
     test('to test the property `yearOptions`', () async {
       // TODO

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -7924,6 +7924,12 @@
             },
             "type": "array"
           },
+          "weekOptions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "yearOptions": {
             "items": {
               "type": "string"
@@ -7934,6 +7940,7 @@
         "required": [
           "yearOptions",
           "monthOptions",
+          "weekOptions",
           "dayOptions",
           "hourOptions",
           "minuteOptions",

--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -16,6 +16,7 @@ import {
   supportedMinuteTokens,
   supportedMonthTokens,
   supportedSecondTokens,
+  supportedWeekTokens,
   supportedYearTokens,
 } from '../system-config';
 import { SystemConfigCore } from '../system-config/system-config.core';
@@ -239,6 +240,7 @@ export class StorageTemplateService {
     const dateTokens = [
       ...supportedYearTokens,
       ...supportedMonthTokens,
+      ...supportedWeekTokens,
       ...supportedDayTokens,
       ...supportedHourTokens,
       ...supportedMinuteTokens,

--- a/server/src/domain/system-config/response-dto/system-config-template-storage-option.dto.ts
+++ b/server/src/domain/system-config/response-dto/system-config-template-storage-option.dto.ts
@@ -1,6 +1,7 @@
 export class SystemConfigTemplateStorageOptionDto {
   yearOptions!: string[];
   monthOptions!: string[];
+  weekOptions!: string[];
   dayOptions!: string[];
   hourOptions!: string[];
   minuteOptions!: string[];

--- a/server/src/domain/system-config/system-config.constants.ts
+++ b/server/src/domain/system-config/system-config.constants.ts
@@ -1,5 +1,6 @@
 export const supportedYearTokens = ['y', 'yy'];
 export const supportedMonthTokens = ['M', 'MM', 'MMM', 'MMMM'];
+export const supportedWeekTokens = ['W', 'WW'];
 export const supportedDayTokens = ['d', 'dd'];
 export const supportedHourTokens = ['h', 'hh', 'H', 'HH'];
 export const supportedMinuteTokens = ['m', 'mm'];
@@ -18,6 +19,7 @@ export const supportedPresetTokens = [
   '{{y}}-{{MMM}}-{{dd}}/{{filename}}',
   '{{y}}-{{MMMM}}-{{dd}}/{{filename}}',
   '{{y}}/{{y}}-{{MM}}/{{filename}}',
+  '{{y}}/{{y}}-{{WW}}/{{filename}}',
 ];
 
 export const INITIAL_SYSTEM_CONFIG = 'INITIAL_SYSTEM_CONFIG';

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -221,8 +221,10 @@ describe(SystemConfigService.name, () => {
           '{{y}}-{{MMM}}-{{dd}}/{{filename}}',
           '{{y}}-{{MMMM}}-{{dd}}/{{filename}}',
           '{{y}}/{{y}}-{{MM}}/{{filename}}',
+          '{{y}}/{{y}}-{{WW}}/{{filename}}',
         ],
         secondOptions: ['s', 'ss'],
+        weekOptions: ['W', 'WW'],
         yearOptions: ['y', 'yy'],
       });
     });

--- a/server/src/domain/system-config/system-config.service.ts
+++ b/server/src/domain/system-config/system-config.service.ts
@@ -10,6 +10,7 @@ import {
   supportedMonthTokens,
   supportedPresetTokens,
   supportedSecondTokens,
+  supportedWeekTokens,
   supportedYearTokens,
 } from './system-config.constants';
 import { SystemConfigCore, SystemConfigValidator } from './system-config.core';
@@ -57,6 +58,7 @@ export class SystemConfigService {
     const options = new SystemConfigTemplateStorageOptionDto();
 
     options.dayOptions = supportedDayTokens;
+    options.weekOptions = supportedWeekTokens;
     options.monthOptions = supportedMonthTokens;
     options.yearOptions = supportedYearTokens;
     options.hourOptions = supportedHourTokens;

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -3547,6 +3547,12 @@ export interface SystemConfigTemplateStorageOptionDto {
      * @type {Array<string>}
      * @memberof SystemConfigTemplateStorageOptionDto
      */
+    'weekOptions': Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof SystemConfigTemplateStorageOptionDto
+     */
     'yearOptions': Array<string>;
 }
 /**

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -58,7 +58,7 @@
       filetypefull: 'IMAGE',
     };
 
-    const dt = luxon.DateTime.fromISO(new Date('2022-09-04T20:03:05.250').toISOString());
+    const dt = luxon.DateTime.fromISO(new Date('2022-02-01T20:03:05.250').toISOString());
 
     const dateTokens = [
       ...templateOptions.yearOptions,

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -58,7 +58,7 @@
       filetypefull: 'IMAGE',
     };
 
-    const dt = luxon.DateTime.fromISO(new Date('2022-02-01T20:03:05.250').toISOString());
+    const dt = luxon.DateTime.fromISO(new Date('2022-02-03T04:56:05.250').toISOString());
 
     const dateTokens = [
       ...templateOptions.yearOptions,

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -63,6 +63,7 @@
     const dateTokens = [
       ...templateOptions.yearOptions,
       ...templateOptions.monthOptions,
+      ...templateOptions.weekOptions,
       ...templateOptions.dayOptions,
       ...templateOptions.hourOptions,
       ...templateOptions.minuteOptions,

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
@@ -16,7 +16,7 @@
 <div class="mt-2 rounded-lg bg-gray-200 p-4 text-xs dark:bg-gray-700 dark:text-immich-dark-fg">
   <div class="mb-2 text-gray-600 dark:text-immich-dark-fg">
     <p>Asset's creation timestamp is used for the datetime information</p>
-    <p>Sample time 2022-02-01T20:03:05.250</p>
+    <p>Sample time 2022-02-03T04:56:05.250</p>
   </div>
   <div class="flex gap-[40px]">
     <div>

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
@@ -16,7 +16,7 @@
 <div class="mt-2 rounded-lg bg-gray-200 p-4 text-xs dark:bg-gray-700 dark:text-immich-dark-fg">
   <div class="mb-2 text-gray-600 dark:text-immich-dark-fg">
     <p>Asset's creation timestamp is used for the datetime information</p>
-    <p>Sample time 2022-09-04T20:03:05.250</p>
+    <p>Sample time 2022-02-01T20:03:05.250</p>
   </div>
   <div class="flex gap-[40px]">
     <div>

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
@@ -18,7 +18,7 @@
     <p>Asset's creation timestamp is used for the datetime information</p>
     <p>Sample time 2022-09-04T20:03:05.250</p>
   </div>
-  <div class="flex gap-[50px]">
+  <div class="flex gap-[40px]">
     <div>
       <p class="font-medium text-immich-primary dark:text-immich-dark-primary">YEAR</p>
       <ul>
@@ -33,6 +33,15 @@
       <ul>
         {#each options.monthOptions as monthFormat}
           <li>{'{{'}{monthFormat}{'}}'} - {getLuxonExample(monthFormat)}</li>
+        {/each}
+      </ul>
+    </div>
+
+    <div>
+      <p class="font-medium text-immich-primary dark:text-immich-dark-primary">WEEK</p>
+      <ul>
+        {#each options.weekOptions as weekFormat}
+          <li>{'{{'}{weekFormat}{'}}'} - {getLuxonExample(weekFormat)}</li>
         {/each}
       </ul>
     </div>


### PR DESCRIPTION
Add the option to use week numbers ('W') and padded week numbers ('WW') for storage templating.

<img width="823" alt="Screenshot 2023-09-28 at 18 59 17" src="https://github.com/immich-app/immich/assets/36593685/393896e2-455b-44ac-9f18-89a51443b801">

<img width="838" alt="Screenshot 2023-09-28 at 18 58 20" src="https://github.com/immich-app/immich/assets/36593685/34fca408-77ad-40c6-a33b-cd07c5925c64">

Closes #4260.