### PR TITLE
feat(server): typesense api key as docker secret

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -222,10 +222,13 @@ the `_FILE` variable should be set to the path of a file containing the variable
 |    `DB_USERNAME`    |      `DB_USERNAME_FILE`<sup>\*1</sup>       |
 |    `DB_PASSWORD`    |      `DB_PASSWORD_FILE`<sup>\*1</sup>       |
 |  `REDIS_PASSWORD`   |     `REDIS_PASSWORD_FILE`<sup>\*2</sup>     |
-| `TYPESENSE_API_KEY` |          `TYPESENSE_API_KEY_FILE`           |
+| `TYPESENSE_API_KEY` |   `TYPESENSE_API_KEY_FILE`<sup>\*3</sup>    |
 
 \*1: See the [official documentation](https://github.com/docker-library/docs/tree/master/postgres#docker-secrets) for
 details on how to use Docker Secrets in the Postgres image.
 
 \*2: See [this comment](https://github.com/docker-library/redis/issues/46#issuecomment-335326234) for an example of how
-to use use a Docker secret for the password in the Redis container.
+to use a Docker secret for the password in the Redis container.
+
+\*3: See [this comment](https://github.com/immich-app/immich/pull/4888#issuecomment-1798791176) for an example of how
+to use a Docker secret for the api key in the Typesense container.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -215,13 +215,14 @@ The following variables support the use of [Docker secrets](https://docs.docker.
 To use any of these, replace the regular environment variable with the equivalent `_FILE` environment variable. The value of
 the `_FILE` variable should be set to the path of a file containing the variable value.
 
-|  Regular Variable  | Equivalent Docker Secrets '\_FILE' Variable |
-| :----------------: | :-----------------------------------------: |
-|   `DB_HOSTNAME`    |      `DB_HOSTNAME_FILE`<sup>\*1</sup>       |
-| `DB_DATABASE_NAME` |    `DB_DATABASE_NAME_FILE`<sup>\*1</sup>    |
-|   `DB_USERNAME`    |      `DB_USERNAME_FILE`<sup>\*1</sup>       |
-|   `DB_PASSWORD`    |      `DB_PASSWORD_FILE`<sup>\*1</sup>       |
-|  `REDIS_PASSWORD`  |     `REDIS_PASSWORD_FILE`<sup>\*2</sup>     |
+|  Regular Variable   | Equivalent Docker Secrets '\_FILE' Variable |
+| :-----------------: | :-----------------------------------------: |
+|    `DB_HOSTNAME`    |      `DB_HOSTNAME_FILE`<sup>\*1</sup>       |
+| `DB_DATABASE_NAME`  |    `DB_DATABASE_NAME_FILE`<sup>\*1</sup>    |
+|    `DB_USERNAME`    |      `DB_USERNAME_FILE`<sup>\*1</sup>       |
+|    `DB_PASSWORD`    |      `DB_PASSWORD_FILE`<sup>\*1</sup>       |
+|  `REDIS_PASSWORD`   |     `REDIS_PASSWORD_FILE`<sup>\*2</sup>     |
+| `TYPESENSE_API_KEY` |          `TYPESENSE_API_KEY_FILE`           |
 
 \*1: See the [official documentation](https://github.com/docker-library/docs/tree/master/postgres#docker-secrets) for
 details on how to use Docker Secrets in the Postgres image.

--- a/server/start.sh
+++ b/server/start.sh
@@ -32,4 +32,9 @@ if [ "$REDIS_PASSWORD_FILE" ]; then
 	unset REDIS_PASSWORD_FILE
 fi
 
+if [ "$TYPESENSE_API_KEY_FILE" ]; then
+	export TYPESENSE_API_KEY=$(cat $TYPESENSE_API_KEY_FILE)
+	unset TYPESENSE_API_KEY_FILE
+fi
+
 exec node dist/main $@


### PR DESCRIPTION
The `TYPESENSE_API_KEY_FILE` variable has been added to be able to use Docker secrets.