### PR TITLE
feat(web): better context menu position

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -6,6 +6,7 @@
   import DotsVertical from 'svelte-material-icons/DotsVertical.svelte';
   import IconButton from '../elements/buttons/icon-button.svelte';
   import type { OnClick, OnShowContextMenu } from './album-card';
+  import { getContextMenuPosition } from '../../utils/context-menu';
 
   export let album: AlbumResponseDto;
   export let isSharingView = false;
@@ -41,12 +42,8 @@
     }
   };
 
-  const showAlbumContextMenu = (e: MouseEvent) => {
-    dispatchShowContextMenu('showalbumcontextmenu', {
-      x: e.clientX,
-      y: e.clientY,
-    });
-  };
+  const showAlbumContextMenu = (e: MouseEvent) =>
+    dispatchShowContextMenu('showalbumcontextmenu', getContextMenuPosition(e));
 
   onMount(async () => {
     imageData = (await loadHighQualityThumbnail(album.albumThumbnailAssetId)) || noThumbnailUrl;

--- a/web/src/lib/components/album-page/share-info-modal.svelte
+++ b/web/src/lib/components/album-page/share-info-modal.svelte
@@ -10,6 +10,8 @@
   import { notificationController, NotificationType } from '../shared-components/notification/notification';
   import { handleError } from '../../utils/handle-error';
   import ConfirmDialogue from '../shared-components/confirm-dialogue.svelte';
+  import { getMenuContext } from '../photos-page/asset-select-context-menu.svelte';
+  import { getContextMenuPosition } from '../../utils/context-menu';
 
   export let album: AlbumResponseDto;
 
@@ -34,16 +36,8 @@
     }
   });
 
-  const showContextMenu = (user: UserResponseDto) => {
-    const iconButton = document.getElementById('icon-' + user.id);
-
-    if (iconButton) {
-      position = {
-        x: iconButton.getBoundingClientRect().left,
-        y: iconButton.getBoundingClientRect().bottom,
-      };
-    }
-
+  const showContextMenu = (event: MouseEvent, user: UserResponseDto) => {
+    position = getContextMenuPosition(event);
     selectedMenuUser = user;
     selectedRemoveUser = null;
   };
@@ -105,7 +99,7 @@
             {#if isOwned}
               <div>
                 <CircleIconButton
-                  on:click={() => showContextMenu(user)}
+                  on:click={(event) => showContextMenu(event, user)}
                   logo={DotsVertical}
                   backgroundColor="transparent"
                   hoverColor="#e2e7e9"

--- a/web/src/lib/components/album-page/share-info-modal.svelte
+++ b/web/src/lib/components/album-page/share-info-modal.svelte
@@ -10,7 +10,6 @@
   import { notificationController, NotificationType } from '../shared-components/notification/notification';
   import { handleError } from '../../utils/handle-error';
   import ConfirmDialogue from '../shared-components/confirm-dialogue.svelte';
-  import { getMenuContext } from '../photos-page/asset-select-context-menu.svelte';
   import { getContextMenuPosition } from '../../utils/context-menu';
 
   export let album: AlbumResponseDto;

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -20,6 +20,7 @@
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import ContextMenu from '../shared-components/context-menu/context-menu.svelte';
   import MenuOption from '../shared-components/context-menu/menu-option.svelte';
+  import { getContextMenuPosition } from '$lib/utils/context-menu';
 
   export let asset: AssetResponseDto;
   export let showCopyButton: boolean;
@@ -52,8 +53,8 @@
   let contextMenuPosition = { x: 0, y: 0 };
   let isShowAssetOptions = false;
 
-  const showOptionsMenu = ({ x, y }: MouseEvent) => {
-    contextMenuPosition = { x, y };
+  const showOptionsMenu = (event: MouseEvent) => {
+    contextMenuPosition = getContextMenuPosition(event, 'top-right');
     isShowAssetOptions = !isShowAssetOptions;
   };
 

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { PersonResponseDto, api } from '@api';
+  import { getContextMenuPosition } from '$lib/utils/context-menu';
   import ImageThumbnail from '../assets/thumbnail/image-thumbnail.svelte';
   import IconButton from '../elements/buttons/icon-button.svelte';
   import DotsVertical from 'svelte-material-icons/DotsVertical.svelte';
@@ -21,8 +22,8 @@
   let showVerticalDots = false;
   let showContextMenu = false;
   let contextMenuPosition = { x: 0, y: 0 };
-  const showMenu = ({ x, y }: MouseEvent) => {
-    contextMenuPosition = { x, y };
+  const showMenu = (event: MouseEvent) => {
+    contextMenuPosition = getContextMenuPosition(event);
     showContextMenu = !showContextMenu;
   };
   const onMenuExit = () => {

--- a/web/src/lib/components/photos-page/asset-select-context-menu.svelte
+++ b/web/src/lib/components/photos-page/asset-select-context-menu.svelte
@@ -19,7 +19,7 @@
   let contextMenuPosition = { x: 0, y: 0 };
 
   const handleShowMenu = (event: MouseEvent) => {
-    contextMenuPosition = getContextMenuPosition(event);
+    contextMenuPosition = getContextMenuPosition(event, 'top-left');
     showContextMenu = !showContextMenu;
   };
 

--- a/web/src/lib/components/photos-page/asset-select-context-menu.svelte
+++ b/web/src/lib/components/photos-page/asset-select-context-menu.svelte
@@ -10,6 +10,7 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import ContextMenu from '$lib/components/shared-components/context-menu/context-menu.svelte';
   import type Icon from 'svelte-material-icons/AbTesting.svelte';
+  import { getContextMenuPosition } from '$lib/utils/context-menu';
 
   export let icon: typeof Icon;
   export let title: string;
@@ -17,9 +18,8 @@
   let showContextMenu = false;
   let contextMenuPosition = { x: 0, y: 0 };
 
-  const handleShowMenu = ({ x }: MouseEvent) => {
-    const navigationBarHeight = 75;
-    contextMenuPosition = { x: x, y: navigationBarHeight };
+  const handleShowMenu = (event: MouseEvent) => {
+    contextMenuPosition = getContextMenuPosition(event);
     showContextMenu = !showContextMenu;
   };
 

--- a/web/src/lib/components/user-settings-page/library-list.svelte
+++ b/web/src/lib/components/user-settings-page/library-list.svelte
@@ -18,6 +18,7 @@
   import Portal from '../shared-components/portal/portal.svelte';
   import ContextMenu from '../shared-components/context-menu/context-menu.svelte';
   import MenuOption from '../shared-components/context-menu/menu-option.svelte';
+  import { getContextMenuPosition } from '$lib/utils/context-menu';
 
   let libraries: LibraryResponseDto[] = [];
 
@@ -60,8 +61,8 @@
     }
   };
 
-  const showMenu = ({ x, y }: MouseEvent, type: LibraryType) => {
-    contextMenuPosition = { x, y };
+  const showMenu = (event: MouseEvent, type: LibraryType) => {
+    contextMenuPosition = getContextMenuPosition(event);
     showContextMenu = !showContextMenu;
     libraryType = type;
   };

--- a/web/src/lib/utils/context-menu.ts
+++ b/web/src/lib/utils/context-menu.ts
@@ -1,11 +1,12 @@
-export type PositionLocation = 'top-right' | 'top-left';
+export type Align = 'middle' | 'top-left' | 'top-right';
 
-// defaults to top-left of clicked element
-export const getContextMenuPosition = (event: MouseEvent, location: PositionLocation = 'top-left') => {
+export const getContextMenuPosition = (event: MouseEvent, align: Align = 'middle') => {
   const { x, y, currentTarget, target } = event;
   const box = ((currentTarget || target) as HTMLElement)?.getBoundingClientRect();
   if (box) {
-    switch (location) {
+    switch (align) {
+      case 'middle':
+        return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
       case 'top-left':
         return { x: box.x, y: box.y };
       case 'top-right':

--- a/web/src/lib/utils/context-menu.ts
+++ b/web/src/lib/utils/context-menu.ts
@@ -1,0 +1,17 @@
+export type PositionLocation = 'top-right' | 'top-left';
+
+// defaults to top-left of clicked element
+export const getContextMenuPosition = (event: MouseEvent, location: PositionLocation = 'top-left') => {
+  const { x, y, currentTarget, target } = event;
+  const box = ((currentTarget || target) as HTMLElement)?.getBoundingClientRect();
+  if (box) {
+    switch (location) {
+      case 'top-left':
+        return { x: box.x, y: box.y };
+      case 'top-right':
+        return { x: box.x + box.width, y: box.y };
+    }
+  }
+
+  return { x, y };
+};

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -45,6 +45,7 @@
   import ShareVariantOutline from 'svelte-material-icons/ShareVariantOutline.svelte';
   import type { PageData } from './$types';
   import { clickOutside } from '$lib/utils/click-outside';
+  import { getContextMenuPosition } from '$lib/utils/context-menu';
 
   export let data: PageData;
 
@@ -193,9 +194,8 @@
     timelineInteractionStore.clearMultiselect();
   };
 
-  const handleOpenAlbumOptions = ({ x }: MouseEvent) => {
-    const navigationBarHeight = 75;
-    contextMenuPosition = { x: x, y: navigationBarHeight };
+  const handleOpenAlbumOptions = (event: MouseEvent) => {
+    contextMenuPosition = getContextMenuPosition(event, 'top-left');
     viewMode = viewMode === ViewMode.VIEW ? ViewMode.ALBUM_OPTIONS : ViewMode.VIEW;
   };
 


### PR DESCRIPTION
Use the position of the clicked element to determine the context menu position (instead of the raw click coordinates).

Navbar context menus use the "top-left" or "top-right" variants, while the rest default to "middle".

| Before | After |
| - | - |
![image](https://github.com/immich-app/immich/assets/4334196/15f77d67-955c-4971-95d6-878aa93c3dd9) | ![image](https://github.com/immich-app/immich/assets/4334196/b550e2ce-f2a8-40e5-99f8-e1e2a9b564e4)
![image](https://github.com/immich-app/immich/assets/4334196/ca9817b2-e0d2-4904-84df-5aa309385f1c) | ![image](https://github.com/immich-app/immich/assets/4334196/0fcb4c99-f300-4b35-9ad7-ab7625f8d23f)
![image](https://github.com/immich-app/immich/assets/4334196/78a50121-07ce-47d3-aa11-174bbd405a41) | ![image](https://github.com/immich-app/immich/assets/4334196/98560bab-b55d-45e4-82d8-02a9a99103d9)
![image](https://github.com/immich-app/immich/assets/4334196/a194da17-dd61-4e87-b8ca-a13c4883c4e4) | ![image](https://github.com/immich-app/immich/assets/4334196/1b234b9b-3b41-4ec7-8d2f-35b8882f2846)



