### PR TITLE
chore(web): handle signals for faster restart

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -59,7 +59,7 @@ services:
     build:
       context: ../web
       dockerfile: Dockerfile
-    command: npm run dev --host
+    command: "node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000"
     env_file:
       - .env
     ports:


### PR DESCRIPTION
`npm` doesn't correctly handle signals, so avoid using in when running inside docker. Restarting or killing the `immich-web` container now exits cleanly after a few seconds, instead of waiting 10 seconds for docker to then kill it.