### PR TITLE
fix(mobile): use proper id for gallery_viewer hero attribute

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -795,8 +795,8 @@ class GalleryViewerPage extends HookConsumerWidget {
                     imageProvider: provider,
                     heroAttributes: PhotoViewHeroAttributes(
                       tag: isFromDto
-                          ? '${a.remoteId}-$heroOffset'
-                          : a.id + heroOffset,
+                          ? '${currentAsset.remoteId}-$heroOffset'
+                          : currentAsset.id + heroOffset,
                       transitionOnUserGestures: true,
                     ),
                     filterQuality: FilterQuality.high,
@@ -815,8 +815,8 @@ class GalleryViewerPage extends HookConsumerWidget {
                         handleSwipeUpDown(details),
                     heroAttributes: PhotoViewHeroAttributes(
                       tag: isFromDto
-                          ? '${a.remoteId}-$heroOffset'
-                          : a.id + heroOffset,
+                          ? '${currentAsset.remoteId}-$heroOffset'
+                          : currentAsset.id + heroOffset,
                     ),
                     filterQuality: FilterQuality.high,
                     maxScale: 1.0,


### PR DESCRIPTION
Fixes #5891 

### Changes made in the PR:

- Uses the proper asset ID for the hero attributes so the hero animation is proper even when we exit from a stack children


https://github.com/immich-app/immich/assets/139912620/2cef9509-b348-4d80-9dfa-e1be458190a5

