### PR TITLE
mobile: allow upload if local asset in selection

### DIFF
--- a/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
+++ b/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
@@ -100,7 +100,7 @@ class ControlBottomAppBar extends ConsumerWidget {
             label: "control_bottom_app_bar_stack".tr(),
             onPressed: enabled ? onStack : null,
           ),
-        if (!hasRemote)
+        if (hasLocal)
           ControlBoxButton(
             iconData: Icons.backup_outlined,
             label: "Upload",

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -169,9 +169,10 @@ class HomePage extends HookConsumerWidget {
         processing.value = true;
         selectionEnabledHook.value = false;
         try {
-          ref
-              .read(manualUploadProvider.notifier)
-              .uploadAssets(context, selection.value);
+          ref.read(manualUploadProvider.notifier).uploadAssets(
+                context,
+                selection.value.where((a) => a.storage == AssetState.local),
+              );
         } finally {
           processing.value = false;
         }


### PR DESCRIPTION
Closes #4726

#### Changes made in PR

- Show manual upload button when at-least one asset is local only
- Filter local only assets before passing them to manual uploads.