### PR TITLE
feat(server, web): Album's options

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -333,6 +333,12 @@ export interface AlbumResponseDto {
     'id': string;
     /**
      * 
+     * @type {boolean}
+     * @memberof AlbumResponseDto
+     */
+    'isActivityEnabled': boolean;
+    /**
+     * 
      * @type {string}
      * @memberof AlbumResponseDto
      */
@@ -4160,6 +4166,12 @@ export interface UpdateAlbumDto {
      * @memberof UpdateAlbumDto
      */
     'description'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof UpdateAlbumDto
+     */
+    'isActivityEnabled'?: boolean;
 }
 /**
  * 

--- a/mobile/openapi/doc/AlbumResponseDto.md
+++ b/mobile/openapi/doc/AlbumResponseDto.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **endDate** | [**DateTime**](DateTime.md) |  | [optional] 
 **hasSharedLink** | **bool** |  | 
 **id** | **String** |  | 
+**isActivityEnabled** | **bool** |  | 
 **lastModifiedAssetTimestamp** | [**DateTime**](DateTime.md) |  | [optional] 
 **owner** | [**UserResponseDto**](UserResponseDto.md) |  | 
 **ownerId** | **String** |  | 

--- a/mobile/openapi/doc/UpdateAlbumDto.md
+++ b/mobile/openapi/doc/UpdateAlbumDto.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **albumName** | **String** |  | [optional] 
 **albumThumbnailAssetId** | **String** |  | [optional] 
 **description** | **String** |  | [optional] 
+**isActivityEnabled** | **bool** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/album_response_dto.dart
+++ b/mobile/openapi/lib/model/album_response_dto.dart
@@ -22,6 +22,7 @@ class AlbumResponseDto {
     this.endDate,
     required this.hasSharedLink,
     required this.id,
+    required this.isActivityEnabled,
     this.lastModifiedAssetTimestamp,
     required this.owner,
     required this.ownerId,
@@ -54,6 +55,8 @@ class AlbumResponseDto {
   bool hasSharedLink;
 
   String id;
+
+  bool isActivityEnabled;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -92,6 +95,7 @@ class AlbumResponseDto {
      other.endDate == endDate &&
      other.hasSharedLink == hasSharedLink &&
      other.id == id &&
+     other.isActivityEnabled == isActivityEnabled &&
      other.lastModifiedAssetTimestamp == lastModifiedAssetTimestamp &&
      other.owner == owner &&
      other.ownerId == ownerId &&
@@ -112,6 +116,7 @@ class AlbumResponseDto {
     (endDate == null ? 0 : endDate!.hashCode) +
     (hasSharedLink.hashCode) +
     (id.hashCode) +
+    (isActivityEnabled.hashCode) +
     (lastModifiedAssetTimestamp == null ? 0 : lastModifiedAssetTimestamp!.hashCode) +
     (owner.hashCode) +
     (ownerId.hashCode) +
@@ -121,7 +126,7 @@ class AlbumResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'AlbumResponseDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, assetCount=$assetCount, assets=$assets, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, owner=$owner, ownerId=$ownerId, shared=$shared, sharedUsers=$sharedUsers, startDate=$startDate, updatedAt=$updatedAt]';
+  String toString() => 'AlbumResponseDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, assetCount=$assetCount, assets=$assets, createdAt=$createdAt, description=$description, endDate=$endDate, hasSharedLink=$hasSharedLink, id=$id, isActivityEnabled=$isActivityEnabled, lastModifiedAssetTimestamp=$lastModifiedAssetTimestamp, owner=$owner, ownerId=$ownerId, shared=$shared, sharedUsers=$sharedUsers, startDate=$startDate, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -142,6 +147,7 @@ class AlbumResponseDto {
     }
       json[r'hasSharedLink'] = this.hasSharedLink;
       json[r'id'] = this.id;
+      json[r'isActivityEnabled'] = this.isActivityEnabled;
     if (this.lastModifiedAssetTimestamp != null) {
       json[r'lastModifiedAssetTimestamp'] = this.lastModifiedAssetTimestamp!.toUtc().toIso8601String();
     } else {
@@ -177,6 +183,7 @@ class AlbumResponseDto {
         endDate: mapDateTime(json, r'endDate', ''),
         hasSharedLink: mapValueOfType<bool>(json, r'hasSharedLink')!,
         id: mapValueOfType<String>(json, r'id')!,
+        isActivityEnabled: mapValueOfType<bool>(json, r'isActivityEnabled')!,
         lastModifiedAssetTimestamp: mapDateTime(json, r'lastModifiedAssetTimestamp', ''),
         owner: UserResponseDto.fromJson(json[r'owner'])!,
         ownerId: mapValueOfType<String>(json, r'ownerId')!,
@@ -239,6 +246,7 @@ class AlbumResponseDto {
     'description',
     'hasSharedLink',
     'id',
+    'isActivityEnabled',
     'owner',
     'ownerId',
     'shared',

--- a/mobile/openapi/lib/model/update_album_dto.dart
+++ b/mobile/openapi/lib/model/update_album_dto.dart
@@ -16,6 +16,7 @@ class UpdateAlbumDto {
     this.albumName,
     this.albumThumbnailAssetId,
     this.description,
+    this.isActivityEnabled,
   });
 
   ///
@@ -42,21 +43,31 @@ class UpdateAlbumDto {
   ///
   String? description;
 
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isActivityEnabled;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is UpdateAlbumDto &&
      other.albumName == albumName &&
      other.albumThumbnailAssetId == albumThumbnailAssetId &&
-     other.description == description;
+     other.description == description &&
+     other.isActivityEnabled == isActivityEnabled;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (albumName == null ? 0 : albumName!.hashCode) +
     (albumThumbnailAssetId == null ? 0 : albumThumbnailAssetId!.hashCode) +
-    (description == null ? 0 : description!.hashCode);
+    (description == null ? 0 : description!.hashCode) +
+    (isActivityEnabled == null ? 0 : isActivityEnabled!.hashCode);
 
   @override
-  String toString() => 'UpdateAlbumDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, description=$description]';
+  String toString() => 'UpdateAlbumDto[albumName=$albumName, albumThumbnailAssetId=$albumThumbnailAssetId, description=$description, isActivityEnabled=$isActivityEnabled]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -75,6 +86,11 @@ class UpdateAlbumDto {
     } else {
     //  json[r'description'] = null;
     }
+    if (this.isActivityEnabled != null) {
+      json[r'isActivityEnabled'] = this.isActivityEnabled;
+    } else {
+    //  json[r'isActivityEnabled'] = null;
+    }
     return json;
   }
 
@@ -89,6 +105,7 @@ class UpdateAlbumDto {
         albumName: mapValueOfType<String>(json, r'albumName'),
         albumThumbnailAssetId: mapValueOfType<String>(json, r'albumThumbnailAssetId'),
         description: mapValueOfType<String>(json, r'description'),
+        isActivityEnabled: mapValueOfType<bool>(json, r'isActivityEnabled'),
       );
     }
     return null;

--- a/mobile/openapi/test/album_response_dto_test.dart
+++ b/mobile/openapi/test/album_response_dto_test.dart
@@ -61,6 +61,11 @@ void main() {
       // TODO
     });
 
+    // bool isActivityEnabled
+    test('to test the property `isActivityEnabled`', () async {
+      // TODO
+    });
+
     // DateTime lastModifiedAssetTimestamp
     test('to test the property `lastModifiedAssetTimestamp`', () async {
       // TODO

--- a/mobile/openapi/test/update_album_dto_test.dart
+++ b/mobile/openapi/test/update_album_dto_test.dart
@@ -31,6 +31,11 @@ void main() {
       // TODO
     });
 
+    // bool isActivityEnabled
+    test('to test the property `isActivityEnabled`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -5877,6 +5877,9 @@
           "id": {
             "type": "string"
           },
+          "isActivityEnabled": {
+            "type": "boolean"
+          },
           "lastModifiedAssetTimestamp": {
             "format": "date-time",
             "type": "string"
@@ -5918,7 +5921,8 @@
           "sharedUsers",
           "hasSharedLink",
           "assets",
-          "owner"
+          "owner",
+          "isActivityEnabled"
         ],
         "type": "object"
       },
@@ -8895,6 +8899,9 @@
           },
           "description": {
             "type": "string"
+          },
+          "isActivityEnabled": {
+            "type": "boolean"
           }
         },
         "type": "object"

--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -140,7 +140,8 @@ export class AccessCore {
       case Permission.ACTIVITY_CREATE:
         return (
           (await this.repository.album.hasOwnerAccess(authUser.id, id)) ||
-          (await this.repository.album.hasSharedAlbumAccess(authUser.id, id))
+          (await this.repository.album.hasSharedAlbumAccess(authUser.id, id)) ||
+          (await this.repository.activity.hasAlbumUpdate(authUser.id, id))
         );
 
       // uses activity id

--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -138,11 +138,7 @@ export class AccessCore {
     switch (permission) {
       // uses album id
       case Permission.ACTIVITY_CREATE:
-        return (
-          ((await this.repository.album.hasOwnerAccess(authUser.id, id)) ||
-            (await this.repository.album.hasSharedAlbumAccess(authUser.id, id))) &&
-          (await this.repository.album.hasActivityAccess(authUser.id, id))
-        );
+        return await this.repository.activity.hasCreateAccess(authUser.id, id);
 
       // uses activity id
       case Permission.ACTIVITY_DELETE:

--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -139,9 +139,9 @@ export class AccessCore {
       // uses album id
       case Permission.ACTIVITY_CREATE:
         return (
-          (await this.repository.album.hasOwnerAccess(authUser.id, id)) ||
-          (await this.repository.album.hasSharedAlbumAccess(authUser.id, id)) ||
-          (await this.repository.activity.hasAlbumUpdate(authUser.id, id))
+          ((await this.repository.album.hasOwnerAccess(authUser.id, id)) ||
+            (await this.repository.album.hasSharedAlbumAccess(authUser.id, id))) &&
+          (await this.repository.album.hasActivityAccess(authUser.id, id))
         );
 
       // uses activity id

--- a/server/src/domain/activity/activity.spec.ts
+++ b/server/src/domain/activity/activity.spec.ts
@@ -95,6 +95,7 @@ describe(ActivityService.name, () => {
 
     it('should create a comment', async () => {
       accessMock.album.hasOwnerAccess.mockResolvedValue(true);
+      accessMock.album.hasActivityAccess.mockResolvedValue(true);
       activityMock.create.mockResolvedValue(activityStub.oneComment);
 
       await sut.create(authStub.admin, {
@@ -113,8 +114,24 @@ describe(ActivityService.name, () => {
       });
     });
 
+    it('should fail because activity is disabled for the album', async () => {
+      accessMock.album.hasOwnerAccess.mockResolvedValue(true);
+      accessMock.album.hasActivityAccess.mockResolvedValue(false);
+      activityMock.create.mockResolvedValue(activityStub.oneComment);
+
+      await expect(
+        sut.create(authStub.admin, {
+          albumId: 'album-id',
+          assetId: 'asset-id',
+          type: ReactionType.COMMENT,
+          comment: 'comment',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
     it('should create a like', async () => {
       accessMock.album.hasOwnerAccess.mockResolvedValue(true);
+      accessMock.album.hasActivityAccess.mockResolvedValue(true);
       activityMock.create.mockResolvedValue(activityStub.liked);
       activityMock.search.mockResolvedValue([]);
 
@@ -134,6 +151,7 @@ describe(ActivityService.name, () => {
 
     it('should skip if like exists', async () => {
       accessMock.album.hasOwnerAccess.mockResolvedValue(true);
+      accessMock.album.hasActivityAccess.mockResolvedValue(true);
       activityMock.search.mockResolvedValue([activityStub.liked]);
 
       await sut.create(authStub.admin, {

--- a/server/src/domain/activity/activity.spec.ts
+++ b/server/src/domain/activity/activity.spec.ts
@@ -94,8 +94,7 @@ describe(ActivityService.name, () => {
     });
 
     it('should create a comment', async () => {
-      accessMock.album.hasOwnerAccess.mockResolvedValue(true);
-      accessMock.album.hasActivityAccess.mockResolvedValue(true);
+      accessMock.activity.hasCreateAccess.mockResolvedValue(true);
       activityMock.create.mockResolvedValue(activityStub.oneComment);
 
       await sut.create(authStub.admin, {
@@ -116,7 +115,7 @@ describe(ActivityService.name, () => {
 
     it('should fail because activity is disabled for the album', async () => {
       accessMock.album.hasOwnerAccess.mockResolvedValue(true);
-      accessMock.album.hasActivityAccess.mockResolvedValue(false);
+      accessMock.activity.hasCreateAccess.mockResolvedValue(false);
       activityMock.create.mockResolvedValue(activityStub.oneComment);
 
       await expect(
@@ -130,8 +129,7 @@ describe(ActivityService.name, () => {
     });
 
     it('should create a like', async () => {
-      accessMock.album.hasOwnerAccess.mockResolvedValue(true);
-      accessMock.album.hasActivityAccess.mockResolvedValue(true);
+      accessMock.activity.hasCreateAccess.mockResolvedValue(true);
       activityMock.create.mockResolvedValue(activityStub.liked);
       activityMock.search.mockResolvedValue([]);
 
@@ -151,7 +149,7 @@ describe(ActivityService.name, () => {
 
     it('should skip if like exists', async () => {
       accessMock.album.hasOwnerAccess.mockResolvedValue(true);
-      accessMock.album.hasActivityAccess.mockResolvedValue(true);
+      accessMock.activity.hasCreateAccess.mockResolvedValue(true);
       activityMock.search.mockResolvedValue([activityStub.liked]);
 
       await sut.create(authStub.admin, {

--- a/server/src/domain/album/album-response.dto.ts
+++ b/server/src/domain/album/album-response.dto.ts
@@ -21,6 +21,7 @@ export class AlbumResponseDto {
   lastModifiedAssetTimestamp?: Date;
   startDate?: Date;
   endDate?: Date;
+  isActivityEnabled!: boolean;
 }
 
 export const mapAlbum = (entity: AlbumEntity, withAssets: boolean): AlbumResponseDto => {
@@ -61,6 +62,7 @@ export const mapAlbum = (entity: AlbumEntity, withAssets: boolean): AlbumRespons
     endDate,
     assets: (withAssets ? assets : []).map((asset) => mapAsset(asset)),
     assetCount: entity.assets?.length || 0,
+    isActivityEnabled: entity.isActivityEnabled,
   };
 };
 

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -125,12 +125,12 @@ export class AlbumService {
         throw new BadRequestException('Invalid album thumbnail');
       }
     }
-
     const updatedAlbum = await this.albumRepository.update({
       id: album.id,
       albumName: dto.albumName,
       description: dto.description,
       albumThumbnailAssetId: dto.albumThumbnailAssetId,
+      isActivityEnabled: dto.isActivityEnabled,
     });
 
     await this.jobRepository.queue({ name: JobName.SEARCH_INDEX_ALBUM, data: { ids: [updatedAlbum.id] } });

--- a/server/src/domain/album/dto/album-update.dto.ts
+++ b/server/src/domain/album/dto/album-update.dto.ts
@@ -1,5 +1,6 @@
-import { IsString } from 'class-validator';
-import { Optional, ValidateUUID } from '../../domain.util';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsString } from 'class-validator';
+import { Optional, ValidateUUID, toBoolean } from '../../domain.util';
 
 export class UpdateAlbumDto {
   @Optional()
@@ -12,4 +13,9 @@ export class UpdateAlbumDto {
 
   @ValidateUUID({ optional: true })
   albumThumbnailAssetId?: string;
+
+  @Optional()
+  @IsBoolean()
+  @Transform(toBoolean)
+  isActivityEnabled?: boolean;
 }

--- a/server/src/domain/album/dto/album-update.dto.ts
+++ b/server/src/domain/album/dto/album-update.dto.ts
@@ -1,6 +1,5 @@
-import { Transform } from 'class-transformer';
 import { IsBoolean, IsString } from 'class-validator';
-import { Optional, ValidateUUID, toBoolean } from '../../domain.util';
+import { Optional, ValidateUUID } from '../../domain.util';
 
 export class UpdateAlbumDto {
   @Optional()
@@ -16,6 +15,5 @@ export class UpdateAlbumDto {
 
   @Optional()
   @IsBoolean()
-  @Transform(toBoolean)
   isActivityEnabled?: boolean;
 }

--- a/server/src/domain/repositories/access.repository.ts
+++ b/server/src/domain/repositories/access.repository.ts
@@ -4,7 +4,6 @@ export interface IAccessRepository {
   activity: {
     hasOwnerAccess(userId: string, activityId: string): Promise<boolean>;
     hasAlbumOwnerAccess(userId: string, activityId: string): Promise<boolean>;
-    hasAlbumUpdate(userId: string, activityId: string): Promise<boolean>;
   };
   asset: {
     hasOwnerAccess(userId: string, assetId: string): Promise<boolean>;
@@ -21,6 +20,7 @@ export interface IAccessRepository {
     hasOwnerAccess(userId: string, albumId: string): Promise<boolean>;
     hasSharedAlbumAccess(userId: string, albumId: string): Promise<boolean>;
     hasSharedLinkAccess(sharedLinkId: string, albumId: string): Promise<boolean>;
+    hasActivityAccess(userId: string, albumId: string): Promise<boolean>;
   };
 
   library: {

--- a/server/src/domain/repositories/access.repository.ts
+++ b/server/src/domain/repositories/access.repository.ts
@@ -2,8 +2,9 @@ export const IAccessRepository = 'IAccessRepository';
 
 export interface IAccessRepository {
   activity: {
-    hasOwnerAccess(userId: string, albumId: string): Promise<boolean>;
-    hasAlbumOwnerAccess(userId: string, albumId: string): Promise<boolean>;
+    hasOwnerAccess(userId: string, activityId: string): Promise<boolean>;
+    hasAlbumOwnerAccess(userId: string, activityId: string): Promise<boolean>;
+    hasAlbumUpdate(userId: string, activityId: string): Promise<boolean>;
   };
   asset: {
     hasOwnerAccess(userId: string, assetId: string): Promise<boolean>;

--- a/server/src/domain/repositories/access.repository.ts
+++ b/server/src/domain/repositories/access.repository.ts
@@ -4,6 +4,7 @@ export interface IAccessRepository {
   activity: {
     hasOwnerAccess(userId: string, activityId: string): Promise<boolean>;
     hasAlbumOwnerAccess(userId: string, activityId: string): Promise<boolean>;
+    hasCreateAccess(userId: string, albumId: string): Promise<boolean>;
   };
   asset: {
     hasOwnerAccess(userId: string, assetId: string): Promise<boolean>;
@@ -20,7 +21,6 @@ export interface IAccessRepository {
     hasOwnerAccess(userId: string, albumId: string): Promise<boolean>;
     hasSharedAlbumAccess(userId: string, albumId: string): Promise<boolean>;
     hasSharedLinkAccess(sharedLinkId: string, albumId: string): Promise<boolean>;
-    hasActivityAccess(userId: string, albumId: string): Promise<boolean>;
   };
 
   library: {

--- a/server/src/infra/entities/album.entity.ts
+++ b/server/src/infra/entities/album.entity.ts
@@ -56,4 +56,7 @@ export class AlbumEntity {
 
   @OneToMany(() => SharedLinkEntity, (link) => link.album)
   sharedLinks!: SharedLinkEntity[];
+
+  @Column({ default: true })
+  isActivityEnabled!: boolean;
 }

--- a/server/src/infra/migrations/1699268680508-DisableActivity.ts
+++ b/server/src/infra/migrations/1699268680508-DisableActivity.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DisableActivity1699268680508 implements MigrationInterface {
+    name = 'DisableActivity1699268680508'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "albums" ADD "isActivityEnabled" boolean NOT NULL DEFAULT true`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "albums" DROP COLUMN "isActivityEnabled"`);
+    }
+
+}

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -43,17 +43,6 @@ export class AccessRepository implements IAccessRepository {
         },
       });
     },
-    hasAlbumUpdate: (userId: string, activityId: string): Promise<boolean> => {
-      return this.activityRepository.exist({
-        where: {
-          id: activityId,
-          userId,
-          album: {
-            isActivityEnabled: true,
-          },
-        },
-      });
-    },
   };
   library = {
     hasOwnerAccess: (userId: string, libraryId: string): Promise<boolean> => {
@@ -227,6 +216,14 @@ export class AccessRepository implements IAccessRepository {
         where: {
           id: sharedLinkId,
           albumId,
+        },
+      });
+    },
+    hasActivityAccess: (_: string, albumId: string): Promise<boolean> => {
+      return this.albumRepository.exist({
+        where: {
+          id: albumId,
+          isActivityEnabled: true,
         },
       });
     },

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -43,6 +43,24 @@ export class AccessRepository implements IAccessRepository {
         },
       });
     },
+    hasCreateAccess: (userId: string, albumId: string): Promise<boolean> => {
+      return this.albumRepository.exist({
+        where: [
+          {
+            id: albumId,
+            isActivityEnabled: true,
+            sharedUsers: {
+              id: userId,
+            },
+          },
+          {
+            id: albumId,
+            isActivityEnabled: true,
+            ownerId: userId,
+          },
+        ],
+      });
+    },
   };
   library = {
     hasOwnerAccess: (userId: string, libraryId: string): Promise<boolean> => {
@@ -216,14 +234,6 @@ export class AccessRepository implements IAccessRepository {
         where: {
           id: sharedLinkId,
           albumId,
-        },
-      });
-    },
-    hasActivityAccess: (_: string, albumId: string): Promise<boolean> => {
-      return this.albumRepository.exist({
-        where: {
-          id: albumId,
-          isActivityEnabled: true,
         },
       });
     },

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -43,6 +43,17 @@ export class AccessRepository implements IAccessRepository {
         },
       });
     },
+    hasAlbumUpdate: (userId: string, activityId: string): Promise<boolean> => {
+      return this.activityRepository.exist({
+        where: {
+          id: activityId,
+          userId,
+          album: {
+            isActivityEnabled: true
+          },
+        },
+      });
+    },
   };
   library = {
     hasOwnerAccess: (userId: string, libraryId: string): Promise<boolean> => {

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -49,7 +49,7 @@ export class AccessRepository implements IAccessRepository {
           id: activityId,
           userId,
           album: {
-            isActivityEnabled: true
+            isActivityEnabled: true,
           },
         },
       });

--- a/server/test/e2e/album.e2e-spec.ts
+++ b/server/test/e2e/album.e2e-spec.ts
@@ -226,6 +226,7 @@ describe(`${AlbumController.name} (e2e)`, () => {
         assets: [],
         assetCount: 0,
         owner: expect.objectContaining({ email: user1.userEmail }),
+        isActivityEnabled: true,
       });
     });
   });

--- a/server/test/fixtures/album.stub.ts
+++ b/server/test/fixtures/album.stub.ts
@@ -18,6 +18,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   sharedWithUser: Object.freeze<AlbumEntity>({
     id: 'album-2',
@@ -33,6 +34,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [userStub.user1],
+    isActivityEnabled: true,
   }),
   sharedWithMultiple: Object.freeze<AlbumEntity>({
     id: 'album-3',
@@ -48,6 +50,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [userStub.user1, userStub.user2],
+    isActivityEnabled: true,
   }),
   sharedWithAdmin: Object.freeze<AlbumEntity>({
     id: 'album-3',
@@ -63,6 +66,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [userStub.admin],
+    isActivityEnabled: true,
   }),
   oneAsset: Object.freeze<AlbumEntity>({
     id: 'album-4',
@@ -78,6 +82,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   twoAssets: Object.freeze<AlbumEntity>({
     id: 'album-4a',
@@ -93,6 +98,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   emptyWithInvalidThumbnail: Object.freeze<AlbumEntity>({
     id: 'album-5',
@@ -108,6 +114,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   emptyWithValidThumbnail: Object.freeze<AlbumEntity>({
     id: 'album-5',
@@ -123,6 +130,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   oneAssetInvalidThumbnail: Object.freeze<AlbumEntity>({
     id: 'album-6',
@@ -138,6 +146,7 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
   oneAssetValidThumbnail: Object.freeze<AlbumEntity>({
     id: 'album-6',
@@ -153,5 +162,6 @@ export const albumStub = {
     deletedAt: null,
     sharedLinks: [],
     sharedUsers: [],
+    isActivityEnabled: true,
   }),
 };

--- a/server/test/fixtures/shared-link.stub.ts
+++ b/server/test/fixtures/shared-link.stub.ts
@@ -100,6 +100,7 @@ const albumResponse: AlbumResponseDto = {
   hasSharedLink: false,
   assets: [],
   assetCount: 1,
+  isActivityEnabled: true,
 };
 
 export const sharedLinkStub = {
@@ -179,6 +180,7 @@ export const sharedLinkStub = {
       albumThumbnailAssetId: null,
       sharedUsers: [],
       sharedLinks: [],
+      isActivityEnabled: true,
       assets: [
         {
           id: 'id_1',

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -31,6 +31,7 @@ export const newAccessRepositoryMock = (reset = true): IAccessRepositoryMock => 
       hasOwnerAccess: jest.fn(),
       hasSharedAlbumAccess: jest.fn(),
       hasSharedLinkAccess: jest.fn(),
+      hasActivityAccess: jest.fn(),
     },
 
     authDevice: {

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -19,6 +19,7 @@ export const newAccessRepositoryMock = (reset = true): IAccessRepositoryMock => 
     activity: {
       hasOwnerAccess: jest.fn(),
       hasAlbumOwnerAccess: jest.fn(),
+      hasCreateAccess: jest.fn(),
     },
     asset: {
       hasOwnerAccess: jest.fn(),
@@ -31,7 +32,6 @@ export const newAccessRepositoryMock = (reset = true): IAccessRepositoryMock => 
       hasOwnerAccess: jest.fn(),
       hasSharedAlbumAccess: jest.fn(),
       hasSharedLinkAccess: jest.fn(),
-      hasActivityAccess: jest.fn(),
     },
 
     authDevice: {

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -333,6 +333,12 @@ export interface AlbumResponseDto {
     'id': string;
     /**
      * 
+     * @type {boolean}
+     * @memberof AlbumResponseDto
+     */
+    'isActivityEnabled': boolean;
+    /**
+     * 
      * @type {string}
      * @memberof AlbumResponseDto
      */
@@ -4160,6 +4166,12 @@ export interface UpdateAlbumDto {
      * @memberof UpdateAlbumDto
      */
     'description'?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof UpdateAlbumDto
+     */
+    'isActivityEnabled'?: boolean;
 }
 /**
  * 

--- a/web/src/lib/components/album-page/album-options.svelte
+++ b/web/src/lib/components/album-page/album-options.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import { mdiClose, mdiPlus } from '@mdi/js';
+  import SettingSwitch from '../admin-page/settings/setting-switch.svelte';
+  import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
+  import FullScreenModal from '../shared-components/full-screen-modal.svelte';
+  import UserAvatar from '../shared-components/user-avatar.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import type { AlbumResponseDto, UserResponseDto } from '../../../api/open-api';
+  import Icon from '$lib/components/elements/icon.svelte';
+
+  export let album: AlbumResponseDto;
+  export let user: UserResponseDto;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    toggleEnableActivity: void;
+    showSelectSharedUser: void;
+  }>();
+</script>
+
+<FullScreenModal on:clickOutside={() => dispatch('close')}>
+  <div class="flex h-full w-full place-content-center place-items-center overflow-hidden p-2 md:p-0">
+    <div
+      class="w-[550px] rounded-3xl border bg-immich-bg shadow-sm dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-fg"
+    >
+      <div class="px-2 pt-2">
+        <div class="flex items-center">
+          <h1 class="px-4 w-full self-center font-medium text-immich-primary dark:text-immich-dark-primary">Options</h1>
+          <div>
+            <CircleIconButton icon={mdiClose} on:click={() => dispatch('close')} />
+          </div>
+        </div>
+
+        <div class=" items-center justify-center p-4">
+          <div class="py-2">
+            <h2 class="text-gray text-sm mb-3">SHARING</h2>
+            <div class="p-2">
+              <SettingSwitch
+                title="Comments & likes"
+                subtitle="Let others respond"
+                checked={album.isActivityEnabled}
+                on:toggle={() => dispatch('toggleEnableActivity')}
+              />
+            </div>
+          </div>
+          <div class="py-2">
+            <div class="text-gray text-sm mb-3">PEOPLE</div>
+            <div class="p-2">
+              <button class="flex items-center gap-2" on:click={() => dispatch('showSelectSharedUser')}>
+                <div class="rounded-full w-10 h-10 border border-gray-500 flex items-center justify-center">
+                  <div><Icon path={mdiPlus} size="25" /></div>
+                </div>
+                <div>Invite People</div>
+              </button>
+              <div class="flex items-center gap-2 py-2 mt-2">
+                <div>
+                  <UserAvatar {user} size="md" />
+                </div>
+                <div class="w-full">{`${user.firstName} ${user.lastName}`}</div>
+                <div>Owner</div>
+              </div>
+              {#each album.sharedUsers as user (user.id)}
+                <div class="flex items-center gap-2 py-2">
+                  <div>
+                    <UserAvatar {user} size="md" />
+                  </div>
+                  <div class="w-full">{`${user.firstName} ${user.lastName}`}</div>
+                </div>
+              {/each}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</FullScreenModal>

--- a/web/src/lib/components/asset-viewer/activity-status.svelte
+++ b/web/src/lib/components/asset-viewer/activity-status.svelte
@@ -7,6 +7,7 @@
   export let isLiked: ActivityResponseDto | null;
   export let numberOfComments: number | undefined;
   export let isShowActivity: boolean | undefined;
+  export let enableLikeButton: boolean;
 
   const dispatch = createEventDispatcher();
 </script>
@@ -14,7 +15,11 @@
 <div
   class="w-full h-14 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"
 >
-  <button on:click={() => dispatch('favorite')}>
+  <button
+    class={!enableLikeButton ? 'cursor-not-allowed' : ''}
+    on:click={() => dispatch('favorite')}
+    disabled={!enableLikeButton}
+  >
     <!-- svelte-ignore missing-declaration -->
     <div class="items-center justify-center">
       <Icon path={isLiked ? mdiHeart : mdiHeartOutline} size={24} />

--- a/web/src/lib/components/asset-viewer/activity-status.svelte
+++ b/web/src/lib/components/asset-viewer/activity-status.svelte
@@ -7,7 +7,7 @@
   export let isLiked: ActivityResponseDto | null;
   export let numberOfComments: number | undefined;
   export let isShowActivity: boolean | undefined;
-  export let enableLikeButton: boolean;
+  export let disabled: boolean;
 
   const dispatch = createEventDispatcher();
 </script>
@@ -15,11 +15,7 @@
 <div
   class="w-full h-14 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"
 >
-  <button
-    class={!enableLikeButton ? 'cursor-not-allowed' : ''}
-    on:click={() => dispatch('favorite')}
-    disabled={!enableLikeButton}
-  >
+  <button class={disabled ? 'cursor-not-allowed' : ''} on:click={() => dispatch('favorite')} {disabled}>
     <!-- svelte-ignore missing-declaration -->
     <div class="items-center justify-center">
       <Icon path={isLiked ? mdiHeart : mdiHeartOutline} size={24} />

--- a/web/src/lib/components/asset-viewer/activity-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/activity-viewer.svelte
@@ -38,6 +38,7 @@
   export let albumId: string;
   export let assetType: AssetTypeEnum | undefined = undefined;
   export let albumOwnerId: string;
+  export let canComment: boolean;
 
   let textArea: HTMLTextAreaElement;
   let innerHeight: number;
@@ -280,12 +281,15 @@
         <form class="flex w-full max-h-56 gap-1" on:submit|preventDefault={() => handleSendComment()}>
           <div class="flex w-full items-center gap-4">
             <textarea
+              disabled={!canComment}
               bind:this={textArea}
               bind:value={message}
-              placeholder="Say something"
+              placeholder={canComment ? 'Say something' : 'Comments are disabled'}
               on:input={autoGrow}
               on:keypress={handleEnter}
-              class="h-[18px] w-full max-h-56 pr-2 items-center overflow-y-auto leading-4 outline-none resize-none bg-gray-200"
+              class="h-[18px] {canComment
+                ? ''
+                : 'cursor-not-allowed'} w-full max-h-56 pr-2 items-center overflow-y-auto leading-4 outline-none resize-none bg-gray-200"
             />
           </div>
           {#if isSendingMessage}

--- a/web/src/lib/components/asset-viewer/activity-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/activity-viewer.svelte
@@ -38,7 +38,7 @@
   export let albumId: string;
   export let assetType: AssetTypeEnum | undefined = undefined;
   export let albumOwnerId: string;
-  export let canComment: boolean;
+  export let disabled: boolean;
 
   let textArea: HTMLTextAreaElement;
   let innerHeight: number;
@@ -281,15 +281,15 @@
         <form class="flex w-full max-h-56 gap-1" on:submit|preventDefault={() => handleSendComment()}>
           <div class="flex w-full items-center gap-4">
             <textarea
-              disabled={!canComment}
+              {disabled}
               bind:this={textArea}
               bind:value={message}
-              placeholder={canComment ? 'Say something' : 'Comments are disabled'}
+              placeholder={disabled ? 'Comments are disabled' : 'Say something'}
               on:input={autoGrow}
               on:keypress={handleEnter}
-              class="h-[18px] {canComment
-                ? ''
-                : 'cursor-not-allowed'} w-full max-h-56 pr-2 items-center overflow-y-auto leading-4 outline-none resize-none bg-gray-200"
+              class="h-[18px] {disabled
+                ? 'cursor-not-allowed'
+                : ''} w-full max-h-56 pr-2 items-center overflow-y-auto leading-4 outline-none resize-none bg-gray-200"
             />
           </div>
           {#if isSendingMessage}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -744,6 +744,7 @@
     >
       <ActivityViewer
         {user}
+        canComment={album.isActivityEnabled}
         assetType={asset.type}
         albumOwnerId={album.ownerId}
         albumId={album.id}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -104,6 +104,12 @@
     }
   }
 
+  $: {
+    if (album && !album.isActivityEnabled && numberOfComments === 0) {
+      isShowActivity = false;
+    }
+  }
+
   const handleAddComment = () => {
     numberOfComments++;
     updateNumberOfComments(1);
@@ -115,7 +121,7 @@
   };
 
   const handleFavorite = async () => {
-    if (album) {
+    if (album && album.isActivityEnabled) {
       try {
         if (isLiked) {
           const activityId = isLiked.id;
@@ -661,9 +667,10 @@
             on:onVideoStarted={handleVideoStarted}
           />
         {/if}
-        {#if $slideshowState === SlideshowState.None && isShared}
+        {#if $slideshowState === SlideshowState.None && isShared && ((album && album.isActivityEnabled) || numberOfComments > 0)}
           <div class="z-[9999] absolute bottom-0 right-0 mb-6 mr-6 justify-self-end">
             <ActivityStatus
+              enableLikeButton={album?.isActivityEnabled || false}
               {isLiked}
               {numberOfComments}
               {isShowActivity}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -670,7 +670,7 @@
         {#if $slideshowState === SlideshowState.None && isShared && ((album && album.isActivityEnabled) || numberOfComments > 0)}
           <div class="z-[9999] absolute bottom-0 right-0 mb-6 mr-6 justify-self-end">
             <ActivityStatus
-              enableLikeButton={album?.isActivityEnabled || false}
+              disabled={!album?.isActivityEnabled}
               {isLiked}
               {numberOfComments}
               {isShowActivity}
@@ -751,7 +751,7 @@
     >
       <ActivityViewer
         {user}
-        canComment={album.isActivityEnabled}
+        disabled={!album.isActivityEnabled}
         assetType={asset.type}
         albumOwnerId={album.ownerId}
         albumId={album.id}

--- a/web/src/lib/stores/activity.store.ts
+++ b/web/src/lib/stores/activity.store.ts
@@ -1,11 +1,11 @@
 import { writable } from 'svelte/store';
 
-export const numberOfComments = writable<number | undefined>(undefined);
+export const numberOfComments = writable<number>(0);
 
 export const setNumberOfComments = (number: number) => {
   numberOfComments.set(number);
 };
 
 export const updateNumberOfComments = (addOrRemove: 1 | -1) => {
-  numberOfComments.update((n) => (n ? n + addOrRemove : undefined));
+  numberOfComments.update((n) => n + addOrRemove);
 };

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -663,7 +663,7 @@
       {#if album.sharedUsers.length > 0 && !$showAssetViewer && (album.isActivityEnabled || ($numberOfComments && $numberOfComments > 0))}
         <div class="absolute z-[2] bottom-0 right-0 mb-6 mr-6 justify-self-end">
           <ActivityStatus
-            enableLikeButton={album.isActivityEnabled}
+            disabled={!album.isActivityEnabled}
             {isLiked}
             numberOfComments={$numberOfComments}
             {isShowActivity}
@@ -684,7 +684,7 @@
       >
         <ActivityViewer
           {user}
-          canComment={album.isActivityEnabled}
+          disabled={!album.isActivityEnabled}
           albumOwnerId={album.ownerId}
           albumId={album.id}
           bind:reactions

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -117,6 +117,8 @@
       assetGridWidth = globalWidth;
     }
   }
+  $: showActivityStatus =
+    album.sharedUsers.length > 0 && !$showAssetViewer && (album.isActivityEnabled || $numberOfComments > 0);
 
   afterNavigate(({ from }) => {
     assetViewingStore.showAssetViewer(false);
@@ -152,7 +154,7 @@
         message: `Activity is ${album.isActivityEnabled ? 'enabled' : 'disabled'}`,
       });
     } catch (error) {
-      handleError(error, "Can't change favorite for asset");
+      handleError(error, `Can't ${!album.isActivityEnabled ? 'enable' : 'disable'} activity`);
     }
   };
 
@@ -660,7 +662,7 @@
         </AssetGrid>
       {/if}
 
-      {#if album.sharedUsers.length > 0 && !$showAssetViewer && (album.isActivityEnabled || ($numberOfComments && $numberOfComments > 0))}
+      {#if showActivityStatus}
         <div class="absolute z-[2] bottom-0 right-0 mb-6 mr-6 justify-self-end">
           <ActivityStatus
             disabled={!album.isActivityEnabled}

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -49,15 +49,12 @@
     mdiLink,
     mdiShareVariantOutline,
     mdiDeleteOutline,
-    mdiClose,
   } from '@mdi/js';
   import { onMount } from 'svelte';
   import { fly } from 'svelte/transition';
   import ActivityViewer from '$lib/components/asset-viewer/activity-viewer.svelte';
   import ActivityStatus from '$lib/components/asset-viewer/activity-status.svelte';
   import { numberOfComments, setNumberOfComments, updateNumberOfComments } from '$lib/stores/activity.store';
-  import FullScreenModal from '$lib/components/shared-components/full-screen-modal.svelte';
-  import SettingSwitch from '$lib/components/admin-page/settings/setting-switch.svelte';
   import AlbumOptions from '$lib/components/album-page/album-options.svelte';
 
   export let data: PageData;

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -58,6 +58,7 @@
   import { numberOfComments, setNumberOfComments, updateNumberOfComments } from '$lib/stores/activity.store';
   import FullScreenModal from '$lib/components/shared-components/full-screen-modal.svelte';
   import SettingSwitch from '$lib/components/admin-page/settings/setting-switch.svelte';
+  import AlbumOptions from '$lib/components/album-page/album-options.svelte';
 
   export let data: PageData;
 
@@ -735,64 +736,13 @@
 {/if}
 
 {#if viewMode === ViewMode.OPTIONS}
-  <FullScreenModal on:clickOutside={() => (viewMode = ViewMode.VIEW)}>
-    <div class="flex h-full w-full place-content-center place-items-center overflow-hidden p-2 md:p-0">
-      <div
-        class="w-[550px] rounded-3xl border bg-immich-bg shadow-sm dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-fg"
-      >
-        <div class="px-2 pt-2">
-          <div class="flex items-center">
-            <h1 class="px-4 w-full self-center font-medium text-immich-primary dark:text-immich-dark-primary">
-              Options
-            </h1>
-            <div>
-              <CircleIconButton icon={mdiClose} on:click={() => (viewMode = ViewMode.VIEW)} />
-            </div>
-          </div>
-
-          <div class=" items-center justify-center p-4">
-            <div class="py-2">
-              <h2 class="text-gray text-sm mb-3">SHARING</h2>
-              <div class="p-2">
-                <SettingSwitch
-                  title="Comments & likes"
-                  subtitle="Let others respond"
-                  checked={album.isActivityEnabled}
-                  on:toggle={handleToggleEnableActivity}
-                />
-              </div>
-            </div>
-            <div class="py-2">
-              <div class="text-gray text-sm mb-3">PEOPLE</div>
-              <div class="p-2">
-                <button class="flex items-center gap-2" on:click={() => (viewMode = ViewMode.SELECT_USERS)}>
-                  <div class="rounded-full w-10 h-10 border border-gray-500 flex items-center justify-center">
-                    <div><Icon path={mdiPlus} size="25" /></div>
-                  </div>
-                  <div>Invite People</div>
-                </button>
-                <div class="flex items-center gap-2 py-2 mt-2">
-                  <div>
-                    <UserAvatar {user} size="md" />
-                  </div>
-                  <div class="w-full">{`${user.firstName} ${user.lastName}`}</div>
-                  <div>Owner</div>
-                </div>
-                {#each album.sharedUsers as user (user.id)}
-                  <div class="flex items-center gap-2 py-2">
-                    <div>
-                      <UserAvatar {user} size="md" />
-                    </div>
-                    <div class="w-full">{`${user.firstName} ${user.lastName}`}</div>
-                  </div>
-                {/each}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </FullScreenModal>
+  <AlbumOptions
+    {album}
+    {user}
+    on:close={() => (viewMode = ViewMode.VIEW)}
+    on:toggleEnableActivity={handleToggleEnableActivity}
+    on:showSelectSharedUser={() => (viewMode = ViewMode.SELECT_USERS)}
+  />
 {/if}
 
 {#if isEditingDescription}

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -752,18 +752,18 @@
 
           <div class=" items-center justify-center p-4">
             <div class="py-2">
-              <h2 class="text-gray">Sharing</h2>
+              <h2 class="text-gray text-sm mb-3">SHARING</h2>
               <div class="p-2">
                 <SettingSwitch
-                  title="Activity"
-                  subtitle="Let users react"
+                  title="Comments & likes"
+                  subtitle="Let others respond"
                   checked={album.isActivityEnabled}
                   on:toggle={handleToggleEnableActivity}
                 />
               </div>
             </div>
             <div class="py-2">
-              <div>People</div>
+              <div class="text-gray text-sm mb-3">PEOPLE</div>
               <div class="p-2">
                 <button class="flex items-center gap-2" on:click={() => (viewMode = ViewMode.SELECT_USERS)}>
                   <div class="rounded-full w-10 h-10 border border-gray-500 flex items-center justify-center">
@@ -771,7 +771,7 @@
                   </div>
                   <div>Invite People</div>
                 </button>
-                <div class="flex items-center gap-2 py-2">
+                <div class="flex items-center gap-2 py-2 mt-2">
                   <div>
                     <UserAvatar {user} size="md" />
                   </div>

--- a/web/src/test-data/factories/album-factory.ts
+++ b/web/src/test-data/factories/album-factory.ts
@@ -17,4 +17,5 @@ export const albumFactory = Sync.makeFactory<AlbumResponseDto>({
   shared: false,
   sharedUsers: [],
   hasSharedLink: false,
+  isActivityEnabled: true,
 });


### PR DESCRIPTION
## Changes made in this PR

Currently, Activity is enabled on all shared albums, this PR adds the ability to the album owner to disable the activity tabs on its albums. Once activity is disabled, previous comments are still displayed and the activity status (the like and comment icons on the bottom right) is still displayed if the viewed asset has still comments. If an album has no comments anymore, the activity status is not displayed

## Screenshots

https://github.com/immich-app/immich/assets/74269598/41564ae5-c2e1-47e4-a37f-79e1fe1c156f




