### PR TITLE
fix(docs) Fix relative paths leading to broken links

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -1,6 +1,6 @@
 # Backup and Restore
 
-A [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) is recommended to protect your data. You should keep copies of your uploaded photos/videos as well as the Immich database for a comprehensive backup solution. This page provides an overview on how to backup the database and the location of user-uploaded pictures and videos. A template bash script that can be run as a cron job is provided [here](../guides/template-backup-script)
+A [3-2-1 backup strategy](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) is recommended to protect your data. You should keep copies of your uploaded photos/videos as well as the Immich database for a comprehensive backup solution. This page provides an overview on how to backup the database and the location of user-uploaded pictures and videos. A template bash script that can be run as a cron job is provided [here](/docs/guides/template-backup-script.md)
 
 ## Database
 

--- a/docs/docs/administration/storage-template.mdx
+++ b/docs/docs/administration/storage-template.mdx
@@ -1,4 +1,4 @@
-import StorageTemplate from '../partials/_storage-template.md';
+import StorageTemplate from '/docs/partials/_storage-template.md';
 
 # Storage Template
 

--- a/docs/docs/administration/user-management.mdx
+++ b/docs/docs/administration/user-management.mdx
@@ -1,5 +1,5 @@
-import RegisterAdminUser from '../partials/_register-admin.md';
-import UserCreate from '../partials/_user-create.md';
+import RegisterAdminUser from '/docs/partials/_register-admin.md';
+import UserCreate from '/docs/partials/_user-create.md';
 
 # User Management
 

--- a/docs/docs/features/mobile-app.mdx
+++ b/docs/docs/features/mobile-app.mdx
@@ -1,6 +1,6 @@
-import MobileAppDownload from '../partials/_mobile-app-download.md';
-import MobileAppLogin from '../partials/_mobile-app-login.md';
-import MobileAppBackup from '../partials/_mobile-app-backup.md';
+import MobileAppDownload from '/docs/partials/_mobile-app-download.md';
+import MobileAppLogin from '/docs/partials/_mobile-app-login.md';
+import MobileAppBackup from '/docs/partials/_mobile-app-backup.md';
 
 # Mobile App
 

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -1,6 +1,6 @@
 # External Library
 
-This guide walks you through adding an [External Library](../features/libraries#external-libraries).
+This guide walks you through adding an [External Library](/docs/features/libraries#external-libraries).
 This guide assumes you are running Immich in Docker and that the files you wish to access are stored
 in a directory on the same machine.
 

--- a/docs/docs/install/post-install.mdx
+++ b/docs/docs/install/post-install.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 90
 ---
 
-import RegisterAdminUser from '../partials/_register-admin.md';
-import UserCreate from '../partials/_user-create.md';
-import StorageTemplate from '../partials/_storage-template.md';
-import MobileAppDownload from '../partials/_mobile-app-download.md';
-import MobileAppLogin from '../partials/_mobile-app-login.md';
-import MobileAppBackup from '../partials/_mobile-app-backup.md';
+import RegisterAdminUser from '/docs/partials/_register-admin.md';
+import UserCreate from '/docs/partials/_user-create.md';
+import StorageTemplate from '/docs/partials/_storage-template.md';
+import MobileAppDownload from '/docs/partials/_mobile-app-download.md';
+import MobileAppLogin from '/docs/partials/_mobile-app-login.md';
+import MobileAppBackup from '/docs/partials/_mobile-app-backup.md';
 
 # Post Install Steps
 

--- a/docs/docs/overview/quick-start.mdx
+++ b/docs/docs/overview/quick-start.mdx
@@ -10,11 +10,11 @@ to install and use it.
 
 ## Requirements
 
-Check the [requirements page](../install/requirements) to get started.
+Check the [requirements page](/docs/install/requirements) to get started.
 
 ## Install and launch via Docker Compose
 
-Follow the [Docker Compose (Recommended)](../install/docker-compose) instructions
+Follow the [Docker Compose (Recommended)](/docs/install/docker-compose) instructions
 to install the server.
 
 - Where random passwords are required, `pwgen` is a handy utility.
@@ -24,7 +24,7 @@ to install the server.
 
 ## Try the Web UI
 
-import RegisterAdminUser from '../partials/_register-admin.md';
+import RegisterAdminUser from '/docs/partials/_register-admin.md';
 
 <RegisterAdminUser />
 
@@ -36,13 +36,13 @@ Try uploading a picture from your browser.
 
 ### Download the Mobile App
 
-import MobileAppDownload from '../partials/_mobile-app-download.md';
+import MobileAppDownload from '/docs/partials/_mobile-app-download.md';
 
 <MobileAppDownload />
 
 ### Login to the Mobile App
 
-import MobileAppLogin from '../partials/_mobile-app-login.md';
+import MobileAppLogin from '/docs/partials/_mobile-app-login.md';
 
 <MobileAppLogin />
 
@@ -50,7 +50,7 @@ In the mobile app, you should see the photo you uploaded from the web UI.
 
 ### Transfer Photos from your Mobile Device
 
-import MobileAppBackup from '../partials/_mobile-app-backup.md';
+import MobileAppBackup from '/docs/partials/_mobile-app-backup.md';
 
 <MobileAppBackup />
 
@@ -59,13 +59,13 @@ take quite a while.
 
 You can select the Jobs tab to see Immich processing your photos.
 
-<img src={require('../guides/img/jobs-tab.png').default} title="Jobs tab" />
+<img src={require('/docs/guides/img/jobs-tab.png').default} title="Jobs tab" />
 
 ## Set up your backups
 
 You may want to back up the content of your Immich instance
 along with other parts of your server; be sure to read about
-[database backup](../administration/backup-and-restore).
+[database backup](/docs/administration/backup-and-restore).
 
 ## Where to go from here?
 
@@ -77,11 +77,11 @@ even those not on your mobile device, via Google Takeout.
 You can use [immich-go](https://github.com/simulot/immich-go) for this.
 
 You may want to
-[upload photos from your own archive](../features/command-line-interface).
+[upload photos from your own archive](/docs/features/command-line-interface).
 
 You may want to incorporate an immutable archive of photos from an
-[External Library](../features/libraries#external-libraries);
-there's a [Guide](../guides/external-library) for that.
+[External Library](/docs/features/libraries#external-libraries);
+there's a [Guide](/docs/guides/external-library) for that.
 
 You may want your mobile device to
-[back photos up to your server automatically](../features/automatic-backup).
+[back photos up to your server automatically](/docs/features/automatic-backup).


### PR DESCRIPTION
If there is a trailing slash on a documentation page, any links referenced as ../xxx/file.md do not work

e.g.,
The links on this page work: https://immich.app/docs/overview/quick-start
The links on this page don't: https://immich.app/docs/overview/quick-start/

The trailing slash is automatically added if the user refreshes the page or gets there from an external link,
Specifying absolute path fixes this.

cc @danieldietzler 