### PR TITLE
chore(dev): move envs to image

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -19,8 +19,6 @@ x-server-build: &server-common
     - /etc/localtime:/etc/localtime:ro
   env_file:
     - .env
-  environment:
-    - NODE_ENV=development
   ulimits:
     nofile:
       soft: 1048576
@@ -87,8 +85,6 @@ services:
       - model-cache:/cache
     env_file:
       - .env
-    environment:
-      - NODE_ENV=development
     depends_on:
       - database
     restart: unless-stopped

--- a/docker/hwaccel.yml
+++ b/docker/hwaccel.yml
@@ -11,7 +11,6 @@ services:
     # volumes:
     #   - /usr/lib/wsl:/usr/lib/wsl # If using VAAPI in WSL2
     # environment:
-    #   - NVIDIA_DRIVER_CAPABILITIES=all # If using NVIDIA GPU
     #   - LD_LIBRARY_PATH=/usr/lib/wsl/lib # If using VAAPI in WSL2
     #   - LIBVA_DRIVER_NAME=d3d12 # If using VAAPI in WSL2
     # deploy: # Uncomment this section if using NVIDIA GPU

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,7 +10,10 @@ RUN npm ci && \
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
 COPY server .
-ENV PATH="${PATH}:/usr/src/app/bin"
+ENV PATH="${PATH}:/usr/src/app/bin" \
+    NODE_ENV=development \
+    NVIDIA_DRIVER_CAPABILITIES=all \
+    NVIDIA_VISIBLE_DEVICES=all
 ENTRYPOINT ["tini", "--", "/bin/sh"]
 
 
@@ -34,7 +37,9 @@ RUN npm run build
 FROM ghcr.io/immich-app/base-server-prod:20231214@sha256:b214f86683fde081b09beed2d7bfc28bec55c829751ccf2e02ad7dd18293f5e0
 
 WORKDIR /usr/src/app
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    NVIDIA_DRIVER_CAPABILITIES=all \
+    NVIDIA_VISIBLE_DEVICES=all
 COPY --from=prod /usr/src/app/node_modules ./node_modules
 COPY --from=prod /usr/src/app/dist ./dist
 COPY --from=prod /usr/src/app/bin ./bin


### PR DESCRIPTION
## Description

There are a few envs that don't really need to be configured, so this PR moves them to the docker images.

- `NVIDIA_DRIVER_CAPABILITIES=all`
- `NVIDIA_VISIBLE_DEVICES=all`
  - These envs are used for nvenc, but they're benign if set anyway so setting it beforehand makes setup easier.
  - Inspired by Jellyfin as they're set in their official image as well.
- `NODE_ENV=development`
  - The dev server uses the dev stage of the image, so no need to set this in the docker-compose instead of the image
  - The prod stage already sets `NODE_ENV=production`
  - Removed from `immich-machine-learning` as it's completely unused there