### PR TITLE
feat(web): bigger dialog box of location change

### DIFF
--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -41,12 +41,13 @@
   confirmColor="primary"
   cancelColor="secondary"
   title="Change Location"
+  width={800}
   on:confirm={handleConfirm}
   on:cancel={handleCancel}
 >
   <div slot="prompt" class="flex flex-col w-full h-full gap-2">
     <label for="datetime">Pick a location</label>
-    <div class="h-[350px] min-h-[300px] w-full">
+    <div class="h-[500px] min-h-[300px] w-full">
       <Map
         mapMarkers={lat && lng && asset ? [{ id: asset.id, lat, lon: lng }] : []}
         {zoom}

--- a/web/src/lib/components/shared-components/confirm-dialogue.svelte
+++ b/web/src/lib/components/shared-components/confirm-dialogue.svelte
@@ -12,6 +12,7 @@
   export let cancelColor: Color = 'primary';
   export let hideCancelButton = false;
   export let disabled = false;
+  export let width = 500;
 
   const dispatch = createEventDispatcher<{ cancel: void; confirm: void; 'click-outside': void }>();
 
@@ -36,7 +37,8 @@
 
 <FullScreenModal on:clickOutside={handleClickOutside} on:escape={() => handleEscape()}>
   <div
-    class="w-[500px] max-w-[95vw] rounded-3xl border bg-immich-bg p-4 py-8 shadow-sm dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-fg"
+    class="max-w-[95vw] rounded-3xl border bg-immich-bg p-4 py-8 shadow-sm dark:border-immich-dark-gray dark:bg-immich-dark-gray dark:text-immich-dark-fg"
+    style="width: {width}px"
   >
     <div
       class="flex flex-col place-content-center place-items-center gap-4 px-4 text-immich-primary dark:text-immich-dark-primary"


### PR DESCRIPTION
This PR makes location change dialog box a bit bigger for easier location targeting and allows `ConfirmDialogue` to have configurable width.

|main|PR|
|-|-|
|![obrazek](https://github.com/immich-app/immich/assets/15554561/4e1fd850-2076-44a3-b553-33905c5f08d7)|![obrazek](https://github.com/immich-app/immich/assets/15554561/bd5106f4-e8c0-4466-a5e6-ff9aeab3504e)|