### PR TITLE
docs: remove citiesFileOverride from config-file.md; fixes #5682

### DIFF
--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -91,8 +91,7 @@ The default configuration looks like this:
     "tileUrl": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
   },
   "reverseGeocoding": {
-    "enabled": true,
-    "citiesFileOverride": "cities500"
+    "enabled": true
   },
   "oauth": {
     "enabled": false,


### PR DESCRIPTION
as a result of PR #5301, the citiesFileOverride  variable is not used anymore.