### PR TITLE
style(web): use filled play and pause icons for video thumbnail

### DIFF
--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Duration } from 'luxon';
   import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
-  import { mdiAlertCircleOutline, mdiPauseCircleOutline, mdiPlayCircleOutline } from '@mdi/js';
+  import { mdiAlertCircle, mdiPauseCircle, mdiPlayCircle } from '@mdi/js';
   import Icon from '$lib/components/elements/icon.svelte';
 
   export let url: string;
@@ -10,8 +10,8 @@
   export let playbackOnIconHover = false;
   export let showTime = true;
   export let curve = false;
-  export let playIcon = mdiPlayCircleOutline;
-  export let pauseIcon = mdiPauseCircleOutline;
+  export let playIcon = mdiPlayCircle;
+  export let pauseIcon = mdiPauseCircle;
 
   let remainingSeconds = durationInSeconds;
   let loading = true;
@@ -54,7 +54,7 @@
       {#if loading}
         <LoadingSpinner />
       {:else if error}
-        <Icon path={mdiAlertCircleOutline} size="24" class="text-red-600" />
+        <Icon path={mdiAlertCircle} size="24" class="text-red-600" />
       {:else}
         <Icon path={pauseIcon} size="24" />
       {/if}


### PR DESCRIPTION
### Changes made

- Updates the video thumbnail indicators to use filled versions of the icons to be consistent with the mobile app and to have better visibility

| Before | After |
| :-: | :-: |
<img width="530" alt="image" src="https://github.com/immich-app/immich/assets/139912620/f96184f4-8fee-4a84-9500-5d1c3dcded8b"> | <img width="530" alt="image" src="https://github.com/immich-app/immich/assets/139912620/ceddd32d-2c01-4215-bb45-ad9034dd40c8">
