### PR TITLE
fix(server): use crf-based two pass for vp9 if max bitrate is disabled

### DIFF
--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -356,7 +356,7 @@ export class VP9Config extends BaseConfig {
 
   getBitrateOptions() {
     const bitrates = this.getBitrateDistribution();
-    if (this.eligibleForTwoPass()) {
+    if (bitrates.max > 0 && this.eligibleForTwoPass()) {
       return [
         `-b:v ${bitrates.target}${bitrates.unit}`,
         `-minrate ${bitrates.min}${bitrates.unit}`,


### PR DESCRIPTION
## Description

The current behavior incorrectly still uses bitrate-based two-pass mode even when the max bitrate is set to 0. There's a unit test for bitrate-based two-pass mode, but not for CRF. This PR also adds a regression test to ensure this behavior is maintained.

Fixes #6472