### PR TITLE
fix(docs): Typo in libraries exclusion pattern

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -75,7 +75,7 @@ Some basic examples:
 - `*.tif` will exclude all files with the extension `.tif`
 - `hidden.jpg` will exclude all files named `hidden.jpg`
 - `**/Raw/**` will exclude all files in any directory named `Raw`
-- `*.(tif,jpg)` will exclude all files with the extension `.tif` or `.jpg`
+- `*.{tif,jpg}` will exclude all files with the extension `.tif` or `.jpg`
 
 ### Nightly job
 


### PR DESCRIPTION
Hi,

There was a typo for the glob list pattern on the libraries exclusion pattern. 

We discussed it on Discord https://discord.com/channels/979116623879368755/1173004229825269924


![image](https://github.com/immich-app/immich/assets/53194438/8d6eaf7e-09d8-4a28-b964-6c9a1e9300b0) ![image](https://github.com/immich-app/immich/assets/53194438/cb9929cf-9ad6-4955-8916-629ca6fb2dff)



I also looked elsewhere on the app and did not find any other occurrence. On the Scan settings page, the feature gives a few examples of patterns to use, but no examples include the List {}. I hesitated to make a commit adding a line, but i'm afraid adding more lines risks hiding the buttons on small viewports.
