### PR TITLE
Fix incorrect hash value

### DIFF
--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -231,7 +231,7 @@ export class LibraryService {
 
     const deviceAssetId = `${basename(assetPath)}`.replace(/\s+/g, '');
 
-    const pathHash = this.cryptoRepository.hashSha1(`path:${assetPath}`);
+    const pathHash = await this.cryptoRepository.hashFile(assetPath);
 
     let assetId;
     if (doImport) {


### PR DESCRIPTION
`hashSha1` is just a hash of the path string.
`hashFile` should be used to generate the correct hash value.