### PR TITLE
chore(renovate): ignore openapi pubspec

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,9 @@
       "versioning": "node"
     }
   ],
+  "ignorePaths": [
+    "mobile/openapi/pubspec.yaml"
+  ],
   "ignoreDeps": [
     "http",
     "latlong2",


### PR DESCRIPTION
#### Changes made

- openapi `pubspec.yaml` file is a generated and the updates are handled by the generator. Renovate can ignore updates to the versions from this file.