### PR TITLE
fix(mobile): use zoomedpagetransition for galleryvieweroute

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -795,6 +795,7 @@ class GalleryViewerPage extends HookConsumerWidget {
                       tag: isFromDto
                           ? '${a.remoteId}-$heroOffset'
                           : a.id + heroOffset,
+                      transitionOnUserGestures: true,
                     ),
                     filterQuality: FilterQuality.high,
                     tightMode: true,

--- a/mobile/lib/modules/search/services/person.service.g.dart
+++ b/mobile/lib/modules/search/services/person.service.g.dart
@@ -6,7 +6,7 @@ part of 'person.service.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$personServiceHash() => r'3fc3dcf4603c7b55c0deae65f39f6c212eea492b';
+String _$personServiceHash() => r'cde0a9c029d16ddde2adcd58ae8c863bf8cc1fed';
 
 /// See also [personService].
 @ProviderFor(personService)

--- a/mobile/lib/modules/settings/providers/app_settings.provider.g.dart
+++ b/mobile/lib/modules/settings/providers/app_settings.provider.g.dart
@@ -7,7 +7,7 @@ part of 'app_settings.provider.dart';
 // **************************************************************************
 
 String _$appSettingsServiceHash() =>
-    r'957a65af6967701112f3076b507f9738fec4b7be';
+    r'45ea609a91d250290431a7a08a14d16b37c7515d';
 
 /// See also [appSettingsService].
 @ProviderFor(appSettingsService)

--- a/mobile/lib/routing/custom_transition_builders.dart
+++ b/mobile/lib/routing/custom_transition_builders.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class CustomTransitionsBuilders {
+  const CustomTransitionsBuilders._();
+
+  static const ZoomPageTransitionsBuilder zoomPageTransitionsBuilder =
+      ZoomPageTransitionsBuilder();
+
+  static const RouteTransitionsBuilder zoomedPage = _zoomedPage;
+
+  static Widget _zoomedPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return zoomPageTransitionsBuilder.buildTransitions(
+      // Empty PageRoute<> object, only used to pass allowSnapshotting to ZoomPageTransitionsBuilder
+      PageRouteBuilder(
+        allowSnapshotting: true,
+        fullscreenDialog: false,
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            const SizedBox.shrink(),
+      ),
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
+  }
+}

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -43,6 +43,7 @@ import 'package:immich_mobile/modules/search/views/search_page.dart';
 import 'package:immich_mobile/modules/search/views/search_result_page.dart';
 import 'package:immich_mobile/modules/settings/views/settings_page.dart';
 import 'package:immich_mobile/routing/auth_guard.dart';
+import 'package:immich_mobile/routing/custom_transition_builders.dart';
 import 'package:immich_mobile/routing/duplicate_guard.dart';
 import 'package:immich_mobile/routing/backup_permission_guard.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
@@ -86,9 +87,10 @@ part 'router.gr.dart';
       ],
       transitionsBuilder: TransitionsBuilders.fadeIn,
     ),
-    AutoRoute(
+    CustomRoute(
       page: GalleryViewerPage,
       guards: [AuthGuard, DuplicateGuard],
+      transitionsBuilder: CustomTransitionsBuilders.zoomedPage,
     ),
     AutoRoute(page: VideoViewerPage, guards: [AuthGuard, DuplicateGuard]),
     AutoRoute(

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -63,7 +63,7 @@ class _$AppRouter extends RootStackRouter {
     },
     GalleryViewerRoute.name: (routeData) {
       final args = routeData.argsAs<GalleryViewerRouteArgs>();
-      return MaterialPageX<dynamic>(
+      return CustomPage<dynamic>(
         routeData: routeData,
         child: GalleryViewerPage(
           key: args.key,
@@ -75,6 +75,9 @@ class _$AppRouter extends RootStackRouter {
           isOwner: args.isOwner,
           sharedAlbumId: args.sharedAlbumId,
         ),
+        transitionsBuilder: CustomTransitionsBuilders.zoomedPage,
+        opaque: true,
+        barrierDismissible: false,
       );
     },
     VideoViewerRoute.name: (routeData) {

--- a/mobile/lib/shared/providers/api.provider.g.dart
+++ b/mobile/lib/shared/providers/api.provider.g.dart
@@ -6,7 +6,7 @@ part of 'api.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$apiServiceHash() => r'03cbd33147a7058d56175e532ac47e1aa4858c6d';
+String _$apiServiceHash() => r'5b8beddb448316bdae5e3963ff77601653715729';
 
 /// See also [apiService].
 @ProviderFor(apiService)

--- a/mobile/lib/utils/immich_app_theme.dart
+++ b/mobile/lib/utils/immich_app_theme.dart
@@ -20,7 +20,7 @@ final immichThemeProvider = StateProvider<ThemeMode>((ref) {
   }
 });
 
-ThemeData base = ThemeData(
+final ThemeData base = ThemeData(
   chipTheme: const ChipThemeData(
     side: BorderSide.none,
   ),
@@ -30,7 +30,7 @@ ThemeData base = ThemeData(
   ),
 );
 
-ThemeData immichLightTheme = ThemeData(
+final ThemeData immichLightTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.light,
   primarySwatch: Colors.indigo,
@@ -153,7 +153,7 @@ ThemeData immichLightTheme = ThemeData(
   ),
 );
 
-ThemeData immichDarkTheme = ThemeData(
+final ThemeData immichDarkTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.dark,
   primarySwatch: Colors.indigo,


### PR DESCRIPTION
#### Changes made in the PR

- Overrides the default transition for the `GalleryViewerRoute` to use the same transition animation in Android and iOS devices. This fixes the issue where opening a thumbnail in iOS shows a `slideLeft` transition for the page, while the hero animation is still in progress resulting in a weird animation

#### Screen capture

| Before | After |
| :-: | :-: |
<video src="https://github.com/immich-app/immich/assets/139912620/b1115c4c-1a89-47e7-ad62-19aecd061e4e.mp4" /> | <video src="https://github.com/immich-app/immich/assets/139912620/51b2ab1d-1997-4a93-8ea2-2568a738a5f6.mp4" />