### PR TITLE
chore(renovate): enforce compatible flavor for guava

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,10 @@
       "matchPackageNames": ["node"],
       "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-.*)?$",
       "versioning": "node"
+    },
+    {
+      "matchPackageNames": ["com.google.guava:guava"],
+      "versionCompatibility": "^(?<version>[^-]+)-(?<compatibility>.*)?$"
     }
   ],
   "ignorePaths": ["mobile/openapi/pubspec.yaml"],


### PR DESCRIPTION
#### Changes made in the PR:

- uses the renovate config `versionCompatibility` to always use the current flavor when upgrading `guava`. This should hopefully prevent renovate from changing the flavor from android to jre during updates.