### PR TITLE
fix(server): Execute query in AlbumRepository.removeAsset method

### DIFF
--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -177,14 +177,15 @@ export class AlbumRepository implements IAlbumRepository {
     });
   }
 
-  // @GenerateSql({ params: [DummyValue.UUID] })
+  @GenerateSql({ params: [DummyValue.UUID] })
   async removeAsset(assetId: string): Promise<void> {
     // Using dataSource, because there is no direct access to albums_assets_assets.
     await this.dataSource
       .createQueryBuilder()
       .delete()
       .from('albums_assets_assets')
-      .where('"albums_assets_assets"."assetsId" = :assetId', { assetId });
+      .where('"albums_assets_assets"."assetsId" = :assetId', { assetId })
+      .execute();
   }
 
   @GenerateSql({ params: [{ albumId: DummyValue.UUID, assetIds: [DummyValue.UUID] }] })

--- a/server/src/infra/sql/album.repository.sql
+++ b/server/src/infra/sql/album.repository.sql
@@ -508,6 +508,11 @@ FROM
 WHERE
   "AlbumEntity"."deletedAt" IS NULL
 
+-- AlbumRepository.removeAsset
+DELETE FROM "albums_assets_assets"
+WHERE
+  "albums_assets_assets"."assetsId" = $1
+
 -- AlbumRepository.removeAssets
 DELETE FROM "albums_assets_assets"
 WHERE


### PR DESCRIPTION
The current `removeAsset` implementation just builds the query but does not execute it. That also seems to be the reason the `@GenerateSql` decorator was commented out.