### PR TITLE
refactor(web): Allow dropdown for more general use

### DIFF
--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -71,12 +71,12 @@
   {#if showMenu}
     <div
       transition:fly={{ y: -30, x: 30, duration: 200 }}
-      class="text-md absolute top-5 z-50 flex flex-col rounded-2xl bg-gray-100 py-4 text-black shadow-lg dark:bg-gray-700 dark:text-white"
+      class="text-md absolute right-0 top-5 z-50 flex min-w-[250px] flex-col rounded-2xl bg-gray-100 py-4 text-black shadow-lg dark:bg-gray-700 dark:text-white"
     >
       {#each options as option (option)}
         {@const renderedOption = renderOption(option)}
         <button
-          class="flex gap-2 p-3 transition-all hover:bg-gray-300 dark:hover:bg-gray-800"
+          class="grid grid-cols-[20px,1fr] place-items-center gap-2 p-4 transition-all hover:bg-gray-300 dark:hover:bg-gray-800"
           on:click={() => handleSelectOption(option)}
         >
           {#if _.isEqual(selectedOption, option)}

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -1,24 +1,31 @@
-<script lang="ts">
-  import Check from 'svelte-material-icons/Check.svelte';
+<script lang="ts" context="module">
+  // Necessary for eslint
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  type T = any;
+</script>
+
+<script lang="ts" generics="T">
+  import _ from 'lodash';
   import LinkButton from './buttons/link-button.svelte';
   import { clickOutside } from '$lib/utils/click-outside';
   import { fly } from 'svelte/transition';
   import type Icon from 'svelte-material-icons/DotsVertical.svelte';
+  import Check from 'svelte-material-icons/Check.svelte';
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher<{
-    select: string;
+    select: T;
   }>();
-  export let options: DropdownItem[];
-  export let key = options[0].key || options[0].value;
 
-  interface DropdownItem {
+  export let options: T[];
+  export let selectedOption = options[0];
+
+  export let render: (item: T) => string | RenderedOption = (item) => String(item);
+
+  type RenderedOption = {
     title: string;
-    /* eslint-disable @typescript-eslint/no-explicit-any*/
-    value: any;
-    key?: string;
     icon?: typeof Icon;
-  }
+  };
 
   let showMenu = false;
 
@@ -26,24 +33,37 @@
     showMenu = false;
   };
 
-  const handleSelectOption = (selectedKey: string) => {
-    key = selectedKey;
-    dispatch('select', key);
+  const handleSelectOption = (option: T) => {
+    dispatch('select', option);
+    selectedOption = option;
 
     showMenu = false;
   };
 
-  $: selectedOption = options.find((option) => key === (option.key ?? option.value));
+  const renderOption = (option: T): RenderedOption => {
+    const renderedOption = render(option);
+    switch (typeof renderedOption) {
+      case 'string':
+        return { title: renderedOption };
+      default:
+        return {
+          title: renderedOption.title,
+          icon: renderedOption.icon,
+        };
+    }
+  };
+
+  $: renderedSelectedOption = renderOption(selectedOption);
 </script>
 
 <div id="dropdown-button" use:clickOutside on:outclick={handleClickOutside} on:escape={handleClickOutside}>
   <!-- BUTTON TITLE -->
   <LinkButton on:click={() => (showMenu = true)}>
     <div class="flex place-items-center gap-2 text-sm">
-      {#if selectedOption?.icon}
-        <svelte:component this={selectedOption.icon} size="18" />
+      {#if renderedSelectedOption?.icon}
+        <svelte:component this={renderedSelectedOption.icon} size="18" />
       {/if}
-      <p class="hidden sm:block">{selectedOption?.value}</p>
+      <p class="hidden sm:block">{renderedSelectedOption.title}</p>
     </div>
   </LinkButton>
 
@@ -51,24 +71,25 @@
   {#if showMenu}
     <div
       transition:fly={{ y: -30, x: 30, duration: 200 }}
-      class="text-md absolute right-0 top-5 z-50 flex min-w-[250px] flex-col rounded-2xl bg-gray-100 py-4 text-black shadow-lg dark:bg-gray-700 dark:text-white"
+      class="text-md absolute top-5 z-50 flex flex-col rounded-2xl bg-gray-100 py-4 text-black shadow-lg dark:bg-gray-700 dark:text-white"
     >
-      {#each options as option}
+      {#each options as option (option)}
+        {@const renderedOption = renderOption(option)}
         <button
-          class="grid grid-cols-[20px,1fr] place-items-center gap-2 p-4 transition-all hover:bg-gray-300 dark:hover:bg-gray-800"
-          on:click={() => handleSelectOption(option.key ?? option.value)}
+          class="flex gap-2 p-3 transition-all hover:bg-gray-300 dark:hover:bg-gray-800"
+          on:click={() => handleSelectOption(option)}
         >
-          {#if key == option.key ?? option.value}
-            <div class="font-medium text-immich-primary dark:text-immich-dark-primary">
+          {#if _.isEqual(selectedOption, option)}
+            <div class="text-immich-primary dark:text-immich-dark-primary">
               <Check size="18" />
             </div>
-            <p class="justify-self-start font-medium text-immich-primary dark:text-immich-dark-primary">
-              {option.title}
+            <p class="justify-self-start text-immich-primary dark:text-immich-dark-primary">
+              {renderedOption.title}
             </p>
           {:else}
             <div />
             <p class="justify-self-start">
-              {option.title}
+              {renderedOption.title}
             </p>
           {/if}
         </button>

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -9,9 +9,16 @@
   const dispatch = createEventDispatcher<{
     select: string;
   }>();
-  export let options: string[];
-  export let value = options[0];
+  export let options: DropdownItem[];
+  export let key = options[0].key || options[0].value;
   export let icons: (typeof Icon)[] | undefined = undefined;
+
+  interface DropdownItem {
+    title: string;
+    /* eslint-disable @typescript-eslint/no-explicit-any*/
+    value: any;
+    key?: string;
+  }
 
   let showMenu = false;
 
@@ -19,18 +26,15 @@
     showMenu = false;
   };
 
-  const handleSelectOption = (index: number) => {
-    if (options[index] === value) {
-      dispatch('select', value);
-    } else {
-      value = options[index];
-    }
+  const handleSelectOption = (selectedKey: string) => {
+    key = selectedKey;
+    dispatch('select', key);
 
     showMenu = false;
   };
 
-  $: index = options.findIndex((option) => option === value);
-  $: icon = icons?.[index];
+  $: value = options.find((option) => key === (option.key ?? option.value))?.value;
+  $: icon = icons?.[key];
 </script>
 
 <div id="dropdown-button" use:clickOutside on:outclick={handleClickOutside} on:escape={handleClickOutside}>
@@ -50,22 +54,22 @@
       transition:fly={{ y: -30, x: 30, duration: 200 }}
       class="text-md absolute right-0 top-5 z-50 flex min-w-[250px] flex-col rounded-2xl bg-gray-100 py-4 text-black shadow-lg dark:bg-gray-700 dark:text-white"
     >
-      {#each options as option, index (option)}
+      {#each options as option}
         <button
           class="grid grid-cols-[20px,1fr] place-items-center gap-2 p-4 transition-all hover:bg-gray-300 dark:hover:bg-gray-800"
-          on:click={() => handleSelectOption(index)}
+          on:click={() => handleSelectOption(option.key ?? option.value)}
         >
-          {#if value == option}
+          {#if key == option.key ?? option.value}
             <div class="font-medium text-immich-primary dark:text-immich-dark-primary">
               <Check size="18" />
             </div>
             <p class="justify-self-start font-medium text-immich-primary dark:text-immich-dark-primary">
-              {option}
+              {option.title}
             </p>
           {:else}
             <div />
             <p class="justify-self-start">
-              {option}
+              {option.title}
             </p>
           {/if}
         </button>

--- a/web/src/lib/components/elements/dropdown.svelte
+++ b/web/src/lib/components/elements/dropdown.svelte
@@ -11,13 +11,13 @@
   }>();
   export let options: DropdownItem[];
   export let key = options[0].key || options[0].value;
-  export let icons: (typeof Icon)[] | undefined = undefined;
 
   interface DropdownItem {
     title: string;
     /* eslint-disable @typescript-eslint/no-explicit-any*/
     value: any;
     key?: string;
+    icon?: typeof Icon;
   }
 
   let showMenu = false;
@@ -33,18 +33,17 @@
     showMenu = false;
   };
 
-  $: value = options.find((option) => key === (option.key ?? option.value))?.value;
-  $: icon = icons?.[key];
+  $: selectedOption = options.find((option) => key === (option.key ?? option.value));
 </script>
 
 <div id="dropdown-button" use:clickOutside on:outclick={handleClickOutside} on:escape={handleClickOutside}>
   <!-- BUTTON TITLE -->
   <LinkButton on:click={() => (showMenu = true)}>
     <div class="flex place-items-center gap-2 text-sm">
-      {#if icon}
-        <svelte:component this={icon} size="18" />
+      {#if selectedOption?.icon}
+        <svelte:component this={selectedOption.icon} size="18" />
       {/if}
-      <p class="hidden sm:block">{value}</p>
+      <p class="hidden sm:block">{selectedOption?.value}</p>
     </div>
   </LinkButton>
 

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -216,8 +216,10 @@
     </LinkButton>
 
     <Dropdown
-      options={Object.values(sortByOptions).map((CourseInfo) => CourseInfo.sortTitle)}
-      bind:value={$albumViewSettings.sortBy}
+      options={Object.values(sortByOptions).map((CourseInfo) => {
+        return { title: CourseInfo.sortTitle, value: CourseInfo.sortTitle };
+      })}
+      bind:key={$albumViewSettings.sortBy}
       icons={Object.keys(sortByOptions).map((key) => (sortByOptions[key].sortDesc ? ArrowDownThin : ArrowUpThin))}
       on:select={(event) => {
         for (const key in sortByOptions) {

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -217,10 +217,13 @@
 
     <Dropdown
       options={Object.values(sortByOptions).map((CourseInfo) => {
-        return { title: CourseInfo.sortTitle, value: CourseInfo.sortTitle };
+        return {
+          title: CourseInfo.sortTitle,
+          value: CourseInfo.sortTitle,
+          icon: CourseInfo.sortDesc ? ArrowDownThin : ArrowUpThin,
+        };
       })}
       bind:key={$albumViewSettings.sortBy}
-      icons={Object.keys(sortByOptions).map((key) => (sortByOptions[key].sortDesc ? ArrowDownThin : ArrowUpThin))}
       on:select={(event) => {
         for (const key in sortByOptions) {
           if (sortByOptions[key].sortTitle === event.detail) {

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -216,20 +216,20 @@
     </LinkButton>
 
     <Dropdown
-      options={Object.values(sortByOptions).map((CourseInfo) => {
+      options={Object.values(sortByOptions)}
+      render={(option) => {
         return {
-          title: CourseInfo.sortTitle,
-          value: CourseInfo.sortTitle,
-          icon: CourseInfo.sortDesc ? ArrowDownThin : ArrowUpThin,
+          title: option.sortTitle,
+          icon: option.sortDesc ? ArrowDownThin : ArrowUpThin,
         };
-      })}
-      bind:key={$albumViewSettings.sortBy}
+      }}
       on:select={(event) => {
         for (const key in sortByOptions) {
-          if (sortByOptions[key].sortTitle === event.detail) {
+          if (sortByOptions[key].sortTitle === event.detail.sortTitle) {
             sortByOptions[key].sortDesc = !sortByOptions[key].sortDesc;
           }
         }
+        $albumViewSettings.sortBy = event.detail.sortTitle;
       }}
     />
 


### PR DESCRIPTION
Now, options can have a generic type. A render function can specify what text (and icon) should be displayed for an option.
Also some design improvements by making the dropdown a little more compact:

Preview is available [here](https://pr-4515.preview.immich.app)
