### PR TITLE
feat(web, server): Allow use of external geocoder service

### DIFF
--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -9070,13 +9070,21 @@
           "citiesFileOverride": {
             "$ref": "#/components/schemas/CitiesFile"
           },
+          "customEndpoint": {
+            "type": "string"
+          },
           "enabled": {
+            "type": "boolean"
+          },
+          "useCustomService": {
             "type": "boolean"
           }
         },
         "required": [
           "citiesFileOverride",
-          "enabled"
+          "enabled",
+          "useCustomService",
+          "customEndpoint"
         ],
         "type": "object"
       },

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -103,7 +103,7 @@ export class MetadataService {
     }
 
     const { reverseGeocoding } = await this.configCore.getConfig();
-    const { citiesFileOverride } = reverseGeocoding;
+    const { citiesFileOverride, customEndpoint } = reverseGeocoding;
 
     if (!reverseGeocoding.enabled) {
       return;
@@ -117,7 +117,7 @@ export class MetadataService {
       }
 
       await this.jobRepository.pause(QueueName.METADATA_EXTRACTION);
-      await this.repository.init({ citiesFileOverride });
+      await this.repository.init({ citiesFileOverride, customEndpoint });
       await this.jobRepository.resume(QueueName.METADATA_EXTRACTION);
 
       this.logger.log(`Initialized local reverse geocoder with ${citiesFileOverride}`);

--- a/server/src/domain/repositories/metadata.repository.ts
+++ b/server/src/domain/repositories/metadata.repository.ts
@@ -30,8 +30,12 @@ export interface ImmichTags extends Omit<Tags, 'FocalLength' | 'Duration'> {
   Duration?: number | ExifDuration;
 }
 
+export type MetadataInitOptions = Partial<InitOptions> & {
+  customEndpoint?: string;
+};
+
 export interface IMetadataRepository {
-  init(options: Partial<InitOptions>): Promise<void>;
+  init(options: MetadataInitOptions): Promise<void>;
   teardown(): Promise<void>;
   reverseGeocode(point: GeoPoint): Promise<ReverseGeocodeResult>;
   deleteCache(): Promise<void>;

--- a/server/src/domain/system-config/dto/system-config-reverse-geocoding.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-reverse-geocoding.dto.ts
@@ -1,6 +1,6 @@
 import { CitiesFile } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsEnum } from 'class-validator';
+import { IsBoolean, IsEnum, IsUrl, ValidateIf } from 'class-validator';
 
 export class SystemConfigReverseGeocodingDto {
   @IsBoolean()
@@ -9,4 +9,11 @@ export class SystemConfigReverseGeocodingDto {
   @IsEnum(CitiesFile)
   @ApiProperty({ enum: CitiesFile, enumName: 'CitiesFile' })
   citiesFileOverride!: CitiesFile;
+
+  @IsBoolean()
+  useCustomService!: boolean;
+
+  @ValidateIf((dto) => dto.enabled && dto.useCustomService)
+  @IsUrl({ require_tld: false, allow_underscores: true })
+  customEndpoint!: string;
 }

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -86,6 +86,8 @@ export const defaults = Object.freeze<SystemConfig>({
   reverseGeocoding: {
     enabled: true,
     citiesFileOverride: CitiesFile.CITIES_500,
+    useCustomService: false,
+    customEndpoint: '',
   },
   oauth: {
     enabled: false,

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -86,6 +86,8 @@ const updatedConfig = Object.freeze<SystemConfig>({
   reverseGeocoding: {
     enabled: true,
     citiesFileOverride: CitiesFile.CITIES_500,
+    useCustomService: false,
+    customEndpoint: '',
   },
   oauth: {
     autoLaunch: true,

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -67,6 +67,8 @@ export enum SystemConfigKey {
 
   REVERSE_GEOCODING_ENABLED = 'reverseGeocoding.enabled',
   REVERSE_GEOCODING_CITIES_FILE_OVERRIDE = 'reverseGeocoding.citiesFileOverride',
+  REVERSE_GEOCODING_USE_CUSTOM_SERVICE = 'reverseGeocoding.useCustomService',
+  REVERSE_GEOCODING_CUSTOM_ENDPOINT = 'reverseGeocoding.customEndpoint',
 
   NEW_VERSION_CHECK_ENABLED = 'newVersionCheck.enabled',
 
@@ -201,6 +203,8 @@ export interface SystemConfig {
   reverseGeocoding: {
     enabled: boolean;
     citiesFileOverride: CitiesFile;
+    useCustomService: boolean;
+    customEndpoint: string;
   };
   oauth: {
     enabled: boolean;

--- a/server/src/infra/repositories/metadata-external.repository.ts
+++ b/server/src/infra/repositories/metadata-external.repository.ts
@@ -1,0 +1,57 @@
+import { GeoPoint, IMetadataRepository, ImmichTags, MetadataInitOptions, ReverseGeocodeResult } from '@app/domain';
+import { Injectable, Logger } from '@nestjs/common';
+import { DefaultReadTaskOptions, exiftool } from 'exiftool-vendored';
+import * as geotz from 'geo-tz';
+
+@Injectable()
+export class MetadataExternalRepository implements IMetadataRepository {
+  private logger = new Logger(MetadataExternalRepository.name);
+  private endpoint?: string;
+
+  async init(options: MetadataInitOptions): Promise<void> {
+    const { customEndpoint } = options;
+    if (!customEndpoint) {
+      throw new Error('Server endpoint for reverse geocode must be defined');
+    }
+
+    this.endpoint = customEndpoint;
+  }
+
+  async teardown(): Promise<void> {}
+
+  async reverseGeocode(point: GeoPoint): Promise<ReverseGeocodeResult> {
+    const params = new URLSearchParams({
+      lat: point.latitude.toString(),
+      lon: point.longitude.toString(),
+    });
+    const url = this.endpoint!;
+    this.logger.debug(`Request using ${url}: ${point.latitude},${point.longitude}`);
+
+    const res = await fetch(`${url}/reverse-geocode?${params}`, { method: 'GET' });
+    if (res.status >= 400) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+
+    return res.json();
+  }
+
+  async deleteCache(): Promise<void> {}
+
+  getExifTags(path: string): Promise<ImmichTags | null> {
+    return exiftool
+      .read(path, undefined, {
+        ...DefaultReadTaskOptions,
+
+        defaultVideosToUTC: true,
+        backfillTimezones: true,
+        inferTimezoneFromDatestamps: true,
+        useMWG: true,
+        numericTags: DefaultReadTaskOptions.numericTags.concat(['FocalLength']),
+        geoTz: (lat, lon) => geotz.find(lat, lon)[0],
+      })
+      .catch((error) => {
+        this.logger.warn(`Error reading exif data (${path}): ${error}`, error?.stack);
+        return null;
+      }) as Promise<ImmichTags | null>;
+  }
+}

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -1,11 +1,11 @@
-import { GeoPoint, IMetadataRepository, ImmichTags, ReverseGeocodeResult } from '@app/domain';
+import { GeoPoint, IMetadataRepository, ImmichTags, MetadataInitOptions, ReverseGeocodeResult } from '@app/domain';
 import { REVERSE_GEOCODING_DUMP_DIRECTORY } from '@app/infra';
 import { Injectable, Logger } from '@nestjs/common';
 import { DefaultReadTaskOptions, exiftool } from 'exiftool-vendored';
 import { readdir, rm } from 'fs/promises';
 import * as geotz from 'geo-tz';
 import { getName } from 'i18n-iso-countries';
-import geocoder, { AddressObject, InitOptions } from 'local-reverse-geocoder';
+import geocoder, { AddressObject } from 'local-reverse-geocoder';
 import path from 'path';
 import { promisify } from 'util';
 
@@ -26,7 +26,10 @@ const lookup = promisify<GeoPoint[], number, AddressObject[][]>(geocoder.lookUp)
 export class MetadataRepository implements IMetadataRepository {
   private logger = new Logger(MetadataRepository.name);
 
-  async init(options: Partial<InitOptions>): Promise<void> {
+  async init(options: MetadataInitOptions): Promise<void> {
+    // drop the customEndpoint field since it does not belong to geocoder
+    delete options.customEndpoint;
+
     return new Promise<void>((resolve) => {
       geocoder.init(
         {

--- a/web/src/lib/components/admin-page/settings/map-settings/map-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/map-settings/map-settings.svelte
@@ -40,6 +40,8 @@
           reverseGeocoding: {
             enabled: config.reverseGeocoding.enabled,
             citiesFileOverride: config.reverseGeocoding.citiesFileOverride,
+            useCustomService: config.reverseGeocoding.useCustomService,
+            customEndpoint: config.reverseGeocoding.customEndpoint,
           },
         },
       });
@@ -132,6 +134,14 @@
                 bind:checked={config.reverseGeocoding.enabled}
               />
 
+              <SettingSwitch
+                title="Custom Service Endpoint"
+                subtitle="Use an external service to reverse geocode"
+                disabled={disabled || !config.reverseGeocoding.enabled}
+                bind:checked={config.reverseGeocoding.useCustomService}
+                isEdited={config.reverseGeocoding.useCustomService !== savedConfig.reverseGeocoding.useCustomService}
+              />
+
               <hr />
 
               <SettingSelect
@@ -145,9 +155,18 @@
                   { value: CitiesFile.Cities5000, text: 'Cities with more than 5000 people' },
                   { value: CitiesFile.Cities15000, text: 'Cities with more than 15000 people' },
                 ]}
-                disabled={disabled || !config.reverseGeocoding.enabled}
+                disabled={disabled || !config.reverseGeocoding.enabled || config.reverseGeocoding.useCustomService}
                 isEdited={config.reverseGeocoding.citiesFileOverride !==
                   savedConfig.reverseGeocoding.citiesFileOverride}
+              />
+
+              <SettingInputField
+                inputType={SettingInputFieldType.TEXT}
+                label="Custom Service URL"
+                desc="(Optional) URL of the geocode server"
+                bind:value={config.reverseGeocoding.customEndpoint}
+                disabled={disabled || !config.reverseGeocoding.enabled || !config.reverseGeocoding.useCustomService}
+                isEdited={config.reverseGeocoding.customEndpoint !== savedConfig.reverseGeocoding.customEndpoint}
               />
             </div></SettingAccordion
           >


### PR DESCRIPTION
This PR adds the ability to use an external service to do the reverse geocoding work.
The reason to allow an external service instead of extending the current implementation is that accurate geocoding is computationally expensive. I. e., self-hosting [Nominatim](https://nominatim.org/) would require at least 64 GiB of RAM.
The other reason is that it allows users to use any service they want without having Immich to support a particular service.

The _Maps & GPS Settings_ part looks like this:
![screenshot_2023-11-24_16-59_immich-settings-custom-geocode-server](https://github.com/immich-app/immich/assets/29659953/b3d075b8-f29f-4137-8883-4e4f21b02ad3)

The drawback of this implementation is, that after the configuration has been changed, the server must be restarted.

Please note that I am not familiar with nestjs. If I violated some paradigms or principles this project follows I am more than happy to rewrite the solution.
This is especially true about the factory to return the different implementations.

An example (PoC) service can be found here: https://gitlab.com/l0nax/immich-external-reverse-geocode

Fixes #2684 