### PR TITLE
fix(mobile): handle non-standard exposure time string

### DIFF
--- a/mobile/lib/shared/models/exif_info.dart
+++ b/mobile/lib/shared/models/exif_info.dart
@@ -1,6 +1,5 @@
 import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
-import 'package:immich_mobile/utils/builtin_extensions.dart';
 
 part 'exif_info.g.dart';
 
@@ -165,7 +164,11 @@ double? _exposureTimeToSeconds(String? s) {
   }
   final parts = s.split("/");
   if (parts.length == 2) {
-    return parts[0].toDouble() / parts[1].toDouble();
+    final numerator = double.tryParse(parts[0]);
+    final denominator = double.tryParse(parts[1]);
+    if (numerator != null && denominator != null) {
+      return numerator / denominator;
+    }
   }
   return null;
 }


### PR DESCRIPTION
Fixes #4376 

#### Changes made in the PR:

- Non standard `exposureTime` values used to throw exceptions during parsing resulting in sync failures. All the double conversions are made optional and exposureTime is calculated only when we receive a valid string else set to empty to prevent sync failures