### PR TITLE
fix(web): allow future timebuckets

### DIFF
--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -760,7 +760,7 @@ export class AssetRepository implements IAssetRepository {
     let builder = this.repository
       .createQueryBuilder('asset')
       .where('asset.isVisible = true')
-      .andWhere('asset.fileCreatedAt < NOW()');
+      .andWhere("asset.fileCreatedAt BETWEEN '4713-01-01 BC' AND '294276-12-31 AD'");
     if (assetType !== undefined) {
       builder = builder.andWhere('asset.type = :assetType', { assetType });
     }

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -760,7 +760,7 @@ export class AssetRepository implements IAssetRepository {
     let builder = this.repository
       .createQueryBuilder('asset')
       .where('asset.isVisible = true')
-      .andWhere("asset.fileCreatedAt BETWEEN '4713-01-01 BC' AND '294276-12-31 AD'");
+      .andWhere("asset.fileCreatedAt BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'");
     if (assetType !== undefined) {
       builder = builder.andWhere('asset.type = :assetType', { assetType });
     }

--- a/server/src/infra/sql/asset.repository.sql
+++ b/server/src/infra/sql/asset.repository.sql
@@ -555,7 +555,7 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
+    AND "asset"."fileCreatedAt" BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'
   )
   AND ("asset"."deletedAt" IS NULL)
 GROUP BY
@@ -668,7 +668,7 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
+    AND "asset"."fileCreatedAt" BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'
     AND (
       date_trunc(
         'month',
@@ -708,7 +708,7 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
+    AND "asset"."fileCreatedAt" BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'
     AND "asset"."type" = $2
     AND "asset"."ownerId" IN ($3)
     AND "asset"."isArchived" = $4
@@ -739,7 +739,7 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
+    AND "asset"."fileCreatedAt" BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'
     AND "asset"."type" = $2
     AND "asset"."ownerId" IN ($3)
     AND "asset"."isArchived" = $4
@@ -761,7 +761,7 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
+    AND "asset"."fileCreatedAt" BETWEEN '4713-01-01 BC' AND '9999-12-31 AD'
     AND "asset"."ownerId" IN ($1)
     AND "asset"."isArchived" = $2
     AND (


### PR DESCRIPTION
fixes #5578

The original cause of the issue was a fix (#4540) intended for #4264 and #4538, which are Postgres "Time zone displacement out of range" errors caused by invalid dates.

[Postgres only supports date values from 4713 BC to 5874897 AD.](https://www.prisma.io/dataguide/postgresql/date-types#:~:text=The%20range%20of%20values%20for,in%20PostgreSQL%20for%20inserting%20data.)

I'm having a hard time replicating the original issues because using any date past 9999 AD in the `.xmp` files seems to reset the postgres date to the current date.

I've tested a smaller date range here though, and it works as expected.