### PR TITLE
fix(web): previous route when hiding a person

### DIFF
--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -8,6 +8,7 @@
   import MenuOption from '../shared-components/context-menu/menu-option.svelte';
   import Portal from '../shared-components/portal/portal.svelte';
   import { createEventDispatcher } from 'svelte';
+  import { AppRoute } from '$lib/constants';
 
   export let person: PersonResponseDto;
 
@@ -42,7 +43,7 @@
   on:mouseleave={() => (showVerticalDots = false)}
   role="group"
 >
-  <a href="/people/{person.id}" draggable="false">
+  <a href="/people/{person.id}?previousRoute={AppRoute.PEOPLE}" draggable="false">
     <div class="h-48 w-48 rounded-xl brightness-95 filter">
       <ImageThumbnail
         shadow

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -245,7 +245,7 @@
   };
 
   const handleMergeFaces = (detail: PersonResponseDto) => {
-    goto(`${AppRoute.PEOPLE}/${detail.id}?action=merge`);
+    goto(`${AppRoute.PEOPLE}/${detail.id}?action=merge&previousRoute=${AppRoute.PEOPLE}`);
   };
 
   const submitNameChange = async () => {

--- a/web/src/routes/(user)/people/[personId]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/+page.svelte
@@ -132,6 +132,10 @@
 
   onMount(() => {
     const action = $page.url.searchParams.get('action');
+    const getPreviousRoute = $page.url.searchParams.get('previousRoute');
+    if (getPreviousRoute) {
+      previousRoute = getPreviousRoute;
+    }
     if (action == 'merge') {
       viewMode = ViewMode.MERGE_FACES;
     }
@@ -176,7 +180,7 @@
         type: NotificationType.Info,
       });
 
-      goto(AppRoute.EXPLORE, { replaceState: true });
+      goto(previousRoute, { replaceState: true });
     } catch (error) {
       handleError(error, 'Unable to hide person');
     }


### PR DESCRIPTION
With this PR, when accessing the person page from the people page and hiding the person, it redirects you to the people page.

Solves #4449