### PR TITLE
fix(mobile): update password change description text to use user name

### DIFF
--- a/mobile/assets/i18n/ca.json
+++ b/mobile/assets/i18n/ca.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Configuració de la memòria cau",
   "change_password_form_confirm_password": "Confirma la contrasenya",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/cs-CZ.json
+++ b/mobile/assets/i18n/cs-CZ.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Místní úložiště",
   "cache_settings_title": "Nastavení vyrovnávací paměti",
   "change_password_form_confirm_password": "Potvrďte heslo",
-  "change_password_form_description": "Dobrý den, {firstName} {lastName},\n\nje to buď poprvé, co se přihlašujete do systému, nebo byl vytvořen požadavek na změnu hesla. Níže zadejte nové heslo.",
+  "change_password_form_description": "Dobrý den, {name},\n\nje to buď poprvé, co se přihlašujete do systému, nebo byl vytvořen požadavek na změnu hesla. Níže zadejte nové heslo.",
   "change_password_form_new_password": "Nové heslo",
   "change_password_form_password_mismatch": "Hesla se neshodují",
   "change_password_form_reenter_new_password": "Znovu zadejte nové heslo",

--- a/mobile/assets/i18n/da-DK.json
+++ b/mobile/assets/i18n/da-DK.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Cache-indstillinger",
   "change_password_form_confirm_password": "Bekræft kodeord",
-  "change_password_form_description": "Hej {firstName} {lastName},\n\nDette er enten første gang du logger ind eller også er der lavet en anmodning om at ændre dit kodeord. Indtast venligst et nyt kodeord nedenfor.",
+  "change_password_form_description": "Hej {name},\n\nDette er enten første gang du logger ind eller også er der lavet en anmodning om at ændre dit kodeord. Indtast venligst et nyt kodeord nedenfor.",
   "change_password_form_new_password": "Nyt kodeord",
   "change_password_form_password_mismatch": "Kodeord er ikke ens",
   "change_password_form_reenter_new_password": "Gentag nyt kodeord",

--- a/mobile/assets/i18n/de-DE.json
+++ b/mobile/assets/i18n/de-DE.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Lokaler Speicher",
   "cache_settings_title": "Zwischenspeicher Einstellungen",
   "change_password_form_confirm_password": "Passwort bestätigen",
-  "change_password_form_description": "Hallo {firstName} {lastName}\n\nDas ist entweder das erste Mal dass du dich einloggst oder eine Anfrage zur Änderung deines Passwortes wurde gestellt. Bitte gebe das neue Passwort ein.",
+  "change_password_form_description": "Hallo {name}\n\nDas ist entweder das erste Mal dass du dich einloggst oder eine Anfrage zur Änderung deines Passwortes wurde gestellt. Bitte gebe das neue Passwort ein.",
   "change_password_form_new_password": "Neues Passwort",
   "change_password_form_password_mismatch": "Passwörter stimmen nicht überein",
   "change_password_form_reenter_new_password": "Passwort erneut eingeben",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/es-ES.json
+++ b/mobile/assets/i18n/es-ES.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Almacenamiento local",
   "cache_settings_title": "Configuración de la caché",
   "change_password_form_confirm_password": "Confirmar Contraseña",
-  "change_password_form_description": "Hola {firstName} {lastName},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
+  "change_password_form_description": "Hola {name},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
   "change_password_form_new_password": "Nueva Contraseña",
   "change_password_form_password_mismatch": "Las contraseñas no coinciden",
   "change_password_form_reenter_new_password": "Vuelve a ingresar la nueva contraseña",

--- a/mobile/assets/i18n/es-MX.json
+++ b/mobile/assets/i18n/es-MX.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Almacenamiento local",
   "cache_settings_title": "Configuración de la caché",
   "change_password_form_confirm_password": "Confirmar Contraseña",
-  "change_password_form_description": "Hola {firstName} {lastName},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
+  "change_password_form_description": "Hola {name},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
   "change_password_form_new_password": "Nueva Contraseña",
   "change_password_form_password_mismatch": "Las contraseñas no coinciden",
   "change_password_form_reenter_new_password": "Vuelve a ingresar la nueva contraseña",

--- a/mobile/assets/i18n/es-PE.json
+++ b/mobile/assets/i18n/es-PE.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Almacenamiento local",
   "cache_settings_title": "Configuración de la caché",
   "change_password_form_confirm_password": "Confirmar Contraseña",
-  "change_password_form_description": "Hola {firstName} {lastName},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
+  "change_password_form_description": "Hola {name},\n\nEsta es la primera vez que inicias sesión en el sistema o se ha solicitado cambiar tu contraseña. Por favor, introduce la nueva contraseña a continuación.",
   "change_password_form_new_password": "Nueva Contraseña",
   "change_password_form_password_mismatch": "Las contraseñas no coinciden",
   "change_password_form_reenter_new_password": "Vuelve a ingresar la nueva contraseña",

--- a/mobile/assets/i18n/fi-FI.json
+++ b/mobile/assets/i18n/fi-FI.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Paikallinen tallennustila",
   "cache_settings_title": "Välimuistin asetukset",
   "change_password_form_confirm_password": "Vahvista salasana",
-  "change_password_form_description": "Hei {firstName} {lastName},\n\nTämä on joko ensimmäinen kirjautumisesi järjestelmään tai salasanan vaihtaminen vaihtaminen on pakotettu. Ole hyvä ja syötä uusi salasana alle.",
+  "change_password_form_description": "Hei {name},\n\nTämä on joko ensimmäinen kirjautumisesi järjestelmään tai salasanan vaihtaminen vaihtaminen on pakotettu. Ole hyvä ja syötä uusi salasana alle.",
   "change_password_form_new_password": "Uusi salasana",
   "change_password_form_password_mismatch": "Salasanat eivät täsmää",
   "change_password_form_reenter_new_password": "Uusi salasana uudelleen",

--- a/mobile/assets/i18n/fr-CA.json
+++ b/mobile/assets/i18n/fr-CA.json
@@ -119,7 +119,7 @@
     "cache_settings_tile_title": "Stockage local",
     "cache_settings_title": "Paramètres de mise en cache",
     "change_password_form_confirm_password": "Confirmez le mot de passe",
-    "change_password_form_description": "Bonjour {firstName} {lastName},\n\nC'est la première fois que vous vous connectez au système ou vous avez demandé de changer votre mot de passe. Veuillez saisir le nouveau mot de passe ci-dessous.",
+    "change_password_form_description": "Bonjour {name},\n\nC'est la première fois que vous vous connectez au système ou vous avez demandé de changer votre mot de passe. Veuillez saisir le nouveau mot de passe ci-dessous.",
     "change_password_form_new_password": "Nouveau mot de passe",
     "change_password_form_password_mismatch": "Les mots de passe ne correspondent pas",
     "change_password_form_reenter_new_password": "Saisissez à nouveau le nouveau mot de passe",

--- a/mobile/assets/i18n/fr-FR.json
+++ b/mobile/assets/i18n/fr-FR.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Stockage local",
   "cache_settings_title": "Paramètres de mise en cache",
   "change_password_form_confirm_password": "Confirmez le mot de passe",
-  "change_password_form_description": "Bonjour {firstName} {lastName},\n\nC'est la première fois que vous vous connectez au système ou vous avez demandé à changer votre mot de passe. Veuillez saisir le nouveau mot de passe ci-dessous.",
+  "change_password_form_description": "Bonjour {name},\n\nC'est la première fois que vous vous connectez au système ou vous avez demandé à changer votre mot de passe. Veuillez saisir le nouveau mot de passe ci-dessous.",
   "change_password_form_new_password": "Nouveau mot de passe",
   "change_password_form_password_mismatch": "Les mots de passe ne correspondent pas",
   "change_password_form_reenter_new_password": "Saisissez à nouveau le nouveau mot de passe",

--- a/mobile/assets/i18n/hi-IN.json
+++ b/mobile/assets/i18n/hi-IN.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/it-IT.json
+++ b/mobile/assets/i18n/it-IT.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Impostazioni della Cache",
   "change_password_form_confirm_password": "Conferma Password ",
-  "change_password_form_description": "Ciao {firstName} {lastName},\n\nQuesto è la prima volta che accedi al sistema oppure è stato fatto una richiesta di cambiare la password. Per favore inserisca la nuova password qui sotto",
+  "change_password_form_description": "Ciao {name},\n\nQuesto è la prima volta che accedi al sistema oppure è stato fatto una richiesta di cambiare la password. Per favore inserisca la nuova password qui sotto",
   "change_password_form_new_password": "Nuova Password",
   "change_password_form_password_mismatch": "Le password non coincidono",
   "change_password_form_reenter_new_password": "Inserisci ancora la nuova password ",

--- a/mobile/assets/i18n/ko-KR.json
+++ b/mobile/assets/i18n/ko-KR.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "로컬 저장소",
   "cache_settings_title": "캐시 설정",
   "change_password_form_confirm_password": "비밀번호 확인",
-  "change_password_form_description": "{firstName} {lastName} 님, 안녕하세요.\n\n시스템에 처음 로그인했거나 비밀번호 변경 요청이 있었습니다. 아래에 새 비밀번호를 입력하세요.",
+  "change_password_form_description": "{name} 님, 안녕하세요.\n\n시스템에 처음 로그인했거나 비밀번호 변경 요청이 있었습니다. 아래에 새 비밀번호를 입력하세요.",
   "change_password_form_new_password": "새 비밀번호",
   "change_password_form_password_mismatch": "비밀번호가 일치하지 않습니다",
   "change_password_form_reenter_new_password": "새 비밀번호 재입력",

--- a/mobile/assets/i18n/lv-LV.json
+++ b/mobile/assets/i18n/lv-LV.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Kešdarbes iestatījumi",
   "change_password_form_confirm_password": "Apstiprināt Paroli",
-  "change_password_form_description": "Sveiki {FirstName} {LastName},\n\nŠī ir pirmā reize, kad pierakstāties sistēmā, vai arī ir iesniegts pieprasījums mainīt paroli. Lūdzu, zemāk ievadiet jauno paroli.",
+  "change_password_form_description": "Sveiki {name},\n\nŠī ir pirmā reize, kad pierakstāties sistēmā, vai arī ir iesniegts pieprasījums mainīt paroli. Lūdzu, zemāk ievadiet jauno paroli.",
   "change_password_form_new_password": "Jauna Parole",
   "change_password_form_password_mismatch": "Paroles nesakrīt",
   "change_password_form_reenter_new_password": "Atkārtoti ievadīt jaunu paroli",

--- a/mobile/assets/i18n/mn.json
+++ b/mobile/assets/i18n/mn.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/nb-NO.json
+++ b/mobile/assets/i18n/nb-NO.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Lokal lagring",
   "cache_settings_title": "Bufringsinnstillinger",
   "change_password_form_confirm_password": "Bekreft passord",
-  "change_password_form_description": "Hei {firstName} {lastName}!\n\nDette er enten første gang du logger på systemet, eller det er sendt en forespørsel om å endre passordet ditt. Vennligst skriv inn det nye passordet nedenfor.",
+  "change_password_form_description": "Hei {name}!\n\nDette er enten første gang du logger på systemet, eller det er sendt en forespørsel om å endre passordet ditt. Vennligst skriv inn det nye passordet nedenfor.",
   "change_password_form_new_password": "Nytt passord",
   "change_password_form_password_mismatch": "Passordene stemmer ikke",
   "change_password_form_reenter_new_password": "Skriv nytt passord igjen",

--- a/mobile/assets/i18n/nl-NL.json
+++ b/mobile/assets/i18n/nl-NL.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Cache-instellingen",
   "change_password_form_confirm_password": "Bevestig wachtwoord",
-  "change_password_form_description": "Hallo {firstName} {lastName},\n\nDit is ofwel de eerste keer dat je inlogt, of er is een verzoek gedaan om je wachtwoord te wijzigen. Vul hieronder een nieuw wachtwoord in.",
+  "change_password_form_description": "Hallo {name},\n\nDit is ofwel de eerste keer dat je inlogt, of er is een verzoek gedaan om je wachtwoord te wijzigen. Vul hieronder een nieuw wachtwoord in.",
   "change_password_form_new_password": "Nieuw wachtwoord",
   "change_password_form_password_mismatch": "Wachtwoorden komen niet overeen",
   "change_password_form_reenter_new_password": "Vul het wachtwoord opnieuw in",

--- a/mobile/assets/i18n/pl-PL.json
+++ b/mobile/assets/i18n/pl-PL.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Lokalny magazyn",
   "cache_settings_title": "Ustawienia Buforowania",
   "change_password_form_confirm_password": "Potwierdź Hasło",
-  "change_password_form_description": "Cześć {firstName} {lastName},\n\nPierwszy raz logujesz się do systemu, albo złożono prośbę o zmianę hasła. Wpisz poniżej nowe hasło.",
+  "change_password_form_description": "Cześć {name},\n\nPierwszy raz logujesz się do systemu, albo złożono prośbę o zmianę hasła. Wpisz poniżej nowe hasło.",
   "change_password_form_new_password": "Nowe Hasło",
   "change_password_form_password_mismatch": "Hasła nie są zgodne",
   "change_password_form_reenter_new_password": "Wprowadź ponownie Nowe Hasło",

--- a/mobile/assets/i18n/ru-RU.json
+++ b/mobile/assets/i18n/ru-RU.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Локальное хранилище",
   "cache_settings_title": "Настройки кэширования",
   "change_password_form_confirm_password": "Подтвердите пароль",
-  "change_password_form_description": "Привет {firstName} {lastName},\n\nЭто либо ваш первый вход в систему, либо был сделан запрос на смену пароля. Пожалуйста, введите новый пароль ниже.",
+  "change_password_form_description": "Привет {name},\n\nЭто либо ваш первый вход в систему, либо был сделан запрос на смену пароля. Пожалуйста, введите новый пароль ниже.",
   "change_password_form_new_password": "Новый пароль",
   "change_password_form_password_mismatch": "Пароли не совпадают",
   "change_password_form_reenter_new_password": "Повторно введите новый пароль",

--- a/mobile/assets/i18n/sk-SK.json
+++ b/mobile/assets/i18n/sk-SK.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Lokálne úložisko",
   "cache_settings_title": "Nastavenia vyrovnávacej pamäte",
   "change_password_form_confirm_password": "Potvrďte heslo",
-  "change_password_form_description": "Dobrý deň, {firstName} {lastName},\n\nBuď sa do systému prihlasujete prvýkrát, alebo bola podaná žiadosť o zmenu hesla. Prosím, zadajte nové heslo nižšie.",
+  "change_password_form_description": "Dobrý deň, {name},\n\nBuď sa do systému prihlasujete prvýkrát, alebo bola podaná žiadosť o zmenu hesla. Prosím, zadajte nové heslo nižšie.",
   "change_password_form_new_password": "Nové heslo",
   "change_password_form_password_mismatch": "Heslá sa nezhodujú",
   "change_password_form_reenter_new_password": "Znova zadajte nové heslo",

--- a/mobile/assets/i18n/sr-Cyrl.json
+++ b/mobile/assets/i18n/sr-Cyrl.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/sv-FI.json
+++ b/mobile/assets/i18n/sv-FI.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/sv-SE.json
+++ b/mobile/assets/i18n/sv-SE.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Cache Inställningar",
   "change_password_form_confirm_password": "Bekräfta lösenord",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "Nytt lösenord",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/th-TH.json
+++ b/mobile/assets/i18n/th-TH.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "ตั้งค่าแคช",
   "change_password_form_confirm_password": "ยืนยันรหัสผ่าน",
-  "change_password_form_description": "สวัสดี {firstName} {lastName},\n\nครั้งนี้อาจจะเป็นครั้งแรกที่คุณเข้าสู่ระบบ หรือมีคำขอเพื่อที่จะเปลี่ยนรหัสผ่านของคุI กรุณาเพิ่มรหัสผ่านใหม่ข้างล่าง",
+  "change_password_form_description": "สวัสดี {name},\n\nครั้งนี้อาจจะเป็นครั้งแรกที่คุณเข้าสู่ระบบ หรือมีคำขอเพื่อที่จะเปลี่ยนรหัสผ่านของคุI กรุณาเพิ่มรหัสผ่านใหม่ข้างล่าง",
   "change_password_form_new_password": "รหัสผ่านใหม่",
   "change_password_form_password_mismatch": "รหัสผ่านไม่ตรงกัน",
   "change_password_form_reenter_new_password": "กรอกรหัสผ่านใหม่",

--- a/mobile/assets/i18n/uk-UA.json
+++ b/mobile/assets/i18n/uk-UA.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Local Storage",
   "cache_settings_title": "Налаштування Кешування",
   "change_password_form_confirm_password": "Підтвердити пароль",
-  "change_password_form_description": "Привіт {firstName} {lastName},\n\nВи або або вперше входите у систему, або було зроблено запит на зміну вашого пароля. \nВведіть ваш новий пароль.",
+  "change_password_form_description": "Привіт {name},\n\nВи або або вперше входите у систему, або було зроблено запит на зміну вашого пароля. \nВведіть ваш новий пароль.",
   "change_password_form_new_password": "Новий Пароль",
   "change_password_form_password_mismatch": "Паролі не співпадають",
   "change_password_form_reenter_new_password": "Повторіть Новий Пароль",

--- a/mobile/assets/i18n/vi-VN.json
+++ b/mobile/assets/i18n/vi-VN.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "Lưu trữ cục bộ",
   "cache_settings_title": "Caching Settings",
   "change_password_form_confirm_password": "Confirm Password",
-  "change_password_form_description": "Hi {firstName} {lastName},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/assets/i18n/zh-CN.json
+++ b/mobile/assets/i18n/zh-CN.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "本地存储",
   "cache_settings_title": "缓存设置",
   "change_password_form_confirm_password": "确认密码",
-  "change_password_form_description": "{firstName} {lastName} 您好，\n\n这是您首次登录系统，或被管理员要求更改密码。\n请在下方输入新密码。",
+  "change_password_form_description": "{name} 您好，\n\n这是您首次登录系统，或被管理员要求更改密码。\n请在下方输入新密码。",
   "change_password_form_new_password": "新密码",
   "change_password_form_password_mismatch": "密码不匹配",
   "change_password_form_reenter_new_password": "重新输入新的密码",

--- a/mobile/assets/i18n/zh-Hans.json
+++ b/mobile/assets/i18n/zh-Hans.json
@@ -119,7 +119,7 @@
   "cache_settings_tile_title": "本地存储",
   "cache_settings_title": "缓存设置",
   "change_password_form_confirm_password": "确认密码",
-  "change_password_form_description": "{firstName} {lastName} 您好，\n\n这是您首次登录系统，或被管理员要求更改密码。\n请在下方输入新密码。",
+  "change_password_form_description": "{name} 您好，\n\n这是您首次登录系统，或被管理员要求更改密码。\n请在下方输入新密码。",
   "change_password_form_new_password": "新密码",
   "change_password_form_password_mismatch": "密码不匹配",
   "change_password_form_reenter_new_password": "重新输入新的密码",


### PR DESCRIPTION
#### Changes made in the PR:

- Password change form description translation text still had the old `{firstName}` and `{lastName}` placeholders which are now renamed to `{name}`