### PR TITLE
fix(mobile): handle shared assets actions in viewer

### DIFF
--- a/mobile/lib/modules/album/views/album_viewer_page.dart
+++ b/mobile/lib/modules/album/views/album_viewer_page.dart
@@ -265,6 +265,7 @@ class AlbumViewerPage extends HookConsumerWidget {
                   if (data.isRemote) buildControlButton(data),
                 ],
               ),
+              isOwner: userId == data.ownerId,
             ),
           ),
         ),

--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -15,6 +15,7 @@ class TopControlAppBar extends HookConsumerWidget {
     required this.isPlayingMotionVideo,
     required this.onFavorite,
     required this.onUploadPressed,
+    required this.isOwner,
   }) : super(key: key);
 
   final Asset asset;
@@ -25,6 +26,7 @@ class TopControlAppBar extends HookConsumerWidget {
   final VoidCallback onAddToAlbumPressed;
   final Function(Asset) onFavorite;
   final bool isPlayingMotionVideo;
+  final bool isOwner;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -123,11 +125,11 @@ class TopControlAppBar extends HookConsumerWidget {
         size: iconSize,
       ),
       actions: [
-        if (asset.isRemote) buildFavoriteButton(a),
+        if (asset.isRemote && isOwner) buildFavoriteButton(a),
         if (asset.livePhotoVideoId != null) buildLivePhotoButton(),
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
-        if (asset.isRemote && !asset.isLocal) buildDownloadButton(),
-        if (asset.isRemote) buildAddToAlbumButtom(),
+        if (asset.isRemote && !asset.isLocal && isOwner) buildDownloadButton(),
+        if (asset.isRemote && isOwner) buildAddToAlbumButtom(),
         buildMoreInfoButton(),
       ],
     );

--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -48,6 +48,7 @@ class GalleryViewerPage extends HookConsumerWidget {
   final int initialIndex;
   final int heroOffset;
   final bool showStack;
+  final bool isOwner;
 
   GalleryViewerPage({
     super.key,
@@ -56,6 +57,7 @@ class GalleryViewerPage extends HookConsumerWidget {
     required this.totalAssets,
     this.heroOffset = 0,
     this.showStack = false,
+    this.isOwner = true,
   }) : controller = PageController(initialPage: initialIndex);
 
   final PageController controller;
@@ -334,6 +336,7 @@ class GalleryViewerPage extends HookConsumerWidget {
           child: Container(
             color: Colors.black.withOpacity(0.4),
             child: TopControlAppBar(
+              isOwner: isOwner,
               isPlayingMotionVideo: isPlayingMotionVideo.value,
               asset: asset(),
               onMoreInfoPressed: showInfo,
@@ -573,35 +576,50 @@ class GalleryViewerPage extends HookConsumerWidget {
           label: 'control_bottom_app_bar_share'.tr(),
           tooltip: 'control_bottom_app_bar_share'.tr(),
         ),
-        asset().isArchived
-            ? BottomNavigationBarItem(
-                icon: const Icon(Icons.unarchive_rounded),
-                label: 'control_bottom_app_bar_unarchive'.tr(),
-                tooltip: 'control_bottom_app_bar_unarchive'.tr(),
-              )
-            : BottomNavigationBarItem(
-                icon: const Icon(Icons.archive_outlined),
-                label: 'control_bottom_app_bar_archive'.tr(),
-                tooltip: 'control_bottom_app_bar_archive'.tr(),
-              ),
-        if (stack.isNotEmpty)
+        if (isOwner)
+          asset().isArchived
+              ? BottomNavigationBarItem(
+                  icon: const Icon(Icons.unarchive_rounded),
+                  label: 'control_bottom_app_bar_unarchive'.tr(),
+                  tooltip: 'control_bottom_app_bar_unarchive'.tr(),
+                )
+              : BottomNavigationBarItem(
+                  icon: const Icon(Icons.archive_outlined),
+                  label: 'control_bottom_app_bar_archive'.tr(),
+                  tooltip: 'control_bottom_app_bar_archive'.tr(),
+                ),
+        if (isOwner && stack.isNotEmpty)
           BottomNavigationBarItem(
             icon: const Icon(Icons.burst_mode_outlined),
             label: 'control_bottom_app_bar_stack'.tr(),
             tooltip: 'control_bottom_app_bar_stack'.tr(),
           ),
-        BottomNavigationBarItem(
-          icon: const Icon(Icons.delete_outline),
-          label: 'control_bottom_app_bar_delete'.tr(),
-          tooltip: 'control_bottom_app_bar_delete'.tr(),
-        ),
+        if (isOwner)
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.delete_outline),
+            label: 'control_bottom_app_bar_delete'.tr(),
+            tooltip: 'control_bottom_app_bar_delete'.tr(),
+          ),
+        if (!isOwner)
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.download_outlined),
+            label: 'download'.tr(),
+            tooltip: 'download'.tr(),
+          ),
       ];
 
       List<Function(int)> actionslist = [
         (_) => shareAsset(),
-        (_) => handleArchive(asset()),
-        if (stack.isNotEmpty) (_) => showStackActionItems(),
-        (_) => handleDelete(asset()),
+        if (isOwner) (_) => handleArchive(asset()),
+        if (isOwner && stack.isNotEmpty) (_) => showStackActionItems(),
+        if (isOwner) (_) => handleDelete(asset()),
+        if (!isOwner)
+          (_) => asset().isLocal
+              ? null
+              : ref.watch(imageViewerStateProvider.notifier).downloadAsset(
+                    asset(),
+                    context,
+                  ),
       ];
 
       return IgnorePointer(

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid.dart
@@ -33,6 +33,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
   final bool shrinkWrap;
   final bool showDragScroll;
   final bool showStack;
+  final bool isOwner;
 
   const ImmichAssetGrid({
     super.key,
@@ -53,6 +54,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
     this.shrinkWrap = false,
     this.showDragScroll = true,
     this.showStack = false,
+    this.isOwner = true,
   });
 
   @override
@@ -117,6 +119,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
           shrinkWrap: shrinkWrap,
           showDragScroll: showDragScroll,
           showStack: showStack,
+          isOwner: isOwner,
         ),
       );
     }

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -38,6 +38,7 @@ class ImmichAssetGridView extends StatefulWidget {
   final bool shrinkWrap;
   final bool showDragScroll;
   final bool showStack;
+  final bool isOwner;
 
   const ImmichAssetGridView({
     super.key,
@@ -58,6 +59,7 @@ class ImmichAssetGridView extends StatefulWidget {
     this.shrinkWrap = false,
     this.showDragScroll = true,
     this.showStack = false,
+    this.isOwner = true,
   });
 
   @override
@@ -138,6 +140,7 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
       showStorageIndicator: widget.showStorageIndicator,
       heroOffset: widget.heroOffset,
       showStack: widget.showStack,
+      isOwner: widget.isOwner,
     );
   }
 

--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -14,6 +14,7 @@ class ThumbnailImage extends StatelessWidget {
   final int totalAssets;
   final bool showStorageIndicator;
   final bool showStack;
+  final bool isOwner;
   final bool useGrayBoxPlaceholder;
   final bool isSelected;
   final bool multiselectEnabled;
@@ -29,6 +30,7 @@ class ThumbnailImage extends StatelessWidget {
     required this.totalAssets,
     this.showStorageIndicator = true,
     this.showStack = false,
+    this.isOwner = true,
     this.useGrayBoxPlaceholder = false,
     this.isSelected = false,
     this.multiselectEnabled = false,
@@ -181,6 +183,7 @@ class ThumbnailImage extends StatelessWidget {
               totalAssets: totalAssets,
               heroOffset: heroOffset,
               showStack: showStack,
+              isOwner: isOwner,
             ),
           );
         }

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -72,6 +72,7 @@ class _$AppRouter extends RootStackRouter {
           totalAssets: args.totalAssets,
           heroOffset: args.heroOffset,
           showStack: args.showStack,
+          isOwner: args.isOwner,
         ),
       );
     },
@@ -749,6 +750,7 @@ class GalleryViewerRoute extends PageRouteInfo<GalleryViewerRouteArgs> {
     required int totalAssets,
     int heroOffset = 0,
     bool showStack = false,
+    bool isOwner = true,
   }) : super(
           GalleryViewerRoute.name,
           path: '/gallery-viewer-page',
@@ -759,6 +761,7 @@ class GalleryViewerRoute extends PageRouteInfo<GalleryViewerRouteArgs> {
             totalAssets: totalAssets,
             heroOffset: heroOffset,
             showStack: showStack,
+            isOwner: isOwner,
           ),
         );
 
@@ -773,6 +776,7 @@ class GalleryViewerRouteArgs {
     required this.totalAssets,
     this.heroOffset = 0,
     this.showStack = false,
+    this.isOwner = true,
   });
 
   final Key? key;
@@ -787,9 +791,11 @@ class GalleryViewerRouteArgs {
 
   final bool showStack;
 
+  final bool isOwner;
+
   @override
   String toString() {
-    return 'GalleryViewerRouteArgs{key: $key, initialIndex: $initialIndex, loadAsset: $loadAsset, totalAssets: $totalAssets, heroOffset: $heroOffset, showStack: $showStack}';
+    return 'GalleryViewerRouteArgs{key: $key, initialIndex: $initialIndex, loadAsset: $loadAsset, totalAssets: $totalAssets, heroOffset: $heroOffset, showStack: $showStack, isOwner: $isOwner}';
   }
 }
 


### PR DESCRIPTION
Fixes #4670.

#### Changes made in the PR

- Uses the owner state to determine the buttons visible in the `gallery_viewer` bottom bar to hide non-owner related actions such as archive, delete, etc.
- The top app bar in gallery viewer is also updated to hide actions such as add to album from non-owners

#### Screenshots

Before | After
:-: | :-:
![Before](https://github.com/immich-app/immich/assets/139912620/c1c7394e-e3a1-474d-aca3-fdbb7d1fdaf9) | ![After](https://github.com/immich-app/immich/assets/139912620/3efc95ac-f3e8-42ef-bc51-2ed0ab5e3aa6)

