### PR TITLE
fix: people initialization on the merge face selector

### DIFF
--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -17,7 +17,7 @@
   import SwapHorizontal from 'svelte-material-icons/SwapHorizontal.svelte';
 
   export let person: PersonResponseDto;
-  let people: PersonResponseDto[];
+  let people: PersonResponseDto[] = [];
   let selectedPeople: PersonResponseDto[] = [];
   let screenHeight: number;
   let isShowConfirmation = false;


### PR DESCRIPTION
## Changes made in this PR

Currently merge face selector modal does not work because the modal does not wait for the people list to be filled and is not initialized to an empty array. This PR fixes it by initializing the variable with an empty array.