### PR TITLE
chore: don't set max old space in e2e tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --max_old_space_size=4096' jest --config test/e2e/jest-e2e.json --runInBand",
+    "test:e2e": "NODE_OPTIONS='--experimental-vm-modules' jest --config test/e2e/jest-e2e.json --runInBand",
     "typeorm": "typeorm",
     "typeorm:migrations:create": "typeorm migration:create",
     "typeorm:migrations:generate": "typeorm migration:generate -d ./dist/infra/database.config.js",


### PR DESCRIPTION
We can remove the max old space env variable in e2e tests since github actions no longer needs it.

Tested by removing the env var and observing it doesn't OOM anymore. :)

Should be trivial to merge IMO