### PR TITLE
fix(mobile): backup indicator wrong when only background backup is enabled

### DIFF
--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -40,7 +40,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
             progressInPercentage: 0,
             cancelToken: CancellationToken(),
             autoBackup: Store.get(StoreKey.autoBackup, false),
-            backgroundBackup: false,
+            backgroundBackup: Store.get(StoreKey.backgroundBackup, false),
             backupRequireWifi: Store.get(StoreKey.backupRequireWifi, true),
             backupRequireCharging:
                 Store.get(StoreKey.backupRequireCharging, false),
@@ -171,6 +171,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
           state.backupRequireCharging,
         );
         await Store.put(StoreKey.backupTriggerDelay, state.backupTriggerDelay);
+        await Store.put(StoreKey.backgroundBackup, state.backgroundBackup);
       } else {
         state = state.copyWith(
           backgroundBackup: wasEnabled,
@@ -383,6 +384,9 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     final isEnabled = await _backgroundService.isBackgroundBackupEnabled();
 
     state = state.copyWith(backgroundBackup: isEnabled);
+    if (isEnabled != Store.get(StoreKey.backgroundBackup, !isEnabled)) {
+      Store.put(StoreKey.backgroundBackup, isEnabled);
+    }
 
     if (state.backupProgress != BackUpProgressEnum.inBackground) {
       await _getBackupAlbumsInfo();

--- a/mobile/lib/shared/models/store.dart
+++ b/mobile/lib/shared/models/store.dart
@@ -156,6 +156,7 @@ enum StoreKey<T> {
   accessToken<String>(11, type: String),
   serverEndpoint<String>(12, type: String),
   autoBackup<bool>(13, type: bool),
+  backgroundBackup<bool>(14, type: bool),
   // user settings from [AppSettingsEnum] below:
   loadPreview<bool>(100, type: bool),
   loadOriginal<bool>(101, type: bool),


### PR DESCRIPTION
The backup indicator in the app bar possibly shows the wrong icon  "cloud disabled" after app start when only the background backup is enabled. The backup state defaults to `false` and was only set when the backup screen was opened. This is now fixed by loading the setting from the `Store`. 

fixes #2591