### PR TITLE
fix(server): make system config core singleton

### DIFF
--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -77,7 +77,7 @@ export class AssetService {
   ) {
     this.access = new AccessCore(accessRepository);
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
   }
 
   canUploadFile({ authUser, fieldName, file }: UploadRequest): true {

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -77,7 +77,7 @@ export class AssetService {
   ) {
     this.access = new AccessCore(accessRepository);
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
   }
 
   canUploadFile({ authUser, fieldName, file }: UploadRequest): true {

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -71,7 +71,7 @@ export class AuthService {
     @Inject(ISharedLinkRepository) private sharedLinkRepository: ISharedLinkRepository,
     @Inject(IKeyRepository) private keyRepository: IKeyRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
     this.userCore = new UserCore(userRepository, libraryRepository, cryptoRepository);
 
     custom.setHttpOptionsDefaults({ timeout: 30000 });

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -71,7 +71,7 @@ export class AuthService {
     @Inject(ISharedLinkRepository) private sharedLinkRepository: ISharedLinkRepository,
     @Inject(IKeyRepository) private keyRepository: IKeyRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
     this.userCore = new UserCore(userRepository, libraryRepository, cryptoRepository);
 
     custom.setHttpOptionsDefaults({ timeout: 30000 });

--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -223,8 +223,7 @@ describe(JobService.name, () => {
     it('should subscribe to config changes', async () => {
       await sut.registerHandlers(makeMockHandlers(false));
 
-      const configCore = SystemConfigCore.get(newSystemConfigRepositoryMock());
-      configCore.config$.next({
+      SystemConfigCore.create(newSystemConfigRepositoryMock(false)).config$.next({
         job: {
           [QueueName.BACKGROUND_TASK]: { concurrency: 10 },
           [QueueName.CLIP_ENCODING]: { concurrency: 10 },

--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -223,7 +223,7 @@ describe(JobService.name, () => {
     it('should subscribe to config changes', async () => {
       await sut.registerHandlers(makeMockHandlers(false));
 
-      const configCore = new SystemConfigCore(newSystemConfigRepositoryMock());
+      const configCore = SystemConfigCore.get(newSystemConfigRepositoryMock());
       configCore.config$.next({
         job: {
           [QueueName.BACKGROUND_TASK]: { concurrency: 10 },

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -21,7 +21,7 @@ export class JobService {
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
     @Inject(IPersonRepository) private personRepository: IPersonRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
   }
 
   async handleCommand(queueName: QueueName, dto: JobCommandDto): Promise<JobStatusDto> {

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -21,7 +21,7 @@ export class JobService {
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
     @Inject(IPersonRepository) private personRepository: IPersonRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
   }
 
   async handleCommand(queueName: QueueName, dto: JobCommandDto): Promise<JobStatusDto> {

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -24,7 +24,7 @@ export class MediaService {
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
     this.storageCore = new StorageCore(this.storageRepository);
   }
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -24,7 +24,7 @@ export class MediaService {
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
     this.storageCore = new StorageCore(this.storageRepository);
   }
 

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -67,7 +67,7 @@ export class MetadataService {
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
     this.configCore.config$.subscribe(() => this.init());
   }
 

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -67,7 +67,7 @@ export class MetadataService {
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
     this.configCore.config$.subscribe(() => this.init());
   }
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -49,7 +49,7 @@ export class PersonService {
   ) {
     this.access = new AccessCore(accessRepository);
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
   }
 
   async getAll(authUser: AuthUserDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -49,7 +49,7 @@ export class PersonService {
   ) {
     this.access = new AccessCore(accessRepository);
     this.storageCore = new StorageCore(storageRepository);
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
   }
 
   async getAll(authUser: AuthUserDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -57,7 +57,7 @@ export class SearchService {
     @Inject(ISearchRepository) private searchRepository: ISearchRepository,
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
   }
 
   teardown() {

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -57,7 +57,7 @@ export class SearchService {
     @Inject(ISearchRepository) private searchRepository: ISearchRepository,
     @Inject(ISystemConfigRepository) configRepository: ISystemConfigRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
   }
 
   teardown() {

--- a/server/src/domain/server-info/server-info.service.ts
+++ b/server/src/domain/server-info/server-info.service.ts
@@ -24,7 +24,7 @@ export class ServerInfoService {
     @Inject(IUserRepository) private userRepository: IUserRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
     this.storageCore = new StorageCore(storageRepository);
   }
 

--- a/server/src/domain/server-info/server-info.service.ts
+++ b/server/src/domain/server-info/server-info.service.ts
@@ -24,7 +24,7 @@ export class ServerInfoService {
     @Inject(IUserRepository) private userRepository: IUserRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
     this.storageCore = new StorageCore(storageRepository);
   }
 

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -17,7 +17,7 @@ export class SmartInfoService {
     @Inject(ISmartInfoRepository) private repository: ISmartInfoRepository,
     @Inject(IMachineLearningRepository) private machineLearning: IMachineLearningRepository,
   ) {
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
   }
 
   async handleQueueObjectTagging({ force }: IBaseJob) {

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -17,7 +17,7 @@ export class SmartInfoService {
     @Inject(ISmartInfoRepository) private repository: ISmartInfoRepository,
     @Inject(IMachineLearningRepository) private machineLearning: IMachineLearningRepository,
   ) {
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
   }
 
   async handleQueueObjectTagging({ force }: IBaseJob) {

--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -42,7 +42,7 @@ export class StorageTemplateService {
     @Inject(IUserRepository) private userRepository: IUserRepository,
   ) {
     this.storageTemplate = this.compile(config.storageTemplate.template);
-    this.configCore = new SystemConfigCore(configRepository);
+    this.configCore = SystemConfigCore.get(configRepository);
     this.configCore.addValidator((config) => this.validate(config));
     this.configCore.config$.subscribe((config) => this.onConfig(config));
     this.storageCore = new StorageCore(storageRepository);

--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -42,7 +42,7 @@ export class StorageTemplateService {
     @Inject(IUserRepository) private userRepository: IUserRepository,
   ) {
     this.storageTemplate = this.compile(config.storageTemplate.template);
-    this.configCore = SystemConfigCore.get(configRepository);
+    this.configCore = SystemConfigCore.create(configRepository);
     this.configCore.addValidator((config) => this.validate(config));
     this.configCore.config$.subscribe((config) => this.onConfig(config));
     this.storageCore = new StorageCore(storageRepository);

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -134,7 +134,7 @@ export enum FeatureFlag {
 
 export type FeatureFlags = Record<FeatureFlag, boolean>;
 
-let instance: SystemConfigCore;
+let instance: SystemConfigCore | null;
 
 @Injectable()
 export class SystemConfigCore {
@@ -148,6 +148,10 @@ export class SystemConfigCore {
 
   static get(repository: ISystemConfigRepository) {
     return instance || (instance = new this(repository));
+  }
+
+  static reset() {
+    instance = null;
   }
 
   async requireFeature(feature: FeatureFlag) {

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -134,21 +134,20 @@ export enum FeatureFlag {
 
 export type FeatureFlags = Record<FeatureFlag, boolean>;
 
-const singleton = new Subject<SystemConfig>();
+let instance: SystemConfigCore;
 
 @Injectable()
 export class SystemConfigCore {
   private logger = new Logger(SystemConfigCore.name);
   private validators: SystemConfigValidator[] = [];
   private configCache: SystemConfig | null = null;
-  private static _instance: SystemConfigCore;
 
-  public config$ = singleton;
+  public config$ = new Subject<SystemConfig>();
 
   private constructor(private repository: ISystemConfigRepository) {}
 
   static get(repository: ISystemConfigRepository) {
-    return this._instance || (this._instance = new this(repository));
+    return instance || (instance = new this(repository));
   }
 
   async requireFeature(feature: FeatureFlag) {

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -141,10 +141,15 @@ export class SystemConfigCore {
   private logger = new Logger(SystemConfigCore.name);
   private validators: SystemConfigValidator[] = [];
   private configCache: SystemConfig | null = null;
+  private static _instance: SystemConfigCore;
 
   public config$ = singleton;
 
-  constructor(private repository: ISystemConfigRepository) {}
+  private constructor(private repository: ISystemConfigRepository) {}
+
+  static get(repository: ISystemConfigRepository) {
+    return this._instance || (this._instance = new this(repository));
+  }
 
   async requireFeature(feature: FeatureFlag) {
     const hasFeature = await this.hasFeature(feature);

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -146,8 +146,11 @@ export class SystemConfigCore {
 
   private constructor(private repository: ISystemConfigRepository) {}
 
-  static get(repository: ISystemConfigRepository) {
-    return instance || (instance = new this(repository));
+  static create(repository: ISystemConfigRepository) {
+    if (!instance) {
+      instance = new SystemConfigCore(repository);
+    }
+    return instance;
   }
 
   static reset() {

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -13,9 +13,10 @@ import {
 } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
 import { newCommunicationRepositoryMock, newJobRepositoryMock, newSystemConfigRepositoryMock } from '@test';
-import { ICommunicationRepository, ISystemConfigRepository } from '..';
+import { ICommunicationRepository } from '../communication';
 import { IJobRepository, JobName, QueueName } from '../job';
-import { SystemConfigCore, SystemConfigValidator, defaults } from './system-config.core';
+import { SystemConfigValidator, defaults } from './system-config.core';
+import { ISystemConfigRepository } from './system-config.repository';
 import { SystemConfigService } from './system-config.service';
 
 const updates: SystemConfigEntity[] = [
@@ -128,8 +129,6 @@ describe(SystemConfigService.name, () => {
     configMock = newSystemConfigRepositoryMock();
     communicationMock = newCommunicationRepositoryMock();
     jobMock = newJobRepositoryMock();
-
-    SystemConfigCore.reset();
     sut = new SystemConfigService(configMock, communicationMock, jobMock);
   });
 

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -13,10 +13,9 @@ import {
 } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
 import { newCommunicationRepositoryMock, newJobRepositoryMock, newSystemConfigRepositoryMock } from '@test';
-import { ICommunicationRepository } from '..';
+import { ICommunicationRepository, ISystemConfigRepository } from '..';
 import { IJobRepository, JobName, QueueName } from '../job';
-import { SystemConfigValidator, defaults } from './system-config.core';
-import { ISystemConfigRepository } from './system-config.repository';
+import { SystemConfigCore, SystemConfigValidator, defaults } from './system-config.core';
 import { SystemConfigService } from './system-config.service';
 
 const updates: SystemConfigEntity[] = [
@@ -129,6 +128,8 @@ describe(SystemConfigService.name, () => {
     configMock = newSystemConfigRepositoryMock();
     communicationMock = newCommunicationRepositoryMock();
     jobMock = newJobRepositoryMock();
+
+    SystemConfigCore.reset();
     sut = new SystemConfigService(configMock, communicationMock, jobMock);
   });
 

--- a/server/src/domain/system-config/system-config.service.ts
+++ b/server/src/domain/system-config/system-config.service.ts
@@ -24,7 +24,7 @@ export class SystemConfigService {
     @Inject(ICommunicationRepository) private communicationRepository: ICommunicationRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
   ) {
-    this.core = SystemConfigCore.get(repository);
+    this.core = SystemConfigCore.create(repository);
   }
 
   get config$() {

--- a/server/src/domain/system-config/system-config.service.ts
+++ b/server/src/domain/system-config/system-config.service.ts
@@ -24,7 +24,7 @@ export class SystemConfigService {
     @Inject(ICommunicationRepository) private communicationRepository: ICommunicationRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
   ) {
-    this.core = new SystemConfigCore(repository);
+    this.core = SystemConfigCore.get(repository);
   }
 
   get config$() {

--- a/server/test/repositories/system-config.repository.mock.ts
+++ b/server/test/repositories/system-config.repository.mock.ts
@@ -1,10 +1,20 @@
 import { ISystemConfigRepository } from '@app/domain';
 
+const singleton = {
+  load: jest.fn().mockResolvedValue([]),
+  readFile: jest.fn(),
+  saveAll: jest.fn().mockResolvedValue([]),
+  deleteKeys: jest.fn(),
+};
+
 export const newSystemConfigRepositoryMock = (): jest.Mocked<ISystemConfigRepository> => {
-  return {
-    load: jest.fn().mockResolvedValue([]),
-    readFile: jest.fn(),
-    saveAll: jest.fn().mockResolvedValue([]),
-    deleteKeys: jest.fn(),
-  };
+  singleton.deleteKeys.mockReset();
+  singleton.load.mockReset();
+  singleton.readFile.mockReset();
+  singleton.saveAll.mockReset();
+
+  singleton.load.mockResolvedValue([]);
+  singleton.saveAll.mockResolvedValue([]);
+
+  return singleton;
 };

--- a/server/test/repositories/system-config.repository.mock.ts
+++ b/server/test/repositories/system-config.repository.mock.ts
@@ -1,20 +1,14 @@
-import { ISystemConfigRepository } from '@app/domain';
+import { ISystemConfigRepository, SystemConfigCore } from '@app/domain';
 
-const singleton = {
-  load: jest.fn().mockResolvedValue([]),
-  readFile: jest.fn(),
-  saveAll: jest.fn().mockResolvedValue([]),
-  deleteKeys: jest.fn(),
-};
+export const newSystemConfigRepositoryMock = (reset = true): jest.Mocked<ISystemConfigRepository> => {
+  if (reset) {
+    SystemConfigCore.reset();
+  }
 
-export const newSystemConfigRepositoryMock = (): jest.Mocked<ISystemConfigRepository> => {
-  singleton.deleteKeys.mockReset();
-  singleton.load.mockReset();
-  singleton.readFile.mockReset();
-  singleton.saveAll.mockReset();
-
-  singleton.load.mockResolvedValue([]);
-  singleton.saveAll.mockResolvedValue([]);
-
-  return singleton;
+  return {
+    load: jest.fn().mockResolvedValue([]),
+    readFile: jest.fn(),
+    saveAll: jest.fn().mockResolvedValue([]),
+    deleteKeys: jest.fn(),
+  };
 };


### PR DESCRIPTION
Currently, config validators wouldn't work because system config core wasn't a singleton and therefore there existed different instances of it with different validators. The instance the service held had no validators at all