### PR TITLE
refactor: mobile - send livephoto as a separate request

### DIFF
--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -293,12 +293,21 @@ class BackupService {
           if (entity.isLivePhoto) {
             var livePhotoRawUploadData = await _getLivePhotoFile(entity);
             if (livePhotoRawUploadData != null) {
-              req.files.removeWhere((data) => data.field == "assetData");
-              req.files.add(livePhotoRawUploadData);
+              var livePhotoReq = MultipartRequest(
+                req.method,
+                req.url,
+                onProgress: req.onProgress,
+              )
+                ..headers.addAll(req.headers)
+                ..fields.addAll(req.fields);
+
+              livePhotoReq.files.add(livePhotoRawUploadData);
               // Send live photo only if the non-motion part is successful
               if (response.statusCode == 200 || response.statusCode == 201) {
-                response =
-                    await httpClient.send(req, cancellationToken: cancelToken);
+                response = await httpClient.send(
+                  livePhotoReq,
+                  cancellationToken: cancelToken,
+                );
               }
             }
           }


### PR DESCRIPTION
#### Changes made in the PR

- Live photos from iOS are uploaded as a separate asset instead of adding it to the upload with the still asset

#### Things to be addressed
- The non-motion asset needs to be successfully uploaded for the app to initiate the upload for the motion part
- The non-motion assets response will be overwritten by the response of the motion asset response. This shouldn't be an issue in practice since livePhoto's motion and non-motion part always goes together.  However, the following cases are still allowed by the current impl:
    - If the non-motion part is duplicated but the motion part is fresh upload, the asset will not be marked as duplicate in the mobile app
    - If the non-motion part is not duplicate, but the motion part is a duplicate, the asset will be marked as a duplicate
    - If the motion part resulted in an error, the asset will be marked as error, even if the non-motion asset is successfully uploaded
- The deviceId and deviceAssetId of the motion photo will be the same as the one for the non-motion part. 
- motion asset's duration will not be set in the request dto
- If the non-motion part got uploaded and the motion part resulted in an error, since the deviceAssetId is stored in the db for the non-motion part, the file will not be retried during the next backup cycle from the mobile app. This is due to the current handling of using deviceAssetId for checking duplicates. This should not happen when we start using checksum for de-dup