### PR TITLE
fix(web): shared album detail panel for anonymous user

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -52,7 +52,7 @@
     }
   }
 
-  $: isOwner = $user.id === asset.ownerId;
+  $: isOwner = $user?.id === asset.ownerId;
 
   $: {
     // Get latest description from server
@@ -356,7 +356,7 @@
           </button>
         {/if}
       </div>
-    {:else if !asset.exifInfo?.dateTimeOriginal && !asset.isReadOnly && $user && asset.ownerId === $user.id}
+    {:else if !asset.exifInfo?.dateTimeOriginal && !asset.isReadOnly && isOwner}
       <div class="flex justify-between place-items-start gap-4 py-4">
         <div class="flex gap-4">
           <div>
@@ -519,7 +519,7 @@
           </div>
         {/if}
       </div>
-    {:else if !asset.exifInfo?.city && !asset.isReadOnly && $user && asset.ownerId === $user.id}
+    {:else if !asset.exifInfo?.city && !asset.isReadOnly && isOwner}
       <div
         class="flex justify-between place-items-start gap-4 py-4 rounded-lg hover:dark:text-immich-dark-primary hover:text-immich-primary"
         on:click={() => (isShowChangeLocation = true)}


### PR DESCRIPTION
## Steps to reproduce
1. Create an album with some photos and share it via link
2. Open this link in incognito
3. Click on some photo and the Info button
4. Website became unresponsible, e.g. can't open photosphere, and there is errors in console

![image](https://github.com/immich-app/immich/assets/13971093/ed2b63f4-b335-4a06-9e35-b23b02b428c2)
![image](https://github.com/immich-app/immich/assets/13971093/43b331ad-44ec-4b2d-9a16-348065c080c7)

## Additional info
The cause of this error is typing in `user.store.ts:4`
```ts
export let user = writable<UserResponseDto>();
```
When user in browser doesn't logged in and viewing shared album the `user` variable will be `undefined` in this case

Would it better to change typing to something like?
```ts
export let user = writable<UserResponseDto | undefined>();
```
This will lead to typescript errors in other pieces of the code, where additional checks will be needed to ensure that the `user` exists.

Also in shared album for anonymous user there is requests
![image](https://github.com/immich-app/immich/assets/13971093/b049c575-0f67-4bac-a741-33fb1bc83a65)

