### PR TITLE
fix(mobile): use cronet / cupertino http clients

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
     - ReachabilitySwift
+  - cupertino_http (0.0.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
@@ -60,6 +62,7 @@ PODS:
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - cupertino_http (from `.symlinks/plugins/cupertino_http/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
@@ -93,6 +96,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
+  cupertino_http:
+    :path: ".symlinks/plugins/cupertino_http/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
@@ -140,6 +145,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
+  cupertino_http: 5f8b1161107fe6c8d94a0c618735a033d93fa7db
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -30,7 +30,6 @@ import 'package:immich_mobile/shared/providers/app_state.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/immich_logger.service.dart';
 import 'package:immich_mobile/shared/services/local_notification.service.dart';
-import 'package:immich_mobile/utils/http_ssl_cert_override.dart';
 import 'package:immich_mobile/utils/immich_app_theme.dart';
 import 'package:immich_mobile/utils/migration.dart';
 import 'package:isar/isar.dart';
@@ -43,7 +42,6 @@ void main() async {
   final db = await loadDb();
   await initApp();
   await migrateDatabaseIfNeeded(db);
-  HttpOverrides.global = HttpSSLCertOverride();
 
   runApp(
     ProviderScope(

--- a/mobile/lib/modules/backup/background_service/background.service.dart
+++ b/mobile/lib/modules/backup/background_service/background.service.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 import 'dart:io';
 import 'dart:isolate';
 import 'dart:ui' show DartPluginRegistrant, IsolateNameServer, PluginUtilities;
-import 'package:cancellation_token_http/http.dart';
+import 'package:cancellation_token/cancellation_token.dart';
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/services.dart';

--- a/mobile/lib/modules/backup/models/backup_state.model.dart
+++ b/mobile/lib/modules/backup/models/backup_state.model.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 
-import 'package:cancellation_token_http/http.dart';
+import 'package:cancellation_token/cancellation_token.dart';
 import 'package:collection/collection.dart';
 import 'package:photo_manager/photo_manager.dart';
 

--- a/mobile/lib/modules/backup/models/manual_upload_state.model.dart
+++ b/mobile/lib/modules/backup/models/manual_upload_state.model.dart
@@ -1,4 +1,4 @@
-import 'package:cancellation_token_http/http.dart';
+import 'package:cancellation_token/cancellation_token.dart';
 import 'package:immich_mobile/modules/backup/models/current_upload_asset.model.dart';
 
 class ManualUploadState {

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:cancellation_token_http/http.dart';
+import 'package:cancellation_token/cancellation_token.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/mobile/lib/modules/backup/providers/manual_upload.provider.dart
+++ b/mobile/lib/modules/backup/providers/manual_upload.provider.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:cancellation_token_http/http.dart';
+import 'package:cancellation_token/cancellation_token.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
 import 'package:fluttertoast/fluttertoast.dart';

--- a/mobile/lib/shared/services/api.service.dart
+++ b/mobile/lib/shared/services/api.service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/utils/http_client_factory.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:openapi/api.dart';
 import 'package:http/http.dart';
@@ -35,6 +36,7 @@ class ApiService {
 
   setEndpoint(String endpoint) {
     _apiClient = ApiClient(basePath: endpoint);
+    _apiClient.client = getHttpClient();
     if (_authToken != null) {
       setAccessToken(_authToken!);
     }
@@ -85,7 +87,7 @@ class ApiService {
   }
 
   Future<bool> _isEndpointAvailable(String serverUrl) async {
-    final Client client = Client();
+    final Client client = getHttpClient();
 
     if (!serverUrl.endsWith('/api')) {
       serverUrl += '/api';
@@ -108,7 +110,7 @@ class ApiService {
   }
 
   Future<String> _getWellKnownEndpoint(String baseUrl) async {
-    final Client client = Client();
+    final Client client = getHttpClient();
 
     try {
       final res = await client.get(

--- a/mobile/lib/utils/http_client_factory.dart
+++ b/mobile/lib/utils/http_client_factory.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:cronet_http/cronet_http.dart';
+import 'package:cupertino_http/cupertino_http.dart';
+import 'package:http/http.dart';
+
+Client getHttpClient() {
+  final Client client;
+  if (Platform.isAndroid) {
+    final engine = CronetEngine.build(
+      enableHttp2: true,
+      enableBrotli: true,
+      cacheMode: CacheMode.memory,
+    );
+    client = CronetClient.fromCronetEngine(engine);
+  } else if (Platform.isIOS) {
+    final config = URLSessionConfiguration.ephemeralSessionConfiguration()
+      ..allowsCellularAccess = true
+      ..allowsConstrainedNetworkAccess = true
+      ..allowsExpensiveNetworkAccess = true;
+    client = CupertinoClient.fromSessionConfiguration(config);
+  } else {
+    client = Client();
+  }
+  return client;
+}

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -170,21 +170,13 @@ packages:
     source: hosted
     version: "1.0.2"
   cancellation_token:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cancellation_token
       sha256: ad95acf9d4b2f3563e25dc937f63587e46a70ce534e910b65d10e115490f1027
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  cancellation_token_http:
-    dependency: "direct main"
-    description:
-      name: cancellation_token_http
-      sha256: bb91655e2e47d6274b681261ee6a687b7aa9023f49cfc28f42d095b2f86febc3
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   characters:
     dependency: transitive
     description:
@@ -273,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cronet_http:
+    dependency: "direct main"
+    description:
+      name: cronet_http
+      sha256: "0fd588fcd566c89de8cfd420f0b9e9babcfc5b263c9b5168a33e1722442d4c7c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   cross_file:
     dependency: transitive
     description:
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  cupertino_http:
+    dependency: "direct main"
+    description:
+      name: cupertino_http
+      sha256: "93cdb8a3aa8bc71caf62fdaca66e613871a6aa1388c7cd7f39b6366b5d2f5af6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   cupertino_icons:
     dependency: transitive
     description:
@@ -876,6 +884,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0+1"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: "0d88790bdf7e298aa65a9094c62b58ea231169a2deb84f23defc7d7955885b43"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   js:
     dependency: transitive
     description:
@@ -1810,5 +1826,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.1.0 <4.0.0"
   flutter: ">=3.10.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -37,7 +37,9 @@ dependencies:
   package_info_plus: ^4.1.0
   url_launcher: ^6.1.3
   http: 0.13.5
-  cancellation_token_http: ^1.1.0
+  cronet_http: ^0.4.2
+  cupertino_http: ^1.1.0
+  cancellation_token: ^2.0.1
   easy_localization: ^3.0.1
   share_plus: ^7.1.0
   flutter_displaymode: ^0.4.0


### PR DESCRIPTION
#### Changes made:

- Updates the mobile app to use [cupertino_http](https://pub.dev/packages/cupertino_http) on iOS and [cronet_http](https://pub.dev/packages/cronet_http) on Android devices which should hopefully respect the system proxy and certs