### PR TITLE
chore(ml): increase spool threshold

### DIFF
--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -24,7 +24,7 @@ from .schemas import (
     TextResponse,
 )
 
-MultiPartParser.max_file_size = 2**24  # spools to disk if payload is 16 MiB or larger
+MultiPartParser.max_file_size = 2**26  # spools to disk if payload is 64 MiB or larger
 app = FastAPI()
 
 


### PR DESCRIPTION
## Description

This change intends to fix #5102 by setting the minimum threshold for spooling to 64MiB. The 16MiB limit was meant to be a high enough number that it shouldn't ever come up, but later thumbnail quality options make it feasible to reach this limit. The cause behind #5102 seems to be that Starlette isn't cleaning up spooled files, so further investigation should be done after this PR to understand why.