### PR TITLE
feat!: add docker project name

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,7 +3,7 @@
 # - https://immich.app/docs/developer/troubleshooting
 
 version: "3.8"
-
+name: immich-dev
 services:
   immich-server:
     container_name: immich_server

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,7 +3,9 @@
 # - https://immich.app/docs/developer/troubleshooting
 
 version: "3.8"
+
 name: immich-dev
+
 services:
   immich-server:
     container_name: immich_server

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,5 +1,7 @@
 version: "3.8"
-name: immich
+
+name: immich-prod
+
 services:
   immich-server:
     container_name: immich_server
@@ -7,7 +9,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: ["./start-server.sh"]
+    command: [ "./start-server.sh" ]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
@@ -27,7 +29,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: ["./start-microservices.sh"]
+    command: [ "./start-microservices.sh" ]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 version: "3.8"
-
+name: immich
 services:
   immich-server:
     container_name: immich_server
@@ -7,7 +7,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: [ "./start-server.sh" ]
+    command: ["./start-server.sh"]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
@@ -27,7 +27,7 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
-    command: [ "./start-microservices.sh" ]
+    command: ["./start-microservices.sh"]
     volumes:
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "3.8"
+
 name: immich
+
 services:
   immich-server:
     container_name: immich_server
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
-    command: ["start.sh", "immich"]
+    command: [ "start.sh", "immich" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
@@ -22,7 +24,7 @@ services:
     # extends:
     #   file: hwaccel.yml
     #   service: hwaccel
-    command: ["start.sh", "microservices"]
+    command: [ "start.sh", "microservices" ]
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 version: "3.8"
-
+name: immich
 services:
   immich-server:
     container_name: immich_server


### PR DESCRIPTION
>[!WARNING]
> With this change, the default compose file now includes `name: immich`, which will result in orphaned containers and volumes if added to an existing install.

I have recently started using immich and loving it. I do run quite a few containers already and immich project always comes up with a generic "docker" which makes it hard to read and find amon many other containers or projects.

![image](https://github.com/immich-app/immich/assets/12991664/11d3ecd8-67ca-4119-a6d6-c2f4a4e1cd10)

So I decided to raise a PR for the fix:

![image](https://github.com/immich-app/immich/assets/12991664/adc5f58d-9553-4f70-90eb-2373e28a0cc4)