### PR TITLE
fix(web): keep url query parameters when swapping people

### DIFF
--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -18,6 +18,7 @@
   import { cloneDeep } from 'lodash-es';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { searchNameLocal } from '$lib/utils/person';
+  import { page } from '$app/stores';
 
   export let person: PersonResponseDto;
   let people: PersonResponseDto[] = [];
@@ -78,7 +79,8 @@
 
   const handleSwapPeople = () => {
     [person, selectedPeople[0]] = [selectedPeople[0], person];
-    goto(`${AppRoute.PEOPLE}/${person.id}?action=merge`);
+    $page.url.searchParams.set('action', 'merge');
+    goto(`${AppRoute.PEOPLE}/${person.id}?${$page.url.searchParams.toString()}`);
   };
 
   const onSelect = (selected: PersonResponseDto) => {


### PR DESCRIPTION
## Changes made in this PR

With this PR, when swapping people on the merge modal, the query parameters are kept.
Fixes https://github.com/immich-app/immich/issues/5463#issuecomment-1837454890