### PR TITLE
feat(web) add hover background to image toolbar icons

### DIFF
--- a/web/src/lib/components/elements/buttons/circle-icon-button.svelte
+++ b/web/src/lib/components/elements/buttons/circle-icon-button.svelte
@@ -2,7 +2,7 @@
   import type Icon from 'svelte-material-icons/AbTesting.svelte';
 
   export let logo: typeof Icon;
-  export let backgroundColor = 'transparent';
+  export let backgroundColor = '';
   export let hoverColor = '#e2e7e9';
   export let padding = '3';
   export let size = '24';
@@ -14,6 +14,7 @@
 
 <button
   {title}
+  style:background-color={backgroundColor}
   style:--immich-icon-button-hover-color={hoverColor}
   class:dark:text-immich-dark-fg={!forceDark}
   class="flex place-content-center place-items-center rounded-full p-{padding} transition-all

--- a/web/src/lib/components/elements/buttons/circle-icon-button.svelte
+++ b/web/src/lib/components/elements/buttons/circle-icon-button.svelte
@@ -14,7 +14,6 @@
 
 <button
   {title}
-  style:background-color={backgroundColor}
   style:--immich-icon-button-hover-color={hoverColor}
   class:dark:text-immich-dark-fg={!forceDark}
   class="flex place-content-center place-items-center rounded-full p-{padding} transition-all


### PR DESCRIPTION
## Intro

Whenever we hover the mouse over a toolbar icon, now this is highlighted according to the material guidelines:
![4343](https://github.com/immich-app/immich/assets/16381881/5f37c9b3-cff4-4390-8bc6-107835729c99)

## Test
Tested both in dark and light background.


## Notes
* the sahed is a bit different than the on in the info icon.
* It would be awesome if this could be eligible for hacktoberfest (add the `hacktoberfest-accepted` label :smile:  )!!
* Closes #4343 