### PR TITLE
fix(mobile): validate response code for downloaded file

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -164,6 +164,7 @@
   "home_page_favorite_err_local": "Can not favorite local assets yet, skipping",
   "home_page_first_time_notice": "If this is your first time using the app, please make sure to choose a backup album(s) so that the timeline can populate photos and videos in the album(s).",
   "image_viewer_page_state_provider_download_error": "Download Error",
+  "image_viewer_page_state_provider_share_error": "Share Error",
   "image_viewer_page_state_provider_download_success": "Download Success",
   "library_page_albums": "Albums",
   "library_page_archive": "Archive",

--- a/mobile/lib/modules/asset_viewer/providers/image_viewer_page_state.provider.dart
+++ b/mobile/lib/modules/asset_viewer/providers/image_viewer_page_state.provider.dart
@@ -57,9 +57,19 @@ class ImageViewerStateNotifier extends StateNotifier<ImageViewerPageState> {
     showDialog(
       context: context,
       builder: (BuildContext buildContext) {
-        _shareService
-            .shareAsset(asset)
-            .then((_) => Navigator.of(buildContext).pop());
+        _shareService.shareAsset(asset).then(
+          (bool status) {
+            if (!status) {
+              ImmichToast.show(
+                context: context,
+                msg: 'image_viewer_page_state_provider_share_error'.tr(),
+                toastType: ToastType.error,
+                gravity: ToastGravity.BOTTOM,
+              );
+            }
+            Navigator.of(buildContext).pop();
+          },
+        );
         return const ShareDialog();
       },
       barrierDismissible: false,

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:logging/logging.dart';
 
 import 'package:photo_manager/photo_manager.dart';
 import 'package:path_provider/path_provider.dart';
@@ -14,6 +15,7 @@ final imageViewerServiceProvider =
 
 class ImageViewerService {
   final ApiService _apiService;
+  final Logger _log = Logger("ImageViewerService");
 
   ImageViewerService(this._apiService);
 
@@ -28,6 +30,16 @@ class ImageViewerService {
         var motionReponse = await _apiService.assetApi.downloadFileWithHttpInfo(
           asset.livePhotoVideoId!,
         );
+
+        if (imageResponse.statusCode != 200 ||
+            motionReponse.statusCode != 200) {
+          final failedResponse =
+              imageResponse.statusCode != 200 ? imageResponse : motionReponse;
+          _log.severe(
+            "Motion asset download failed with status - ${failedResponse.statusCode} and response - ${failedResponse.body}",
+          );
+          return false;
+        }
 
         final AssetEntity? entity;
 
@@ -47,6 +59,13 @@ class ImageViewerService {
       } else {
         var res = await _apiService.assetApi
             .downloadFileWithHttpInfo(asset.remoteId!);
+
+        if (res.statusCode != 200) {
+          _log.severe(
+            "Asset download failed with status - ${res.statusCode} and response - ${res.body}",
+          );
+          return false;
+        }
 
         final AssetEntity? entity;
 

--- a/mobile/lib/utils/selection_handlers.dart
+++ b/mobile/lib/utils/selection_handlers.dart
@@ -1,3 +1,4 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,10 +16,19 @@ void handleShareAssets(
   showDialog(
     context: context,
     builder: (BuildContext buildContext) {
-      ref
-          .watch(shareServiceProvider)
-          .shareAssets(selection.toList())
-          .then((_) => Navigator.of(buildContext).pop());
+      ref.watch(shareServiceProvider).shareAssets(selection.toList()).then(
+        (bool status) {
+          if (!status) {
+            ImmichToast.show(
+              context: context,
+              msg: 'image_viewer_page_state_provider_share_error'.tr(),
+              toastType: ToastType.error,
+              gravity: ToastGravity.BOTTOM,
+            );
+          }
+          Navigator.of(buildContext).pop();
+        },
+      );
       return const ShareDialog();
     },
     barrierDismissible: false,


### PR DESCRIPTION
Fixes #4285 

#### Change made in the PR

- Handle non-success response code for download assets

#### How was this tested

- Tried downloading an offline file and made sure an error toast is displayed instead of a success message
- Tried sharing an offline asset and made sure an error toast is displayed