### PR TITLE
fix(server): stricter dim size check for pgvecto.rs migration

### DIFF
--- a/server/src/infra/migrations/1700713871511-UsePgVectors.ts
+++ b/server/src/infra/migrations/1700713871511-UsePgVectors.ts
@@ -31,7 +31,9 @@ export class UsePgVectors1700713871511 implements MigrationInterface {
         INSERT INTO smart_search("assetId", embedding)
         SELECT si."assetId", si."clipEmbedding"
         FROM smart_info si
-        WHERE "clipEmbedding" IS NOT NULL AND CARDINALITY("clipEmbedding"::real[]) = ${clipDimSize}`);
+        WHERE "clipEmbedding" IS NOT NULL
+        AND CARDINALITY("clipEmbedding"::real[]) = ${clipDimSize}
+        AND array_position(si."clipEmbedding", NULL) IS NULL`);
 
     await queryRunner.query(`ALTER TABLE smart_info DROP COLUMN IF EXISTS "clipEmbedding"`);
     }

--- a/server/src/infra/migrations/1700713871511-UsePgVectors.ts
+++ b/server/src/infra/migrations/1700713871511-UsePgVectors.ts
@@ -1,4 +1,6 @@
+import { getCLIPModelInfo } from '@app/domain/smart-info/smart-info.constant';
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { setTimeout } from 'timers/promises';
 
 export class UsePgVectors1700713871511 implements MigrationInterface {
   name = 'UsePgVectors1700713871511';
@@ -8,13 +10,11 @@ export class UsePgVectors1700713871511 implements MigrationInterface {
         SELECT CARDINALITY(embedding::real[]) as dimsize
         FROM asset_faces
         LIMIT 1`);
-    const clipDimQuery = await queryRunner.query(`
-        SELECT CARDINALITY("clipEmbedding"::real[]) as dimsize
-        FROM smart_info
-        LIMIT 1`);
-
     const faceDimSize = faceDimQuery?.[0]?.['dimsize'] ?? 512;
-    const clipDimSize = clipDimQuery?.[0]?.['dimsize'] ?? 512;
+
+    const clipModelNameQuery = await queryRunner.query(`SELECT value FROM system_config WHERE key = 'machineLearning.clip.modelName'`);
+    const clipModelName: string = clipModelNameQuery?.[0]?.['value'] ?? 'ViT-B-32__openai';
+    const clipDimSize = getCLIPModelInfo(clipModelName.replace(/"/g, '')).dimSize;
 
     await queryRunner.query('CREATE EXTENSION IF NOT EXISTS vectors');
 
@@ -32,7 +32,7 @@ export class UsePgVectors1700713871511 implements MigrationInterface {
         INSERT INTO smart_search("assetId", embedding)
         SELECT si."assetId", si."clipEmbedding"
         FROM smart_info si
-        WHERE "clipEmbedding" IS NOT NULL`);
+        WHERE "clipEmbedding" IS NOT NULL AND CARDINALITY("clipEmbedding"::real[]) = ${clipDimSize}`);
 
     await queryRunner.query(`ALTER TABLE smart_info DROP COLUMN IF EXISTS "clipEmbedding"`);
     }

--- a/server/src/infra/migrations/1700713871511-UsePgVectors.ts
+++ b/server/src/infra/migrations/1700713871511-UsePgVectors.ts
@@ -1,6 +1,5 @@
 import { getCLIPModelInfo } from '@app/domain/smart-info/smart-info.constant';
 import { MigrationInterface, QueryRunner } from 'typeorm';
-import { setTimeout } from 'timers/promises';
 
 export class UsePgVectors1700713871511 implements MigrationInterface {
   name = 'UsePgVectors1700713871511';


### PR DESCRIPTION
## Description

This PR changes the migration to now check the clip model being used and determine the dim size from that. It then filters to only migrate the embeddings that have this dim size.

The current implementation looks at the dim size of the embedding in the first row of the smart_info table, which can cause issues if the dim size is (for some reason) inconsistent across rows. It also checks for the presence of NULLs in the embeddings since there seem to be reports of this happening.

## How Has This Been Tested?

I created a 1.90.2 instance, changed the ML model to `XLM-Roberta-Large-Vit-L-14` (which has 768 dims rather than the default models' 512) and upgraded to 1.91 successfully.