### PR TITLE
suggestion (mobile): Update the search behaviour in mobile

### DIFF
--- a/mobile/lib/modules/search/views/search_result_page.dart
+++ b/mobile/lib/modules/search/views/search_result_page.dart
@@ -84,8 +84,6 @@ class SearchResultPage extends HookConsumerWidget {
         focusNode: searchFocusNode,
         autofocus: false,
         onTap: () {
-          searchTermController.clear();
-          ref.watch(searchPageStateProvider.notifier).setSearchTerm("");
           searchFocusNode?.requestFocus();
         },
         textInputAction: TextInputAction.search,


### PR DESCRIPTION
**Current behaviour :**

- If the user is typing to search, let say 'Sunny Winter Day'. And then (s)he decided to make it 'Rainy Winter Day', so the way to do it could be double click on the 'Sunny' word to select it and then change it to 'Rainy', or maybe click after the 'Sunny' word so (s)he can use the keyboard to delete the word. **But** today implementation will give him/her a bad experience as the moment the text is clicked, it get all cleared and s(he) need to type again the search. 

**Suggested changes :** 

- Avoid having the text get deleted 