### PR TITLE
fix(mobile): add to album - list thumbnails

### DIFF
--- a/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
+++ b/mobile/lib/modules/album/ui/album_thumbnail_listtile.dart
@@ -46,12 +46,12 @@ class AlbumThumbnailListTile extends StatelessWidget {
         fadeInDuration: const Duration(milliseconds: 200),
         imageUrl: getAlbumThumbnailUrl(
           album,
-          type: ThumbnailFormat.JPEG,
+          type: ThumbnailFormat.WEBP,
         ),
         httpHeaders: {
           "Authorization": "Bearer ${Store.get(StoreKey.accessToken)}",
         },
-        cacheKey: getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.JPEG),
+        cacheKey: getAlbumThumbNailCacheKey(album, type: ThumbnailFormat.WEBP),
         errorWidget: (context, url, error) =>
             const Icon(Icons.image_not_supported_outlined),
       );


### PR DESCRIPTION
Don't use full resolution thumbnails for those tiny album icons in the album list while adding assets to albums.
Loading of albums thumbnails is much faster now and lowers crash probability when a high number of albums exist (hundreds).
Workaround for https://github.com/immich-app/immich/issues/5428 until shared album list is redesigned.

