### PR TITLE
fix(server): Return correct asset count in album

### DIFF
--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -76,7 +76,7 @@ export class AlbumRepository implements IAlbumRepository {
       .select('album.id')
       .addSelect('MIN(assets.fileCreatedAt)', 'start_date')
       .addSelect('MAX(assets.fileCreatedAt)', 'end_date')
-      .addSelect('COUNT(album_assets.assetsId)', 'asset_count')
+      .addSelect('COUNT(assets.id)', 'asset_count')
       .leftJoin('albums_assets_assets', 'album_assets', 'album_assets.albumsId = album.id')
       .leftJoin('assets', 'assets', 'assets.id = album_assets.assetsId')
       .where('album.id IN (:...ids)', { ids })

--- a/server/src/infra/sql/album.repository.sql
+++ b/server/src/infra/sql/album.repository.sql
@@ -207,7 +207,7 @@ SELECT
   "album"."id" AS "album_id",
   MIN("assets"."fileCreatedAt") AS "start_date",
   MAX("assets"."fileCreatedAt") AS "end_date",
-  COUNT("album_assets"."assetsId") AS "asset_count"
+  COUNT("assets"."id") AS "asset_count"
 FROM
   "albums" "album"
   LEFT JOIN "albums_assets_assets" "album_assets" ON "album_assets"."albumsId" = "album"."id"


### PR DESCRIPTION
Fixes deleted assets which are part of an album to be counted toward album asset count.

This is a small but important fix: [Mobile checks if album metadata's asset count matches the actual asset count](https://github.com/immich-app/immich/blob/6d3421a505a9f75795773c3d9f0977ca42b5f3a4/mobile/lib/shared/services/sync.service.dart#L394). Even if an asset is deleted, it is still stored as part of an album, and the album metadata's asset count included these assets. The actual asset count and the metadata's asset count did not match anymore. Hence, the album did not get listed in mobile version (contrary to the web version).

Might fix https://github.com/immich-app/immich/issues/3179 for some cases (this was the case for me at least)