### PR TITLE
fix(server): handle number lists in metadata extraction

### DIFF
--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -122,4 +122,14 @@ describe(MetadataService.name, () => {
       });
     });
   });
+
+  describe('handleMetadataExtraction', () => {
+    it('should handle lists of numbers', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image1]);
+      storageMock.stat.mockResolvedValue({ size: 123456 } as any);
+      metadataMock.getExifTags.mockResolvedValue({ ISO: [160] as any });
+      await sut.handleMetadataExtraction({ id: assetStub.image1.id });
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(expect.objectContaining({ iso: 160 }));
+    });
+  });
 });

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -32,6 +32,11 @@ type ExifEntityWithoutGeocodeAndTypeOrm = Omit<
 const exifDate = (dt: ExifDateTime | string | undefined) => (dt instanceof ExifDateTime ? dt?.toDate() : null);
 
 const validate = <T>(value: T): NonNullable<T> | null => {
+  // handle lists of numbers
+  if (Array.isArray(value)) {
+    value = value[0];
+  }
+
   if (typeof value === 'string') {
     // string means a failure to parse a number, throw out result
     return null;


### PR DESCRIPTION
Fixes #4245

Specifically when setting ISO via a XMP file, it seems to usually get saved as a _list_, which was the root cause of this issue. Adding (back) support to handle this case (and an associated unit test for it)