### PR TITLE
docs: remove tsc check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,6 @@ jobs:
         run: npm run format
         if: ${{ !cancelled() }}
 
-      - name: Run tsc
-        run: npm run check
-        if: ${{ !cancelled() }}
-
       - name: Run build
         run: npm run build
         if: ${{ !cancelled() }}

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,7 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids",
-    "check": "tsc"
+    "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.3",


### PR DESCRIPTION
The tsconfig file is only used for a nice editor experience. Removing the `tsc` check as we are already building the production app in a subsequent step.