### PR TITLE
feat(web): show trash days info in trash page

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -325,7 +325,7 @@
   "map_location_dialog_cancel": "Cancel",
   "map_location_dialog_yes": "Yes",
   "trash_page_title": "Trash ({})",
-  "trash_page_info": "Backed up items will be permanently deleted after {} days",
+  "trash_page_info": "Trashed items will be permanently deleted after {} days",
   "trash_page_no_assets": "No trashed assets",
   "trash_page_delete": "Delete",
   "trash_page_delete_all": "Delete All",

--- a/web/src/routes/(user)/trash/+page.svelte
+++ b/web/src/routes/(user)/trash/+page.svelte
@@ -19,7 +19,7 @@
   import DeleteOutline from 'svelte-material-icons/DeleteOutline.svelte';
   import HistoryOutline from 'svelte-material-icons/History.svelte';
   import type { PageData } from './$types';
-  import { featureFlags } from '$lib/stores/server-config.store';
+  import { featureFlags, serverConfig } from '$lib/stores/server-config.store';
   import { goto } from '$app/navigation';
   import empty3Url from '$lib/assets/empty-3.svg';
   import ConfirmDialogue from '$lib/components/shared-components/confirm-dialogue.svelte';
@@ -87,6 +87,9 @@
     </div>
 
     <AssetGrid forceDelete {assetStore} {assetInteractionStore}>
+      <p class="font-medium text-gray-500/60 dark:text-gray-300/60">
+        Trashed items will be permanently deleted after {$serverConfig.trashDays} days.
+      </p>
       <EmptyPlaceholder
         text="Trashed photos and videos will show up here."
         alt="Empty trash can"


### PR DESCRIPTION
#### Changes made in the PR

- The number of days configured for the Trash cleanup is displayed as in the Trash page similar to the one in mobile app
- The mobile app text is updated to be consistent with the text from the web

Before | After
:-: | :-:
<img width="1624" alt="Before" src="https://github.com/immich-app/immich/assets/139912620/0ae00d7c-a5b5-45d2-8aba-f23b6353ea97"> | <img width="1624" alt="After" src="https://github.com/immich-app/immich/assets/139912620/18412889-8843-41c2-a9e0-b90949d0672c">
