### PR TITLE
chore(web): Use percentage sign for uploads

### DIFF
--- a/web/src/lib/components/shared-components/upload-asset-preview.svelte
+++ b/web/src/lib/components/shared-components/upload-asset-preview.svelte
@@ -53,7 +53,7 @@
             {#if uploadAsset.message}
               {uploadAsset.message}
             {:else}
-              {uploadAsset.progress}/100 - {asByteUnitString(uploadAsset.speed || 0, $locale)}/s - {uploadAsset.eta}s
+              {uploadAsset.progress}% - {asByteUnitString(uploadAsset.speed || 0, $locale)}/s - {uploadAsset.eta}s
             {/if}
           </p>
         {:else if uploadAsset.state === UploadState.PENDING}


### PR DESCRIPTION
Tiny change, but matches the rest of the progress indicators.

Before:

![image](https://github.com/immich-app/immich/assets/3867850/cf3dc08b-37e7-48c1-a25c-a28cc74067cc)

After:

![image](https://github.com/immich-app/immich/assets/3867850/0823bbea-75d9-4401-a3e4-25ec4d8680e6)
