### PR TITLE
feat(web): auto changing theme

### DIFF
--- a/web/src/lib/components/shared-components/theme-button.svelte
+++ b/web/src/lib/components/shared-components/theme-button.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { colorTheme } from '$lib/stores/preferences.store';
   import IconButton from '../elements/buttons/icon-button.svelte';
+
+  import { appearanceSettings } from '../../stores/preferences.store';
 
   const toggleTheme = () => {
     $colorTheme = $colorTheme === 'dark' ? 'light' : 'dark';
   };
 
-  $: {
+  function checkSystemTheme() {
+    if($appearanceSettings.autoTheme) {
+      const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      $colorTheme = darkModeMediaQuery.matches ? 'dark' : 'light';
+      changeTheme()
+    }
+  };
+
+  function changeTheme() {
     if (browser) {
       if ($colorTheme === 'light') {
         document.documentElement.classList.remove('dark');
@@ -15,7 +26,21 @@
         document.documentElement.classList.add('dark');
       }
     }
+  };
+
+  $: {
+    const theme = $colorTheme;
+    changeTheme();
   }
+
+  $: {
+    const autoTheme = $appearanceSettings.autoTheme;
+    checkSystemTheme();
+  }
+
+  onMount(() => {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', checkSystemTheme);
+  });
 </script>
 
 <IconButton on:click={toggleTheme} title="Toggle theme">

--- a/web/src/lib/components/user-settings-page/appearance-settings.svelte
+++ b/web/src/lib/components/user-settings-page/appearance-settings.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition';
+  import { appearanceSettings } from '../../stores/preferences.store';
+  import SettingSwitch from '../admin-page/settings/setting-switch.svelte';
+</script>
+
+<section class="my-4">
+  <div in:fade={{ duration: 500 }}>
+    <div class="ml-4 mt-4 flex flex-col gap-4">
+      <div class="ml-4">
+        <SettingSwitch title="Theme selection" subtitle="Automatically set the theme to light or dark based on your browser's system preference." bind:checked={$appearanceSettings.autoTheme} />
+      </div>
+    </div>
+  </div>
+</section>

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -11,6 +11,7 @@
   import OAuthSettings from './oauth-settings.svelte';
   import PartnerSettings from './partner-settings.svelte';
   import SidebarSettings from './sidebar-settings.svelte';
+  import AppearanceSettings from './appearance-settings.svelte';
   import UserAPIKeyList from './user-api-key-list.svelte';
   import UserProfileSettings from './user-profile-settings.svelte';
 
@@ -66,4 +67,8 @@
 
 <SettingAccordion title="Sidebar" subtitle="Manage sidebar settings">
   <SidebarSettings />
+</SettingAccordion>
+
+<SettingAccordion title="Appearance" subtitle="Manage the appearance of Immich">
+  <AppearanceSettings />
 </SettingAccordion>

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -35,6 +35,10 @@
   <UserAPIKeyList bind:keys />
 </SettingAccordion>
 
+<SettingAccordion title="Appearance" subtitle="Manage the appearance of Immich">
+  <AppearanceSettings />
+</SettingAccordion>
+
 <SettingAccordion title="Authorized Devices" subtitle="Manage your logged-in devices">
   <DeviceList bind:devices />
 </SettingAccordion>
@@ -67,8 +71,4 @@
 
 <SettingAccordion title="Sidebar" subtitle="Manage sidebar settings">
   <SidebarSettings />
-</SettingAccordion>
-
-<SettingAccordion title="Appearance" subtitle="Manage the appearance of Immich">
-  <AppearanceSettings />
 </SettingAccordion>

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -57,6 +57,14 @@ export const sidebarSettings = persisted<SidebarSettings>('sidebar-settings-1', 
   sharing: true,
 });
 
+export interface AppearanceSettings {
+  autoTheme: boolean;
+}
+
+export const appearanceSettings = persisted<AppearanceSettings>('appearance-settings-1', {
+  autoTheme: false,
+});
+
 export enum AlbumViewMode {
   Cover = 'Cover',
   List = 'List',


### PR DESCRIPTION
New feature: the ability to auto change the theme of immich (dark/light) based on the browser's setting. There is a new menu on the profile page with the option to enable or disable this new feature

<img width="1048" alt="image" src="https://github.com/immich-app/immich/assets/51788939/60603994-5311-4fdc-8182-111c9c44d276">

https://github.com/immich-app/immich/assets/51788939/421cc6d9-4a9b-49d9-8e43-9ca79ee73f3a

