### PR TITLE
fix: open external link in new tab

### DIFF
--- a/web/src/lib/components/shared-components/status-box.svelte
+++ b/web/src/lib/components/shared-components/status-box.svelte
@@ -100,6 +100,7 @@
         <a
           href="https://github.com/immich-app/immich/releases"
           class="font-medium text-immich-primary dark:text-immich-dark-primary"
+          target="_blank"
         >
           {serverVersion}
         </a>


### PR DESCRIPTION
Following up on [my own suggestion](https://github.com/immich-app/immich/commit/8d5e782fc47af63dcce75ed124008a5992356bfe#r128810810) :-)

Rationale: external links should be opened in a separate browser context. I believe it's a good UX practice in general.