### PR TITLE
fix(ml): error logging

### DIFF
--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -91,7 +91,7 @@ class CustomRichHandler(RichHandler):
                 if any(excluded in tb.tb_frame.f_code.co_filename for excluded in self.excluded):
                     tb.tb_frame.f_locals["_rich_traceback_omit"] = True
                 tb = tb.tb_next
-            
+
         return super().emit(record)
 
 

--- a/machine-learning/app/config.py
+++ b/machine-learning/app/config.py
@@ -1,10 +1,13 @@
+import concurrent.futures
 import logging
 import os
 import sys
 from pathlib import Path
 from socket import socket
 
+import fastapi
 import starlette
+import uvicorn
 from gunicorn.arbiter import Arbiter
 from pydantic import BaseSettings
 from rich.console import Console
@@ -74,10 +77,16 @@ log_settings = LogSettings()
 class CustomRichHandler(RichHandler):
     def __init__(self) -> None:
         console = Console(color_system="standard", no_color=log_settings.no_color)
-        super().__init__(show_path=False, omit_repeated_times=False, console=console, tracebacks_suppress=[starlette])
+        super().__init__(
+            show_path=False,
+            omit_repeated_times=False,
+            console=console,
+            rich_tracebacks=True,
+            tracebacks_suppress=[uvicorn, starlette, fastapi, concurrent.futures],
+        )
 
 
-log = logging.getLogger("gunicorn.access")
+log = logging.getLogger("ml.log")
 log.setLevel(LOG_LEVELS.get(log_settings.log_level.lower(), logging.INFO))
 
 

--- a/machine-learning/log_conf.json
+++ b/machine-learning/log_conf.json
@@ -1,16 +1,15 @@
 {
   "version": 1,
-  "disable_existing_loggers": true,
-  "formatters": { "rich": { "show_path": false, "omit_repeated_times": false } },
+  "disable_existing_loggers": false,
   "handlers": {
     "console": {
-      "class": "app.config.CustomRichHandler",
-      "formatter": "rich"
+      "class": "app.config.CustomRichHandler"
     }
   },
   "loggers": {
-    "gunicorn.access": { "propagate": true },
-    "gunicorn.error": { "propagate": true }
+    "gunicorn.error": {
+      "handlers": ["console"]
+    }
   },
   "root": { "handlers": ["console"] }
 }


### PR DESCRIPTION
## Description

The ML service's logging configuration is buggy. It only logs `log.error` calls, not actual exceptions. This led to misleading logs that suggested that it e.g. loads models several times, when in fact it has just been failing to load them and didn't print the exception.

I also tweaked the traceback output to suppress frames from FastAPI etc. The traceback ends up being very long and noisy with irrelevant frames. It still shows the path and line for those, but doesn't show the code.