### PR TITLE
chore(server): use force instead of forceRefresh

### DIFF
--- a/server/src/domain/job/job.interface.ts
+++ b/server/src/domain/job/job.interface.ts
@@ -23,7 +23,6 @@ export interface IOfflineLibraryFileJob extends IEntityJob {
 export interface ILibraryFileJob extends IEntityJob {
   ownerId: string;
   assetPath: string;
-  forceRefresh: boolean;
 }
 
 export interface ILibraryRefreshJob extends IEntityJob {

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -99,7 +99,7 @@ describe(LibraryService.name, () => {
               id: libraryStub.externalLibrary1.id,
               ownerId: libraryStub.externalLibrary1.owner.id,
               assetPath: '/data/user1/photo.jpg',
-              forceRefresh: false,
+              force: false,
             },
           },
         ],
@@ -174,7 +174,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/file.xyz',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);
@@ -187,7 +187,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/file.xyz',
-        forceRefresh: false,
+        force: false,
       };
 
       await expect(sut.handleAssetRefresh(mockLibraryJob)).rejects.toBeInstanceOf(BadRequestException);
@@ -198,7 +198,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);
@@ -245,7 +245,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);
@@ -293,7 +293,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/video.mp4',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);
@@ -348,7 +348,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);
@@ -365,7 +365,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       storageMock.stat.mockResolvedValue({
@@ -386,7 +386,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.image);
@@ -417,7 +417,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       expect(sut.handleAssetRefresh(mockLibraryJob)).resolves.toBe(false);
@@ -431,7 +431,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       expect(sut.handleAssetRefresh(mockLibraryJob)).resolves.toBe(false);
@@ -445,7 +445,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/etc/rootpassword.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       expect(sut.handleAssetRefresh(mockLibraryJob)).resolves.toBe(false);
@@ -459,7 +459,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/../../etc/rootpassword.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       expect(sut.handleAssetRefresh(mockLibraryJob)).resolves.toBe(false);
@@ -472,7 +472,7 @@ describe(LibraryService.name, () => {
         id: assetStub.image.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.image);
@@ -489,7 +489,7 @@ describe(LibraryService.name, () => {
         id: assetStub.offline.id,
         ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.offline);
@@ -520,7 +520,7 @@ describe(LibraryService.name, () => {
         id: assetStub.image.id,
         ownerId: assetStub.image.ownerId,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.image);
@@ -536,7 +536,7 @@ describe(LibraryService.name, () => {
         id: assetStub.image.id,
         ownerId: assetStub.image.ownerId,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: true,
+        force: true,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.image);
@@ -558,7 +558,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: userStub.admin.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       storageMock.stat.mockResolvedValue({
@@ -585,7 +585,7 @@ describe(LibraryService.name, () => {
         id: libraryStub.externalLibrary1.id,
         ownerId: userStub.admin.id,
         assetPath: '/data/user1/photo.jpg',
-        forceRefresh: false,
+        force: false,
       };
 
       assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(null);

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -186,7 +186,7 @@ export class LibraryService {
     let doImport = false;
     let doRefresh = false;
 
-    if (job.forceRefresh) {
+    if (job.force) {
       doRefresh = true;
     }
 
@@ -200,7 +200,7 @@ export class LibraryService {
         `File modification time has changed, re-importing asset: ${assetPath}. Old mtime: ${existingAssetEntity.fileModifiedAt}. New mtime: ${stats.mtime}`,
       );
       doRefresh = true;
-    } else if (!job.forceRefresh && stats && !existingAssetEntity.isOffline) {
+    } else if (!job.force && stats && !existingAssetEntity.isOffline) {
       // Asset exists on disk and in db and mtime has not changed. Also, we are not forcing refresn. Therefore, do nothing
       this.logger.debug(`Asset already exists in database and on disk, will not import: ${assetPath}`);
     }
@@ -410,7 +410,7 @@ export class LibraryService {
           id: job.id,
           assetPath: path.normalize(assetPath),
           ownerId: library.ownerId,
-          forceRefresh: job.refreshAllFiles ?? false,
+          force: job.refreshAllFiles ?? false,
         };
 
         await this.jobRepository.queue({ name: JobName.LIBRARY_SCAN_ASSET, data: libraryJobData });


### PR DESCRIPTION
There is already a job property on the base job for `force`, so updated the library jobs to use that one.