### PR TITLE
fix(web): navigate to album from search

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -7,6 +7,7 @@
   import { flip } from 'svelte/animate';
   import { getThumbnailSize } from '$lib/utils/thumbnail-util';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { onDestroy } from 'svelte';
 
   export let assets: AssetResponseDto[];
   export let selectedAssets: Set<AssetResponseDto> = new Set();
@@ -80,6 +81,10 @@
     $showAssetViewer = false;
     history.pushState(null, '', `${$page.url.pathname}`);
   };
+
+  onDestroy(() => {
+    $showAssetViewer = false;
+  });
 </script>
 
 {#if assets.length > 0}

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -121,7 +121,7 @@
   afterNavigate(({ from }) => {
     assetViewingStore.showAssetViewer(false);
 
-    let url: string | undefined = from?.url.pathname;
+    let url: string | undefined = from?.url?.pathname;
 
     if (from?.route.id === '/(user)/search') {
       url = from.url.href;

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -70,7 +70,7 @@
 
   afterNavigate(({ from }) => {
     // Prevent setting previousRoute to the current page.
-    if (from && from.route.id !== $page.route.id) {
+    if (from?.url && from.route.id !== $page.route.id) {
       previousRoute = from.url.href;
     }
 
@@ -145,7 +145,7 @@
       </section>
     {/if}
     <section id="search-content" class="relative bg-immich-bg dark:bg-immich-dark-bg">
-      {#if data.results?.assets?.items.length > 0}
+      {#if searchResultAssets.length > 0}
         <div class="pl-4">
           <GalleryViewer assets={searchResultAssets} bind:selectedAssets showArchiveIcon={true} />
         </div>


### PR DESCRIPTION
Disable the asset viewer on gallery viewer dismount, to prevent a runtime issue where it would be open with a null asset.