### PR TITLE
fix(mobile): cache key for assets from dto

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -90,7 +90,7 @@ class GalleryViewerPage extends HookConsumerWidget {
         : <Asset>[];
     final stackElements = showStack ? [currentAsset, ...stack] : <Asset>[];
     // Assets from response DTOs do not have an isar id, querying which would give us the default autoIncrement id
-    final isFromResponse = currentAsset.id == Isar.autoIncrement;
+    final isFromDto = currentAsset.id == Isar.autoIncrement;
 
     Asset asset() => stackIndex.value == -1
         ? currentAsset
@@ -773,7 +773,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                     },
                     imageProvider: provider,
                     heroAttributes: PhotoViewHeroAttributes(
-                      tag: isFromResponse
+                      tag: isFromDto
                           ? '${a.remoteId}-$heroOffset'
                           : a.id + heroOffset,
                     ),
@@ -792,7 +792,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                     onDragUpdate: (_, details, __) =>
                         handleSwipeUpDown(details),
                     heroAttributes: PhotoViewHeroAttributes(
-                      tag: isFromResponse
+                      tag: isFromDto
                           ? '${a.remoteId}-$heroOffset'
                           : a.id + heroOffset,
                     ),

--- a/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/thumbnail_image.dart
@@ -45,7 +45,7 @@ class ThumbnailImage extends StatelessWidget {
     final assetContainerColor =
         isDarkTheme ? Colors.blueGrey : Theme.of(context).primaryColorLight;
     // Assets from response DTOs do not have an isar id, querying which would give us the default autoIncrement id
-    final isFromResponse = asset.id == Isar.autoIncrement;
+    final isFromDto = asset.id == Isar.autoIncrement;
 
     Widget buildSelectionIcon(Asset asset) {
       if (isSelected) {
@@ -134,7 +134,7 @@ class ThumbnailImage extends StatelessWidget {
         width: 300,
         height: 300,
         child: Hero(
-          tag: isFromResponse
+          tag: isFromDto
               ? '${asset.remoteId}-$heroOffset'
               : asset.id + heroOffset,
           child: ImmichImage(

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -1,6 +1,7 @@
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 
 String getThumbnailUrl(
@@ -35,8 +36,10 @@ String getAlbumThumbnailUrl(
   if (album.thumbnail.value?.remoteId == null) {
     return '';
   }
-  return getThumbnailUrlForRemoteId(album.thumbnail.value!.remoteId!,
-      type: type,);
+  return getThumbnailUrlForRemoteId(
+    album.thumbnail.value!.remoteId!,
+    type: type,
+  );
 }
 
 String getAlbumThumbNailCacheKey(
@@ -57,7 +60,9 @@ String getImageUrl(final Asset asset) {
 }
 
 String getImageCacheKey(final Asset asset) {
-  return '${asset.id}_fullStage';
+  // Assets from response DTOs do not have an isar id, querying which would give us the default autoIncrement id
+  final isFromDto = asset.id == Isar.autoIncrement;
+  return '${isFromDto ? asset.remoteId : asset.id}_fullStage';
 }
 
 String getThumbnailUrlForRemoteId(


### PR DESCRIPTION
Fixes #4614 , #4446 

#### Issue:

- Same as the unique hero tag issue from #4600, the assets from the response dto do not have isar id set. Using the isar id for caching resulted in the cache returning the first opened image because of the same cache key

#### Change made in the PR:

- `remoteId` is used instead of isar id as the cache key for the assets from renderlist created directly from the response dto