### PR TITLE
fix(web): Map clustering when zoomed in

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -87,10 +87,19 @@
 </script>
 
 {#await style then style}
-  <MapLibre {style} class="h-full" {center} {zoom} attributionControl={false} diffStyleUpdates={true} let:map>
+  <MapLibre
+    {style}
+    class="h-full"
+    {center}
+    {zoom}
+    attributionControl={false}
+    diffStyleUpdates={true}
+    let:map
+    on:load={(event) => event.detail.setMaxZoom(14)}
+  >
     <NavigationControl position="top-left" showCompass={!simplified} />
     {#if !simplified}
-      <GeolocateControl position="top-left" fitBoundsOptions={{ maxZoom: 12 }} />
+      <GeolocateControl position="top-left" />
       <FullscreenControl position="top-left" />
       <ScaleControl />
       <AttributionControl compact={false} />
@@ -110,7 +119,7 @@
         }),
       }}
       id="geojson"
-      cluster={{ maxZoom: 20, radius: 500 }}
+      cluster={{ radius: 500 }}
     >
       <MarkerLayer
         applyToClusters

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -110,7 +110,7 @@
         }),
       }}
       id="geojson"
-      cluster={{ maxZoom: 14, radius: 500 }}
+      cluster={{ maxZoom: 20, radius: 500 }}
     >
       <MarkerLayer
         applyToClusters


### PR DESCRIPTION
Fixes #5297.
Sets the `maxZoom` to a value that cannot be reached, therefore enabling clustering for any zoom.