### PR TITLE
feat(server)!: move welcome message to settings

### DIFF
--- a/cli/src/api/open-api/api.ts
+++ b/cli/src/api/open-api/api.ts
@@ -4038,6 +4038,12 @@ export interface SystemConfigServerDto {
      * @memberof SystemConfigServerDto
      */
     'externalDomain': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SystemConfigServerDto
+     */
+    'loginPageMessage': string;
 }
 /**
  * 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -30,15 +30,14 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## General
 
-| Variable                    | Description                                  |       Default       | Services                                     |
-| :-------------------------- | :------------------------------------------- | :-----------------: | :------------------------------------------- |
-| `TZ`                        | Timezone                                     |                     | microservices                                |
-| `NODE_ENV`                  | Environment (production, development)        |    `production`     | server, microservices, machine learning, web |
-| `LOG_LEVEL`                 | Log Level (verbose, debug, log, warn, error) |        `log`        | server, microservices                        |
-| `IMMICH_MEDIA_LOCATION`     | Media Location                               |     `./upload`      | server, microservices                        |
-| `PUBLIC_LOGIN_PAGE_MESSAGE` | Public Login Page Message                    |                     | web                                          |
-| `IMMICH_CONFIG_FILE`        | Path to config file                          |                     | server                                       |
-| `IMMICH_WEB_ROOT`           | Path of root index.html                      | `/usr/src/app/www'` | server                                       |
+| Variable                | Description                                  |       Default       | Services                                     |
+| :---------------------- | :------------------------------------------- | :-----------------: | :------------------------------------------- |
+| `TZ`                    | Timezone                                     |                     | microservices                                |
+| `NODE_ENV`              | Environment (production, development)        |    `production`     | server, microservices, machine learning, web |
+| `LOG_LEVEL`             | Log Level (verbose, debug, log, warn, error) |        `log`        | server, microservices                        |
+| `IMMICH_MEDIA_LOCATION` | Media Location                               |     `./upload`      | server, microservices                        |
+| `IMMICH_CONFIG_FILE`    | Path to config file                          |                     | server                                       |
+| `IMMICH_WEB_ROOT`       | Path of root index.html                      | `/usr/src/app/www'` | server                                       |
 
 :::tip
 

--- a/mobile/openapi/doc/SystemConfigServerDto.md
+++ b/mobile/openapi/doc/SystemConfigServerDto.md
@@ -9,6 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **externalDomain** | **String** |  | 
+**loginPageMessage** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/system_config_server_dto.dart
+++ b/mobile/openapi/lib/model/system_config_server_dto.dart
@@ -14,25 +14,31 @@ class SystemConfigServerDto {
   /// Returns a new [SystemConfigServerDto] instance.
   SystemConfigServerDto({
     required this.externalDomain,
+    required this.loginPageMessage,
   });
 
   String externalDomain;
 
+  String loginPageMessage;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigServerDto &&
-     other.externalDomain == externalDomain;
+     other.externalDomain == externalDomain &&
+     other.loginPageMessage == loginPageMessage;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (externalDomain.hashCode);
+    (externalDomain.hashCode) +
+    (loginPageMessage.hashCode);
 
   @override
-  String toString() => 'SystemConfigServerDto[externalDomain=$externalDomain]';
+  String toString() => 'SystemConfigServerDto[externalDomain=$externalDomain, loginPageMessage=$loginPageMessage]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'externalDomain'] = this.externalDomain;
+      json[r'loginPageMessage'] = this.loginPageMessage;
     return json;
   }
 
@@ -45,6 +51,7 @@ class SystemConfigServerDto {
 
       return SystemConfigServerDto(
         externalDomain: mapValueOfType<String>(json, r'externalDomain')!,
+        loginPageMessage: mapValueOfType<String>(json, r'loginPageMessage')!,
       );
     }
     return null;
@@ -93,6 +100,7 @@ class SystemConfigServerDto {
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
     'externalDomain',
+    'loginPageMessage',
   };
 }
 

--- a/mobile/openapi/test/system_config_server_dto_test.dart
+++ b/mobile/openapi/test/system_config_server_dto_test.dart
@@ -21,6 +21,11 @@ void main() {
       // TODO
     });
 
+    // String loginPageMessage
+    test('to test the property `loginPageMessage`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/server/immich-openapi-specs.json
+++ b/server/immich-openapi-specs.json
@@ -9371,10 +9371,14 @@
         "properties": {
           "externalDomain": {
             "type": "string"
+          },
+          "loginPageMessage": {
+            "type": "string"
           }
         },
         "required": [
-          "externalDomain"
+          "externalDomain",
+          "loginPageMessage"
         ],
         "type": "object"
       },

--- a/server/src/domain/server-info/server-info.service.ts
+++ b/server/src/domain/server-info/server-info.service.ts
@@ -78,14 +78,10 @@ export class ServerInfoService {
 
   async getConfig(): Promise<ServerConfigDto> {
     const config = await this.configCore.getConfig();
-
-    // TODO move to system config
-    const loginPageMessage = process.env.PUBLIC_LOGIN_PAGE_MESSAGE || '';
-
     const isInitialized = await this.userRepository.hasAdmin();
 
     return {
-      loginPageMessage,
+      loginPageMessage: config.server.loginPageMessage,
       trashDays: config.trash.days,
       oauthButtonText: config.oauth.buttonText,
       isInitialized,

--- a/server/src/domain/system-config/dto/system-config-server.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-server.dto.ts
@@ -3,4 +3,7 @@ import { IsString } from 'class-validator';
 export class SystemConfigServerDto {
   @IsString()
   externalDomain!: string;
+
+  @IsString()
+  loginPageMessage!: string;
 }

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -129,6 +129,7 @@ export const defaults = Object.freeze<SystemConfig>({
   },
   server: {
     externalDomain: '',
+    loginPageMessage: '',
   },
 });
 

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -102,6 +102,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
   },
   server: {
     externalDomain: '',
+    loginPageMessage: '',
   },
   storageTemplate: {
     enabled: false,

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -85,6 +85,7 @@ export enum SystemConfigKey {
   PASSWORD_LOGIN_ENABLED = 'passwordLogin.enabled',
 
   SERVER_EXTERNAL_DOMAIN = 'server.externalDomain',
+  SERVER_LOGIN_PAGE_MESSAGE = 'server.loginPageMessage',
 
   STORAGE_TEMPLATE_ENABLED = 'storageTemplate.enabled',
   STORAGE_TEMPLATE_HASH_VERIFICATION_ENABLED = 'storageTemplate.hashVerificationEnabled',
@@ -248,5 +249,6 @@ export interface SystemConfig {
   };
   server: {
     externalDomain: string;
+    loginPageMessage: string;
   };
 }

--- a/web/src/api/open-api/api.ts
+++ b/web/src/api/open-api/api.ts
@@ -4038,6 +4038,12 @@ export interface SystemConfigServerDto {
      * @memberof SystemConfigServerDto
      */
     'externalDomain': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SystemConfigServerDto
+     */
+    'loginPageMessage': string;
 }
 /**
  * 

--- a/web/src/lib/components/admin-page/settings/server/server-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/server/server-settings.svelte
@@ -92,6 +92,15 @@
             bind:value={serverConfig.externalDomain}
             isEdited={serverConfig.externalDomain !== savedConfig.externalDomain}
           />
+
+          <SettingInputField
+            inputType={SettingInputFieldType.TEXT}
+            label="WELCOME MESSAGE"
+            desc="A message that is displayed on the login page."
+            bind:value={serverConfig.loginPageMessage}
+            isEdited={serverConfig.loginPageMessage !== savedConfig.loginPageMessage}
+          />
+
           <div class="ml-4">
             <SettingButtonsRow
               on:reset={({ detail }) => handleReset(detail)}


### PR DESCRIPTION
> [!Warning]
> ### Breaking change 
> The environment variable `PUBLIC_LOGIN_PAGE_MESSAGE` has been replaced with a new admin setting.

In this PR:
- Remove the environment variable `PUBLIC_LOGIN_PAGE_MESSAGE`
- Add a new setting: Admin > Settings > Server Settings > Welcome Message

Tested by:
- Setting a value, logging out and seeing it
- Clearing the value using reset to default, logging out, and seeing it disappear

![image](https://github.com/immich-app/immich/assets/4334196/9c722ac5-dd59-4497-88e4-6081474b5da1)
