### PR TITLE
Remove /etc/timezone volume mount from compose

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,7 +13,6 @@ services:
       - ../server:/usr/src/app
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /usr/src/app/node_modules
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
       - 3001:3001
@@ -42,7 +41,6 @@ services:
       - ../server:/usr/src/app
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /usr/src/app/node_modules
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -10,7 +10,6 @@ services:
     command: ["./start-server.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
@@ -44,7 +43,6 @@ services:
     command: ["./start-microservices.sh"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     command: ["start.sh", "immich"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
@@ -26,7 +25,6 @@ services:
     command: ["start.sh", "microservices"]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-      - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env


### PR DESCRIPTION
Removing /etc/timezone from server and microservices services in docker compose still allows all Linux systems to pass through the host timezone without causing errors on non debian systems.

Fixes #4333