### PR TITLE
fix(server): Split database queries based on PostgreSQL bound params limit

### DIFF
--- a/server/src/domain/album/album.service.spec.ts
+++ b/server/src/domain/album/album.service.spec.ts
@@ -679,7 +679,7 @@ describe(AlbumService.name, () => {
       ]);
 
       expect(albumMock.update).toHaveBeenCalledWith({ id: 'album-123', updatedAt: expect.any(Date) });
-      expect(albumMock.removeAssets).toHaveBeenCalledWith({ assetIds: ['asset-id'], albumId: 'album-123' });
+      expect(albumMock.removeAssets).toHaveBeenCalledWith('album-123', ['asset-id']);
     });
 
     it('should skip assets not in the album', async () => {

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -231,7 +231,7 @@ export class AlbumService {
 
     const removedIds = results.filter(({ success }) => success).map(({ id }) => id);
     if (removedIds.length > 0) {
-      await this.albumRepository.removeAssets({ albumId: id, assetIds: removedIds });
+      await this.albumRepository.removeAssets(id, removedIds);
       await this.albumRepository.update({ id, updatedAt: new Date() });
       if (album.albumThumbnailAssetId && removedIds.includes(album.albumThumbnailAssetId)) {
         await this.albumRepository.updateThumbnails();

--- a/server/src/domain/domain.util.ts
+++ b/server/src/domain/domain.util.ts
@@ -13,6 +13,7 @@ import {
   ValidationOptions,
 } from 'class-validator';
 import { CronJob } from 'cron';
+import _ from 'lodash';
 import { basename, extname } from 'node:path';
 import sanitize from 'sanitize-filename';
 
@@ -173,6 +174,32 @@ export function Optional({ nullable, ...validationOptions }: OptionalOptions = {
   }
 
   return ValidateIf((obj: any, v: any) => v !== undefined, validationOptions);
+}
+
+/**
+ * Chunks an array or set into smaller arrays of the specified size.
+ *
+ * @param collection The collection to chunk.
+ * @param size The size of each chunk.
+ */
+export function chunks<T>(collection: Array<T> | Set<T>, size: number): T[][] {
+  if (collection instanceof Set) {
+    const result = [];
+    let chunk = [];
+    for (const elem of collection) {
+      chunk.push(elem);
+      if (chunk.length === size) {
+        result.push(chunk);
+        chunk = [];
+      }
+    }
+    if (chunk.length > 0) {
+      result.push(chunk);
+    }
+    return result;
+  } else {
+    return _.chunk(collection, size);
+  }
 }
 
 // NOTE: The following Set utils have been added here, to easily determine where they are used.

--- a/server/src/domain/repositories/album.repository.ts
+++ b/server/src/domain/repositories/album.repository.ts
@@ -31,7 +31,7 @@ export interface IAlbumRepository {
   getAssetIds(albumId: string, assetIds?: string[]): Promise<Set<string>>;
   hasAsset(asset: AlbumAsset): Promise<boolean>;
   removeAsset(assetId: string): Promise<void>;
-  removeAssets(assets: AlbumAssets): Promise<void>;
+  removeAssets(albumId: string, assetIds: string[]): Promise<void>;
   getMetadataForIds(ids: string[]): Promise<AlbumAssetCount[]>;
   getInvalidThumbnail(): Promise<string[]>;
   getOwned(ownerId: string): Promise<AlbumEntity[]>;

--- a/server/src/infra/infra.util.ts
+++ b/server/src/infra/infra.util.ts
@@ -18,3 +18,9 @@ export const DummyValue = {
   BUFFER: Buffer.from('abcdefghi'),
   DATE: new Date(),
 };
+
+// PostgreSQL uses a 16-bit integer to indicate the number of bound parameters. This means that the
+// maximum number of parameters is 65535. Any query that tries to bind more than that (e.g. searching
+// by a list of IDs) requires splitting the query into multiple chunks.
+// We are rounding down this limit, as queries commonly include other filters and parameters.
+export const DATABASE_PARAMETER_CHUNK_SIZE = 65500;

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -1,6 +1,8 @@
 import { IAccessRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
+import _ from 'lodash';
 import { Brackets, In, Repository } from 'typeorm';
+import { setUnion } from '../../domain/domain.util';
 import {
   ActivityEntity,
   AlbumEntity,
@@ -12,6 +14,7 @@ import {
   SharedLinkEntity,
   UserTokenEntity,
 } from '../entities';
+import { DATABASE_PARAMETER_CHUNK_SIZE } from '../infra.util';
 
 export class AccessRepository implements IAccessRepository {
   constructor(
@@ -32,15 +35,19 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.activityRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...activityIds]),
-            userId,
-          },
-        })
-        .then((activities) => new Set(activities.map((activity) => activity.id)));
+      return Promise.all(
+        _.chunk([...activityIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.activityRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                userId,
+              },
+            })
+            .then((activities) => new Set(activities.map((activity) => activity.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkAlbumOwnerAccess: async (userId: string, activityIds: Set<string>): Promise<Set<string>> => {
@@ -48,17 +55,21 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.activityRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...activityIds]),
-            album: {
-              ownerId: userId,
-            },
-          },
-        })
-        .then((activities) => new Set(activities.map((activity) => activity.id)));
+      return Promise.all(
+        _.chunk([...activityIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.activityRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                album: {
+                  ownerId: userId,
+                },
+              },
+            })
+            .then((activities) => new Set(activities.map((activity) => activity.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkCreateAccess: async (userId: string, albumIds: Set<string>): Promise<Set<string>> => {
@@ -66,19 +77,23 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.albumRepository
-        .createQueryBuilder('album')
-        .select('album.id')
-        .leftJoin('album.sharedUsers', 'sharedUsers')
-        .where('album.id IN (:...albumIds)', { albumIds: [...albumIds] })
-        .andWhere('album.isActivityEnabled = true')
-        .andWhere(
-          new Brackets((qb) => {
-            qb.where('album.ownerId = :userId', { userId }).orWhere('sharedUsers.id = :userId', { userId });
-          }),
-        )
-        .getMany()
-        .then((albums) => new Set(albums.map((album) => album.id)));
+      return Promise.all(
+        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.albumRepository
+            .createQueryBuilder('album')
+            .select('album.id')
+            .leftJoin('album.sharedUsers', 'sharedUsers')
+            .where('album.id IN (:...albumIds)', { albumIds: idChunk })
+            .andWhere('album.isActivityEnabled = true')
+            .andWhere(
+              new Brackets((qb) => {
+                qb.where('album.ownerId = :userId', { userId }).orWhere('sharedUsers.id = :userId', { userId });
+              }),
+            )
+            .getMany()
+            .then((albums) => new Set(albums.map((album) => album.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -88,15 +103,19 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.libraryRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...libraryIds]),
-            ownerId: userId,
-          },
-        })
-        .then((libraries) => new Set(libraries.map((library) => library.id)));
+      return Promise.all(
+        _.chunk([...libraryIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.libraryRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                ownerId: userId,
+              },
+            })
+            .then((libraries) => new Set(libraries.map((library) => library.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkPartnerAccess: async (userId: string, partnerIds: Set<string>): Promise<Set<string>> => {
@@ -104,13 +123,17 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.partnerRepository
-        .createQueryBuilder('partner')
-        .select('partner.sharedById')
-        .where('partner.sharedById IN (:...partnerIds)', { partnerIds: [...partnerIds] })
-        .andWhere('partner.sharedWithId = :userId', { userId })
-        .getMany()
-        .then((partners) => new Set(partners.map((partner) => partner.sharedById)));
+      return Promise.all(
+        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.partnerRepository
+            .createQueryBuilder('partner')
+            .select('partner.sharedById')
+            .where('partner.sharedById IN (:...partnerIds)', { partnerIds: idChunk })
+            .andWhere('partner.sharedWithId = :userId', { userId })
+            .getMany()
+            .then((partners) => new Set(partners.map((partner) => partner.sharedById))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -120,13 +143,17 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.partnerRepository
-        .createQueryBuilder('partner')
-        .select('partner.sharedById')
-        .where('partner.sharedById IN (:...partnerIds)', { partnerIds: [...partnerIds] })
-        .andWhere('partner.sharedWithId = :userId', { userId })
-        .getMany()
-        .then((partners) => new Set(partners.map((partner) => partner.sharedById)));
+      return Promise.all(
+        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.partnerRepository
+            .createQueryBuilder('partner')
+            .select('partner.sharedById')
+            .where('partner.sharedById IN (:...partnerIds)', { partnerIds: idChunk })
+            .andWhere('partner.sharedWithId = :userId', { userId })
+            .getMany()
+            .then((partners) => new Set(partners.map((partner) => partner.sharedById))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -136,33 +163,37 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.albumRepository
-        .createQueryBuilder('album')
-        .innerJoin('album.assets', 'asset')
-        .leftJoin('album.sharedUsers', 'sharedUsers')
-        .select('asset.id', 'assetId')
-        .addSelect('asset.livePhotoVideoId', 'livePhotoVideoId')
-        .where('array["asset"."id", "asset"."livePhotoVideoId"] && array[:...assetIds]::uuid[]', {
-          assetIds: [...assetIds],
-        })
-        .andWhere(
-          new Brackets((qb) => {
-            qb.where('album.ownerId = :userId', { userId }).orWhere('sharedUsers.id = :userId', { userId });
-          }),
-        )
-        .getRawMany()
-        .then((rows) => {
-          const allowedIds = new Set<string>();
-          for (const row of rows) {
-            if (row.assetId && assetIds.has(row.assetId)) {
-              allowedIds.add(row.assetId);
-            }
-            if (row.livePhotoVideoId && assetIds.has(row.livePhotoVideoId)) {
-              allowedIds.add(row.livePhotoVideoId);
-            }
-          }
-          return allowedIds;
-        });
+      return Promise.all(
+        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.albumRepository
+            .createQueryBuilder('album')
+            .innerJoin('album.assets', 'asset')
+            .leftJoin('album.sharedUsers', 'sharedUsers')
+            .select('asset.id', 'assetId')
+            .addSelect('asset.livePhotoVideoId', 'livePhotoVideoId')
+            .where('array["asset"."id", "asset"."livePhotoVideoId"] && array[:...assetIds]::uuid[]', {
+              assetIds: idChunk,
+            })
+            .andWhere(
+              new Brackets((qb) => {
+                qb.where('album.ownerId = :userId', { userId }).orWhere('sharedUsers.id = :userId', { userId });
+              }),
+            )
+            .getRawMany()
+            .then((rows) => {
+              const allowedIds = new Set<string>();
+              for (const row of rows) {
+                if (row.assetId && assetIds.has(row.assetId)) {
+                  allowedIds.add(row.assetId);
+                }
+                if (row.livePhotoVideoId && assetIds.has(row.livePhotoVideoId)) {
+                  allowedIds.add(row.livePhotoVideoId);
+                }
+              }
+              return allowedIds;
+            }),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkOwnerAccess: async (userId: string, assetIds: Set<string>): Promise<Set<string>> => {
@@ -170,16 +201,20 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.assetRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...assetIds]),
-            ownerId: userId,
-          },
-          withDeleted: true,
-        })
-        .then((assets) => new Set(assets.map((asset) => asset.id)));
+      return Promise.all(
+        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.assetRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                ownerId: userId,
+              },
+              withDeleted: true,
+            })
+            .then((assets) => new Set(assets.map((asset) => asset.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkPartnerAccess: async (userId: string, assetIds: Set<string>): Promise<Set<string>> => {
@@ -187,15 +222,19 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.partnerRepository
-        .createQueryBuilder('partner')
-        .innerJoin('partner.sharedBy', 'sharedBy')
-        .innerJoin('sharedBy.assets', 'asset')
-        .select('asset.id', 'assetId')
-        .where('partner.sharedWithId = :userId', { userId })
-        .andWhere('asset.id IN (:...assetIds)', { assetIds: [...assetIds] })
-        .getRawMany()
-        .then((rows) => new Set(rows.map((row) => row.assetId)));
+      return Promise.all(
+        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.partnerRepository
+            .createQueryBuilder('partner')
+            .innerJoin('partner.sharedBy', 'sharedBy')
+            .innerJoin('sharedBy.assets', 'asset')
+            .select('asset.id', 'assetId')
+            .where('partner.sharedWithId = :userId', { userId })
+            .andWhere('asset.id IN (:...assetIds)', { assetIds: idChunk })
+            .getRawMany()
+            .then((rows) => new Set(rows.map((row) => row.assetId))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkSharedLinkAccess: async (sharedLinkId: string, assetIds: Set<string>): Promise<Set<string>> => {
@@ -203,41 +242,45 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.sharedLinkRepository
-        .createQueryBuilder('sharedLink')
-        .leftJoin('sharedLink.album', 'album')
-        .leftJoin('sharedLink.assets', 'assets')
-        .leftJoin('album.assets', 'albumAssets')
-        .select('assets.id', 'assetId')
-        .addSelect('albumAssets.id', 'albumAssetId')
-        .addSelect('assets.livePhotoVideoId', 'assetLivePhotoVideoId')
-        .addSelect('albumAssets.livePhotoVideoId', 'albumAssetLivePhotoVideoId')
-        .where('sharedLink.id = :sharedLinkId', { sharedLinkId })
-        .andWhere(
-          'array["assets"."id", "assets"."livePhotoVideoId", "albumAssets"."id", "albumAssets"."livePhotoVideoId"] && array[:...assetIds]::uuid[]',
-          {
-            assetIds: [...assetIds],
-          },
-        )
-        .getRawMany()
-        .then((rows) => {
-          const allowedIds = new Set<string>();
-          for (const row of rows) {
-            if (row.assetId && assetIds.has(row.assetId)) {
-              allowedIds.add(row.assetId);
-            }
-            if (row.assetLivePhotoVideoId && assetIds.has(row.assetLivePhotoVideoId)) {
-              allowedIds.add(row.assetLivePhotoVideoId);
-            }
-            if (row.albumAssetId && assetIds.has(row.albumAssetId)) {
-              allowedIds.add(row.albumAssetId);
-            }
-            if (row.albumAssetLivePhotoVideoId && assetIds.has(row.albumAssetLivePhotoVideoId)) {
-              allowedIds.add(row.albumAssetLivePhotoVideoId);
-            }
-          }
-          return allowedIds;
-        });
+      return Promise.all(
+        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.sharedLinkRepository
+            .createQueryBuilder('sharedLink')
+            .leftJoin('sharedLink.album', 'album')
+            .leftJoin('sharedLink.assets', 'assets')
+            .leftJoin('album.assets', 'albumAssets')
+            .select('assets.id', 'assetId')
+            .addSelect('albumAssets.id', 'albumAssetId')
+            .addSelect('assets.livePhotoVideoId', 'assetLivePhotoVideoId')
+            .addSelect('albumAssets.livePhotoVideoId', 'albumAssetLivePhotoVideoId')
+            .where('sharedLink.id = :sharedLinkId', { sharedLinkId })
+            .andWhere(
+              'array["assets"."id", "assets"."livePhotoVideoId", "albumAssets"."id", "albumAssets"."livePhotoVideoId"] && array[:...assetIds]::uuid[]',
+              {
+                assetIds: idChunk,
+              },
+            )
+            .getRawMany()
+            .then((rows) => {
+              const allowedIds = new Set<string>();
+              for (const row of rows) {
+                if (row.assetId && assetIds.has(row.assetId)) {
+                  allowedIds.add(row.assetId);
+                }
+                if (row.assetLivePhotoVideoId && assetIds.has(row.assetLivePhotoVideoId)) {
+                  allowedIds.add(row.assetLivePhotoVideoId);
+                }
+                if (row.albumAssetId && assetIds.has(row.albumAssetId)) {
+                  allowedIds.add(row.albumAssetId);
+                }
+                if (row.albumAssetLivePhotoVideoId && assetIds.has(row.albumAssetLivePhotoVideoId)) {
+                  allowedIds.add(row.albumAssetLivePhotoVideoId);
+                }
+              }
+              return allowedIds;
+            }),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -247,15 +290,19 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.tokenRepository
-        .find({
-          select: { id: true },
-          where: {
-            userId,
-            id: In([...deviceIds]),
-          },
-        })
-        .then((tokens) => new Set(tokens.map((token) => token.id)));
+      return Promise.all(
+        _.chunk([...deviceIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.tokenRepository
+            .find({
+              select: { id: true },
+              where: {
+                userId,
+                id: In(idChunk),
+              },
+            })
+            .then((tokens) => new Set(tokens.map((token) => token.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -265,15 +312,19 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.albumRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...albumIds]),
-            ownerId: userId,
-          },
-        })
-        .then((albums) => new Set(albums.map((album) => album.id)));
+      return Promise.all(
+        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.albumRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                ownerId: userId,
+              },
+            })
+            .then((albums) => new Set(albums.map((album) => album.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkSharedAlbumAccess: async (userId: string, albumIds: Set<string>): Promise<Set<string>> => {
@@ -281,17 +332,21 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.albumRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...albumIds]),
-            sharedUsers: {
-              id: userId,
-            },
-          },
-        })
-        .then((albums) => new Set(albums.map((album) => album.id)));
+      return Promise.all(
+        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.albumRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                sharedUsers: {
+                  id: userId,
+                },
+              },
+            })
+            .then((albums) => new Set(albums.map((album) => album.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkSharedLinkAccess: async (sharedLinkId: string, albumIds: Set<string>): Promise<Set<string>> => {
@@ -299,18 +354,22 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.sharedLinkRepository
-        .find({
-          select: { albumId: true },
-          where: {
-            id: sharedLinkId,
-            albumId: In([...albumIds]),
-          },
-        })
-        .then(
-          (sharedLinks) =>
-            new Set(sharedLinks.flatMap((sharedLink) => (!!sharedLink.albumId ? [sharedLink.albumId] : []))),
-        );
+      return Promise.all(
+        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.sharedLinkRepository
+            .find({
+              select: { albumId: true },
+              where: {
+                id: sharedLinkId,
+                albumId: In(idChunk),
+              },
+            })
+            .then(
+              (sharedLinks) =>
+                new Set(sharedLinks.flatMap((sharedLink) => (!!sharedLink.albumId ? [sharedLink.albumId] : []))),
+            ),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -320,32 +379,41 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.personRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...personIds]),
-            ownerId: userId,
-          },
-        })
-        .then((persons) => new Set(persons.map((person) => person.id)));
+      return Promise.all(
+        _.chunk([...personIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.personRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                ownerId: userId,
+              },
+            })
+            .then((persons) => new Set(persons.map((person) => person.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
 
     checkFaceOwnerAccess: async (userId: string, assetFaceIds: Set<string>): Promise<Set<string>> => {
       if (assetFaceIds.size === 0) {
         return new Set();
       }
-      return this.assetFaceRepository
-        .find({
-          select: { id: true },
-          where: {
-            id: In([...assetFaceIds]),
-            asset: {
-              ownerId: userId,
-            },
-          },
-        })
-        .then((faces) => new Set(faces.map((face) => face.id)));
+
+      return Promise.all(
+        _.chunk([...assetFaceIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.assetFaceRepository
+            .find({
+              select: { id: true },
+              where: {
+                id: In(idChunk),
+                asset: {
+                  ownerId: userId,
+                },
+              },
+            })
+            .then((faces) => new Set(faces.map((face) => face.id))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 
@@ -355,13 +423,17 @@ export class AccessRepository implements IAccessRepository {
         return new Set();
       }
 
-      return this.partnerRepository
-        .createQueryBuilder('partner')
-        .select('partner.sharedById')
-        .where('partner.sharedById IN (:...partnerIds)', { partnerIds: [...partnerIds] })
-        .andWhere('partner.sharedWithId = :userId', { userId })
-        .getMany()
-        .then((partners) => new Set(partners.map((partner) => partner.sharedById)));
+      return Promise.all(
+        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+          this.partnerRepository
+            .createQueryBuilder('partner')
+            .select('partner.sharedById')
+            .where('partner.sharedById IN (:...partnerIds)', { partnerIds: idChunk })
+            .andWhere('partner.sharedWithId = :userId', { userId })
+            .getMany()
+            .then((partners) => new Set(partners.map((partner) => partner.sharedById))),
+        ),
+      ).then((results) => setUnion(...results));
     },
   };
 }

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -1,8 +1,7 @@
 import { IAccessRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
-import _ from 'lodash';
 import { Brackets, In, Repository } from 'typeorm';
-import { setUnion } from '../../domain/domain.util';
+import { chunks, setUnion } from '../../domain/domain.util';
 import {
   ActivityEntity,
   AlbumEntity,
@@ -36,7 +35,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...activityIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(activityIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.activityRepository
             .find({
               select: { id: true },
@@ -56,7 +55,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...activityIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(activityIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.activityRepository
             .find({
               select: { id: true },
@@ -78,7 +77,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(albumIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.albumRepository
             .createQueryBuilder('album')
             .select('album.id')
@@ -104,7 +103,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...libraryIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(libraryIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.libraryRepository
             .find({
               select: { id: true },
@@ -124,7 +123,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(partnerIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.partnerRepository
             .createQueryBuilder('partner')
             .select('partner.sharedById')
@@ -144,7 +143,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(partnerIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.partnerRepository
             .createQueryBuilder('partner')
             .select('partner.sharedById')
@@ -164,7 +163,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(assetIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.albumRepository
             .createQueryBuilder('album')
             .innerJoin('album.assets', 'asset')
@@ -202,7 +201,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(assetIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.assetRepository
             .find({
               select: { id: true },
@@ -223,7 +222,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(assetIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.partnerRepository
             .createQueryBuilder('partner')
             .innerJoin('partner.sharedBy', 'sharedBy')
@@ -243,7 +242,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...assetIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(assetIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.sharedLinkRepository
             .createQueryBuilder('sharedLink')
             .leftJoin('sharedLink.album', 'album')
@@ -291,7 +290,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...deviceIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(deviceIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.tokenRepository
             .find({
               select: { id: true },
@@ -313,7 +312,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(albumIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.albumRepository
             .find({
               select: { id: true },
@@ -333,7 +332,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(albumIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.albumRepository
             .find({
               select: { id: true },
@@ -355,7 +354,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...albumIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(albumIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.sharedLinkRepository
             .find({
               select: { albumId: true },
@@ -380,7 +379,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...personIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(personIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.personRepository
             .find({
               select: { id: true },
@@ -400,7 +399,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...assetFaceIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(assetFaceIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.assetFaceRepository
             .find({
               select: { id: true },
@@ -424,7 +423,7 @@ export class AccessRepository implements IAccessRepository {
       }
 
       return Promise.all(
-        _.chunk([...partnerIds], DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
+        chunks(partnerIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
           this.partnerRepository
             .createQueryBuilder('partner')
             .select('partner.sharedById')

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -27,7 +27,7 @@ import { DateTime } from 'luxon';
 import { And, FindOptionsRelations, FindOptionsWhere, In, IsNull, LessThan, Not, Repository } from 'typeorm';
 import { AssetEntity, AssetJobStatusEntity, AssetType, ExifEntity, SmartInfoEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';
-import { Chunked, OptionalBetween, paginate } from '../infra.utils';
+import { Chunked, ChunkedArray, OptionalBetween, paginate } from '../infra.utils';
 
 const DEFAULT_SEARCH_SIZE = 250;
 
@@ -248,7 +248,7 @@ export class AssetRepository implements IAssetRepository {
   }
 
   @GenerateSql({ params: [[DummyValue.UUID]] })
-  @Chunked({ flatten: true })
+  @ChunkedArray()
   getByIds(ids: string[], relations?: FindOptionsRelations<AssetEntity>): Promise<AssetEntity[]> {
     if (!relations) {
       relations = {
@@ -302,7 +302,7 @@ export class AssetRepository implements IAssetRepository {
   }
 
   @GenerateSql({ params: [[DummyValue.UUID]] })
-  @Chunked({ flatten: true })
+  @ChunkedArray()
   getByLibraryId(libraryIds: string[]): Promise<AssetEntity[]> {
     return this.repository.find({
       where: { library: { id: In(libraryIds) } },

--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -10,7 +10,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { AssetEntity, AssetFaceEntity, PersonEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';
-import { Chunked, asVector } from '../infra.utils';
+import { Chunked, ChunkedArray, asVector } from '../infra.utils';
 
 export class PersonRepository implements IPersonRepository {
   constructor(
@@ -237,7 +237,7 @@ export class PersonRepository implements IPersonRepository {
   }
 
   @GenerateSql({ params: [[{ assetId: DummyValue.UUID, personId: DummyValue.UUID }]] })
-  @Chunked({ flatten: true })
+  @ChunkedArray()
   async getFacesByIds(ids: AssetFaceId[]): Promise<AssetFaceEntity[]> {
     return this.assetFaceRepository.find({ where: ids, relations: { asset: true }, withDeleted: true });
   }

--- a/server/src/infra/repositories/system-config.repository.ts
+++ b/server/src/infra/repositories/system-config.repository.ts
@@ -2,9 +2,10 @@ import { ISystemConfigRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import { readFile } from 'fs/promises';
+import _ from 'lodash';
 import { In, Repository } from 'typeorm';
 import { SystemConfigEntity } from '../entities';
-import { DummyValue, GenerateSql } from '../infra.util';
+import { DATABASE_PARAMETER_CHUNK_SIZE, DummyValue, GenerateSql } from '../infra.util';
 
 export class SystemConfigRepository implements ISystemConfigRepository {
   constructor(
@@ -30,6 +31,8 @@ export class SystemConfigRepository implements ISystemConfigRepository {
 
   @GenerateSql({ params: [DummyValue.STRING] })
   async deleteKeys(keys: string[]): Promise<void> {
-    await this.repository.delete({ key: In(keys) });
+    for (const keyChunk of _.chunk(keys, DATABASE_PARAMETER_CHUNK_SIZE)) {
+      await this.repository.delete({ key: In(keyChunk) });
+    }
   }
 }

--- a/server/src/infra/repositories/system-config.repository.ts
+++ b/server/src/infra/repositories/system-config.repository.ts
@@ -2,10 +2,10 @@ import { ISystemConfigRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import { readFile } from 'fs/promises';
-import _ from 'lodash';
 import { In, Repository } from 'typeorm';
 import { SystemConfigEntity } from '../entities';
-import { DATABASE_PARAMETER_CHUNK_SIZE, DummyValue, GenerateSql } from '../infra.util';
+import { DummyValue, GenerateSql } from '../infra.util';
+import { Chunked } from '../infra.utils';
 
 export class SystemConfigRepository implements ISystemConfigRepository {
   constructor(
@@ -30,9 +30,8 @@ export class SystemConfigRepository implements ISystemConfigRepository {
   }
 
   @GenerateSql({ params: [DummyValue.STRING] })
+  @Chunked()
   async deleteKeys(keys: string[]): Promise<void> {
-    for (const keyChunk of _.chunk(keys, DATABASE_PARAMETER_CHUNK_SIZE)) {
-      await this.repository.delete({ key: In(keyChunk) });
-    }
+    await this.repository.delete({ key: In(keys) });
   }
 }


### PR DESCRIPTION
PostgreSQL uses a 16-bit integer to indicate the number of bound parameters.

This means that the maximum number of parameters for any query is 65535. Any query that tries to bind more than that (e.g. searching by a list of IDs) requires splitting the query into multiple chunks.

This change includes refactoring every Repository that runs queries using a list of ids, and either flattening or merging results.

Fixes #5788, fixes #5997.

Also, potentially a fix for #4648 (at least based on [this comment](https://github.com/immich-app/immich/issues/4648#issuecomment-1826134027)).

References:

* https://github.com/typeorm/typeorm/issues/7565
* [PostgreSQL message format - Bind](https://www.postgresql.org/docs/15/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-BIND)