### PR TITLE
fix(mobile): reduce server version api calls

### DIFF
--- a/mobile/lib/modules/album/views/sharing_page.dart
+++ b/mobile/lib/modules/album/views/sharing_page.dart
@@ -117,6 +117,7 @@ class SharingPage extends HookConsumerWidget {
         padding: const EdgeInsets.only(
           left: 12.0,
           right: 12.0,
+          top: 24.0,
           bottom: 12.0,
         ),
         child: Row(

--- a/mobile/lib/routing/tab_navigation_observer.dart
+++ b/mobile/lib/routing/tab_navigation_observer.dart
@@ -64,10 +64,10 @@ class TabNavigationObserver extends AutoRouterObserver {
         }
 
         Store.put(StoreKey.currentUser, User.fromDto(userResponseDto));
+        ref.read(serverInfoProvider.notifier).getServerVersion();
       } catch (e) {
         debugPrint("Error refreshing user info $e");
       }
     }
-    ref.watch(serverInfoProvider.notifier).getServerVersion();
   }
 }


### PR DESCRIPTION
#### Changes made in this PR:

- The server version number is only used in the app server info box and home page app bar. However, the `getServerVersion` was getting called on each bottom tab switch resulting in unnecessary calls to the server each time a tab was switched. This PR reduces this to only fetch the server version when the user navigates to the home page / timeline. 

> [!NOTE]  
> We can also entirely remove this call from tab navigation. The server info calls are also sent on app start, app resumes and during backups which should be more than sufficient for the actual usage value it has.

- The sharing page's top button did not have any top padding set.  Updated them to use the same padding as the one used in the library page to make them consistent

Before | After
:-: | :-:
![Before](https://github.com/immich-app/immich/assets/139912620/a61b411d-b4b1-42bf-8459-fa37d34c8eb8) | ![After](https://github.com/immich-app/immich/assets/139912620/eff260ea-9992-406f-b37f-9c56b7dd9f5c)
