### PR TITLE
fix(web): timeline scrolling

### DIFF
--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -13,7 +13,6 @@
   import type { AssetStore } from '$lib/stores/assets.store';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import type { Viewport } from '$lib/stores/assets.store';
-  import { flip } from 'svelte/animate';
 
   export let assets: AssetResponseDto[];
   export let bucketDate: string;
@@ -177,7 +176,6 @@
           <div
             class="absolute"
             style="width: {box.width}px; height: {box.height}px; top: {box.top}px; left: {box.left}px"
-            animate:flip={{ duration: 350 }}
           >
             <Thumbnail
               {asset}


### PR DESCRIPTION
## Description

This PR fixes the web timeline shifting/jumping while scrolling up that was caused by the `flip` animation used in the `AssetDateGroup` component. Also, the horizontal resizing of the timeline is much smoother/faster now
