### PR TITLE
fix(server): include trashed asset during face re-index and cleanup

### DIFF
--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -51,7 +51,7 @@ export class PersonRepository implements IPersonRepository {
   }
 
   getAllFaces(): Promise<AssetFaceEntity[]> {
-    return this.assetFaceRepository.find({ relations: { asset: true } });
+    return this.assetFaceRepository.find({ relations: { asset: true }, withDeleted: true });
   }
 
   getAll(): Promise<PersonEntity[]> {
@@ -88,6 +88,7 @@ export class PersonRepository implements IPersonRepository {
       .leftJoin('person.faces', 'face')
       .having('COUNT(face.assetId) = 0')
       .groupBy('person.id')
+      .withDeleted()
       .getMany();
   }
 
@@ -142,7 +143,7 @@ export class PersonRepository implements IPersonRepository {
   }
 
   async getFacesByIds(ids: AssetFaceId[]): Promise<AssetFaceEntity[]> {
-    return this.assetFaceRepository.find({ where: ids, relations: { asset: true } });
+    return this.assetFaceRepository.find({ where: ids, relations: { asset: true }, withDeleted: true });
   }
 
   async getRandomFace(personId: string): Promise<AssetFaceEntity | null> {


### PR DESCRIPTION
#### Changes made in this PR

- Include trashed asset during remaining asset calculation for face cleanup
- include trashed assets in `getFacesByIds` and `getAllFaces` used during search re-indexing

Fixes #4448 