### PR TITLE
fix(immich-admin): in dev mode

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,6 +10,7 @@ RUN npm ci && \
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
 COPY server .
+ENV PATH="${PATH}:/usr/src/app/bin"
 ENTRYPOINT ["tini", "--", "/bin/sh"]
 
 


### PR DESCRIPTION
This adds the `bin/` to the path _in dev_, which makes the `immich` and `immich-admin` commands available out of the box, similar to production.