### PR TITLE
fix(web): prevent layout change from scrollbar in admin settings

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -132,4 +132,8 @@ input:focus-visible {
     display: none;
     scrollbar-width: none;
   }
+
+  .scrollbar-stable {
+    scrollbar-gutter: stable both-edges;
+  }
 }

--- a/web/src/lib/components/layouts/user-page-layout.svelte
+++ b/web/src/lib/components/layouts/user-page-layout.svelte
@@ -42,7 +42,7 @@
       </div>
     {/if}
 
-    <div class="{scrollbarClass} absolute {hasTitleClass} w-full overflow-y-auto">
+    <div class="{scrollbarClass} scrollbar-stable absolute {hasTitleClass} w-full overflow-y-auto">
       <slot />
     </div>
   </section>


### PR DESCRIPTION
## Description

When initially visiting the admin settings, there may be no scrollbar. Currently, when an accordion is expanded and a scrollbar appears, all the settings are shifted slightly to the left. This PR adds the new [scrollbar-gutter](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) CSS property that allows the layout to compensate for this.

Notably, Safari only supports this property behind a feature flag, so it will not have an effect on this browser yet.

## How Has This Been Tested?

The admin settings no longer shift when the scrollbar appears.