### PR TITLE
docs: add troubleshooting info to libraries + minor docs tweaks

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
+    # Any external library import paths go here, for example:
+    # - /media/my/photos/:/data/import/photos/
     env_file:
       - .env
     depends_on:
@@ -26,6 +28,8 @@ services:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
+    # Any external library import paths go here, for example:
+    # - /media/my/photos/:/data/import/photos/
     env_file:
       - .env
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
-    # Any external library import paths go here, for example:
-    # - /media/my/photos/:/data/import/photos/
     env_file:
       - .env
     depends_on:
@@ -28,8 +26,6 @@ services:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
-    # Any external library import paths go here, for example:
-    # - /media/my/photos/:/data/import/photos/
     env_file:
       - .env
     depends_on:

--- a/docs/docs/FAQ.md
+++ b/docs/docs/FAQ.md
@@ -20,22 +20,9 @@ Immich doesn't have two-way synchronization ([yet](https://github.com/immich-app
 
 The initial approach of Immich is to become a backup tool, primarily for mobile device usage. Thus, all the assets must be uploaded from the mobile client. The app was architectured to perform that job well.
 
-### Why does my uploaded photo show up with the wrong date or time in Immich?
-
-When a photo is initially uploaded Immich uses the create date of the file to determine where it belongs in the timeline. After that, background jobs will run that extract [exif metadata](https://en.wikipedia.org/wiki/Exif), including the CreateDate, to provide a more accurate date for the photo. If that is not available it will fallback to the modified date. If you want to ensure your photo has the right date, check the exif metadata before uploading.
-
-If the timezone is incorrect in an uploaded photo, check the `DateTimeOriginal` exif field of the uploaded file. Immich uses the very competent library [exiftool-vendored.js](https://github.com/photostructure/exiftool-vendored.js#dates) to handle timezone parsing, but in some cases (like photos taken with DSLR cameras) it has to fallback on the local timezone. If you are using docker, this fallback will be UTC. (Note that even the photo backup app that can't be named [has the same bug!](https://photo.stackexchange.com/a/126978)) In Immich, it is possible to change this assumed fallback timezone system-wide by setting the timezone in the microservices docker container. You might need to run the "Extract Metadata" job after to effect the change.
-
-As an example, the following modification of `docker-compose.yml` will set the timezone of the microservices container to be `Europe/Stockholm`
-
-```
-    environment:
-      - TZ=Europe/Stockholm # <---- Add this line in the microservices config
-```
-
 ### Why are only photos and not videos being uploaded to Immich?
 
-This often happens when using a reverse proxy or cloudflare tunnel in front of Immich. Make sure to set your reverse proxy to allow large POST requests. In `nginx`, set `client_max_body_size 50000M;` or similar. Cloudflare tunnels are limited to 100 mb file sizes.
+This often happens when using a reverse proxy or cloudflare tunnel in front of Immich. Make sure to set your reverse proxy to allow large POST requests. In `nginx`, set `client_max_body_size 50000M;` or similar. Cloudflare tunnels are limited to 100 mb file sizes. Also check the disk space of your reverse proxy, in some cases proxies caches requests to disk before passing them on, and if disk space runs out the request fails.
 
 ### Why is Immich slow on low-memory systems like the Raspberry Pi?
 

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -42,7 +42,25 @@ Finally, files can be deleted from Immich via the `Remove Offline Files` job. An
 
 External libraries use import paths to determine which files to scan. Each library can have multiple import paths so that files from different locations can be added to the same library. Import paths are scanned recursively, and if a file is in multiple import paths, it will only be added once. If the import paths are edited in a way that an external file is no longer in any import path, it will be removed from the library in the same way a deleted file would. If the file is moved back to an import path, it will be added again as if it was a new file.
 
+### Troubleshooting
+
+Sometimes, an external library will not scan correctly. This can happen if the immich_server or immich_microservices can't access the files. Here are some things to check:
+
+- Is the external path set correctly?
+- In the docker-compose file, are the volumes mounted correctly?
+- Are the volumes identical between the `server` and `microservices` container?
+- Are the import paths set correctly, and do they match the path set in docker-compose file?
+- Are the permissions set correctly?
+
+If all else fails, you can always start a shell inside the container and check if the path is accessible. For example, `docker exec -it immich_microservices /bin/bash` will start a bash shell. If your import path, for instance, is `/data/import/photos`, you can check if the files are accessible by running `ls /data/import/photos`. Also check the `immich_server` container in the same way.
+
 ### Security Considerations
+
+:::caution
+
+Please read and understand this section before setting external paths, as there are important security considerations.
+
+:::
 
 For security purposes, each Immich user is disallowed to add external files by default. This is to prevent devastating [path traversal attacks](https://owasp.org/www-community/attacks/Path_Traversal). An admin can allow individual users to use external path feature via the `external path` setting found in the admin panel. Without the external path restriction, a user can add any image or video file on the Immich host filesystem to be imported into Immich, potentially allowing sensitive data to be accessed. If you are running Immich as root in your Docker setup (which is the default), all external file reads are done with root privileges. This is particularly dangerous if the Immich host is a shared server.
 
@@ -58,6 +76,10 @@ Some basic examples:
 - `hidden.jpg` will exclude all files named `hidden.jpg`
 - `**/Raw/**` will exclude all files in any directory named `Raw`
 - `*.(tif,jpg)` will exclude all files with the extension `.tif` or `.jpg`
+
+### Nightly job
+
+There is an automatic job that's run once a day and refreshes all modified files in all libraries as well as cleans up any libraries stuck in deletion.
 
 ## Usage
 


### PR DESCRIPTION
Add information that will help users troubleshooting library refreshes. Also add some external library examples to the docker compose.