### PR TITLE
feat(web): focus search bar input when using explore shortcut "/"

### DIFF
--- a/web/src/lib/components/layouts/user-page-layout.svelte
+++ b/web/src/lib/components/layouts/user-page-layout.svelte
@@ -8,13 +8,25 @@
   export let showUploadButton = false;
   export let title: string | undefined = undefined;
   export let scrollbar = true;
+  export function focusSearchInput() {
+    if (navigationBar) {
+      navigationBar.focusSearchInput();
+    }
+  }
+
+  let navigationBar: NavigationBar;
 
   $: scrollbarClass = scrollbar ? 'immich-scrollbar p-4 pb-8' : 'scrollbar-hidden pl-4';
 </script>
 
 <header>
   {#if !hideNavbar}
-    <NavigationBar {user} {showUploadButton} on:uploadClicked={() => openFileUploadDialog()} />
+    <NavigationBar
+      {user}
+      {showUploadButton}
+      on:uploadClicked={() => openFileUploadDialog()}
+      bind:this={navigationBar}
+    />
   {/if}
 
   <slot name="header" />

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -18,6 +18,7 @@
   import ShowShortcuts from '../shared-components/show-shortcuts.svelte';
   import AssetDateGroup from './asset-date-group.svelte';
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
+  import { fromShortcut } from '$lib/stores/explore.store';
 
   export let isSelectionMode = false;
   export let singleSelect = false;
@@ -72,6 +73,7 @@
           return;
         case '/':
           event.preventDefault();
+          $fromShortcut = true;
           goto(AppRoute.EXPLORE);
           return;
       }

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -19,9 +19,15 @@
   import { featureFlags } from '$lib/stores/server-config.store';
   export let user: UserResponseDto;
   export let showUploadButton = true;
+  export function focusSearchInput() {
+    if (searchBar) {
+      searchBar.focus();
+    }
+  }
 
   let shouldShowAccountInfo = false;
   let shouldShowAccountInfoPanel = false;
+  let searchBar: SearchBar;
 
   const dispatch = createEventDispatcher();
 
@@ -47,7 +53,7 @@
     <div class="flex justify-between gap-16 pr-6">
       <div class="hidden w-full max-w-5xl flex-1 pl-4 sm:block">
         {#if $featureFlags.search}
-          <SearchBar grayTheme={true} />
+          <SearchBar grayTheme={true} bind:this={searchBar} />
         {/if}
       </div>
 

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -8,6 +8,11 @@
   import { clickOutside } from '$lib/utils/click-outside';
   export let value = '';
   export let grayTheme: boolean;
+  export function focus() {
+    // since onFocusIn is bound to the click event, we need to trigger it manually
+    input.click();
+    input.focus();
+  }
 
   let input: HTMLInputElement;
 

--- a/web/src/lib/stores/explore.store.ts
+++ b/web/src/lib/stores/explore.store.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const fromShortcut = writable(false);

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -10,8 +10,12 @@
   import PlayCircleOutline from 'svelte-material-icons/PlayCircleOutline.svelte';
   import Rotate360Icon from 'svelte-material-icons/Rotate360.svelte';
   import type { PageData } from './$types';
+  import { onMount } from 'svelte';
+  import { fromShortcut } from '$lib/stores/explore.store';
 
   export let data: PageData;
+
+  let pageLayout: UserPageLayout;
 
   enum Field {
     CITY = 'exifInfo.city',
@@ -29,9 +33,16 @@
   $: places = getFieldItems(data.items, Field.CITY);
   $: people = data.response.people.slice(0, MAX_ITEMS);
   $: hasPeople = data.response.total > 0;
+
+  onMount(async () => {
+    if ($fromShortcut) {
+      $fromShortcut = false;
+      pageLayout.focusSearchInput();
+    }
+  });
 </script>
 
-<UserPageLayout user={data.user} title={data.meta.title}>
+<UserPageLayout user={data.user} title={data.meta.title} bind:this={pageLayout}>
   {#if hasPeople}
     <div class="mb-6 mt-2">
       <div class="flex justify-between">


### PR DESCRIPTION
This PR will focus the search bar when using the explore (actually search) shortcut as in Google Photos.

The code needs a serious review because I have little to no experience with Svelte - I started exploring it with Immich - and I don't know if this is the right approach.
Mainly it's about communicating from asset-grid (which receives the keydown event) to search-bar which involves traversing the component tree in a weird way. Maybe there should be some refactoring, i.e. "global" shortcuts like this one should be handled in a proper parent (very high in the tree) component?
If someone would point me to the right direction I'll be glad to implement this in a different way.

### How was this tested?

- [x] clicking "Explore" link normally does not focus the search bar
- [x] typing "/" from an asset grid will focus the search bar after navigating into the explore page