### PR TITLE
chore(cli): push to npm

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,10 @@
+**/*.spec.js
+.editorconfig
+.eslintignore
+.eslintrc.js
+.prettierignore
+.prettierrc
+package-lock.json
+testSetup.js
+tsconfig.json
+tsconfig.build.json

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Hau Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@immich/cli",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@immich/cli",
-      "version": "2.0.0",
+      "version": "2.0.4",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
         "byte-size": "^8.1.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@immich/cli",
-  "version": "2.0.0",
+  "version": "2.0.3",
+  "description": "Command Line Interface (CLI) for Immich",
   "main": "dist/index.js",
   "bin": {
     "immich": "./dist/index.js"
   },
+  "license": "MIT",
   "dependencies": {
     "axios": "^1.6.2",
     "byte-size": "^8.1.1",
@@ -45,7 +47,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "lint": "eslint \"src/**/*.ts\" --max-warnings 0",
-    "prepack": "yarn build ",
+    "prepack": "npm run build",
     "test": "jest",
     "test:cov": "jest --coverage",
     "format": "prettier --check .",


### PR DESCRIPTION
- Publish the CLI to npm on workflow dispatch
- Add ignore file for use on publish
- Switch from yarn to npm in build step
- Add LICENSE stuff
- Change package.json version to 2.0.3 since 2.0.2 has already been pushed to npm

The package.json version field will need to be manually bumped prior to running the workflow. We can look into including that as part of this release workflow in the future