### PR TITLE
fix(web): always use websocket transport

### DIFF
--- a/server/src/infra/repositories/communication.repository.ts
+++ b/server/src/infra/repositories/communication.repository.ts
@@ -16,7 +16,11 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 
-@WebSocketGateway({ cors: true, path: '/api/socket.io' })
+@WebSocketGateway({
+  cors: true,
+  path: '/api/socket.io',
+  transports: ['websocket'],
+})
 export class CommunicationRepository
   implements OnGatewayConnection, OnGatewayDisconnect, OnGatewayInit, ICommunicationRepository
 {

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -37,6 +37,7 @@ export const openWebsocketConnection = async () => {
 
     websocket = io('', {
       path: '/api/socket.io',
+      transports: ['websocket'],
       reconnection: true,
       forceNew: true,
       autoConnect: true,


### PR DESCRIPTION
Fixes #4611 by always using the websocket transport. This change no longer falls backs to `polling`, which requires a sticky session implementation (webserver proxy)  to work in multi-server environments.