### PR TITLE
Make running local dev instance on Windows work regardless of git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,5 @@ web/src/api/open-api/**/*.md -diff -merge
 web/src/api/open-api/**/*.md linguist-generated=true
 web/src/api/open-api/**/*.ts -diff -merge
 web/src/api/open-api/**/*.ts linguist-generated=true
+
+*.sh text eol=lf


### PR DESCRIPTION
The only issue was that line endings of shell scripts may be \r\n when cloned on Windows with autocrlf and shells don't like that.