### PR TITLE
chore: use relative import to find package.json

### DIFF
--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -1,7 +1,7 @@
 import { AssetType } from '@app/infra/entities';
 import { Duration } from 'luxon';
 import { extname, join } from 'node:path';
-import pkg from 'src/../../package.json';
+import pkg from '../../package.json';
 
 export const AUDIT_LOG_MAX_DURATION = Duration.fromObject({ days: 100 });
 export const ONE_HOUR = Duration.fromObject({ hours: 1 });

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -1,7 +1,9 @@
 import { AssetType } from '@app/infra/entities';
 import { Duration } from 'luxon';
+import { readFileSync } from 'node:fs';
 import { extname, join } from 'node:path';
-import pkg from '../../package.json';
+
+const pkg = JSON.parse(readFileSync('../../package.json', 'utf8'));
 
 export const AUDIT_LOG_MAX_DURATION = Duration.fromObject({ days: 100 });
 export const ONE_HOUR = Duration.fromObject({ hours: 1 });


### PR DESCRIPTION
This import line keep causing me headaches as I try to convert things over to use vitest. I don't understand the current import syntax. There's no `src` directory inside the `domain` folder, which is what you'd expect this to be referring to. And if you treat it relative from the `server` directory `src/../../package.json` isn't a file that exists. Hopefully this relative syntax would be equivalent to what the current syntax is.