### PR TITLE
feat(web): increase map max zoom

### DIFF
--- a/mobile/lib/modules/map/providers/map_state.provider.dart
+++ b/mobile/lib/modules/map/providers/map_state.provider.dart
@@ -44,7 +44,7 @@ class MapStateNotifier extends StateNotifier<MapState> {
       state.mapStyle != null && state.mapStyle!.rasterTileProvider != null;
 
   double get maxZoom =>
-      (isRaster ? state.mapStyle!.rasterTileProvider!.maximumZoom : 14)
+      (isRaster ? state.mapStyle!.rasterTileProvider!.maximumZoom : 18)
           .toDouble();
 
   void switchTheme(bool isDarkTheme) {

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -115,7 +115,7 @@
     attributionControl={false}
     diffStyleUpdates={true}
     let:map
-    on:load={(event) => event.detail.setMaxZoom(14)}
+    on:load={(event) => event.detail.setMaxZoom(18)}
     on:load={(event) => event.detail.on('click', handleMapClick)}
     bind:map
   >


### PR DESCRIPTION
This PR increases max zoom of the map, to be able see detail location and mainly set gps location to an asset precisely.

|before (14)|PR (18)|
|-|-|
|![obrazek](https://github.com/immich-app/immich/assets/15554561/da7735ed-72e3-4210-be9e-abdbdf253ee5)|![obrazek](https://github.com/immich-app/immich/assets/15554561/2684ab21-da71-4979-8aa1-d3bdfa4c9109)|