### PR TITLE
feat(web): lazy loading on album/sharing/search

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -14,6 +14,7 @@
   export let isSharingView = false;
   export let showItemCount = true;
   export let showContextMenu = true;
+  export let preload = false;
   let showVerticalDots = false;
 
   $: imageData = album.albumThumbnailAssetId
@@ -83,6 +84,7 @@
 
   <div class={`relative aspect-square`}>
     <img
+      loading={preload ? 'eager' : 'lazy'}
       src={imageData}
       alt={album.id}
       class={`z-0 h-full w-full rounded-3xl object-cover transition-all duration-300 hover:shadow-lg`}

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -289,9 +289,13 @@
     <!-- Album Card -->
     {#if $albumViewSettings.view === AlbumViewMode.Cover}
       <div class="grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))]">
-        {#each $albums as album (album.id)}
+        {#each $albums as album, idx (album.id)}
           <a data-sveltekit-preload-data="hover" href="{AppRoute.ALBUMS}/{album.id}" animate:flip={{ duration: 200 }}>
-            <AlbumCard {album} on:showalbumcontextmenu={(e) => showAlbumContextMenu(e.detail, album)} />
+            <AlbumCard
+              preload={idx < 20}
+              {album}
+              on:showalbumcontextmenu={(e) => showAlbumContextMenu(e.detail, album)}
+            />
           </a>
         {/each}
       </div>

--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -144,9 +144,15 @@
       <section>
         <div class="ml-6 text-4xl font-medium text-black/70 dark:text-white/80">ALBUMS</div>
         <div class="grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))]">
-          {#each albums as album (album.id)}
+          {#each albums as album, idx (album.id)}
             <a data-sveltekit-preload-data="hover" href={`albums/${album.id}`} animate:flip={{ duration: 200 }}>
-              <AlbumCard {album} isSharingView={false} showItemCount={false} showContextMenu={false} />
+              <AlbumCard
+                preload={idx < 20}
+                {album}
+                isSharingView={false}
+                showItemCount={false}
+                showContextMenu={false}
+              />
             </a>
           {/each}
         </div>

--- a/web/src/routes/(user)/sharing/+page.svelte
+++ b/web/src/routes/(user)/sharing/+page.svelte
@@ -94,9 +94,9 @@
       <div>
         <!-- Share Album List -->
         <div class="grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))]">
-          {#each data.sharedAlbums as album (album.id)}
+          {#each data.sharedAlbums as album, idx (album.id)}
             <a data-sveltekit-preload-data="hover" href={`albums/${album.id}`} animate:flip={{ duration: 200 }}>
-              <AlbumCard {album} isSharingView showContextMenu={false} />
+              <AlbumCard preload={idx < 20} {album} isSharingView showContextMenu={false} />
             </a>
           {/each}
         </div>


### PR DESCRIPTION
## Description
Page album, sharing, and search currently don't support image lazy loading.

Add lazy loading like Issue #5356 
## Changes
Add lazy loading on album, sharing, and search, since they're all using `AlbumCard`.

If there are more than **20** cards on the page, the first 20 cards load **eagerly**, and the following cards load **lazily**.