### PR TITLE
Add tip showing common error messages

### DIFF
--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -138,6 +138,17 @@ docker compose up -d
 ```
 
 :::tip
+If you get an error ``unknown shorthand flag: 'd' in -d``, you are probably running the wrong Docker version. (This happens, for example, with the docker.io package in Ubuntu 22.04.3 LTS.) You can correct the problem by `apt remove`ing Ubuntu's docker.io package and installing docker and docker-compose via [Docker's official repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).
+
+Note that the correct command really is `docker compose`, not `docker-compose`. If you try the latter on vanilla Ubuntu 22.04 it will fail in a different way:
+```
+The Compose file './docker-compose.yml' is invalid because:
+'name' does not match any of the regexes: '^x-'
+```
+See the previous paragraph about installing from the official docker repository.
+:::
+
+:::tip
 For more information on how to use the application, please refer to the [Post Installation](/docs/install/post-install.mdx) guide.
 :::
 

--- a/docs/docs/install/docker-compose.md
+++ b/docs/docs/install/docker-compose.md
@@ -138,13 +138,15 @@ docker compose up -d
 ```
 
 :::tip
-If you get an error ``unknown shorthand flag: 'd' in -d``, you are probably running the wrong Docker version. (This happens, for example, with the docker.io package in Ubuntu 22.04.3 LTS.) You can correct the problem by `apt remove`ing Ubuntu's docker.io package and installing docker and docker-compose via [Docker's official repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).
+If you get an error `unknown shorthand flag: 'd' in -d`, you are probably running the wrong Docker version. (This happens, for example, with the docker.io package in Ubuntu 22.04.3 LTS.) You can correct the problem by `apt remove`ing Ubuntu's docker.io package and installing docker and docker-compose via [Docker's official repository](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository).
 
 Note that the correct command really is `docker compose`, not `docker-compose`. If you try the latter on vanilla Ubuntu 22.04 it will fail in a different way:
+
 ```
 The Compose file './docker-compose.yml' is invalid because:
 'name' does not match any of the regexes: '^x-'
 ```
+
 See the previous paragraph about installing from the official docker repository.
 :::
 


### PR DESCRIPTION
I encountered two errors trying to use Ubuntu-distributed docker. These tips make the error messages searchable, with a pointer to the solution (use docker's packages).