### PR TITLE
fix(mobile): Remove occurrences of manual string pluralization

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -12,8 +12,10 @@
   "advanced_settings_troubleshooting_title": "Troubleshooting",
   "album_info_card_backup_album_excluded": "EXCLUDED",
   "album_info_card_backup_album_included": "INCLUDED",
-  "album_thumbnail_card_item": "1 item",
-  "album_thumbnail_card_items": "{} items",
+  "album_thumbnail_card_items": {
+    "one": "{} item",
+    "other": "{} items"
+  },
   "album_thumbnail_card_shared": " · Shared",
   "album_thumbnail_owned": "Owned",
   "album_thumbnail_shared_by": "Shared by {}",
@@ -179,6 +181,14 @@
   "home_page_archive_err_partner": "Can not archive partner assets, skipping",
   "home_page_building_timeline": "Building the timeline",
   "home_page_delete_err_partner": "Can not delete partner assets, skipping",
+  "home_page_deleted_permanently": {
+    "one": "{} asset deleted permanently",
+    "other": "{} assets deleted permanently"
+  },
+  "home_page_deleted_to_trash": {
+    "one": "{} asset trashed",
+    "other": "{} assets trashed"
+  },
   "home_page_favorite_err_local": "Can not favorite local assets yet, skipping",
   "home_page_favorite_err_partner": "Can not favorite partner assets yet, skipping",
   "home_page_first_time_notice": "If this is your first time using the app, please make sure to choose a backup album(s) so that the timeline can populate photos and videos in the album(s).",
@@ -319,6 +329,22 @@
   "select_additional_user_for_sharing_page_suggestions": "Suggestions",
   "select_user_for_sharing_page_err_album": "Failed to create album",
   "select_user_for_sharing_page_share_suggestions": "Suggestions",
+  "selection_handler_add_assets_to_favorites": {
+    "one": "Added {} asset to favorites",
+    "other": "Added {} assets to favorites"
+  },
+  "selection_handler_move_assets_to_archive": {
+    "one": "Moved {} asset to archive",
+    "other": "Moved {} assets to archive"
+  },
+  "selection_handler_move_assets_to_library": {
+    "one": "Moved {} asset to library",
+    "other": "Moved {} assets to library"
+  },
+  "selection_handler_remove_assets_from_favorites": {
+    "one": "Removed {} asset from favorites",
+    "other": "Removed {} assets from favorites"
+  },
   "server_info_box_app_version": "App Version",
   "server_info_box_server_url": "Server URL",
   "server_info_box_server_version": "Server Version",
@@ -436,6 +462,14 @@
   "theme_setting_three_stage_loading_subtitle": "Three-stage loading might increase the loading performance but causes significantly higher network load",
   "theme_setting_three_stage_loading_title": "Enable three-stage loading",
   "translated_text_options": "Options",
+  "trash_page_assets_deleted": {
+    "one": "{} assets deleted permanently",
+    "other": "{} assets deleted permanently"
+  },
+  "trash_page_assets_restored": {
+    "one": "{} assets restored successfully",
+    "other": "{} assets restored successfully"
+  },
   "trash_page_delete": "Delete",
   "trash_page_delete_all": "Delete All",
   "trash_page_empty_trash_btn": "Empty trash",

--- a/mobile/lib/modules/album/ui/album_thumbnail_card.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_card.dart
@@ -67,11 +67,7 @@ class AlbumThumbnailCard extends StatelessWidget {
             text: TextSpan(
               children: [
                 TextSpan(
-                  text: album.assetCount == 1
-                      ? 'album_thumbnail_card_item'
-                          .tr(args: ['${album.assetCount}'])
-                      : 'album_thumbnail_card_items'
-                          .tr(args: ['${album.assetCount}']),
+                  text: 'album_thumbnail_card_items'.plural(album.assetCount),
                   style: context.textTheme.bodyMedium,
                 ),
                 if (owner != null) const TextSpan(text: ' · '),

--- a/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
@@ -90,14 +90,12 @@ class AlbumThumbnailListTile extends StatelessWidget {
                   Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text(
-                        album.assetCount == 1
-                            ? 'album_thumbnail_card_item'
-                            : 'album_thumbnail_card_items',
-                        style: const TextStyle(
+                      const Text(
+                        'album_thumbnail_card_items',
+                        style: TextStyle(
                           fontSize: 12,
                         ),
-                      ).tr(args: ['${album.assetCount}']),
+                      ).plural(album.assetCount),
                       if (album.shared)
                         const Text(
                           'album_thumbnail_card_shared',

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -192,13 +192,12 @@ class HomePage extends HookConsumerWidget {
               .deleteAssets(toDelete, force: !trashEnabled);
 
           final hasRemote = toDelete.any((a) => a.isRemote);
-          final assetOrAssets = toDelete.length > 1 ? 'assets' : 'asset';
-          final trashOrRemoved =
-              !trashEnabled ? 'deleted permanently' : 'trashed';
+          final toastMessage =
+              !trashEnabled ? 'home_page_deleted_permanently' : 'home_page_deleted_to_trash';
           if (hasRemote) {
             ImmichToast.show(
               context: context,
-              msg: '${selection.value.length} $assetOrAssets $trashOrRemoved',
+              msg: toastMessage.plural(selection.value.length),
               gravity: ToastGravity.BOTTOM,
             );
           }

--- a/mobile/lib/modules/trash/views/trash_page.dart
+++ b/mobile/lib/modules/trash/views/trash_page.dart
@@ -68,12 +68,10 @@ class TrashPage extends HookConsumerWidget {
               .read(assetProvider.notifier)
               .deleteAssets(selection.value, force: true);
 
-          final assetOrAssets = selection.value.length > 1 ? 'assets' : 'asset';
           if (context.mounted) {
             ImmichToast.show(
               context: context,
-              msg:
-                  '${selection.value.length} $assetOrAssets deleted permanently',
+              msg: 'trash_page_assets_deleted'.plural(selection.value.length),
               gravity: ToastGravity.BOTTOM,
             );
           }
@@ -108,12 +106,10 @@ class TrashPage extends HookConsumerWidget {
               .read(trashProvider.notifier)
               .restoreAssets(selection.value);
 
-          final assetOrAssets = selection.value.length > 1 ? 'assets' : 'asset';
           if (result && context.mounted) {
             ImmichToast.show(
               context: context,
-              msg:
-                  '${selection.value.length} $assetOrAssets restored successfully',
+              msg: 'trash_page_assets_restored'.plural(selection.value.length),
               gravity: ToastGravity.BOTTOM,
             );
           }

--- a/mobile/lib/utils/selection_handlers.dart
+++ b/mobile/lib/utils/selection_handlers.dart
@@ -48,12 +48,13 @@ Future<void> handleArchiveAssets(
         .read(assetProvider.notifier)
         .toggleArchive(selection, shouldArchive);
 
-    final assetOrAssets = selection.length > 1 ? 'assets' : 'asset';
-    final archiveOrLibrary = shouldArchive ? 'archive' : 'library';
+    final toastMessage = shouldArchive
+        ? 'selection_handler_move_assets_to_archive'
+        : 'selection_handler_move_assets_to_library';
     if (context.mounted) {
       ImmichToast.show(
         context: context,
-        msg: 'Moved ${selection.length} $assetOrAssets to $archiveOrLibrary',
+        msg: toastMessage.plural(selection.length),
         gravity: toastGravity,
       );
     }
@@ -72,14 +73,13 @@ Future<void> handleFavoriteAssets(
         .watch(assetProvider.notifier)
         .toggleFavorite(selection, shouldFavorite);
 
-    final assetOrAssets = selection.length > 1 ? 'assets' : 'asset';
     final toastMessage = shouldFavorite
-        ? 'Added ${selection.length} $assetOrAssets to favorites'
-        : 'Removed ${selection.length} $assetOrAssets from favorites';
+        ? 'selection_handler_add_assets_to_favorites'
+        : 'selection_handler_remove_assets_from_favorites';
     if (context.mounted) {
       ImmichToast.show(
         context: context,
-        msg: toastMessage,
+        msg: toastMessage.plural(selection.length),
         gravity: ToastGravity.BOTTOM,
       );
     }


### PR DESCRIPTION
Instead, use `.plural` to find the correct string translation.