### PR TITLE
chore(renovate): Only update to node LTS versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", "docker:pinDigests"],
   "minimumReleaseAge": "5",
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,12 @@
     {
       "groupName": "base-image",
       "matchPackagePrefixes": ["ghcr.io/immich-app/base-server"]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["node"],
+      "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-.*)?$",
+      "versioning": "node"
     }
   ],
   "ignoreDeps": [

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,7 +13,7 @@ RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 
 # web build
-FROM node:20.10-alpine3.18 as web
+FROM node:iron-alpine3.18 as web
 
 WORKDIR /usr/src/app
 COPY web/package.json web/package-lock.json ./

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10-alpine3.18
+FROM node:iron-alpine3.18
 
 WORKDIR /usr/src/app
 COPY --chown=node:node package*.json ./


### PR DESCRIPTION
Also enables pinning docker image digests, because that should really be standard practice.