### PR TITLE
fix(mobile): Fix "Live Images" and "Recently added" page

### DIFF
--- a/mobile/lib/modules/search/providers/all_motion_photos.provider.dart
+++ b/mobile/lib/modules/search/providers/all_motion_photos.provider.dart
@@ -1,29 +1,12 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
+import 'package:isar/isar.dart';
 
 final allMotionPhotosProvider = FutureProvider<List<Asset>>( (ref) async {
-  final search = await ref.watch(apiServiceProvider).searchApi.search(
-    motion: true,
-  );
-
-  if (search == null) {
-    return [];
-  }
-
   return ref.watch(dbProvider)
-      .assets
-      .getAllByRemoteId(
-        search.assets.items.map((e) => e.id),
-      );
-
-
-  /// This works offline, but we use the above
-  /*
-     return ref.watch(dbProvider).assets
-      .filter()
-      .livePhotoVideoIdIsNotNull()
-      .findAll();
-  */
+    .assets
+    .filter()
+    .livePhotoVideoIdIsNotNull()
+    .findAll();
 });

--- a/mobile/lib/modules/search/providers/recently_added.provider.dart
+++ b/mobile/lib/modules/search/providers/recently_added.provider.dart
@@ -1,20 +1,12 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
-import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/providers/db.provider.dart';
+import 'package:isar/isar.dart';
 
 final recentlyAddedProvider = FutureProvider<List<Asset>>( (ref) async {
-  final search = await ref.watch(apiServiceProvider).searchApi.search(
-    recent: true,
-  );
-
-  if (search == null) {
-    return [];
-  }
-
   return ref.watch(dbProvider)
       .assets
-      .getAllByRemoteId(
-        search.assets.items.map((e) => e.id),
-      );
+      .where()
+      .sortByFileCreatedAtDesc()
+      .findAll();
 });


### PR DESCRIPTION
This PR resolves the error when going to the _Live Images_ page on the mobile app.

The reason why some of the category pages do not work anymore on mobile is due to a change made with 1e99ba8167: The server always expects  a non-empty query: https://github.com/immich-app/immich/blob/27bc77758146a38704ab2ac850f695989acfb640/server/src/domain/search/search.service.ts#L58-L61

The behavior is the same with the _Recently Added_ page.

And it seems that the `recent` parameter of the `search` API endpoint is now a no-op. Is this intentional?

Related #5971