### PR TITLE
chore(web): run as root in dev

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:iron-alpine3.18
 
+USER node
 WORKDIR /usr/src/app
 COPY --chown=node:node package*.json ./
 RUN npm ci


### PR DESCRIPTION
Tested by being able to delete generated folders `.svelte-kit` and `build`, although users might have to chown or manually delete them originally.