### PR TITLE
feat(cli): Add assets to album when detected as duplicates

### DIFF
--- a/cli/test/e2e/upload.e2e-spec.ts
+++ b/cli/test/e2e/upload.e2e-spec.ts
@@ -46,4 +46,20 @@ describe(`upload (e2e)`, () => {
     const natureAlbum = albums[0];
     expect(natureAlbum.albumName).toEqual('nature');
   });
+
+  it('should add existing assets to album', async () => {
+    await new Upload(CLI_BASE_OPTIONS).run([`${IMMICH_TEST_ASSET_PATH}/albums/nature/`], {
+      recursive: true,
+    });
+
+    await new Upload(CLI_BASE_OPTIONS).run([`${IMMICH_TEST_ASSET_PATH}/albums/nature/`], {
+      recursive: true,
+      album: true,
+    });
+
+    const albums = await api.albumApi.getAllAlbums(server, admin.accessToken);
+    expect(albums.length).toEqual(1);
+    const natureAlbum = albums[0];
+    expect(natureAlbum.albumName).toEqual('nature');
+  });
 });


### PR DESCRIPTION
When upload is skipped because of a duplicate asset, allow the asset to be added to the album. 

The solution proposed in PR #5838 disable the hash check before upload. We should keep it and use the response from `checkBulkUpload` to determine the assetId to add to the album. 

This is fixing https://github.com/immich-app/immich/issues/5776

