### PR TITLE
fix(server): include trashed assets in existing assets list

### DIFF
--- a/server/src/immich/api-v1/asset/asset-repository.ts
+++ b/server/src/immich/api-v1/asset/asset-repository.ts
@@ -172,6 +172,7 @@ export class AssetRepository implements IAssetRepository {
         deviceId,
         isVisible: true,
       },
+      withDeleted: true,
     });
 
     return items.map((asset) => asset.deviceAssetId);
@@ -205,6 +206,7 @@ export class AssetRepository implements IAssetRepository {
         deviceId: checkDuplicateAssetDto.deviceId,
         ownerId,
       },
+      withDeleted: true,
     });
     return assets.map((asset) => asset.deviceAssetId);
   }


### PR DESCRIPTION
#### Changes made in this PR

- Trashed assets are now included in the results of the `getExistingAssets` & `getAllByDeviceId` queries which are used to filter out already uploaded assets from being uploaded again in the mobile app.

Without this, a trashed asset might be added to the upload queue from the mobile app, gets marked as duplicate during upload, gets added to the `duplicatedAssets` collection and will never be uploaded again even if the remote asset from the server is deleted.

@alextran1502  Thank you for the report. Always amazed by the efforts you put into testing each change before it is released.