### PR TITLE
feat: memory lane duration

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -1386,6 +1386,12 @@ export interface CreateUserDto {
     'lastName': string;
     /**
      * 
+     * @type {number}
+     * @memberof CreateUserDto
+     */
+    'memoriesDuration'?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof CreateUserDto
      */
@@ -4293,6 +4299,12 @@ export interface UpdateUserDto {
     'lastName'?: string;
     /**
      * 
+     * @type {number}
+     * @memberof UpdateUserDto
+     */
+    'memoriesDuration'?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof UpdateUserDto
      */
@@ -4450,6 +4462,12 @@ export interface UserResponseDto {
      * @memberof UserResponseDto
      */
     'lastName': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof UserResponseDto
+     */
+    'memoriesDuration'?: number;
     /**
      * 
      * @type {boolean}
@@ -7236,10 +7254,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @param {number} day 
          * @param {number} month 
+         * @param {number} [days] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMemoryLane: async (day: number, month: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getMemoryLane: async (day: number, month: number, days?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'day' is not null or undefined
             assertParamExists('getMemoryLane', 'day', day)
             // verify required parameter 'month' is not null or undefined
@@ -7271,6 +7290,10 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
 
             if (month !== undefined) {
                 localVarQueryParameter['month'] = month;
+            }
+
+            if (days !== undefined) {
+                localVarQueryParameter['days'] = days;
             }
 
 
@@ -8190,11 +8213,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * 
          * @param {number} day 
          * @param {number} month 
+         * @param {number} [days] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMemoryLane(day: number, month: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemoryLaneResponseDto>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getMemoryLane(day, month, options);
+        async getMemoryLane(day: number, month: number, days?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemoryLaneResponseDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMemoryLane(day, month, days, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -8510,7 +8534,7 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * @throws {RequiredError}
          */
         getMemoryLane(requestParameters: AssetApiGetMemoryLaneRequest, options?: AxiosRequestConfig): AxiosPromise<Array<MemoryLaneResponseDto>> {
-            return localVarFp.getMemoryLane(requestParameters.day, requestParameters.month, options).then((request) => request(axios, basePath));
+            return localVarFp.getMemoryLane(requestParameters.day, requestParameters.month, requestParameters.days, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -8993,6 +9017,13 @@ export interface AssetApiGetMemoryLaneRequest {
      * @memberof AssetApiGetMemoryLane
      */
     readonly month: number
+
+    /**
+     * 
+     * @type {number}
+     * @memberof AssetApiGetMemoryLane
+     */
+    readonly days?: number
 }
 
 /**
@@ -9539,7 +9570,7 @@ export class AssetApi extends BaseAPI {
      * @memberof AssetApi
      */
     public getMemoryLane(requestParameters: AssetApiGetMemoryLaneRequest, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getMemoryLane(requestParameters.day, requestParameters.month, options).then((request) => request(this.axios, this.basePath));
+        return AssetApiFp(this.configuration).getMemoryLane(requestParameters.day, requestParameters.month, requestParameters.days, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -962,7 +962,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getMemoryLane**
-> List<MemoryLaneResponseDto> getMemoryLane(day, month)
+> List<MemoryLaneResponseDto> getMemoryLane(day, month, days)
 
 
 
@@ -987,9 +987,10 @@ import 'package:openapi/api.dart';
 final api_instance = AssetApi();
 final day = 56; // int | 
 final month = 56; // int | 
+final days = 56; // int | 
 
 try {
-    final result = api_instance.getMemoryLane(day, month);
+    final result = api_instance.getMemoryLane(day, month, days);
     print(result);
 } catch (e) {
     print('Exception when calling AssetApi->getMemoryLane: $e\n');
@@ -1002,6 +1003,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **day** | **int**|  | 
  **month** | **int**|  | 
+ **days** | **int**|  | [optional] 
 
 ### Return type
 

--- a/mobile/openapi/doc/CreateUserDto.md
+++ b/mobile/openapi/doc/CreateUserDto.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **externalPath** | **String** |  | [optional] 
 **firstName** | **String** |  | 
 **lastName** | **String** |  | 
+**memoriesDuration** | **int** |  | [optional] 
 **memoriesEnabled** | **bool** |  | [optional] 
 **password** | **String** |  | 
 **storageLabel** | **String** |  | [optional] 

--- a/mobile/openapi/doc/UpdateUserDto.md
+++ b/mobile/openapi/doc/UpdateUserDto.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **id** | **String** |  | 
 **isAdmin** | **bool** |  | [optional] 
 **lastName** | **String** |  | [optional] 
+**memoriesDuration** | **int** |  | [optional] 
 **memoriesEnabled** | **bool** |  | [optional] 
 **password** | **String** |  | [optional] 
 **shouldChangePassword** | **bool** |  | [optional] 

--- a/mobile/openapi/doc/UserResponseDto.md
+++ b/mobile/openapi/doc/UserResponseDto.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **id** | **String** |  | 
 **isAdmin** | **bool** |  | 
 **lastName** | **String** |  | 
+**memoriesDuration** | **int** |  | [optional] 
 **memoriesEnabled** | **bool** |  | [optional] 
 **oauthId** | **String** |  | 
 **profileImagePath** | **String** |  | 

--- a/mobile/openapi/lib/api/asset_api.dart
+++ b/mobile/openapi/lib/api/asset_api.dart
@@ -970,7 +970,9 @@ class AssetApi {
   /// * [int] day (required):
   ///
   /// * [int] month (required):
-  Future<Response> getMemoryLaneWithHttpInfo(int day, int month,) async {
+  ///
+  /// * [int] days:
+  Future<Response> getMemoryLaneWithHttpInfo(int day, int month, { int? days, }) async {
     // ignore: prefer_const_declarations
     final path = r'/asset/memory-lane';
 
@@ -983,6 +985,9 @@ class AssetApi {
 
       queryParams.addAll(_queryParams('', 'day', day));
       queryParams.addAll(_queryParams('', 'month', month));
+    if (days != null) {
+      queryParams.addAll(_queryParams('', 'days', days));
+    }
 
     const contentTypes = <String>[];
 
@@ -1003,8 +1008,10 @@ class AssetApi {
   /// * [int] day (required):
   ///
   /// * [int] month (required):
-  Future<List<MemoryLaneResponseDto>?> getMemoryLane(int day, int month,) async {
-    final response = await getMemoryLaneWithHttpInfo(day, month,);
+  ///
+  /// * [int] days:
+  Future<List<MemoryLaneResponseDto>?> getMemoryLane(int day, int month, { int? days, }) async {
+    final response = await getMemoryLaneWithHttpInfo(day, month,  days: days, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/create_user_dto.dart
+++ b/mobile/openapi/lib/model/create_user_dto.dart
@@ -17,6 +17,7 @@ class CreateUserDto {
     this.externalPath,
     required this.firstName,
     required this.lastName,
+    this.memoriesDuration,
     this.memoriesEnabled,
     required this.password,
     this.storageLabel,
@@ -36,6 +37,14 @@ class CreateUserDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
+  int? memoriesDuration;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
   bool? memoriesEnabled;
 
   String password;
@@ -48,6 +57,7 @@ class CreateUserDto {
      other.externalPath == externalPath &&
      other.firstName == firstName &&
      other.lastName == lastName &&
+     other.memoriesDuration == memoriesDuration &&
      other.memoriesEnabled == memoriesEnabled &&
      other.password == password &&
      other.storageLabel == storageLabel;
@@ -59,12 +69,13 @@ class CreateUserDto {
     (externalPath == null ? 0 : externalPath!.hashCode) +
     (firstName.hashCode) +
     (lastName.hashCode) +
+    (memoriesDuration == null ? 0 : memoriesDuration!.hashCode) +
     (memoriesEnabled == null ? 0 : memoriesEnabled!.hashCode) +
     (password.hashCode) +
     (storageLabel == null ? 0 : storageLabel!.hashCode);
 
   @override
-  String toString() => 'CreateUserDto[email=$email, externalPath=$externalPath, firstName=$firstName, lastName=$lastName, memoriesEnabled=$memoriesEnabled, password=$password, storageLabel=$storageLabel]';
+  String toString() => 'CreateUserDto[email=$email, externalPath=$externalPath, firstName=$firstName, lastName=$lastName, memoriesDuration=$memoriesDuration, memoriesEnabled=$memoriesEnabled, password=$password, storageLabel=$storageLabel]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -76,6 +87,11 @@ class CreateUserDto {
     }
       json[r'firstName'] = this.firstName;
       json[r'lastName'] = this.lastName;
+    if (this.memoriesDuration != null) {
+      json[r'memoriesDuration'] = this.memoriesDuration;
+    } else {
+    //  json[r'memoriesDuration'] = null;
+    }
     if (this.memoriesEnabled != null) {
       json[r'memoriesEnabled'] = this.memoriesEnabled;
     } else {
@@ -102,6 +118,7 @@ class CreateUserDto {
         externalPath: mapValueOfType<String>(json, r'externalPath'),
         firstName: mapValueOfType<String>(json, r'firstName')!,
         lastName: mapValueOfType<String>(json, r'lastName')!,
+        memoriesDuration: mapValueOfType<int>(json, r'memoriesDuration'),
         memoriesEnabled: mapValueOfType<bool>(json, r'memoriesEnabled'),
         password: mapValueOfType<String>(json, r'password')!,
         storageLabel: mapValueOfType<String>(json, r'storageLabel'),

--- a/mobile/openapi/lib/model/update_user_dto.dart
+++ b/mobile/openapi/lib/model/update_user_dto.dart
@@ -19,6 +19,7 @@ class UpdateUserDto {
     required this.id,
     this.isAdmin,
     this.lastName,
+    this.memoriesDuration,
     this.memoriesEnabled,
     this.password,
     this.shouldChangePassword,
@@ -73,6 +74,14 @@ class UpdateUserDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
+  int? memoriesDuration;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
   bool? memoriesEnabled;
 
   ///
@@ -107,6 +116,7 @@ class UpdateUserDto {
      other.id == id &&
      other.isAdmin == isAdmin &&
      other.lastName == lastName &&
+     other.memoriesDuration == memoriesDuration &&
      other.memoriesEnabled == memoriesEnabled &&
      other.password == password &&
      other.shouldChangePassword == shouldChangePassword &&
@@ -121,13 +131,14 @@ class UpdateUserDto {
     (id.hashCode) +
     (isAdmin == null ? 0 : isAdmin!.hashCode) +
     (lastName == null ? 0 : lastName!.hashCode) +
+    (memoriesDuration == null ? 0 : memoriesDuration!.hashCode) +
     (memoriesEnabled == null ? 0 : memoriesEnabled!.hashCode) +
     (password == null ? 0 : password!.hashCode) +
     (shouldChangePassword == null ? 0 : shouldChangePassword!.hashCode) +
     (storageLabel == null ? 0 : storageLabel!.hashCode);
 
   @override
-  String toString() => 'UpdateUserDto[email=$email, externalPath=$externalPath, firstName=$firstName, id=$id, isAdmin=$isAdmin, lastName=$lastName, memoriesEnabled=$memoriesEnabled, password=$password, shouldChangePassword=$shouldChangePassword, storageLabel=$storageLabel]';
+  String toString() => 'UpdateUserDto[email=$email, externalPath=$externalPath, firstName=$firstName, id=$id, isAdmin=$isAdmin, lastName=$lastName, memoriesDuration=$memoriesDuration, memoriesEnabled=$memoriesEnabled, password=$password, shouldChangePassword=$shouldChangePassword, storageLabel=$storageLabel]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -156,6 +167,11 @@ class UpdateUserDto {
       json[r'lastName'] = this.lastName;
     } else {
     //  json[r'lastName'] = null;
+    }
+    if (this.memoriesDuration != null) {
+      json[r'memoriesDuration'] = this.memoriesDuration;
+    } else {
+    //  json[r'memoriesDuration'] = null;
     }
     if (this.memoriesEnabled != null) {
       json[r'memoriesEnabled'] = this.memoriesEnabled;
@@ -194,6 +210,7 @@ class UpdateUserDto {
         id: mapValueOfType<String>(json, r'id')!,
         isAdmin: mapValueOfType<bool>(json, r'isAdmin'),
         lastName: mapValueOfType<String>(json, r'lastName'),
+        memoriesDuration: mapValueOfType<int>(json, r'memoriesDuration'),
         memoriesEnabled: mapValueOfType<bool>(json, r'memoriesEnabled'),
         password: mapValueOfType<String>(json, r'password'),
         shouldChangePassword: mapValueOfType<bool>(json, r'shouldChangePassword'),

--- a/mobile/openapi/lib/model/user_response_dto.dart
+++ b/mobile/openapi/lib/model/user_response_dto.dart
@@ -21,6 +21,7 @@ class UserResponseDto {
     required this.id,
     required this.isAdmin,
     required this.lastName,
+    this.memoriesDuration,
     this.memoriesEnabled,
     required this.oauthId,
     required this.profileImagePath,
@@ -51,6 +52,14 @@ class UserResponseDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
+  int? memoriesDuration;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
   bool? memoriesEnabled;
 
   String oauthId;
@@ -73,6 +82,7 @@ class UserResponseDto {
      other.id == id &&
      other.isAdmin == isAdmin &&
      other.lastName == lastName &&
+     other.memoriesDuration == memoriesDuration &&
      other.memoriesEnabled == memoriesEnabled &&
      other.oauthId == oauthId &&
      other.profileImagePath == profileImagePath &&
@@ -91,6 +101,7 @@ class UserResponseDto {
     (id.hashCode) +
     (isAdmin.hashCode) +
     (lastName.hashCode) +
+    (memoriesDuration == null ? 0 : memoriesDuration!.hashCode) +
     (memoriesEnabled == null ? 0 : memoriesEnabled!.hashCode) +
     (oauthId.hashCode) +
     (profileImagePath.hashCode) +
@@ -99,7 +110,7 @@ class UserResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'UserResponseDto[createdAt=$createdAt, deletedAt=$deletedAt, email=$email, externalPath=$externalPath, firstName=$firstName, id=$id, isAdmin=$isAdmin, lastName=$lastName, memoriesEnabled=$memoriesEnabled, oauthId=$oauthId, profileImagePath=$profileImagePath, shouldChangePassword=$shouldChangePassword, storageLabel=$storageLabel, updatedAt=$updatedAt]';
+  String toString() => 'UserResponseDto[createdAt=$createdAt, deletedAt=$deletedAt, email=$email, externalPath=$externalPath, firstName=$firstName, id=$id, isAdmin=$isAdmin, lastName=$lastName, memoriesDuration=$memoriesDuration, memoriesEnabled=$memoriesEnabled, oauthId=$oauthId, profileImagePath=$profileImagePath, shouldChangePassword=$shouldChangePassword, storageLabel=$storageLabel, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -119,6 +130,11 @@ class UserResponseDto {
       json[r'id'] = this.id;
       json[r'isAdmin'] = this.isAdmin;
       json[r'lastName'] = this.lastName;
+    if (this.memoriesDuration != null) {
+      json[r'memoriesDuration'] = this.memoriesDuration;
+    } else {
+    //  json[r'memoriesDuration'] = null;
+    }
     if (this.memoriesEnabled != null) {
       json[r'memoriesEnabled'] = this.memoriesEnabled;
     } else {
@@ -152,6 +168,7 @@ class UserResponseDto {
         id: mapValueOfType<String>(json, r'id')!,
         isAdmin: mapValueOfType<bool>(json, r'isAdmin')!,
         lastName: mapValueOfType<String>(json, r'lastName')!,
+        memoriesDuration: mapValueOfType<int>(json, r'memoriesDuration'),
         memoriesEnabled: mapValueOfType<bool>(json, r'memoriesEnabled'),
         oauthId: mapValueOfType<String>(json, r'oauthId')!,
         profileImagePath: mapValueOfType<String>(json, r'profileImagePath')!,

--- a/mobile/openapi/test/asset_api_test.dart
+++ b/mobile/openapi/test/asset_api_test.dart
@@ -105,7 +105,7 @@ void main() {
       // TODO
     });
 
-    //Future<List<MemoryLaneResponseDto>> getMemoryLane(int day, int month) async
+    //Future<List<MemoryLaneResponseDto>> getMemoryLane(int day, int month, { int days }) async
     test('test getMemoryLane', () async {
       // TODO
     });

--- a/mobile/openapi/test/create_user_dto_test.dart
+++ b/mobile/openapi/test/create_user_dto_test.dart
@@ -36,6 +36,11 @@ void main() {
       // TODO
     });
 
+    // int memoriesDuration
+    test('to test the property `memoriesDuration`', () async {
+      // TODO
+    });
+
     // bool memoriesEnabled
     test('to test the property `memoriesEnabled`', () async {
       // TODO

--- a/mobile/openapi/test/update_user_dto_test.dart
+++ b/mobile/openapi/test/update_user_dto_test.dart
@@ -46,6 +46,11 @@ void main() {
       // TODO
     });
 
+    // int memoriesDuration
+    test('to test the property `memoriesDuration`', () async {
+      // TODO
+    });
+
     // bool memoriesEnabled
     test('to test the property `memoriesEnabled`', () async {
       // TODO

--- a/mobile/openapi/test/user_response_dto_test.dart
+++ b/mobile/openapi/test/user_response_dto_test.dart
@@ -56,6 +56,11 @@ void main() {
       // TODO
     });
 
+    // int memoriesDuration
+    test('to test the property `memoriesDuration`', () async {
+      // TODO
+    });
+
     // bool memoriesEnabled
     test('to test the property `memoriesEnabled`', () async {
       // TODO

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -1626,6 +1626,14 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "days",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -6746,6 +6754,9 @@
           "lastName": {
             "type": "string"
           },
+          "memoriesDuration": {
+            "type": "integer"
+          },
           "memoriesEnabled": {
             "type": "boolean"
           },
@@ -8982,6 +8993,9 @@
           "lastName": {
             "type": "string"
           },
+          "memoriesDuration": {
+            "type": "integer"
+          },
           "memoriesEnabled": {
             "type": "boolean"
           },
@@ -9089,6 +9103,9 @@
           "lastName": {
             "type": "string"
           },
+          "memoriesDuration": {
+            "type": "integer"
+          },
           "memoriesEnabled": {
             "type": "boolean"
           },
@@ -9111,11 +9128,6 @@
           }
         },
         "required": [
-          "id",
-          "firstName",
-          "lastName",
-          "email",
-          "profileImagePath",
           "storageLabel",
           "externalPath",
           "shouldChangePassword",
@@ -9123,7 +9135,12 @@
           "createdAt",
           "deletedAt",
           "updatedAt",
-          "oauthId"
+          "oauthId",
+          "id",
+          "firstName",
+          "lastName",
+          "email",
+          "profileImagePath"
         ],
         "type": "object"
       },

--- a/server/src/domain/asset/asset.service.spec.ts
+++ b/server/src/domain/asset/asset.service.spec.ts
@@ -309,7 +309,7 @@ describe(AssetService.name, () => {
     it('should set the title correctly', async () => {
       assetMock.getByDayOfYear.mockResolvedValue([assetStub.image, assetStub.imageFrom2015]);
 
-      await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1 })).resolves.toEqual([
+      await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1, days: 1 })).resolves.toEqual([
         { title: '1 year since...', assets: [mapAsset(assetStub.image)] },
         { title: '9 years since...', assets: [mapAsset(assetStub.imageFrom2015)] },
       ]);

--- a/server/src/domain/asset/dto/memory-lane.dto.ts
+++ b/server/src/domain/asset/dto/memory-lane.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, Max, Min } from 'class-validator';
+import { Optional } from '../../domain.util';
 
 export class MemoryLaneDto {
   @IsInt()
@@ -16,4 +17,11 @@ export class MemoryLaneDto {
   @Min(1)
   @ApiProperty({ type: 'integer' })
   month!: number;
+
+  @IsInt()
+  @Type(() => Number)
+  @Min(0)
+  @ApiProperty({ type: 'integer' })
+  @Optional()
+  days?: number;
 }

--- a/server/src/domain/partner/partner.service.spec.ts
+++ b/server/src/domain/partner/partner.service.spec.ts
@@ -20,6 +20,7 @@ const responseDto = {
     updatedAt: new Date('2021-01-01'),
     externalPath: null,
     memoriesEnabled: true,
+    memoriesDuration: 3,
   },
   user1: <UserResponseDto>{
     email: 'immich@test.com',
@@ -36,6 +37,7 @@ const responseDto = {
     updatedAt: new Date('2021-01-01'),
     externalPath: null,
     memoriesEnabled: true,
+    memoriesDuration: 3,
   },
 };
 

--- a/server/src/domain/user/dto/create-user.dto.ts
+++ b/server/src/domain/user/dto/create-user.dto.ts
@@ -1,5 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsEmail, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 import { Optional, toEmail, toSanitized } from '../../domain.util';
 
 export class CreateUserDto {
@@ -31,6 +32,12 @@ export class CreateUserDto {
   @Optional()
   @IsBoolean()
   memoriesEnabled?: boolean;
+
+  @Optional()
+  @IsInt()
+  @Min(0)
+  @ApiProperty({ type: 'integer' })
+  memoriesDuration?: number;
 }
 
 export class CreateAdminDto {

--- a/server/src/domain/user/dto/update-user.dto.ts
+++ b/server/src/domain/user/dto/update-user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsEmail, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsBoolean, IsEmail, IsInt, IsNotEmpty, IsString, IsUUID, Min } from 'class-validator';
 import { Optional, toEmail, toSanitized } from '../../domain.util';
 
 export class UpdateUserDto {
@@ -49,4 +49,10 @@ export class UpdateUserDto {
   @Optional()
   @IsBoolean()
   memoriesEnabled?: boolean;
+
+  @Optional()
+  @IsInt()
+  @Min(0)
+  @ApiProperty({ type: 'integer' })
+  memoriesDuration?: number;
 }

--- a/server/src/domain/user/response-dto/user-response.dto.ts
+++ b/server/src/domain/user/response-dto/user-response.dto.ts
@@ -1,4 +1,5 @@
 import { UserEntity } from '@app/infra/entities';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserDto {
   id!: string;
@@ -18,6 +19,8 @@ export class UserResponseDto extends UserDto {
   updatedAt!: Date;
   oauthId!: string;
   memoriesEnabled?: boolean;
+  @ApiProperty({ type: 'integer' })
+  memoriesDuration?: number;
 }
 
 export const mapSimpleUser = (entity: UserEntity): UserDto => {
@@ -42,5 +45,6 @@ export function mapUser(entity: UserEntity): UserResponseDto {
     updatedAt: entity.updatedAt,
     oauthId: entity.oauthId,
     memoriesEnabled: entity.memoriesEnabled,
+    memoriesDuration: entity.memoriesDuration,
   };
 }

--- a/server/src/infra/entities/user.entity.ts
+++ b/server/src/infra/entities/user.entity.ts
@@ -57,6 +57,9 @@ export class UserEntity {
   @Column({ default: true })
   memoriesEnabled!: boolean;
 
+  @Column({ default: 3 })
+  memoriesDuration!: number;
+
   @OneToMany(() => TagEntity, (tag) => tag.user)
   tags!: TagEntity[];
 

--- a/server/src/infra/migrations/1698953923131-AddMemoriesDuration.ts
+++ b/server/src/infra/migrations/1698953923131-AddMemoriesDuration.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddMemoriesDuration1698953923131 implements MigrationInterface {
+    name = 'AddMemoriesDuration1698953923131'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" ADD "memoriesDuration" integer NOT NULL DEFAULT '3'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "memoriesDuration"`);
+    }
+
+}

--- a/server/test/fixtures/user.stub.ts
+++ b/server/test/fixtures/user.stub.ts
@@ -18,6 +18,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   user1: Object.freeze<UserEntity>({
     ...authStub.user1,
@@ -35,6 +36,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   user2: Object.freeze<UserEntity>({
     ...authStub.user2,
@@ -52,6 +54,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   storageLabel: Object.freeze<UserEntity>({
     ...authStub.user1,
@@ -69,6 +72,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   externalPath1: Object.freeze<UserEntity>({
     ...authStub.user1,
@@ -86,6 +90,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   externalPath2: Object.freeze<UserEntity>({
     ...authStub.user1,
@@ -103,6 +108,7 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
   profilePath: Object.freeze<UserEntity>({
     ...authStub.user1,
@@ -120,5 +126,6 @@ export const userStub = {
     tags: [],
     assets: [],
     memoriesEnabled: true,
+    memoriesDuration: 3,
   }),
 };

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -1386,6 +1386,12 @@ export interface CreateUserDto {
     'lastName': string;
     /**
      * 
+     * @type {number}
+     * @memberof CreateUserDto
+     */
+    'memoriesDuration'?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof CreateUserDto
      */
@@ -4293,6 +4299,12 @@ export interface UpdateUserDto {
     'lastName'?: string;
     /**
      * 
+     * @type {number}
+     * @memberof UpdateUserDto
+     */
+    'memoriesDuration'?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof UpdateUserDto
      */
@@ -4450,6 +4462,12 @@ export interface UserResponseDto {
      * @memberof UserResponseDto
      */
     'lastName': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof UserResponseDto
+     */
+    'memoriesDuration'?: number;
     /**
      * 
      * @type {boolean}
@@ -7236,10 +7254,11 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
          * 
          * @param {number} day 
          * @param {number} month 
+         * @param {number} [days] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMemoryLane: async (day: number, month: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getMemoryLane: async (day: number, month: number, days?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'day' is not null or undefined
             assertParamExists('getMemoryLane', 'day', day)
             // verify required parameter 'month' is not null or undefined
@@ -7271,6 +7290,10 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
 
             if (month !== undefined) {
                 localVarQueryParameter['month'] = month;
+            }
+
+            if (days !== undefined) {
+                localVarQueryParameter['days'] = days;
             }
 
 
@@ -8190,11 +8213,12 @@ export const AssetApiFp = function(configuration?: Configuration) {
          * 
          * @param {number} day 
          * @param {number} month 
+         * @param {number} [days] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMemoryLane(day: number, month: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemoryLaneResponseDto>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getMemoryLane(day, month, options);
+        async getMemoryLane(day: number, month: number, days?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<MemoryLaneResponseDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getMemoryLane(day, month, days, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -8510,7 +8534,7 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          * @throws {RequiredError}
          */
         getMemoryLane(requestParameters: AssetApiGetMemoryLaneRequest, options?: AxiosRequestConfig): AxiosPromise<Array<MemoryLaneResponseDto>> {
-            return localVarFp.getMemoryLane(requestParameters.day, requestParameters.month, options).then((request) => request(axios, basePath));
+            return localVarFp.getMemoryLane(requestParameters.day, requestParameters.month, requestParameters.days, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -8993,6 +9017,13 @@ export interface AssetApiGetMemoryLaneRequest {
      * @memberof AssetApiGetMemoryLane
      */
     readonly month: number
+
+    /**
+     * 
+     * @type {number}
+     * @memberof AssetApiGetMemoryLane
+     */
+    readonly days?: number
 }
 
 /**
@@ -9539,7 +9570,7 @@ export class AssetApi extends BaseAPI {
      * @memberof AssetApi
      */
     public getMemoryLane(requestParameters: AssetApiGetMemoryLaneRequest, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getMemoryLane(requestParameters.day, requestParameters.month, options).then((request) => request(this.axios, this.basePath));
+        return AssetApiFp(this.configuration).getMemoryLane(requestParameters.day, requestParameters.month, requestParameters.days, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/web/src/lib/components/admin-page/settings/setting-input-field.svelte
+++ b/web/src/lib/components/admin-page/settings/setting-input-field.svelte
@@ -12,7 +12,7 @@
   import { fly } from 'svelte/transition';
 
   export let inputType: SettingInputFieldType;
-  export let value: string | number;
+  export let value: string | number | undefined = undefined;
   export let min = Number.MIN_SAFE_INTEGER.toString();
   export let max = Number.MAX_SAFE_INTEGER.toString();
   export let step = '1';
@@ -48,9 +48,7 @@
   </div>
 
   {#if desc}
-    <p class="immich-form-label pb-2 text-sm" id="{label}-desc">
-      {desc}
-    </p>
+    <p class="text-sm dark:text-immich-dark-fg pb-2" id="{label}-desc">{desc}</p>
   {:else}
     <slot name="desc" />
   {/if}

--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { api } from '@api';
+  import { UserResponseDto, api } from '@api';
   import Icon from '$lib/components/elements/icon.svelte';
   import { memoryStore } from '$lib/stores/memory.store';
   import { goto } from '$app/navigation';
   import { fade } from 'svelte/transition';
   import { mdiChevronLeft, mdiChevronRight } from '@mdi/js';
+
+  export let user: UserResponseDto;
 
   $: shouldRender = $memoryStore?.length > 0;
 
@@ -14,6 +16,7 @@
     const { data } = await api.assetApi.getMemoryLane({
       month: localTime.getMonth() + 1,
       day: localTime.getDate(),
+      days: user.memoriesDuration,
     });
     $memoryStore = data;
   });

--- a/web/src/lib/components/user-settings-page/memories-settings.svelte
+++ b/web/src/lib/components/user-settings-page/memories-settings.svelte
@@ -6,6 +6,7 @@
   import { api, UserResponseDto } from '@api';
   import { fade } from 'svelte/transition';
   import { handleError } from '../../utils/handle-error';
+  import SettingInputField, { SettingInputFieldType } from '../admin-page/settings/setting-input-field.svelte';
   import SettingSwitch from '../admin-page/settings/setting-switch.svelte';
   import Button from '../elements/buttons/button.svelte';
 
@@ -17,6 +18,7 @@
         updateUserDto: {
           id: user.id,
           memoriesEnabled: user.memoriesEnabled,
+          memoriesDuration: user.memoriesDuration,
         },
       });
 
@@ -32,12 +34,19 @@
 <section class="my-4">
   <div in:fade={{ duration: 500 }}>
     <form autocomplete="off" on:submit|preventDefault>
-      <div class="ml-4 mt-4 flex flex-col gap-4">
-        <div class="ml-4">
+      <div class="ml-4 mt-4">
+        <div class="ml-4 flex flex-col gap-4">
           <SettingSwitch
             title="Time-based memories"
             subtitle="Photos from previous years"
             bind:checked={user.memoriesEnabled}
+          />
+          <SettingInputField
+            inputType={SettingInputFieldType.NUMBER}
+            label="Duration"
+            desc="Memories will be displayed for this many days before being removed."
+            bind:value={user.memoriesDuration}
+            required={true}
           />
         </div>
         <div class="flex justify-end">

--- a/web/src/routes/(user)/photos/+page.svelte
+++ b/web/src/routes/(user)/photos/+page.svelte
@@ -80,7 +80,7 @@
     withStacked
   >
     {#if data.user.memoriesEnabled}
-      <MemoryLane />
+      <MemoryLane user={data.user} />
     {/if}
     <EmptyPlaceholder
       text="CLICK TO UPLOAD YOUR FIRST PHOTO"


### PR DESCRIPTION
Show memories for more than one day. Duration is per-user configuration and persisted in the database, defaulted to 3 and shows today + X days in the future.

This also adds a `days` parameter to the memories endpoint, which allows a user to get an arbitrary number of days.

![image](https://github.com/immich-app/immich/assets/4334196/53b1a0ce-42ae-4139-8951-f3aac9091764)
