### PR TITLE
fix: update like status

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -142,6 +142,8 @@
         });
         if (data.length > 0) {
           isLiked = data[0];
+        } else {
+          isLiked = null;
         }
       } catch (error) {
         handleError(error, "Can't get Favorite");


### PR DESCRIPTION
When navigating from one asset to another if the current asset is liked and the next asset is not liked, the like status is not updated