### PR TITLE
fix: handle livePhotos using originFileWithSubType

### DIFF
--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -382,6 +382,7 @@ class BackupService {
       } finally {
         if (Platform.isIOS) {
           file?.deleteSync();
+          livePhotoFile?.deleteSync();
         }
       }
     }

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -22,7 +21,6 @@ import 'package:openapi/api.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:cancellation_token_http/http.dart' as http;
-import 'package:path/path.dart' as p;
 
 final backupServiceProvider = Provider(
   (ref) => BackupService(
@@ -273,7 +271,6 @@ class BackupService {
           );
 
           file = await entity.loadFile(progressHandler: pmProgressHandler);
-          // TODO: verify if this is needed
           livePhotoFile = await entity.loadFile(
             withSubtype: true,
             progressHandler: pmProgressHandler,

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -327,7 +327,7 @@ class BackupService {
               );
               final fileStream = livePhotoFile.openRead();
               final livePhotoRawUploadData = http.MultipartFile(
-                "assetData",
+                "livePhotoData",
                 fileStream,
                 livePhotoFile.lengthSync(),
                 filename: livePhotoTitle,

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -21,6 +21,7 @@ import 'package:openapi/api.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:cancellation_token_http/http.dart' as http;
+import 'package:path/path.dart' as p;
 
 final backupServiceProvider = Provider(
   (ref) => BackupService(

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -227,6 +227,7 @@ class BackupService {
     final String deviceId = Store.get(StoreKey.deviceId);
     final String savedEndpoint = Store.get(StoreKey.serverEndpoint);
     File? file;
+    File? livePhotoFile;
     bool anyErrors = false;
     final List<String> duplicatedAssetIds = [];
 
@@ -249,7 +250,8 @@ class BackupService {
 
     for (var entity in assetsToUpload) {
       try {
-        final isAvailableLocally = await entity.isLocallyAvailable();
+        final isAvailableLocally =
+            await entity.isLocallyAvailable(isOrigin: true);
 
         // Handle getting files from iCloud
         if (!isAvailableLocally && Platform.isIOS) {
@@ -271,11 +273,20 @@ class BackupService {
           );
 
           file = await entity.loadFile(progressHandler: pmProgressHandler);
+          // TODO: verify if this is needed
+          livePhotoFile = await entity.loadFile(
+            withSubtype: true,
+            progressHandler: pmProgressHandler,
+          );
         } else {
           if (entity.type == AssetType.video) {
             file = await entity.originFile;
           } else {
             file = await entity.originFile.timeout(const Duration(seconds: 5));
+            if (entity.isLivePhoto) {
+              livePhotoFile = await entity.originFileWithSubtype
+                  .timeout(const Duration(seconds: 5));
+            }
           }
         }
 
@@ -380,18 +391,14 @@ class BackupService {
     return !anyErrors;
   }
 
-  Future<MultipartFile?> _getLivePhotoFile(AssetEntity entity) async {
-    var motionFilePath = await entity.getMediaUrl();
-
-    if (motionFilePath != null) {
-      var validPath = motionFilePath.replaceAll('file://', '');
-      var motionFile = File(validPath);
-      var fileStream = motionFile.openRead();
-      String fileName = p.basename(motionFile.path);
+  Future<MultipartFile?> _getLivePhotoMultiPart(File? livePhotoFile) async {
+    if (livePhotoFile != null) {
+      var fileStream = livePhotoFile.openRead();
+      String fileName = p.basename(livePhotoFile.path);
       return http.MultipartFile(
         "livePhotoData",
         fileStream,
-        motionFile.lengthSync(),
+        livePhotoFile.lengthSync(),
         filename: fileName,
       );
     }


### PR DESCRIPTION
####  Changes made:

- Live photo video assets are fetched using `originFileWithSubtype`
- `isLocallyAvailable` now checks for the existence of the `originFile`