### PR TITLE
fix(web): warning when building web

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=dev /usr/src/app/node_modules/@img ./node_modules/@img
 FROM node:iron-alpine3.18 as web
 
 WORKDIR /usr/src/app
-COPY web/package.json web/package-lock.json ./
+COPY web/package*.json web/svelte.config.js .
 RUN npm ci
 COPY web .
 RUN npm run build

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "format:fix": "prettier --write .",
     "test": "jest",
     "test:cov": "jest --coverage",
-    "test:watch": "npm test -- --watch"
+    "test:watch": "npm test -- --watch",
+    "prepare": "svelte-kit sync"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
Fixes the warning `[WARNING] Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]` when building the web app