### PR TITLE
fix(mobile): reset trashed state for local assets on deletion

### DIFF
--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -178,6 +178,7 @@ class SyncService {
       if (onlyLocal.isNotEmpty) {
         for (final Asset a in onlyLocal) {
           a.remoteId = null;
+          a.isTrashed = false;
         }
         await _db.assets.putAll(onlyLocal);
       }


### PR DESCRIPTION
#### Changes made in the PR

- Merged assets state were not reverted properly when the remote asset is deleted in the server. Due to this, if an asset is trashed previously and is permanently removed from the server, the local asset in the mobile app still will not get displayed in the main timeline

#### How was this tested

- Trashed an asset and permanently removed it from the web client and ensure that the state is changed to local and the asset is displayed in the main timeline