### PR TITLE
docs: Semantic fixes and improvements for the main documentation page

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ function HomepageHeader() {
   return (
     <header>
       <section className="text-center m-6 p-12 border border-red-400 rounded-[50px] bg-gray-100 dark:bg-immich-dark-gray">
-        <img src="img/immich-logo.svg" className="md:h-24 h-12 mb-2" />
+        <img src="img/immich-logo.svg" className="md:h-24 h-12 mb-2" alt="Immich logo" />
         <h1 className="md:text-6xl font-immich-title mb-10 text-immich-primary dark:text-immich-dark-primary">
           IMMICH
         </h1>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -11,9 +11,11 @@ function HomepageHeader() {
           Immich
         </h1>
         <div className="font-thin sm:text-base md:text-2xl my-12 sm:leading-tight">
-          <p className="mb-1">SELF-HOSTED BACKUP SOLUTION </p>
-          <p className="mb-1">FOR PHOTOS AND VIDEOS</p>
-          <p className="mb-1">ON MOBILE DEVICE</p>
+          <p className="mb-1 uppercase">
+            Self-hosted backup solution <span class="block"></span>
+            for photos and videos <span class="block"></span>
+            on mobile device
+          </p>
         </div>
 
         <div className="flex flex-col sm:flex-row place-items-center place-content-center mt-9 mb-16 gap-4 ">

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -12,8 +12,8 @@ function HomepageHeader() {
         </h1>
         <div className="font-thin sm:text-base md:text-2xl my-12 sm:leading-tight">
           <p className="mb-1 uppercase">
-            Self-hosted backup solution <span class="block"></span>
-            for photos and videos <span class="block"></span>
+            Self-hosted backup solution <span className="block"></span>
+            for photos and videos <span className="block"></span>
             on mobile device
           </p>
         </div>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -7,8 +7,8 @@ function HomepageHeader() {
     <header>
       <section className="text-center m-6 p-12 border border-red-400 rounded-[50px] bg-gray-100 dark:bg-immich-dark-gray">
         <img src="img/immich-logo.svg" className="md:h-24 h-12 mb-2" alt="Immich logo" />
-        <h1 className="md:text-6xl font-immich-title mb-10 text-immich-primary dark:text-immich-dark-primary">
-          IMMICH
+        <h1 className="md:text-6xl font-immich-title mb-10 text-immich-primary dark:text-immich-dark-primary uppercase">
+          Immich
         </h1>
         <div className="font-thin sm:text-base md:text-2xl my-12 sm:leading-tight">
           <p className="mb-1">SELF-HOSTED BACKUP SOLUTION </p>
@@ -18,17 +18,17 @@ function HomepageHeader() {
 
         <div className="flex flex-col sm:flex-row place-items-center place-content-center mt-9 mb-16 gap-4 ">
           <Link
-            className="flex place-items-center place-content-center py-3 px-8 border bg-immich-primary dark:bg-immich-dark-primary rounded-full no-underline hover:no-underline text-white hover:text-gray-50 dark:text-immich-dark-bg font-bold"
+            className="flex place-items-center place-content-center py-3 px-8 border bg-immich-primary dark:bg-immich-dark-primary rounded-full no-underline hover:no-underline text-white hover:text-gray-50 dark:text-immich-dark-bg font-bold uppercase"
             to="docs/overview/introduction"
           >
-            GET STARTED
+            Get started
           </Link>
 
           <Link
-            className="flex place-items-center place-content-center py-3 px-8 border bg-immich-primary/10 dark:bg-gray-300  rounded-full hover:no-underline text-immich-primary dark:text-immich-dark-bg font-bold"
+            className="flex place-items-center place-content-center py-3 px-8 border bg-immich-primary/10 dark:bg-gray-300  rounded-full hover:no-underline text-immich-primary dark:text-immich-dark-bg font-bold uppercase"
             to="https://demo.immich.app/"
           >
-            DEMO PORTAL
+            Demo portal
           </Link>
         </div>
 


### PR DESCRIPTION
Alt text for the logo,
using CSS for uppercase styling instead of HTML,
breaking a sentence with CSS instead of using three paragraphs.