### PR TITLE
fix(server): use fileCreatedAt in bucket calculation

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -474,7 +474,7 @@ export class AssetRepository implements IAssetRepository {
   getByTimeBucket(timeBucket: string, options: TimeBucketOptions): Promise<AssetEntity[]> {
     const truncateValue = truncateMap[options.size];
     return this.getBuilder(options)
-      .andWhere(`date_trunc('${truncateValue}', "localDateTime") = :timeBucket`, { timeBucket })
+      .andWhere(`date_trunc('${truncateValue}', "fileCreatedAt") = :timeBucket`, { timeBucket })
       .orderBy(`date_trunc('day', "localDateTime")`, 'DESC')
       .addOrderBy('asset.fileCreatedAt', 'DESC')
       .getMany();


### PR DESCRIPTION
This is a minor fix that uses fileCreatedAt when computing time buckets. This fixes a bug we found for some users that don't use docker but instead run postgres locally. In that case, the db timezone will not be UTC and this means the time bucket call returns nothing, causing an empty timeline.

The root cause is likely a timezone translation between server and db.

How this has been tested: The bug is solved for the user. Also, I've tested on my docker setup and it works fine to browse and upload images. Should be trivial to merge.