### PR TITLE
feat(mobile): Added support for BasicAuth via userinfo in server url

### DIFF
--- a/docs/docs/partials/_mobile-app-login.md
+++ b/docs/docs/partials/_mobile-app-login.md
@@ -1,3 +1,5 @@
 Login to the mobile app with the server endpoint URL at `http://<machine-ip-address>:2283/api`
 
 <img src={require('./img/sign-in-phone.jpeg').default} width='50%' title='Mobile App Sign In' />
+
+Note that if the Immich server is hosted behind a proxy requiring Basic Authentication, this is supported using a server endpoint URL in the format `http://username:password@<machine-ip-address>:2283/api`

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
+import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:openapi/api.dart' as api;
 
@@ -96,7 +97,7 @@ class ImmichImage extends StatelessWidget {
     final String thumbnailRequestUrl = getThumbnailUrl(asset, type: type);
     return CachedNetworkImage(
       imageUrl: thumbnailRequestUrl,
-      httpHeaders: {"Authorization": "Bearer $token"},
+      httpHeaders: getAuthHeaders(thumbnailRequestUrl, token),
       cacheKey: getThumbnailCacheKey(asset, type: type),
       width: width,
       height: height,

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:immich_mobile/shared/models/store.dart';
 
 String sanitizeUrl(String url) {
@@ -19,4 +20,22 @@ String? getServerUrl() {
   return serverUri.hasPort
       ? "${serverUri.scheme}://${serverUri.host}:${serverUri.port}"
       : "${serverUri.scheme}://${serverUri.host}";
+}
+
+Map<String, String> getAuthHeaders(String url, String? accessToken) {
+  final uri = Uri.parse(url);
+  Map<String, String> headers = {};
+
+  if(uri.userInfo.contains(":")) { //need BasicAuth, use custom header for Bearer Auth
+    headers['Authorization'] = "Basic ${base64.encode(utf8.encode(uri.userInfo))}";
+
+    if(accessToken != null) {
+      headers['x-immich-user-token'] = accessToken;
+    }
+
+  } else if(accessToken != null) {
+    headers['Authorization'] = 'Bearer $accessToken';
+  }
+
+  return headers;
 }


### PR DESCRIPTION
Added support for BasicAuth protected immich servers to mobile apps.

Allows specifying credentials in `https://user:pass@host` format in server URL. They will be sent in the `Authorization` header for all requests - in this case moving the bearer token auth to the (already supported) `x-immich-user-token` (it's not moved when BasicAuth is not used). I have added a note in the docs, and tested using Traefik.