### PR TITLE
feat(mobile): share assets from album

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -23,6 +23,7 @@
   "album_viewer_appbar_share_err_title": "Failed to change album title",
   "album_viewer_appbar_share_leave": "Leave album",
   "album_viewer_appbar_share_remove": "Remove from album",
+  "album_viewer_appbar_share_to": "Share to",
   "album_viewer_page_share_add_users": "Add users",
   "all_people_page_title": "People",
   "all_videos_page_title": "Videos",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -23,7 +23,7 @@
   "album_viewer_appbar_share_err_title": "Failed to change album title",
   "album_viewer_appbar_share_leave": "Leave album",
   "album_viewer_appbar_share_remove": "Remove from album",
-  "album_viewer_appbar_share_to": "Share to",
+  "album_viewer_appbar_share_to": "Share To",
   "album_viewer_page_share_add_users": "Add users",
   "all_people_page_title": "People",
   "all_videos_page_title": "Videos",

--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -7,6 +7,8 @@ import 'package:immich_mobile/modules/album/providers/album.provider.dart';
 import 'package:immich_mobile/modules/album/providers/album_detail.provider.dart';
 import 'package:immich_mobile/modules/album/providers/album_viewer.provider.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
+import 'package:immich_mobile/shared/ui/share_dialog.dart';
+import 'package:immich_mobile/shared/services/share.service.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/album.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
@@ -160,40 +162,83 @@ class AlbumViewerAppbar extends HookConsumerWidget
       ImmichLoadingOverlayController.appLoader.hide();
     }
 
-    buildBottomSheetActionButton() {
+    void handleShareAssets(
+      WidgetRef ref,
+      BuildContext context,
+      Set<Asset> selection,
+    ) {
+      showDialog(
+        context: context,
+        builder: (BuildContext buildContext) {
+          ref.watch(shareServiceProvider).shareAssets(selection.toList()).then(
+            (bool status) {
+              if (!status) {
+                ImmichToast.show(
+                  context: context,
+                  msg: 'image_viewer_page_state_provider_share_error'.tr(),
+                  toastType: ToastType.error,
+                  gravity: ToastGravity.BOTTOM,
+                );
+              }
+              Navigator.of(buildContext).pop();
+            },
+          );
+          return const ShareDialog();
+        },
+        barrierDismissible: false,
+      );
+    }
+
+    void onShareAssetsTo() async {
+      ImmichLoadingOverlayController.appLoader.show();
+      handleShareAssets(ref, context, selected);
+      ImmichLoadingOverlayController.appLoader.hide();
+    }
+
+    buildBottomSheetActions() {
       if (selected.isNotEmpty) {
-        if (album.ownerId == userId) {
-          return ListTile(
+        return [
+          ListTile(
+            leading: const Icon(Icons.ios_share_rounded),
+            title: const Text(
+              'album_viewer_appbar_share_to',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ).tr(),
+            onTap: () => onShareAssetsTo(),
+          ),
+          if (album.ownerId == userId)
+          ListTile(
             leading: const Icon(Icons.delete_sweep_rounded),
             title: const Text(
               'album_viewer_appbar_share_remove',
               style: TextStyle(fontWeight: FontWeight.bold),
             ).tr(),
             onTap: () => onRemoveFromAlbumPressed(),
-          );
-        } else {
-          return const SizedBox();
-        }
+          )
+          else
+          const SizedBox(),
+        ];
       } else {
-        if (album.ownerId == userId) {
-          return ListTile(
+        return [
+        if (album.ownerId == userId)
+          ListTile(
             leading: const Icon(Icons.delete_forever_rounded),
             title: const Text(
               'album_viewer_appbar_share_delete',
               style: TextStyle(fontWeight: FontWeight.bold),
             ).tr(),
             onTap: () => onDeleteAlbumPressed(),
-          );
-        } else {
-          return ListTile(
+          )
+          else
+          ListTile(
             leading: const Icon(Icons.person_remove_rounded),
             title: const Text(
               'album_viewer_appbar_share_leave',
               style: TextStyle(fontWeight: FontWeight.bold),
             ).tr(),
             onTap: () => onLeaveAlbumPressed(),
-          );
-        }
+          ),
+        ];
       }
     }
 
@@ -257,7 +302,7 @@ class AlbumViewerAppbar extends HookConsumerWidget
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  buildBottomSheetActionButton(),
+                  ...buildBottomSheetActions(),
                   if (selected.isEmpty && onAddPhotos != null) ...commonActions,
                   if (selected.isEmpty &&
                       onAddPhotos != null &&

--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -206,31 +206,25 @@ class AlbumViewerAppbar extends HookConsumerWidget
             ).tr(),
             onTap: () => onShareAssetsTo(),
           ),
-          if (album.ownerId == userId)
-          ListTile(
+          album.ownerId == userId ? ListTile(
             leading: const Icon(Icons.delete_sweep_rounded),
             title: const Text(
               'album_viewer_appbar_share_remove',
               style: TextStyle(fontWeight: FontWeight.bold),
             ).tr(),
             onTap: () => onRemoveFromAlbumPressed(),
-          )
-          else
-          const SizedBox(),
+          ) : const SizedBox(),
         ];
       } else {
         return [
-        if (album.ownerId == userId)
-          ListTile(
+          album.ownerId == userId ? ListTile(
             leading: const Icon(Icons.delete_forever_rounded),
             title: const Text(
               'album_viewer_appbar_share_delete',
               style: TextStyle(fontWeight: FontWeight.bold),
             ).tr(),
             onTap: () => onDeleteAlbumPressed(),
-          )
-          else
-          ListTile(
+          ) : ListTile(
             leading: const Icon(Icons.person_remove_rounded),
             title: const Text(
               'album_viewer_appbar_share_leave',


### PR DESCRIPTION
Adds ability to share assets from album locally. There is a new action menu item "Share to".

![Screenshot_20231103_134241](https://github.com/immich-app/immich/assets/15554561/b456678d-81fa-4a66-9d35-4226b64edc32)
