### PR TITLE
Revert "feat(web): added toggle for Sharing button in the sidebar (#4674)"

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/side-bar.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar.svelte
@@ -77,25 +77,23 @@
       <SideBarButton title="People" icon={mdiAccount} isSelected={$page.route.id === '/(user)/people'} />
     </a>
   {/if}
-  {#if $sidebarSettings.sharing}
-    <a data-sveltekit-preload-data="hover" href={AppRoute.SHARING} draggable="false">
-      <SideBarButton
-        title="Sharing"
-        icon={isSharingSelected ? mdiAccountMultiple : mdiAccountMultipleOutline}
-        isSelected={isSharingSelected}
-      >
-        <svelte:fragment slot="moreInformation">
-          {#await getAlbumCount()}
-            <LoadingSpinner />
-          {:then data}
-            <div>
-              <p>{data.shared.toLocaleString($locale)} Albums</p>
-            </div>
-          {/await}
-        </svelte:fragment>
-      </SideBarButton>
-    </a>
-  {/if}
+  <a data-sveltekit-preload-data="hover" href={AppRoute.SHARING} draggable="false">
+    <SideBarButton
+      title="Sharing"
+      icon={isSharingSelected ? mdiAccountMultiple : mdiAccountMultipleOutline}
+      isSelected={isSharingSelected}
+    >
+      <svelte:fragment slot="moreInformation">
+        {#await getAlbumCount()}
+          <LoadingSpinner />
+        {:then data}
+          <div>
+            <p>{data.shared.toLocaleString($locale)} Albums</p>
+          </div>
+        {/await}
+      </svelte:fragment>
+    </SideBarButton>
+  </a>
 
   <div class="text-xs transition-all duration-200 dark:text-immich-dark-fg">
     <p class="hidden p-6 group-hover:sm:block md:block">LIBRARY</p>

--- a/web/src/lib/components/user-settings-page/sidebar-settings.svelte
+++ b/web/src/lib/components/user-settings-page/sidebar-settings.svelte
@@ -10,9 +10,6 @@
       <div class="ml-4">
         <SettingSwitch title="People" subtitle="Display a link to People" bind:checked={$sidebarSettings.people} />
       </div>
-      <div class="ml-4">
-        <SettingSwitch title="Sharing" subtitle="Display a link to Sharing" bind:checked={$sidebarSettings.sharing} />
-      </div>
     </div>
   </div>
 </section>

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -49,12 +49,10 @@ export interface AlbumViewSettings {
 
 export interface SidebarSettings {
   people: boolean;
-  sharing: boolean;
 }
 
 export const sidebarSettings = persisted<SidebarSettings>('sidebar-settings', {
   people: false,
-  sharing: true,
 });
 
 export enum AlbumViewMode {


### PR DESCRIPTION
This reverts commit daad02504f1937f89f9bb12d425fca80f9a5dd20.


@upsetdog  Please take a look at this, the default value is `true` however, when you first starter a session, it renders as `false` and therefore, hide the Sharing tab