### PR TITLE
fix(server): delete library actually deletes (all) assets

### DIFF
--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -137,14 +137,16 @@ export class LibraryService {
     }
 
     // TODO use pagination
-    const assetIds = await this.repository.getAssetIds(job.id);
+    const assetIds = await this.repository.getAssetIds(job.id, true);
     this.logger.debug(`Will delete ${assetIds.length} asset(s) in library ${job.id}`);
     for (const assetId of assetIds) {
       await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: assetId, fromExternal: true } });
     }
 
-    this.logger.log(`Deleting library ${job.id}`);
-    await this.repository.delete(job.id);
+    if (assetIds.length === 0) {
+      this.logger.log(`Deleting library ${job.id}`);
+      await this.repository.delete(job.id);
+    }
     return true;
   }
 


### PR DESCRIPTION
When we changed to queueing the deletion of assets, a race condition got introduced: Most of the time the library deletion gets executed before the asset deletion queue is done. 
Since the `delete` method of the library repository always does cascading (be aware that TypeORM cascading is something different. `delete` doesn't do TypeORM cascading - in contrast to `remove`, however both use database cascades), resulting in the deletion of all assets from the database before they actually got deleted.

This caused all pending asset deletion jobs to basically do nothing because they just return if the asset couldn't be found. 
Therefore the library now gets only deleted if there aren't any assets linked with it. This results in the need that `handleDeleteLibrary` needs to be called twice, however that is taken care of by the nightly cleanup job. Therefore the only "downside" of this is that a soft deleted library will still hang around in the database until midnight.

Additionally, when trying to fetch all assets of a library, within `handleDeleteLibrary`, the result is always an empty array because the library is already soft deleted and `getAssetIds` wasn't called with the optional parameter `withDeleted`.
So basically no assets get deleted. Ever. Even besides the race condition :D
Fixed that as well.

Thanks to @jrasm91 for helping me figure this one out.