### PR TITLE
fix(web): copy shared link

### DIFF
--- a/web/src/api/utils.ts
+++ b/web/src/api/utils.ts
@@ -20,8 +20,11 @@ export const copyToClipboard = async (secret: string) => {
 };
 
 export const makeSharedLinkUrl = (externalDomain: string, key: string) => {
-  const url = externalDomain || window.location.origin;
-  return `${url + url.endsWith('/') ? '' : '/'}share/${key}`;
+  let url = externalDomain || window.location.origin;
+  if (!url.endsWith('/')) {
+    url += '/';
+  }
+  return `${url}share/${key}`;
 };
 
 export const oauth = {

--- a/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
+++ b/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
@@ -94,7 +94,7 @@
       return;
     }
 
-    await copyToClipboard(password ? `Link: ${sharedLink}\nPassword: ${password}` : sharedLink);
+    await copyToClipboard(sharedLink);
   };
 
   const getExpirationTimeInMillisecond = () => {


### PR DESCRIPTION
Closes #6280

- Only copy the link (not the password) and
- Fix resolving domain name with trailing slash