### PR TITLE
fix(cli): ignore web socket when unavailable and skip metadata init

### DIFF
--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -67,6 +67,10 @@ describe(MetadataService.name, () => {
     );
   });
 
+  afterEach(async () => {
+    await sut.teardown();
+  });
+
   it('should be defined', () => {
     expect(sut).toBeDefined();
   });

--- a/server/src/infra/repositories/communication.repository.ts
+++ b/server/src/infra/repositories/communication.repository.ts
@@ -10,7 +10,7 @@ export class CommunicationRepository implements OnGatewayConnection, OnGatewayDi
 
   constructor(private authService: AuthService) {}
 
-  @WebSocketServer() server!: Server;
+  @WebSocketServer() server?: Server;
 
   addEventListener(event: 'connect', callback: Callback) {
     this.onConnectCallbacks.push(callback);
@@ -37,10 +37,10 @@ export class CommunicationRepository implements OnGatewayConnection, OnGatewayDi
   }
 
   send(event: CommunicationEvent, userId: string, data: any) {
-    this.server.to(userId).emit(event, data);
+    this.server?.to(userId).emit(event, data);
   }
 
   broadcast(event: CommunicationEvent, data: any) {
-    this.server.emit(event, data);
+    this.server?.emit(event, data);
   }
 }


### PR DESCRIPTION
Fixes #4667

The CLI commands were failing because:
- It now tries to send a websocket broadcast on a config change
- It also tries to re-init the reverse geocoder on an config change