### PR TITLE
feat(server): add env for reverse geocoding path

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -30,14 +30,15 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## General
 
-| Variable                | Description                                  |       Default       | Services                                     |
-| :---------------------- | :------------------------------------------- | :-----------------: | :------------------------------------------- |
-| `TZ`                    | Timezone                                     |                     | microservices                                |
-| `NODE_ENV`              | Environment (production, development)        |    `production`     | server, microservices, machine learning, web |
-| `LOG_LEVEL`             | Log Level (verbose, debug, log, warn, error) |        `log`        | server, microservices                        |
-| `IMMICH_MEDIA_LOCATION` | Media Location                               |     `./upload`      | server, microservices                        |
-| `IMMICH_CONFIG_FILE`    | Path to config file                          |                     | server                                       |
-| `IMMICH_WEB_ROOT`       | Path of root index.html                      | `/usr/src/app/www'` | server                                       |
+| Variable                        | Description                                  |        Default        | Services                                     |
+| :------------------------------ | :------------------------------------------- | :-------------------: | :------------------------------------------- |
+| `TZ`                            | Timezone                                     |                       | microservices                                |
+| `NODE_ENV`                      | Environment (production, development)        |     `production`      | server, microservices, machine learning, web |
+| `LOG_LEVEL`                     | Log Level (verbose, debug, log, warn, error) |         `log`         | server, microservices                        |
+| `IMMICH_MEDIA_LOCATION`         | Media Location                               |      `./upload`       | server, microservices                        |
+| `IMMICH_CONFIG_FILE`            | Path to config file                          |                       | server                                       |
+| `IMMICH_WEB_ROOT`               | Path of root index.html                      |  `/usr/src/app/www'`  | server                                       |
+| `IMMICH_REVERSE_GEOCODING_ROOT` | Path of reverse geocoding dump directory     | `/usr/src/resources'` | microservices                                |
 
 :::tip
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -30,15 +30,15 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## General
 
-| Variable                        | Description                                  |        Default        | Services                                     |
-| :------------------------------ | :------------------------------------------- | :-------------------: | :------------------------------------------- |
-| `TZ`                            | Timezone                                     |                       | microservices                                |
-| `NODE_ENV`                      | Environment (production, development)        |     `production`      | server, microservices, machine learning, web |
-| `LOG_LEVEL`                     | Log Level (verbose, debug, log, warn, error) |         `log`         | server, microservices                        |
-| `IMMICH_MEDIA_LOCATION`         | Media Location                               |      `./upload`       | server, microservices                        |
-| `IMMICH_CONFIG_FILE`            | Path to config file                          |                       | server                                       |
-| `IMMICH_WEB_ROOT`               | Path of root index.html                      |  `/usr/src/app/www'`  | server                                       |
-| `IMMICH_REVERSE_GEOCODING_ROOT` | Path of reverse geocoding dump directory     | `/usr/src/resources'` | microservices                                |
+| Variable                        | Description                                  |       Default        | Services                                     |
+| :------------------------------ | :------------------------------------------- | :------------------: | :------------------------------------------- |
+| `TZ`                            | Timezone                                     |                      | microservices                                |
+| `NODE_ENV`                      | Environment (production, development)        |     `production`     | server, microservices, machine learning, web |
+| `LOG_LEVEL`                     | Log Level (verbose, debug, log, warn, error) |        `log`         | server, microservices                        |
+| `IMMICH_MEDIA_LOCATION`         | Media Location                               |      `./upload`      | server, microservices                        |
+| `IMMICH_CONFIG_FILE`            | Path to config file                          |                      | server                                       |
+| `IMMICH_WEB_ROOT`               | Path of root index.html                      |  `/usr/src/app/www`  | server                                       |
+| `IMMICH_REVERSE_GEOCODING_ROOT` | Path of reverse geocoding dump directory     | `/usr/src/resources` | microservices                                |
 
 :::tip
 

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -72,6 +72,14 @@ export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload
 
 export const WEB_ROOT_PATH = join(process.env.IMMICH_WEB_ROOT || '/usr/src/app/www', 'index.html');
 
+const GEODATA_ROOT_PATH = process.env.IMMICH_REVERSE_GEOCODING_ROOT || '/usr/src/resources';
+
+export const citiesFile = 'cities500.txt';
+export const geodataDatePath = join(GEODATA_ROOT_PATH, 'geodata-date.txt');
+export const geodataAdmin1Path = join(GEODATA_ROOT_PATH, 'admin1CodesASCII.txt');
+export const geodataAdmin2Path = join(GEODATA_ROOT_PATH, 'admin2Codes.txt');
+export const geodataCitites500Path = join(GEODATA_ROOT_PATH, citiesFile);
+
 const image: Record<string, string[]> = {
   '.3fr': ['image/3fr', 'image/x-hasselblad-3fr'],
   '.ari': ['image/ari', 'image/x-arriflex-ari'],

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -1,4 +1,9 @@
 import {
+  citiesFile,
+  geodataAdmin1Path,
+  geodataAdmin2Path,
+  geodataCitites500Path,
+  geodataDatePath,
   GeoPoint,
   IMetadataRepository,
   ImmichTags,
@@ -20,8 +25,6 @@ import { DataSource, DeepPartial, QueryRunner, Repository } from 'typeorm';
 type GeoEntity = GeodataPlacesEntity | GeodataAdmin1Entity | GeodataAdmin2Entity;
 type GeoEntityClass = typeof GeodataPlacesEntity | typeof GeodataAdmin1Entity | typeof GeodataAdmin2Entity;
 
-const CITIES_FILE = 'cities500.txt';
-
 export class MetadataRepository implements IMetadataRepository {
   constructor(
     @InjectRepository(GeodataPlacesEntity) private readonly geodataPlacesRepository: Repository<GeodataPlacesEntity>,
@@ -35,7 +38,7 @@ export class MetadataRepository implements IMetadataRepository {
 
   async init(): Promise<void> {
     this.logger.log('Initializing metadata repository');
-    const geodataDate = await readFile('/usr/src/resources/geodata-date.txt', 'utf8');
+    const geodataDate = await readFile(geodataDatePath, 'utf8');
 
     const geocodingMetadata = await this.systemMetadataRepository.get(SystemMetadataKey.REVERSE_GEOCODING_STATE);
 
@@ -48,7 +51,7 @@ export class MetadataRepository implements IMetadataRepository {
 
     await this.systemMetadataRepository.set(SystemMetadataKey.REVERSE_GEOCODING_STATE, {
       lastUpdate: geodataDate,
-      lastImportFileName: CITIES_FILE,
+      lastImportFileName: citiesFile,
     });
 
     this.logger.log('Geodata import completed');
@@ -116,7 +119,7 @@ export class MetadataRepository implements IMetadataRepository {
           admin2Code: lineSplit[11],
           modificationDate: lineSplit[18],
         }),
-      `/usr/src/resources/${CITIES_FILE}`,
+      geodataCitites500Path,
       GeodataPlacesEntity,
     );
   }
@@ -129,7 +132,7 @@ export class MetadataRepository implements IMetadataRepository {
           key: lineSplit[0],
           name: lineSplit[1],
         }),
-      '/usr/src/resources/admin1CodesASCII.txt',
+      geodataAdmin1Path,
       GeodataAdmin1Entity,
     );
   }
@@ -142,7 +145,7 @@ export class MetadataRepository implements IMetadataRepository {
           key: lineSplit[0],
           name: lineSplit[1],
         }),
-      '/usr/src/resources/admin2Codes.txt',
+      geodataAdmin2Path,
       GeodataAdmin2Entity,
     );
   }


### PR DESCRIPTION
## Changes made in this PR

This PR adds an environment variable (`IMMICH_REVERSE_GEOCODING_ROOT`) to set the path of the reverse geocoding dump directory.