### PR TITLE
fix(server): send upload_success notification only for non hidden assets

### DIFF
--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -223,7 +223,9 @@ export class JobService {
         }
 
         const [asset] = await this.assetRepository.getByIds([item.data.id]);
-        if (asset) {
+
+        // Only live-photo motion part will be marked as not visible immediately on upload. Skip notifying clients
+        if (asset && asset.isVisible) {
           this.communicationRepository.send(CommunicationEvent.UPLOAD_SUCCESS, asset.ownerId, mapAsset(asset));
         }
       }


### PR DESCRIPTION
#### Change made in the PR

- `UPLOAD_SUCCESS` event is only send to assets that are not hidden. 

Fixes the issue where the live part of a live photo is displayed as a separate asset in the mobile app