### PR TITLE
fix(mobile): first char miss in new description

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/description_input.dart
+++ b/mobile/lib/modules/asset_viewer/ui/description_input.dart
@@ -31,7 +31,14 @@ class DescriptionInput extends HookConsumerWidget {
     final owner = ref.watch(currentUserProvider);
     final hasError = useState(false);
 
-    controller.text = description;
+    useEffect(
+      () {
+        controller.text = description;
+        isTextEmpty.value = description.isEmpty;
+        return null;
+      },
+      [description],
+    );
 
     submitDescription(String description) async {
       hasError.value = false;


### PR DESCRIPTION
Fixes #4691 

#### Issue

The controller's text was set to the description value from remote on each widget rebuilds. When the first character is typed, a state variable `isTextEmpty` is updated, which triggers a rebuild and thereby emptying the controller's text. This results in the first character typed by the user getting missed out. 

#### Change made in the PR

The controller's text value is now updated only on the first build and only if the remote description is updated in the subsequent rebuilds.