### PR TITLE
fix(server): handle 5 digit years

### DIFF
--- a/server/e2e/api/specs/asset.e2e-spec.ts
+++ b/server/e2e/api/specs/asset.e2e-spec.ts
@@ -1073,6 +1073,16 @@ describe(`${AssetController.name} (e2e)`, () => {
       expect(body).toEqual(errorStub.unauthorized);
     });
 
+    it('should handle 5 digit years', async () => {
+      const { status, body } = await request(server)
+        .get('/asset/time-bucket')
+        .query({ size: TimeBucketSize.MONTH, timeBucket: '+012345-01-01T00:00:00.000Z' })
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+
+      expect(status).toBe(200);
+      expect(body).toEqual([]);
+    });
+
     // it('should fail if time bucket is invalid', async () => {
     //   const { status, body } = await request(server)
     //     .get('/asset/time-bucket')

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -687,7 +687,7 @@ export class AssetRepository implements IAssetRepository {
     const truncated = dateTrunc(options);
     return (
       this.getBuilder(options)
-        .andWhere(`${truncated} = :timeBucket`, { timeBucket })
+        .andWhere(`${truncated} = :timeBucket`, { timeBucket: timeBucket.replace(/^[+-]/, '') })
         // First sort by the day in localtime (put it in the right bucket)
         .orderBy(truncated, 'DESC')
         // and then sort by the actual time
@@ -757,10 +757,7 @@ export class AssetRepository implements IAssetRepository {
   private getBuilder(options: AssetBuilderOptions) {
     const { isArchived, isFavorite, isTrashed, albumId, personId, userIds, withStacked, exifInfo, assetType } = options;
 
-    let builder = this.repository
-      .createQueryBuilder('asset')
-      .where('asset.isVisible = true')
-      .andWhere('asset.fileCreatedAt < NOW()');
+    let builder = this.repository.createQueryBuilder('asset').where('asset.isVisible = true');
     if (assetType !== undefined) {
       builder = builder.andWhere('asset.type = :assetType', { assetType });
     }

--- a/server/src/infra/sql/asset.repository.sql
+++ b/server/src/infra/sql/asset.repository.sql
@@ -553,10 +553,7 @@ FROM
   LEFT JOIN "assets" "stack" ON "stack"."stackParentId" = "asset"."id"
   AND ("stack"."deletedAt" IS NULL)
 WHERE
-  (
-    "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
-  )
+  ("asset"."isVisible" = true)
   AND ("asset"."deletedAt" IS NULL)
 GROUP BY
   (
@@ -668,7 +665,6 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
     AND (
       date_trunc(
         'month',
@@ -708,7 +704,6 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
     AND "asset"."type" = $2
     AND "asset"."ownerId" IN ($3)
     AND "asset"."isArchived" = $4
@@ -739,7 +734,6 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
     AND "asset"."type" = $2
     AND "asset"."ownerId" IN ($3)
     AND "asset"."isArchived" = $4
@@ -761,7 +755,6 @@ FROM
 WHERE
   (
     "asset"."isVisible" = true
-    AND "asset"."fileCreatedAt" < NOW()
     AND "asset"."ownerId" IN ($1)
     AND "asset"."isArchived" = $2
     AND (


### PR DESCRIPTION
The ISO 8601 allows for use of +/- signs if the year is bigger than 4 digitis. For example,

```typescript
new Date(12345, 0, 0).toISOString();
// '+012344-12-31T05:00:00.000Z'
```

However, plus signs in postgres queries are used to specify timezone offset, hence the error `time zone displacement out of range`.

This PR strips out the plus when the time bucket query is used in postgres, and again allows for time buckets to return assets in the future.

Supersedes #6117.
Actually fixes #4264, #4538, and #5578.