### PR TITLE
feat: Run postgres container as non-root

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -114,6 +114,7 @@ services:
   database:
     container_name: immich_postgres
     image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    user: 70:70
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -84,6 +84,7 @@ services:
   database:
     container_name: immich_postgres
     image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    user: 70:70
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -27,6 +27,7 @@ services:
   immich-database-test:
     container_name: immich-database-test
     image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    user: 70:70
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,6 +70,7 @@ services:
   database:
     container_name: immich_postgres
     image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    user: 70:70
     env_file:
       - .env
     environment:


### PR DESCRIPTION
postgres images support running as non-root user as mentionned in [1]. However, the user needs to exist. An existing user is "postgres" (uid 70), as defined in [2].

[1]: https://github.com/docker-library/docs/blob/master/postgres/README.md#arbitrary---user-notes
[2]: https://github.com/docker-library/postgres/blob/2bff0ce33b76f03f4e6986497e0ab084dad10e9d/Dockerfile-alpine.template#L4-L11