### PR TITLE
refactor(mobile): use startOAuth and server features flags

### DIFF
--- a/mobile/lib/modules/login/services/oauth.service.dart
+++ b/mobile/lib/modules/login/services/oauth.service.dart
@@ -11,15 +11,16 @@ class OAuthService {
   final log = Logger('OAuthService');
   OAuthService(this._apiService);
 
-  Future<OAuthConfigResponseDto?> getOAuthServerConfig(
+  Future<String?> getOAuthServerUrl(
     String serverUrl,
   ) async {
     // Resolve API server endpoint from user provided serverUrl
     await _apiService.resolveAndSetEndpoint(serverUrl);
 
-    return await _apiService.oAuthApi.generateOAuthConfig(
+    final dto = await _apiService.oAuthApi.startOAuth(
       OAuthConfigDto(redirectUri: '$callbackUrlScheme:/'),
     );
+    return dto?.url;
   }
 
   Future<LoginResponseDto?> oAuthLogin(String oauthUrl) async {

--- a/mobile/lib/shared/models/server_info/server_config.model.dart
+++ b/mobile/lib/shared/models/server_info/server_config.model.dart
@@ -2,40 +2,46 @@ import 'package:openapi/api.dart';
 
 class ServerConfig {
   final int trashDays;
+  final String oauthButtonText;
   final String externalDomain;
 
   const ServerConfig({
     required this.trashDays,
+    required this.oauthButtonText,
     required this.externalDomain,
   });
 
   ServerConfig copyWith({
     int? trashDays,
+    String? oauthButtonText,
     String? externalDomain,
   }) {
     return ServerConfig(
       trashDays: trashDays ?? this.trashDays,
+      oauthButtonText: oauthButtonText ?? this.oauthButtonText,
       externalDomain: externalDomain ?? this.externalDomain,
     );
   }
 
   @override
   String toString() =>
-      'ServerConfig(trashDays: $trashDays, externalDomain: $externalDomain)';
+      'ServerConfig(trashDays: $trashDays, oauthButtonText: $oauthButtonText, externalDomain: $externalDomain)';
 
   ServerConfig.fromDto(ServerConfigDto dto)
       : trashDays = dto.trashDays,
+        oauthButtonText = dto.oauthButtonText,
         externalDomain = dto.externalDomain;
 
   @override
-  bool operator ==(Object other) {
+  bool operator ==(covariant ServerConfig other) {
     if (identical(this, other)) return true;
 
-    return other is ServerConfig &&
-        other.trashDays == trashDays &&
+    return other.trashDays == trashDays &&
+        other.oauthButtonText == oauthButtonText &&
         other.externalDomain == externalDomain;
   }
 
   @override
-  int get hashCode => trashDays.hashCode ^ externalDomain.hashCode;
+  int get hashCode =>
+      trashDays.hashCode ^ oauthButtonText.hashCode ^ externalDomain.hashCode;
 }

--- a/mobile/lib/shared/models/server_info/server_features.model.dart
+++ b/mobile/lib/shared/models/server_info/server_features.model.dart
@@ -3,40 +3,56 @@ import 'package:openapi/api.dart';
 class ServerFeatures {
   final bool trash;
   final bool map;
+  final bool oauthEnabled;
+  final bool passwordLogin;
 
   const ServerFeatures({
     required this.trash,
     required this.map,
+    required this.oauthEnabled,
+    required this.passwordLogin,
   });
 
   ServerFeatures copyWith({
     bool? trash,
     bool? map,
+    bool? oauthEnabled,
+    bool? passwordLogin,
   }) {
     return ServerFeatures(
       trash: trash ?? this.trash,
       map: map ?? this.map,
+      oauthEnabled: oauthEnabled ?? this.oauthEnabled,
+      passwordLogin: passwordLogin ?? this.passwordLogin,
     );
   }
 
   @override
   String toString() {
-    return 'ServerFeatures(trash: $trash, map: $map)';
+    return 'ServerFeatures(trash: $trash, map: $map, oauthEnabled: $oauthEnabled, passwordLogin: $passwordLogin)';
   }
 
   ServerFeatures.fromDto(ServerFeaturesDto dto)
       : trash = dto.trash,
-        map = dto.map;
+        map = dto.map,
+        oauthEnabled = dto.oauth,
+        passwordLogin = dto.passwordLogin;
 
   @override
-  bool operator ==(Object other) {
+  bool operator ==(covariant ServerFeatures other) {
     if (identical(this, other)) return true;
 
-    return other is ServerFeatures && other.trash == trash && other.map == map;
+    return other.trash == trash &&
+        other.map == map &&
+        other.oauthEnabled == oauthEnabled &&
+        other.passwordLogin == passwordLogin;
   }
 
   @override
   int get hashCode {
-    return trash.hashCode ^ map.hashCode;
+    return trash.hashCode ^
+        map.hashCode ^
+        oauthEnabled.hashCode ^
+        passwordLogin.hashCode;
   }
 }

--- a/mobile/lib/shared/providers/server_info.provider.dart
+++ b/mobile/lib/shared/providers/server_info.provider.dart
@@ -26,9 +26,12 @@ class ServerInfoNotifier extends StateNotifier<ServerInfo> {
             serverFeatures: const ServerFeatures(
               map: true,
               trash: true,
+              oauthEnabled: false,
+              passwordLogin: true,
             ),
             serverConfig: const ServerConfig(
               trashDays: 30,
+              oauthButtonText: '',
               externalDomain: '',
             ),
             serverDiskInfo: const ServerDiskInfo(
@@ -45,10 +48,10 @@ class ServerInfoNotifier extends StateNotifier<ServerInfo> {
 
   final ServerInfoService _serverInfoService;
 
-  getServerInfo() {
-    getServerVersion();
-    getServerFeatures();
-    getServerConfig();
+  Future<void> getServerInfo() async {
+    await getServerVersion();
+    await getServerFeatures();
+    await getServerConfig();
   }
 
   getServerVersion() async {


### PR DESCRIPTION
#### Changes made:

- Use `startOAuth` instead of `generateOAuthConfig` to get the redirect URL
- Use oauth feature flags and button text from server features and server config, instead of from the `generateOAuthConfig` api