### PR TITLE
docs: fix shell comnad for restoring the database

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -20,6 +20,7 @@ docker exec -t immich_postgres pg_dumpall -c -U postgres | gzip > "/path/to/back
 docker-compose down -v  # CAUTION! Deletes all Immich data to start from scratch.
 docker-compose pull     # Update to latest version of Immich (if desired)
 docker-compose create   # Create Docker containers for Immich apps without running them.
+docker network create immich-app_default     # Create a docker network 
 docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
 gunzip < "/path/to/backup/dump.sql.gz" | docker exec -i immich_postgres psql -U postgres -d immich    # Restore Backup


### PR DESCRIPTION
Hi, i was restoring a database of an earlier immich instance on a brand new server, but the command provided by the documentation kept failing with 
`Error response from daemon: network immich-app_default not found
Error: failed to start containers: immich_postgres`. 
Manually starting the network before starting the database seemed to fix the issue. I was able to reproduce the issue on my second laptop and creating the network before starting the database also fixed that. 