### PR TITLE
fix(server): disable classification by default

### DIFF
--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -159,6 +159,9 @@ describe(JobService.name, () => {
 
     it('should handle a start object tagging command', async () => {
       jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: false });
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
 
       await sut.handleCommand(QueueName.OBJECT_TAGGING, { command: JobCommand.START, force: false });
 

--- a/server/src/domain/server-info/server-info.service.spec.ts
+++ b/server/src/domain/server-info/server-info.service.spec.ts
@@ -171,7 +171,7 @@ describe(ServerInfoService.name, () => {
         passwordLogin: true,
         search: true,
         sidecar: true,
-        tagImage: true,
+        tagImage: false,
         configFile: false,
         trash: true,
       });

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -48,6 +48,12 @@ describe(SmartInfoService.name, () => {
   });
 
   describe('handleQueueObjectTagging', () => {
+    beforeEach(async () => {
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
+    });
+
     it('should do nothing if machine learning is disabled', async () => {
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.MACHINE_LEARNING_ENABLED, value: false }]);
 
@@ -58,6 +64,9 @@ describe(SmartInfoService.name, () => {
     });
 
     it('should queue the assets without tags', async () => {
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
       assetMock.getWithout.mockResolvedValue({
         items: [assetStub.image],
         hasNextPage: false,
@@ -70,6 +79,9 @@ describe(SmartInfoService.name, () => {
     });
 
     it('should queue all the assets', async () => {
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
       assetMock.getAll.mockResolvedValue({
         items: [assetStub.image],
         hasNextPage: false,
@@ -103,6 +115,9 @@ describe(SmartInfoService.name, () => {
     });
 
     it('should save the returned tags', async () => {
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
       machineMock.classifyImage.mockResolvedValue(['tag1', 'tag2', 'tag3']);
 
       await sut.handleClassifyImage({ id: asset.id });
@@ -121,6 +136,9 @@ describe(SmartInfoService.name, () => {
     });
 
     it('should always overwrite old tags', async () => {
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.MACHINE_LEARNING_CLASSIFICATION_ENABLED, value: true },
+      ]);
       machineMock.classifyImage.mockResolvedValue([]);
 
       await sut.handleClassifyImage({ id: asset.id });

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -67,7 +67,7 @@ export const defaults = Object.freeze<SystemConfig>({
     enabled: process.env.IMMICH_MACHINE_LEARNING_ENABLED !== 'false',
     url: process.env.IMMICH_MACHINE_LEARNING_URL || 'http://immich-machine-learning:3003',
     classification: {
-      enabled: true,
+      enabled: false,
       modelName: 'microsoft/resnet-50',
       minScore: 0.9,
     },

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -66,7 +66,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     enabled: true,
     url: 'http://immich-machine-learning:3003',
     classification: {
-      enabled: true,
+      enabled: false,
       modelName: 'microsoft/resnet-50',
       minScore: 0.9,
     },


### PR DESCRIPTION
## Description

There's been a recent uptick in issues relating to image tagging. When the image classification model is being exported, it can fail on ARM devices and crash the ML service along with it. As it restarts, it once again receives an object tagging request, and hence effectively gets stuck in a crash loop. Since we're moving away from using this model, it's better to keep it disabled by default to avoid this issue.

Fixes #4918
Fixes #5234
Fixes #5634
