### PR TITLE
fix(mobile): ensure notifier is mounted before updating state

### DIFF
--- a/mobile/lib/modules/album/providers/album.provider.dart
+++ b/mobile/lib/modules/album/providers/album.provider.dart
@@ -16,7 +16,11 @@ class AlbumNotifier extends StateNotifier<List<Album>> {
     final query = db.albums
         .filter()
         .owner((q) => q.isarIdEqualTo(Store.get(StoreKey.currentUser).isarId));
-    query.findAll().then((value) => state = value);
+    query.findAll().then((value) {
+      if (mounted) {
+        state = value;
+      }
+    });
     _streamSub = query.watch().listen((data) => state = data);
   }
   final AlbumService _albumService;

--- a/mobile/lib/modules/album/providers/shared_album.provider.dart
+++ b/mobile/lib/modules/album/providers/shared_album.provider.dart
@@ -12,7 +12,11 @@ import 'package:isar/isar.dart';
 class SharedAlbumNotifier extends StateNotifier<List<Album>> {
   SharedAlbumNotifier(this._albumService, Isar db) : super([]) {
     final query = db.albums.filter().sharedEqualTo(true).sortByCreatedAtDesc();
-    query.findAll().then((value) => state = value);
+    query.findAll().then((value) {
+      if (mounted) {
+        state = value;
+      }
+    });
     _streamSub = query.watch().listen((data) => state = data);
   }
 


### PR DESCRIPTION
#### Changes made

- Ensures that the notifier is mounted before updating the state to prevent state not mounted error when opening the app