### PR TITLE
chore: update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: Report an issue with Immich
 description: Report an issue with Immich
-title: ""
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,6 @@
 name: Report an issue with Immich
 description: Report an issue with Immich
-labels: ["bug", "need triage"]
-title: "[BUG] <title>"
+title: ""
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
- We don't really use the triage label
- All issues are supposed to be bugs, so the bug label seems redundant
- Removing the `[Bug]` title prefix because of the above mentioned, also it should make the title nicer when non-bugs are converted to discussions.