### PR TITLE
chore(renovate): enforce compatible flavor for guava using versionScheme

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,8 +68,9 @@
       "versioning": "node"
     },
     {
-      "matchPackageNames": ["com.google.guava:guava"],
-      "versionCompatibility": "^(?<version>[^-]+)-(?<compatibility>.*)?$"
+      "managers": ["maven"],
+      "packageNames": ["com.google.guava:guava"],
+      "versionScheme": "docker"
     }
   ],
   "ignorePaths": ["mobile/openapi/pubspec.yaml"],


### PR DESCRIPTION
#### Changes made:

- Ensure version compatibility for guava updates in renovate using `versionScheme`.