### PR TITLE
fix(cli): uploadCounters increase only when files are uploaded

### DIFF
--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -107,6 +107,7 @@ export class Upload extends BaseCommand {
               const formData = asset.getUploadFormData();
               const res = await this.uploadAsset(formData);
               existingAssetId = res.data.id;
+              uploadCounter++;
             }
 
             if ((options.album || options.albumName) && asset.albumName !== undefined) {
@@ -129,7 +130,6 @@ export class Upload extends BaseCommand {
           }
 
           totalSizeUploaded += asset.fileSize;
-          uploadCounter++;
         }
 
         sizeSoFar += asset.fileSize;

--- a/cli/src/commands/upload.ts
+++ b/cli/src/commands/upload.ts
@@ -108,6 +108,7 @@ export class Upload extends BaseCommand {
               const res = await this.uploadAsset(formData);
               existingAssetId = res.data.id;
               uploadCounter++;
+              totalSizeUploaded += asset.fileSize;
             }
 
             if ((options.album || options.albumName) && asset.albumName !== undefined) {
@@ -128,8 +129,6 @@ export class Upload extends BaseCommand {
               }
             }
           }
-
-          totalSizeUploaded += asset.fileSize;
         }
 
         sizeSoFar += asset.fileSize;


### PR DESCRIPTION
## Description

Currectly the upload function increase the `uploadCounter` for every asset that can not skip, causing issue #6263. 

This PR moves `uploadCounter++;` before, increase the counter only when files are actually uploaded. 






## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable