### PR TITLE
refactor(mobile): stack only through merging from timeline 

### DIFF
--- a/mobile/lib/modules/asset_viewer/providers/asset_stack.provider.dart
+++ b/mobile/lib/modules/asset_viewer/providers/asset_stack.provider.dart
@@ -46,5 +46,6 @@ final assetStackProvider =
       .isArchivedEqualTo(false)
       .isTrashedEqualTo(false)
       .stackParentIdEqualTo(asset.remoteId)
+      .sortByFileCreatedAtDesc()
       .findAll();
 });

--- a/mobile/lib/modules/home/models/selection_state.dart
+++ b/mobile/lib/modules/home/models/selection_state.dart
@@ -4,33 +4,38 @@ class SelectionAssetState {
   final bool hasRemote;
   final bool hasLocal;
   final bool hasMerged;
+  final int selectedCount;
 
   const SelectionAssetState({
     this.hasRemote = false,
     this.hasLocal = false,
     this.hasMerged = false,
+    this.selectedCount = 0,
   });
 
   SelectionAssetState copyWith({
     bool? hasRemote,
     bool? hasLocal,
     bool? hasMerged,
+    int? selectedCount,
   }) {
     return SelectionAssetState(
       hasRemote: hasRemote ?? this.hasRemote,
       hasLocal: hasLocal ?? this.hasLocal,
       hasMerged: hasMerged ?? this.hasMerged,
+      selectedCount: selectedCount ?? this.selectedCount,
     );
   }
 
   SelectionAssetState.fromSelection(Set<Asset> selection)
       : hasLocal = selection.any((e) => e.storage == AssetState.local),
         hasMerged = selection.any((e) => e.storage == AssetState.merged),
-        hasRemote = selection.any((e) => e.storage == AssetState.remote);
+        hasRemote = selection.any((e) => e.storage == AssetState.remote),
+        selectedCount = selection.length;
 
   @override
   String toString() =>
-      'SelectionAssetState(hasRemote: $hasRemote, hasMerged: $hasMerged, hasMerged: $hasMerged)';
+      'SelectionAssetState(hasRemote: $hasRemote, hasMerged: $hasMerged, hasMerged: $hasMerged, selectedCount: $selectedCount)';
 
   @override
   bool operator ==(covariant SelectionAssetState other) {
@@ -38,10 +43,14 @@ class SelectionAssetState {
 
     return other.hasRemote == hasRemote &&
         other.hasLocal == hasLocal &&
-        other.hasMerged == hasMerged;
+        other.hasMerged == hasMerged &&
+        other.selectedCount == selectedCount;
   }
 
   @override
   int get hashCode =>
-      hasRemote.hashCode ^ hasLocal.hashCode ^ hasMerged.hashCode;
+      hasRemote.hashCode ^
+      hasLocal.hashCode ^
+      hasMerged.hashCode ^
+      selectedCount.hashCode;
 }

--- a/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
+++ b/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
@@ -94,7 +94,7 @@ class ControlBottomAppBar extends ConsumerWidget {
                 }
               : null,
         ),
-        if (!hasLocal)
+        if (!hasLocal && selectionAssetState.selectedCount > 1)
           ControlBoxButton(
             iconData: Icons.filter_none_rounded,
             label: "control_bottom_app_bar_stack".tr(),

--- a/mobile/lib/shared/providers/asset.provider.dart
+++ b/mobile/lib/shared/providers/asset.provider.dart
@@ -245,31 +245,3 @@ QueryBuilder<Asset, Asset, QAfterSortBy>? getRemoteAssetQuery(WidgetRef ref) {
       .stackParentIdIsNull()
       .sortByFileCreatedAtDesc();
 }
-
-QueryBuilder<Asset, Asset, QAfterSortBy>? getAssetStackSelectionQuery(
-  WidgetRef ref,
-  Asset parentAsset,
-) {
-  final userId = ref.watch(currentUserProvider)?.isarId;
-  if (userId == null || !parentAsset.isRemote) {
-    return null;
-  }
-  return ref
-      .watch(dbProvider)
-      .assets
-      .where()
-      .remoteIdIsNotNull()
-      .filter()
-      .isArchivedEqualTo(false)
-      .ownerIdEqualTo(userId)
-      .not()
-      .remoteIdEqualTo(parentAsset.remoteId)
-      // Show existing stack children in selection page
-      .group(
-        (q) => q
-            .stackParentIdIsNull()
-            .or()
-            .stackParentIdEqualTo(parentAsset.remoteId),
-      )
-      .sortByFileCreatedAtDesc();
-}


### PR DESCRIPTION
#### Changes made in the PR

- Asset selection based handling is removed for stacking since selecting multiple assets and stacking them from the timeline is more natural.
- Show stack button only when at-least two assets are selected in the timeline
- Sort stack children by their `fileCreateAt` time

>[!Note]
> The previous asset selection page based handling allowed one to remove multiple children by deselecting them from the asset selection page. With this change, children can only be removed one at a time or the entire group can be un-stacked and re-stacked. 