### PR TITLE
fix: album performances

### DIFF
--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -81,7 +81,7 @@ export class AlbumService {
   async get(authUser: AuthUserDto, id: string, dto: AlbumInfoDto): Promise<AlbumResponseDto> {
     await this.access.requirePermission(authUser, Permission.ALBUM_READ, id);
     await this.albumRepository.updateThumbnails();
-    return mapAlbum(await this.findOrFail(id, { withAssets: true }), !dto.withoutAssets);
+    return mapAlbum(await this.findOrFail(id, { withAssets: false }), !dto.withoutAssets);
   }
 
   async create(authUser: AuthUserDto, dto: CreateAlbumDto): Promise<AlbumResponseDto> {

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -81,7 +81,8 @@ export class AlbumService {
   async get(authUser: AuthUserDto, id: string, dto: AlbumInfoDto): Promise<AlbumResponseDto> {
     await this.access.requirePermission(authUser, Permission.ALBUM_READ, id);
     await this.albumRepository.updateThumbnails();
-    return mapAlbum(await this.findOrFail(id, { withAssets: false }), !dto.withoutAssets);
+    const withAssets = dto.withoutAssets === undefined ? true : !dto.withoutAssets;
+    return mapAlbum(await this.findOrFail(id, { withAssets }), !dto.withoutAssets);
   }
 
   async create(authUser: AuthUserDto, dto: CreateAlbumDto): Promise<AlbumResponseDto> {

--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -56,6 +56,7 @@ export class AlbumRepository implements IAlbumRepository {
       ],
       relations: { owner: true, sharedUsers: true },
       order: { createdAt: 'DESC' },
+      relationLoadStrategy: 'query',
     });
   }
 
@@ -91,6 +92,7 @@ export class AlbumRepository implements IAlbumRepository {
       relations: { sharedUsers: true, sharedLinks: true, owner: true },
       where: { ownerId },
       order: { createdAt: 'DESC' },
+      relationLoadStrategy: 'query',
     });
   }
 
@@ -106,6 +108,7 @@ export class AlbumRepository implements IAlbumRepository {
         { ownerId, sharedUsers: { id: Not(IsNull()) } },
       ],
       order: { createdAt: 'DESC' },
+      relationLoadStrategy: 'query',
     });
   }
 
@@ -117,6 +120,7 @@ export class AlbumRepository implements IAlbumRepository {
       relations: { sharedUsers: true, sharedLinks: true, owner: true },
       where: { ownerId, sharedUsers: { id: IsNull() }, sharedLinks: { id: IsNull() } },
       order: { createdAt: 'DESC' },
+      relationLoadStrategy: 'query',
     });
   }
 


### PR DESCRIPTION
## Changes made in this PR

This PR aims to improve the performances with the album view and the album list
- The queries to get all the albums have many relations are a bit slow, adding `relationLoadStrategy: 'query'` lower the response time from 600ms to 8ms for 10 albums.
- On the page load, the server loads the album's data with the assets