### PR TITLE
fix(mobile): use proper context for popping out from share

### DIFF
--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -188,7 +188,7 @@ class AlbumViewerAppbar extends HookConsumerWidget
                   gravity: ToastGravity.BOTTOM,
                 );
               }
-              context.pop();
+              buildContext.pop();
             },
           );
           return const ShareDialog();

--- a/mobile/lib/modules/asset_viewer/providers/image_viewer_page_state.provider.dart
+++ b/mobile/lib/modules/asset_viewer/providers/image_viewer_page_state.provider.dart
@@ -68,7 +68,7 @@ class ImageViewerStateNotifier extends StateNotifier<ImageViewerPageState> {
                 gravity: ToastGravity.BOTTOM,
               );
             }
-            context.pop();
+            buildContext.pop();
           },
         );
         return const ShareDialog();

--- a/mobile/lib/utils/selection_handlers.dart
+++ b/mobile/lib/utils/selection_handlers.dart
@@ -27,7 +27,7 @@ void handleShareAssets(
               gravity: ToastGravity.BOTTOM,
             );
           }
-          context.pop();
+          buildContext.pop();
         },
       );
       return const ShareDialog();


### PR DESCRIPTION
Fixes #5119 

#### Changes made in the PR:

- Uses the proper context object to pop-out from the dialog shown when sharing assets.