### PR TITLE
refactor(server): auth delete device

### DIFF
--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -21,6 +21,8 @@ export enum Permission {
   ALBUM_SHARE = 'album.share',
   ALBUM_DOWNLOAD = 'album.download',
 
+  AUTH_DEVICE_DELETE = 'authDevice.delete',
+
   ARCHIVE_READ = 'archive.read',
 
   TIMELINE_READ = 'timeline.read',
@@ -195,6 +197,9 @@ export class AccessCore {
 
       case Permission.ARCHIVE_READ:
         return authUser.id === id;
+
+      case Permission.AUTH_DEVICE_DELETE:
+        return this.repository.authDevice.hasOwnerAccess(authUser.id, id);
 
       case Permission.TIMELINE_READ:
         return authUser.id === id || (await this.repository.timeline.hasPartnerAccess(authUser.id, id));

--- a/server/src/domain/repositories/access.repository.ts
+++ b/server/src/domain/repositories/access.repository.ts
@@ -8,6 +8,10 @@ export interface IAccessRepository {
     hasSharedLinkAccess(sharedLinkId: string, assetId: string): Promise<boolean>;
   };
 
+  authDevice: {
+    hasOwnerAccess(userId: string, deviceId: string): Promise<boolean>;
+  };
+
   album: {
     hasOwnerAccess(userId: string, albumId: string): Promise<boolean>;
     hasSharedAlbumAccess(userId: string, albumId: string): Promise<boolean>;

--- a/server/src/domain/repositories/user-token.repository.ts
+++ b/server/src/domain/repositories/user-token.repository.ts
@@ -5,7 +5,7 @@ export const IUserTokenRepository = 'IUserTokenRepository';
 export interface IUserTokenRepository {
   create(dto: Partial<UserTokenEntity>): Promise<UserTokenEntity>;
   save(dto: Partial<UserTokenEntity>): Promise<UserTokenEntity>;
-  delete(userId: string, id: string): Promise<void>;
+  delete(id: string): Promise<void>;
   getByToken(token: string): Promise<UserTokenEntity | null>;
   getAll(userId: string): Promise<UserTokenEntity[]>;
 }

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -1,16 +1,25 @@
 import { IAccessRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { AlbumEntity, AssetEntity, LibraryEntity, PartnerEntity, PersonEntity, SharedLinkEntity } from '../entities';
+import {
+  AlbumEntity,
+  AssetEntity,
+  LibraryEntity,
+  PartnerEntity,
+  PersonEntity,
+  SharedLinkEntity,
+  UserTokenEntity,
+} from '../entities';
 
 export class AccessRepository implements IAccessRepository {
   constructor(
     @InjectRepository(AssetEntity) private assetRepository: Repository<AssetEntity>,
     @InjectRepository(AlbumEntity) private albumRepository: Repository<AlbumEntity>,
+    @InjectRepository(LibraryEntity) private libraryRepository: Repository<LibraryEntity>,
     @InjectRepository(PartnerEntity) private partnerRepository: Repository<PartnerEntity>,
     @InjectRepository(PersonEntity) private personRepository: Repository<PersonEntity>,
     @InjectRepository(SharedLinkEntity) private sharedLinkRepository: Repository<SharedLinkEntity>,
-    @InjectRepository(LibraryEntity) private libraryRepository: Repository<LibraryEntity>,
+    @InjectRepository(UserTokenEntity) private tokenRepository: Repository<UserTokenEntity>,
   ) {}
 
   library = {
@@ -144,6 +153,17 @@ export class AccessRepository implements IAccessRepository {
             },
           },
         ],
+      });
+    },
+  };
+
+  authDevice = {
+    hasOwnerAccess: (userId: string, deviceId: string): Promise<boolean> => {
+      return this.tokenRepository.exist({
+        where: {
+          userId,
+          id: deviceId,
+        },
       });
     },
   };

--- a/server/src/infra/repositories/user-token.repository.ts
+++ b/server/src/infra/repositories/user-token.repository.ts
@@ -35,7 +35,7 @@ export class UserTokenRepository implements IUserTokenRepository {
     return this.repository.save(userToken);
   }
 
-  async delete(userId: string, id: string): Promise<void> {
-    await this.repository.delete({ userId, id });
+  async delete(id: string): Promise<void> {
+    await this.repository.delete({ id });
   }
 }

--- a/server/test/e2e/auth.e2e-spec.ts
+++ b/server/test/e2e/auth.e2e-spec.ts
@@ -189,6 +189,14 @@ describe(`${AuthController.name} (e2e)`, () => {
       expect(body).toEqual(errorStub.unauthorized);
     });
 
+    it('should throw an error for a non-existent device id', async () => {
+      const { status, body } = await request(server)
+        .delete(`/auth/devices/${uuidStub.notFound}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+      expect(status).toBe(400);
+      expect(body).toEqual(errorStub.badRequest('Not found or no authDevice.delete access'));
+    });
+
     it('should logout a device', async () => {
       const [device] = await api.authApi.getAuthDevices(server, accessToken);
       const { status } = await request(server)

--- a/server/test/e2e/person.e2e-spec.ts
+++ b/server/test/e2e/person.e2e-spec.ts
@@ -139,10 +139,10 @@ describe(`${PersonController.name}`, () => {
 
     it('should not accept invalid birth dates', async () => {
       for (const { birthDate, response } of [
-        { birthDate: false, response: ['id must be a UUID'] },
+        { birthDate: false, response: 'Not found or no person.write access' },
         { birthDate: 'false', response: ['birthDate must be a Date instance'] },
-        { birthDate: '123567', response: ['id must be a UUID'] },
-        { birthDate: 123456, response: ['id must be a UUID'] },
+        { birthDate: '123567', response: 'Not found or no person.write access' },
+        { birthDate: 123567, response: 'Not found or no person.write access' },
       ]) {
         const { status, body } = await request(server)
           .put(`/person/${uuidStub.notFound}`)

--- a/server/test/fixtures/uuid.stub.ts
+++ b/server/test/fixtures/uuid.stub.ts
@@ -1,4 +1,5 @@
 export const uuidStub = {
   invalid: 'invalid-uuid',
-  notFound: '00000000-0000-0000-0000-000000000000',
+  // valid uuid v4
+  notFound: '00000000-0000-4000-a000-000000000000',
 };

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -3,6 +3,7 @@ import { AccessCore, IAccessRepository } from '@app/domain';
 export interface IAccessRepositoryMock {
   asset: jest.Mocked<IAccessRepository['asset']>;
   album: jest.Mocked<IAccessRepository['album']>;
+  authDevice: jest.Mocked<IAccessRepository['authDevice']>;
   library: jest.Mocked<IAccessRepository['library']>;
   timeline: jest.Mocked<IAccessRepository['timeline']>;
   person: jest.Mocked<IAccessRepository['person']>;
@@ -25,6 +26,10 @@ export const newAccessRepositoryMock = (reset = true): IAccessRepositoryMock => 
       hasOwnerAccess: jest.fn(),
       hasSharedAlbumAccess: jest.fn(),
       hasSharedLinkAccess: jest.fn(),
+    },
+
+    authDevice: {
+      hasOwnerAccess: jest.fn(),
     },
 
     library: {


### PR DESCRIPTION
Migrate delete user token to delete by id, instead of user id and device id (standardizing). This implies using access core to check for device access and throwing an error for a not found / not owned device id (instead of silently returning a 200 success)