### PR TITLE
system-config/core: pretty print json object in error message

### DIFF
--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -328,7 +328,7 @@ export class SystemConfigCore {
         }
 
         if (!_.isEmpty(file)) {
-          throw new Error(`Unknown keys found: ${file}`);
+          throw new Error(`Unknown keys found: ${JSON.stringify(file)}`);
         }
 
         this.configCache = overrides;


### PR DESCRIPTION
This PR improves error message when immich reads an invalid/broken config file.


Error message today,

```
[Nest] 2039  - 11/14/2023, 5:56:43 PM   ERROR [SystemConfigCore] Unable to load configuration file: /var/lib/immich/immich/config due to Error: Unknown keys found: [object Object]
```


Error message after this patch,
```
[Nest] 2053  - 11/14/2023, 5:57:58 PM   ERROR [SystemConfigCore] Unable to load configuration file: /var/lib/immich/immich/config due to Error: Unknown keys found: {"map":{"tileURL":"askjdha"}}
```