### PR TITLE
fix(server): duplicate faces bug

### DIFF
--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -1,4 +1,4 @@
-import { Colorspace, SystemConfigKey } from '@app/infra/entities';
+import { AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   IAccessRepositoryMock,
@@ -445,6 +445,23 @@ describe(PersonService.name, () => {
 
     it('should skip when no resize path', async () => {
       assetMock.getByIds.mockResolvedValue([assetStub.noResizePath]);
+      await sut.handleRecognizeFaces({ id: assetStub.noResizePath.id });
+      expect(machineLearningMock.detectFaces).not.toHaveBeenCalled();
+    });
+
+    it('should skip it the asset has already been processed', async () => {
+      assetMock.getByIds.mockResolvedValue([
+        {
+          ...assetStub.noResizePath,
+          faces: [
+            {
+              id: 'asset-face-1',
+              assetId: assetStub.noResizePath.id,
+              personId: faceStub.face1.personId,
+            } as AssetFaceEntity,
+          ],
+        },
+      ]);
       await sut.handleRecognizeFaces({ id: assetStub.noResizePath.id });
       expect(machineLearningMock.detectFaces).not.toHaveBeenCalled();
     });

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -217,7 +217,7 @@ export class PersonService {
     }
 
     const [asset] = await this.assetRepository.getByIds([id]);
-    if (!asset || !asset.resizePath) {
+    if (!asset || !asset.resizePath || asset.faces?.length > 0) {
       return false;
     }
 


### PR DESCRIPTION
Fixes #4818, although this does not repair damage caused by it in the first place.

Prevent an asset from being processed by facial recognition multiple times, which now has started to result in duplicate faces being added to the database.

