### PR TITLE
feat(web): version links to releases page

### DIFF
--- a/web/src/lib/components/shared-components/status-box.svelte
+++ b/web/src/lib/components/shared-components/status-box.svelte
@@ -97,9 +97,12 @@
 
       <div class="mt-2 flex justify-between justify-items-center">
         <p>Version</p>
-        <p class="font-medium text-immich-primary dark:text-immich-dark-primary">
+        <a
+          href="https://github.com/immich-app/immich/releases"
+          class="font-medium text-immich-primary dark:text-immich-dark-primary"
+        >
           {serverVersion}
-        </p>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Clicking on the version in the sidebar links to https://github.com/immich-app/immich/releases.

Thanks for having the idea in #4287!