### PR TITLE
feat(mobile): load server result assets from local DB

### DIFF
--- a/mobile/lib/modules/map/services/map.service.dart
+++ b/mobile/lib/modules/map/services/map.service.dart
@@ -48,10 +48,8 @@ class MapSerivce {
       if (assets.isNotEmpty) return assets[0];
 
       final dto = await _apiService.assetApi.getAssetById(remoteId);
-      if (dto == null) {
-        return null;
-      }
-      return Asset.remote(dto);
+      if (dto == null) return null;
+      return _db.assets.getByRemoteId(dto.id);
     } catch (error, stack) {
       _log.severe(
         "Cannot get asset for marker ${error.toString()}",

--- a/mobile/lib/modules/memories/services/memory.service.dart
+++ b/mobile/lib/modules/memories/services/memory.service.dart
@@ -2,13 +2,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/modules/memories/models/memory.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
+import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 
 final memoryServiceProvider = StateProvider<MemoryService>((ref) {
   return MemoryService(
     ref.watch(apiServiceProvider),
+    ref.watch(dbProvider),
   );
 });
 
@@ -16,8 +19,9 @@ class MemoryService {
   final log = Logger("MemoryService");
 
   final ApiService _apiService;
+  final Isar _db;
 
-  MemoryService(this._apiService);
+  MemoryService(this._apiService, this._db);
 
   Future<List<Memory>?> getMemoryLane() async {
     try {
@@ -36,7 +40,7 @@ class MemoryService {
         memories.add(
           Memory(
             title: title,
-            assets: assets.map((a) => Asset.remote(a)).toList(),
+            assets: await _db.assets.getAllByRemoteId(assets.map((e) => e.id)),
           ),
         );
       }

--- a/mobile/lib/modules/search/providers/all_video_assets.provider.dart
+++ b/mobile/lib/modules/search/providers/all_video_assets.provider.dart
@@ -1,28 +1,13 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
+import 'package:isar/isar.dart';
 
-final allVideoAssetsProvider = FutureProvider<List<Asset>>( (ref) async {
-  final search = await ref.watch(apiServiceProvider).searchApi.search(
-    type: 'VIDEO',
-  );
-
-  if (search == null) {
-    return [];
-  }
-
-  return ref.watch(dbProvider)
+final allVideoAssetsProvider = FutureProvider<List<Asset>>((ref) async {
+  return ref
+      .watch(dbProvider)
       .assets
-      .getAllByRemoteId(
-        search.assets.items.map((e) => e.id),
-      );
-
-  /// This works offline, but we use the above
-  /* 
-  return ref.watch(dbProvider).assets
       .filter()
-      .durationInSecondsGreaterThan(0)
+      .typeEqualTo(AssetType.video)
       .findAll();
-  */
 });

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -472,6 +472,8 @@ extension AssetsHelper on IsarCollection<Asset> {
       ids.isEmpty ? Future.value([]) : remote(ids).findAll();
   Future<List<Asset>> getAllByLocalId(Iterable<String> ids) =>
       ids.isEmpty ? Future.value([]) : local(ids).findAll();
+  Future<Asset?> getByRemoteId(String id) =>
+      where().remoteIdEqualTo(id).findFirst();
 
   QueryBuilder<Asset, Asset, QAfterWhereClause> remote(Iterable<String> ids) =>
       where().anyOf(ids, (q, String e) => q.remoteIdEqualTo(e));


### PR DESCRIPTION
with this PR server asset results (person/face assets, map assets, memories) are fetched from isar DB, thereby using the local assets if available (just like it is already done for search results)

fix #3782