### PR TITLE
feat(web): prefer higher GiB values

### DIFF
--- a/web/src/lib/utils/byte-units.ts
+++ b/web/src/lib/utils/byte-units.ts
@@ -9,7 +9,7 @@
  * @returns size (number) and unit (string)
  */
 export function getBytesWithUnit(bytes: number, maxPrecision = 1): [number, string] {
-  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
+  const units = ['B', 'KiB', 'MiB', 'GiB'];
 
   let magnitude = 0;
   let remainder = bytes;


### PR DESCRIPTION
Cap units at GiB. So show `1234 GiB` instead of `1 TiB`, especially on the server info page.

| Before | After |
| - | - |
| ![image](https://github.com/immich-app/immich/assets/4334196/f2d75c1f-c088-4897-90e1-423d043ba1aa) | ![image](https://github.com/immich-app/immich/assets/4334196/dd68eabf-047f-4b53-b2b4-03612681ed7a) |
