### PR TITLE
Fix Issues hyperlink pointing to Releases

### DIFF
--- a/docs/docs/overview/help.md
+++ b/docs/docs/overview/help.md
@@ -11,6 +11,6 @@ Running into an issue or have a question? Try the following:
 3. Search through existing [GitHub Issues][github-issues].
 4. Open a help ticket on [Discord][discord-link].
 
-[github-issues]: https://github.com/immich-app/immich/releases
+[github-issues]: https://github.com/immich-app/immich/issues
 [github-releases]: https://github.com/immich-app/immich/releases
 [discord-link]: https://discord.com/invite/D8JsnBEuKb


### PR DESCRIPTION
On the help page https://immich.app/docs/overview/help, the link to the Issues points to Releases. This PR updates the link to the correct Issues page.