### PR TITLE
 fix(mobile): copy shared link

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -378,7 +378,6 @@
   "share_dialog_preparing": "Preparing...",
   "shared_link_app_bar_title": "Shared Links",
   "shared_link_clipboard_copied_massage": "Copied to clipboard",
-  "shared_link_clipboard_text": "Link: {}\nPassword: {}",
   "shared_link_create_app_bar_title": "Create link to share",
   "shared_link_create_error": "Error while creating shared link",
   "shared_link_create_info": "Let anyone with the link see the selected photo(s)",

--- a/mobile/lib/modules/shared_link/ui/shared_link_item.dart
+++ b/mobile/lib/modules/shared_link/ui/shared_link_item.dart
@@ -76,8 +76,11 @@ class SharedLinkItem extends ConsumerWidget {
       final externalDomain = ref.read(
         serverInfoProvider.select((s) => s.serverConfig.externalDomain),
       );
-      final serverUrl =
+      var serverUrl =
           externalDomain.isNotEmpty ? externalDomain : getServerUrl();
+      if (serverUrl != null && !serverUrl.endsWith('/')) {
+        serverUrl += '/';
+      }
       if (serverUrl == null) {
         ImmichToast.show(
           context: context,
@@ -89,7 +92,7 @@ class SharedLinkItem extends ConsumerWidget {
       }
 
       Clipboard.setData(
-        ClipboardData(text: "$serverUrl/share/${sharedLink.key}"),
+        ClipboardData(text: "${serverUrl}share/${sharedLink.key}"),
       ).then((_) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/mobile/lib/modules/shared_link/ui/shared_link_item.dart
+++ b/mobile/lib/modules/shared_link/ui/shared_link_item.dart
@@ -89,9 +89,7 @@ class SharedLinkItem extends ConsumerWidget {
       }
 
       Clipboard.setData(
-        ClipboardData(
-          text: "$serverUrl/share/${sharedLink.key}",
-        ),
+        ClipboardData(text: "$serverUrl/share/${sharedLink.key}"),
       ).then((_) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -350,10 +350,13 @@ class SharedLinkEditPage extends HookConsumerWidget {
       final externalDomain = ref.read(
         serverInfoProvider.select((s) => s.serverConfig.externalDomain),
       );
-      final serverUrl =
+      var serverUrl =
           externalDomain.isNotEmpty ? externalDomain : getServerUrl();
+      if (serverUrl != null && !serverUrl.endsWith('/')) {
+        serverUrl += '/';
+      }
       if (newLink != null && serverUrl != null) {
-        newShareLink.value = "$serverUrl/share/${newLink.key}";
+        newShareLink.value = "${serverUrl}share/${newLink.key}";
         copyLinkToClipboard();
       } else if (newLink == null) {
         ImmichToast.show(

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -267,15 +267,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
     }
 
     void copyLinkToClipboard() {
-      Clipboard.setData(
-        ClipboardData(
-          text: passwordController.text.isEmpty
-              ? newShareLink.value
-              : "shared_link_clipboard_text".tr(
-                  args: [newShareLink.value, passwordController.text],
-                ),
-        ),
-      ).then((_) {
+      Clipboard.setData(ClipboardData(text: newShareLink.value)).then((_) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(


### PR DESCRIPTION
#### Changes made:

- Fixes the mobile side handling to be in sync with the web client changes from #6309 
    - Only copy the shared link URL and not the password
    - Handle trailing slash in External Domain