### PR TITLE
chore(server): faster shutdown

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -29,7 +29,7 @@ x-server-build: &server-common
 services:
   immich-server:
     container_name: immich_server
-    command: npm run start:debug immich
+    command: [ "/usr/src/app/bin/immich-dev", "immich" ]
     <<: *server-common
     ports:
       - 3001:3001
@@ -40,7 +40,7 @@ services:
 
   immich-microservices:
     container_name: immich_microservices
-    command: npm run start:debug microservices
+    command: [ "/usr/src/app/bin/immich-dev", "microservices" ]
     <<: *server-common
     # extends:
     #   file: hwaccel.yml

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -9,7 +9,8 @@ services:
       context: ../
       dockerfile: server/Dockerfile
       target: dev
-    command: npm run test:e2e
+    entrypoint: [ "/usr/local/bin/npm", "run" ]
+    command: test:e2e
     volumes:
       - ../server:/usr/src/app
       - /usr/src/app/node_modules

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,7 @@
 # dev build
 FROM ghcr.io/immich-app/base-server-dev:20231207@sha256:175d55f2fff48e0edeaf359c1aa0572b923db0c19304c22136a39061b8bc8179 as dev
 
+RUN apt-get install --no-install-recommends -yqq tini
 WORKDIR /usr/src/app
 COPY server/package.json server/package-lock.json ./
 RUN npm ci && \
@@ -9,6 +10,7 @@ RUN npm ci && \
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
 COPY server .
+ENTRYPOINT ["tini", "--", "/bin/sh"]
 
 
 FROM dev AS prod

--- a/server/bin/immich-dev
+++ b/server/bin/immich-dev
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+node /usr/src/app/node_modules/.bin/nest start --debug "0.0.0.0:9230" --watch -- "$@"


### PR DESCRIPTION
`npm run` doesn't handle signals from docker compose for container shutdown, and so it waits ten seconds before killing the container forcefully instead. This PR migrates to using `tini` and starting nest/node directly, which does respond correctly to signals. As a result, the shutdown time is significantly faster.

Before (~25 seconds):
![image](https://github.com/immich-app/immich/assets/4334196/8cb529ea-94ba-4f11-8eb7-10d1fb82eae9)

After (~6 seconds):
![image](https://github.com/immich-app/immich/assets/4334196/c32f4bba-5f7a-437d-ae9e-8bd30266517d)
