### PR TITLE
fix: notify mobile app when live photos are linked

### DIFF
--- a/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
@@ -68,46 +68,46 @@ class AlbumThumbnailListTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             ClipRRect(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: const BorderRadius.all(Radius.circular(8)),
               child: album.thumbnail.value == null
                   ? buildEmptyThumbnail()
                   : buildAlbumThumbnail(),
             ),
-            Padding(
-              padding: const EdgeInsets.only(
-                left: 8.0,
-                right: 8.0,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    album.name,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      album.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        album.assetCount == 1
-                            ? 'album_thumbnail_card_item'
-                            : 'album_thumbnail_card_items',
-                        style: const TextStyle(
-                          fontSize: 12,
-                        ),
-                      ).tr(args: ['${album.assetCount}']),
-                      if (album.shared)
-                        const Text(
-                          'album_thumbnail_card_shared',
-                          style: TextStyle(
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          album.assetCount == 1
+                              ? 'album_thumbnail_card_item'
+                              : 'album_thumbnail_card_items',
+                          style: const TextStyle(
                             fontSize: 12,
                           ),
-                        ).tr(),
-                    ],
-                  ),
-                ],
+                        ).tr(args: ['${album.assetCount}']),
+                        if (album.shared)
+                          const Text(
+                            'album_thumbnail_card_shared',
+                            style: TextStyle(
+                              fontSize: 12,
+                            ),
+                          ).tr(),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -188,15 +188,6 @@ export class JobService {
         break;
 
       case JobName.LINK_LIVE_PHOTOS:
-        // Notify clients to hide the linked live photo asset
-        const [asset] = await this.assetRepository.getByIds([item.data.id]);
-        if (asset) {
-          const motionId = asset.type == AssetType.VIDEO && !asset.isVisible ? asset.id : asset.livePhotoVideoId;
-          if (motionId) {
-            this.communicationRepository.send(CommunicationEvent.ASSET_HIDDEN, asset.ownerId, motionId);
-          }
-        }
-
         await this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: item.data });
         break;
 

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -188,6 +188,15 @@ export class JobService {
         break;
 
       case JobName.LINK_LIVE_PHOTOS:
+        // Notify clients to hide the linked live photo asset
+        const [asset] = await this.assetRepository.getByIds([item.data.id]);
+        if (asset) {
+          const motionId = asset.type == AssetType.VIDEO && !asset.isVisible ? asset.id : asset.livePhotoVideoId;
+          if (motionId) {
+            this.communicationRepository.send(CommunicationEvent.ASSET_HIDDEN, asset.ownerId, motionId);
+          }
+        }
+
         await this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: item.data });
         break;
 

--- a/server/src/domain/repositories/communication.repository.ts
+++ b/server/src/domain/repositories/communication.repository.ts
@@ -5,6 +5,7 @@ export enum CommunicationEvent {
   ASSET_DELETE = 'on_asset_delete',
   ASSET_TRASH = 'on_asset_trash',
   ASSET_UPDATE = 'on_asset_update',
+  ASSET_HIDDEN = 'on_asset_hidden',
   ASSET_RESTORE = 'on_asset_restore',
   PERSON_THUMBNAIL = 'on_person_thumbnail',
   SERVER_VERSION = 'on_server_version',


### PR DESCRIPTION
#### Changes made in the PR:

- A new event `on_asset_hidden` is added to notify the clients when an asset is hidden in the server
- The new end point is used to notify the clients when motion part of a live photo is hidden so that the clients in turn can handle them
- The `on_asset_hidden` event is handled in the mobile app by removing the asset from the local db
- The websocket pending changes code is also refactored. A new ID field is added to each pending change and processed changes are removed based on the ID instead of removing them based on the type which could result in cases where an event might be missed

- The changes in `album_thumbnail_listtile.dart` is not related to this PR, but all it does is to wrap the children in an `Expanded` widget to prevent overflows in albums having large title 