### PR TITLE
feat(mobile): Focus search on doubletap nav button

### DIFF
--- a/mobile/lib/modules/search/providers/search_focus_notifier.provider.dart
+++ b/mobile/lib/modules/search/providers/search_focus_notifier.provider.dart
@@ -1,9 +1,0 @@
-import 'package:flutter/material.dart';
-
-final searchFocusNotifierProvider = SearchFocusNotifier();
-
-class SearchFocusNotifier with ChangeNotifier {
-  void requestFocus() {
-    notifyListeners();
-  }
-}

--- a/mobile/lib/modules/search/providers/search_focus_notifier.provider.dart
+++ b/mobile/lib/modules/search/providers/search_focus_notifier.provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+final searchFocusNotifierProvider = SearchFocusNotifier();
+
+class SearchFocusNotifier with ChangeNotifier {
+  void requestFocus() {
+    notifyListeners();
+  }
+}

--- a/mobile/lib/modules/search/ui/immich_search_bar.dart
+++ b/mobile/lib/modules/search/ui/immich_search_bar.dart
@@ -4,7 +4,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
-import 'package:immich_mobile/modules/search/providers/search_focus_notifier.provider.dart';
 
 class ImmichSearchBar extends HookConsumerWidget
     implements PreferredSizeWidget {
@@ -36,9 +35,9 @@ class ImmichSearchBar extends HookConsumerWidget
 
     useEffect(
       () {
-        searchFocusNotifierProvider.addListener(onSearchFocusRequest);
+        searchFocusNotifier.addListener(onSearchFocusRequest);
         return () {
-          searchFocusNotifierProvider.removeListener(onSearchFocusRequest);
+          searchFocusNotifier.removeListener(onSearchFocusRequest);
         };
       },
       [],
@@ -92,4 +91,14 @@ class ImmichSearchBar extends HookConsumerWidget
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}
+
+// Used to focus search from outside this widget.
+// For example when double pressing the search nav icon.
+final searchFocusNotifier = SearchFocusNotifier();
+
+class SearchFocusNotifier with ChangeNotifier {
+  void requestFocus() {
+    notifyListeners();
+  }
 }

--- a/mobile/lib/modules/search/ui/immich_search_bar.dart
+++ b/mobile/lib/modules/search/ui/immich_search_bar.dart
@@ -59,9 +59,7 @@ class ImmichSearchBar extends HookConsumerWidget
         controller: searchTermController,
         focusNode: searchFocusNode,
         autofocus: false,
-        onTap: focusSearch
-          focusSearch();
-        },
+        onTap: focusSearch,
         onSubmitted: (searchTerm) {
           onSubmitted(searchTerm);
           searchTermController.clear();

--- a/mobile/lib/modules/search/ui/immich_search_bar.dart
+++ b/mobile/lib/modules/search/ui/immich_search_bar.dart
@@ -63,7 +63,7 @@ class ImmichSearchBar extends HookConsumerWidget
         controller: searchTermController,
         focusNode: searchFocusNode,
         autofocus: false,
-        onTap: () {
+        onTap: focusSearch
           focusSearch();
         },
         onSubmitted: (searchTerm) {

--- a/mobile/lib/modules/search/ui/immich_search_bar.dart
+++ b/mobile/lib/modules/search/ui/immich_search_bar.dart
@@ -29,15 +29,12 @@ class ImmichSearchBar extends HookConsumerWidget
 
       searchFocusNode.requestFocus();
     }
-    onSearchFocusRequest() {
-      focusSearch();
-    }
 
     useEffect(
       () {
-        searchFocusNotifier.addListener(onSearchFocusRequest);
+        searchFocusNotifier.addListener(focusSearch);
         return () {
-          searchFocusNotifier.removeListener(onSearchFocusRequest);
+          searchFocusNotifier.removeListener(focusSearch);
         };
       },
       [],

--- a/mobile/lib/modules/search/ui/immich_search_bar.dart
+++ b/mobile/lib/modules/search/ui/immich_search_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/search/providers/search_page_state.provider.dart';
+import 'package:immich_mobile/modules/search/providers/search_focus_notifier.provider.dart';
 
 class ImmichSearchBar extends HookConsumerWidget
     implements PreferredSizeWidget {
@@ -20,6 +21,28 @@ class ImmichSearchBar extends HookConsumerWidget
   Widget build(BuildContext context, WidgetRef ref) {
     final searchTermController = useTextEditingController(text: "");
     final isSearchEnabled = ref.watch(searchPageStateProvider).isSearchEnabled;
+
+    focusSearch() {
+      searchTermController.clear();
+      ref.watch(searchPageStateProvider.notifier).getSuggestedSearchTerms();
+      ref.watch(searchPageStateProvider.notifier).enableSearch();
+      ref.watch(searchPageStateProvider.notifier).setSearchTerm("");
+
+      searchFocusNode.requestFocus();
+    }
+    onSearchFocusRequest() {
+      focusSearch();
+    }
+
+    useEffect(
+      () {
+        searchFocusNotifierProvider.addListener(onSearchFocusRequest);
+        return () {
+          searchFocusNotifierProvider.removeListener(onSearchFocusRequest);
+        };
+      },
+      [],
+    );
 
     return AppBar(
       automaticallyImplyLeading: false,
@@ -41,12 +64,7 @@ class ImmichSearchBar extends HookConsumerWidget
         focusNode: searchFocusNode,
         autofocus: false,
         onTap: () {
-          searchTermController.clear();
-          ref.watch(searchPageStateProvider.notifier).getSuggestedSearchTerms();
-          ref.watch(searchPageStateProvider.notifier).enableSearch();
-          ref.watch(searchPageStateProvider.notifier).setSearchTerm("");
-
-          searchFocusNode.requestFocus();
+          focusSearch();
         },
         onSubmitted: (searchTerm) {
           onSubmitted(searchTerm);

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -6,7 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/asset_viewer/providers/scroll_notifier.provider.dart';
 import 'package:immich_mobile/modules/home/providers/multiselect.provider.dart';
-import 'package:immich_mobile/modules/search/providers/search_focus_notifier.provider.dart';
+import 'package:immich_mobile/modules/search/ui/immich_search_bar.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/tab.provider.dart';
@@ -54,7 +54,7 @@ class TabControllerPage extends HookConsumerWidget {
           }
           if (tabsRouter.activeIndex == 1 && index == 1) {
             // Focus search
-            searchFocusNotifierProvider.requestFocus();
+            searchFocusNotifier.requestFocus();
           }
 
           HapticFeedback.selectionClick();
@@ -112,7 +112,7 @@ class TabControllerPage extends HookConsumerWidget {
           }
           if (tabsRouter.activeIndex == 1 && index == 1) {
             // Focus search
-            searchFocusNotifierProvider.requestFocus();
+            searchFocusNotifier.requestFocus();
           }
           HapticFeedback.selectionClick();
           tabsRouter.setActiveIndex(index);

--- a/mobile/lib/shared/views/tab_controller_page.dart
+++ b/mobile/lib/shared/views/tab_controller_page.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/asset_viewer/providers/scroll_notifier.provider.dart';
 import 'package:immich_mobile/modules/home/providers/multiselect.provider.dart';
+import 'package:immich_mobile/modules/search/providers/search_focus_notifier.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/tab.provider.dart';
@@ -51,6 +52,11 @@ class TabControllerPage extends HookConsumerWidget {
             // Scroll to top
             scrollToTopNotifierProvider.scrollToTop();
           }
+          if (tabsRouter.activeIndex == 1 && index == 1) {
+            // Focus search
+            searchFocusNotifierProvider.requestFocus();
+          }
+
           HapticFeedback.selectionClick();
           tabsRouter.setActiveIndex(index);
           ref.read(tabProvider.notifier).state = TabEnum.values[index];
@@ -103,6 +109,10 @@ class TabControllerPage extends HookConsumerWidget {
           if (tabsRouter.activeIndex == 0 && index == 0) {
             // Scroll to top
             scrollToTopNotifierProvider.scrollToTop();
+          }
+          if (tabsRouter.activeIndex == 1 && index == 1) {
+            // Focus search
+            searchFocusNotifierProvider.requestFocus();
           }
           HapticFeedback.selectionClick();
           tabsRouter.setActiveIndex(index);


### PR DESCRIPTION
Superseeds #6040 

Focuses search when tapping on the 'search' navigational button when search page already active.

Small demo:

https://github.com/immich-app/immich/assets/9844285/1f10bbf5-3b0a-4b63-8186-08f78c88a365

This was my first change in a Flutter codebase. The way I declare a closure to capture the `WidgetRef` inside `ImmichSearchBar` feels a bit dirty. Would love to hear what would be a better approach.

Tested on "tablet size"-screens by hardcoding the conditional to use that layout.