### PR TITLE
fix: enable/disable password login on truenas

### DIFF
--- a/server/src/immich-admin/commands/password-login.ts
+++ b/server/src/immich-admin/commands/password-login.ts
@@ -1,5 +1,4 @@
 import { SystemConfigService } from '@app/domain';
-import axios from 'axios';
 import { Command, CommandRunner } from 'nest-commander';
 
 @Command({
@@ -15,7 +14,6 @@ export class EnablePasswordLoginCommand extends CommandRunner {
     const config = await this.configService.getConfig();
     config.passwordLogin.enabled = true;
     await this.configService.updateConfig(config);
-    await axios.post('http://localhost:3001/api/refresh-config');
     console.log('Password login has been enabled.');
   }
 }
@@ -33,7 +31,6 @@ export class DisablePasswordLoginCommand extends CommandRunner {
     const config = await this.configService.getConfig();
     config.passwordLogin.enabled = false;
     await this.configService.updateConfig(config);
-    await axios.post('http://localhost:3001/api/refresh-config');
     console.log('Password login has been disabled.');
   }
 }

--- a/server/src/immich-admin/main.ts
+++ b/server/src/immich-admin/main.ts
@@ -1,6 +1,9 @@
+import { LogLevel } from '@app/infra/entities';
 import { CommandFactory } from 'nest-commander';
 import { AppModule } from './app.module';
 
+process.env.LOG_LEVEL = LogLevel.WARN;
+
 export async function bootstrap() {
-  await CommandFactory.run(AppModule, ['warn', 'error']);
+  await CommandFactory.run(AppModule);
 }

--- a/server/src/immich/controllers/app.controller.ts
+++ b/server/src/immich/controllers/app.controller.ts
@@ -1,5 +1,5 @@
 import { SystemConfigService } from '@app/domain';
-import { Controller, Get, Header, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Controller, Get, Header } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
 import { PublicRoute } from '../app.guard';
 
@@ -23,12 +23,5 @@ export class AppController {
   @Header('Content-Type', 'text/css')
   getCustomCss() {
     return this.service.getCustomCss();
-  }
-
-  @ApiExcludeEndpoint()
-  @Post('refresh-config')
-  @HttpCode(HttpStatus.OK)
-  public reloadConfig() {
-    return this.service.refreshConfig();
   }
 }


### PR DESCRIPTION
Fixes #4667

- It's no longer necessary to tell the immich-server to "reload the config", since the password enabled/disabled flag is always queried directly from the database during a login attempt.
- Correctly sets the `ImmichLogger` log level to WARN, which is the prior behavior for the CLI. The CLI itself uses console.log for interactions. Warning/errors would only be shown through the `ImmichLogger` if the database was unavailable, etc.