### PR TITLE
feat(web): display age in months when age is 0

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -280,8 +280,8 @@
                         { locale: $locale },
                       )}
                     >
-                      {#if age == 0 && ageInMonths >= 0 && ageInMonths <= 11}
-                        Age {ageInMonths}mo
+                      {#if ageInMonths <= 11}
+                        Age {ageInMonths} months
                       {:else}
                         Age {age}
                       {/if}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -265,6 +265,9 @@
                 {#if person.birthDate}
                   {@const personBirthDate = DateTime.fromISO(person.birthDate)}
                   {@const age = Math.floor(DateTime.fromISO(asset.fileCreatedAt).diff(personBirthDate, 'years').years)}
+                  {@const ageInMonths = Math.floor(
+                    DateTime.fromISO(asset.fileCreatedAt).diff(personBirthDate, 'months').months,
+                  )}
                   {#if age >= 0}
                     <p
                       class="font-light"
@@ -277,7 +280,11 @@
                         { locale: $locale },
                       )}
                     >
-                      Age {age}
+                      {#if age == 0 && ageInMonths >= 0 && ageInMonths <= 11}
+                        Age {ageInMonths}mo
+                      {:else}
+                        Age {age}
+                      {/if}
                     </p>
                   {/if}
                 {/if}


### PR DESCRIPTION
I have quite a few baby pictures in my library and being able to see age in months is valuable to me rather than seeing the value 0.
<img width="146" alt="Screenshot 2023-12-24 at 10 35 02 AM" src="https://github.com/immich-app/immich/assets/6643192/ea10dabe-6aa3-447b-8dd5-f4d4c28d4646">
