### PR TITLE
fix(mobile): Add translatable strings for shared links info

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -390,6 +390,28 @@
   "shared_link_edit_show_meta": "Show metadata",
   "shared_link_edit_submit_button": "Update link",
   "shared_link_empty": "You don't have any shared links",
+  "shared_link_error_server_url_fetch": "Cannot fetch the server url",
+  "shared_link_expired": "Expired",
+  "shared_link_expires_days": {
+    "one": "Expires in {} day",
+    "other": "Expires in {} days"
+  },
+  "shared_link_expires_hours": {
+    "one": "Expires in {} hour",
+    "other": "Expires in {} hours"
+  },
+  "shared_link_expires_minutes": {
+    "one": "Expires in {} minute",
+    "other": "Expires in {} minutes"
+  },
+  "shared_link_expires_seconds": {
+    "one": "Expires in {} second",
+    "other": "Expires in {} seconds"
+  },
+  "shared_link_expires_never": "Expires ∞",
+  "shared_link_info_chip_download": "Download",
+  "shared_link_info_chip_metadata": "EXIF",
+  "shared_link_info_chip_upload": "Upload",
   "shared_link_manage_links": "Manage Shared links",
   "share_done": "Done",
   "share_invite": "Invite to album",

--- a/mobile/assets/i18n/es-US.json
+++ b/mobile/assets/i18n/es-US.json
@@ -390,6 +390,28 @@
   "shared_link_edit_show_meta": "Mostrar metadatos",
   "shared_link_edit_submit_button": "Actualizar enlace",
   "shared_link_empty": "No tienes ningún enlace compartido",
+  "shared_link_error_server_url_fetch": "No se puede obtener la URL del servidor",
+  "shared_link_expired": "Expirado",
+  "shared_link_expires_days": {
+    "one": "Expira en {} día",
+    "other": "Expira en {} días"
+  },
+  "shared_link_expires_hours": {
+    "one": "Expira en {} hora",
+    "other": "Expira en {} horas"
+  },
+  "shared_link_expires_minutes": {
+    "one": "Expira en {} minuto",
+    "other": "Expira en {} minutos"
+  },
+  "shared_link_expires_seconds": {
+    "one": "Expira en {} segundo",
+    "other": "Expira en {} segundos"
+  },
+  "shared_link_expires_never": "Sin expiración",
+  "shared_link_info_chip_download": "Descargar",
+  "shared_link_info_chip_metadata": "EXIF",
+  "shared_link_info_chip_upload": "Subir",
   "shared_link_manage_links": "Administrar enlaces compartidos",
   "share_done": "Hecho",
   "share_invite": "Invitar al álbum",

--- a/mobile/lib/modules/shared_link/ui/shared_link_item.dart
+++ b/mobile/lib/modules/shared_link/ui/shared_link_item.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -26,13 +27,13 @@ class SharedLinkItem extends ConsumerWidget {
   }
 
   Widget getExpiryDuration(bool isDarkMode) {
-    var expiresText = "Expires ∞";
+    var expiresText = "shared_link_expires_never".tr();
     if (sharedLink.expiresAt != null) {
       if (isExpired()) {
         return Text(
-          "Expired",
+          "shared_link_expired",
           style: TextStyle(color: Colors.red[300]),
-        );
+        ).tr();
       }
       final difference = sharedLink.expiresAt!.difference(DateTime.now());
       debugPrint("Difference: $difference");
@@ -41,13 +42,13 @@ class SharedLinkItem extends ConsumerWidget {
         if (difference.inHours % 24 > 12) {
           dayDifference += 1;
         }
-        expiresText = "in $dayDifference days";
+        expiresText = "shared_link_expires_days".plural(dayDifference);
       } else if (difference.inHours > 0) {
-        expiresText = "in ${difference.inHours} hours";
+        expiresText = "shared_link_expires_hours".plural(difference.inHours);
       } else if (difference.inMinutes > 0) {
-        expiresText = "in ${difference.inMinutes} minutes";
+        expiresText = "shared_link_expires_minutes".plural(difference.inMinutes);
       } else if (difference.inSeconds > 0) {
-        expiresText = "in ${difference.inSeconds} seconds";
+        expiresText = "shared_link_expires_seconds".plural(difference.inSeconds);
       }
     }
     return Text(
@@ -72,7 +73,7 @@ class SharedLinkItem extends ConsumerWidget {
           context: context,
           gravity: ToastGravity.BOTTOM,
           toastType: ToastType.error,
-          msg: 'Cannot fetch the server url',
+          msg: "shared_link_error_server_url_fetch".tr(),
         );
         return;
       }
@@ -83,11 +84,9 @@ class SharedLinkItem extends ConsumerWidget {
         ),
       ).then((_) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text(
-              "Copied to clipboard",
-            ),
-            duration: Duration(seconds: 2),
+          SnackBar(
+            content: const Text("shared_link_clipboard_copied_massage").tr(),
+            duration: const Duration(seconds: 2),
           ),
         );
       });
@@ -163,9 +162,9 @@ class SharedLinkItem extends ConsumerWidget {
     Widget buildBottomInfo() {
       return Row(
         children: [
-          if (sharedLink.allowUpload) buildInfoChip("Upload"),
-          if (sharedLink.allowDownload) buildInfoChip("Download"),
-          if (sharedLink.showMetadata) buildInfoChip("EXIF"),
+          if (sharedLink.allowUpload) buildInfoChip("shared_link_info_chip_upload".tr()),
+          if (sharedLink.allowDownload) buildInfoChip("shared_link_info_chip_download".tr()),
+          if (sharedLink.showMetadata) buildInfoChip("shared_link_info_chip_metadata".tr()),
         ],
       );
     }


### PR DESCRIPTION
Mark more strings as translatable, regarding shared link information and expiration.