### PR TITLE
fix(web): better button placement within the user management table

### DIFF
--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -212,7 +212,7 @@
                   </div>
                 </td>
 
-                <td class="w-4/12 lg:w-3/12 xl:w-2/12 text-ellipsis break-all px-4 text-sm">
+                <td class="w-4/12 lg:w-3/12 xl:w-2/12 text-ellipsis break-all text-sm">
                   {#if !isDeleted(immichUser)}
                     <button
                       on:click={() => editUserHandler(immichUser)}


### PR DESCRIPTION
Since the addition of the "Has quota" and "Can import" columns, action buttons look crammed for viewports between 1280px and 1535px. I fixed this by removing the table cell padding, which seemed unnecessary to me given that these buttons already have margins that are wide enough on all screen sizes.

Before:
![Screenshot 2024-01-20 at 00-20-12 User Management](https://github.com/immich-app/immich/assets/3842222/afdc2d16-0005-4a49-b1c7-e5a3deeaa852)
After:
![Screenshot 2024-01-20 at 00-10-44 User Management](https://github.com/immich-app/immich/assets/3842222/ce37393c-8315-4349-a479-2704c1a5ced2)
