### PR TITLE
fix(mobile): don't show lens info if it's not available

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_bottom_sheet.dart
@@ -297,9 +297,9 @@ class ExifBottomSheet extends HookConsumerWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
-              subtitle: Text(
+              subtitle: exifInfo.f != null || exifInfo.exposureSeconds != null || exifInfo.mm != null || exifInfo.iso != null ? Text(
                 "ƒ/${exifInfo.fNumber}   ${exifInfo.exposureTime}   ${exifInfo.focalLength} mm   ISO ${exifInfo.iso ?? ''} ",
-              ),
+              ) : null,
             ),
         ],
       );


### PR DESCRIPTION
Consolidation with web version.

|before|after|
|--|--|
|![Screenshot_20231031_075221](https://github.com/immich-app/immich/assets/15554561/a57791bb-40f1-419b-a468-2247dc2259fb)|![Screenshot_20231031_080419](https://github.com/immich-app/immich/assets/15554561/e6e27a61-54ca-4f91-90ba-90e60dd8648c)|

