### PR TITLE
feat(web): allow showing hidden people in image asset details view

### DIFF
--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -98,7 +98,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     tags: entity.tags?.map(mapTag),
     people: entity.faces
       ?.map(mapFace)
-      .filter((person): person is PersonResponseDto => person !== null && !person.isHidden)
+      .filter((person): person is PersonResponseDto => person !== null)
       .reduce((people, person) => {
         const existingPerson = people.find((p) => p.id === person.id);
         if (!existingPerson) {

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -19,8 +19,11 @@
     mdiImageOutline,
     mdiMapMarkerOutline,
     mdiInformationOutline,
+    mdiEye,
+    mdiEyeOff,
   } from '@mdi/js';
   import Icon from '$lib/components/elements/icon.svelte';
+  import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import Map from '../shared-components/map/map.svelte';
   import { websocketStore } from '$lib/stores/websocket';
   import { AppRoute } from '$lib/constants';
@@ -56,6 +59,7 @@
   })();
 
   $: people = asset.people || [];
+  $: showingHiddenPeople = false;
 
   const unsubscribe = websocketStore.onAssetUpdate.subscribe((assetUpdate) => {
     if (assetUpdate && assetUpdate.id === asset.id) {
@@ -176,25 +180,38 @@
 
   {#if !api.isSharedLink && people.length > 0}
     <section class="px-4 py-4 text-sm">
-      <h2>PEOPLE</h2>
+      <div class="flex w-full items-center justify-between">
+        <h2>PEOPLE</h2>
+        <div class={people.reduce((acc, p) => acc || p.isHidden, false) ? '' : 'hidden'}>
+          <CircleIconButton
+            title="Show hidden people"
+            icon={showingHiddenPeople ? mdiEyeOff : mdiEye}
+            padding="0"
+            on:click={() => (showingHiddenPeople = !showingHiddenPeople)}
+          />
+        </div>
+      </div>
 
       <div class="mt-4 flex flex-wrap gap-2">
         {#each people as person (person.id)}
           <a
             href="/people/{person.id}?previousRoute={albumId ? `${AppRoute.ALBUMS}/${albumId}` : AppRoute.PHOTOS}"
-            class="w-[90px]"
+            class="w-[90px] {!showingHiddenPeople && person.isHidden ? 'hidden' : ''}"
             on:click={() => dispatch('close-viewer')}
           >
-            <ImageThumbnail
-              curve
-              shadow
-              url={api.getPeopleThumbnailUrl(person.id)}
-              altText={person.name}
-              title={person.name}
-              widthStyle="90px"
-              heightStyle="90px"
-              thumbhash={null}
-            />
+            <div class="relative">
+              <ImageThumbnail
+                curve
+                shadow
+                url={api.getPeopleThumbnailUrl(person.id)}
+                altText={person.name}
+                title={person.name}
+                widthStyle="90px"
+                heightStyle="90px"
+                thumbhash={null}
+                hidden={person.isHidden}
+              />
+            </div>
             <p class="mt-1 truncate font-medium" title={person.name}>{person.name}</p>
             {#if person.birthDate}
               {@const personBirthDate = DateTime.fromISO(person.birthDate)}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -180,19 +180,19 @@
 
   {#if !api.isSharedLink && people.length > 0}
     <section class="px-4 py-4 text-sm">
-      <div class="flex w-full items-center justify-between">
+      <div class="flex h-10 w-full items-center justify-between">
         <h2>PEOPLE</h2>
-        <div class={people.reduce((acc, p) => acc || p.isHidden, false) ? '' : 'hidden'}>
+        {#if people.some((person) => person.isHidden)}
           <CircleIconButton
             title="Show hidden people"
             icon={showingHiddenPeople ? mdiEyeOff : mdiEye}
-            padding="0"
+            padding="1"
             on:click={() => (showingHiddenPeople = !showingHiddenPeople)}
           />
-        </div>
+        {/if}
       </div>
 
-      <div class="mt-4 flex flex-wrap gap-2">
+      <div class="mt-2 flex flex-wrap gap-2">
         {#each people as person (person.id)}
           <a
             href="/people/{person.id}?previousRoute={albumId ? `${AppRoute.ALBUMS}/${albumId}` : AppRoute.PHOTOS}"


### PR DESCRIPTION
This makes it possible to easily find people/faces that have accidentally been hidden. Unhiding them still requires clicking on the person to go to their page to unhide them.

 

This adds the show/hide button to the people section header if the photo has hidden people
![image](https://github.com/immich-app/immich/assets/6151791/6c26d807-46a5-44c8-92fc-dc5ff16ffc13)

And clicking the button shows the hidden people
![image](https://github.com/immich-app/immich/assets/6151791/e3c8262a-a73f-4b50-8ac1-088001b37b34)

And the view for when there are no hidden people remains unchanged, with no toggle button.
![image](https://github.com/immich-app/immich/assets/6151791/79e9cc0f-9ec9-43c4-829e-740f5c009796)
