### PR TITLE
feat(wip): add Combobox component for timezone picker

### DIFF
--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -10,7 +10,7 @@
   import { createEventDispatcher } from 'svelte';
   import { DateTime } from 'luxon';
   import ConfirmDialogue from './confirm-dialogue.svelte';
-  import Dropdown from '../elements/dropdown.svelte';
+  import Combobox from './combobox.svelte';
   export let initialDate: DateTime = DateTime.now();
 
   interface ZoneOption {
@@ -25,6 +25,10 @@
 
   const initialOption = timezones.find((item) => item.offset === 'UTC' + initialDate.toFormat('ZZ'));
 
+  let selectedOption = {
+    zone: initialOption?.zone || '',
+    offset: initialOption?.offset || '',
+  };
   let selectedDate = initialDate.toFormat("yyyy-MM-dd'T'HH:mm");
   let selectedTimezone = initialOption?.offset || null;
   let disabled = false;
@@ -120,7 +124,8 @@
         <label for="timezone">Timezone</label>
 
         <div class="relative">
-          <input
+          <Combobox bind:selectedOption options={filteredTimezones} />
+          <!-- <input
             class="text-sm my-4 w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600"
             id="timezoneSearch"
             type="text"
@@ -139,7 +144,7 @@
             controlable={true}
             bind:showMenu={isDropdownOpen}
             on:click-outside={isSearching ? null : closeDropdown}
-          />
+          /> -->
         </div>
       </div>
     </div>

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -93,10 +93,7 @@
       </div>
       <div class="flex flex-col w-full mt-2">
         <label for="timezone">Timezone</label>
-
-        <div class="relative">
-          <Combobox bind:selectedOption options={timezones} placeholder="Search timezone..." />
-        </div>
+        <Combobox bind:selectedOption options={timezones} placeholder="Search timezone..." />
       </div>
     </div>
   </ConfirmDialogue>

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -124,7 +124,7 @@
         <label for="timezone">Timezone</label>
 
         <div class="relative">
-          <Combobox bind:selectedOption options={filteredTimezones} />
+          <Combobox bind:selectedOption options={filteredTimezones} placeholder="Search timezone..." />
           <!-- <input
             class="text-sm my-4 w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600"
             id="timezoneSearch"

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -30,7 +30,7 @@
   };
 
   const timezones: ZoneOption[] = Intl.supportedValuesOf('timeZone').map((zone: string) => ({
-    label: zone,
+    label: zone + ` (${DateTime.local({ zone }).toFormat('ZZ')})`,
     value: 'UTC' + DateTime.local({ zone }).toFormat('ZZ'),
   }));
 

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,20 +1,20 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import Icon from '$lib/components/elements/icon.svelte';
   import { mdiMagnify, mdiUnfoldMoreHorizontal } from '@mdi/js';
 
-  export let options: {
-    zone: string;
-    offset: string;
-  }[] = [];
-  export let selectedOption: {
-    zone: string;
-    offset: string;
+  type ComboBoxOption = {
+    label: string;
+    value: T;
   };
+
+  export let options: ComboBoxOption[] = [];
+  export let selectedOption: ComboBoxOption;
   export let placeholder = '';
 
   let isOpened = false;
   let searchQuery = '';
-  $: filteredOptions = options.filter((option) => option.zone.toLowerCase().includes(searchQuery.toLowerCase()));
+
+  $: filteredOptions = options.filter((option) => option.label.toLowerCase().includes(searchQuery.toLowerCase()));
 </script>
 
 <div class="relative">
@@ -24,7 +24,7 @@
       searchQuery = '';
       isOpened = !isOpened;
     }}
-    >{selectedOption.zone}
+    >{selectedOption.label}
   </button>
 
   <div class="absolute right-0 top-0 h-full flex px-4 justify-center items-center">
@@ -51,15 +51,15 @@
         {#each filteredOptions as option}
           <button
             class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-all
-             ${option.zone === selectedOption.zone ? 'bg-gray-300 dark:bg-gray-600' : ''}
+             ${option.label === selectedOption.label ? 'bg-gray-300 dark:bg-gray-600' : ''}
             "
-            class:bg-gray-300={option.zone === selectedOption.zone}
+            class:bg-gray-300={option.label === selectedOption.label}
             on:click={() => {
               selectedOption = option;
               isOpened = false;
             }}
           >
-            {option.zone}
+            {option.label} - {option.value}
           </button>
         {/each}
       </div>

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -59,7 +59,7 @@
               isOpened = false;
             }}
           >
-            {option.label} - {option.value}
+            {option.label}
           </button>
         {/each}
       </div>

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
-  import { mdiMagnify } from '@mdi/js';
+  import { mdiMagnify, mdiUnfoldMoreHorizontal } from '@mdi/js';
 
   export let options: {
     zone: string;
@@ -16,39 +16,53 @@
   $: filteredOptions = options.filter((option) => option.zone.toLowerCase().includes(searchQuery.toLowerCase()));
 </script>
 
-<button
-  class="text-sm my-4 text-left w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600"
-  on:click={() => (isOpened = !isOpened)}
-  >{selectedOption.zone}
-</button>
+<div class="relative">
+  <button
+    class="text-sm text-left w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600 dark:hover:bg-gray-500 transition-all"
+    on:click={() => {
+      searchQuery = '';
+      isOpened = !isOpened;
+    }}
+    >{selectedOption.zone}
+  </button>
 
-{#if isOpened}
-  <div class="absolute w-full dark:bg-gray-800 rounded-lg border border-gray-700">
-    <div class="relative border-b border-gray-700 flex">
-      <div class="absolute inset-y-0 left-0 flex items-center pl-3">
-        <div class="dark:text-immich-dark-fg/75">
-          <button class="flex items-center">
-            <Icon path={mdiMagnify} size="1rem" />
-          </button>
-        </div>
-      </div>
-
-      <input bind:value={searchQuery} placeholder="Search timezone..." class="ml-9 grow bg-transparent py-2" />
-    </div>
-    <div class="h-64 overflow-y-auto">
-      {#each filteredOptions as option}
-        <button
-          class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
-          class:bg-gray-700={option.zone === selectedOption.zone}
-          on:click={() => {
-            selectedOption = option;
-            isOpened = false;
-            searchQuery = '';
-          }}
-        >
-          {option.zone}
-        </button>
-      {/each}
-    </div>
+  <div class="absolute right-0 top-0 h-full flex px-4 justify-center items-center">
+    <Icon path={mdiUnfoldMoreHorizontal} size="1rem" />
   </div>
-{/if}
+
+  {#if isOpened}
+    <div class="absolute w-full top-full mt-2 dark:bg-gray-800 rounded-lg border border-gray-700">
+      <div class="relative border-b border-gray-700 flex">
+        <div class="absolute inset-y-0 left-0 flex items-center pl-3">
+          <div class="dark:text-immich-dark-fg/75">
+            <button class="flex items-center">
+              <Icon path={mdiMagnify} size="1rem" />
+            </button>
+          </div>
+        </div>
+
+        <!-- svelte-ignore a11y-autofocus -->
+        <input
+          bind:value={searchQuery}
+          autofocus
+          placeholder="Search timezone..."
+          class="ml-9 grow bg-transparent py-2"
+        />
+      </div>
+      <div class="h-64 overflow-y-auto">
+        {#each filteredOptions as option}
+          <button
+            class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
+            class:bg-gray-700={option.zone === selectedOption.zone}
+            on:click={() => {
+              selectedOption = option;
+              isOpened = false;
+            }}
+          >
+            {option.zone}
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T">
   import Icon from '$lib/components/elements/icon.svelte';
+  import { clickOutside } from '$lib/utils/click-outside';
   import { mdiMagnify, mdiUnfoldMoreHorizontal } from '@mdi/js';
 
   type ComboBoxOption = {
@@ -11,27 +12,38 @@
   export let selectedOption: ComboBoxOption;
   export let placeholder = '';
 
-  let isOpened = false;
+  let isOpen = false;
   let searchQuery = '';
 
   $: filteredOptions = options.filter((option) => option.label.toLowerCase().includes(searchQuery.toLowerCase()));
+
+  let handleClick = () => {
+    searchQuery = '';
+    isOpen = !isOpen;
+  };
+
+  let handleOutClick = () => {
+    searchQuery = '';
+    isOpen = false;
+  };
+
+  let handleSelect = (option: ComboBoxOption) => {
+    selectedOption = option;
+    isOpen = false;
+  };
 </script>
 
-<div class="relative">
+<div class="relative" use:clickOutside on:outclick={handleOutClick}>
   <button
     class="text-sm text-left w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600 dark:hover:bg-gray-500 transition-all"
-    on:click={() => {
-      searchQuery = '';
-      isOpened = !isOpened;
-    }}
+    on:click={handleClick}
     >{selectedOption.label}
+    <div class="absolute right-0 top-0 h-full flex px-4 justify-center items-center content-between">
+      <Icon path={mdiUnfoldMoreHorizontal} />
+    </div>
   </button>
 
-  <div class="absolute right-0 top-0 h-full flex px-4 justify-center items-center">
-    <Icon path={mdiUnfoldMoreHorizontal} size="1rem" />
-  </div>
-
-  {#if isOpened}
+  {#if isOpen}
     <div
       class="absolute w-full top-full mt-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-900"
     >
@@ -39,7 +51,7 @@
         <div class="absolute inset-y-0 left-0 flex items-center pl-3">
           <div class="dark:text-immich-dark-fg/75">
             <button class="flex items-center">
-              <Icon path={mdiMagnify} size="1rem" />
+              <Icon path={mdiMagnify} />
             </button>
           </div>
         </div>
@@ -48,16 +60,13 @@
         <input bind:value={searchQuery} autofocus {placeholder} class="ml-9 grow bg-transparent py-2" />
       </div>
       <div class="h-64 overflow-y-auto">
-        {#each filteredOptions as option}
+        {#each filteredOptions as option (option.label)}
           <button
             class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-all
              ${option.label === selectedOption.label ? 'bg-gray-300 dark:bg-gray-600' : ''}
             "
             class:bg-gray-300={option.label === selectedOption.label}
-            on:click={() => {
-              selectedOption = option;
-              isOpened = false;
-            }}
+            on:click={() => handleSelect(option)}
           >
             {option.label}
           </button>

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  export let options: {
+    zone: string;
+    offset: string;
+  }[] = [];
+  export let selectedOption: {
+    zone: string;
+    offset: string;
+  };
+  let isOpened = false;
+</script>
+
+<button
+  class="text-sm my-4 text-left w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600"
+  placeholder="Search timezone..."
+  on:click={() => (isOpened = !isOpened)}
+  >{selectedOption.zone}
+</button>
+
+{#if isOpened}
+  <div class="absolute w-full h-32 overflow-auto dark:bg-gray-800">
+    {#each options as option}
+      <button
+        class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
+        class:bg-gray-700={option.zone === selectedOption.zone}
+        on:click={() => {
+          selectedOption = option;
+          isOpened = false;
+        }}
+      >
+        {option.zone}
+      </button>
+    {/each}
+  </div>
+{/if}

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,3 +1,9 @@
+<script lang="ts" context="module">
+  // Necessary for eslint
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  type T = any;
+</script>
+
 <script lang="ts" generics="T">
   import Icon from '$lib/components/elements/icon.svelte';
   import { clickOutside } from '$lib/utils/click-outside';

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -10,9 +10,10 @@
     zone: string;
     offset: string;
   };
+  export let placeholder = '';
+
   let isOpened = false;
   let searchQuery = '';
-
   $: filteredOptions = options.filter((option) => option.zone.toLowerCase().includes(searchQuery.toLowerCase()));
 </script>
 
@@ -31,8 +32,10 @@
   </div>
 
   {#if isOpened}
-    <div class="absolute w-full top-full mt-2 dark:bg-gray-800 rounded-lg border border-gray-700">
-      <div class="relative border-b border-gray-700 flex">
+    <div
+      class="absolute w-full top-full mt-2 bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-900"
+    >
+      <div class="relative border-b flex">
         <div class="absolute inset-y-0 left-0 flex items-center pl-3">
           <div class="dark:text-immich-dark-fg/75">
             <button class="flex items-center">
@@ -42,18 +45,15 @@
         </div>
 
         <!-- svelte-ignore a11y-autofocus -->
-        <input
-          bind:value={searchQuery}
-          autofocus
-          placeholder="Search timezone..."
-          class="ml-9 grow bg-transparent py-2"
-        />
+        <input bind:value={searchQuery} autofocus {placeholder} class="ml-9 grow bg-transparent py-2" />
       </div>
       <div class="h-64 overflow-y-auto">
         {#each filteredOptions as option}
           <button
-            class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
-            class:bg-gray-700={option.zone === selectedOption.zone}
+            class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-all
+             ${option.zone === selectedOption.zone ? 'bg-gray-300 dark:bg-gray-600' : ''}
+            "
+            class:bg-gray-300={option.zone === selectedOption.zone}
             on:click={() => {
               selectedOption = option;
               isOpened = false;

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import Icon from '$lib/components/elements/icon.svelte';
+  import { mdiMagnify } from '@mdi/js';
+
   export let options: {
     zone: string;
     offset: string;
@@ -12,13 +15,23 @@
 
 <button
   class="text-sm my-4 text-left w-full bg-gray-200 p-3 rounded-lg dark:text-white dark:bg-gray-600"
-  placeholder="Search timezone..."
   on:click={() => (isOpened = !isOpened)}
   >{selectedOption.zone}
 </button>
 
 {#if isOpened}
-  <div class="absolute w-full h-32 overflow-auto dark:bg-gray-800">
+  <div class="absolute h-64 overflow-x-auto dark:bg-gray-800 rounded-lg border border-gray-700">
+    <div class="relative border-b border-gray-700 flex">
+      <div class="absolute inset-y-0 left-0 flex items-center pl-3">
+        <div class="dark:text-immich-dark-fg/75">
+          <button class="flex items-center">
+            <Icon path={mdiMagnify} size="1rem" />
+          </button>
+        </div>
+      </div>
+
+      <input placeholder="Search timezone..." class="ml-9 grow bg-transparent py-2" />
+    </div>
     {#each options as option}
       <button
         class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -23,7 +23,7 @@
 </button>
 
 {#if isOpened}
-  <div class="absolute h-64 overflow-x-auto dark:bg-gray-800 rounded-lg border border-gray-700">
+  <div class="absolute w-full dark:bg-gray-800 rounded-lg border border-gray-700">
     <div class="relative border-b border-gray-700 flex">
       <div class="absolute inset-y-0 left-0 flex items-center pl-3">
         <div class="dark:text-immich-dark-fg/75">
@@ -35,18 +35,20 @@
 
       <input bind:value={searchQuery} placeholder="Search timezone..." class="ml-9 grow bg-transparent py-2" />
     </div>
-    {#each filteredOptions as option}
-      <button
-        class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
-        class:bg-gray-700={option.zone === selectedOption.zone}
-        on:click={() => {
-          selectedOption = option;
-          isOpened = false;
-          searchQuery = '';
-        }}
-      >
-        {option.zone}
-      </button>
-    {/each}
+    <div class="h-64 overflow-y-auto">
+      {#each filteredOptions as option}
+        <button
+          class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
+          class:bg-gray-700={option.zone === selectedOption.zone}
+          on:click={() => {
+            selectedOption = option;
+            isOpened = false;
+            searchQuery = '';
+          }}
+        >
+          {option.zone}
+        </button>
+      {/each}
+    </div>
   </div>
 {/if}

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -11,6 +11,9 @@
     offset: string;
   };
   let isOpened = false;
+  let searchQuery = '';
+
+  $: filteredOptions = options.filter((option) => option.zone.toLowerCase().includes(searchQuery.toLowerCase()));
 </script>
 
 <button
@@ -30,15 +33,16 @@
         </div>
       </div>
 
-      <input placeholder="Search timezone..." class="ml-9 grow bg-transparent py-2" />
+      <input bind:value={searchQuery} placeholder="Search timezone..." class="ml-9 grow bg-transparent py-2" />
     </div>
-    {#each options as option}
+    {#each filteredOptions as option}
       <button
         class="block text-left w-full px-4 py-2 cursor-pointer hover:bg-gray-700"
         class:bg-gray-700={option.zone === selectedOption.zone}
         on:click={() => {
           selectedOption = option;
           isOpened = false;
+          searchQuery = '';
         }}
       >
         {option.zone}


### PR DESCRIPTION
This change introduces a new Combobox component, a custom select with autocomplete functionality.

The purpose of this component is to replace the current timezone dropdown and be used wherever we need it in the future:

**Current:**
<img width="523" alt="CleanShot_2024-01-01_at_16 10 432x" src="https://github.com/immich-app/immich/assets/37197876/9f0ad0fa-c6da-4a2e-9f8c-ae3ec1940c4d">

**New (WIP):**
<img width="507" alt="CleanShot 2024-01-03 at 18 59 24@2x" src="https://github.com/immich-app/immich/assets/37197876/d2aa7806-2557-4156-b184-b22023a7a5c5">


