### PR TITLE
fix(web,server): web socket auth (for web)

### DIFF
--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -147,7 +147,7 @@ export class AuthService {
     return mapAdminSignupResponse(admin);
   }
 
-  async validate(headers: IncomingHttpHeaders, params: Record<string, string>): Promise<AuthUserDto | null> {
+  async validate(headers: IncomingHttpHeaders, params: Record<string, string>): Promise<AuthUserDto> {
     const shareKey = (headers['x-immich-share-key'] || params.key) as string;
     const userToken = (headers['x-immich-user-token'] ||
       params.userToken ||

--- a/server/src/immich/app.guard.ts
+++ b/server/src/immich/app.guard.ts
@@ -99,11 +99,6 @@ export class AppGuard implements CanActivate {
     const req = context.switchToHttp().getRequest<AuthRequest>();
 
     const authDto = await this.authService.validate(req.headers, req.query as Record<string, string>);
-    if (!authDto) {
-      this.logger.warn(`Denied access to authenticated route: ${req.path}`);
-      return false;
-    }
-
     if (authDto.isPublicUser && !isSharedRoute) {
       this.logger.warn(`Denied access to non-shared route: ${req.path}`);
       return false;

--- a/server/src/infra/repositories/communication.repository.ts
+++ b/server/src/infra/repositories/communication.repository.ts
@@ -18,26 +18,22 @@ export class CommunicationRepository implements OnGatewayConnection, OnGatewayDi
 
   async handleConnection(client: Socket) {
     try {
-      this.logger.log(`New websocket connection: ${client.id}`);
+      this.logger.log(`Websocket Connect:    ${client.id}`);
       const user = await this.authService.validate(client.request.headers, {});
-      if (user) {
-        await client.join(user.id);
-        for (const callback of this.onConnectCallbacks) {
-          await callback(user.id);
-        }
-      } else {
-        client.emit('error', 'unauthorized');
-        client.disconnect();
+      await client.join(user.id);
+      for (const callback of this.onConnectCallbacks) {
+        await callback(user.id);
       }
-    } catch (e) {
+    } catch (error: Error | any) {
+      this.logger.error(`Websocket connection error: ${error}`, error?.stack);
       client.emit('error', 'unauthorized');
       client.disconnect();
     }
   }
 
   async handleDisconnect(client: Socket) {
+    this.logger.log(`Websocket Disconnect: ${client.id}`);
     await client.leave(client.nsp.name);
-    this.logger.log(`Client ${client.id} disconnected from Websocket`);
   }
 
   send(event: CommunicationEvent, userId: string, data: any) {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
   import { handleError } from '$lib/utils/handle-error';
   import { dragAndDropFilesStore } from '$lib/stores/drag-and-drop-files.store';
   import { api } from '@api';
-  import { openWebsocketConnection } from '$lib/stores/websocket';
+  import { closeWebsocketConnection, openWebsocketConnection } from '$lib/stores/websocket';
 
   let showNavigationLoadingBar = false;
   export let data: LayoutData;
@@ -28,7 +28,18 @@
     api.setKey($page.params.key);
   }
 
-  beforeNavigate(() => {
+  beforeNavigate(({ from, to }) => {
+    const fromRoute = from?.route?.id || '';
+    const toRoute = to?.route?.id || '';
+
+    if (fromRoute.startsWith('/auth') && !toRoute.startsWith('/auth')) {
+      openWebsocketConnection();
+    }
+
+    if (!fromRoute.startsWith('/auth') && toRoute.startsWith('/auth')) {
+      closeWebsocketConnection();
+    }
+
     showNavigationLoadingBar = true;
   });
 
@@ -37,7 +48,9 @@
   });
 
   onMount(async () => {
-    openWebsocketConnection();
+    if ($page.route.id?.startsWith('/auth') === false) {
+      openWebsocketConnection();
+    }
 
     try {
       await loadConfig();


### PR DESCRIPTION
Fixes #4521

The websocket connection requires authentication, so only open a connection after loggin in and disconnect after logging out.

Login and logout is determined by navigating to/from routes that start with `/auth*