### PR TITLE
feat(web): uniform random asset selection in slideshow mode

### DIFF
--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -32,7 +32,7 @@ export class AssetBucket {
    */
   bucketHeight!: number;
   bucketDate!: string;
-  totalAssets!: number;
+  bucketCount!: number;
   assets!: AssetResponseDto[];
   cancelToken!: AbortController | null;
   position!: BucketPosition;
@@ -159,7 +159,7 @@ export class AssetStore {
       return {
         bucketDate: bucket.timeBucket,
         bucketHeight: height,
-        totalAssets: bucket.count,
+        bucketCount: bucket.count,
         assets: [],
         cancelToken: null,
         position: BucketPosition.Unknown,
@@ -276,7 +276,7 @@ export class AssetStore {
       bucket = {
         bucketDate: timeBucket,
         bucketHeight: THUMBNAIL_HEIGHT,
-        totalAssets: 0,
+        bucketCount: 0,
         assets: [],
         cancelToken: null,
         position: BucketPosition.Unknown,
@@ -316,9 +316,9 @@ export class AssetStore {
   }
 
   async getRandomAsset(): Promise<AssetResponseDto | null> {
-    let index = Math.floor(Math.random() * this.buckets.reduce((acc, bucket) => acc + bucket.totalAssets, 0));
+    let index = Math.floor(Math.random() * this.buckets.reduce((acc, bucket) => acc + bucket.bucketCount, 0));
     for (const bucket of this.buckets) {
-      if (index < bucket.totalAssets) {
+      if (index < bucket.bucketCount) {
         if (bucket.assets.length === 0) {
           await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
         }
@@ -326,7 +326,7 @@ export class AssetStore {
         return bucket.assets[index] || null;
       }
 
-      index -= bucket.totalAssets;
+      index -= bucket.bucketCount;
     }
 
     return null;
@@ -420,7 +420,7 @@ export class AssetStore {
       for (let i = 0; i < this.buckets.length; i++) {
         const bucket = this.buckets[i];
         if (bucket.assets.length !== 0) {
-          bucket.totalAssets = bucket.assets.length;
+          bucket.bucketCount = bucket.assets.length;
         }
         for (let j = 0; j < bucket.assets.length; j++) {
           const asset = bucket.assets[j];

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -32,6 +32,7 @@ export class AssetBucket {
    */
   bucketHeight!: number;
   bucketDate!: string;
+  totalAssets!: number;
   assets!: AssetResponseDto[];
   cancelToken!: AbortController | null;
   position!: BucketPosition;
@@ -158,6 +159,7 @@ export class AssetStore {
       return {
         bucketDate: bucket.timeBucket,
         bucketHeight: height,
+        totalAssets: bucket.count,
         assets: [],
         cancelToken: null,
         position: BucketPosition.Unknown,
@@ -274,6 +276,7 @@ export class AssetStore {
       bucket = {
         bucketDate: timeBucket,
         bucketHeight: THUMBNAIL_HEIGHT,
+        totalAssets: 0,
         assets: [],
         cancelToken: null,
         position: BucketPosition.Unknown,
@@ -313,16 +316,20 @@ export class AssetStore {
   }
 
   async getRandomAsset(): Promise<AssetResponseDto | null> {
-    const bucket = this.buckets[Math.floor(Math.random() * this.buckets.length)] || null;
-    if (!bucket) {
-      return null;
+    let index = Math.floor(Math.random() * this.buckets.reduce((acc, bucket) => acc + bucket.totalAssets, 0));
+    for (const bucket of this.buckets) {
+      if (index < bucket.totalAssets) {
+        if (bucket.assets.length === 0) {
+          await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
+        }
+
+        return bucket.assets[index] || null;
+      }
+
+      index -= bucket.totalAssets;
     }
 
-    if (bucket.assets.length === 0) {
-      await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
-    }
-
-    return bucket.assets[Math.floor(Math.random() * bucket.assets.length)] || null;
+    return null;
   }
 
   updateAsset(_asset: AssetResponseDto, recalculate = false) {
@@ -412,6 +419,9 @@ export class AssetStore {
       const assetToBucket: Record<string, AssetLookup> = {};
       for (let i = 0; i < this.buckets.length; i++) {
         const bucket = this.buckets[i];
+        if (bucket.assets.length !== 0) {
+          bucket.totalAssets = bucket.assets.length;
+        }
         for (let j = 0; j < bucket.assets.length; j++) {
           const asset = bucket.assets[j];
           assetToBucket[asset.id] = { bucket, bucketIndex: i, assetIndex: j };

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -319,10 +319,7 @@ export class AssetStore {
     let index = Math.floor(Math.random() * this.buckets.reduce((acc, bucket) => acc + bucket.bucketCount, 0));
     for (const bucket of this.buckets) {
       if (index < bucket.bucketCount) {
-        if (bucket.assets.length === 0) {
-          await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
-        }
-
+        await this.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
         return bucket.assets[index] || null;
       }
 


### PR DESCRIPTION
## Description
Currently we randomly select a bucket and then randomly select an asset from that bucket. This approach is not truly uniform because it doesn't take into account the number of assets in each  bucket. As a result, assets in buckets with more assets are less likely to be selected.
This PR takes into account the asset count in each bucket. This ensures that each asset has an equal chance of being selected.