### PR TITLE
fix(server): fix inconsistent explore queries

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -706,9 +706,7 @@ export class AssetRepository implements IAssetRepository {
       .createQueryBuilder('e')
       .select('city')
       .groupBy('city')
-      .having('count(city) >= :minAssetsPerField', { minAssetsPerField })
-      .orderBy('random()')
-      .limit(maxFields);
+      .having('count(city) >= :minAssetsPerField', { minAssetsPerField });
 
     const items = await this.getBuilder({
       userIds: [ownerId],
@@ -737,9 +735,7 @@ export class AssetRepository implements IAssetRepository {
       .createQueryBuilder('si')
       .select('unnest(tags)', 'tag')
       .groupBy('tag')
-      .having('count(*) >= :minAssetsPerField', { minAssetsPerField })
-      .orderBy('random()')
-      .limit(maxFields);
+      .having('count(*) >= :minAssetsPerField', { minAssetsPerField });
 
     const items = await this.getBuilder({
       userIds: [ownerId],

--- a/server/src/infra/sql/asset.repository.sql
+++ b/server/src/infra/sql/asset.repository.sql
@@ -618,10 +618,6 @@ WITH
       city
     HAVING
       count(city) >= $1
-    ORDER BY
-      random() ASC
-    LIMIT
-      12
   )
 SELECT DISTINCT
   ON (c.city) "asset"."id" AS "data",
@@ -653,10 +649,6 @@ WITH
       tag
     HAVING
       count(*) >= $1
-    ORDER BY
-      random() ASC
-    LIMIT
-      12
   )
 SELECT DISTINCT
   ON (unnest("si"."tags")) "asset"."id" AS "data",


### PR DESCRIPTION
## Description

The CTE in the explore queries has the limit set equal to `maxFields`, but it doesn't have the same `WHERE` conditions as the second part of the query. This means the number of rows returned can be less than requested if one or more of the CTE rows are entirely filtered out by the `WHERE` conditions.

This PR removes the limit to ensure the correct number of results. Since a join without a limit set already sorts the results, this PR also removes the sort by random as there's no point.