### PR TITLE
chore: add warning to compose file and readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,5 @@
+> [!CAUTION]
+> Make sure to use the docker-compose.yml of the current release:
+> https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+> 
+> The compose file on main may not be compatible with the latest release.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,13 @@
 version: "3.8"
 
+#
+# WARNING: Make sure to use the docker-compose.yml of the current release:
+#
+# https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+#
+# The the compose file on main may not be compatible with the latest release.
+#
+
 name: immich
 
 services:


### PR DESCRIPTION
Making sure that people use the release `docker-compose.yml` and not the latest compose file on main.