### PR TITLE
fix(server): disable sharp file caching

### DIFF
--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -9,6 +9,7 @@ import { promisify } from 'util';
 
 const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);
 sharp.concurrency(0);
+sharp.cache({ files: 0 });
 
 export class MediaRepository implements IMediaRepository {
   private logger = new ImmichLogger(MediaRepository.name);


### PR DESCRIPTION
## Description

sharp / libvips holds up to 20 files open as part of its operation cache by default (see [here](https://sharp.pixelplumbing.com/api-utility#cache)). This has a dramatic effect on RAM consumption, especially in the case of RAW files. There's normally a 50mb limit on the cache, so I'm not sure if this is expected behavior.

This change will most likely not have an effect on performance since we process each thumbnail of each asset at different times, so the original image will have been evicted from the cache by the time we generate another thumbnail for it.

Should fix #4391

## How Has This Been Tested?

I uploaded a number of RAW images with and without this change multiple times, force deleting the images in-between each run so they were reprocessed. WIthout this change, the container's memory usage increased dramatically with each image, using several gigabytes of memory after a handful of images. With this change, there was still an increase, but the increase was on the order of a few hundred megabytes and stabilized.