### PR TITLE
fix(web): delete modal z-index

### DIFF
--- a/web/src/lib/components/shared-components/full-screen-modal.svelte
+++ b/web/src/lib/components/shared-components/full-screen-modal.svelte
@@ -12,7 +12,7 @@
 <section
   in:fade={{ duration: 100 }}
   out:fade={{ duration: 100 }}
-  class="fixed left-0 top-0 z-[990] flex h-screen w-screen place-content-center place-items-center bg-black/40"
+  class="fixed left-0 top-0 z-[9990] flex h-screen w-screen place-content-center place-items-center bg-black/40"
 >
   <div
     class="z-[9999]"


### PR DESCRIPTION
This fixes #4954 

When trashing a photo, it should move to the next photo automatically. If there is no next photo, then the previous photo, and otherwise close the asset viewer. This matches Google Photos behavior.

The current code does not work because the deleted photo's next asset reference is null after the `deleteAssets(...)` call.

I'm new to Svelte, all code suggestions are welcome.