### PR TITLE
feat(build): add docker compose project name

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,7 +3,7 @@
 # - https://immich.app/docs/developer/troubleshooting
 
 version: "3.8"
-
+name: immich-dev
 services:
   immich-server:
     container_name: immich_server

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 version: "3.8"
-
+name: immich
 services:
   immich-server:
     container_name: immich_server
@@ -7,7 +7,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: [ "./start-server.sh" ]
+    command: ["./start-server.sh"]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
@@ -27,7 +27,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: [ "./start-microservices.sh" ]
+    command: ["./start-microservices.sh"]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,7 +1,6 @@
 version: "3.8"
 
 name: "immich-test-e2e"
-
 services:
   immich-server:
     image: immich-server-dev:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.8"
-
+name: immich
 services:
   immich-server:
     container_name: immich_server
@@ -26,6 +26,7 @@ services:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
+      - /e/poseidon-backup/images:/mnt/media/images:ro
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
I have recently started using immich and loving it. I do run quite a few containers already and immich project always comes up with a generic "docker" which makes it hard to read and find amon many other containers or projects.

![image](https://github.com/immich-app/immich/assets/12991664/e772b921-a388-41df-9611-438cddcf2dc4)

So I decided to raise a PR for the fix:

![image](https://github.com/immich-app/immich/assets/12991664/198f1088-73d8-4eb0-a809-35fea5b56ac3)

