### PR TITLE
fix(web): Prevents nav loop from person->album->albums

### DIFF
--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -94,7 +94,7 @@
       url = from.url.href;
     }
 
-    if (from?.route.id === '/(user)/albums/[albumId]') {
+    if (from?.route.id === '/(user)/albums/[albumId]' || from?.route.id === '/(user)/people/[personId]') {
       url = AppRoute.ALBUMS;
     }
 


### PR DESCRIPTION
## Description
  - If the `from` is the person detail when getting back to the album overview, set backUrl to albums page

Fixes #3820 


## How Has This Been Tested? 
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
```
1. Go to album
2. Click on asset with recognized face
3. Click on face in asset info panel
4. Navigate back from face overview clicking the "back" arrow
5. Try to navigate back (out of album) once more
6. You're back at the face overview

After running the above, navigation ends up at the albums overview page instead of a nav loop
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable