### PR TITLE
fix(web): show one face for the same person in the detail panel

### DIFF
--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -98,7 +98,14 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     tags: entity.tags?.map(mapTag),
     people: entity.faces
       ?.map(mapFace)
-      .filter((person): person is PersonResponseDto => person !== null && !person.isHidden),
+      .filter((person): person is PersonResponseDto => person !== null && !person.isHidden)
+      .reduce((people, person) => {
+        const existingPerson = people.find((p) => p.id === person.id);
+        if (!existingPerson) {
+          people.push(person);
+        }
+        return people;
+      }, [] as PersonResponseDto[]),
     checksum: entity.checksum.toString('base64'),
     stackParentId: entity.stackParentId,
     stack: withStack ? entity.stack?.map((a) => mapAsset(a, { stripMetadata })) ?? undefined : undefined,


### PR DESCRIPTION
Currently if two faces are detected as the same person in the same image, the same person will be shown multiple times in the detail panel. 