### PR TITLE
feat: storage template locking + fix for database locks

### DIFF
--- a/server/src/domain/repositories/database.repository.ts
+++ b/server/src/domain/repositories/database.repository.ts
@@ -8,6 +8,7 @@ export enum DatabaseExtension {
 
 export enum DatabaseLock {
   GeodataImport = 100,
+  StorageTemplateMigration = 420,
   CLIPDimSize = 512,
 }
 

--- a/server/src/domain/storage-template/storage-template.service.spec.ts
+++ b/server/src/domain/storage-template/storage-template.service.spec.ts
@@ -2,6 +2,7 @@ import {
   IAlbumRepository,
   IAssetRepository,
   ICryptoRepository,
+  IDatabaseRepository,
   IMoveRepository,
   IPersonRepository,
   IStorageRepository,
@@ -16,6 +17,7 @@ import {
   newAlbumRepositoryMock,
   newAssetRepositoryMock,
   newCryptoRepositoryMock,
+  newDatabaseRepositoryMock,
   newMoveRepositoryMock,
   newPersonRepositoryMock,
   newStorageRepositoryMock,
@@ -36,6 +38,7 @@ describe(StorageTemplateService.name, () => {
   let storageMock: jest.Mocked<IStorageRepository>;
   let userMock: jest.Mocked<IUserRepository>;
   let cryptoMock: jest.Mocked<ICryptoRepository>;
+  let databaseRepository: jest.Mocked<IDatabaseRepository>;
 
   it('should work', () => {
     expect(sut).toBeDefined();
@@ -50,6 +53,7 @@ describe(StorageTemplateService.name, () => {
     storageMock = newStorageRepositoryMock();
     userMock = newUserRepositoryMock();
     cryptoMock = newCryptoRepositoryMock();
+    databaseRepository = newDatabaseRepositoryMock();
 
     sut = new StorageTemplateService(
       albumMock,
@@ -61,6 +65,7 @@ describe(StorageTemplateService.name, () => {
       storageMock,
       userMock,
       cryptoMock,
+      databaseRepository,
     );
 
     configMock.load.mockResolvedValue([{ key: SystemConfigKey.STORAGE_TEMPLATE_ENABLED, value: true }]);


### PR DESCRIPTION
This PR fixes database locking so that it always uses the same session for unlocking as was used for locking.
It also adds locking to the storage template migration solution so only a single file is moved at a time, regardless of how many microservice instances you have running.

PR based on top of #5917