### PR TITLE
feat(web): shuffle slideshow order

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -654,7 +654,7 @@
             on:onVideoStarted={handleVideoStarted}
           />
         {/if}
-        {#if isShared}
+        {#if $slideshowState === SlideshowState.None && isShared}
           <div class="z-[9999] absolute bottom-0 right-0 mb-6 mr-6 justify-self-end">
             <div
               class="w-full h-14 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -171,7 +171,8 @@
 
     slideshowStateUnsubscribe = slideshowState.subscribe((value) => {
       if (value === SlideshowState.PlaySlideshow) {
-        slideshowHistory.reset(asset.id);
+        slideshowHistory.reset();
+        slideshowHistory.queue(asset.id);
         handlePlaySlideshow();
       } else if (value === SlideshowState.StopSlideshow) {
         handleStopSlideshow();
@@ -180,7 +181,8 @@
 
     shuffleSlideshowUnsubscribe = slideshowShuffle.subscribe((value) => {
       if (value) {
-        slideshowHistory.reset(asset.id);
+        slideshowHistory.reset();
+        slideshowHistory.queue(asset.id);
       }
     });
 
@@ -303,7 +305,7 @@
       return;
     }
 
-    slideshowHistory.append(asset.id);
+    slideshowHistory.queue(asset.id);
 
     setAssetId(asset.id);
     progressBar.restart(true);
@@ -311,7 +313,7 @@
 
   const navigateAssetForward = async (e?: Event) => {
     if ($slideshowState === SlideshowState.PlaySlideshow && $slideshowShuffle) {
-      return slideshowHistory.navigateForward() || navigateAssetRandom();
+      return slideshowHistory.next() || navigateAssetRandom();
     }
 
     if ($slideshowState === SlideshowState.PlaySlideshow && assetStore && progressBar) {
@@ -329,7 +331,7 @@
 
   const navigateAssetBackward = (e?: Event) => {
     if ($slideshowState === SlideshowState.PlaySlideshow && $slideshowShuffle) {
-      slideshowHistory.navigateBackward();
+      slideshowHistory.previous();
       return;
     }
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -87,6 +87,7 @@
   let shouldShowDownloadButton = sharedLink ? sharedLink.allowDownload : !asset.isOffline;
   let shouldShowDetailButton = asset.hasMetadata;
   let canCopyImagesToClipboard: boolean;
+  let slideshowStateUnsubscribe: () => void;
   let previewStackedAsset: AssetResponseDto | undefined;
   let isShowActivity = false;
   let isLiked: ActivityResponseDto | null = null;
@@ -166,6 +167,14 @@
   onMount(async () => {
     document.addEventListener('keydown', onKeyboardPress);
 
+    slideshowStateUnsubscribe = slideshowState.subscribe((value) => {
+      if (value === SlideshowState.PlaySlideshow) {
+        handlePlaySlideshow();
+      } else if (value === SlideshowState.StopSlideshow) {
+        handleStopSlideshow();
+      }
+    });
+
     if (!sharedLink) {
       await getAllAlbums();
     }
@@ -189,19 +198,13 @@
     if (browser) {
       document.removeEventListener('keydown', onKeyboardPress);
     }
+
+    if (slideshowStateUnsubscribe) {
+      slideshowStateUnsubscribe();
+    }
   });
 
   $: asset.id && !sharedLink && getAllAlbums(); // Update the album information when the asset ID changes
-
-  $: $slideshowState,
-    (() => {
-      if ($slideshowState === SlideshowState.PlaySlideshow) {
-        handlePlaySlideshow();
-      } else if ($slideshowState === SlideshowState.StopSlideshow) {
-        handleStopSlideshow();
-      }
-    })();
-
   $: $slideshowShuffle && preload();
 
   const getAllAlbums = async () => {

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -549,7 +549,9 @@
 
   const handleStopSlideshow = async () => {
     try {
-      await document.exitFullscreen();
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      }
     } catch (error) {
       console.error('Error exiting fullscreen', error);
     } finally {

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -545,12 +545,49 @@
 <section
   id="immich-asset-viewer"
   class="fixed left-0 top-0 z-[1001] grid h-screen w-screen grid-cols-4 grid-rows-[64px_1fr] overflow-y-hidden bg-black"
-  bind:this={assetViewerHtmlElement}
 >
-  <div class="z-[1000] col-span-4 col-start-1 row-span-1 row-start-1 transition-transform">
+  <!-- Top navigation bar -->
+  {#if $slideshowState === SlideshowState.None}
+    <div class="z-[1002] col-span-4 col-start-1 row-span-1 row-start-1 transition-transform">
+      <AssetViewerNavBar
+        {asset}
+        isMotionPhotoPlaying={shouldPlayMotionPhoto}
+        showCopyButton={canCopyImagesToClipboard && asset.type === AssetTypeEnum.Image}
+        showZoomButton={asset.type === AssetTypeEnum.Image}
+        showMotionPlayButton={!!asset.livePhotoVideoId}
+        showDownloadButton={shouldShowDownloadButton}
+        showDetailButton={shouldShowDetailButton}
+        showSlideshow={!!assetStore}
+        hasStackChildern={$stackAssetsStore.length > 0}
+        on:goBack={closeViewer}
+        on:showDetail={showDetailInfoHandler}
+        on:download={() => downloadFile(asset)}
+        on:delete={trashOrDelete}
+        on:favorite={toggleFavorite}
+        on:addToAlbum={() => openAlbumPicker(false)}
+        on:addToSharedAlbum={() => openAlbumPicker(true)}
+        on:playMotionPhoto={() => (shouldPlayMotionPhoto = true)}
+        on:stopMotionPhoto={() => (shouldPlayMotionPhoto = false)}
+        on:toggleArchive={toggleArchive}
+        on:asProfileImage={() => (isShowProfileImageCrop = true)}
+        on:runJob={({ detail: job }) => handleRunJob(job)}
+        on:playSlideShow={() => ($slideshowState = SlideshowState.PlaySlideshow)}
+        on:unstack={handleUnstack}
+      />
+    </div>
+  {/if}
+
+  {#if $slideshowState === SlideshowState.None && showNavigation}
+    <div class="z-[1001] column-span-1 col-start-1 row-span-1 row-start-2 mb-[60px] justify-self-start">
+      <NavigationArea on:click={navigateAssetBackward}><Icon path={mdiChevronLeft} size="36" /></NavigationArea>
+    </div>
+  {/if}
+
+  <!-- Asset Viewer -->
+  <div class="z-[1000] relative col-start-1 col-span-4 row-start-1 row-span-full" bind:this={assetViewerHtmlElement}>
     {#if $slideshowState != SlideshowState.None}
-      <!-- SlideShowController -->
-      <div class="flex">
+      <!-- Slideshow actions bar -->
+      <div class="z-[1000] absolute w-full flex">
         <div class="m-4 flex gap-2">
           <CircleIconButton
             icon={mdiClose}
@@ -582,42 +619,8 @@
           duration={5000}
         />
       </div>
-    {:else}
-      <AssetViewerNavBar
-        {asset}
-        isMotionPhotoPlaying={shouldPlayMotionPhoto}
-        showCopyButton={canCopyImagesToClipboard && asset.type === AssetTypeEnum.Image}
-        showZoomButton={asset.type === AssetTypeEnum.Image}
-        showMotionPlayButton={!!asset.livePhotoVideoId}
-        showDownloadButton={shouldShowDownloadButton}
-        showDetailButton={shouldShowDetailButton}
-        showSlideshow={!!assetStore}
-        hasStackChildern={$stackAssetsStore.length > 0}
-        on:goBack={closeViewer}
-        on:showDetail={showDetailInfoHandler}
-        on:download={() => downloadFile(asset)}
-        on:delete={trashOrDelete}
-        on:favorite={toggleFavorite}
-        on:addToAlbum={() => openAlbumPicker(false)}
-        on:addToSharedAlbum={() => openAlbumPicker(true)}
-        on:playMotionPhoto={() => (shouldPlayMotionPhoto = true)}
-        on:stopMotionPhoto={() => (shouldPlayMotionPhoto = false)}
-        on:toggleArchive={toggleArchive}
-        on:asProfileImage={() => (isShowProfileImageCrop = true)}
-        on:runJob={({ detail: job }) => handleRunJob(job)}
-        on:playSlideShow={() => ($slideshowState = SlideshowState.PlaySlideshow)}
-        on:unstack={handleUnstack}
-      />
     {/if}
-  </div>
 
-  {#if $slideshowState === SlideshowState.None && showNavigation}
-    <div class="column-span-1 z-[999] col-start-1 row-span-1 row-start-2 mb-[60px] justify-self-start">
-      <NavigationArea on:click={navigateAssetBackward}><Icon path={mdiChevronLeft} size="36" /></NavigationArea>
-    </div>
-  {/if}
-  <!-- Asset Viewer -->
-  <div class="relative col-span-4 col-start-1 row-span-full row-start-1">
     {#if previewStackedAsset}
       {#key previewStackedAsset.id}
         {#if previewStackedAsset.type === AssetTypeEnum.Image}
@@ -726,7 +729,7 @@
   </div>
 
   {#if $slideshowState === SlideshowState.None && showNavigation}
-    <div class="z-[999] col-span-1 col-start-4 row-span-1 row-start-2 mb-[60px] justify-self-end">
+    <div class="z-[1001] col-span-1 col-start-4 row-span-1 row-start-2 mb-[60px] justify-self-end">
       <NavigationArea on:click={navigateAssetForward}><Icon path={mdiChevronRight} size="36" /></NavigationArea>
     </div>
   {/if}
@@ -735,7 +738,7 @@
     <div
       transition:fly={{ duration: 150 }}
       id="detail-panel"
-      class="z-[1002] row-start-1 row-span-5 w-[360px] overflow-y-auto bg-immich-bg transition-all dark:border-l dark:border-l-immich-dark-gray dark:bg-immich-dark-bg"
+      class="z-[1002] row-start-1 row-span-4 w-[360px] overflow-y-auto bg-immich-bg transition-all dark:border-l dark:border-l-immich-dark-gray dark:bg-immich-dark-bg"
       translate="yes"
     >
       <DetailPanel

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -28,10 +28,11 @@
   import NavigationArea from './navigation-area.svelte';
   import { browser } from '$app/environment';
   import { handleError } from '$lib/utils/handle-error';
-  import type { AssetStore } from '$lib/stores/assets.store';
+  import { BucketPosition, type AssetStore } from '$lib/stores/assets.store';
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import ProgressBar, { ProgressBarStatus } from '../shared-components/progress-bar/progress-bar.svelte';
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
+  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import {
     mdiChevronLeft,
@@ -43,6 +44,8 @@
     mdiImageBrokenVariant,
     mdiPause,
     mdiPlay,
+    mdiShuffle,
+    mdiShuffleDisabled,
   } from '@mdi/js';
   import Icon from '$lib/components/elements/icon.svelte';
   import Thumbnail from '../assets/thumbnail/thumbnail.svelte';
@@ -61,6 +64,8 @@
   export let album: AlbumResponseDto | null = null;
 
   let reactions: ActivityResponseDto[] = [];
+
+  const { slideshow, slideshowShuffle, setAssetId } = assetViewingStore;
 
   const dispatch = createEventDispatcher<{
     archived: AssetResponseDto;
@@ -187,6 +192,8 @@
   });
 
   $: asset.id && !sharedLink && getAllAlbums(); // Update the album information when the asset ID changes
+  $: $slideshow ? handlePlaySlideshow() : handleStopSlideshow();
+  $: $slideshowShuffle && preload();
 
   const getAllAlbums = async () => {
     if (api.isSharedLink) {
@@ -262,8 +269,26 @@
 
   const closeViewer = () => dispatch('close');
 
+  const navigateAssetRandom = async () => {
+    if (!assetStore) {
+      return;
+    }
+
+    const asset = assetStore.getRandomAsset();
+    if (!asset) {
+      return;
+    }
+
+    setAssetId(asset.id);
+    progressBar.restart(true);
+  };
+
   const navigateAssetForward = async (e?: Event) => {
-    if (isSlideshowMode && assetStore && progressBar) {
+    if ($slideshow && $slideshowShuffle) {
+      return navigateAssetRandom();
+    }
+
+    if ($slideshow && assetStore && progressBar) {
       const hasNext = await assetStore.getNextAssetId(asset.id);
       if (hasNext) {
         progressBar.restart(true);
@@ -277,7 +302,11 @@
   };
 
   const navigateAssetBackward = (e?: Event) => {
-    if (isSlideshowMode && progressBar) {
+    if ($slideshow && $slideshowShuffle) {
+      return navigateAssetRandom();
+    }
+
+    if ($slideshow && progressBar) {
       progressBar.restart(true);
     }
 
@@ -426,40 +455,55 @@
    * Slide show mode
    */
 
-  let isSlideshowMode = false;
   let assetViewerHtmlElement: HTMLElement;
   let progressBar: ProgressBar;
   let progressBarStatus: ProgressBarStatus;
 
   const handleVideoStarted = () => {
-    if (isSlideshowMode) {
+    if ($slideshow) {
       progressBar.restart(false);
     }
   };
 
   const handleVideoEnded = async () => {
-    if (isSlideshowMode) {
+    if ($slideshow) {
       await navigateAssetForward();
     }
   };
 
+  const preload = async () => {
+    // load all the asset buckets
+    if (assetStore && $slideshowShuffle) {
+      for (const bucket of assetStore.buckets) {
+        await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
+      }
+    }
+  };
+
   const handlePlaySlideshow = async () => {
+    if ($slideshow) {
+      return;
+    }
+
     try {
       await assetViewerHtmlElement.requestFullscreen();
     } catch (error) {
       console.error('Error entering fullscreen', error);
-    } finally {
-      isSlideshowMode = true;
+      $slideshow = false;
     }
   };
 
   const handleStopSlideshow = async () => {
+    if (!$slideshow) {
+      return;
+    }
+
     try {
       await document.exitFullscreen();
     } catch (error) {
       console.error('Error exiting fullscreen', error);
     } finally {
-      isSlideshowMode = false;
+      $slideshow = false;
       progressBar.restart(false);
     }
   };
@@ -500,11 +544,20 @@
   bind:this={assetViewerHtmlElement}
 >
   <div class="z-[1000] col-span-4 col-start-1 row-span-1 row-start-1 transition-transform">
-    {#if isSlideshowMode}
+    {#if $slideshow}
       <!-- SlideShowController -->
       <div class="flex">
         <div class="m-4 flex gap-2">
-          <CircleIconButton icon={mdiClose} on:click={handleStopSlideshow} title="Exit Slideshow" />
+          <CircleIconButton icon={mdiClose} on:click={() => ($slideshow = false)} title="Exit Slideshow" />
+          {#if $slideshowShuffle}
+            <CircleIconButton icon={mdiShuffle} on:click={() => ($slideshowShuffle = false)} title="Shuffle" />
+          {:else}
+            <CircleIconButton
+              icon={mdiShuffleDisabled}
+              on:click={() => ($slideshowShuffle = true)}
+              title="No shuffle"
+            />
+          {/if}
           <CircleIconButton
             icon={progressBarStatus === ProgressBarStatus.Paused ? mdiPlay : mdiPause}
             on:click={() => (progressBarStatus === ProgressBarStatus.Paused ? progressBar.play() : progressBar.pause())}
@@ -544,13 +597,13 @@
         on:toggleArchive={toggleArchive}
         on:asProfileImage={() => (isShowProfileImageCrop = true)}
         on:runJob={({ detail: job }) => handleRunJob(job)}
-        on:playSlideShow={handlePlaySlideshow}
+        on:playSlideShow={() => ($slideshow = true)}
         on:unstack={handleUnstack}
       />
     {/if}
   </div>
 
-  {#if !isSlideshowMode && showNavigation}
+  {#if !$slideshow && showNavigation}
     <div class="column-span-1 z-[999] col-start-1 row-span-1 row-start-2 mb-[60px] justify-self-start">
       <NavigationArea on:click={navigateAssetBackward}><Icon path={mdiChevronLeft} size="36" /></NavigationArea>
     </div>
@@ -664,15 +717,13 @@
     {/if}
   </div>
 
-  <!-- Stack & Stack Controller -->
-
-  {#if !isSlideshowMode && showNavigation}
+  {#if !$slideshow && showNavigation}
     <div class="z-[999] col-span-1 col-start-4 row-span-1 row-start-2 mb-[60px] justify-self-end">
       <NavigationArea on:click={navigateAssetForward}><Icon path={mdiChevronRight} size="36" /></NavigationArea>
     </div>
   {/if}
 
-  {#if !isSlideshowMode && $isShowDetail}
+  {#if !$slideshow && $isShowDetail}
     <div
       transition:fly={{ duration: 150 }}
       id="detail-panel"

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -205,7 +205,6 @@
   });
 
   $: asset.id && !sharedLink && getAllAlbums(); // Update the album information when the asset ID changes
-  $: $slideshowShuffle && preload();
 
   const getAllAlbums = async () => {
     if (api.isSharedLink) {
@@ -286,7 +285,7 @@
       return;
     }
 
-    const asset = assetStore.getRandomAsset();
+    const asset = await assetStore.getRandomAsset();
     if (!asset) {
       return;
     }
@@ -480,15 +479,6 @@
   const handleVideoEnded = async () => {
     if ($slideshowState === SlideshowState.PlaySlideshow) {
       await navigateAssetForward();
-    }
-  };
-
-  const preload = async () => {
-    // load all the asset buckets
-    if (assetStore && $slideshowShuffle) {
-      for (const bucket of assetStore.buckets) {
-        await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
-      }
     }
   };
 

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
+  import ProgressBar, { ProgressBarStatus } from '../shared-components/progress-bar/progress-bar.svelte';
+  import { slideshowStore } from '$lib/stores/slideshow.store';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import {
+    mdiChevronLeft,
+    mdiChevronRight,
+    mdiClose,
+    mdiPause,
+    mdiPlay,
+    mdiShuffle,
+    mdiShuffleDisabled,
+  } from '@mdi/js';
+
+  const { slideshowShuffle } = slideshowStore;
+  const { restartProgress, stopProgress } = slideshowStore;
+
+  let progressBarStatus: ProgressBarStatus;
+  let progressBar: ProgressBar;
+
+  let unsubscribeRestart: () => void;
+  let unsubscribeStop: () => void;
+
+  const dispatch = createEventDispatcher<{
+    next: void;
+    prev: void;
+    close: void;
+  }>();
+
+  onMount(() => {
+    unsubscribeRestart = restartProgress.subscribe((value) => {
+      if (value) {
+        progressBar.restart(value);
+      }
+    });
+
+    unsubscribeStop = stopProgress.subscribe((value) => {
+      if (value) {
+        progressBar.restart(false);
+      }
+    });
+  });
+
+  onDestroy(() => {
+    if (unsubscribeRestart) {
+      unsubscribeRestart();
+    }
+
+    if (unsubscribeStop) {
+      unsubscribeStop();
+    }
+  });
+</script>
+
+<div class="m-4 flex gap-2">
+  <CircleIconButton icon={mdiClose} on:click={() => dispatch('close')} title="Exit Slideshow" />
+  {#if $slideshowShuffle}
+    <CircleIconButton icon={mdiShuffle} on:click={() => ($slideshowShuffle = false)} title="Shuffle" />
+  {:else}
+    <CircleIconButton icon={mdiShuffleDisabled} on:click={() => ($slideshowShuffle = true)} title="No shuffle" />
+  {/if}
+  <CircleIconButton
+    icon={progressBarStatus === ProgressBarStatus.Paused ? mdiPlay : mdiPause}
+    on:click={() => (progressBarStatus === ProgressBarStatus.Paused ? progressBar.play() : progressBar.pause())}
+    title={progressBarStatus === ProgressBarStatus.Paused ? 'Play' : 'Pause'}
+  />
+  <CircleIconButton icon={mdiChevronLeft} on:click={() => dispatch('prev')} title="Previous" />
+  <CircleIconButton icon={mdiChevronRight} on:click={() => dispatch('next')} title="Next" />
+</div>
+
+<ProgressBar
+  autoplay
+  bind:this={progressBar}
+  bind:status={progressBarStatus}
+  on:done={() => dispatch('next')}
+  duration={5000}
+/>

--- a/web/src/lib/stores/asset-viewing.store.ts
+++ b/web/src/lib/stores/asset-viewing.store.ts
@@ -1,19 +1,9 @@
 import { writable } from 'svelte/store';
 import { api, type AssetResponseDto } from '@api';
-import { persisted } from 'svelte-local-storage-store';
-
-export enum SlideshowState {
-  PlaySlideshow = 'play-slideshow',
-  StopSlideshow = 'stop-slideshow',
-  None = 'none',
-}
 
 function createAssetViewingStore() {
   const viewingAssetStoreState = writable<AssetResponseDto>();
   const viewState = writable<boolean>(false);
-
-  const slideshowShuffle = persisted<boolean>('slideshow-shuffle', true);
-  const slideshowState = writable<SlideshowState>(SlideshowState.None);
 
   const setAssetId = async (id: string) => {
     const { data } = await api.assetApi.getAssetById({ id, key: api.getKey() });
@@ -35,8 +25,6 @@ function createAssetViewingStore() {
     },
     setAssetId,
     showAssetViewer,
-    slideshowShuffle,
-    slideshowState,
   };
 }
 

--- a/web/src/lib/stores/asset-viewing.store.ts
+++ b/web/src/lib/stores/asset-viewing.store.ts
@@ -1,9 +1,12 @@
 import { writable } from 'svelte/store';
 import { api, type AssetResponseDto } from '@api';
+import { persisted } from 'svelte-local-storage-store';
 
 function createAssetViewingStore() {
   const viewingAssetStoreState = writable<AssetResponseDto>();
   const viewState = writable<boolean>(false);
+  const slideshow = writable<boolean>(false);
+  const slideshowShuffle = persisted<boolean>('slideshow-shuffle', true);
 
   const setAssetId = async (id: string) => {
     const { data } = await api.assetApi.getAssetById({ id, key: api.getKey() });
@@ -25,6 +28,8 @@ function createAssetViewingStore() {
     },
     setAssetId,
     showAssetViewer,
+    slideshow,
+    slideshowShuffle,
   };
 }
 

--- a/web/src/lib/stores/asset-viewing.store.ts
+++ b/web/src/lib/stores/asset-viewing.store.ts
@@ -2,11 +2,18 @@ import { writable } from 'svelte/store';
 import { api, type AssetResponseDto } from '@api';
 import { persisted } from 'svelte-local-storage-store';
 
+export enum SlideshowState {
+  PlaySlideshow = 'play-slideshow',
+  StopSlideshow = 'stop-slideshow',
+  None = 'none',
+}
+
 function createAssetViewingStore() {
   const viewingAssetStoreState = writable<AssetResponseDto>();
   const viewState = writable<boolean>(false);
-  const slideshow = writable<boolean>(false);
+
   const slideshowShuffle = persisted<boolean>('slideshow-shuffle', true);
+  const slideshowState = writable<SlideshowState>(SlideshowState.None);
 
   const setAssetId = async (id: string) => {
     const { data } = await api.assetApi.getAssetById({ id, key: api.getKey() });
@@ -28,8 +35,8 @@ function createAssetViewingStore() {
     },
     setAssetId,
     showAssetViewer,
-    slideshow,
     slideshowShuffle,
+    slideshowState,
   };
 }
 

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -304,6 +304,10 @@ export class AssetStore {
     return this.assetToBucket[assetId]?.bucketIndex ?? null;
   }
 
+  getRandomAsset(): AssetResponseDto | null {
+    return this.assets[Math.floor(Math.random() * this.assets.length)] || null;
+  }
+
   updateAsset(_asset: AssetResponseDto) {
     const asset = this.assets.find((asset) => asset.id === _asset.id);
     if (!asset) {

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -304,8 +304,17 @@ export class AssetStore {
     return this.assetToBucket[assetId]?.bucketIndex ?? null;
   }
 
-  getRandomAsset(): AssetResponseDto | null {
-    return this.assets[Math.floor(Math.random() * this.assets.length)] || null;
+  async getRandomAsset(): Promise<AssetResponseDto | null> {
+    const bucket = this.buckets[Math.floor(Math.random() * this.buckets.length)] || null;
+    if (!bucket) {
+      return null;
+    }
+
+    if (bucket.assets.length === 0) {
+      await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
+    }
+
+    return bucket.assets[Math.floor(Math.random() * bucket.assets.length)] || null;
   }
 
   updateAsset(_asset: AssetResponseDto) {

--- a/web/src/lib/stores/slideshow.store.ts
+++ b/web/src/lib/stores/slideshow.store.ts
@@ -18,8 +18,8 @@ function createSlideshowStore() {
     restartProgress: {
       subscribe: restartState.subscribe,
       set: (value: boolean) => {
-        // Trigger an action whenever the restart is set to true. Automatically
-        // reset the stop state after that
+        // Trigger an action whenever the restartProgress is set to true. Automatically
+        // reset the restart state after that
         if (value) {
           restartState.set(true);
           restartState.set(false);
@@ -29,7 +29,7 @@ function createSlideshowStore() {
     stopProgress: {
       subscribe: stopState.subscribe,
       set: (value: boolean) => {
-        // Trigger an action whenever the stop is set to true. Automatically
+        // Trigger an action whenever the stopProgress is set to true. Automatically
         // reset the stop state after that
         if (value) {
           stopState.set(true);

--- a/web/src/lib/stores/slideshow.store.ts
+++ b/web/src/lib/stores/slideshow.store.ts
@@ -1,0 +1,45 @@
+import { persisted } from 'svelte-local-storage-store';
+import { writable } from 'svelte/store';
+
+export enum SlideshowState {
+  PlaySlideshow = 'play-slideshow',
+  StopSlideshow = 'stop-slideshow',
+  None = 'none',
+}
+
+function createSlideshowStore() {
+  const restartState = writable<boolean>(false);
+  const stopState = writable<boolean>(false);
+
+  const slideshowShuffle = persisted<boolean>('slideshow-shuffle', true);
+  const slideshowState = writable<SlideshowState>(SlideshowState.None);
+
+  return {
+    restartProgress: {
+      subscribe: restartState.subscribe,
+      set: (value: boolean) => {
+        // Trigger an action whenever the restart is set to true. Automatically
+        // reset the stop state after that
+        if (value) {
+          restartState.set(true);
+          restartState.set(false);
+        }
+      },
+    },
+    stopProgress: {
+      subscribe: stopState.subscribe,
+      set: (value: boolean) => {
+        // Trigger an action whenever the stop is set to true. Automatically
+        // reset the stop state after that
+        if (value) {
+          stopState.set(true);
+          stopState.set(false);
+        }
+      },
+    },
+    slideshowShuffle,
+    slideshowState,
+  };
+}
+
+export const slideshowStore = createSlideshowStore();

--- a/web/src/lib/utils/slideshow-history.ts
+++ b/web/src/lib/utils/slideshow-history.ts
@@ -1,0 +1,40 @@
+export class SlideshowHistory {
+  private slideshowHistory: string[] = [];
+  private slideshowHistoryIndex = 0;
+
+  constructor(private onNavigate: (assetId: string) => void) {}
+
+  reset = (assetId: string) => {
+    this.slideshowHistory = [assetId];
+    this.slideshowHistoryIndex = 0;
+  };
+
+  append = (assetId: string) => {
+    this.slideshowHistory.push(assetId);
+
+    // If we were at the end of the slideshow history, move the index to the new end
+    if (this.slideshowHistoryIndex === this.slideshowHistory.length - 2) {
+      this.slideshowHistoryIndex++;
+    }
+  };
+
+  navigateForward = (): boolean => {
+    if (this.slideshowHistoryIndex === this.slideshowHistory.length - 1) {
+      return false;
+    }
+
+    this.slideshowHistoryIndex++;
+    this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
+    return true;
+  };
+
+  navigateBackward = (): boolean => {
+    if (this.slideshowHistoryIndex === 0) {
+      return false;
+    }
+
+    this.slideshowHistoryIndex--;
+    this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
+    return true;
+  };
+}

--- a/web/src/lib/utils/slideshow-history.ts
+++ b/web/src/lib/utils/slideshow-history.ts
@@ -1,40 +1,40 @@
 export class SlideshowHistory {
-  private slideshowHistory: string[] = [];
-  private slideshowHistoryIndex = 0;
+  private history: string[] = [];
+  private index = 0;
 
-  constructor(private onNavigate: (assetId: string) => void) {}
+  constructor(private onChange: (assetId: string) => void) {}
 
-  reset(assetId: string) {
-    this.slideshowHistory = [assetId];
-    this.slideshowHistoryIndex = 0;
+  reset() {
+    this.history = [];
+    this.index = 0;
   }
 
-  append(assetId: string) {
-    this.slideshowHistory.push(assetId);
+  queue(assetId: string) {
+    this.history.push(assetId);
 
     // If we were at the end of the slideshow history, move the index to the new end
-    if (this.slideshowHistoryIndex === this.slideshowHistory.length - 2) {
-      this.slideshowHistoryIndex++;
+    if (this.index === this.history.length - 2) {
+      this.index++;
     }
   }
 
-  navigateForward(): boolean {
-    if (this.slideshowHistoryIndex === this.slideshowHistory.length - 1) {
+  next(): boolean {
+    if (this.index === this.history.length - 1) {
       return false;
     }
 
-    this.slideshowHistoryIndex++;
-    this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
+    this.index++;
+    this.onChange(this.history[this.index]);
     return true;
   }
 
-  navigateBackward(): boolean {
-    if (this.slideshowHistoryIndex === 0) {
+  previous(): boolean {
+    if (this.index === 0) {
       return false;
     }
 
-    this.slideshowHistoryIndex--;
-    this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
+    this.index--;
+    this.onChange(this.history[this.index]);
     return true;
   }
 }

--- a/web/src/lib/utils/slideshow-history.ts
+++ b/web/src/lib/utils/slideshow-history.ts
@@ -4,21 +4,21 @@ export class SlideshowHistory {
 
   constructor(private onNavigate: (assetId: string) => void) {}
 
-  reset = (assetId: string) => {
+  reset(assetId: string) {
     this.slideshowHistory = [assetId];
     this.slideshowHistoryIndex = 0;
-  };
+  }
 
-  append = (assetId: string) => {
+  append(assetId: string) {
     this.slideshowHistory.push(assetId);
 
     // If we were at the end of the slideshow history, move the index to the new end
     if (this.slideshowHistoryIndex === this.slideshowHistory.length - 2) {
       this.slideshowHistoryIndex++;
     }
-  };
+  }
 
-  navigateForward = (): boolean => {
+  navigateForward(): boolean {
     if (this.slideshowHistoryIndex === this.slideshowHistory.length - 1) {
       return false;
     }
@@ -26,9 +26,9 @@ export class SlideshowHistory {
     this.slideshowHistoryIndex++;
     this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
     return true;
-  };
+  }
 
-  navigateBackward = (): boolean => {
+  navigateBackward(): boolean {
     if (this.slideshowHistoryIndex === 0) {
       return false;
     }
@@ -36,5 +36,5 @@ export class SlideshowHistory {
     this.slideshowHistoryIndex--;
     this.onNavigate(this.slideshowHistory[this.slideshowHistoryIndex]);
     return true;
-  };
+  }
 }

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -28,7 +28,7 @@
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
   import { AppRoute, dateFormats } from '$lib/constants';
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
-  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { SlideshowState, assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { AssetStore } from '$lib/stores/assets.store';
   import { locale } from '$lib/stores/preferences.store';
   import { downloadArchive } from '$lib/utils/asset-utils';
@@ -52,7 +52,7 @@
 
   export let data: PageData;
 
-  let { isViewing: showAssetViewer, setAssetId, slideshow, slideshowShuffle } = assetViewingStore;
+  let { isViewing: showAssetViewer, setAssetId, slideshowState, slideshowShuffle } = assetViewingStore;
 
   let album = data.album;
   $: album = data.album;
@@ -112,7 +112,7 @@
     const asset = $slideshowShuffle ? assetStore.getRandomAsset() : assetStore.assets[0];
     if (asset) {
       setAssetId(asset.id);
-      $slideshow = true;
+      $slideshowState = SlideshowState.PlaySlideshow;
     }
   };
 

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -52,7 +52,7 @@
 
   export let data: PageData;
 
-  let { isViewing: showAssetViewer } = assetViewingStore;
+  let { isViewing: showAssetViewer, setAssetId, slideshow, slideshowShuffle } = assetViewingStore;
 
   let album = data.album;
   $: album = data.album;
@@ -107,6 +107,14 @@
       isCreatingSharedAlbum = true;
     }
   });
+
+  const handleStartSlideshow = () => {
+    const asset = $slideshowShuffle ? assetStore.getRandomAsset() : assetStore.assets[0];
+    if (asset) {
+      setAssetId(asset.id);
+      $slideshow = true;
+    }
+  };
 
   const handleEscape = () => {
     if (viewMode === ViewMode.SELECT_USERS) {
@@ -365,6 +373,9 @@
                 <CircleIconButton title="Album options" on:click={handleOpenAlbumOptions} icon={mdiDotsVertical}>
                   {#if viewMode === ViewMode.ALBUM_OPTIONS}
                     <ContextMenu {...contextMenuPosition}>
+                      {#if album.assetCount !== 0}
+                        <MenuOption on:click={handleStartSlideshow} text="Slideshow" />
+                      {/if}
                       <MenuOption on:click={() => (viewMode = ViewMode.SELECT_THUMBNAIL)} text="Set album cover" />
                     </ContextMenu>
                   {/if}

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -28,7 +28,8 @@
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
   import { AppRoute, dateFormats } from '$lib/constants';
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
-  import { SlideshowState, assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
   import { AssetStore } from '$lib/stores/assets.store';
   import { locale } from '$lib/stores/preferences.store';
   import { downloadArchive } from '$lib/utils/asset-utils';
@@ -52,7 +53,8 @@
 
   export let data: PageData;
 
-  let { isViewing: showAssetViewer, setAssetId, slideshowState, slideshowShuffle } = assetViewingStore;
+  let { isViewing: showAssetViewer, setAssetId } = assetViewingStore;
+  let { slideshowState, slideshowShuffle } = slideshowStore;
 
   let album = data.album;
   $: album = data.album;

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -108,8 +108,8 @@
     }
   });
 
-  const handleStartSlideshow = () => {
-    const asset = $slideshowShuffle ? assetStore.getRandomAsset() : assetStore.assets[0];
+  const handleStartSlideshow = async () => {
+    const asset = $slideshowShuffle ? await assetStore.getRandomAsset() : assetStore.assets[0];
     if (asset) {
       setAssetId(asset.id);
       $slideshowState = SlideshowState.PlaySlideshow;


### PR DESCRIPTION
Add an option to randomize (shuffle) the order of the pictures in the slideshow:

![image](https://github.com/immich-app/immich/assets/4334196/b481f042-a9a5-4746-939b-f4363916747d)
![image](https://github.com/immich-app/immich/assets/4334196/c07918bf-dfe1-4598-80c3-98a7e5cba307)

Add an option to launch the slideshow from the album options:

![image](https://github.com/immich-app/immich/assets/4334196/26e8f3a2-eb75-4ecf-9d32-6e86be750c7d)

I would love to have the shuffle button be different colors to indicate if it is active or not, but the circle button doesn't support anything like that right now.