### PR TITLE
fix(mobile): first stack list asset is now highlighted on view

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -443,7 +443,8 @@ class GalleryViewerPage extends HookConsumerWidget {
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(6),
-                  border: index == stackIndex.value
+                  border: (stackIndex.value == -1 && index == 0) ||
+                          index == stackIndex.value
                       ? Border.all(
                           color: Colors.white,
                           width: 2,


### PR DESCRIPTION
When you view a stacked asset on mobile, the first thumbnail in the lower list isn't highlighted, like it is on the web app.

Currently:

https://github.com/immich-app/immich/assets/69658702/197fe38b-a37d-4ad9-849b-e0f347bd9c7d

Fixed (the first stack asset thumbnail has a white border by default)
![fix](https://github.com/immich-app/immich/assets/69658702/b25b2a77-5f1d-4dc4-970b-5b2c51f20bb9)
