### PR TITLE
fix(server): clean up android motion assets

### DIFF
--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -312,7 +312,7 @@ describe(MetadataService.name, () => {
           type: AssetType.VIDEO,
           originalFileName: assetStub.livePhotoStillAsset.originalFileName,
           isVisible: false,
-          isReadOnly: true,
+          isReadOnly: false,
         }),
       );
       expect(assetMock.save).toHaveBeenCalledWith({

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -291,7 +291,7 @@ export class MetadataService {
           originalPath: this.storageCore.ensurePath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}-MP.mp4`),
           originalFileName: asset.originalFileName,
           isVisible: false,
-          isReadOnly: true,
+          isReadOnly: false,
           deviceAssetId: 'NONE',
           deviceId: 'NONE',
         });


### PR DESCRIPTION
For some reason (probably copy/paste error), android motion assets are marked as read only, and therefore not deleted from disk, when they should be.