### PR TITLE
fix(server): improve library scan queuing performance

### DIFF
--- a/server/src/domain/job/job.constants.ts
+++ b/server/src/domain/job/job.constants.ts
@@ -69,7 +69,6 @@ export enum JobName {
   LIBRARY_SCAN = 'library-refresh',
   LIBRARY_SCAN_ASSET = 'library-refresh-asset',
   LIBRARY_REMOVE_OFFLINE = 'library-remove-offline',
-  LIBRARY_MARK_ASSET_OFFLINE = 'library-mark-asset-offline',
   LIBRARY_DELETE = 'library-delete',
   LIBRARY_QUEUE_SCAN_ALL = 'library-queue-all-refresh',
   LIBRARY_QUEUE_CLEANUP = 'library-queue-cleanup',
@@ -172,7 +171,6 @@ export const JOBS_TO_QUEUE: Record<JobName, QueueName> = {
 
   // Library managment
   [JobName.LIBRARY_SCAN_ASSET]: QueueName.LIBRARY,
-  [JobName.LIBRARY_MARK_ASSET_OFFLINE]: QueueName.LIBRARY,
   [JobName.LIBRARY_SCAN]: QueueName.LIBRARY,
   [JobName.LIBRARY_DELETE]: QueueName.LIBRARY,
   [JobName.LIBRARY_REMOVE_OFFLINE]: QueueName.LIBRARY,

--- a/server/src/domain/job/job.interface.ts
+++ b/server/src/domain/job/job.interface.ts
@@ -16,10 +16,6 @@ export interface IAssetDeletionJob extends IEntityJob {
   fromExternal?: boolean;
 }
 
-export interface IOfflineLibraryFileJob extends IEntityJob {
-  assetPath: string;
-}
-
 export interface ILibraryFileJob extends IEntityJob {
   ownerId: string;
   assetPath: string;

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -147,7 +147,7 @@ describe(LibraryService.name, () => {
 
       userMock.get.mockResolvedValue(userStub.user1);
 
-      expect(sut.handleQueueAssetRefresh(mockLibraryJob)).resolves.toBe(false);
+      await expect(sut.handleQueueAssetRefresh(mockLibraryJob)).resolves.toBe(false);
     });
 
     it('should not scan upload libraries', async () => {
@@ -159,7 +159,7 @@ describe(LibraryService.name, () => {
 
       libraryMock.get.mockResolvedValue(libraryStub.uploadLibrary1);
 
-      expect(sut.handleQueueAssetRefresh(mockLibraryJob)).resolves.toBe(false);
+      await expect(sut.handleQueueAssetRefresh(mockLibraryJob)).resolves.toBe(false);
     });
   });
 

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -16,7 +16,7 @@ import {
   userStub,
 } from '@test';
 import { Stats } from 'fs';
-import { ILibraryFileJob, ILibraryRefreshJob, IOfflineLibraryFileJob, JobName } from '../job';
+import { ILibraryFileJob, ILibraryRefreshJob, JobName } from '../job';
 import {
   IAssetRepository,
   ICryptoRepository,

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -126,14 +126,11 @@ describe(LibraryService.name, () => {
 
       await sut.handleQueueAssetRefresh(mockLibraryJob);
 
-      expect(jobMock.queue.mock.calls).toEqual([
+      expect(assetMock.updateAll.mock.calls).toEqual([
         [
+          [assetStub.external.id],
           {
-            name: JobName.LIBRARY_MARK_ASSET_OFFLINE,
-            data: {
-              id: libraryStub.externalLibrary1.id,
-              assetPath: '/data/user1/photo.jpg',
-            },
+            isOffline: true,
           },
         ],
       ]);
@@ -597,24 +594,6 @@ describe(LibraryService.name, () => {
       assetMock.create.mockResolvedValue(assetStub.image);
 
       await expect(sut.handleAssetRefresh(mockLibraryJob)).rejects.toBeInstanceOf(BadRequestException);
-    });
-  });
-
-  describe('handleOfflineAsset', () => {
-    it('should mark an asset as offline', async () => {
-      const offlineJob: IOfflineLibraryFileJob = {
-        id: libraryStub.externalLibrary1.id,
-        assetPath: '/data/user1/photo.jpg',
-      };
-
-      assetMock.getByLibraryIdAndOriginalPath.mockResolvedValue(assetStub.image);
-
-      await expect(sut.handleOfflineAsset(offlineJob)).resolves.toBe(true);
-
-      expect(assetMock.save).toHaveBeenCalledWith({
-        id: assetStub.image.id,
-        isOffline: true,
-      });
     });
   });
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -380,7 +380,7 @@ export class LibraryService {
         const existingPaths = await this.repository.getOnlineAssetPaths(job.id);
         this.logger.debug(`Found ${existingPaths.length} existing asset(s) in library ${job.id}`);
 
-        filteredPaths = crawledAssetPaths.filter((assetPath) => !existingPaths.includes(assetPath));
+        filteredPaths = crawledAssetPaths.filter((assetPath) => !onlineFiles.has(assetPath));
         this.logger.debug(`After db comparison, ${filteredPaths.length} asset(s) remain to be imported`);
       }
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -10,7 +10,6 @@ import { mimeTypes } from '../domain.constant';
 import { usePagination } from '../domain.util';
 import { IBaseJob, IEntityJob, ILibraryFileJob, ILibraryRefreshJob, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 
-import { filter } from 'lodash';
 import {
   IAccessRepository,
   IAssetRepository,

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -378,10 +378,10 @@ export class LibraryService {
       if (job.refreshAllFiles || job.refreshModifiedFiles) {
         filteredPaths = crawledAssetPaths;
       } else {
-        const existingPaths = await this.repository.getOnlineAssetPaths(job.id);
-        this.logger.debug(`Found ${existingPaths.length} existing asset(s) in library ${job.id}`);
+        const existingPaths = new Set(await this.repository.getOnlineAssetPaths(job.id));
+        this.logger.debug(`Found ${existingPaths.size} existing asset(s) in library ${job.id}`);
 
-        filteredPaths = crawledAssetPaths.filter((assetPath) => !onlineFiles.has(assetPath));
+        filteredPaths = crawledAssetPaths.filter((assetPath) => !existingPaths.has(assetPath));
         this.logger.debug(`After db comparison, ${filteredPaths.length} asset(s) remain to be imported`);
       }
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -8,15 +8,7 @@ import { AccessCore, Permission } from '../access';
 import { AuthUserDto } from '../auth';
 import { mimeTypes } from '../domain.constant';
 import { usePagination } from '../domain.util';
-import {
-  IBaseJob,
-  IEntityJob,
-  ILibraryFileJob,
-  ILibraryRefreshJob,
-  IOfflineLibraryFileJob,
-  JOBS_ASSET_PAGINATION_SIZE,
-  JobName,
-} from '../job';
+import { IBaseJob, IEntityJob, ILibraryFileJob, ILibraryRefreshJob, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 
 import {
   IAccessRepository,

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -388,7 +388,7 @@ export class LibraryService {
     const offlineAssetIds = assetsInLibrary
       .filter((asset) => !crawledAssetPaths.includes(asset.originalPath))
       .map((asset) => asset.id);
-    this.logger.debug(`${offlineAssetIds.length} assets in library are not present on disk and will be marked offline`);
+    this.logger.debug(`Marking ${offlineAssetIds.length} assets as offline`);
 
     await this.assetRepository.updateAll(offlineAssetIds, { isOffline: true });
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -367,6 +367,7 @@ export class LibraryService {
     const onlineFiles = new Set(crawledAssetPaths);
     const offlineAssetIds = assetsInLibrary
       .filter((asset) => !onlineFiles.has(asset.originalPath))
+      .filter((asset) => !asset.isOffline)
       .map((asset) => asset.id);
     this.logger.debug(`Marking ${offlineAssetIds.length} assets as offline`);
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -377,8 +377,9 @@ export class LibraryService {
 
     this.logger.debug(`Found ${crawledAssetPaths.length} assets when crawling import paths ${library.importPaths}`);
     const assetsInLibrary = await this.assetRepository.getByLibraryId([job.id]);
+    const onlineFiles = new Set(crawledAssetPaths);
     const offlineAssetIds = assetsInLibrary
-      .filter((asset) => !crawledAssetPaths.includes(asset.originalPath))
+      .filter((asset) => !onlineFiles.has(asset.originalPath))
       .map((asset) => asset.id);
     this.logger.debug(`Marking ${offlineAssetIds.length} assets as offline`);
 

--- a/server/src/domain/repositories/job.repository.ts
+++ b/server/src/domain/repositories/job.repository.ts
@@ -9,7 +9,6 @@ import {
   IEntityJob,
   ILibraryFileJob,
   ILibraryRefreshJob,
-  IOfflineLibraryFileJob,
 } from '../job/job.interface';
 
 export interface JobCounts {

--- a/server/src/domain/repositories/job.repository.ts
+++ b/server/src/domain/repositories/job.repository.ts
@@ -88,7 +88,6 @@ export type JobItem =
 
   // Library Managment
   | { name: JobName.LIBRARY_SCAN_ASSET; data: ILibraryFileJob }
-  | { name: JobName.LIBRARY_MARK_ASSET_OFFLINE; data: IOfflineLibraryFileJob }
   | { name: JobName.LIBRARY_SCAN; data: ILibraryRefreshJob }
   | { name: JobName.LIBRARY_REMOVE_OFFLINE; data: IEntityJob }
   | { name: JobName.LIBRARY_DELETE; data: IEntityJob }

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -52,7 +52,7 @@ export const defaults = Object.freeze<SystemConfig>({
     [QueueName.RECOGNIZE_FACES]: { concurrency: 2 },
     [QueueName.SEARCH]: { concurrency: 5 },
     [QueueName.SIDECAR]: { concurrency: 5 },
-    [QueueName.LIBRARY]: { concurrency: 1 },
+    [QueueName.LIBRARY]: { concurrency: 5 },
     [QueueName.STORAGE_TEMPLATE_MIGRATION]: { concurrency: 5 },
     [QueueName.MIGRATION]: { concurrency: 5 },
     [QueueName.THUMBNAIL_GENERATION]: { concurrency: 5 },

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -33,7 +33,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     [QueueName.RECOGNIZE_FACES]: { concurrency: 2 },
     [QueueName.SEARCH]: { concurrency: 5 },
     [QueueName.SIDECAR]: { concurrency: 5 },
-    [QueueName.LIBRARY]: { concurrency: 1 },
+    [QueueName.LIBRARY]: { concurrency: 5 },
     [QueueName.STORAGE_TEMPLATE_MIGRATION]: { concurrency: 5 },
     [QueueName.MIGRATION]: { concurrency: 5 },
     [QueueName.THUMBNAIL_GENERATION]: { concurrency: 5 },

--- a/server/src/infra/repositories/filesystem.provider.spec.ts
+++ b/server/src/infra/repositories/filesystem.provider.spec.ts
@@ -182,8 +182,6 @@ const tests: Test[] = [
 describe(FilesystemProvider.name, () => {
   const sut = new FilesystemProvider();
 
-  console.log(process.cwd());
-
   afterEach(() => {
     mockfs.restore();
   });

--- a/server/src/microservices/app.service.ts
+++ b/server/src/microservices/app.service.ts
@@ -83,7 +83,6 @@ export class AppService {
       [JobName.SIDECAR_DISCOVERY]: (data) => this.metadataService.handleSidecarDiscovery(data),
       [JobName.SIDECAR_SYNC]: () => this.metadataService.handleSidecarSync(),
       [JobName.LIBRARY_SCAN_ASSET]: (data) => this.libraryService.handleAssetRefresh(data),
-      [JobName.LIBRARY_MARK_ASSET_OFFLINE]: (data) => this.libraryService.handleOfflineAsset(data),
       [JobName.LIBRARY_SCAN]: (data) => this.libraryService.handleQueueAssetRefresh(data),
       [JobName.LIBRARY_DELETE]: (data) => this.libraryService.handleDeleteLibrary(data),
       [JobName.LIBRARY_REMOVE_OFFLINE]: (data) => this.libraryService.handleOfflineRemoval(data),

--- a/server/test/e2e/library.e2e-spec.ts
+++ b/server/test/e2e/library.e2e-spec.ts
@@ -407,7 +407,7 @@ describe(`${LibraryController.name} (e2e)`, () => {
       );
     });
 
-    it('should delete an extnernal library with assets', async () => {
+    it('should delete an external library with assets', async () => {
       const library = await api.libraryApi.create(server, admin.accessToken, {
         type: LibraryType.EXTERNAL,
         importPaths: [`${IMMICH_TEST_ASSET_PATH}/albums/nature`],

--- a/server/test/e2e/library.e2e-spec.ts
+++ b/server/test/e2e/library.e2e-spec.ts
@@ -41,7 +41,7 @@ describe(`${LibraryController.name} (e2e)`, () => {
 
   beforeEach(async () => {
     await db.reset();
-    restoreTempFolder();
+    await restoreTempFolder();
     await api.authApi.adminSignUp(server);
     admin = await api.authApi.adminLogin(server);
   });
@@ -49,7 +49,7 @@ describe(`${LibraryController.name} (e2e)`, () => {
   afterAll(async () => {
     await db.disconnect();
     await app.close();
-    restoreTempFolder();
+    await restoreTempFolder();
   });
 
   describe('GET /library', () => {


### PR DESCRIPTION
Here, we mark library assets as offline in a single db query rather than queueing individual jobs. The performance improvement is immense. We also removed all queue preparation steps that had quadratic complexity, greatly improving performance for very large libraries.