### PR TITLE
fix(web): auto generate open api build

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -54,11 +54,10 @@ services:
 
   immich-web:
     container_name: immich_web
-    image: immich-web-dev:1.9.0
+    image: immich-web-dev:latest
     build:
       context: ../web
-      dockerfile: Dockerfile
-    command: "node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000"
+    command: "/usr/src/app/bin/immich-web"
     env_file:
       - .env
     ports:

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -35,15 +35,13 @@ All the services are packaged to run as with single Docker Compose command.
 1. Clone the project repo.
 2. Run `cp docker/example.env docker/.env`.
 3. Edit `docker/.env` to provide values for the required variable `UPLOAD_LOCATION`.
-4. Install the required dependencies (nodejs >20, a modern java version e.g. OpenJDK 17)
-5. From the root directory, run:
+4. From the root directory, run:
 
 ```bash title="Start development server"
-make open-api # this is the only step that requires the above dependencies
 make dev # required Makefile installed on the system.
 ```
 
-6. Access the dev instance in your browser at http://localhost:2283, or connect via the mobile app.
+5. Access the dev instance in your browser at http://localhost:2283, or connect via the mobile app.
 
 All the services will be started with hot-reloading enabled for a quick feedback loop.
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,4 +8,3 @@ COPY --chown=node:node . .
 ENV CHOKIDAR_USEPOLLING=true
 EXPOSE 24678
 EXPOSE 3000
-CMD ["npm", "run", "dev"]

--- a/web/bin/immich-web
+++ b/web/bin/immich-web
@@ -1,10 +1,13 @@
 #!/usr/bin/env sh
 
-if [ ! -d "/usr/src/open-api/typescript-sdk/build" ]; then
-  echo "Building typescript-sdk"
-  npm --prefix /usr/src/open-api/typescript-sdk install
-  npm --prefix /usr/src/open-api/typescript-sdk run build
-fi
+TYPESCRIPT_SDK=/usr/src/open-api/typescript-sdk
 
+if [ ! -d "$TYPESCRIPT_SDK/build" ]; then
+  echo "$TYPESCRIPT_SDK/build does not exist, building"
+  npm --prefix "$TYPESCRIPT_SDK" install
+  npm --prefix "$TYPESCRIPT_SDK" run build
+else
+  echo "$TYPESCRIPT_SDK/build exists, skipping"
+fi
 
 node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000

--- a/web/bin/immich-web
+++ b/web/bin/immich-web
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+if [ ! -d "/usr/src/open-api/typescript-sdk/build" ]; then
+  echo "Building typescript-sdk"
+  npm --prefix /usr/src/open-api/typescript-sdk install
+  npm --prefix /usr/src/open-api/typescript-sdk run build
+fi
+
+
+node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000


### PR DESCRIPTION
Automatically run `npm ci` and `npm run build` in the typescript-sdk folder when building the web docker image for development.