### PR TITLE
feat(ml): add face models

### DIFF
--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -38,8 +38,16 @@ class LogSettings(BaseSettings):
 _clean_name = str.maketrans(":\\/", "___", ".")
 
 
+def clean_name(model_name: str) -> str:
+    return model_name.split("/")[-1].translate(_clean_name)
+
+
 def get_cache_dir(model_name: str, model_type: ModelType) -> Path:
-    return Path(settings.cache_folder) / model_type.value / model_name.translate(_clean_name)
+    return Path(settings.cache_folder) / model_type.value / clean_name(model_name)
+
+
+def get_hf_model_name(model_name: str) -> str:
+    return f"immich-app/{clean_name(model_name)}"
 
 
 LOG_LEVELS: dict[str, int] = {

--- a/machine-learning/app/models/__init__.py
+++ b/machine-learning/app/models/__init__.py
@@ -3,7 +3,8 @@ from typing import Any
 from app.schemas import ModelType
 
 from .base import InferenceModel
-from .clip import MCLIPEncoder, OpenCLIPEncoder, is_mclip, is_openclip
+from .clip import MCLIPEncoder, OpenCLIPEncoder
+from .constants import is_insightface, is_mclip, is_openclip
 from .facial_recognition import FaceRecognizer
 from .image_classification import ImageClassifier
 
@@ -15,11 +16,12 @@ def from_model_type(model_type: ModelType, model_name: str, **model_kwargs: Any)
                 return OpenCLIPEncoder(model_name, **model_kwargs)
             elif is_mclip(model_name):
                 return MCLIPEncoder(model_name, **model_kwargs)
-            else:
-                raise ValueError(f"Unknown CLIP model {model_name}")
         case ModelType.FACIAL_RECOGNITION:
-            return FaceRecognizer(model_name, **model_kwargs)
+            if is_insightface(model_name):
+                return FaceRecognizer(model_name, **model_kwargs)
         case ModelType.IMAGE_CLASSIFICATION:
             return ImageClassifier(model_name, **model_kwargs)
         case _:
             raise ValueError(f"Unknown model type {model_type}")
+
+    raise ValueError(f"Unknown ${model_type} model {model_name}")

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -7,8 +7,9 @@ from shutil import rmtree
 from typing import Any
 
 import onnxruntime as ort
+from huggingface_hub import snapshot_download
 
-from ..config import get_cache_dir, log, settings
+from ..config import get_cache_dir, get_hf_model_name, log, settings
 from ..schemas import ModelType
 
 
@@ -78,9 +79,13 @@ class InferenceModel(ABC):
     def configure(self, **model_kwargs: Any) -> None:
         pass
 
-    @abstractmethod
     def _download(self) -> None:
-        ...
+        snapshot_download(
+            get_hf_model_name(self.model_name),
+            cache_dir=self.cache_dir,
+            local_dir=self.cache_dir,
+            local_dir_use_symlinks=False,
+        )
 
     @abstractmethod
     def _load(self) -> None:

--- a/machine-learning/app/models/constants.py
+++ b/machine-learning/app/models/constants.py
@@ -1,0 +1,57 @@
+from app.config import clean_name
+
+_OPENCLIP_MODELS = {
+    "RN50__openai",
+    "RN50__yfcc15m",
+    "RN50__cc12m",
+    "RN101__openai",
+    "RN101__yfcc15m",
+    "RN50x4__openai",
+    "RN50x16__openai",
+    "RN50x64__openai",
+    "ViT-B-32__openai",
+    "ViT-B-32__laion2b_e16",
+    "ViT-B-32__laion400m_e31",
+    "ViT-B-32__laion400m_e32",
+    "ViT-B-32__laion2b-s34b-b79k",
+    "ViT-B-16__openai",
+    "ViT-B-16__laion400m_e31",
+    "ViT-B-16__laion400m_e32",
+    "ViT-B-16-plus-240__laion400m_e31",
+    "ViT-B-16-plus-240__laion400m_e32",
+    "ViT-L-14__openai",
+    "ViT-L-14__laion400m_e31",
+    "ViT-L-14__laion400m_e32",
+    "ViT-L-14__laion2b-s32b-b82k",
+    "ViT-L-14-336__openai",
+    "ViT-H-14__laion2b-s32b-b79k",
+    "ViT-g-14__laion2b-s12b-b42k",
+}
+
+
+_MCLIP_MODELS = {
+    "LABSE-Vit-L-14",
+    "XLM-Roberta-Large-Vit-B-32",
+    "XLM-Roberta-Large-Vit-B-16Plus",
+    "XLM-Roberta-Large-Vit-L-14",
+}
+
+
+_INSIGHTFACE_MODELS = {
+    "antelopev2",
+    "buffalo_l",
+    "buffalo_m",
+    "buffalo_s",
+}
+
+
+def is_openclip(model_name: str) -> bool:
+    return clean_name(model_name) in _OPENCLIP_MODELS
+
+
+def is_mclip(model_name: str) -> bool:
+    return clean_name(model_name) in _MCLIP_MODELS
+
+
+def is_insightface(model_name: str) -> bool:
+    return clean_name(model_name) in _INSIGHTFACE_MODELS

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -106,13 +106,13 @@ class TestCLIP:
 class TestFaceRecognition:
     def test_set_min_score(self, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
-        face_recognizer = FaceRecognizer("test_model_name", cache_dir="test_cache", min_score=0.5)
+        face_recognizer = FaceRecognizer("buffalo_s", cache_dir="test_cache", min_score=0.5)
 
         assert face_recognizer.min_score == 0.5
 
     def test_basic(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
-        face_recognizer = FaceRecognizer("test_model_name", min_score=0.0, cache_dir="test_cache")
+        face_recognizer = FaceRecognizer("buffalo_s", min_score=0.0, cache_dir="test_cache")
 
         det_model = mock.Mock()
         num_faces = 2

--- a/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
@@ -160,11 +160,13 @@
 
             <SettingSelect
               label="FACIAL RECOGNITION MODEL"
-              desc="Smaller models are faster and use less memory, but perform worse. Note that you must re-run the Recognize Faces job for all images upon changing a model."
+              desc="Models are listed in descending order of size. Larger models are slower and use more memory, but produce better results. Note that you must re-run the Recognize Faces job for all images upon changing a model."
               name="facial-recognition-model"
               bind:value={machineLearningConfig.facialRecognition.modelName}
               options={[
+                { value: 'antelopev2', text: 'antelopev2' },
                 { value: 'buffalo_l', text: 'buffalo_l' },
+                { value: 'buffalo_m', text: 'buffalo_m' },
                 { value: 'buffalo_s', text: 'buffalo_s' },
               ]}
               disabled={disabled || !machineLearningConfig.enabled || !machineLearningConfig.facialRecognition.enabled}


### PR DESCRIPTION
## Description

This PR adds `antelopev2` and `buffalo_m` as supported facial recognition models. `antelopev2` has the same detection model as `buffalo_l`, but a roughly 50% larger recognition model. `buffalo_m` has the same recognition model as `buffalo_l`, but a smaller detection model.

Since these models aren't available through their Python API, facial recognition models are now hosted and downloaded from Hugging Face. 

Fixes #4924

## How Has This Been Tested?

Tested downloading and running each facial recognition model with local POST requests. Image classification and CLIP models continue to work as normal as well.