### PR TITLE
mobile: add initial DCM analysis_options

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -61,9 +61,15 @@ IMMICH_SERVER_URL=https://demo.immich.app/api npm run dev
 
 Setting these in the IDE give a better developer experience, auto-formatting code on save, and providing instant feedback on lint issues.
 
+### Dart Code Metris
+
+The mobile app uses DCM (Dart Code Metrics) for linting and metrics calculation. Please refer to the [Getting Started](https://dcm.dev/docs/getting-started/#installation) page for more information on setting up DCM
+
+Note: Activating the license is not required.
+
 ### VSCode
 
-Install `Flutter`, `Prettier`, `ESLint` and `Svelte` extensions.
+Install `Flutter`, `DCM`, `Prettier`, `ESLint` and `Svelte` extensions.
 
 in User `settings.json` (`cmd + shift + p` and search for `Open User Settings JSON`) add the following:
 

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -36,3 +36,55 @@ analyzer:
     - openapi/
     - openapi/test/
     - lib/generated_plugin_registrant.dart
+
+dart_code_metrics:
+  metrics:
+    cyclomatic-complexity: 20
+    number-of-parameters: 4
+    maximum-nesting-level: 5
+  rules:
+    # Common
+    - avoid-accessing-collections-by-constant-index
+    - avoid-accessing-other-classes-private-members
+    - avoid-async-call-in-sync-function
+    - avoid-cascade-after-if-null
+    - avoid-collapsible-if
+    - avoid-collection-methods-with-unrelated-types
+    - avoid-declaring-call-method
+    - avoid-double-slash-imports
+    - avoid-duplicate-cascades
+    - avoid-duplicate-patterns
+    - avoid-generics-shadowing
+    - avoid-global-state
+    # Flutter
+    - add-copy-with:
+        file-name-pattern: '.model.dart'
+    - always-remove-listener
+    - avoid-border-all
+    - avoid-empty-setstate
+    - avoid-expanded-as-spacer
+    - avoid-incomplete-copy-with
+    - avoid-inherited-widget-in-initstate
+    - avoid-late-context
+    - avoid-recursive-widget-calls
+    - avoid-returning-widgets
+    - avoid-shrink-wrap-in-lists
+    - avoid-single-child-column-or-row
+    - avoid-state-constructors
+    - avoid-stateless-widget-initialized-fields
+    - avoid-unnecessary-overrides-in-state
+    - avoid-unnecessary-stateful-widgets
+    - avoid-wrapping-in-padding
+    - dispose-fields
+    - prefer-const-border-radius
+    - prefer-correct-edge-insets-constructor
+    - prefer-dedicated-media-query-methods
+    - prefer-define-hero-tag
+    - prefer-extracting-callbacks
+    - prefer-single-widget-per-file:
+        ignore-private-widgets: true
+    - prefer-sliver-prefix
+    - prefer-text-rich
+    - prefer-using-list-view
+    - proper-super-calls
+    - use-setstate-synchronously


### PR DESCRIPTION
### Changes made in the PR:

- Adds the `dart_code_metrics` entry to `analysis_options.yaml` of the mobile app for [DCM](https://dcm.dev/) to start providing lints
- Updated developer docs with link to the installation page of DCM

> [!Note]
> The DCM rules & metrics configuration is still WIP