### PR TITLE
fix(mobile): clear album provider on logout

### DIFF
--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -375,6 +375,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       await _getBackupAlbumsInfo();
       await updateServerInfo();
       await _updateBackupAssetCount();
+    } else {
+      log.warning("cannot get backup info - background backup is in progress!");
     }
   }
 

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_udid/flutter_udid.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/modules/album/providers/album.provider.dart';
+import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/shared/models/user.dart';
@@ -21,6 +23,7 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
   AuthenticationNotifier(
     this._apiService,
     this._db,
+    this._ref,
   ) : super(
           AuthenticationState(
             deviceId: "",
@@ -36,6 +39,8 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
 
   final ApiService _apiService;
   final Isar _db;
+  final StateNotifierProviderRef<AuthenticationNotifier, AuthenticationState>
+      _ref;
   final _log = Logger("AuthenticationNotifier");
 
   Future<bool> login(
@@ -111,6 +116,8 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         Store.delete(StoreKey.currentUser),
         Store.delete(StoreKey.accessToken),
       ]);
+      _ref.invalidate(albumProvider);
+      _ref.invalidate(sharedAlbumProvider);
 
       state = state.copyWith(
         deviceId: "",
@@ -222,5 +229,6 @@ final authenticationProvider =
   return AuthenticationNotifier(
     ref.watch(apiServiceProvider),
     ref.watch(dbProvider),
+    ref,
   );
 });

--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -401,6 +401,10 @@ class SyncService {
 
       final Album a = await Album.remote(dto);
       await _db.writeTxn(() => _db.albums.store(a));
+    } else {
+      _log.warning(
+          "Failed to add album from server: assetCount ${dto.assetCount} != "
+          "asset array length ${dto.assets.length} for album ${dto.albumName}");
     }
   }
 


### PR DESCRIPTION
it seems `autoDispose` on the album providers is not enough as we keep a reference somewhere even during logout; thus this PR manually invalidates the album providers so that a newly logged in user does not see the old user's albums.