### PR TITLE
feat(web): job concurrency order

### DIFF
--- a/web/src/lib/components/admin-page/settings/job-settings/job-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/job-settings/job-settings.svelte
@@ -16,8 +16,18 @@
   let savedConfig: SystemConfigJobDto;
   let defaultConfig: SystemConfigJobDto;
 
-  const ignoredJobs = [JobName.BackgroundTask, JobName.Search] as JobName[];
-  const jobNames = Object.values(JobName).filter((jobName) => !ignoredJobs.includes(jobName as JobName));
+  const jobNames = [
+    JobName.ThumbnailGeneration,
+    JobName.MetadataExtraction,
+    JobName.Library,
+    JobName.Sidecar,
+    JobName.ObjectTagging,
+    JobName.ClipEncoding,
+    JobName.RecognizeFaces,
+    JobName.VideoConversion,
+    JobName.StorageTemplateMigration,
+    JobName.Migration,
+  ];
 
   async function getConfigs() {
     [savedConfig, defaultConfig] = await Promise.all([


### PR DESCRIPTION
Update the order to match what is on the job screen. Supersedes #5076.