### PR TITLE
feat(server): load face entities faster

### DIFF
--- a/server/src/infra/entities/asset-face.entity.ts
+++ b/server/src/infra/entities/asset-face.entity.ts
@@ -1,8 +1,9 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { AssetEntity } from './asset.entity';
 import { PersonEntity } from './person.entity';
 
 @Entity('asset_faces')
+@Index(['personId', 'assetId'])
 export class AssetFaceEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/server/src/infra/entities/asset.entity.ts
+++ b/server/src/infra/entities/asset.entity.ts
@@ -33,6 +33,7 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_library_checksum';
 @Index('IDX_day_of_month', { synchronize: false })
 @Index('IDX_month', { synchronize: false })
 @Index('IDX_originalPath_libraryId', ['originalPath', 'libraryId'])
+@Index(['stackParentId'])
 // For all assets, each originalpath must be unique per user and library
 export class AssetEntity {
   @PrimaryGeneratedColumn('uuid')

--- a/server/src/infra/migrations/1700752078178-AddAssetFaceIndicies.ts
+++ b/server/src/infra/migrations/1700752078178-AddAssetFaceIndicies.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAssetFaceIndicies1700752078178 implements MigrationInterface {
+    name = 'AddAssetFaceIndicies1700752078178'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE INDEX "IDX_bf339a24070dac7e71304ec530" ON "asset_faces" ("personId", "assetId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_b463c8edb01364bf2beba08ef1" ON "assets" ("stackParentId") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "public"."IDX_b463c8edb01364bf2beba08ef1"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_bf339a24070dac7e71304ec530"`);
+    }
+
+}


### PR DESCRIPTION
The added indices are based on monitoring a server with 
- 6 users
- 120.000+ Pictures
- 500+ GiB Storage

Especially the query executed when loading the peoples' page gains a speedup of 4x.
