### PR TITLE
chore(server,web): bump node version to 20.8

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm@sha256:c85dc4392f44f5de1d0d72dd20a088a542734445f99bed7aa8ac895c706d370d as builder
+FROM node:20.8-bookworm as builder
 
 WORKDIR /usr/src/app
 
@@ -29,7 +29,7 @@ FROM builder as prod
 RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 
-FROM node:18-bookworm-slim@sha256:a0cca98f2896135d4c0386922211c1f90f98f27a58b8f2c07850d0fbe1c2104e
+FROM node:20.8-bookworm
 
 ENV NODE_ENV=production
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Our Node base image
-FROM node:20.8-alpine3.18@sha256:9036ddb8252ba7089c2c83eb2b0dcaf74ff1069e8ddf86fe2bd6dc5fecc9492d as base
+FROM node:20.8-alpine3.18 as base
 
 WORKDIR /usr/src/app
 EXPOSE 3000

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Our Node base image
-FROM node:18.16.0-alpine3.18@sha256:9036ddb8252ba7089c2c83eb2b0dcaf74ff1069e8ddf86fe2bd6dc5fecc9492d as base
+FROM node:20.8-alpine3.18@sha256:9036ddb8252ba7089c2c83eb2b0dcaf74ff1069e8ddf86fe2bd6dc5fecc9492d as base
 
 WORKDIR /usr/src/app
 EXPOSE 3000


### PR DESCRIPTION
Upgrade node from 18 to 20.8.

Importantly, version 20.8 will be able to run e2e testing without segfaults.

I've tested this manually by uploading images, browsing around etc.