### PR TITLE
feat(web): add (lower) thumbnail resolution options 

### DIFF
--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -91,6 +91,7 @@
               { value: 720, text: '720p' },
               { value: 480, text: '480p' },
               { value: 250, text: '250p' },
+              { value: 200, text: '200p' },
             ]}
             name="resolution"
             isEdited={thumbnailConfig.webpSize !== savedConfig.webpSize}
@@ -105,6 +106,7 @@
             options={[
               { value: 2160, text: '4K' },
               { value: 1440, text: '1440p' },
+              { value: 720, text: '720p' },
             ]}
             name="resolution"
             isEdited={thumbnailConfig.jpegSize !== savedConfig.jpegSize}

--- a/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/thumbnail/thumbnail-settings.svelte
@@ -106,6 +106,7 @@
             options={[
               { value: 2160, text: '4K' },
               { value: 1440, text: '1440p' },
+              { value: 1080, text: '1080p' },
               { value: 720, text: '720p' },
             ]}
             name="resolution"


### PR DESCRIPTION
Added 200p and 720p as options for small and large thumbnails resolutions respectively.

For scenarios in which users have many assets (like for instance over 750GB of pictures/videos) the generated thumbnails consume considerable storage and time to get processed. The proposed options could alleviate users in such scenarios.

I have tried this and other features like face matching do not seem to be hardly impacted with the reduced size of the "large" thumbnails. Mobile apps looks practically the same, and the Web UI shows a minimal quality degradation, but also a reduced bandwidth consumption in both scenarios.

In my tests (i.e. forcing the proposed values directly via the API), it went from about ~60GB to ~20GB in storage and 12 hours to 5 hours of processing (14 cores with 8GB RAM).