### PR TITLE
feat(ml): dynamic batching

### DIFF
--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     request_threads: int = os.cpu_count() or 4
     model_inter_op_threads: int = 1
     model_intra_op_threads: int = 2
-    max_batch_size: int = 8
+    max_batch_size: int = 1
     batch_timeout_s: float = 0.005
 
     class Config:

--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -21,6 +21,8 @@ class Settings(BaseSettings):
     request_threads: int = os.cpu_count() or 4
     model_inter_op_threads: int = 1
     model_intra_op_threads: int = 2
+    max_batch_size: int = 8
+    batch_timeout_s: float = 0.005
 
     class Config:
         env_prefix = "MACHINE_LEARNING_"

--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -76,8 +76,13 @@ async def predict(
 
     model = await load(await app.state.model_cache.get(model_name, model_type, **kwargs))
     model.configure(**kwargs)
-    batcher: Batcher = app.state.model_batcher.get(model_name, model_type, **kwargs)
-    outputs = await batcher.batch_process(element, run, model)
+
+    if settings.max_batch_size > 1:
+        batcher: Batcher = app.state.model_batcher.get(model_name, model_type, **kwargs)
+        outputs = await batcher.batch_process(element, run, model)
+    else:
+        outputs = await run(model, [element])
+
     return ORJSONResponse(outputs)
 
 

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -12,6 +12,10 @@ from ..config import get_cache_dir, log, settings
 from ..schemas import ModelType
 
 
+def get_model_key(model_name: str, model_type: ModelType, mode: str = "") -> str:
+    return f"{model_name}{model_type.value}{mode}"
+
+
 class InferenceModel(ABC):
     _model_type: ModelType
 
@@ -65,14 +69,15 @@ class InferenceModel(ABC):
         self._load()
         self.loaded = True
 
-    def predict(self, inputs: Any, **model_kwargs: Any) -> Any:
+    def predict(self, element: Any) -> Any:
+        return self.predict_batch([element])[0]
+    
+    def predict_batch(self, inputs: list[Any]) -> list[Any]:
         self.load()
-        if model_kwargs:
-            self.configure(**model_kwargs)
-        return self._predict(inputs)
+        return self._predict_batch(inputs)
 
     @abstractmethod
-    def _predict(self, inputs: Any) -> Any:
+    def _predict_batch(self, inputs: list[Any]) -> Any:
         ...
 
     def configure(self, **model_kwargs: Any) -> None:

--- a/machine-learning/app/models/batcher.py
+++ b/machine-learning/app/models/batcher.py
@@ -1,0 +1,65 @@
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, TypeVar
+
+from app.schemas import ModelType
+
+from .base import get_model_key, log
+
+
+F = TypeVar("F")
+P = TypeVar("P")
+R = TypeVar("R")
+
+
+class Batcher:
+    def __init__(self, max_size: int = 16, timeout_s: float = 0.005) -> None:
+        self.max_size = max_size
+        self.timeout_s = timeout_s
+        self.queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=max_size)
+        self.lock = asyncio.Lock()
+        self.processing: dict[int, Any] = {}
+        self.processed: dict[int, Any] = {}
+        self.element_id = 0
+
+    async def batch_process(self, element: Any, func: Callable[[list[P]], Awaitable[list[R]]], *args: Any, **kwargs: Any) -> Any:
+        cur_idx = self.element_id
+        self.element_id += 1
+        self.processing[cur_idx] = element
+        await self.queue.put(cur_idx)
+        try:
+            async with self.lock:
+                await self._batch(cur_idx)
+                if cur_idx not in self.processed:
+                    await self._process(func, *args, **kwargs)
+            return self.processed.pop(cur_idx)
+        finally:
+            self.processing.pop(cur_idx, None)
+            self.processed.pop(cur_idx, None)
+    
+    async def _batch(self, idx: int) -> list[Any]:
+        if idx not in self.processed:
+            start = time.monotonic()
+            while self.queue.qsize() < self.max_size and time.monotonic() - start < self.timeout_s:
+                await asyncio.sleep(0)
+
+    async def _process(self, func: Callable[[list[P]], Awaitable[list[R]]], *args, **kwargs) -> None:
+        batch_ids = [self.queue.get_nowait() for _ in range(self.queue.qsize())]
+        batch = [self.processing.pop(id) for id in batch_ids]
+        outputs = await func(*args, batch, **kwargs)
+        for id, output in zip(batch_ids, outputs):
+            self.processed[id] = output
+
+
+class ModelBatcher:
+    def __init__(self, max_size: int = 16, timeout_s: float = 0.005) -> None:
+        self.batchers = {}
+        self.max_size = max_size
+        self.timeout_s = timeout_s
+
+    def get(self, model_name: str, model_type: ModelType, **model_kwargs: Any):
+        key = get_model_key(model_name, model_type, model_kwargs.get("mode", ""))
+        if key not in self.batchers:
+            self.batchers[key] = Batcher(max_size=self.max_size, timeout_s=self.timeout_s)
+        
+        return self.batchers[key]

--- a/machine-learning/app/models/cache.py
+++ b/machine-learning/app/models/cache.py
@@ -5,7 +5,7 @@ from aiocache.lock import OptimisticLock
 from aiocache.plugins import BasePlugin, TimingPlugin
 
 from ..schemas import ModelType
-from .base import InferenceModel
+from .base import InferenceModel, get_model_key
 
 
 class ModelCache:
@@ -46,7 +46,7 @@ class ModelCache:
             model: The requested model.
         """
 
-        key = f"{model_name}{model_type.value}{model_kwargs.get('mode', '')}"
+        key = get_model_key(model_name, model_type, model_kwargs.get("mode", ""))
         async with OptimisticLock(self.cache, key) as lock:
             model = await self.cache.get(key)
             if model is None:

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -1,5 +1,7 @@
 from enum import StrEnum
+from typing import Any, TypeAlias
 
+import numpy as np
 from pydantic import BaseModel
 
 
@@ -31,3 +33,6 @@ class ModelType(StrEnum):
     IMAGE_CLASSIFICATION = "image-classification"
     CLIP = "clip"
     FACIAL_RECOGNITION = "facial-recognition"
+
+
+ndarray: TypeAlias = np.ndarray[int, np.dtype[Any]]


### PR DESCRIPTION
### Description

Models are optimized for processing inputs in batches, but until now the ML service has processed each input individually without any batching. This is particularly consequential when using acceleration devices; the overhead of moving data repeatedly to and from a device can undermine its performance. On the other hand, batching adds complexity to server code, particularly in the case of failures.

This PR aggregates request payloads within a certain timeframe into a single model input, improving performance for acceleration devices while being self-contained in the ML service. This does come at a cost: dynamic batching is less efficient than fixed batching, and in the case of CPUs, the overhead it adds outweighs the performance benefit. Because of this, it is disabled by default and can be enabled by setting `MACHINE_LEARNING_MAX_BATCH_SIZE` greater than 1.