### PR TITLE
chore(mobile): handle delete file error

### DIFF
--- a/mobile/lib/modules/backup/services/backup.service.dart
+++ b/mobile/lib/modules/backup/services/backup.service.dart
@@ -394,8 +394,12 @@ class BackupService {
         continue;
       } finally {
         if (Platform.isIOS) {
-          file?.deleteSync();
-          livePhotoFile?.deleteSync();
+          try {
+            await file?.delete();
+            await livePhotoFile?.delete();
+          } catch (e) {
+            debugPrint("ERROR deleting file: ${e.toString()}");
+          }
         }
       }
     }


### PR DESCRIPTION
Some users are still having issues deleting files. Adding a try/catch clause to prevent the upload process from hanging