### PR TITLE
refactor: run dev-down on unclean dev-new exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev:
 	docker-compose -f ./docker/docker-compose.dev.yml up --remove-orphans
 
 dev-new:
-	docker compose -f ./docker/docker-compose.dev.yml up --remove-orphans
+	docker compose -f ./docker/docker-compose.dev.yml up --remove-orphans || make dev-down
 
 dev-down:
 	docker compose -f ./docker/docker-compose.dev.yml down --remove-orphans


### PR DESCRIPTION
Currently, if you ^C the dev server, it exits uncleanly and doesn't clean up the orphaned containers. This means that if you then try to run a production Immich instance, all of the containers hang on "Creating". This PR catches the unclean exit and cleans up properly.