### PR TITLE
feat(server): track metadata extracted at

### DIFF
--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -252,6 +252,11 @@ export class MetadataService {
       fileCreatedAt: exifData.dateTimeOriginal ?? undefined,
     });
 
+    await this.assetRepository.upsertJobStatus({
+      assetId: asset.id,
+      metadataExtractedAt: new Date(),
+    });
+
     return true;
   }
 

--- a/server/src/infra/entities/asset-job-status.entity.ts
+++ b/server/src/infra/entities/asset-job-status.entity.ts
@@ -12,4 +12,7 @@ export class AssetJobStatusEntity {
 
   @Column({ type: 'timestamptz', nullable: true })
   facesRecognizedAt!: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  metadataExtractedAt!: Date | null;
 }

--- a/server/src/infra/migrations/1705094221536-AddMetadataExtractedAt.ts
+++ b/server/src/infra/migrations/1705094221536-AddMetadataExtractedAt.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMetadataExtractedAt1705094221536 implements MigrationInterface {
+  name = 'AddMetadataExtractedAt1705094221536';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "asset_job_status" ADD "metadataExtractedAt" TIMESTAMP WITH TIME ZONE`);
+    await queryRunner.query(`
+      UPDATE "asset_job_status"
+      SET "metadataExtractedAt" = NOW()
+      FROM "exif"
+      WHERE "exif"."assetId" = "asset_job_status"."assetId";
+`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "asset_job_status" DROP COLUMN "metadataExtractedAt"`);
+  }
+}

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -474,11 +474,12 @@ export class AssetRepository implements IAssetRepository {
       case WithoutProperty.EXIF:
         relations = {
           exifInfo: true,
+          jobStatus: true,
         };
         where = {
           isVisible: true,
-          exifInfo: {
-            assetId: IsNull(),
+          jobStatus: {
+            metadataExtractedAt: IsNull(),
           },
         };
         break;


### PR DESCRIPTION
Queue and track "missing exif" via the AssetJobStatus entity. Makes it possible to merge quotas (#4471) without dealing with re-organizing the exif table right away.