### PR TITLE
chore(server): set db relations for `getByIds`

### DIFF
--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -216,7 +216,13 @@ export class PersonService {
       return true;
     }
 
-    const [asset] = await this.assetRepository.getByIds([id]);
+    const relations = {
+      exifInfo: true,
+      faces: {
+        person: true,
+      },
+    };
+    const [asset] = await this.assetRepository.getByIds([id], relations);
     if (!asset || !asset.resizePath || asset.faces?.length > 0) {
       return false;
     }

--- a/server/src/domain/repositories/asset.repository.ts
+++ b/server/src/domain/repositories/asset.repository.ts
@@ -1,4 +1,5 @@
 import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
+import { FindOptionsRelations } from 'typeorm';
 import { Paginated, PaginationOptions } from '../domain.util';
 
 export type AssetStats = Record<AssetType, number>;
@@ -99,7 +100,7 @@ export const IAssetRepository = 'IAssetRepository';
 export interface IAssetRepository {
   create(asset: AssetCreate): Promise<AssetEntity>;
   getByDate(ownerId: string, date: Date): Promise<AssetEntity[]>;
-  getByIds(ids: string[]): Promise<AssetEntity[]>;
+  getByIds(ids: string[], relations?: FindOptionsRelations<AssetEntity>): Promise<AssetEntity[]>;
   getByDayOfYear(ownerId: string, monthDay: MonthDay): Promise<AssetEntity[]>;
   getByChecksum(userId: string, checksum: Buffer): Promise<AssetEntity | null>;
   getByAlbumId(pagination: PaginationOptions, albumId: string): Paginated<AssetEntity>;

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -104,10 +104,9 @@ export class AssetRepository implements IAssetRepository {
       .getMany();
   }
 
-  getByIds(ids: string[]): Promise<AssetEntity[]> {
-    return this.repository.find({
-      where: { id: In(ids) },
-      relations: {
+  getByIds(ids: string[], relations?: FindOptionsRelations<AssetEntity>): Promise<AssetEntity[]> {
+    if (!relations) {
+      relations = {
         exifInfo: true,
         smartInfo: true,
         tags: true,
@@ -115,7 +114,11 @@ export class AssetRepository implements IAssetRepository {
           person: true,
         },
         stack: true,
-      },
+      };
+    }
+    return this.repository.find({
+      where: { id: In(ids) },
+      relations,
       withDeleted: true,
     });
   }


### PR DESCRIPTION
## Description

This is a small change to allow explicit specification of relations when making database queries with `getByIds`.

The default when this isn't passed is to maintain the current behavior. Existing uses of `getByIds` can be gradually updated to specifying relations in order to reduce query cost.

One such change included in this PR is for facial recognition, where the change led to much lower CPU usage and faster processing.

## How Has This Been Tested?

Tested by running a facial recognition job with and without this change, observing a notable difference in performance.