### PR TITLE
fix(mobile): live / motion photo download

### DIFF
--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -21,7 +21,7 @@ class ImageViewerService {
   Future<bool> downloadAssetToDevice(Asset asset) async {
     try {
       // Download LivePhotos image and motion part
-      if (asset.isImage && asset.livePhotoVideoId != null) {
+      if (asset.isImage && asset.livePhotoVideoId != null && Platform.isIOS) {
         var imageResponse = await _apiService.assetApi.downloadFileWithHttpInfo(
           asset.remoteId!,
         );

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -19,6 +19,8 @@ class ImageViewerService {
   ImageViewerService(this._apiService);
 
   Future<bool> downloadAssetToDevice(Asset asset) async {
+    File? imageFile;
+    File? videoFile;
     try {
       // Download LivePhotos image and motion part
       if (asset.isImage && asset.livePhotoVideoId != null && Platform.isIOS) {
@@ -40,11 +42,11 @@ class ImageViewerService {
           return false;
         }
 
-        final AssetEntity? entity;
+        AssetEntity? entity;
 
         final tempDir = await getTemporaryDirectory();
-        File videoFile = await File('${tempDir.path}/livephoto.mov').create();
-        File imageFile = await File('${tempDir.path}/livephoto.heic').create();
+        videoFile = await File('${tempDir.path}/livephoto.mov').create();
+        imageFile = await File('${tempDir.path}/livephoto.heic').create();
         videoFile.writeAsBytesSync(motionReponse.bodyBytes);
         imageFile.writeAsBytesSync(imageResponse.bodyBytes);
 
@@ -53,6 +55,17 @@ class ImageViewerService {
           videoFile: videoFile,
           title: asset.fileName,
         );
+
+        if (entity == null) {
+          _log.warning(
+            "Asset cannot be saved as a live photo. This is most likely a motion photo. Saving only the image file",
+          );
+
+          entity = await PhotoManager.editor.saveImage(
+            imageResponse.bodyBytes,
+            title: asset.fileName,
+          );
+        }
 
         return entity != null;
       } else {
@@ -75,17 +88,20 @@ class ImageViewerService {
           );
         } else {
           final tempDir = await getTemporaryDirectory();
-          File tempFile =
-              await File('${tempDir.path}/${asset.fileName}').create();
-          tempFile.writeAsBytesSync(res.bodyBytes);
+          videoFile = await File('${tempDir.path}/${asset.fileName}').create();
+          videoFile.writeAsBytesSync(res.bodyBytes);
           entity = await PhotoManager.editor
-              .saveVideo(tempFile, title: asset.fileName);
+              .saveVideo(videoFile, title: asset.fileName);
         }
         return entity != null;
       }
     } catch (error, stack) {
       _log.severe("Error saving file ${error.toString()}", error, stack);
       return false;
+    } finally {
+      // Clear temp files
+      imageFile?.delete();
+      videoFile?.delete();
     }
   }
 }

--- a/mobile/lib/modules/backup/background_service/background.service.dart
+++ b/mobile/lib/modules/backup/background_service/background.service.dart
@@ -453,7 +453,7 @@ class BackgroundService {
     );
 
     _cancellationToken = CancellationToken();
-    final pmProgressHandler = PMProgressHandler();
+    final pmProgressHandler = Platform.isIOS ? PMProgressHandler() : null;
 
     final bool ok = await backupService.backupAsset(
       toUpload,

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
@@ -447,9 +449,9 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       // Perform Backup
       state = state.copyWith(cancelToken: CancellationToken());
 
-      final pmProgressHandler = PMProgressHandler();
+      final pmProgressHandler = Platform.isIOS ? PMProgressHandler() : null;
 
-      pmProgressHandler.stream.listen((event) {
+      pmProgressHandler?.stream.listen((event) {
         final double progress = event.progress;
         state = state.copyWith(iCloudDownloadProgress: progress);
       });

--- a/mobile/lib/modules/backup/providers/manual_upload.provider.dart
+++ b/mobile/lib/modules/backup/providers/manual_upload.provider.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cancellation_token_http/http.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
@@ -208,7 +210,7 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
                 state.totalAssetsToUpload == 1;
         state =
             state.copyWith(showDetailedNotification: showDetailedNotification);
-        final pmProgressHandler = PMProgressHandler();
+        final pmProgressHandler = Platform.isIOS ? PMProgressHandler() : null;
 
         final bool ok = await ref.read(backupServiceProvider).backupAsset(
               allUploadAssets,

--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -206,7 +206,7 @@ class BackupService {
   Future<bool> backupAsset(
     Iterable<AssetEntity> assetList,
     http.CancellationToken cancelToken,
-    PMProgressHandler pmProgressHandler,
+    PMProgressHandler? pmProgressHandler,
     Function(String, String, bool) uploadSuccessCb,
     Function(int, int) uploadProgressCb,
     Function(CurrentUploadAsset) setCurrentUploadAssetCb,

--- a/mobile/lib/shared/ui/user_circle_avatar.dart
+++ b/mobile/lib/shared/ui/user_circle_avatar.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
 import 'package:immich_mobile/shared/ui/transparent_image.dart';
@@ -35,11 +34,10 @@ class UserCircleAvatar extends ConsumerWidget {
         color: isDarkTheme && user.avatarColor == AvatarColorEnum.primary
             ? Colors.black
             : Colors.white,
-        backgroundColor: user.avatarColor.toColor(),
       ),
     );
     return CircleAvatar(
-      backgroundColor: context.primaryColor,
+      backgroundColor: user.avatarColor.toColor(),
       radius: radius,
       child: user.profileImagePath.isEmpty
           ? textIcon


### PR DESCRIPTION
Fixes #3734
Fixes #3693

#### Changes made in the PR

- Reverts the changes from #5566 since it was a regression
- Initializing `PMProgressHandler` in non-iOS devices throws as error. So handled them appropriately.
- Download handling for live / motion photos is updated

This is the current state of download

|  Download type   |        ios           |     Android     |
| ----------------  | ------------- | ------------- |
| Live photo | Saved as live photo  | Fails |
| Motion photo  | Fails | Fails |

The following table summarizes how download behaves after the PR

|  Download type   |        ios           |     Android     |
| ----------------  | ------------- | ------------- |
| Live photo | Saved as live photo  | Saved as a photo |
| Motion photo  | Saved as a motion photo  | Saved as a motion photo |

> [!Note]
> On iOS, for assets with liveVideoId, we'll download both the motion and photo assets and the app will try to stitch them together. If it fails, It'll fall back to saving only the photo part which should also contain the video part for a motion photo