### PR TITLE
chore(mobile): pump photo_manager version

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1071,10 +1071,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: b2d81bd197323697d1b335e2e04cea2f67e11624ced77cfd02917a10afaeba73
+      sha256: "41eaa1d1fa51bac1c8f2f6debfd34074edcc6b330aa96bb3d33c3bc2fc6c8a5c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.7.2"
   platform:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   path_provider_ios:
-  photo_manager: ^2.5.0
+  photo_manager: ^2.7.2
   flutter_hooks: ^0.18.6
   hooks_riverpod: ^2.2.0
   cached_network_image: ^3.2.2


### PR DESCRIPTION
This PR pumps the `photo_manager` version which fixes the `FullSizeRender` name issue on iOS on Portrait/Panorama mode. All Portrait mode is now uploaded as its original filename

Fixes #2676
Fixes #4088

Thanks @xick for fixing this issue upstream