### PR TITLE
fix(ml): remove unused import

### DIFF
--- a/machine-learning/app/main.py
+++ b/machine-learning/app/main.py
@@ -43,7 +43,7 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None, None]:
             f"{f'after {settings.model_ttl}s of inactivity' if settings.model_ttl > 0 else 'disabled'}."
         )
     )
-    
+
     try:
         if settings.request_threads > 0:
             # asyncio is a huge bottleneck for performance, so we use a thread pool to run blocking code

--- a/machine-learning/export/models/openclip.py
+++ b/machine-learning/export/models/openclip.py
@@ -1,7 +1,6 @@
 import tempfile
 import warnings
 from dataclasses import dataclass, field
-from math import e
 from pathlib import Path
 
 import open_clip


### PR DESCRIPTION
## Description

A linting check failed because of an unused import, but the PR was still strangely auto-merged.