### PR TITLE
fix(mobile): add label for expire after in shared link edit page

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -316,6 +316,7 @@
   "shared_link_edit_description": "Description",
   "shared_link_edit_description_hint": "Enter the share description",
   "shared_link_edit_password": "Password",
+  "shared_link_edit_expire_after": "Expire after",
   "shared_link_edit_password_hint": "Enter the share password",
   "shared_link_edit_show_meta": "Show metadata",
   "shared_link_edit_submit_button": "Update link",

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -206,6 +206,13 @@ class SharedLinkEditPage extends HookConsumerWidget {
 
     Widget buildExpiryAfterButton() {
       return DropdownMenu(
+        label: Text(
+          "shared_link_edit_expire_after",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: themeData.primaryColor,
+          ),
+        ).tr(),
         enableSearch: false,
         enableFilter: false,
         width: MediaQuery.of(context).size.width - 40,


### PR DESCRIPTION
Closes #4912 

#### Changes made in the PR:

- Shared Link edit page now includes a helper label for "Expire After" as well