### PR TITLE
fix: missing environment variable for machine learning

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -126,16 +126,18 @@ Redis (Sentinel) URL example JSON before encoding:
 
 ## Machine Learning
 
-| Variable                                         | Description                                                       |       Default       | Services         |
-| :----------------------------------------------- | :---------------------------------------------------------------- | :-----------------: | :--------------- |
-| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0) |        `300`        | machine learning |
-| `MACHINE_LEARNING_MODEL_TTL_POLL_S`              | Interval (s) between checks for the model TTL (disabled if <= 0)  |        `10`         | machine learning |
-| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                             |      `/cache`       | machine learning |
-| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)        | number of CPU cores | machine learning |
-| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                               |         `1`         | machine learning |
-| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                        |         `2`         | machine learning |
-| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                               |         `1`         | machine learning |
-| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed    |        `120`        | machine learning |
+| Variable                                         | Description                                                       |                Default                | Services              |
+| :----------------------------------------------- | :---------------------------------------------------------------- | :-----------------------------------: | :-------------------- |
+| `IMMICH_MACHINE_LEARNING_ENABLED`                | Enable machine-learning                                           |                `true`                 | server, microservices |
+| `IMMICH_MACHINE_LEARNING_URL`                    | Machine-learning url                                              | `http://immich-machine-learning:3003` | server, microservices |
+| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if <= 0) |                 `300`                 | machine learning      |
+| `MACHINE_LEARNING_MODEL_TTL_POLL_S`              | Interval (s) between checks for the model TTL (disabled if <= 0)  |                 `10`                  | machine learning      |
+| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                             |               `/cache`                | machine learning      |
+| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if <= 0)        |          number of CPU cores          | machine learning      |
+| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                               |                  `1`                  | machine learning      |
+| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                        |                  `2`                  | machine learning      |
+| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                               |                  `1`                  | machine learning      |
+| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed    |                 `120`                 | machine learning      |
 
 \*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 


### PR DESCRIPTION
The docs does not mention the ability to edit  machine learning with environment variables.
Env added : `IMMICH_MACHINE_LEARNING_ENABLED` and `IMMICH_MACHINE_LEARNING_URL`