### PR TITLE
chore(server): bump exiftool-vendored to 23.1.0

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -28,7 +28,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
-        "exiftool-vendored": "~22.2.3",
+        "exiftool-vendored": "~23.1.0",
         "exiftool-vendored.pl": "~12.65.0",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^7.0.7",
@@ -6825,25 +6825,25 @@
       }
     },
     "node_modules/exiftool-vendored": {
-      "version": "22.2.3",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-22.2.3.tgz",
-      "integrity": "sha512-kEHMlP9y30CSiOgVYoBtsoNNv96C5dejuUE0T/fgiEMlLJCOQfBlcx2ZHQq8lZyoT7gLRQOYRaFmrbT+guDuUg==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-23.1.0.tgz",
+      "integrity": "sha512-sZ1OUpvAWbUCCoidMMKDTTJ3hHE3mHxb4ihWKmta/eQYYMR54Mssp6+Nf7HoFvY//nX5YK2VCOGVexGGuhM8Bw==",
       "dependencies": {
         "@photostructure/tz-lookup": "^8.0.0",
         "@types/luxon": "^3.3.2",
         "batch-cluster": "^12.1.0",
         "he": "^1.2.0",
-        "luxon": "^3.4.2"
+        "luxon": "^3.4.3"
       },
       "optionalDependencies": {
-        "exiftool-vendored.exe": "12.65.0",
-        "exiftool-vendored.pl": "12.65.0"
+        "exiftool-vendored.exe": "12.67.0",
+        "exiftool-vendored.pl": "12.67.0"
       }
     },
     "node_modules/exiftool-vendored.exe": {
-      "version": "12.65.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.65.0.tgz",
-      "integrity": "sha512-VDTSW3/u5bdLlg516g1oTypq2Sxd3I2pWTzdd5EmDtSjmvvBCLyDlMpv4Gnz8dnlQTRsEqwIgv/TAtdWykwEBg==",
+      "version": "12.67.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.67.0.tgz",
+      "integrity": "sha512-wzgMDoL/VWH34l38g22cVUn43mVFtTSVj0HRjfjR46+4fGwpSvSueeYbwLCZ5NvBAVINCS5Rz9Rl2DVmqoIjsw==",
       "optional": true,
       "os": [
         "win32"
@@ -6853,6 +6853,15 @@
       "version": "12.65.0",
       "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.65.0.tgz",
       "integrity": "sha512-BpR+rwKLWqUAPbsW17fw+8FAmyijkMhjaLu3fWU2QX6rpBJnOfn+lQp4Txkq44avL1LDV+eQ8pbWXyimjkPw0Q==",
+      "os": [
+        "!win32"
+      ]
+    },
+    "node_modules/exiftool-vendored/node_modules/exiftool-vendored.pl": {
+      "version": "12.67.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.67.0.tgz",
+      "integrity": "sha512-Jvjkv4Cad+Bnp/4PuLEhO2BSpKy0MBccmq8if/H8V2ykssZrpUh8DRwEJkONnsaNX7dqKfObbOFig3vwoDyXsA==",
+      "optional": true,
       "os": [
         "!win32"
       ]
@@ -19191,23 +19200,31 @@
       }
     },
     "exiftool-vendored": {
-      "version": "22.2.3",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-22.2.3.tgz",
-      "integrity": "sha512-kEHMlP9y30CSiOgVYoBtsoNNv96C5dejuUE0T/fgiEMlLJCOQfBlcx2ZHQq8lZyoT7gLRQOYRaFmrbT+guDuUg==",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-23.1.0.tgz",
+      "integrity": "sha512-sZ1OUpvAWbUCCoidMMKDTTJ3hHE3mHxb4ihWKmta/eQYYMR54Mssp6+Nf7HoFvY//nX5YK2VCOGVexGGuhM8Bw==",
       "requires": {
         "@photostructure/tz-lookup": "^8.0.0",
         "@types/luxon": "^3.3.2",
         "batch-cluster": "^12.1.0",
-        "exiftool-vendored.exe": "12.65.0",
-        "exiftool-vendored.pl": "12.65.0",
+        "exiftool-vendored.exe": "12.67.0",
+        "exiftool-vendored.pl": "12.67.0",
         "he": "^1.2.0",
-        "luxon": "^3.4.2"
+        "luxon": "^3.4.3"
+      },
+      "dependencies": {
+        "exiftool-vendored.pl": {
+          "version": "12.67.0",
+          "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.67.0.tgz",
+          "integrity": "sha512-Jvjkv4Cad+Bnp/4PuLEhO2BSpKy0MBccmq8if/H8V2ykssZrpUh8DRwEJkONnsaNX7dqKfObbOFig3vwoDyXsA==",
+          "optional": true
+        }
       }
     },
     "exiftool-vendored.exe": {
-      "version": "12.65.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.65.0.tgz",
-      "integrity": "sha512-VDTSW3/u5bdLlg516g1oTypq2Sxd3I2pWTzdd5EmDtSjmvvBCLyDlMpv4Gnz8dnlQTRsEqwIgv/TAtdWykwEBg==",
+      "version": "12.67.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.67.0.tgz",
+      "integrity": "sha512-wzgMDoL/VWH34l38g22cVUn43mVFtTSVj0HRjfjR46+4fGwpSvSueeYbwLCZ5NvBAVINCS5Rz9Rl2DVmqoIjsw==",
       "optional": true
     },
     "exiftool-vendored.pl": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -29,7 +29,7 @@
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
         "exiftool-vendored": "~23.1.0",
-        "exiftool-vendored.pl": "~12.65.0",
+        "exiftool-vendored.pl": "12.67",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^7.0.7",
         "glob": "^10.3.3",
@@ -6850,18 +6850,9 @@
       ]
     },
     "node_modules/exiftool-vendored.pl": {
-      "version": "12.65.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.65.0.tgz",
-      "integrity": "sha512-BpR+rwKLWqUAPbsW17fw+8FAmyijkMhjaLu3fWU2QX6rpBJnOfn+lQp4Txkq44avL1LDV+eQ8pbWXyimjkPw0Q==",
-      "os": [
-        "!win32"
-      ]
-    },
-    "node_modules/exiftool-vendored/node_modules/exiftool-vendored.pl": {
       "version": "12.67.0",
       "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.67.0.tgz",
       "integrity": "sha512-Jvjkv4Cad+Bnp/4PuLEhO2BSpKy0MBccmq8if/H8V2ykssZrpUh8DRwEJkONnsaNX7dqKfObbOFig3vwoDyXsA==",
-      "optional": true,
       "os": [
         "!win32"
       ]
@@ -19211,14 +19202,6 @@
         "exiftool-vendored.pl": "12.67.0",
         "he": "^1.2.0",
         "luxon": "^3.4.3"
-      },
-      "dependencies": {
-        "exiftool-vendored.pl": {
-          "version": "12.67.0",
-          "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.67.0.tgz",
-          "integrity": "sha512-Jvjkv4Cad+Bnp/4PuLEhO2BSpKy0MBccmq8if/H8V2ykssZrpUh8DRwEJkONnsaNX7dqKfObbOFig3vwoDyXsA==",
-          "optional": true
-        }
       }
     },
     "exiftool-vendored.exe": {
@@ -19228,9 +19211,9 @@
       "optional": true
     },
     "exiftool-vendored.pl": {
-      "version": "12.65.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.65.0.tgz",
-      "integrity": "sha512-BpR+rwKLWqUAPbsW17fw+8FAmyijkMhjaLu3fWU2QX6rpBJnOfn+lQp4Txkq44avL1LDV+eQ8pbWXyimjkPw0Q=="
+      "version": "12.67.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.67.0.tgz",
+      "integrity": "sha512-Jvjkv4Cad+Bnp/4PuLEhO2BSpKy0MBccmq8if/H8V2ykssZrpUh8DRwEJkONnsaNX7dqKfObbOFig3vwoDyXsA=="
     },
     "exit": {
       "version": "0.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -58,7 +58,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
-    "exiftool-vendored": "~22.2.3",
+    "exiftool-vendored": "~23.1.3",
     "exiftool-vendored.pl": "~12.65.0",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^7.0.7",

--- a/server/package.json
+++ b/server/package.json
@@ -58,7 +58,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
-    "exiftool-vendored": "~23.1.3",
+    "exiftool-vendored": "~23.1.0",
     "exiftool-vendored.pl": "~12.65.0",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^7.0.7",

--- a/server/package.json
+++ b/server/package.json
@@ -59,7 +59,7 @@
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
     "exiftool-vendored": "~23.1.0",
-    "exiftool-vendored.pl": "~12.65.0",
+    "exiftool-vendored.pl": "12.67",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^7.0.7",
     "glob": "^10.3.3",


### PR DESCRIPTION
Use the latest release of exiftool-vendored that fixes a bug we ran into that displayed incorrect timezones: https://github.com/photostructure/exiftool-vendored.js/issues/157

Before PR:
![image](https://github.com/immich-app/immich/assets/135728/5f341f19-d33d-40dc-8120-fccbaee10b2c)

After PR:
![image](https://github.com/immich-app/immich/assets/135728/17d306ef-c0d6-4c16-a45c-5c5750286779)

