### PR TITLE
fix(mobile): asset state change not updated in gallery app bar

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
+import 'package:immich_mobile/shared/providers/asset.provider.dart';
 
 class TopControlAppBar extends HookConsumerWidget {
   const TopControlAppBar({
@@ -14,7 +15,6 @@ class TopControlAppBar extends HookConsumerWidget {
     required this.isPlayingMotionVideo,
     required this.onFavorite,
     required this.onUploadPressed,
-    required this.isFavorite,
   }) : super(key: key);
 
   final Asset asset;
@@ -23,19 +23,19 @@ class TopControlAppBar extends HookConsumerWidget {
   final VoidCallback? onDownloadPressed;
   final VoidCallback onToggleMotionVideo;
   final VoidCallback onAddToAlbumPressed;
-  final VoidCallback? onFavorite;
+  final Function(Asset) onFavorite;
   final bool isPlayingMotionVideo;
-  final bool isFavorite;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     const double iconSize = 22.0;
+    final a = ref.watch(assetWatcher(asset)).value ?? asset;
 
-    Widget buildFavoriteButton() {
+    Widget buildFavoriteButton(a) {
       return IconButton(
-        onPressed: onFavorite,
+        onPressed: () => onFavorite(a),
         icon: Icon(
-          isFavorite ? Icons.favorite : Icons.favorite_border,
+          a.isFavorite ? Icons.favorite : Icons.favorite_border,
           color: Colors.grey[200],
         ),
       );
@@ -123,7 +123,7 @@ class TopControlAppBar extends HookConsumerWidget {
         size: iconSize,
       ),
       actions: [
-        if (asset.isRemote) buildFavoriteButton(),
+        if (asset.isRemote) buildFavoriteButton(a),
         if (asset.livePhotoVideoId != null) buildLivePhotoButton(),
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal) buildDownloadButton(),

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -297,10 +297,8 @@ class GalleryViewerPage extends HookConsumerWidget {
             child: TopControlAppBar(
               isPlayingMotionVideo: isPlayingMotionVideo.value,
               asset: asset(),
-              isFavorite: asset().isFavorite,
               onMoreInfoPressed: showInfo,
-              onFavorite:
-                  asset().isRemote ? () => toggleFavorite(asset()) : null,
+              onFavorite: toggleFavorite,
               onUploadPressed:
                   asset().isLocal ? () => handleUpload(asset()) : null,
               onDownloadPressed: asset().isLocal

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -200,6 +200,12 @@ final assetDetailProvider =
   }
 });
 
+final assetWatcher =
+    StreamProvider.autoDispose.family<Asset?, Asset>((ref, asset) {
+  final db = ref.watch(dbProvider);
+  return db.assets.watchObject(asset.id, fireImmediately: true);
+});
+
 final assetsProvider =
     StreamProvider.family<RenderList, int?>((ref, userId) async* {
   if (userId == null) return;


### PR DESCRIPTION
#### Changes made in this PR

- `TopControlAppBar` now watches for changes in the currently displayed asset to update it's status indicators accordingly

> [!Note]
> This does result in the control app bar getting rendered twice, but I don't think there is an easier way currently to achieve this.

> [!Warning]
> The gallery viewer in search and explore page still does not update it's app bar state immediately. It requires a different handling altogether.

### How was this tested

- Open an asset and favorite it from the home page and ensure the favorite indicator is updated immediately
- Ensured that navigating through the assets also preserves the favorites status

Fixes #4132 