### PR TITLE
fix(docs): remove spurious hyphen in docker compose cmd

### DIFF
--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -55,7 +55,7 @@ Optionally, you can use the [`hwaccel.yml`][hw-file] file to enable hardware acc
 
 ### Step 3 - Start the containers
 
-From the directory you created in Step 1, (which should now contain your customized `docker-compose.yml` and `.env` files) run `docker-compose up -d`.
+From the directory you created in Step 1, (which should now contain your customized `docker-compose.yml` and `.env` files) run `docker compose up -d`.
 
 ```bash title="Start the containers using docker compose command"
 docker compose up -d


### PR DESCRIPTION
The command example is correct, but the text just before it still references the old docker-compose command.