### PR TITLE
fix(mobile): memory lane not displayed in mobile app

### DIFF
--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/album/providers/album.provider.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
 import 'package:immich_mobile/modules/home/providers/multiselect.provider.dart';
+import 'package:immich_mobile/modules/memories/ui/memory_lane.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/server_info.provider.dart';
 import 'package:immich_mobile/shared/providers/user.provider.dart';
@@ -95,8 +96,12 @@ class HomePage extends HookConsumerWidget {
       }
     }
 
-    Widget buildBody() {
-      return MultiselectGrid(
+    return Scaffold(
+      appBar: ref.watch(multiselectProvider) ? null : const ImmichAppBar(),
+      body: MultiselectGrid(
+        topWidget: (currentUser != null && currentUser.memoryEnabled)
+            ? const MemoryLane()
+            : const SizedBox(),
         renderListProvider: timelineUsers.length > 1
             ? multiUserAssetsProvider(timelineUsers)
             : assetsProvider(currentUser?.isarId),
@@ -105,12 +110,7 @@ class HomePage extends HookConsumerWidget {
         stackEnabled: true,
         archiveEnabled: true,
         editEnabled: true,
-      );
-    }
-
-    return Scaffold(
-      appBar: ref.watch(multiselectProvider) ? null : const ImmichAppBar(),
-      body: buildBody(),
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixes #5586 

### Changes made in the PR

- Adds back the memory lane as the top widget in Photos page