### PR TITLE
docs: update backup-and-restore.md

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -44,7 +44,6 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       SCHEDULE: "@daily"
-      BACKUP_NUM_KEEP: 7
       BACKUP_DIR: /db_dumps
     volumes:
       - ./db_dumps:/db_dumps


### PR DESCRIPTION
Removes `BACKUP_KEEP_NUM` option from docker-compose example for database dumping, since it no longer exists in the linked image. 

The image has sensible defaults for backups to keep (7 daily, 4 weekly, 6 monthly), so I haven't replaced the argument with an alternative.