### PR TITLE
feat(server): Enqueue jobs in bulk

### DIFF
--- a/server/src/domain/asset/asset.service.spec.ts
+++ b/server/src/domain/asset/asset.service.spec.ts
@@ -784,9 +784,9 @@ describe(AssetService.name, () => {
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: true });
 
-      expect(jobMock.queue.mock.calls).toEqual([
-        [{ name: JobName.ASSET_DELETION, data: { id: 'asset1' } }],
-        [{ name: JobName.ASSET_DELETION, data: { id: 'asset2' } }],
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.ASSET_DELETION, data: { id: 'asset1' } },
+        { name: JobName.ASSET_DELETION, data: { id: 'asset2' } },
       ]);
     });
 
@@ -895,6 +895,7 @@ describe(AssetService.name, () => {
       await sut.handleAssetDeletion({ id: assetStub.external.id });
 
       expect(jobMock.queue).not.toBeCalled();
+      expect(jobMock.queueAll).not.toBeCalled();
       expect(assetMock.remove).not.toBeCalled();
     });
 
@@ -952,19 +953,21 @@ describe(AssetService.name, () => {
     it('should run the refresh metadata job', async () => {
       accessMock.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
       await sut.run(authStub.admin, { assetIds: ['asset-1'], name: AssetJobName.REFRESH_METADATA }),
-        expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.METADATA_EXTRACTION, data: { id: 'asset-1' } });
+        expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.METADATA_EXTRACTION, data: { id: 'asset-1' } }]);
     });
 
     it('should run the refresh thumbnails job', async () => {
       accessMock.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
       await sut.run(authStub.admin, { assetIds: ['asset-1'], name: AssetJobName.REGENERATE_THUMBNAIL }),
-        expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1' } });
+        expect(jobMock.queueAll).toHaveBeenCalledWith([
+          { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1' } },
+        ]);
     });
 
     it('should run the transcode video', async () => {
       accessMock.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
       await sut.run(authStub.admin, { assetIds: ['asset-1'], name: AssetJobName.TRANSCODE_VIDEO }),
-        expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.VIDEO_CONVERSION, data: { id: 'asset-1' } });
+        expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.VIDEO_CONVERSION, data: { id: 'asset-1' } }]);
     });
   });
 

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -21,6 +21,7 @@ import {
   IStorageRepository,
   ISystemConfigRepository,
   ImmichReadStream,
+  JobItem,
   TimeBucketOptions,
 } from '../repositories';
 import { StorageCore, StorageFolder } from '../storage';
@@ -449,9 +450,9 @@ export class AssetService {
     );
 
     for await (const assets of assetPagination) {
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.id } });
-      }
+      await this.jobRepository.queueAll(
+        assets.map((asset) => ({ name: JobName.ASSET_DELETION, data: { id: asset.id } })),
+      );
     }
 
     return true;
@@ -504,9 +505,7 @@ export class AssetService {
     await this.access.requirePermission(auth, Permission.ASSET_DELETE, ids);
 
     if (force) {
-      for (const id of ids) {
-        await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id } });
-      }
+      await this.jobRepository.queueAll(ids.map((id) => ({ name: JobName.ASSET_DELETION, data: { id } })));
     } else {
       await this.assetRepository.softDeleteAll(ids);
       this.communicationRepository.send(ClientEvent.ASSET_TRASH, auth.user.id, ids);
@@ -529,9 +528,9 @@ export class AssetService {
 
     if (action == TrashAction.EMPTY_ALL) {
       for await (const assets of assetPagination) {
-        for (const asset of assets) {
-          await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.id } });
-        }
+        await this.jobRepository.queueAll(
+          assets.map((asset) => ({ name: JobName.ASSET_DELETION, data: { id: asset.id } })),
+        );
       }
       return;
     }
@@ -566,21 +565,25 @@ export class AssetService {
   async run(auth: AuthDto, dto: AssetJobsDto) {
     await this.access.requirePermission(auth, Permission.ASSET_UPDATE, dto.assetIds);
 
+    const jobs: JobItem[] = [];
+
     for (const id of dto.assetIds) {
       switch (dto.name) {
         case AssetJobName.REFRESH_METADATA:
-          await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id } });
+          jobs.push({ name: JobName.METADATA_EXTRACTION, data: { id } });
           break;
 
         case AssetJobName.REGENERATE_THUMBNAIL:
-          await this.jobRepository.queue({ name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id } });
+          jobs.push({ name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id } });
           break;
 
         case AssetJobName.TRANSCODE_VIDEO:
-          await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id } });
+          jobs.push({ name: JobName.VIDEO_CONVERSION, data: { id } });
           break;
       }
     }
+
+    await this.jobRepository.queueAll(jobs);
   }
 
   private async updateMetadata(dto: ISidecarWriteJob) {

--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -55,12 +55,12 @@ describe(JobService.name, () => {
     it('should run the scheduled jobs', async () => {
       await sut.handleNightlyJobs();
 
-      expect(jobMock.queue.mock.calls).toEqual([
-        [{ name: JobName.ASSET_DELETION_CHECK }],
-        [{ name: JobName.USER_DELETE_CHECK }],
-        [{ name: JobName.PERSON_CLEANUP }],
-        [{ name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } }],
-        [{ name: JobName.CLEAN_OLD_AUDIT_LOGS }],
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.ASSET_DELETION_CHECK },
+        { name: JobName.USER_DELETE_CHECK },
+        { name: JobName.PERSON_CLEANUP },
+        { name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } },
+        { name: JobName.CLEAN_OLD_AUDIT_LOGS },
       ]);
     });
   });
@@ -138,6 +138,7 @@ describe(JobService.name, () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
 
     it('should handle a start video conversion command', async () => {
@@ -204,6 +205,7 @@ describe(JobService.name, () => {
       ).rejects.toBeInstanceOf(BadRequestException);
 
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
   });
 
@@ -278,18 +280,18 @@ describe(JobService.name, () => {
         item: { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1' } },
         jobs: [
           JobName.GENERATE_WEBP_THUMBNAIL,
+          JobName.GENERATE_THUMBHASH_THUMBNAIL,
           JobName.ENCODE_CLIP,
           JobName.RECOGNIZE_FACES,
-          JobName.GENERATE_THUMBHASH_THUMBNAIL,
         ],
       },
       {
         item: { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1', source: 'upload' } },
         jobs: [
           JobName.GENERATE_WEBP_THUMBNAIL,
+          JobName.GENERATE_THUMBHASH_THUMBNAIL,
           JobName.ENCODE_CLIP,
           JobName.RECOGNIZE_FACES,
-          JobName.GENERATE_THUMBHASH_THUMBNAIL,
           JobName.VIDEO_CONVERSION,
         ],
       },
@@ -297,9 +299,9 @@ describe(JobService.name, () => {
         item: { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-live-image', source: 'upload' } },
         jobs: [
           JobName.GENERATE_WEBP_THUMBNAIL,
-          JobName.RECOGNIZE_FACES,
           JobName.GENERATE_THUMBHASH_THUMBNAIL,
           JobName.ENCODE_CLIP,
+          JobName.RECOGNIZE_FACES,
           JobName.VIDEO_CONVERSION,
         ],
       },
@@ -329,9 +331,15 @@ describe(JobService.name, () => {
         await jobMock.addHandler.mock.calls[0][2](item);
         await asyncTick(3);
 
-        expect(jobMock.queue).toHaveBeenCalledTimes(jobs.length);
-        for (const jobName of jobs) {
-          expect(jobMock.queue).toHaveBeenCalledWith({ name: jobName, data: expect.anything() });
+        if (jobs.length > 1) {
+          expect(jobMock.queueAll).toHaveBeenCalledWith(
+            jobs.map((jobName) => ({ name: jobName, data: expect.anything() })),
+          );
+        } else {
+          expect(jobMock.queue).toHaveBeenCalledTimes(jobs.length);
+          for (const jobName of jobs) {
+            expect(jobMock.queue).toHaveBeenCalledWith({ name: jobName, data: expect.anything() });
+          }
         }
       });
 
@@ -340,7 +348,7 @@ describe(JobService.name, () => {
         await jobMock.addHandler.mock.calls[0][2](item);
         await asyncTick(3);
 
-        expect(jobMock.queue).not.toHaveBeenCalled();
+        expect(jobMock.queueAll).not.toHaveBeenCalled();
       });
     }
 

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -151,11 +151,13 @@ export class JobService {
   }
 
   async handleNightlyJobs() {
-    await this.jobRepository.queue({ name: JobName.ASSET_DELETION_CHECK });
-    await this.jobRepository.queue({ name: JobName.USER_DELETE_CHECK });
-    await this.jobRepository.queue({ name: JobName.PERSON_CLEANUP });
-    await this.jobRepository.queue({ name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } });
-    await this.jobRepository.queue({ name: JobName.CLEAN_OLD_AUDIT_LOGS });
+    await this.jobRepository.queueAll([
+      { name: JobName.ASSET_DELETION_CHECK },
+      { name: JobName.USER_DELETE_CHECK },
+      { name: JobName.PERSON_CLEANUP },
+      { name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } },
+      { name: JobName.CLEAN_OLD_AUDIT_LOGS },
+    ]);
   }
 
   /**
@@ -203,19 +205,23 @@ export class JobService {
         break;
 
       case JobName.GENERATE_JPEG_THUMBNAIL: {
-        await this.jobRepository.queue({ name: JobName.GENERATE_WEBP_THUMBNAIL, data: item.data });
-        await this.jobRepository.queue({ name: JobName.GENERATE_THUMBHASH_THUMBNAIL, data: item.data });
-        await this.jobRepository.queue({ name: JobName.ENCODE_CLIP, data: item.data });
-        await this.jobRepository.queue({ name: JobName.RECOGNIZE_FACES, data: item.data });
+        const jobs: JobItem[] = [
+          { name: JobName.GENERATE_WEBP_THUMBNAIL, data: item.data },
+          { name: JobName.GENERATE_THUMBHASH_THUMBNAIL, data: item.data },
+          { name: JobName.ENCODE_CLIP, data: item.data },
+          { name: JobName.RECOGNIZE_FACES, data: item.data },
+        ];
 
         const [asset] = await this.assetRepository.getByIds([item.data.id]);
         if (asset) {
           if (asset.type === AssetType.VIDEO) {
-            await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: item.data });
+            jobs.push({ name: JobName.VIDEO_CONVERSION, data: item.data });
           } else if (asset.livePhotoVideoId) {
-            await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
+            jobs.push({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
           }
         }
+
+        await this.jobRepository.queueAll(jobs);
         break;
       }
 

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -135,18 +135,16 @@ describe(LibraryService.name, () => {
 
       await sut.handleQueueAssetRefresh(mockLibraryJob);
 
-      expect(jobMock.queue.mock.calls).toEqual([
-        [
-          {
-            name: JobName.LIBRARY_SCAN_ASSET,
-            data: {
-              id: libraryStub.externalLibrary1.id,
-              ownerId: libraryStub.externalLibrary1.owner.id,
-              assetPath: '/data/user1/photo.jpg',
-              force: false,
-            },
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.LIBRARY_SCAN_ASSET,
+          data: {
+            id: libraryStub.externalLibrary1.id,
+            ownerId: libraryStub.externalLibrary1.owner.id,
+            assetPath: '/data/user1/photo.jpg',
+            force: false,
           },
-        ],
+        },
       ]);
     });
 
@@ -420,6 +418,7 @@ describe(LibraryService.name, () => {
       await expect(sut.handleAssetRefresh(mockLibraryJob)).resolves.toBe(true);
 
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
 
     it('should import an asset when mtime differs from db asset', async () => {
@@ -468,6 +467,7 @@ describe(LibraryService.name, () => {
 
       expect(assetMock.save).toHaveBeenCalledWith({ id: assetStub.image.id, isOffline: true });
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
 
     it('should online a previously-offline asset', async () => {
@@ -607,6 +607,7 @@ describe(LibraryService.name, () => {
       );
 
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
       expect(libraryMock.softDelete).not.toHaveBeenCalled();
     });
 
@@ -953,9 +954,9 @@ describe(LibraryService.name, () => {
       libraryMock.getAllDeleted.mockResolvedValue([libraryStub.uploadLibrary1, libraryStub.externalLibrary1]);
       await expect(sut.handleQueueCleanup()).resolves.toBe(true);
 
-      expect(jobMock.queue.mock.calls).toEqual([
-        [{ name: JobName.LIBRARY_DELETE, data: { id: libraryStub.uploadLibrary1.id } }],
-        [{ name: JobName.LIBRARY_DELETE, data: { id: libraryStub.externalLibrary1.id } }],
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        { name: JobName.LIBRARY_DELETE, data: { id: libraryStub.uploadLibrary1.id } },
+        { name: JobName.LIBRARY_DELETE, data: { id: libraryStub.externalLibrary1.id } },
       ]);
     });
   });
@@ -1101,16 +1102,16 @@ describe(LibraryService.name, () => {
             data: {},
           },
         ],
-        [
-          {
-            name: JobName.LIBRARY_SCAN,
-            data: {
-              id: libraryStub.externalLibrary1.id,
-              refreshModifiedFiles: true,
-              refreshAllFiles: false,
-            },
+      ]);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.LIBRARY_SCAN,
+          data: {
+            id: libraryStub.externalLibrary1.id,
+            refreshModifiedFiles: true,
+            refreshAllFiles: false,
           },
-        ],
+        },
       ]);
     });
 
@@ -1126,16 +1127,16 @@ describe(LibraryService.name, () => {
             data: {},
           },
         ],
-        [
-          {
-            name: JobName.LIBRARY_SCAN,
-            data: {
-              id: libraryStub.externalLibrary1.id,
-              refreshModifiedFiles: false,
-              refreshAllFiles: true,
-            },
+      ]);
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.LIBRARY_SCAN,
+          data: {
+            id: libraryStub.externalLibrary1.id,
+            refreshModifiedFiles: false,
+            refreshAllFiles: true,
           },
-        ],
+        },
       ]);
     });
   });
@@ -1147,13 +1148,11 @@ describe(LibraryService.name, () => {
 
       await expect(sut.handleOfflineRemoval({ id: libraryStub.externalLibrary1.id })).resolves.toBe(true);
 
-      expect(jobMock.queue.mock.calls).toEqual([
-        [
-          {
-            name: JobName.ASSET_DELETION,
-            data: { id: assetStub.image1.id, fromExternal: true },
-          },
-        ],
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.ASSET_DELETION,
+          data: { id: assetStub.image1.id, fromExternal: true },
+        },
       ]);
     });
   });

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -73,17 +73,21 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).toHaveBeenCalled();
       expect(assetMock.getWithout).not.toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_JPEG_THUMBNAIL,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_JPEG_THUMBNAIL,
+          data: { id: assetStub.image.id },
+        },
+      ]);
 
       expect(personMock.getAll).toHaveBeenCalled();
       expect(personMock.getAllWithoutThumbnail).not.toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_PERSON_THUMBNAIL,
-        data: { id: personStub.newThumbnail.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_PERSON_THUMBNAIL,
+          data: { id: personStub.newThumbnail.id },
+        },
+      ]);
     });
 
     it('should queue all people with missing thumbnail path', async () => {
@@ -102,12 +106,14 @@ describe(MediaService.name, () => {
       expect(personMock.getAll).not.toHaveBeenCalled();
       expect(personMock.getAllWithoutThumbnail).toHaveBeenCalled();
       expect(personMock.getRandomFace).toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_PERSON_THUMBNAIL,
-        data: {
-          id: personStub.newThumbnail.id,
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_PERSON_THUMBNAIL,
+          data: {
+            id: personStub.newThumbnail.id,
+          },
         },
-      });
+      ]);
     });
 
     it('should queue all assets with missing resize path', async () => {
@@ -121,10 +127,12 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.THUMBNAIL);
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_JPEG_THUMBNAIL,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_JPEG_THUMBNAIL,
+          data: { id: assetStub.image.id },
+        },
+      ]);
 
       expect(personMock.getAll).not.toHaveBeenCalled();
       expect(personMock.getAllWithoutThumbnail).toHaveBeenCalled();
@@ -141,10 +149,12 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.THUMBNAIL);
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_WEBP_THUMBNAIL,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_WEBP_THUMBNAIL,
+          data: { id: assetStub.image.id },
+        },
+      ]);
 
       expect(personMock.getAll).not.toHaveBeenCalled();
       expect(personMock.getAllWithoutThumbnail).toHaveBeenCalled();
@@ -161,10 +171,12 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.THUMBNAIL);
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.GENERATE_THUMBHASH_THUMBNAIL,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.GENERATE_THUMBHASH_THUMBNAIL,
+          data: { id: assetStub.image.id },
+        },
+      ]);
 
       expect(personMock.getAll).not.toHaveBeenCalled();
       expect(personMock.getAllWithoutThumbnail).toHaveBeenCalled();
@@ -384,10 +396,12 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).toHaveBeenCalledWith({ skip: 0, take: 1000 }, { type: AssetType.VIDEO });
       expect(assetMock.getWithout).not.toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.VIDEO_CONVERSION,
-        data: { id: assetStub.video.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.VIDEO_CONVERSION,
+          data: { id: assetStub.video.id },
+        },
+      ]);
     });
 
     it('should queue all video assets without encoded videos', async () => {
@@ -400,10 +414,12 @@ describe(MediaService.name, () => {
 
       expect(assetMock.getAll).not.toHaveBeenCalled();
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.ENCODED_VIDEO);
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.VIDEO_CONVERSION,
-        data: { id: assetStub.video.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.VIDEO_CONVERSION,
+          data: { id: assetStub.video.id },
+        },
+      ]);
     });
   });
 

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -86,7 +86,7 @@ export class MediaService {
 
     const people = force ? await this.personRepository.getAll() : await this.personRepository.getAllWithoutThumbnail();
 
-    const idsToGenerateThumbnail = new Set<string>();
+    const jobs: JobItem[] = [];
     for (const person of people) {
       if (!person.faceAssetId) {
         const face = await this.personRepository.getRandomFace(person.id);
@@ -97,12 +97,10 @@ export class MediaService {
         await this.personRepository.update({ id: person.id, faceAssetId: face.assetId });
       }
 
-      idsToGenerateThumbnail.add(person.id);
+      jobs.push({ name: JobName.GENERATE_PERSON_THUMBNAIL, data: { id: person.id } });
     }
 
-    await this.jobRepository.queueAll(
-      Array.from(idsToGenerateThumbnail).map((id) => ({ name: JobName.GENERATE_PERSON_THUMBNAIL, data: { id } })),
-    );
+    await this.jobRepository.queueAll(jobs);
 
     return true;
   }

--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -203,10 +203,12 @@ describe(MetadataService.name, () => {
 
       await expect(sut.handleQueueMetadataExtraction({ force: false })).resolves.toBe(true);
       expect(assetMock.getWithout).toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.METADATA_EXTRACTION,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.METADATA_EXTRACTION,
+          data: { id: assetStub.image.id },
+        },
+      ]);
     });
 
     it('should queue metadata extraction for all assets', async () => {
@@ -214,10 +216,12 @@ describe(MetadataService.name, () => {
 
       await expect(sut.handleQueueMetadataExtraction({ force: true })).resolves.toBe(true);
       expect(assetMock.getAll).toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.METADATA_EXTRACTION,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.METADATA_EXTRACTION,
+          data: { id: assetStub.image.id },
+        },
+      ]);
     });
   });
 
@@ -324,6 +328,7 @@ describe(MetadataService.name, () => {
       expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.livePhotoMotionAsset.id]);
       expect(storageMock.writeFile).not.toHaveBeenCalled();
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
       expect(assetMock.save).not.toHaveBeenCalledWith(
         expect.objectContaining({ assetType: AssetType.VIDEO, isVisible: false }),
       );
@@ -516,10 +521,12 @@ describe(MetadataService.name, () => {
 
       expect(assetMock.getWith).toHaveBeenCalledWith({ take: 1000, skip: 0 }, WithProperty.SIDECAR);
       expect(assetMock.getWithout).not.toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.SIDECAR_SYNC,
-        data: { id: assetStub.sidecar.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SIDECAR_SYNC,
+          data: { id: assetStub.sidecar.id },
+        },
+      ]);
     });
 
     it('should queue assets without sidecar files', async () => {
@@ -529,10 +536,12 @@ describe(MetadataService.name, () => {
 
       expect(assetMock.getWithout).toHaveBeenCalledWith({ take: 1000, skip: 0 }, WithoutProperty.SIDECAR);
       expect(assetMock.getWith).not.toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.SIDECAR_DISCOVERY,
-        data: { id: assetStub.image.id },
-      });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([
+        {
+          name: JobName.SIDECAR_DISCOVERY,
+          data: { id: assetStub.image.id },
+        },
+      ]);
     });
   });
 

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -186,9 +186,9 @@ export class MetadataService {
     });
 
     for await (const assets of assetPagination) {
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: asset.id } });
-      }
+      await this.jobRepository.queueAll(
+        assets.map((asset) => ({ name: JobName.METADATA_EXTRACTION, data: { id: asset.id } })),
+      );
     }
 
     return true;
@@ -254,10 +254,12 @@ export class MetadataService {
     });
 
     for await (const assets of assetPagination) {
-      for (const asset of assets) {
-        const name = force ? JobName.SIDECAR_SYNC : JobName.SIDECAR_DISCOVERY;
-        await this.jobRepository.queue({ name, data: { id: asset.id } });
-      }
+      await this.jobRepository.queueAll(
+        assets.map((asset) => ({
+          name: force ? JobName.SIDECAR_SYNC : JobName.SIDECAR_DISCOVERY,
+          data: { id: asset.id },
+        })),
+      );
     }
 
     return true;

--- a/server/src/domain/repositories/job.repository.ts
+++ b/server/src/domain/repositories/job.repository.ts
@@ -103,6 +103,7 @@ export interface IJobRepository {
   deleteCronJob(name: string): void;
   setConcurrency(queueName: QueueName, concurrency: number): void;
   queue(item: JobItem): Promise<void>;
+  queueAll(items: JobItem[]): Promise<void>;
   pause(name: QueueName): Promise<void>;
   resume(name: QueueName): Promise<void>;
   empty(name: QueueName): Promise<void>;

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -65,7 +65,7 @@ describe(SmartInfoService.name, () => {
 
       await sut.handleQueueEncodeClip({ force: false });
 
-      expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.ENCODE_CLIP, data: { id: assetStub.image.id } });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.ENCODE_CLIP, data: { id: assetStub.image.id } }]);
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.CLIP_ENCODING);
     });
 
@@ -77,7 +77,7 @@ describe(SmartInfoService.name, () => {
 
       await sut.handleQueueEncodeClip({ force: true });
 
-      expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.ENCODE_CLIP, data: { id: assetStub.image.id } });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.ENCODE_CLIP, data: { id: assetStub.image.id } }]);
       expect(assetMock.getAll).toHaveBeenCalled();
     });
   });

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -59,9 +59,7 @@ export class SmartInfoService {
     });
 
     for await (const assets of assetPagination) {
-      for (const asset of assets) {
-        await this.jobRepository.queue({ name: JobName.ENCODE_CLIP, data: { id: asset.id } });
-      }
+      await this.jobRepository.queueAll(assets.map((asset) => ({ name: JobName.ENCODE_CLIP, data: { id: asset.id } })));
     }
 
     return true;

--- a/server/src/domain/user/user.service.spec.ts
+++ b/server/src/domain/user/user.service.spec.ts
@@ -342,7 +342,7 @@ describe(UserService.name, () => {
       userMock.update.mockResolvedValue({ ...userStub.admin, profileImagePath: file.path });
 
       await sut.createProfileImage(authStub.admin, file);
-      await expect(jobMock.queue.mock.calls).toEqual([[{ name: JobName.DELETE_FILES, data: { files } }]]);
+      expect(jobMock.queue.mock.calls).toEqual([[{ name: JobName.DELETE_FILES, data: { files } }]]);
     });
 
     it('should not delete the profile image if it has not been set', async () => {
@@ -352,6 +352,7 @@ describe(UserService.name, () => {
 
       await sut.createProfileImage(authStub.admin, file);
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
   });
 
@@ -361,6 +362,7 @@ describe(UserService.name, () => {
 
       await expect(sut.deleteProfileImage(authStub.admin)).rejects.toBeInstanceOf(BadRequestException);
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
 
     it('should delete the profile image if user has one', async () => {
@@ -368,7 +370,7 @@ describe(UserService.name, () => {
       const files = [userStub.profilePath.profileImagePath];
 
       await sut.deleteProfileImage(authStub.admin);
-      await expect(jobMock.queue.mock.calls).toEqual([[{ name: JobName.DELETE_FILES, data: { files } }]]);
+      expect(jobMock.queue.mock.calls).toEqual([[{ name: JobName.DELETE_FILES, data: { files } }]]);
     });
   });
 
@@ -456,6 +458,7 @@ describe(UserService.name, () => {
 
       expect(userMock.getDeletedUsers).toHaveBeenCalled();
       expect(jobMock.queue).not.toHaveBeenCalled();
+      expect(jobMock.queueAll).toHaveBeenCalledWith([]);
     });
 
     it('should queue user ready for deletion', async () => {
@@ -465,7 +468,7 @@ describe(UserService.name, () => {
       await sut.handleUserDeleteCheck();
 
       expect(userMock.getDeletedUsers).toHaveBeenCalled();
-      expect(jobMock.queue).toHaveBeenCalledWith({ name: JobName.USER_DELETION, data: { id: user.id } });
+      expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.USER_DELETION, data: { id: user.id } }]);
     });
   });
 

--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -129,12 +129,9 @@ export class UserService {
 
   async handleUserDeleteCheck() {
     const users = await this.userRepository.getDeletedUsers();
-    for (const user of users) {
-      if (this.isReadyForDeletion(user)) {
-        await this.jobRepository.queue({ name: JobName.USER_DELETION, data: { id: user.id } });
-      }
-    }
-
+    await this.jobRepository.queueAll(
+      users.filter(this.isReadyForDeletion).map((user) => ({ name: JobName.USER_DELETION, data: { id: user.id } })),
+    );
     return true;
   }
 

--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -130,7 +130,9 @@ export class UserService {
   async handleUserDeleteCheck() {
     const users = await this.userRepository.getDeletedUsers();
     await this.jobRepository.queueAll(
-      users.filter(this.isReadyForDeletion).map((user) => ({ name: JobName.USER_DELETION, data: { id: user.id } })),
+      users.flatMap((user) =>
+        this.isReadyForDeletion(user) ? [{ name: JobName.USER_DELETION, data: { id: user.id } }] : [],
+      ),
     );
     return true;
   }

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -11,6 +11,7 @@ export const newJobRepositoryMock = (): jest.Mocked<IJobRepository> => {
     pause: jest.fn(),
     resume: jest.fn(),
     queue: jest.fn().mockImplementation(() => Promise.resolve()),
+    queueAll: jest.fn().mockImplementation(() => Promise.resolve()),
     getQueueStatus: jest.fn(),
     getJobCounts: jest.fn(),
     clear: jest.fn(),

--- a/server/test/test-utils.ts
+++ b/server/test/test-utils.ts
@@ -77,6 +77,7 @@ export const testApp = {
         deleteCronJob: jest.fn(),
         validateCronExpression: jest.fn(),
         queue: (item: JobItem) => jobs && _handler(item),
+        queueAll: (items: JobItem[]) => jobs && Promise.all(items.map(_handler)).then(() => Promise.resolve()),
         resume: jest.fn(),
         empty: jest.fn(),
         setConcurrency: jest.fn(),


### PR DESCRIPTION
The Job Repository now has a `queueAll` method, that enqueues messages in bulk (using BullMQ's
[`addBulk`](https://docs.bullmq.io/guide/queues/adding-bulks)), improving performance when many jobs must be enqueued within the same operation.

Primary change is in `server/src/infra/repositories/job.repository.ts`, and other services have been refactored to use `queueAll` when useful.

As a simple local benchmark, triggering a full thumbnail generation process over a library of ~1,200 assets and ~350 faces went from **~600ms** to **~250ms**.