### PR TITLE
Move 'Add' button on album user invite to the same row as 'To' List 

### DIFF
--- a/web/src/lib/components/album-page/user-selection-modal.svelte
+++ b/web/src/lib/components/album-page/user-selection-modal.svelte
@@ -76,6 +76,9 @@
             </button>
           {/key}
         {/each}
+        <div class="flex place-content-end mr-0 ml-auto p-5">
+          <Button size="sm" rounded="lg" on:click={() => dispatch('select', selectedUsers)}>Add</Button>
+        </div>
       </div>
     {/if}
 
@@ -112,12 +115,6 @@
       <p class="p-5 text-sm">
         Looks like you have shared this album with all users or you don't have any user to share with.
       </p>
-    {/if}
-
-    {#if selectedUsers.length > 0}
-      <div class="flex place-content-end p-5">
-        <Button size="sm" rounded="lg" on:click={() => dispatch('select', selectedUsers)}>Add</Button>
-      </div>
     {/if}
   </div>
 


### PR DESCRIPTION
This pull requests moves the "Add" Button in the album user adding modal to the same row as the list of added users in order to fix #6446.

Note: When adding many users, the users and the add button still get hidden behind a horizontal scrollbar.

---
Edit with Screenshots
Before:
![Screenshot_20240117_122152](https://github.com/immich-app/immich/assets/44997401/b2d338f3-e03d-4266-9837-77cfd3e5740f)

After:
![Screenshot_20240117_122108](https://github.com/immich-app/immich/assets/44997401/3519c061-d5b1-40cc-8caa-68b216279aab)
