### PR TITLE
fix(server): video orientation

### DIFF
--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -33,7 +33,7 @@ import {
   WithProperty,
   WithoutProperty,
 } from '../repositories';
-import { MetadataService } from './metadata.service';
+import { MetadataService, Orientation } from './metadata.service';
 
 describe(MetadataService.name, () => {
   let albumMock: jest.Mocked<IAlbumRepository>;
@@ -302,7 +302,9 @@ describe(MetadataService.name, () => {
       await sut.handleMetadataExtraction({ id: assetStub.video.id });
 
       expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.video.id]);
-      expect(assetMock.upsertExif).toHaveBeenCalledWith(expect.objectContaining({ orientation: '8' }));
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({ orientation: Orientation.Rotate270CW }),
+      );
     });
 
     it('should apply motion photos', async () => {

--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -5,11 +5,13 @@ import {
   newAssetRepositoryMock,
   newCryptoRepositoryMock,
   newJobRepositoryMock,
+  newMediaRepositoryMock,
   newMetadataRepositoryMock,
   newMoveRepositoryMock,
   newPersonRepositoryMock,
   newStorageRepositoryMock,
   newSystemConfigRepositoryMock,
+  probeStub,
 } from '@test';
 import { randomBytes } from 'crypto';
 import { Stats } from 'fs';
@@ -21,6 +23,7 @@ import {
   IAssetRepository,
   ICryptoRepository,
   IJobRepository,
+  IMediaRepository,
   IMetadataRepository,
   IMoveRepository,
   IPersonRepository,
@@ -40,6 +43,7 @@ describe(MetadataService.name, () => {
   let jobMock: jest.Mocked<IJobRepository>;
   let metadataMock: jest.Mocked<IMetadataRepository>;
   let moveMock: jest.Mocked<IMoveRepository>;
+  let mediaMock: jest.Mocked<IMediaRepository>;
   let personMock: jest.Mocked<IPersonRepository>;
   let storageMock: jest.Mocked<IStorageRepository>;
   let sut: MetadataService;
@@ -54,6 +58,7 @@ describe(MetadataService.name, () => {
     moveMock = newMoveRepositoryMock();
     personMock = newPersonRepositoryMock();
     storageMock = newStorageRepositoryMock();
+    mediaMock = newMediaRepositoryMock();
 
     sut = new MetadataService(
       albumMock,
@@ -63,6 +68,7 @@ describe(MetadataService.name, () => {
       metadataMock,
       storageMock,
       configMock,
+      mediaMock,
       moveMock,
       personMock,
     );
@@ -277,6 +283,7 @@ describe(MetadataService.name, () => {
 
     it('should not apply motion photos if asset is video', async () => {
       assetMock.getByIds.mockResolvedValue([{ ...assetStub.livePhotoMotionAsset, isVisible: true }]);
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
 
       await sut.handleMetadataExtraction({ id: assetStub.livePhotoMotionAsset.id });
       expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.livePhotoMotionAsset.id]);
@@ -285,6 +292,17 @@ describe(MetadataService.name, () => {
       expect(assetMock.save).not.toHaveBeenCalledWith(
         expect.objectContaining({ assetType: AssetType.VIDEO, isVisible: false }),
       );
+    });
+
+    it('should extract the correct video orientation', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamVertical2160p);
+      metadataMock.readTags.mockResolvedValue(null);
+
+      await sut.handleMetadataExtraction({ id: assetStub.video.id });
+
+      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.video.id]);
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(expect.objectContaining({ orientation: '8' }));
     });
 
     it('should apply motion photos', async () => {

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -50,6 +50,17 @@ interface DirectoryEntry {
   Item: DirectoryItem;
 }
 
+export enum Orientation {
+  Horizontal = '1',
+  MirrorHorizontal = '2',
+  Rotate180 = '3',
+  MirrorVertical = '4',
+  MirrorHorizontalRotate270CW = '5',
+  Rotate90CW = '6',
+  MirrorHorizontalRotate90CW = '7',
+  Rotate270CW = '8',
+}
+
 type ExifEntityWithoutGeocodeAndTypeOrm = Omit<
   ExifEntity,
   'city' | 'state' | 'country' | 'description' | 'exifTextSearchableColumn'
@@ -190,16 +201,16 @@ export class MetadataService {
       if (videoStreams[0]) {
         switch (videoStreams[0].rotation) {
           case -90:
-            exifData.orientation = '6';
-            break;
-          case 90:
-            exifData.orientation = '8';
-            break;
-          case 180:
-            exifData.orientation = '3';
+            exifData.orientation = Orientation.Rotate90CW;
             break;
           case 0:
-            exifData.orientation = '1';
+            exifData.orientation = Orientation.Horizontal;
+            break;
+          case 90:
+            exifData.orientation = Orientation.Rotate270CW;
+            break;
+          case 180:
+            exifData.orientation = Orientation.Rotate180;
             break;
         }
       }


### PR DESCRIPTION
## Changes made in this PR

With this PR, video rotation metadata is extracted with ffprobe using the first video stream. It fixes incorrect ratios for vertical videos on the asset grid. With ffprobe, rotation metadata is saved as a number corresponding to an angle in degrees. This PR translates the angle into exiftool rotation values:

```
1 = Horizontal (normal)
2 = Mirror horizontal
3 = Rotate 180
4 = Mirror vertical
5 = Mirror horizontal and rotate 270 CW
6 = Rotate 90 CW
7 = Mirror horizontal and rotate 90 CW
8 = Rotate 270 CW
```

## Screenshots

The asset is a vertical video, taken with an iphone : 

![Screenshot from 2023-12-02 21-28-46](https://github.com/immich-app/immich/assets/74269598/2f648a8f-8893-4a18-9a50-aebc2b433ae1)


| Before | After |
| :---: | :---: |
|![Screenshot from 2023-12-02 21-06-03](https://github.com/immich-app/immich/assets/74269598/85a03594-8ff7-44a8-b9a7-4f3ff259ca0c) | ![Screenshot from 2023-12-02 21-06-19](https://github.com/immich-app/immich/assets/74269598/463fecca-bbdd-41ad-a670-0e5b2ce490ee) |


