### PR TITLE
added a configuration option to select the dri node in transcoding

### DIFF
--- a/mobile/openapi/doc/SystemConfigFFmpegDto.md
+++ b/mobile/openapi/doc/SystemConfigFFmpegDto.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **gopSize** | **int** |  | 
 **maxBitrate** | **String** |  | 
 **npl** | **int** |  | 
+**preferredHwDevice** | **String** |  | 
 **preset** | **String** |  | 
 **refs** | **int** |  | 
 **targetAudioCodec** | [**AudioCodec**](AudioCodec.md) |  | 

--- a/mobile/openapi/lib/model/system_config_f_fmpeg_dto.dart
+++ b/mobile/openapi/lib/model/system_config_f_fmpeg_dto.dart
@@ -22,6 +22,7 @@ class SystemConfigFFmpegDto {
     required this.gopSize,
     required this.maxBitrate,
     required this.npl,
+    required this.preferredHwDevice,
     required this.preset,
     required this.refs,
     required this.targetAudioCodec,
@@ -51,6 +52,8 @@ class SystemConfigFFmpegDto {
   String maxBitrate;
 
   int npl;
+
+  String preferredHwDevice;
 
   String preset;
 
@@ -83,6 +86,7 @@ class SystemConfigFFmpegDto {
     other.gopSize == gopSize &&
     other.maxBitrate == maxBitrate &&
     other.npl == npl &&
+    other.preferredHwDevice == preferredHwDevice &&
     other.preset == preset &&
     other.refs == refs &&
     other.targetAudioCodec == targetAudioCodec &&
@@ -106,6 +110,7 @@ class SystemConfigFFmpegDto {
     (gopSize.hashCode) +
     (maxBitrate.hashCode) +
     (npl.hashCode) +
+    (preferredHwDevice.hashCode) +
     (preset.hashCode) +
     (refs.hashCode) +
     (targetAudioCodec.hashCode) +
@@ -118,7 +123,7 @@ class SystemConfigFFmpegDto {
     (twoPass.hashCode);
 
   @override
-  String toString() => 'SystemConfigFFmpegDto[accel=$accel, acceptedAudioCodecs=$acceptedAudioCodecs, acceptedVideoCodecs=$acceptedVideoCodecs, bframes=$bframes, cqMode=$cqMode, crf=$crf, gopSize=$gopSize, maxBitrate=$maxBitrate, npl=$npl, preset=$preset, refs=$refs, targetAudioCodec=$targetAudioCodec, targetResolution=$targetResolution, targetVideoCodec=$targetVideoCodec, temporalAQ=$temporalAQ, threads=$threads, tonemap=$tonemap, transcode=$transcode, twoPass=$twoPass]';
+  String toString() => 'SystemConfigFFmpegDto[accel=$accel, acceptedAudioCodecs=$acceptedAudioCodecs, acceptedVideoCodecs=$acceptedVideoCodecs, bframes=$bframes, cqMode=$cqMode, crf=$crf, gopSize=$gopSize, maxBitrate=$maxBitrate, npl=$npl, preferredHwDevice=$preferredHwDevice, preset=$preset, refs=$refs, targetAudioCodec=$targetAudioCodec, targetResolution=$targetResolution, targetVideoCodec=$targetVideoCodec, temporalAQ=$temporalAQ, threads=$threads, tonemap=$tonemap, transcode=$transcode, twoPass=$twoPass]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -131,6 +136,7 @@ class SystemConfigFFmpegDto {
       json[r'gopSize'] = this.gopSize;
       json[r'maxBitrate'] = this.maxBitrate;
       json[r'npl'] = this.npl;
+      json[r'preferredHwDevice'] = this.preferredHwDevice;
       json[r'preset'] = this.preset;
       json[r'refs'] = this.refs;
       json[r'targetAudioCodec'] = this.targetAudioCodec;
@@ -161,6 +167,7 @@ class SystemConfigFFmpegDto {
         gopSize: mapValueOfType<int>(json, r'gopSize')!,
         maxBitrate: mapValueOfType<String>(json, r'maxBitrate')!,
         npl: mapValueOfType<int>(json, r'npl')!,
+        preferredHwDevice: mapValueOfType<String>(json, r'preferredHwDevice')!,
         preset: mapValueOfType<String>(json, r'preset')!,
         refs: mapValueOfType<int>(json, r'refs')!,
         targetAudioCodec: AudioCodec.fromJson(json[r'targetAudioCodec'])!,
@@ -227,6 +234,7 @@ class SystemConfigFFmpegDto {
     'gopSize',
     'maxBitrate',
     'npl',
+    'preferredHwDevice',
     'preset',
     'refs',
     'targetAudioCodec',

--- a/mobile/openapi/test/system_config_f_fmpeg_dto_test.dart
+++ b/mobile/openapi/test/system_config_f_fmpeg_dto_test.dart
@@ -61,6 +61,11 @@ void main() {
       // TODO
     });
 
+    // String preferredHwDevice
+    test('to test the property `preferredHwDevice`', () async {
+      // TODO
+    });
+
     // String preset
     test('to test the property `preset`', () async {
       // TODO

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -9422,6 +9422,9 @@
           "npl": {
             "type": "integer"
           },
+          "preferredHwDevice": {
+            "type": "string"
+          },
           "preset": {
             "type": "string"
           },
@@ -9463,6 +9466,7 @@
           "gopSize",
           "maxBitrate",
           "npl",
+          "preferredHwDevice",
           "preset",
           "refs",
           "targetAudioCodec",

--- a/open-api/typescript-sdk/client/api.ts
+++ b/open-api/typescript-sdk/client/api.ts
@@ -3717,6 +3717,12 @@ export interface SystemConfigFFmpegDto {
      * @type {string}
      * @memberof SystemConfigFFmpegDto
      */
+    'preferredHwDevice': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SystemConfigFFmpegDto
+     */
     'preset': string;
     /**
      * 

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -287,14 +287,17 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
   }
 
   getPreferredHardwareDevice(): string | null {
-    if (this.config.preferredHwDevice !== 'auto') {
-      if (!this.devices.includes(this.config.preferredHwDevice.replace('/dev/dri/', ''))) {
-        throw new Error(`Device '${this.config.preferredHwDevice}' does not exist`);
-      }
-      return this.config.preferredHwDevice;
+    const device = this.config.preferredHwDevice;
+    if (device === 'auto') {
+      return null;
     }
 
-    return null;
+    const deviceName = device.replace('/dev/dri/', '');
+    if (!this.devices.includes(deviceName)) {
+      throw new Error(`Device '${device}' does not exist`);
+    }
+
+    return device;
   }
 }
 

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -285,6 +285,17 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
     }
     return this.config.gopSize;
   }
+
+  getPreferredHardwareDevice(): string | null {
+    if (this.config.preferredHwDevice !== 'auto') {
+      if (!this.devices.includes(this.config.preferredHwDevice.replace('/dev/dri/', ''))) {
+        throw new Error(`Device '${this.config.preferredHwDevice}' does not exist`);
+      }
+      return this.config.preferredHwDevice;
+    }
+
+    return null;
+  }
 }
 
 export class ThumbnailConfig extends BaseConfig {
@@ -463,7 +474,14 @@ export class QSVConfig extends BaseHWConfig {
     if (!this.devices.length) {
       throw Error('No QSV device found');
     }
-    return ['-init_hw_device qsv=hw', '-filter_hw_device hw'];
+
+    let qsvString = '';
+    const hwDevice = this.getPreferredHardwareDevice();
+    if (hwDevice !== null) {
+      qsvString = `,child_device=${hwDevice}`;
+    }
+
+    return [`-init_hw_device qsv=hw${qsvString}`, '-filter_hw_device hw'];
   }
 
   getBaseOutputOptions(videoStream: VideoStreamInfo, audioStream?: AudioStreamInfo) {
@@ -527,9 +545,15 @@ export class QSVConfig extends BaseHWConfig {
 export class VAAPIConfig extends BaseHWConfig {
   getBaseInputOptions() {
     if (this.devices.length === 0) {
-      throw Error('No VAAPI device found');
+      throw new Error('No VAAPI device found');
     }
-    return [`-init_hw_device vaapi=accel:/dev/dri/${this.devices[0]}`, '-filter_hw_device accel'];
+
+    let hwDevice = this.getPreferredHardwareDevice();
+    if (hwDevice === null) {
+      hwDevice = `/dev/dri/${this.devices[0]}`;
+    }
+
+    return [`-init_hw_device vaapi=accel:${hwDevice}`, '-filter_hw_device accel'];
   }
 
   getFilterOptions(videoStream: VideoStreamInfo) {

--- a/server/src/domain/system-config/dto/system-config-ffmpeg.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-ffmpeg.dto.ts
@@ -78,6 +78,9 @@ export class SystemConfigFFmpegDto {
   @IsBoolean()
   twoPass!: boolean;
 
+  @IsString()
+  preferredHwDevice!: string;
+
   @IsEnum(TranscodePolicy)
   @ApiProperty({ enumName: 'TranscodePolicy', enum: TranscodePolicy })
   transcode!: TranscodePolicy;

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -43,6 +43,7 @@ export const defaults = Object.freeze<SystemConfig>({
     temporalAQ: false,
     cqMode: CQMode.AUTO,
     twoPass: false,
+    preferredHwDevice: 'auto',
     transcode: TranscodePolicy.REQUIRED,
     tonemap: ToneMapping.HABLE,
     accel: TranscodeHWAccel.DISABLED,

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -55,6 +55,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     temporalAQ: false,
     cqMode: CQMode.AUTO,
     twoPass: false,
+    preferredHwDevice: 'auto',
     transcode: TranscodePolicy.REQUIRED,
     accel: TranscodeHWAccel.DISABLED,
     tonemap: ToneMapping.HABLE,

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -30,6 +30,7 @@ export enum SystemConfigKey {
   FFMPEG_TEMPORAL_AQ = 'ffmpeg.temporalAQ',
   FFMPEG_CQ_MODE = 'ffmpeg.cqMode',
   FFMPEG_TWO_PASS = 'ffmpeg.twoPass',
+  FFMPEG_PREFERRED_HW_DEVICE = 'ffmpeg.preferredHwDevice',
   FFMPEG_TRANSCODE = 'ffmpeg.transcode',
   FFMPEG_ACCEL = 'ffmpeg.accel',
   FFMPEG_TONEMAP = 'ffmpeg.tonemap',
@@ -176,6 +177,7 @@ export interface SystemConfig {
     temporalAQ: boolean;
     cqMode: CQMode;
     twoPass: boolean;
+    preferredHwDevice: string;
     transcode: TranscodePolicy;
     accel: TranscodeHWAccel;
     tonemap: ToneMapping;

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -282,6 +282,13 @@
               bind:checked={config.ffmpeg.temporalAQ}
               isEdited={config.ffmpeg.temporalAQ !== savedConfig.ffmpeg.temporalAQ}
             />
+            <SettingInputField
+              inputType={SettingInputFieldType.TEXT}
+              label="PREFERRED HARDWARE DEVICE FOR TRANSCODING"
+              desc="Applies only to VAAPI and QSV. Sets the dri node used for hardware transcoding. Set to 'auto' to let immich decide for you"
+              bind:value={config.ffmpeg.preferredHwDevice}
+              isEdited={config.ffmpeg.preferredHwDevice !== savedConfig.ffmpeg.preferredHwDevice}
+            />
           </div>
         </SettingAccordion>
 


### PR DESCRIPTION
This code adds a field in SystemConfigFFmpegDto to specify the node in /dev/dri used for VAAPI hardware transcoding. 

The default value is auto, and in that case the VAAPIConfig config class works like up until now (it chooses the first available node in /dev/dri), but if the field is configured with a path to a dri node that exists (/dev/dri/renderD128 for example) it uses that node in the ffmpeg command in -init_hw_device parameter