### PR TITLE
fix(server): connection aborted logging

### DIFF
--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -21,6 +21,8 @@ export type Options = {
   each?: boolean;
 };
 
+export const isConnectionAborted = (error: Error | any) => error.code === 'ECONNABORTED';
+
 export function ValidateUUID({ optional, each }: Options = { optional: false, each: false }) {
   return applyDecorators(
     IsUUID('4', { each }),

--- a/server/src/immich/interceptors/error.interceptor.ts
+++ b/server/src/immich/interceptors/error.interceptor.ts
@@ -8,6 +8,7 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { Observable, catchError, throwError } from 'rxjs';
+import { isConnectionAborted } from '../../domain';
 import { routeToErrorMessage } from '../app.utils';
 
 @Injectable()
@@ -20,7 +21,9 @@ export class ErrorInterceptor implements NestInterceptor {
         throwError(() => {
           if (error instanceof HttpException === false) {
             const errorMessage = routeToErrorMessage(context.getHandler().name);
-            this.logger.error(errorMessage, error, error?.errors);
+            if (!isConnectionAborted(error)) {
+              this.logger.error(errorMessage, error, error?.errors);
+            }
             return new InternalServerErrorException(errorMessage);
           } else {
             return error;


### PR DESCRIPTION
When the client terminates the connection one of two cases seem to happen server-side:
1. "connection aborted request" or 
2. Error write EPIPE

Error write EPIPE implies writing to a closed connection, which was already indicated via the connection aborted error. As far as I can tell, throwing an error in the service method, prevents nestjs from trying to write to the socket. That, combined with ignoring (not logging errors) for connection aborted requests seem to be the behavior we are looking for.