### PR TITLE
fix(web): dev mode repeatedly optimizing dependencies

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -25,7 +25,7 @@ const config = {
   plugins: [sveltekit()],
   optimizeDeps: {
     entries: ['src/**/*.{svelte, ts, html}'],
-  }
+  },
 };
 
 export default config;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -23,6 +23,9 @@ const config = {
     },
   },
   plugins: [sveltekit()],
+  optimizeDeps: {
+    entries: ['src/**/*.{svelte, ts, html}'],
+  }
 };
 
 export default config;


### PR DESCRIPTION
## Description

There's an issue with the current setup where dependencies in .svelte files are only evaluated on page load. These dependencies are optimized by Vite, but this can take long enough that the page fails to load and a refresh or different page load is necessary. Additionally, the optimization cache can be invalidated by later page loads in this way, meaning this process can repeat several times before it reaches consistency.

This PR adds a glob to make Vite check all source files for optimization. This causes the initial page load to be slightly slower since optimization is upfront, but page navigation is snappy afterwards.

## How Has This Been Tested?

I ran a dev deployment with this change (with `--force-recreate` for a clean container) and observed smoother page loading.