### PR TITLE
feat(server): provide the ability to search archived photos

### DIFF
--- a/docs/docs/features/search.md
+++ b/docs/docs/features/search.md
@@ -6,6 +6,8 @@ Smart search is powered by the [pgvecto.rs](https://github.com/tensorchord/pgvec
 
 Metadata search (prefixed with `m:`) can search specifically by text without the use of a model.
 
+Archived photos are not included in search results by default. Archived photos can be included in the response by including a query parameter in the url specifying `searchArchived=true`.
+
 Some search examples:
 <img src={require('./img/search-ex-2.webp').default} title='Search Example 1' />
 

--- a/docs/docs/features/search.md
+++ b/docs/docs/features/search.md
@@ -6,7 +6,7 @@ Smart search is powered by the [pgvecto.rs](https://github.com/tensorchord/pgvec
 
 Metadata search (prefixed with `m:`) can search specifically by text without the use of a model.
 
-Archived photos are not included in search results by default. Archived photos can be included in the response by including a query parameter in the url specifying `searchArchived=true`.
+Archived photos are not included in search results by default. To include them, add the query parameter `withArchived=true` to the url.
 
 Some search examples:
 <img src={require('./img/search-ex-2.webp').default} title='Search Example 1' />

--- a/mobile/openapi/doc/SearchApi.md
+++ b/mobile/openapi/doc/SearchApi.md
@@ -66,7 +66,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **search**
-> SearchResponseDto search(q, query, clip, type, recent, motion)
+> SearchResponseDto search(q, query, clip, type, recent, motion, searchArchived)
 
 
 
@@ -95,9 +95,10 @@ final clip = true; // bool |
 final type = type_example; // String | 
 final recent = true; // bool | 
 final motion = true; // bool | 
+final searchArchived = true; // bool | 
 
 try {
-    final result = api_instance.search(q, query, clip, type, recent, motion);
+    final result = api_instance.search(q, query, clip, type, recent, motion, searchArchived);
     print(result);
 } catch (e) {
     print('Exception when calling SearchApi->search: $e\n');
@@ -114,6 +115,7 @@ Name | Type | Description  | Notes
  **type** | **String**|  | [optional] 
  **recent** | **bool**|  | [optional] 
  **motion** | **bool**|  | [optional] 
+ **searchArchived** | **bool**|  | [optional] 
 
 ### Return type
 

--- a/mobile/openapi/doc/SearchApi.md
+++ b/mobile/openapi/doc/SearchApi.md
@@ -66,7 +66,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **search**
-> SearchResponseDto search(q, query, clip, type, recent, motion, searchArchived)
+> SearchResponseDto search(q, query, clip, type, recent, motion, withArchived)
 
 
 
@@ -95,10 +95,10 @@ final clip = true; // bool |
 final type = type_example; // String | 
 final recent = true; // bool | 
 final motion = true; // bool | 
-final searchArchived = true; // bool | 
+final withArchived = true; // bool | 
 
 try {
-    final result = api_instance.search(q, query, clip, type, recent, motion, searchArchived);
+    final result = api_instance.search(q, query, clip, type, recent, motion, withArchived);
     print(result);
 } catch (e) {
     print('Exception when calling SearchApi->search: $e\n');
@@ -115,7 +115,7 @@ Name | Type | Description  | Notes
  **type** | **String**|  | [optional] 
  **recent** | **bool**|  | [optional] 
  **motion** | **bool**|  | [optional] 
- **searchArchived** | **bool**|  | [optional] 
+ **withArchived** | **bool**|  | [optional] 
 
 ### Return type
 

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -74,7 +74,9 @@ class SearchApi {
   /// * [bool] recent:
   ///
   /// * [bool] motion:
-  Future<Response> searchWithHttpInfo({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, }) async {
+  ///
+  /// * [bool] searchArchived:
+  Future<Response> searchWithHttpInfo({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? searchArchived, }) async {
     // ignore: prefer_const_declarations
     final path = r'/search';
 
@@ -102,6 +104,9 @@ class SearchApi {
     }
     if (motion != null) {
       queryParams.addAll(_queryParams('', 'motion', motion));
+    }
+    if (searchArchived != null) {
+      queryParams.addAll(_queryParams('', 'searchArchived', searchArchived));
     }
 
     const contentTypes = <String>[];
@@ -131,8 +136,10 @@ class SearchApi {
   /// * [bool] recent:
   ///
   /// * [bool] motion:
-  Future<SearchResponseDto?> search({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, }) async {
-    final response = await searchWithHttpInfo( q: q, query: query, clip: clip, type: type, recent: recent, motion: motion, );
+  ///
+  /// * [bool] searchArchived:
+  Future<SearchResponseDto?> search({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? searchArchived, }) async {
+    final response = await searchWithHttpInfo( q: q, query: query, clip: clip, type: type, recent: recent, motion: motion, searchArchived: searchArchived, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -75,8 +75,8 @@ class SearchApi {
   ///
   /// * [bool] motion:
   ///
-  /// * [bool] searchArchived:
-  Future<Response> searchWithHttpInfo({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? searchArchived, }) async {
+  /// * [bool] withArchived:
+  Future<Response> searchWithHttpInfo({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? withArchived, }) async {
     // ignore: prefer_const_declarations
     final path = r'/search';
 
@@ -105,8 +105,8 @@ class SearchApi {
     if (motion != null) {
       queryParams.addAll(_queryParams('', 'motion', motion));
     }
-    if (searchArchived != null) {
-      queryParams.addAll(_queryParams('', 'searchArchived', searchArchived));
+    if (withArchived != null) {
+      queryParams.addAll(_queryParams('', 'withArchived', withArchived));
     }
 
     const contentTypes = <String>[];
@@ -137,9 +137,9 @@ class SearchApi {
   ///
   /// * [bool] motion:
   ///
-  /// * [bool] searchArchived:
-  Future<SearchResponseDto?> search({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? searchArchived, }) async {
-    final response = await searchWithHttpInfo( q: q, query: query, clip: clip, type: type, recent: recent, motion: motion, searchArchived: searchArchived, );
+  /// * [bool] withArchived:
+  Future<SearchResponseDto?> search({ String? q, String? query, bool? clip, String? type, bool? recent, bool? motion, bool? withArchived, }) async {
+    final response = await searchWithHttpInfo( q: q, query: query, clip: clip, type: type, recent: recent, motion: motion, withArchived: withArchived, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/test/search_api_test.dart
+++ b/mobile/openapi/test/search_api_test.dart
@@ -22,7 +22,7 @@ void main() {
       // TODO
     });
 
-    //Future<SearchResponseDto> search({ String q, String query, bool clip, String type, bool recent, bool motion, bool searchArchived }) async
+    //Future<SearchResponseDto> search({ String q, String query, bool clip, String type, bool recent, bool motion, bool withArchived }) async
     test('test search', () async {
       // TODO
     });

--- a/mobile/openapi/test/search_api_test.dart
+++ b/mobile/openapi/test/search_api_test.dart
@@ -22,7 +22,7 @@ void main() {
       // TODO
     });
 
-    //Future<SearchResponseDto> search({ String q, String query, bool clip, String type, bool recent, bool motion }) async
+    //Future<SearchResponseDto> search({ String q, String query, bool clip, String type, bool recent, bool motion, bool searchArchived }) async
     test('test search', () async {
       // TODO
     });

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4578,7 +4578,7 @@
             }
           },
           {
-            "name": "searchArchived",
+            "name": "withArchived",
             "required": false,
             "in": "query",
             "schema": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4576,6 +4576,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "searchArchived",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/open-api/typescript-sdk/client/api.ts
+++ b/open-api/typescript-sdk/client/api.ts
@@ -14596,11 +14596,11 @@ export const SearchApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER'} [type] 
          * @param {boolean} [recent] 
          * @param {boolean} [motion] 
-         * @param {boolean} [searchArchived] 
+         * @param {boolean} [withArchived] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        search: async (q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, searchArchived?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        search: async (q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, withArchived?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/search`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -14646,8 +14646,8 @@ export const SearchApiAxiosParamCreator = function (configuration?: Configuratio
                 localVarQueryParameter['motion'] = motion;
             }
 
-            if (searchArchived !== undefined) {
-                localVarQueryParameter['searchArchived'] = searchArchived;
+            if (withArchived !== undefined) {
+                localVarQueryParameter['withArchived'] = withArchived;
             }
 
 
@@ -14738,12 +14738,12 @@ export const SearchApiFp = function(configuration?: Configuration) {
          * @param {'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER'} [type] 
          * @param {boolean} [recent] 
          * @param {boolean} [motion] 
-         * @param {boolean} [searchArchived] 
+         * @param {boolean} [withArchived] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async search(q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, searchArchived?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.search(q, query, clip, type, recent, motion, searchArchived, options);
+        async search(q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, withArchived?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.search(q, query, clip, type, recent, motion, withArchived, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -14782,7 +14782,7 @@ export const SearchApiFactory = function (configuration?: Configuration, basePat
          * @throws {RequiredError}
          */
         search(requestParameters: SearchApiSearchRequest = {}, options?: AxiosRequestConfig): AxiosPromise<SearchResponseDto> {
-            return localVarFp.search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.searchArchived, options).then((request) => request(axios, basePath));
+            return localVarFp.search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.withArchived, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -14849,7 +14849,7 @@ export interface SearchApiSearchRequest {
      * @type {boolean}
      * @memberof SearchApiSearch
      */
-    readonly searchArchived?: boolean
+    readonly withArchived?: boolean
 }
 
 /**
@@ -14898,7 +14898,7 @@ export class SearchApi extends BaseAPI {
      * @memberof SearchApi
      */
     public search(requestParameters: SearchApiSearchRequest = {}, options?: AxiosRequestConfig) {
-        return SearchApiFp(this.configuration).search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.searchArchived, options).then((request) => request(this.axios, this.basePath));
+        return SearchApiFp(this.configuration).search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.withArchived, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/open-api/typescript-sdk/client/api.ts
+++ b/open-api/typescript-sdk/client/api.ts
@@ -14596,10 +14596,11 @@ export const SearchApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER'} [type] 
          * @param {boolean} [recent] 
          * @param {boolean} [motion] 
+         * @param {boolean} [searchArchived] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        search: async (q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        search: async (q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, searchArchived?: boolean, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/search`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -14643,6 +14644,10 @@ export const SearchApiAxiosParamCreator = function (configuration?: Configuratio
 
             if (motion !== undefined) {
                 localVarQueryParameter['motion'] = motion;
+            }
+
+            if (searchArchived !== undefined) {
+                localVarQueryParameter['searchArchived'] = searchArchived;
             }
 
 
@@ -14733,11 +14738,12 @@ export const SearchApiFp = function(configuration?: Configuration) {
          * @param {'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER'} [type] 
          * @param {boolean} [recent] 
          * @param {boolean} [motion] 
+         * @param {boolean} [searchArchived] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async search(q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.search(q, query, clip, type, recent, motion, options);
+        async search(q?: string, query?: string, clip?: boolean, type?: 'IMAGE' | 'VIDEO' | 'AUDIO' | 'OTHER', recent?: boolean, motion?: boolean, searchArchived?: boolean, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.search(q, query, clip, type, recent, motion, searchArchived, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -14776,7 +14782,7 @@ export const SearchApiFactory = function (configuration?: Configuration, basePat
          * @throws {RequiredError}
          */
         search(requestParameters: SearchApiSearchRequest = {}, options?: AxiosRequestConfig): AxiosPromise<SearchResponseDto> {
-            return localVarFp.search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, options).then((request) => request(axios, basePath));
+            return localVarFp.search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.searchArchived, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -14837,6 +14843,13 @@ export interface SearchApiSearchRequest {
      * @memberof SearchApiSearch
      */
     readonly motion?: boolean
+
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SearchApiSearch
+     */
+    readonly searchArchived?: boolean
 }
 
 /**
@@ -14885,7 +14898,7 @@ export class SearchApi extends BaseAPI {
      * @memberof SearchApi
      */
     public search(requestParameters: SearchApiSearchRequest = {}, options?: AxiosRequestConfig) {
-        return SearchApiFp(this.configuration).search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, options).then((request) => request(this.axios, this.basePath));
+        return SearchApiFp(this.configuration).search(requestParameters.q, requestParameters.query, requestParameters.clip, requestParameters.type, requestParameters.recent, requestParameters.motion, requestParameters.searchArchived, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/server/src/domain/repositories/smart-info.repository.ts
+++ b/server/src/domain/repositories/smart-info.repository.ts
@@ -9,6 +9,7 @@ export interface EmbeddingSearch {
   embedding: Embedding;
   numResults: number;
   maxDistance?: number;
+  searchArchived?: boolean;
 }
 
 export interface ISmartInfoRepository {

--- a/server/src/domain/repositories/smart-info.repository.ts
+++ b/server/src/domain/repositories/smart-info.repository.ts
@@ -9,7 +9,7 @@ export interface EmbeddingSearch {
   embedding: Embedding;
   numResults: number;
   maxDistance?: number;
-  searchArchived?: boolean;
+  withArchived?: boolean;
 }
 
 export interface ISmartInfoRepository {

--- a/server/src/domain/search/dto/search.dto.ts
+++ b/server/src/domain/search/dto/search.dto.ts
@@ -32,6 +32,11 @@ export class SearchDto {
   @Optional()
   @Transform(toBoolean)
   motion?: boolean;
+
+  @IsBoolean()
+  @Optional()
+  @Transform(toBoolean)
+  searchArchived?: boolean;
 }
 
 export class SearchPeopleDto {

--- a/server/src/domain/search/dto/search.dto.ts
+++ b/server/src/domain/search/dto/search.dto.ts
@@ -36,7 +36,7 @@ export class SearchDto {
   @IsBoolean()
   @Optional()
   @Transform(toBoolean)
-  searchArchived?: boolean;
+  withArchived?: boolean;
 }
 
 export class SearchPeopleDto {

--- a/server/src/domain/search/search.service.spec.ts
+++ b/server/src/domain/search/search.service.spec.ts
@@ -114,6 +114,39 @@ describe(SearchService.name, () => {
       expect(smartInfoMock.searchCLIP).not.toHaveBeenCalled();
     });
 
+    it('should search archived photos if `searchArchived` option is true', async () => {
+      const dto: SearchDto = { q: 'test query', clip: true, searchArchived: true };
+      const embedding = [1, 2, 3];
+      smartInfoMock.searchCLIP.mockResolvedValueOnce([assetStub.image]);
+      machineMock.encodeText.mockResolvedValueOnce(embedding);
+      partnerMock.getAll.mockResolvedValueOnce([]);
+      const expectedResponse = {
+        albums: {
+          total: 0,
+          count: 0,
+          items: [],
+          facets: [],
+        },
+        assets: {
+          total: 1,
+          count: 1,
+          items: [mapAsset(assetStub.image)],
+          facets: [],
+        },
+      };
+
+      const result = await sut.search(authStub.user1, dto);
+
+      expect(result).toEqual(expectedResponse);
+      expect(smartInfoMock.searchCLIP).toHaveBeenCalledWith({
+        userIds: [authStub.user1.user.id],
+        embedding,
+        numResults: 100,
+        searchArchived: true,
+      });
+      expect(assetMock.searchMetadata).not.toHaveBeenCalled();
+    });
+
     it('should search by CLIP if `clip` option is true', async () => {
       const dto: SearchDto = { q: 'test query', clip: true };
       const embedding = [1, 2, 3];
@@ -142,6 +175,7 @@ describe(SearchService.name, () => {
         userIds: [authStub.user1.user.id],
         embedding,
         numResults: 100,
+        searchArchived: false,
       });
       expect(assetMock.searchMetadata).not.toHaveBeenCalled();
     });

--- a/server/src/domain/search/search.service.spec.ts
+++ b/server/src/domain/search/search.service.spec.ts
@@ -114,8 +114,8 @@ describe(SearchService.name, () => {
       expect(smartInfoMock.searchCLIP).not.toHaveBeenCalled();
     });
 
-    it('should search archived photos if `searchArchived` option is true', async () => {
-      const dto: SearchDto = { q: 'test query', clip: true, searchArchived: true };
+    it('should search archived photos if `withArchived` option is true', async () => {
+      const dto: SearchDto = { q: 'test query', clip: true, withArchived: true };
       const embedding = [1, 2, 3];
       smartInfoMock.searchCLIP.mockResolvedValueOnce([assetStub.image]);
       machineMock.encodeText.mockResolvedValueOnce(embedding);
@@ -142,7 +142,7 @@ describe(SearchService.name, () => {
         userIds: [authStub.user1.user.id],
         embedding,
         numResults: 100,
-        searchArchived: true,
+        withArchived: true,
       });
       expect(assetMock.searchMetadata).not.toHaveBeenCalled();
     });
@@ -175,7 +175,7 @@ describe(SearchService.name, () => {
         userIds: [authStub.user1.user.id],
         embedding,
         numResults: 100,
-        searchArchived: false,
+        withArchived: false,
       });
       expect(assetMock.searchMetadata).not.toHaveBeenCalled();
     });

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -67,7 +67,7 @@ export class SearchService {
     }
     const strategy = dto.clip ? SearchStrategy.CLIP : SearchStrategy.TEXT;
     const userIds = await this.getUserIdsToSearch(auth);
-    const searchArchived = dto.searchArchived || false;
+    const withArchived = dto.withArchived || false;
 
     let assets: AssetEntity[] = [];
 
@@ -82,7 +82,7 @@ export class SearchService {
           userIds: userIds,
           embedding,
           numResults: 100,
-          searchArchived,
+          withArchived,
         });
         break;
       case SearchStrategy.TEXT:

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -67,6 +67,7 @@ export class SearchService {
     }
     const strategy = dto.clip ? SearchStrategy.CLIP : SearchStrategy.TEXT;
     const userIds = await this.getUserIdsToSearch(auth);
+    const searchArchived = dto.searchArchived || false;
 
     let assets: AssetEntity[] = [];
 
@@ -77,7 +78,12 @@ export class SearchService {
           { text: query },
           machineLearning.clip,
         );
-        assets = await this.smartInfoRepository.searchCLIP({ userIds: userIds, embedding, numResults: 100 });
+        assets = await this.smartInfoRepository.searchCLIP({
+          userIds: userIds,
+          embedding,
+          numResults: 100,
+          searchArchived,
+        });
         break;
       case SearchStrategy.TEXT:
         assets = await this.assetRepository.searchMetadata(query, userIds, { numResults: 250 });

--- a/server/src/infra/repositories/smart-info.repository.ts
+++ b/server/src/infra/repositories/smart-info.repository.ts
@@ -43,7 +43,7 @@ export class SmartInfoRepository implements ISmartInfoRepository {
   @GenerateSql({
     params: [{ userIds: [DummyValue.UUID], embedding: Array.from({ length: 512 }, Math.random), numResults: 100 }],
   })
-  async searchCLIP({ userIds, embedding, numResults, searchArchived }: EmbeddingSearch): Promise<AssetEntity[]> {
+  async searchCLIP({ userIds, embedding, numResults, withArchived }: EmbeddingSearch): Promise<AssetEntity[]> {
     if (!isValidInteger(numResults, { min: 1 })) {
       throw new Error(`Invalid value for 'numResults': ${numResults}`);
     }
@@ -52,14 +52,15 @@ export class SmartInfoRepository implements ISmartInfoRepository {
     await this.assetRepository.manager.transaction(async (manager) => {
       await manager.query(`SET LOCAL vectors.k = '${numResults}'`);
       await manager.query(`SET LOCAL vectors.enable_prefilter = on`);
-      let query = manager
+
+      const query = manager
         .createQueryBuilder(AssetEntity, 'a')
         .innerJoin('a.smartSearch', 's')
         .where('a.ownerId IN (:...userIds )')
         .andWhere('a.isVisible = true');
 
-      if (!searchArchived) {
-        query = query.andWhere('a.isArchived = false');
+      if (!withArchived) {
+        query.andWhere('a.isArchived = false');
       }
 
       results = await query


### PR DESCRIPTION
## Description

Adds a query parameter (`withArchived`) to the search URL parameters to allow the results to contain archived photos.

I commented on #5806 that it might be useful if we could optionally search archived photos, and this PR adds that ability. I'm not really a UI developer, so I've only added the ability to optionally perform this search with a query parameter for now. Eventually we might want to add radio options or magic search terms to enable searching archived/non-visible photos.

## How has this been tested

- Import photos
- Perform search that returns some of those photos.
- Archive some of the returned photos.
- Repeat search and confirm the archived photos are not returned.
- Add query parameter to URL `&withArchived=true`
- Confirm that the previously archived photos are now returned as part of the search.