### PR TITLE
renovate: Constrain python version

### DIFF
--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "app"}]
 
 [tool.poetry.dependencies]
-python = "=3.11.*"
+python = ">=3.10,<3.12"
 onnxruntime = "^1.15.0"
 insightface = "^0.7.3"
 opencv-python-headless = "^4.7.0.72"

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "docker:pinDigests"],
   "minimumReleaseAge": "5 days",
+  "constraints": {
+    "python": "< 3.12"
+  },
+  "constraintsFiltering": "strict",
   "packageRules": [
     {
       "matchFileNames": ["cli/**"],


### PR DESCRIPTION
## Description

It's obnoxiously insistent on using 3.12 despite the pyproject.toml constraint, so this adds a constraint to `renovate.json`.