### PR TITLE
fix: remove show metadata button from album sharing

### DIFF
--- a/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
+++ b/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
@@ -184,10 +184,6 @@
         </div>
 
         <div class="my-3">
-          <SettingSwitch bind:checked={showExif} title={'Show metadata'} />
-        </div>
-
-        <div class="my-3">
           <SettingSwitch bind:checked={allowDownload} title={'Allow public user to download'} />
         </div>
 


### PR DESCRIPTION
This is a band-aid to remove a confusing option in albums sharing that can lead to security issues: https://github.com/immich-app/immich/issues/4382#issuecomment-1757063048

"Don't show metadata" doesn't actually do anything useful so we remove it.

In a later PR we might look at fixing the underlying issue but that will be non-trivial.

![image](https://github.com/immich-app/immich/assets/135728/6f703ef9-4e35-4757-a9dd-25da083583bd)

Related to #4382 