### PR TITLE
fix: prevent loop on search

### DIFF
--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -76,6 +76,10 @@
       previousRoute = from.url.href;
     }
 
+    if (from?.route.id === '/(user)/people/[personId]') {
+      previousRoute = AppRoute.PHOTOS;
+    }
+
     if (from?.route.id === '/(user)/albums/[albumId]') {
       previousRoute = AppRoute.EXPLORE;
     }


### PR DESCRIPTION
## Changes made in this PR

This PR prevents an endless loop when navigation on search : If you search something, go to a person page and comes back on search, click on the back button brings you back to the person page

## Screenshots

| Before | After |
| :---:  | :---: |
|<video src="https://github.com/immich-app/immich/assets/74269598/54dc1d00-f13e-44c1-acde-978b734259a7"> | <video src="https://github.com/immich-app/immich/assets/74269598/4c22bbe2-6b17-4a7b-a2f2-33de1210f0cf">  |