### PR TITLE
Fix not awaiting `sendFile`

### DIFF
--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -336,14 +336,18 @@ export class AssetService {
 
     res.set('Cache-Control', 'private, max-age=86400, no-transform');
     res.header('Content-Type', mimeTypes.lookup(filepath));
-    res.sendFile(filepath, options, (error: Error) => {
-      if (!error) {
-        return;
-      }
+    return new Promise((resolve, reject) => {
+      res.sendFile(filepath, options, (error: Error) => {
+        if (!error) {
+          resolve();
+          return;
+        }
 
-      if (error.message !== 'Request aborted') {
-        this.logger.error(`Unable to send file: ${error.name}`, error.stack);
-      }
+        if (error.message !== 'Request aborted') {
+          this.logger.error(`Unable to send file: ${error.name}`, error.stack);
+        }
+        reject(error);
+      });
     });
   }
 


### PR DESCRIPTION
resolves #4762 #4754 

This change fixes the intermittent EPIPE errors that myself and others are seeing.

By explicitly returning a promise we ensure the caller correctly waits until the `sendFile` is complete before potentially closing or cleaning the socket. This is the most likely bug that would cause EPIPE errors.

To confirm the fix, I manually edited the file in a running docker container. The EPIPE errors were especially noticeable on Firefox with videos and after this patch, they are completely gone.