### PR TITLE
fix(mobile): display simple album date when range is single day

### DIFF
--- a/mobile/lib/modules/album/views/album_viewer_page.dart
+++ b/mobile/lib/modules/album/views/album_viewer_page.dart
@@ -171,11 +171,19 @@ class AlbumViewerPage extends HookConsumerWidget {
         return const SizedBox();
       }
 
-      final String startDateText = (startDate.year == endDate.year
-              ? DateFormat.MMMd()
-              : DateFormat.yMMMd())
-          .format(startDate);
-      final String endDateText = DateFormat.yMMMd().format(endDate);
+      final String dateRangeText;
+      if (startDate.day == endDate.day &&
+          startDate.month == endDate.month &&
+          startDate.year == endDate.year) {
+        dateRangeText = DateFormat.yMMMd().format(startDate);
+      } else {
+        final String startDateText = (startDate.year == endDate.year
+                ? DateFormat.MMMd()
+                : DateFormat.yMMMd())
+            .format(startDate);
+        final String endDateText = DateFormat.yMMMd().format(endDate);
+        dateRangeText = "$startDateText - $endDateText";
+      }
 
       return Padding(
         padding: EdgeInsets.only(
@@ -183,7 +191,7 @@ class AlbumViewerPage extends HookConsumerWidget {
           bottom: album.shared ? 0.0 : 8.0,
         ),
         child: Text(
-          "$startDateText - $endDateText",
+          dateRangeText,
           style: const TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.bold,


### PR DESCRIPTION
This change makes albums with same start and end date, to just display a single date.

Currently, date range is displayed as `Nov 9 - Nov 9 2023`. With this change, just `Nov 9 2023` is displayed. No changes are made for albums where start and end dates do not match.

![image](https://github.com/immich-app/immich/assets/3867850/e4917fc6-2846-467d-975d-a206e6984774)
![image](https://github.com/immich-app/immich/assets/3867850/8e4972b6-3213-4cc3-b415-fa652526b58e)
![image](https://github.com/immich-app/immich/assets/3867850/adae02de-ea37-4036-8543-20c8bb15051e)
