### PR TITLE
Fixed errors regarding the installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,8 @@ download_dot_env_file() {
 }
 
 replace_env_value() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  if [ "$KERNEL" = "darwin" ]; then
     sed -i '' "s|$1=.*|$1=$2|" ./.env
   else
     sed -i "s|$1=.*|$1=$2|" ./.env
@@ -39,9 +40,9 @@ populate_upload_location() {
 start_docker_compose() {
   echo "Starting Immich's docker containers"
 
-  if docker compose &>/dev/null; then
+  if docker compose > /dev/null 2>&1; then
     docker_bin="docker compose"
-  elif docker-compose &>/dev/null; then
+  elif docker-compose > /dev/null 2>&1; then
     docker_bin="docker-compose"
   else
     echo 'Cannot find `docker compose` or `docker-compose`.'


### PR DESCRIPTION

Fix
---
Before:
- The check for the system was wrong.
- When directing all the output into the docker control it was always successful since it did not return an exit number. So "docker compose" was always used.

After:
- Now the checking for the OS is more precise and the bash errors have been fixed.
- Redirects have been fixed.

Tested on:
---
```sh
PRETTY_NAME="Ubuntu 22.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.2 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```
from `/etc/os-release`.

Full output with error:
---
```sh
Starting Immich installation...
Creating Immich directory...
Downloading docker-compose.yml...
Downloading .env file...
Populating default UPLOAD_LOCATION value...
./install.sh: 26: [[: not found
Starting Immich's docker containers
unknown flag: --remove-orphans
See 'docker --help'.

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Common Commands:
  run         Create and run a new container from an image
  exec        Execute a command in a running container
  ps          List containers
  build       Build an image from a Dockerfile
  pull        Download an image from a registry
  push        Upload an image to a registry
  images      List images
  login       Log in to a registry
  logout      Log out from a registry
  search      Search Docker Hub for images
  version     Show the Docker version information
  info        Display system-wide information

Management Commands:
  builder     Manage builds
  container   Manage containers
  context     Manage contexts
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  network     Manage networks
  plugin      Manage plugins
  system      Manage Docker
  trust       Manage trust on Docker images
  volume      Manage volumes

Swarm Commands:
  swarm       Manage Swarm

Commands:
  attach      Attach local standard input, output, and error streams to a running container
  commit      Create a new image from a container's changes
  cp          Copy files/folders between a container and the local filesystem
  create      Create a new container
  diff        Inspect changes to files or directories on a container's filesystem
  events      Get real time events from the server
  export      Export a container's filesystem as a tar archive
  history     Show the history of an image
  import      Import the contents from a tarball to create a filesystem image
  inspect     Return low-level information on Docker objects
  kill        Kill one or more running containers
  load        Load an image from a tar archive or STDIN
  logs        Fetch the logs of a container
  pause       Pause all processes within one or more containers
  port        List port mappings or a specific mapping for the container
  rename      Rename a container
  restart     Restart one or more containers
  rm          Remove one or more containers
  rmi         Remove one or more images
  save        Save one or more images to a tar archive (streamed to STDOUT by default)
  start       Start one or more stopped containers
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop one or more running containers
  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
  top         Display the running processes of a container
  unpause     Unpause all processes within one or more containers
  update      Update configuration of one or more containers
  wait        Block until one or more containers stop, then print their exit codes

Global Options:
      --config string      Location of client config files (default "/root/.docker")
  -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with "docker context use")
  -D, --debug              Enable debug mode
  -H, --host list          Daemon socket to connect to
  -l, --log-level string   Set the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
      --tls                Use TLS; implied by --tlsverify
      --tlscacert string   Trust certs signed only by this CA (default "/root/.docker/ca.pem")
      --tlscert string     Path to TLS certificate file (default "/root/.docker/cert.pem")
      --tlskey string      Path to TLS key file (default "/root/.docker/key.pem")
      --tlsverify          Use TLS and verify the remote
  -v, --version            Print version information and quit

Run 'docker COMMAND --help' for more information on a command.

For more help on how to use Docker, head to https://docs.docker.com/go/guides/

Could not start. Check for errors above.
docker: 'compose' is not a docker command.
See 'docker --help'
```
