### PR TITLE
chore(server): Prepare access interfaces for bulk permission checks

### DIFF
--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -144,6 +144,8 @@ export class AlbumService {
     await this.access.requirePermission(authUser, Permission.ALBUM_READ, id);
 
     const existingAssetIds = await this.albumRepository.getAssetIds(id, dto.ids);
+    const notPresentAssetIds = new Set(dto.ids.filter((id) => !existingAssetIds.has(id)));
+    const allowedAssetIds = await this.access.getAllowedIds(authUser, Permission.ASSET_SHARE, notPresentAssetIds);
 
     const results: BulkIdResponseDto[] = [];
     for (const assetId of dto.ids) {
@@ -153,7 +155,7 @@ export class AlbumService {
         continue;
       }
 
-      const hasAccess = await this.access.hasPermission(authUser, Permission.ASSET_SHARE, assetId);
+      const hasAccess = allowedAssetIds.has(assetId);
       if (!hasAccess) {
         results.push({ id: assetId, success: false, error: BulkIdErrorReason.NO_PERMISSION });
         continue;
@@ -181,6 +183,12 @@ export class AlbumService {
     await this.access.requirePermission(authUser, Permission.ALBUM_READ, id);
 
     const existingAssetIds = await this.albumRepository.getAssetIds(id, dto.ids);
+    const assetIdsWithRemoveAccess = await this.access.getAllowedIds(
+      authUser,
+      Permission.ALBUM_REMOVE_ASSET,
+      existingAssetIds,
+    );
+    const assetIdsWithShareAccess = await this.access.getAllowedIds(authUser, Permission.ASSET_SHARE, existingAssetIds);
 
     const results: BulkIdResponseDto[] = [];
     for (const assetId of dto.ids) {
@@ -190,10 +198,7 @@ export class AlbumService {
         continue;
       }
 
-      const hasAccess = await this.access.hasAny(authUser, [
-        { permission: Permission.ALBUM_REMOVE_ASSET, id: assetId },
-        { permission: Permission.ASSET_SHARE, id: assetId },
-      ]);
+      const hasAccess = assetIdsWithRemoveAccess.has(assetId) || assetIdsWithShareAccess.has(assetId);
       if (!hasAccess) {
         results.push({ id: assetId, success: false, error: BulkIdErrorReason.NO_PERMISSION });
         continue;

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -183,10 +183,9 @@ export class AlbumService {
     await this.access.requirePermission(authUser, Permission.ALBUM_READ, id);
 
     const existingAssetIds = await this.albumRepository.getAssetIds(id, dto.ids);
-    const allowedAssetIds = new Set([
-      ...(await this.access.checkAccess(authUser, Permission.ALBUM_REMOVE_ASSET, existingAssetIds)),
-      ...(await this.access.checkAccess(authUser, Permission.ASSET_SHARE, existingAssetIds)),
-    ]);
+    const canRemove = await this.access.checkAccess(authUser, Permission.ALBUM_REMOVE_ASSET, existingAssetIds);
+    const canShare = await this.access.checkAccess(authUser, Permission.ASSET_SHARE, existingAssetIds);
+    const allowedAssetIds = new Set([...canRemove, ...canShare]);
 
     const results: BulkIdResponseDto[] = [];
     for (const assetId of dto.ids) {

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -375,7 +375,7 @@ export class PersonService {
 
     const results: BulkIdResponseDto[] = [];
 
-    const allowedIds = await this.access.getAllowedIds(authUser, Permission.PERSON_MERGE, new Set(mergeIds));
+    const allowedIds = await this.access.checkAccess(authUser, Permission.PERSON_MERGE, mergeIds);
 
     for (const mergeId of mergeIds) {
       const hasAccess = allowedIds.has(mergeId);

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -375,10 +375,11 @@ export class PersonService {
 
     const results: BulkIdResponseDto[] = [];
 
-    for (const mergeId of mergeIds) {
-      const hasPermission = await this.access.hasPermission(authUser, Permission.PERSON_MERGE, mergeId);
+    const allowedIds = await this.access.getAllowedIds(authUser, Permission.PERSON_MERGE, new Set(mergeIds));
 
-      if (!hasPermission) {
+    for (const mergeId of mergeIds) {
+      const hasAccess = allowedIds.has(mergeId);
+      if (!hasAccess) {
         results.push({ id: mergeId, success: false, error: BulkIdErrorReason.NO_PERMISSION });
         continue;
       }

--- a/server/src/domain/shared-link/shared-link.service.ts
+++ b/server/src/domain/shared-link/shared-link.service.ts
@@ -119,15 +119,19 @@ export class SharedLinkService {
       throw new BadRequestException('Invalid shared link type');
     }
 
+    const existingAssetIds = new Set(sharedLink.assets.map((asset) => asset.id));
+    const notPresentAssetIds = new Set(dto.assetIds.filter((assetId) => !existingAssetIds.has(assetId)));
+    const allowedAssetIds = await this.access.getAllowedIds(authUser, Permission.ASSET_SHARE, notPresentAssetIds);
+
     const results: AssetIdsResponseDto[] = [];
     for (const assetId of dto.assetIds) {
-      const hasAsset = sharedLink.assets.find((asset) => asset.id === assetId);
+      const hasAsset = existingAssetIds.has(assetId);
       if (hasAsset) {
         results.push({ assetId, success: false, error: AssetIdErrorReason.DUPLICATE });
         continue;
       }
 
-      const hasAccess = await this.access.hasPermission(authUser, Permission.ASSET_SHARE, assetId);
+      const hasAccess = allowedAssetIds.has(assetId);
       if (!hasAccess) {
         results.push({ assetId, success: false, error: AssetIdErrorReason.NO_PERMISSION });
         continue;

--- a/server/src/domain/shared-link/shared-link.service.ts
+++ b/server/src/domain/shared-link/shared-link.service.ts
@@ -120,8 +120,8 @@ export class SharedLinkService {
     }
 
     const existingAssetIds = new Set(sharedLink.assets.map((asset) => asset.id));
-    const notPresentAssetIds = new Set(dto.assetIds.filter((assetId) => !existingAssetIds.has(assetId)));
-    const allowedAssetIds = await this.access.getAllowedIds(authUser, Permission.ASSET_SHARE, notPresentAssetIds);
+    const notPresentAssetIds = dto.assetIds.filter((assetId) => !existingAssetIds.has(assetId));
+    const allowedAssetIds = await this.access.checkAccess(authUser, Permission.ASSET_SHARE, notPresentAssetIds);
 
     const results: AssetIdsResponseDto[] = [];
     for (const assetId of dto.assetIds) {


### PR DESCRIPTION
This change adds the `AccessCore.getAllowedIds` method, to evaluate permissions in bulk, along with some other `getAllowedIds*` private methods.

The added methods still calculate permissions by id, and are not optimized to reduce the amount of queries and execution time, which will be implemented in separate pull requests.

Services that were evaluating permissions in a loop have been refactored to make use of the bulk approach.