### PR TITLE
chore(docs): update docs to use docker compose

### DIFF
--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -144,7 +144,7 @@ PUBLIC_LOGIN_PAGE_MESSAGE="My Family Photos and Videos Backup Server"
 From the directory you created in Step 1, (which should now contain your customized `docker-compose.yml` and `.env` files) run `docker-compose up -d`.
 
 ```bash title="Start the containers using docker compose command"
-docker-compose up -d     # or `docker compose up -d` based on your docker-compose version
+docker compose up -d
 ```
 
 :::tip
@@ -162,7 +162,7 @@ If `IMMICH_VERSION` is set, it will need to be updated to the latest or desired 
 When a new version of Immich is [released](https://github.com/immich-app/immich/releases), the application can be upgraded with the following commands, run in the directory with the `docker-compose.yml` file:
 
 ```bash title="Upgrade Immich"
-docker-compose pull && docker-compose up -d     # Or `docker compose up -d`
+docker compose pull && docker compose up -d
 ```
 
 :::caution Automatic Updates


### PR DESCRIPTION
I think `docker-compose` isn't being supported anymore or at least it seems to not support some features.