### PR TITLE
fix(mobile): allow editing asset dates in the future

### DIFF
--- a/mobile/lib/shared/ui/date_time_picker.dart
+++ b/mobile/lib/shared/ui/date_time_picker.dart
@@ -86,11 +86,14 @@ class _DateTimePicker extends HookWidget {
     final timeZones = useMemoized(() => getAllTimeZones(), const []);
 
     void pickDate() async {
+      final now = DateTime.now();
+      // Handles cases where the date from the asset is far off in the future
+      final initialDate = date.value.isAfter(now) ? now : date.value;
       final newDate = await showDatePicker(
         context: context,
-        initialDate: date.value,
+        initialDate: initialDate,
         firstDate: DateTime(1800),
-        lastDate: DateTime.now(),
+        lastDate: now,
       );
       if (newDate == null) {
         return;


### PR DESCRIPTION
#### Changes made:

- Fixes the issue from https://github.com/immich-app/immich/pull/5461#issuecomment-1842695255

Previously, it was not possible to edit an asset which has the time set to a future time since we restrict the last date in the date picker to be the current day of the user and the framework prevents an `initialDate` which is older than the `lastDate`. The initialDate of the datePicker is now forced to be the current date if it a date in the future