### PR TITLE
fix(web): unstack after stack child selection

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -545,11 +545,10 @@
       await api.assetApi.updateAssets({ assetBulkUpdateDto: { ids, removeParent: true } });
       for (const child of $stackAssetsStore) {
         child.stackParentId = null;
+        child.stackCount = 0;
+        child.stack = [];
         assetStore?.addAsset(child);
       }
-      asset.stackCount = 0;
-      asset.stack = [];
-      assetStore?.updateAsset(asset, true);
 
       dispatch('unstack');
       notificationController.show({ type: NotificationType.Info, message: 'Un-stacked', timeout: 1500 });

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -261,6 +261,9 @@ export class AssetStore {
       isMismatched(this.options.isArchived, asset.isArchived) ||
       isMismatched(this.options.isFavorite, asset.isFavorite)
     ) {
+      // If asset is already in the bucket we don't need to recalculate
+      // asset store containers
+      this.updateAsset(asset);
       return;
     }
 
@@ -290,6 +293,11 @@ export class AssetStore {
       const bDate = DateTime.fromISO(b.fileCreatedAt).toUTC();
       return bDate.diff(aDate).milliseconds;
     });
+
+    // If we added an asset to the store, we need to recalculate
+    // asset store containers
+    this.assets.push(asset);
+    this.updateAsset(asset, true);
   }
 
   getBucketByDate(bucketDate: string): AssetBucket | null {


### PR DESCRIPTION
## Description

This PR fixes the following unstacking issue:
  * Click on a stacked asset in the timeline
  * Select another child to view by clicking on its thumbnail
  * Execute the unstack action
  
Result: The timeline still shows the stacked asset

It seems that now `addAsset` becomes a self-contained function, which correctly adds assets to the timeline

## Before/After

https://github.com/immich-app/immich/assets/71479/0de27511-0641-4042-9425-0a31ac98398d

https://github.com/immich-app/immich/assets/71479/ad8bdba0-8e55-421a-91c3-a86466b1e5e0

