### PR TITLE
fix(web): improve year label position

### DIFF
--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -134,7 +134,7 @@
         {#if segment.hasLabel}
           <div
             aria-label={segment.timeGroup + ' ' + segment.count}
-            class="absolute right-0 z-10 pr-5 text-xs font-medium dark:text-immich-dark-fg font-mono"
+            class="absolute right-0 bottom-0 z-10 pr-5 text-xs font-medium dark:text-immich-dark-fg font-mono"
           >
             {segment.date.year}
           </div>


### PR DESCRIPTION
The year label is shown at the top of the segment - i.e. at the end of the year. Not only it makes more sense to have it at the bottom, at least in my opinion, but that's also how Google Photos does it.
Immich:
<img width="97" alt="Screenshot 2023-11-18 at 21 25 33 (2)" src="https://github.com/immich-app/immich/assets/3842222/510545ea-9d70-4c21-8f16-337b4c566f7b">
Google Photos:
<img width="86" alt="Screenshot 2023-11-18 at 21 23 50 (2)" src="https://github.com/immich-app/immich/assets/3842222/c8ed3fce-8adb-4860-a7b4-8caa9acdf81e">
