### PR TITLE
fix(server): extraction of Samsung Motionphoto videos

### DIFF
--- a/server/e2e/jobs/specs/metadata.e2e-spec.ts
+++ b/server/e2e/jobs/specs/metadata.e2e-spec.ts
@@ -36,7 +36,7 @@ describe(`${AssetController.name} (e2e)`, () => {
     await restoreTempFolder();
   });
 
-  describe.only('should strip metadata of', () => {
+  describe('should strip metadata of', () => {
     let assetWithLocation: AssetResponseDto;
 
     beforeEach(async () => {
@@ -82,6 +82,28 @@ describe(`${AssetController.name} (e2e)`, () => {
 
       expect(exifData).not.toHaveProperty('GPSLongitude');
       expect(exifData).not.toHaveProperty('GPSLatitude');
+    });
+  });
+
+  describe.each([
+    // These hashes were created by copying the image files to a Samsung phone,
+    // exporting the video from Samsung's stock Gallery app, and hashing them locally.
+    // This ensures that immich+exiftool are extracting the videos the same way Samsung does.
+    // DO NOT assume immich+exiftool are doing things correctly and just copy whatever hash it gives
+    // into the test here.
+    ['Samsung One UI 5.jpg', 'fr14niqCq6N20HB8rJYEvpsUVtI='],
+    ['Samsung One UI 6.jpg', 'lT9Uviw/FFJYCjfIxAGPTjzAmmw='],
+    ['Samsung One UI 6.heic', '/ejgzywvgvzvVhUYVfvkLzFBAF0='],
+  ])('should extract motionphoto video', (file, checksum) => {
+    itif(runAllTests)(`with checksum ${checksum} from ${file}`, async () => {
+      const fileContent = await fs.promises.readFile(`${IMMICH_TEST_ASSET_PATH}/formats/motionphoto/${file}`);
+
+      const response = await api.assetApi.upload(server, admin.accessToken, 'test-asset-id', { content: fileContent });
+      const asset = await api.assetApi.get(server, admin.accessToken, response.id);
+      expect(asset).toHaveProperty('livePhotoVideoId');
+      const video = await api.assetApi.get(server, admin.accessToken, asset.livePhotoVideoId as string);
+
+      expect(video.checksum).toStrictEqual(checksum);
     });
   });
 });

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -1,7 +1,7 @@
 import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
 import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
-import { ExifDateTime, Tags, exiftool } from 'exiftool-vendored';
+import { ExifDateTime, Tags } from 'exiftool-vendored';
 import { firstDateTime } from 'exiftool-vendored/dist/FirstDateTime';
 import { constants } from 'fs/promises';
 import _ from 'lodash';
@@ -394,11 +394,11 @@ export class MetadataService {
       // Samsung MotionPhoto video extraction
       // JPEG-encoded
       if (tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideo) {
-        video = await this.repository.extractBinaryTag('EmbeddedVideo', asset.originalPath);
+        video = await this.repository.extractBinaryTag(asset.originalPath, 'EmbeddedVideo');
       }
       // HEIC-encoded
       else if (tags.MotionPhotoVideo) {
-        video = await this.repository.extractBinaryTag('MotionPhotoVideo', asset.originalPath);
+        video = await this.repository.extractBinaryTag(asset.originalPath, 'MotionPhotoVideo');
       }
       // Default video extraction
       else {

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -434,10 +434,6 @@ export class MetadataService {
           deviceId: 'NONE',
         });
 
-        await this.storageRepository.writeFile(motionAsset.originalPath, video);
-        await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: motionAsset.id } });
-        await this.assetRepository.save({ id: asset.id, livePhotoVideoId: motionAsset.id });
-
         // If the asset already had an associated livePhotoVideo, delete it, because
         // its checksum doesn't match the checksum of the motionAsset we just extracted
         // (if it did, getByChecksum() would've returned non-null)
@@ -445,6 +441,11 @@ export class MetadataService {
           await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.livePhotoVideoId } });
           this.logger.log(`Removed old motion photo video asset (${asset.livePhotoVideoId})`);
         }
+
+        await this.storageRepository.writeFile(motionAsset.originalPath, video);
+        await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: motionAsset.id } });
+        await this.assetRepository.save({ id: asset.id, livePhotoVideoId: motionAsset.id });
+
       } else {
         this.logger.debug(
           `Asset ${asset.id}'s motion photo video with checksum ${checksum.toString('base64')} already exists in the repository`,

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -354,7 +354,7 @@ export class MetadataService {
   }
 
   private async applyMotionPhotos(asset: AssetEntity, tags: ImmichTags) {
-    if (asset.type !== AssetType.IMAGE || asset.livePhotoVideoId) {
+    if (asset.type !== AssetType.IMAGE) {
       return;
     }
 
@@ -362,6 +362,8 @@ export class MetadataService {
     const isMotionPhoto = tags.MotionPhoto;
     const isMicroVideo = tags.MicroVideo;
     const videoOffset = tags.MicroVideoOffset;
+    const hasMotionPhotoVideo = tags.MotionPhotoVideo;
+    const hasEmbeddedVideoFile = tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideoFile;
     const directory = Array.isArray(rawDirectory) ? (rawDirectory as DirectoryEntry[]) : null;
 
     let length = 0;
@@ -381,7 +383,7 @@ export class MetadataService {
       length = videoOffset;
     }
 
-    if (!length) {
+    if (!length && !hasEmbeddedVideoFile && !hasMotionPhotoVideo) {
       return;
     }
 
@@ -392,12 +394,12 @@ export class MetadataService {
       const position = stat.size - length - padding;
       let video: Buffer;
       // Samsung MotionPhoto video extraction
-      // HEIC-encoded
-      if (tags.MotionPhotoVideo) {
+      //     HEIC-encoded
+      if (hasMotionPhotoVideo) {
         video = await this.repository.extractBinaryTag(asset.originalPath, 'MotionPhotoVideo');
       }
-      // JPEG-encoded; HEIC also contains these tags, so this conditional must come second
-      else if (tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideoFile) {
+      //     JPEG-encoded; HEIC also contains these tags, so this conditional must come second
+      else if (hasEmbeddedVideoFile) {
         video = await this.repository.extractBinaryTag(asset.originalPath, 'EmbeddedVideoFile');
       }
       // Default video extraction
@@ -434,9 +436,20 @@ export class MetadataService {
 
         await this.storageRepository.writeFile(motionAsset.originalPath, video);
         await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: motionAsset.id } });
-      }
+        await this.assetRepository.save({ id: asset.id, livePhotoVideoId: motionAsset.id });
 
-      await this.assetRepository.save({ id: asset.id, livePhotoVideoId: motionAsset.id });
+        // If the asset already had an associated livePhotoVideo, delete it, because
+        // its checksum doesn't match the checksum of the motionAsset we just extracted
+        // (if it did, getByChecksum() would've returned non-null)
+        if (asset.livePhotoVideoId) {
+          await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.livePhotoVideoId } });
+          this.logger.log(`Removed old motion photo video asset (${asset.livePhotoVideoId})`);
+        }
+      } else {
+        this.logger.debug(
+          `Asset ${asset.id}'s motion photo video with checksum ${checksum.toString('base64')} already exists in the repository`,
+        );
+      }
 
       this.logger.debug(`Finished motion photo video extraction (${asset.id})`);
     } catch (error: Error | any) {

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -368,7 +368,6 @@ export class MetadataService {
     let length = 0;
     let padding = 0;
 
-    // Not needed for extractBinaryTagToBuffer()
     if (isMotionPhoto && directory) {
       for (const entry of directory) {
         if (entry.Item.Semantic == 'MotionPhoto') {
@@ -393,14 +392,16 @@ export class MetadataService {
       const stat = await this.storageRepository.stat(asset.originalPath);
       const position = stat.size - length - padding;
       let video: Buffer;
+      // Samsung MotionPhoto video extraction
+      // JPEG-encoded
       if (tags.EmbeddedVideoType === "MotionPhoto_Data" && tags.EmbeddedVideo) {
-        video = await exiftool.extractBinaryTagToBuffer("EmbeddedVideoFile", asset.originalPath)
-        await exiftool.end()
+        video = await this.repository.extractBinaryTag("EmbeddedVideo", asset.originalPath)
       }
+      // HEIC-encoded
       else if (tags.MotionPhotoVideo) {
-        video = await exiftool.extractBinaryTagToBuffer("MotionPhotoVideo", asset.originalPath)
-        await exiftool.end()
+        video = await this.repository.extractBinaryTag("MotionPhotoVideo", asset.originalPath)
       }
+      // Default video extraction
       else {
         video = await this.storageRepository.readFile(asset.originalPath, {
           buffer: Buffer.alloc(length),

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -1,7 +1,7 @@
 import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
 import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
-import { ExifDateTime, Tags } from 'exiftool-vendored';
+import { ExifDateTime, Tags, exiftool } from 'exiftool-vendored';
 import { firstDateTime } from 'exiftool-vendored/dist/FirstDateTime';
 import { constants } from 'fs/promises';
 import _ from 'lodash';
@@ -31,7 +31,6 @@ import {
 } from '../repositories';
 import { StorageCore } from '../storage';
 import { FeatureFlag, SystemConfigCore } from '../system-config';
-import { exiftool } from 'exiftool-vendored';
 
 /** look for a date from these tags (in order) */
 const EXIF_DATE_TAGS: Array<keyof Tags> = [
@@ -394,12 +393,12 @@ export class MetadataService {
       let video: Buffer;
       // Samsung MotionPhoto video extraction
       // JPEG-encoded
-      if (tags.EmbeddedVideoType === "MotionPhoto_Data" && tags.EmbeddedVideo) {
-        video = await this.repository.extractBinaryTag("EmbeddedVideo", asset.originalPath)
+      if (tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideo) {
+        video = await this.repository.extractBinaryTag('EmbeddedVideo', asset.originalPath);
       }
       // HEIC-encoded
       else if (tags.MotionPhotoVideo) {
-        video = await this.repository.extractBinaryTag("MotionPhotoVideo", asset.originalPath)
+        video = await this.repository.extractBinaryTag('MotionPhotoVideo', asset.originalPath);
       }
       // Default video extraction
       else {

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -392,13 +392,13 @@ export class MetadataService {
       const position = stat.size - length - padding;
       let video: Buffer;
       // Samsung MotionPhoto video extraction
-      // JPEG-encoded
-      if (tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideo) {
-        video = await this.repository.extractBinaryTag(asset.originalPath, 'EmbeddedVideo');
-      }
       // HEIC-encoded
-      else if (tags.MotionPhotoVideo) {
+      if (tags.MotionPhotoVideo) {
         video = await this.repository.extractBinaryTag(asset.originalPath, 'MotionPhotoVideo');
+      }
+      // JPEG-encoded; HEIC also contains these tags, so this conditional must come second
+      else if (tags.EmbeddedVideoType === 'MotionPhoto_Data' && tags.EmbeddedVideoFile) {
+        video = await this.repository.extractBinaryTag(asset.originalPath, 'EmbeddedVideoFile');
       }
       // Default video extraction
       else {

--- a/server/src/domain/repositories/metadata.repository.ts
+++ b/server/src/domain/repositories/metadata.repository.ts
@@ -1,4 +1,4 @@
-import { Tags } from 'exiftool-vendored';
+import { BinaryField, Tags } from 'exiftool-vendored';
 
 export const IMetadataRepository = 'IMetadataRepository';
 
@@ -27,6 +27,9 @@ export interface ImmichTags extends Omit<Tags, 'FocalLength' | 'Duration'> {
   ImagePixelDepth?: string;
   FocalLength?: number;
   Duration?: number | ExifDuration;
+  EmbeddedVideoType?: string;
+  EmbeddedVideo?: BinaryField;
+  MotionPhotoVideo?: BinaryField;
 }
 
 export interface IMetadataRepository {

--- a/server/src/domain/repositories/metadata.repository.ts
+++ b/server/src/domain/repositories/metadata.repository.ts
@@ -38,4 +38,5 @@ export interface IMetadataRepository {
   reverseGeocode(point: GeoPoint): Promise<ReverseGeocodeResult | null>;
   readTags(path: string): Promise<ImmichTags | null>;
   writeTags(path: string, tags: Partial<Tags>): Promise<void>;
+  extractBinaryTag(tagName: string, path: string): Promise<Buffer>;
 }

--- a/server/src/domain/repositories/metadata.repository.ts
+++ b/server/src/domain/repositories/metadata.repository.ts
@@ -28,7 +28,7 @@ export interface ImmichTags extends Omit<Tags, 'FocalLength' | 'Duration'> {
   FocalLength?: number;
   Duration?: number | ExifDuration;
   EmbeddedVideoType?: string;
-  EmbeddedVideo?: BinaryField;
+  EmbeddedVideoFile?: BinaryField;
   MotionPhotoVideo?: BinaryField;
 }
 

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -104,7 +104,7 @@ export class StorageCore {
   }
 
   static getAndroidMotionPath(asset: AssetEntity, uuid: string) {
-    return StorageCore.getNestedPath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}-MP-${uuid}.mp4`);
+    return StorageCore.getNestedPath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${uuid}-MP.mp4`);
   }
 
   static isAndroidMotionPath(originalPath: string) {

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -103,8 +103,8 @@ export class StorageCore {
     return StorageCore.getNestedPath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}.mp4`);
   }
 
-  static getAndroidMotionPath(asset: AssetEntity) {
-    return StorageCore.getNestedPath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}-MP.mp4`);
+  static getAndroidMotionPath(asset: AssetEntity, uuid: string) {
+    return StorageCore.getNestedPath(StorageFolder.ENCODED_VIDEO, asset.ownerId, `${asset.id}-MP-${uuid}.mp4`);
   }
 
   static isAndroidMotionPath(originalPath: string) {

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -201,7 +201,7 @@ export class MetadataRepository implements IMetadataRepository {
       }) as Promise<ImmichTags | null>;
   }
 
-  extractBinaryTag(tagName: string, path: string): Promise<Buffer> {
+  extractBinaryTag(path: string, tagName: string): Promise<Buffer> {
     return exiftool.extractBinaryTagToBuffer(tagName, path);
   }
 

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -201,6 +201,10 @@ export class MetadataRepository implements IMetadataRepository {
       }) as Promise<ImmichTags | null>;
   }
 
+  extractBinaryTag(tagName: string, path: string): Promise<Buffer> {
+    return exiftool.extractBinaryTagToBuffer(tagName, path)
+  }
+
   async writeTags(path: string, tags: Partial<Tags>): Promise<void> {
     try {
       await exiftool.write(path, tags, ['-overwrite_original']);

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -202,7 +202,7 @@ export class MetadataRepository implements IMetadataRepository {
   }
 
   extractBinaryTag(tagName: string, path: string): Promise<Buffer> {
-    return exiftool.extractBinaryTagToBuffer(tagName, path)
+    return exiftool.extractBinaryTagToBuffer(tagName, path);
   }
 
   async writeTags(path: string, tags: Partial<Tags>): Promise<void> {

--- a/server/test/fixtures/asset.stub.ts
+++ b/server/test/fixtures/asset.stub.ts
@@ -401,7 +401,7 @@ export const assetStub = {
   }),
 
   livePhotoMotionAsset: Object.freeze({
-    id: 'live-photo-motion-asset',
+    id: fileStub.livePhotoMotion.uuid,
     originalPath: fileStub.livePhotoMotion.originalPath,
     ownerId: authStub.user1.user.id,
     type: AssetType.VIDEO,

--- a/server/test/fixtures/file.stub.ts
+++ b/server/test/fixtures/file.stub.ts
@@ -7,7 +7,7 @@ export const fileStub = {
     size: 42,
   }),
   livePhotoMotion: Object.freeze({
-    uuid: 'random-uuid',
+    uuid: 'live-photo-motion-asset',
     originalPath: 'fake_path/asset_1.mp4',
     checksum: Buffer.from('live photo file hash', 'utf8'),
     originalName: 'asset_1.mp4',

--- a/server/test/repositories/metadata.repository.mock.ts
+++ b/server/test/repositories/metadata.repository.mock.ts
@@ -7,5 +7,6 @@ export const newMetadataRepositoryMock = (): jest.Mocked<IMetadataRepository> =>
     reverseGeocode: jest.fn(),
     readTags: jest.fn(),
     writeTags: jest.fn(),
+    extractBinaryTag: jest.fn()
   };
 };

--- a/server/test/repositories/metadata.repository.mock.ts
+++ b/server/test/repositories/metadata.repository.mock.ts
@@ -7,6 +7,6 @@ export const newMetadataRepositoryMock = (): jest.Mocked<IMetadataRepository> =>
     reverseGeocode: jest.fn(),
     readTags: jest.fn(),
     writeTags: jest.fn(),
-    extractBinaryTag: jest.fn()
+    extractBinaryTag: jest.fn(),
   };
 };


### PR DESCRIPTION
Fixes #4873.

The issue is that the current video extraction relies on data length and padding from the XMP inside the EXIF. This happened to work on One UI 5 (the resulting mp4 file was technically invalid, but still worked because the extra bytes were at the end), but stopped working on One UI 6. In any case, the author of exiftool recommends not using the XMP because it doesn't have any fundamental connection to the "Trailer" of the jpeg where the video data actually resides. See https://exiftool.org/forum/index.php?topic=15565.0

Fortunately, exiftool is already able to parse the jpeg trailer data structure, and exiftool-vendored has methods to leverage that. The data structure is somewhat complicated, (see https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/Samsung.pm#L1532), so I think it's unwise to attempt to parse the structure ourselves.

This also adds support for extracting the video from an heic-encoded motionphoto, since it's just a different tag name. (see https://exiftool.org/forum/index.php?topic=7161)

This is a minimally-invasive but naive implementation. Creating a dedicated exiftool singleton for each video that has to be extracted is inefficient and the performance hit would probably be noticeable if you upload a lot of motionphotos at once. Fixing this pretty straightforward; it would just mean refactoring exiftool up from `metadata.repository` into `metadata.service`.

I also didn't touch any of the existing extraction code. I'm not sure if it's still needed for iOS or other motionphoto implementations (Google?), but it could potentially be removed if not.