### PR TITLE
feat(server,ml): add new models

### DIFF
--- a/server/src/domain/smart-info/smart-info.constant.ts
+++ b/server/src/domain/smart-info/smart-info.constant.ts
@@ -72,7 +72,16 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   'ViT-L-14-336__openai': {
     dimSize: 768,
   },
+  'ViT-L-14-quickgelu__dfn2b': {
+    dimSize: 768,
+  },
   'ViT-H-14__laion2b-s32b-b79k': {
+    dimSize: 1024,
+  },
+  'ViT-H-14-quickgelu__dfn5b': {
+    dimSize: 1024,
+  },
+  'ViT-H-14-378-quickgelu__dfn5b ': {
     dimSize: 1024,
   },
   'ViT-g-14__laion2b-s12b-b42k': {
@@ -89,6 +98,15 @@ export const CLIP_MODEL_INFO: Record<string, ModelInfo> = {
   },
   'XLM-Roberta-Large-Vit-L-14': {
     dimSize: 768,
+  },
+  'XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k': {
+    dimSize: 1024,
+  },
+  'nllb-clip-base-siglip__v1': {
+    dimSize: 768,
+  },
+  'nllb-clip-large-siglip__v1': {
+    dimSize: 1152,
   },
 };
 


### PR DESCRIPTION
## Description

The HF model catalog now includes a few new models:

English:

- `ViT-L-14-quickgelu__dfn2b`
- `ViT-H-14-quickgelu__dfn5b`
- `ViT-H-14-378-quickgelu__dfn5b`

Multilingual:

- `nllb-clip-base-siglip__v1`
- `XLM-Roberta-Large-ViT-H-14__frozen_laion5b_s13b_b90k`
- `nllb-clip-large-siglip__v1`

This PR adds them to the list of supported models so users can use them in the next release.