### PR TITLE
fix(web): statusbox re-rendering and nav bar when trashing assets

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -21,6 +21,7 @@
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
   import { mdiFileImagePlusOutline, mdiFolderDownloadOutline } from '@mdi/js';
   import UpdatePanel from '../shared-components/update-panel.svelte';
+  import { autoGrowHeight } from '$lib/utils/autogrow';
 
   export let sharedLink: SharedLinkResponseDto;
   export let user: UserResponseDto | undefined = undefined;
@@ -28,6 +29,7 @@
   const album = sharedLink.album as AlbumResponseDto;
 
   let { isViewing: showAssetViewer } = assetViewingStore;
+  let textArea: HTMLTextAreaElement;
 
   const assetStore = new AssetStore({ albumId: album.id });
   const assetInteractionStore = createAssetInteractionStore();
@@ -159,9 +161,16 @@
       {/if}
 
       <!-- ALBUM DESCRIPTION -->
-      <p class="mb-12 mt-6 w-full pb-2 text-left text-lg font-medium dark:text-gray-300">
-        {album.description}
-      </p>
+      {#if album.description}
+        <textarea
+          class="w-full resize-none overflow-hidden text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
+          bind:this={textArea}
+          bind:value={album.description}
+          disabled={true}
+          on:input={() => autoGrowHeight(textArea)}
+          use:autoGrowHeight
+        />
+      {/if}
     </section>
   </AssetGrid>
   <UpdatePanel {assetStore} />

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -161,16 +161,9 @@
       {/if}
 
       <!-- ALBUM DESCRIPTION -->
-      {#if album.description}
-        <textarea
-          class="w-full resize-none overflow-hidden text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
-          bind:this={textArea}
-          bind:value={album.description}
-          disabled={true}
-          on:input={() => autoGrowHeight(textArea)}
-          use:autoGrowHeight
-        />
-      {/if}
+      <p class="mb-12 mt-6 w-full pb-2 text-left text-lg font-medium dark:text-gray-300">
+        {album.description}
+      </p>
     </section>
   </AssetGrid>
   <UpdatePanel {assetStore} />

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -21,7 +21,6 @@
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
   import { mdiFileImagePlusOutline, mdiFolderDownloadOutline } from '@mdi/js';
   import UpdatePanel from '../shared-components/update-panel.svelte';
-  import { autoGrowHeight } from '$lib/utils/autogrow';
 
   export let sharedLink: SharedLinkResponseDto;
   export let user: UserResponseDto | undefined = undefined;
@@ -29,7 +28,6 @@
   const album = sharedLink.album as AlbumResponseDto;
 
   let { isViewing: showAssetViewer } = assetViewingStore;
-  let textArea: HTMLTextAreaElement;
 
   const assetStore = new AssetStore({ albumId: album.id });
   const assetInteractionStore = createAssetInteractionStore();

--- a/web/src/lib/components/photos-page/actions/delete-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/delete-assets.svelte
@@ -12,7 +12,7 @@
   export let menuItem = false;
   export let force = !$featureFlags.trash;
 
-  const { getOwnedAssets } = getAssetControlContext();
+  const { clearSelect, getOwnedAssets } = getAssetControlContext();
 
   const dispatch = createEventDispatcher<{
     escape: void;
@@ -36,6 +36,7 @@
       .filter((a) => !a.isExternal)
       .map((a) => a.id);
     await deleteAssets(force, onAssetDelete, ids);
+    clearSelect();
     isShowConfirmation = false;
     loading = false;
   };

--- a/web/src/lib/components/shared-components/status-box.svelte
+++ b/web/src/lib/components/shared-components/status-box.svelte
@@ -48,10 +48,6 @@
         const { data } = await api.serverInfoApi.getServerInfo();
         $serverInfoStore = data;
       }
-      if (!$user) {
-        const { data } = await api.userApi.getMyUserInfo();
-        $user = data;
-      }
     } catch (e) {
       console.log('Error [StatusBox] [onMount]');
     }

--- a/web/src/lib/components/shared-components/status-box.svelte
+++ b/web/src/lib/components/shared-components/status-box.svelte
@@ -2,22 +2,22 @@
   import Icon from '$lib/components/elements/icon.svelte';
   import { locale } from '$lib/stores/preferences.store';
   import { websocketStore } from '$lib/stores/websocket';
-  import { type UserResponseDto, api } from '@api';
+  import { api } from '@api';
   import { onMount } from 'svelte';
   import { asByteUnitString } from '../../utils/byte-units';
   import LoadingSpinner from './loading-spinner.svelte';
   import { mdiChartPie, mdiDns } from '@mdi/js';
   import { serverInfoStore } from '$lib/stores/server-info.store';
+  import { user } from '$lib/stores/user.store';
 
   const { serverVersion, connected } = websocketStore;
 
-  let userInfo: UserResponseDto;
   let usageClasses = '';
 
   $: version = $serverVersion ? `v${$serverVersion.major}.${$serverVersion.minor}.${$serverVersion.patch}` : null;
-  $: hasQuota = userInfo?.quotaSizeInBytes !== null;
-  $: availableBytes = (hasQuota ? userInfo?.quotaSizeInBytes : $serverInfoStore.diskSizeRaw) || 0;
-  $: usedBytes = (hasQuota ? userInfo?.quotaUsageInBytes : $serverInfoStore.diskUseRaw) || 0;
+  $: hasQuota = $user?.quotaSizeInBytes !== null;
+  $: availableBytes = (hasQuota ? $user?.quotaSizeInBytes : $serverInfoStore?.diskSizeRaw) || 0;
+  $: usedBytes = (hasQuota ? $user?.quotaUsageInBytes : $serverInfoStore?.diskUseRaw) || 0;
   $: usedPercentage = Math.round((usedBytes / availableBytes) * 100);
 
   const onUpdate = () => {
@@ -36,7 +36,7 @@
     return 'bg-immich-primary dark:bg-immich-dark-primary';
   };
 
-  $: userInfo && onUpdate();
+  $: $user && onUpdate();
 
   onMount(async () => {
     await refresh();
@@ -44,10 +44,14 @@
 
   const refresh = async () => {
     try {
-      [$serverInfoStore, userInfo] = await Promise.all([
-        api.serverInfoApi.getServerInfo().then(({ data }) => data),
-        api.userApi.getMyUserInfo().then(({ data }) => data),
-      ]);
+      if (!$serverInfoStore) {
+        const { data } = await api.serverInfoApi.getServerInfo();
+        $serverInfoStore = data;
+      }
+      if (!$user) {
+        const { data } = await api.userApi.getMyUserInfo();
+        $user = data;
+      }
     } catch (e) {
       console.log('Error [StatusBox] [onMount]');
     }


### PR DESCRIPTION
- fixes #6570 
- avoids unnecessary re-rendering of storage statistics in the `StatusBox` each time a page loads.