### PR TITLE
fix(ml): disable core dumps

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -28,8 +28,7 @@ ENV NODE_ENV=production \
 # prevent core dumps
 RUN echo "hard core 0" >> /etc/security/limits.conf && \
     echo "fs.suid_dumpable 0" >> /etc/sysctl.conf && \
-    echo 'ulimit -S -c 0 > /dev/null 2>&1' >> /etc/profile && \
-    sysctl -p
+    echo 'ulimit -S -c 0 > /dev/null 2>&1' >> /etc/profile
 
 COPY --from=builder /opt/venv /opt/venv
 COPY start.sh log_conf.json ./

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -25,6 +25,12 @@ ENV NODE_ENV=production \
   PATH="/opt/venv/bin:$PATH" \
   PYTHONPATH=/usr/src
 
+# prevent core dumps
+RUN echo "hard core 0" >> /etc/security/limits.conf && \
+    echo "fs.suid_dumpable 0" >> /etc/sysctl.conf && \
+    echo 'ulimit -S -c 0 > /dev/null 2>&1' >> /etc/profile && \
+    sysctl -p
+
 COPY --from=builder /opt/venv /opt/venv
 COPY start.sh log_conf.json ./
 COPY app .


### PR DESCRIPTION
## Description

If the ML service gets stuck in a crashloop, it can produce a large number of core dumps that bloat the size of the container. This PR disables core dumps for immich-machine-learning. 

Fixes #5634


## How Has This Been Tested?

The ML service boots as normal with this change.