### PR TITLE
fix(web): storage decimals

### DIFF
--- a/web/src/lib/components/admin-page/server-stats/server-stats-panel.svelte
+++ b/web/src/lib/components/admin-page/server-stats/server-stats-panel.svelte
@@ -21,7 +21,8 @@
     return '0'.repeat(zeroLength);
   };
 
-  $: [statsUsage, statsUsageUnit] = getBytesWithUnit(stats.usage, 0);
+  const TiB = 1024 ** 4;
+  $: [statsUsage, statsUsageUnit] = getBytesWithUnit(stats.usage, stats.usage > TiB ? 2 : 0);
 </script>
 
 <div class="flex flex-col gap-5">

--- a/web/src/lib/utils/byte-units.ts
+++ b/web/src/lib/utils/byte-units.ts
@@ -9,7 +9,7 @@
  * @returns size (number) and unit (string)
  */
 export function getBytesWithUnit(bytes: number, maxPrecision = 1): [number, string] {
-  const units = ['B', 'KiB', 'MiB', 'GiB'];
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
 
   let magnitude = 0;
   let remainder = bytes;


### PR DESCRIPTION
Follow up to #5340.

Restore old behavior, and then change it to show decimals on the stats page when usage units are TiB or higher.

![image](https://github.com/immich-app/immich/assets/4334196/b8e30386-cbe8-488c-93af-d3439e44d9be)
