### PR TITLE
fix(server): config update queue

### DIFF
--- a/server/src/domain/job/job.constants.ts
+++ b/server/src/domain/job/job.constants.ts
@@ -110,6 +110,7 @@ export const JOBS_TO_QUEUE: Record<JobName, QueueName> = {
   [JobName.CLEAN_OLD_AUDIT_LOGS]: QueueName.BACKGROUND_TASK,
   [JobName.PERSON_CLEANUP]: QueueName.BACKGROUND_TASK,
   [JobName.PERSON_DELETE]: QueueName.BACKGROUND_TASK,
+  [JobName.SYSTEM_CONFIG_CHANGE]: QueueName.BACKGROUND_TASK,
 
   // conversion
   [JobName.QUEUE_VIDEO_CONVERSION]: QueueName.VIDEO_CONVERSION,
@@ -130,7 +131,6 @@ export const JOBS_TO_QUEUE: Record<JobName, QueueName> = {
   // storage template
   [JobName.STORAGE_TEMPLATE_MIGRATION]: QueueName.STORAGE_TEMPLATE_MIGRATION,
   [JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE]: QueueName.STORAGE_TEMPLATE_MIGRATION,
-  [JobName.SYSTEM_CONFIG_CHANGE]: QueueName.STORAGE_TEMPLATE_MIGRATION,
 
   // migration
   [JobName.QUEUE_MIGRATION]: QueueName.MIGRATION,

--- a/server/src/infra/repositories/job.repository.ts
+++ b/server/src/infra/repositories/job.repository.ts
@@ -74,6 +74,8 @@ export class JobRepository implements IJobRepository {
         return { jobId: item.data.id };
       case JobName.GENERATE_PERSON_THUMBNAIL:
         return { priority: 1 };
+      case JobName.SYSTEM_CONFIG_CHANGE:
+        return { priority: 1 };
 
       default:
         return null;


### PR DESCRIPTION
Storage config is still processed by the migration queue, but more appropriate is the background queue. Additionally, it now gets a priority to make sure it is picked up ahead and any other jobs that might be in the queue.