### PR TITLE
feat(web): go back on the onboarding

### DIFF
--- a/web/src/lib/components/onboarding-page/onboarding-theme.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-theme.svelte
@@ -28,7 +28,10 @@
 
   <div class="flex gap-4 mb-6">
     <button
-      class="w-1/2 aspect-square bg-immich-bg rounded-3xl transition-all shadow-sm hover:shadow-xl"
+      class="w-1/2 aspect-square bg-immich-bg rounded-3xl transition-all shadow-sm hover:shadow-xl {$colorTheme ==
+      'light'
+        ? 'border-[3px] border-immich-dark-primary/80 border-immich-primary'
+        : 'border border-transparent'}"
       on:click={toggleLightTheme}
     >
       <div
@@ -39,7 +42,9 @@
       </div>
     </button>
     <button
-      class="w-1/2 aspect-square bg-immich-dark-bg rounded-3xl border border-transparent"
+      class="w-1/2 aspect-square bg-immich-dark-bg rounded-3xl {$colorTheme == 'dark'
+        ? 'border-[3px] border-immich-dark-primary/80 border-immich-primary'
+        : 'border border-transparent'}"
       on:click={toggleDarkTheme}
     >
       <div

--- a/web/src/routes/auth/onboarding/+page.svelte
+++ b/web/src/routes/auth/onboarding/+page.svelte
@@ -22,20 +22,16 @@
 
   $: {
     const action = $page.url.searchParams.get('step');
-    const tempIndex =
-      onboardingSteps.findIndex((step) => step.name === action) >= 0
-        ? onboardingSteps.findIndex((step) => step.name === action)
-        : 0;
-    index = tempIndex !== -1 ? tempIndex : 0;
+    const tempIndex = onboardingSteps.findIndex((step) => step.name === action);
+    index = tempIndex >= 0 ? tempIndex : 0;
   }
 
   const handleDoneClicked = async () => {
-    index++;
-
-    if (index >= onboardingSteps.length) {
+    if (index >= onboardingSteps.length - 1) {
       await api.serverInfoApi.setAdminOnboarding();
       goto(AppRoute.PHOTOS);
     } else {
+      index++;
       goto(`${AppRoute.AUTH_ONBOARDING}?step=${onboardingSteps[index].name}`);
     }
   };

--- a/web/src/routes/auth/onboarding/+page.svelte
+++ b/web/src/routes/auth/onboarding/+page.svelte
@@ -21,8 +21,8 @@
   ];
 
   $: {
-    const action = $page.url.searchParams.get('step');
-    const tempIndex = onboardingSteps.findIndex((step) => step.name === action);
+    const stepState = $page.url.searchParams.get('step');
+    const tempIndex = onboardingSteps.findIndex((step) => step.name === stepState);
     index = tempIndex >= 0 ? tempIndex : 0;
   }
 

--- a/web/src/routes/auth/onboarding/+page.svelte
+++ b/web/src/routes/auth/onboarding/+page.svelte
@@ -5,10 +5,29 @@
   import { api } from '@api';
   import { goto } from '$app/navigation';
   import { AppRoute } from '$lib/constants';
+  import { page } from '$app/stores';
 
   let index = 0;
 
-  let onboardingSteps = [OnboardingHello, OnboardingTheme, OnboadingStorageTemplate];
+  interface OnboardingStep {
+    name: string;
+    component: typeof OnboardingHello | typeof OnboardingTheme | typeof OnboadingStorageTemplate;
+  }
+
+  let onboardingSteps: OnboardingStep[] = [
+    { name: 'hello', component: OnboardingHello },
+    { name: 'theme', component: OnboardingTheme },
+    { name: 'storage', component: OnboadingStorageTemplate },
+  ];
+
+  $: {
+    const action = $page.url.searchParams.get('step');
+    const tempIndex =
+      onboardingSteps.findIndex((step) => step.name === action) >= 0
+        ? onboardingSteps.findIndex((step) => step.name === action)
+        : 0;
+    index = tempIndex !== -1 ? tempIndex : 0;
+  }
 
   const handleDoneClicked = async () => {
     index++;
@@ -16,10 +35,12 @@
     if (index >= onboardingSteps.length) {
       await api.serverInfoApi.setAdminOnboarding();
       goto(AppRoute.PHOTOS);
+    } else {
+      goto(`${AppRoute.AUTH_ONBOARDING}?step=${onboardingSteps[index].name}`);
     }
   };
 </script>
 
 <section id="onboarding-page" class="min-w-screen flex min-h-screen place-content-center place-items-center p-4">
-  <svelte:component this={onboardingSteps[index]} on:done={handleDoneClicked} />
+  <svelte:component this={onboardingSteps[index].component} on:done={handleDoneClicked} />
 </section>


### PR DESCRIPTION
## Changes made in this PR

This PR adds the ability to use the browser history to go through each steps of the onboarding. Also adds a border to show which theme is selected.

## Screenshots

https://github.com/immich-app/immich/assets/74269598/8ebda6fd-a4d8-47f5-b25b-c6b15d4de900

