### PR TITLE
fix(server): add original path and library id index to asset

### DIFF
--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -4357,6 +4357,16 @@
       "put": {
         "operationId": "updateConfig",
         "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SystemConfigDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -4357,16 +4357,6 @@
       "put": {
         "operationId": "updateConfig",
         "parameters": [],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SystemConfigDto"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
           "200": {
             "content": {

--- a/server/src/infra/entities/asset.entity.ts
+++ b/server/src/infra/entities/asset.entity.ts
@@ -31,7 +31,7 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_library_checksum';
 })
 @Index('IDX_day_of_month', { synchronize: false })
 @Index('IDX_month', { synchronize: false })
-@Index('IDX_originalPath', ['originalPath'])
+@Index('IDX_originalPath_libraryId', ['originalPath', 'libraryId'])
 // For all assets, each originalpath must be unique per user and library
 export class AssetEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/server/src/infra/entities/asset.entity.ts
+++ b/server/src/infra/entities/asset.entity.ts
@@ -31,6 +31,7 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_library_checksum';
 })
 @Index('IDX_day_of_month', { synchronize: false })
 @Index('IDX_month', { synchronize: false })
+@Index('IDX_originalPath', ['originalPath'])
 // For all assets, each originalpath must be unique per user and library
 export class AssetEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/server/src/infra/migrations/1696888644031-AddOriginalPathIndex.ts
+++ b/server/src/infra/migrations/1696888644031-AddOriginalPathIndex.ts
@@ -4,10 +4,10 @@ export class AddOriginalPathIndex1696888644031 implements MigrationInterface {
   name = 'AddOriginalPathIndex1696888644031';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`CREATE INDEX "IDX_originalPath" ON "assets" ("originalPath") `);
+    await queryRunner.query(`CREATE INDEX "IDX_originalPath_libraryId" ON "assets" ("originalPath", "libraryId")`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "public"."IDX_originalPath"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_originalPath_libraryId"`);
   }
 }

--- a/server/src/infra/migrations/1696888644031-AddOriginalPathIndex.ts
+++ b/server/src/infra/migrations/1696888644031-AddOriginalPathIndex.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOriginalPathIndex1696888644031 implements MigrationInterface {
+  name = 'AddOriginalPathIndex1696888644031';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE INDEX "IDX_originalPath" ON "assets" ("originalPath") `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_originalPath"`);
+  }
+}


### PR DESCRIPTION
This adds an index to the original asset path. Since we often do lookups on original path this should speed things up for large libraries