### PR TITLE
fix(server): storage migration job move files without exifInfo.fileSizeInByte

### DIFF
--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -149,9 +149,9 @@ export class StorageTemplateService {
       const oldPath = originalPath;
       const newPath = await this.getTemplatePath(asset, metadata);
 
-      if (!exifInfo || !exifInfo.fileSizeInByte) {
-        this.logger.error(`Asset ${id} missing exif info, skipping storage template migration`);
-        return;
+      let fileSizeInByte = (await this.storageRepository.stat(oldPath)).size;
+      if (exifInfo && exifInfo.fileSizeInByte) {
+        fileSizeInByte = exifInfo.fileSizeInByte;
       }
 
       try {
@@ -160,7 +160,7 @@ export class StorageTemplateService {
           pathType: AssetPathType.ORIGINAL,
           oldPath,
           newPath,
-          assetInfo: { sizeInBytes: exifInfo.fileSizeInByte, checksum: asset.checksum },
+          assetInfo: { sizeInBytes: fileSizeInByte, checksum: asset.checksum },
         });
         if (sidecarPath) {
           await this.storageCore.moveFile({


### PR DESCRIPTION
This might fix https://github.com/immich-app/immich/issues/6375 https://github.com/immich-app/immich/discussions/6411
I haven't tested yet.