### PR TITLE
fix(mobile): do not show trashed assets in album viewer page

### DIFF
--- a/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
+++ b/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
@@ -37,6 +37,7 @@ class TrashNotifier extends StateNotifier<bool> {
           .remoteIdProperty()
           .findAll();
 
+      // TODO: handle local asset removal on emptyTrash
       _ref
           .read(syncServiceProvider)
           .handleRemoteAssetRemoval(idsToRemove.cast<String>().toList());

--- a/mobile/lib/shared/models/album.dart
+++ b/mobile/lib/shared/models/album.dart
@@ -77,7 +77,8 @@ class Album {
   }
 
   Stream<void> watchRenderList(GroupAssetsBy groupAssetsBy) async* {
-    final query = assets.filter().sortByFileCreatedAtDesc();
+    final query =
+        assets.filter().isTrashedEqualTo(false).sortByFileCreatedAtDesc();
     _renderList = await RenderList.fromQuery(query, groupAssetsBy);
     yield _renderList;
     await for (final _ in query.watchLazy()) {


### PR DESCRIPTION
Fixes #4891

#### Changes made in the PR

- Trashed assets are now filtered from the list of assets belonging to an album