### PR TITLE
feat(server): Two updates to dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ dev:
 dev-new:
 	docker compose -f ./docker/docker-compose.dev.yml up --remove-orphans
 
+dev-down:
+	docker compose -f ./docker/docker-compose.dev.yml down --remove-orphans
+
 dev-new-update:
 	docker compose -f ./docker/docker-compose.dev.yml up --build -V --remove-orphans
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -21,6 +21,10 @@ services:
       - .env
     environment:
       - NODE_ENV=development
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     depends_on:
       - redis
       - database
@@ -48,6 +52,10 @@ services:
       - 9231:9230
     environment:
       - NODE_ENV=development
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     depends_on:
       - database
       - immich-server
@@ -73,6 +81,10 @@ services:
     volumes:
       - ../web:/usr/src/app
       - /usr/src/app/node_modules
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     restart: unless-stopped
     depends_on:
       - immich-server


### PR DESCRIPTION
1. In the `docker-compose.dev.yml` file, increased ulimits for the containers that use TS code. This was one of the reasons for failures in my Podman (on macOS/arm64) environment. It wasn't the only failure with Podman, and didn't investigate further (I switched to Docker on Linux/amd64 after), but it can still help others.

2. Added a `make dev-down` to perform a `docker-compose down` on the dev environment