### PR TITLE
chore(server): remove old device id endpoint

### DIFF
--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -111,7 +111,6 @@ Class | Method | HTTP request | Description
 *AssetApi* | [**getRandom**](doc//AssetApi.md#getrandom) | **GET** /asset/random | 
 *AssetApi* | [**getTimeBucket**](doc//AssetApi.md#gettimebucket) | **GET** /asset/time-bucket | 
 *AssetApi* | [**getTimeBuckets**](doc//AssetApi.md#gettimebuckets) | **GET** /asset/time-buckets | 
-*AssetApi* | [**getUserAssetsByDeviceId**](doc//AssetApi.md#getuserassetsbydeviceid) | **GET** /asset/{deviceId} | Use /asset/device/:deviceId instead - Remove in 1.92 release
 *AssetApi* | [**restoreAssets**](doc//AssetApi.md#restoreassets) | **POST** /asset/restore | 
 *AssetApi* | [**restoreTrash**](doc//AssetApi.md#restoretrash) | **POST** /asset/trash/restore | 
 *AssetApi* | [**runAssetJobs**](doc//AssetApi.md#runassetjobs) | **POST** /asset/jobs | 

--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -29,7 +29,6 @@ Method | HTTP request | Description
 [**getRandom**](AssetApi.md#getrandom) | **GET** /asset/random | 
 [**getTimeBucket**](AssetApi.md#gettimebucket) | **GET** /asset/time-bucket | 
 [**getTimeBuckets**](AssetApi.md#gettimebuckets) | **GET** /asset/time-buckets | 
-[**getUserAssetsByDeviceId**](AssetApi.md#getuserassetsbydeviceid) | **GET** /asset/{deviceId} | Use /asset/device/:deviceId instead - Remove in 1.92 release
 [**restoreAssets**](AssetApi.md#restoreassets) | **POST** /asset/restore | 
 [**restoreTrash**](AssetApi.md#restoretrash) | **POST** /asset/trash/restore | 
 [**runAssetJobs**](AssetApi.md#runassetjobs) | **POST** /asset/jobs | 
@@ -1197,61 +1196,6 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**List<TimeBucketResponseDto>**](TimeBucketResponseDto.md)
-
-### Authorization
-
-[cookie](../README.md#cookie), [api_key](../README.md#api_key), [bearer](../README.md#bearer)
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# **getUserAssetsByDeviceId**
-> List<String> getUserAssetsByDeviceId(deviceId)
-
-Use /asset/device/:deviceId instead - Remove in 1.92 release
-
-### Example
-```dart
-import 'package:openapi/api.dart';
-// TODO Configure API key authorization: cookie
-//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKey = 'YOUR_API_KEY';
-// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//defaultApiClient.getAuthentication<ApiKeyAuth>('cookie').apiKeyPrefix = 'Bearer';
-// TODO Configure API key authorization: api_key
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKey = 'YOUR_API_KEY';
-// uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
-// TODO Configure HTTP Bearer authorization: bearer
-// Case 1. Use String Token
-//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken('YOUR_ACCESS_TOKEN');
-// Case 2. Use Function which generate token.
-// String yourTokenGeneratorFunction() { ... }
-//defaultApiClient.getAuthentication<HttpBearerAuth>('bearer').setAccessToken(yourTokenGeneratorFunction);
-
-final api_instance = AssetApi();
-final deviceId = deviceId_example; // String | 
-
-try {
-    final result = api_instance.getUserAssetsByDeviceId(deviceId);
-    print(result);
-} catch (e) {
-    print('Exception when calling AssetApi->getUserAssetsByDeviceId: $e\n');
-}
-```
-
-### Parameters
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **deviceId** | **String**|  | 
-
-### Return type
-
-**List<String>**
 
 ### Authorization
 

--- a/mobile/openapi/lib/api/asset_api.dart
+++ b/mobile/openapi/lib/api/asset_api.dart
@@ -1267,62 +1267,6 @@ class AssetApi {
     return null;
   }
 
-  /// Use /asset/device/:deviceId instead - Remove in 1.92 release
-  ///
-  /// Note: This method returns the HTTP [Response].
-  ///
-  /// Parameters:
-  ///
-  /// * [String] deviceId (required):
-  Future<Response> getUserAssetsByDeviceIdWithHttpInfo(String deviceId,) async {
-    // ignore: prefer_const_declarations
-    final path = r'/asset/{deviceId}'
-      .replaceAll('{deviceId}', deviceId);
-
-    // ignore: prefer_final_locals
-    Object? postBody;
-
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
-
-    const contentTypes = <String>[];
-
-
-    return apiClient.invokeAPI(
-      path,
-      'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
-    );
-  }
-
-  /// Use /asset/device/:deviceId instead - Remove in 1.92 release
-  ///
-  /// Parameters:
-  ///
-  /// * [String] deviceId (required):
-  Future<List<String>?> getUserAssetsByDeviceId(String deviceId,) async {
-    final response = await getUserAssetsByDeviceIdWithHttpInfo(deviceId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
-    }
-    // When a remote server returns no body with a status of 204, we shall not decode it.
-    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
-    // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<String>') as List)
-        .cast<String>()
-        .toList();
-
-    }
-    return null;
-  }
-
   /// Performs an HTTP 'POST /asset/restore' operation and returns the [Response].
   /// Parameters:
   ///

--- a/mobile/openapi/test/asset_api_test.dart
+++ b/mobile/openapi/test/asset_api_test.dart
@@ -127,13 +127,6 @@ void main() {
       // TODO
     });
 
-    // Use /asset/device/:deviceId instead - Remove in 1.92 release
-    //
-    //Future<List<String>> getUserAssetsByDeviceId(String deviceId) async
-    test('test getUserAssetsByDeviceId', () async {
-      // TODO
-    });
-
     //Future restoreAssets(BulkIdsDto bulkIdsDto) async
     test('test restoreAssets', () async {
       // TODO

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -2318,52 +2318,6 @@
         ]
       }
     },
-    "/asset/{deviceId}": {
-      "get": {
-        "deprecated": true,
-        "operationId": "getUserAssetsByDeviceId",
-        "parameters": [
-          {
-            "name": "deviceId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "cookie": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "summary": "Use /asset/device/:deviceId instead - Remove in 1.92 release",
-        "tags": [
-          "Asset"
-        ]
-      }
-    },
     "/asset/{id}": {
       "put": {
         "operationId": "updateAsset",

--- a/open-api/typescript-sdk/client/api.ts
+++ b/open-api/typescript-sdk/client/api.ts
@@ -7803,50 +7803,6 @@ export const AssetApiAxiosParamCreator = function (configuration?: Configuration
         },
         /**
          * 
-         * @summary Use /asset/device/:deviceId instead - Remove in 1.92 release
-         * @param {string} deviceId 
-         * @param {*} [options] Override http request option.
-         * @deprecated
-         * @throws {RequiredError}
-         */
-        getUserAssetsByDeviceId: async (deviceId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'deviceId' is not null or undefined
-            assertParamExists('getUserAssetsByDeviceId', 'deviceId', deviceId)
-            const localVarPath = `/asset/{deviceId}`
-                .replace(`{${"deviceId"}}`, encodeURIComponent(String(deviceId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication cookie required
-
-            // authentication api_key required
-            await setApiKeyToObject(localVarHeaderParameter, "x-api-key", configuration)
-
-            // authentication bearer required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @param {BulkIdsDto} bulkIdsDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -8796,18 +8752,6 @@ export const AssetApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Use /asset/device/:deviceId instead - Remove in 1.92 release
-         * @param {string} deviceId 
-         * @param {*} [options] Override http request option.
-         * @deprecated
-         * @throws {RequiredError}
-         */
-        async getUserAssetsByDeviceId(deviceId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<string>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getUserAssetsByDeviceId(deviceId, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
-         * 
          * @param {BulkIdsDto} bulkIdsDto 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -9138,17 +9082,6 @@ export const AssetApiFactory = function (configuration?: Configuration, basePath
          */
         getTimeBuckets(requestParameters: AssetApiGetTimeBucketsRequest, options?: AxiosRequestConfig): AxiosPromise<Array<TimeBucketResponseDto>> {
             return localVarFp.getTimeBuckets(requestParameters.size, requestParameters.userId, requestParameters.albumId, requestParameters.personId, requestParameters.isArchived, requestParameters.isFavorite, requestParameters.isTrashed, requestParameters.withStacked, requestParameters.withPartners, requestParameters.key, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @summary Use /asset/device/:deviceId instead - Remove in 1.92 release
-         * @param {AssetApiGetUserAssetsByDeviceIdRequest} requestParameters Request parameters.
-         * @param {*} [options] Override http request option.
-         * @deprecated
-         * @throws {RequiredError}
-         */
-        getUserAssetsByDeviceId(requestParameters: AssetApiGetUserAssetsByDeviceIdRequest, options?: AxiosRequestConfig): AxiosPromise<Array<string>> {
-            return localVarFp.getUserAssetsByDeviceId(requestParameters.deviceId, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -9721,20 +9654,6 @@ export interface AssetApiGetTimeBucketsRequest {
      * @memberof AssetApiGetTimeBuckets
      */
     readonly key?: string
-}
-
-/**
- * Request parameters for getUserAssetsByDeviceId operation in AssetApi.
- * @export
- * @interface AssetApiGetUserAssetsByDeviceIdRequest
- */
-export interface AssetApiGetUserAssetsByDeviceIdRequest {
-    /**
-     * 
-     * @type {string}
-     * @memberof AssetApiGetUserAssetsByDeviceId
-     */
-    readonly deviceId: string
 }
 
 /**
@@ -10476,19 +10395,6 @@ export class AssetApi extends BaseAPI {
      */
     public getTimeBuckets(requestParameters: AssetApiGetTimeBucketsRequest, options?: AxiosRequestConfig) {
         return AssetApiFp(this.configuration).getTimeBuckets(requestParameters.size, requestParameters.userId, requestParameters.albumId, requestParameters.personId, requestParameters.isArchived, requestParameters.isFavorite, requestParameters.isTrashed, requestParameters.withStacked, requestParameters.withPartners, requestParameters.key, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @summary Use /asset/device/:deviceId instead - Remove in 1.92 release
-     * @param {AssetApiGetUserAssetsByDeviceIdRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @deprecated
-     * @throws {RequiredError}
-     * @memberof AssetApi
-     */
-    public getUserAssetsByDeviceId(requestParameters: AssetApiGetUserAssetsByDeviceIdRequest, options?: AxiosRequestConfig) {
-        return AssetApiFp(this.configuration).getUserAssetsByDeviceId(requestParameters.deviceId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/server/src/domain/asset/dto/asset.dto.ts
+++ b/server/src/domain/asset/dto/asset.dto.ts
@@ -17,6 +17,12 @@ import {
 import { Optional, QueryBoolean, QueryDate, ValidateUUID } from '../../domain.util';
 import { BulkIdsDto } from '../response-dto';
 
+export class DeviceIdDto {
+  @IsNotEmpty()
+  @IsString()
+  deviceId!: string;
+}
+
 export enum AssetOrder {
   ASC = 'asc',
   DESC = 'desc',

--- a/server/src/immich/api-v1/asset/asset-repository.ts
+++ b/server/src/immich/api-v1/asset/asset-repository.ts
@@ -25,7 +25,6 @@ export interface IAssetRepository {
   create(asset: AssetCreate): Promise<AssetEntity>;
   upsertExif(exif: Partial<ExifEntity>): Promise<void>;
   getAllByUserId(userId: string, dto: AssetSearchDto): Promise<AssetEntity[]>;
-  getAllByDeviceId(userId: string, deviceId: string): Promise<string[]>;
   getById(assetId: string): Promise<AssetEntity>;
   getLocationsByUserId(userId: string): Promise<CuratedLocationsResponseDto[]>;
   getDetectedObjectsByUserId(userId: string): Promise<CuratedObjectsResponseDto[]>;
@@ -168,27 +167,6 @@ export class AssetRepository implements IAssetRepository {
 
   async upsertExif(exif: Partial<ExifEntity>): Promise<void> {
     await this.exifRepository.upsert(exif, { conflictPaths: ['assetId'] });
-  }
-
-  /**
-   * Get assets by device's Id on the database
-   * @param ownerId
-   * @param deviceId
-   *
-   * @returns Promise<string[]> - Array of assetIds belong to the device
-   */
-  async getAllByDeviceId(ownerId: string, deviceId: string): Promise<string[]> {
-    const items = await this.assetRepository.find({
-      select: { deviceAssetId: true },
-      where: {
-        ownerId,
-        deviceId,
-        isVisible: true,
-      },
-      withDeleted: true,
-    });
-
-    return items.map((asset) => asset.deviceAssetId);
   }
 
   /**

--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -15,7 +15,7 @@ import {
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiHeader, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiHeader, ApiTags } from '@nestjs/swagger';
 import { NextFunction, Response } from 'express';
 import { Auth, Authenticated, FileResponse, SharedLinkRoute } from '../../app.guard';
 import { sendFile } from '../../app.utils';
@@ -27,7 +27,6 @@ import { AssetBulkUploadCheckDto } from './dto/asset-check.dto';
 import { AssetSearchDto } from './dto/asset-search.dto';
 import { CheckExistingAssetsDto } from './dto/check-existing-assets.dto';
 import { CreateAssetDto } from './dto/create-asset.dto';
-import { DeviceIdDto } from './dto/device-id.dto';
 import { GetAssetThumbnailDto } from './dto/get-asset-thumbnail.dto';
 import { ServeFileDto } from './dto/serve-file.dto';
 import { AssetBulkUploadCheckResponseDto } from './response-dto/asset-check-response.dto';
@@ -139,15 +138,6 @@ export class AssetController {
     @Query(new ValidationPipe({ transform: true })) dto: AssetSearchDto,
   ): Promise<AssetResponseDto[]> {
     return this.assetService.getAllAssets(auth, dto);
-  }
-
-  /**
-   * @deprecated Use /asset/device/:deviceId instead - Remove at 1.92 release
-   */
-  @Get('/:deviceId')
-  @ApiOperation({ deprecated: true, summary: 'Use /asset/device/:deviceId instead - Remove in 1.92 release' })
-  getUserAssetsByDeviceId(@Auth() auth: AuthDto, @Param() { deviceId }: DeviceIdDto) {
-    return this.assetService.getUserAssetsByDeviceId(auth, deviceId);
   }
 
   /**

--- a/server/src/immich/api-v1/asset/asset.service.spec.ts
+++ b/server/src/immich/api-v1/asset/asset.service.spec.ts
@@ -56,32 +56,6 @@ const _getAsset_1 = () => {
   return asset_1;
 };
 
-const _getAsset_2 = () => {
-  const asset_2 = new AssetEntity();
-
-  asset_2.id = 'id_2';
-  asset_2.ownerId = 'user_id_1';
-  asset_2.deviceAssetId = 'device_asset_id_2';
-  asset_2.deviceId = 'device_id_1';
-  asset_2.type = AssetType.VIDEO;
-  asset_2.originalPath = 'fake_path/asset_2.jpeg';
-  asset_2.resizePath = '';
-  asset_2.fileModifiedAt = new Date('2022-06-19T23:41:36.910Z');
-  asset_2.fileCreatedAt = new Date('2022-06-19T23:41:36.910Z');
-  asset_2.updatedAt = new Date('2022-06-19T23:41:36.910Z');
-  asset_2.isFavorite = false;
-  asset_2.isArchived = false;
-  asset_2.webpPath = '';
-  asset_2.encodedVideoPath = '';
-  asset_2.duration = '0:00:00.000000';
-
-  return asset_2;
-};
-
-const _getAssets = () => {
-  return [_getAsset_1(), _getAsset_2()];
-};
-
 describe('AssetService', () => {
   let sut: AssetService;
   let accessMock: IAccessRepositoryMock;
@@ -97,7 +71,6 @@ describe('AssetService', () => {
       upsertExif: jest.fn(),
 
       getAllByUserId: jest.fn(),
-      getAllByDeviceId: jest.fn(),
       getById: jest.fn(),
       getDetectedObjectsByUserId: jest.fn(),
       getLocationsByUserId: jest.fn(),
@@ -197,20 +170,6 @@ describe('AssetService', () => {
       ]);
       expect(userMock.updateUsage).toHaveBeenCalledWith(authStub.user1.user.id, 111);
     });
-  });
-
-  it('get assets by device id', async () => {
-    const assets = _getAssets();
-
-    assetRepositoryMock.getAllByDeviceId.mockImplementation(() =>
-      Promise.resolve<string[]>(Array.from(assets.map((asset) => asset.deviceAssetId))),
-    );
-
-    const deviceId = 'device_id_1';
-    const result = await sut.getUserAssetsByDeviceId(authStub.user1, deviceId);
-
-    expect(result.length).toEqual(2);
-    expect(result).toEqual(assets.map((asset) => asset.deviceAssetId));
   });
 
   describe('bulkUploadCheck', () => {

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -111,10 +111,6 @@ export class AssetService {
     }
   }
 
-  public async getUserAssetsByDeviceId(auth: AuthDto, deviceId: string) {
-    return this._assetRepository.getAllByDeviceId(auth.user.id, deviceId);
-  }
-
   public async getAllAssets(auth: AuthDto, dto: AssetSearchDto): Promise<AssetResponseDto[]> {
     const userId = dto.userId || auth.user.id;
     await this.access.requirePermission(auth, Permission.TIMELINE_READ, userId);

--- a/server/src/immich/api-v1/asset/dto/device-id.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/device-id.dto.ts
@@ -1,7 +1,0 @@
-import { IsNotEmpty, IsString } from 'class-validator';
-
-export class DeviceIdDto {
-  @IsNotEmpty()
-  @IsString()
-  deviceId!: string;
-}

--- a/server/src/immich/controllers/asset.controller.ts
+++ b/server/src/immich/controllers/asset.controller.ts
@@ -10,6 +10,7 @@ import {
   AssetStatsResponseDto,
   AuthDto,
   BulkIdsDto,
+  DeviceIdDto,
   DownloadInfoDto,
   DownloadResponseDto,
   MapMarkerDto,
@@ -41,7 +42,6 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NextFunction, Response } from 'express';
-import { DeviceIdDto } from '../api-v1/asset/dto/device-id.dto';
 import { Auth, Authenticated, FileResponse, SharedLinkRoute } from '../app.guard';
 import { UseValidation, asStreamableFile, sendFile } from '../app.utils';
 import { Route } from '../interceptors';


### PR DESCRIPTION
> [!WARNING]
> Mobile apps connecting to server versions prior to 1.92 will no longer be able to use the full device id sync endpoint

- We added a new device id endpoint (#5273) in v1.89
- We started using the new endpoint (#6108) in v1.92
- We removed it in this PR, which can be included in v1.94.

