### PR TITLE
refactor(server): drop module aliases

### DIFF
--- a/server/e2e/api/jest-e2e.json
+++ b/server/e2e/api/jest-e2e.json
@@ -14,11 +14,5 @@
     "!<rootDir>/src/**/*.spec.(t|s)s",
     "!<rootDir>/src/infra/migrations/**"
   ],
-  "coverageDirectory": "./coverage",
-  "moduleNameMapper": {
-    "^@test(|/.*)$": "<rootDir>/test/$1",
-    "^@app/immich(|/.*)$": "<rootDir>/src/immich/$1",
-    "^@app/infra(|/.*)$": "<rootDir>/src/infra/$1",
-    "^@app/domain(|/.*)$": "<rootDir>/src/domain/$1"
-  }
+  "coverageDirectory": "./coverage"
 }

--- a/server/e2e/api/specs/activity.e2e-spec.ts
+++ b/server/e2e/api/specs/activity.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { AlbumResponseDto, LoginResponseDto, ReactionType } from '@app/domain';
-import { ActivityController } from '@app/immich';
-import { AssetFileUploadResponseDto } from '@app/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
-import { ActivityEntity } from '@app/infra/entities';
-import { errorStub, userDto, uuidStub } from '@test/fixtures';
+import { AlbumResponseDto, LoginResponseDto, ReactionType } from 'src/domain';
+import { ActivityController } from 'src/immich';
+import { AssetFileUploadResponseDto } from 'src/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
+import { ActivityEntity } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, userDto, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/album.e2e-spec.ts
+++ b/server/e2e/api/specs/album.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { AlbumResponseDto, LoginResponseDto } from '@app/domain';
-import { AlbumController } from '@app/immich';
-import { AssetFileUploadResponseDto } from '@app/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
-import { SharedLinkType } from '@app/infra/entities';
-import { errorStub, userDto, uuidStub } from '@test/fixtures';
+import { AlbumResponseDto, LoginResponseDto } from 'src/domain';
+import { AlbumController } from 'src/immich';
+import { AssetFileUploadResponseDto } from 'src/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
+import { SharedLinkType } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, userDto, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/asset.e2e-spec.ts
+++ b/server/e2e/api/specs/asset.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { INestApplication } from '@nestjs/common';
+import { randomBytes } from 'crypto';
 import {
   AssetResponseDto,
   IAssetRepository,
@@ -8,14 +10,12 @@ import {
   WithoutProperty,
   mapAsset,
   usePagination,
-} from '@app/domain';
-import { AssetController } from '@app/immich';
-import { AssetEntity, AssetStackEntity, AssetType, SharedLinkType } from '@app/infra/entities';
-import { AssetRepository } from '@app/infra/repositories';
-import { INestApplication } from '@nestjs/common';
-import { errorStub, userDto, uuidStub } from '@test/fixtures';
-import { randomBytes } from 'crypto';
+} from 'src/domain';
+import { AssetController } from 'src/immich';
+import { AssetEntity, AssetStackEntity, AssetType, SharedLinkType } from 'src/infra/entities';
+import { AssetRepository } from 'src/infra/repositories';
 import request from 'supertest';
+import { errorStub, userDto, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { generateAsset, testApp, today, yesterday } from '../utils';
 

--- a/server/e2e/api/specs/auth.e2e-spec.ts
+++ b/server/e2e/api/specs/auth.e2e-spec.ts
@@ -1,4 +1,5 @@
-import { AuthController } from '@app/immich';
+import { AuthController } from 'src/immich';
+import request from 'supertest';
 import {
   adminSignupStub,
   changePasswordStub,
@@ -7,8 +8,7 @@ import {
   loginResponseStub,
   loginStub,
   uuidStub,
-} from '@test/fixtures';
-import request from 'supertest';
+} from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/library.e2e-spec.ts
+++ b/server/e2e/api/specs/library.e2e-spec.ts
@@ -1,8 +1,8 @@
-import { LibraryResponseDto, LoginResponseDto } from '@app/domain';
-import { LibraryController } from '@app/immich';
-import { LibraryType } from '@app/infra/entities';
-import { errorStub, userDto, uuidStub } from '@test/fixtures';
+import { LibraryResponseDto, LoginResponseDto } from 'src/domain';
+import { LibraryController } from 'src/immich';
+import { LibraryType } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, userDto, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/oauth.e2e-spec.ts
+++ b/server/e2e/api/specs/oauth.e2e-spec.ts
@@ -1,6 +1,6 @@
-import { OAuthController } from '@app/immich';
-import { errorStub } from '@test/fixtures';
+import { OAuthController } from 'src/immich';
 import request from 'supertest';
+import { errorStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/partner.e2e-spec.ts
+++ b/server/e2e/api/specs/partner.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { LoginResponseDto, PartnerDirection } from '@app/domain';
-import { PartnerController } from '@app/immich';
-import { errorStub, userDto } from '@test/fixtures';
+import { LoginResponseDto, PartnerDirection } from 'src/domain';
+import { PartnerController } from 'src/immich';
 import request from 'supertest';
+import { errorStub, userDto } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/person.e2e-spec.ts
+++ b/server/e2e/api/specs/person.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { IPersonRepository, LoginResponseDto } from '@app/domain';
-import { PersonController } from '@app/immich';
-import { PersonEntity } from '@app/infra/entities';
 import { INestApplication } from '@nestjs/common';
-import { errorStub, uuidStub } from '@test/fixtures';
+import { IPersonRepository, LoginResponseDto } from 'src/domain';
+import { PersonController } from 'src/immich';
+import { PersonEntity } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/search.e2e-spec.ts
+++ b/server/e2e/api/specs/search.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { INestApplication } from '@nestjs/common';
 import {
   AssetResponseDto,
   IAssetRepository,
@@ -5,11 +6,10 @@ import {
   LibraryResponseDto,
   LoginResponseDto,
   mapAsset,
-} from '@app/domain';
-import { SearchController } from '@app/immich';
-import { INestApplication } from '@nestjs/common';
-import { errorStub, searchStub } from '@test/fixtures';
+} from 'src/domain';
+import { SearchController } from 'src/immich';
 import request from 'supertest';
+import { errorStub, searchStub } from 'test/fixtures';
 import { api } from '../../client';
 import { generateAsset, testApp } from '../utils';
 

--- a/server/e2e/api/specs/server-info.e2e-spec.ts
+++ b/server/e2e/api/specs/server-info.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { LoginResponseDto } from '@app/domain';
-import { ServerInfoController } from '@app/immich';
-import { errorStub, userDto } from '@test/fixtures';
+import { LoginResponseDto } from 'src/domain';
+import { ServerInfoController } from 'src/immich';
 import request from 'supertest';
+import { errorStub, userDto } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/shared-link.e2e-spec.ts
+++ b/server/e2e/api/specs/shared-link.e2e-spec.ts
@@ -1,16 +1,16 @@
+import { INestApplication } from '@nestjs/common';
+import { DateTime } from 'luxon';
 import {
   AlbumResponseDto,
   AssetResponseDto,
   IAssetRepository,
   LoginResponseDto,
   SharedLinkResponseDto,
-} from '@app/domain';
-import { SharedLinkController } from '@app/immich';
-import { SharedLinkType } from '@app/infra/entities';
-import { INestApplication } from '@nestjs/common';
-import { errorStub, userDto, uuidStub } from '@test/fixtures';
-import { DateTime } from 'luxon';
+} from 'src/domain';
+import { SharedLinkController } from 'src/immich';
+import { SharedLinkType } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, userDto, uuidStub } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/system-config.e2e-spec.ts
+++ b/server/e2e/api/specs/system-config.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { LoginResponseDto } from '@app/domain';
-import { SystemConfigController } from '@app/immich';
-import { errorStub, userDto } from '@test/fixtures';
+import { LoginResponseDto } from 'src/domain';
+import { SystemConfigController } from 'src/immich';
 import request from 'supertest';
+import { errorStub, userDto } from 'test/fixtures';
 import { api } from '../../client';
 import { testApp } from '../utils';
 

--- a/server/e2e/api/specs/user.e2e-spec.ts
+++ b/server/e2e/api/specs/user.e2e-spec.ts
@@ -1,10 +1,10 @@
-import { LoginResponseDto, UserResponseDto, UserService } from '@app/domain';
-import { AppModule, UserController } from '@app/immich';
-import { UserEntity } from '@app/infra/entities';
 import { INestApplication } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { errorStub, userDto, userSignupStub, userStub } from '@test/fixtures';
+import { LoginResponseDto, UserResponseDto, UserService } from 'src/domain';
+import { AppModule, UserController } from 'src/immich';
+import { UserEntity } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, userDto, userSignupStub, userStub } from 'test/fixtures';
 import { Repository } from 'typeorm';
 import { api } from '../../client';
 import { testApp } from '../utils';

--- a/server/e2e/api/utils.ts
+++ b/server/e2e/api/utils.ts
@@ -1,11 +1,11 @@
-import { AssetCreate, IJobRepository, IMetadataRepository, LibraryResponseDto } from '@app/domain';
-import { AppModule } from '@app/immich';
-import { InfraModule, InfraTestModule, dataSource } from '@app/infra';
-import { AssetEntity, AssetType, LibraryType } from '@app/infra/entities';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { randomBytes } from 'crypto';
 import { DateTime } from 'luxon';
+import { AssetCreate, IJobRepository, IMetadataRepository, LibraryResponseDto } from 'src/domain';
+import { AppModule } from 'src/immich';
+import { InfraModule, InfraTestModule, dataSource } from 'src/infra';
+import { AssetEntity, AssetType, LibraryType } from 'src/infra/entities';
 import { EntityTarget, ObjectLiteral } from 'typeorm';
 import { AppService } from '../../src/microservices/app.service';
 import { newJobRepositoryMock, newMetadataRepositoryMock } from '../../test';

--- a/server/e2e/client/activity-api.ts
+++ b/server/e2e/client/activity-api.ts
@@ -1,4 +1,4 @@
-import { ActivityCreateDto, ActivityResponseDto } from '@app/domain';
+import { ActivityCreateDto, ActivityResponseDto } from 'src/domain';
 import request from 'supertest';
 
 export const activityApi = {

--- a/server/e2e/client/album-api.ts
+++ b/server/e2e/client/album-api.ts
@@ -1,4 +1,4 @@
-import { AddUsersDto, AlbumResponseDto, BulkIdResponseDto, BulkIdsDto, CreateAlbumDto } from '@app/domain';
+import { AddUsersDto, AlbumResponseDto, BulkIdResponseDto, BulkIdsDto, CreateAlbumDto } from 'src/domain';
 import request from 'supertest';
 
 export const albumApi = {

--- a/server/e2e/client/api-key-api.ts
+++ b/server/e2e/client/api-key-api.ts
@@ -1,6 +1,6 @@
-import { APIKeyCreateResponseDto } from '@app/domain';
-import { apiKeyCreateStub } from '@test';
+import { APIKeyCreateResponseDto } from 'src/domain';
 import request from 'supertest';
+import { apiKeyCreateStub } from 'test';
 
 export const apiKeyApi = {
   createApiKey: async (server: any, accessToken: string) => {

--- a/server/e2e/client/asset-api.ts
+++ b/server/e2e/client/asset-api.ts
@@ -1,7 +1,7 @@
-import { AssetResponseDto } from '@app/domain';
-import { CreateAssetDto } from '@app/immich/api-v1/asset/dto/create-asset.dto';
-import { AssetFileUploadResponseDto } from '@app/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
 import { randomBytes } from 'crypto';
+import { AssetResponseDto } from 'src/domain';
+import { CreateAssetDto } from 'src/immich/api-v1/asset/dto/create-asset.dto';
+import { AssetFileUploadResponseDto } from 'src/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
 import request from 'supertest';
 
 type UploadDto = Partial<CreateAssetDto> & { content?: Buffer; filename?: string };

--- a/server/e2e/client/auth-api.ts
+++ b/server/e2e/client/auth-api.ts
@@ -1,6 +1,6 @@
-import { AuthDeviceResponseDto, LoginCredentialDto, LoginResponseDto, UserResponseDto } from '@app/domain';
-import { adminSignupStub, loginResponseStub, loginStub } from '@test';
+import { AuthDeviceResponseDto, LoginCredentialDto, LoginResponseDto, UserResponseDto } from 'src/domain';
 import request from 'supertest';
+import { adminSignupStub, loginResponseStub, loginStub } from 'test';
 
 export const authApi = {
   adminSignUp: async (server: any) => {

--- a/server/e2e/client/library-api.ts
+++ b/server/e2e/client/library-api.ts
@@ -1,4 +1,4 @@
-import { CreateLibraryDto, LibraryResponseDto, LibraryStatsResponseDto, ScanLibraryDto } from '@app/domain';
+import { CreateLibraryDto, LibraryResponseDto, LibraryStatsResponseDto, ScanLibraryDto } from 'src/domain';
 import request from 'supertest';
 
 export const libraryApi = {

--- a/server/e2e/client/partner-api.ts
+++ b/server/e2e/client/partner-api.ts
@@ -1,4 +1,4 @@
-import { PartnerResponseDto } from '@app/domain';
+import { PartnerResponseDto } from 'src/domain';
 import request from 'supertest';
 
 export const partnerApi = {

--- a/server/e2e/client/server-info-api.ts
+++ b/server/e2e/client/server-info-api.ts
@@ -1,4 +1,4 @@
-import { ServerConfigDto } from '@app/domain';
+import { ServerConfigDto } from 'src/domain';
 import request from 'supertest';
 
 export const serverInfoApi = {

--- a/server/e2e/client/shared-link-api.ts
+++ b/server/e2e/client/shared-link-api.ts
@@ -1,4 +1,4 @@
-import { SharedLinkCreateDto, SharedLinkResponseDto } from '@app/domain';
+import { SharedLinkCreateDto, SharedLinkResponseDto } from 'src/domain';
 import request from 'supertest';
 
 export const sharedLinkApi = {

--- a/server/e2e/client/user-api.ts
+++ b/server/e2e/client/user-api.ts
@@ -1,4 +1,4 @@
-import { CreateUserDto, UpdateUserDto, UserResponseDto } from '@app/domain';
+import { CreateUserDto, UpdateUserDto, UserResponseDto } from 'src/domain';
 import request from 'supertest';
 
 export const userApi = {

--- a/server/e2e/jobs/jest-e2e.json
+++ b/server/e2e/jobs/jest-e2e.json
@@ -14,11 +14,5 @@
     "!<rootDir>/src/**/*.spec.(t|s)s",
     "!<rootDir>/src/infra/migrations/**"
   ],
-  "coverageDirectory": "./coverage",
-  "moduleNameMapper": {
-    "^@test(|/.*)$": "<rootDir>/test/$1",
-    "^@app/immich(|/.*)$": "<rootDir>/src/immich/$1",
-    "^@app/infra(|/.*)$": "<rootDir>/src/infra/$1",
-    "^@app/domain(|/.*)$": "<rootDir>/src/domain/$1"
-  }
+  "coverageDirectory": "./coverage"
 }

--- a/server/e2e/jobs/specs/formats.e2e-spec.ts
+++ b/server/e2e/jobs/specs/formats.e2e-spec.ts
@@ -1,7 +1,7 @@
-import { LoginResponseDto } from '@app/domain';
-import { AssetType } from '@app/infra/entities';
 import { readFile } from 'fs/promises';
 import { basename, join } from 'path';
+import { LoginResponseDto } from 'src/domain';
+import { AssetType } from 'src/infra/entities';
 import { api } from '../../client';
 import { IMMICH_TEST_ASSET_PATH, testApp } from '../utils';
 

--- a/server/e2e/jobs/specs/library.e2e-spec.ts
+++ b/server/e2e/jobs/specs/library.e2e-spec.ts
@@ -1,9 +1,9 @@
-import { LibraryResponseDto, LoginResponseDto } from '@app/domain';
-import { LibraryController } from '@app/immich';
-import { AssetType, LibraryType } from '@app/infra/entities';
-import { errorStub, uuidStub } from '@test/fixtures';
 import * as fs from 'fs';
+import { LibraryResponseDto, LoginResponseDto } from 'src/domain';
+import { LibraryController } from 'src/immich';
+import { AssetType, LibraryType } from 'src/infra/entities';
 import request from 'supertest';
+import { errorStub, uuidStub } from 'test/fixtures';
 import { utimes } from 'utimes';
 import { api } from '../../client';
 import { IMMICH_TEST_ASSET_PATH, IMMICH_TEST_ASSET_TEMP_PATH, restoreTempFolder, testApp } from '../utils';

--- a/server/e2e/jobs/specs/metadata.e2e-spec.ts
+++ b/server/e2e/jobs/specs/metadata.e2e-spec.ts
@@ -1,8 +1,8 @@
-import { AssetResponseDto, LoginResponseDto } from '@app/domain';
-import { AssetController } from '@app/immich';
 import { INestApplication } from '@nestjs/common';
 import { exiftool } from 'exiftool-vendored';
 import { readFile, writeFile } from 'fs/promises';
+import { AssetResponseDto, LoginResponseDto } from 'src/domain';
+import { AssetController } from 'src/immich';
 import { api } from '../../client';
 import { IMMICH_TEST_ASSET_PATH, IMMICH_TEST_ASSET_TEMP_PATH, db, restoreTempFolder, testApp } from '../utils';
 

--- a/server/e2e/jobs/utils.ts
+++ b/server/e2e/jobs/utils.ts
@@ -1,12 +1,12 @@
-import { IJobRepository, JobItem, JobItemHandler, QueueName } from '@app/domain';
-import { AppModule } from '@app/immich';
-import { InfraModule, InfraTestModule, dataSource } from '@app/infra';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { DateTime } from 'luxon';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { Server } from 'node:tls';
+import { IJobRepository, JobItem, JobItemHandler, QueueName } from 'src/domain';
+import { AppModule } from 'src/immich';
+import { InfraModule, InfraTestModule, dataSource } from 'src/infra';
 import { EntityTarget, ObjectLiteral } from 'typeorm';
 import { AppService } from '../../src/microservices/app.service';
 

--- a/server/package.json
+++ b/server/package.json
@@ -149,12 +149,6 @@
       }
     },
     "testEnvironment": "node",
-    "moduleNameMapper": {
-      "^@test(|/.*)$": "<rootDir>/test/$1",
-      "^@app/immich(|/.*)$": "<rootDir>/src/immich/$1",
-      "^@app/infra(|/.*)$": "<rootDir>/src/infra/$1",
-      "^@app/domain(|/.*)$": "<rootDir>/src/domain/$1"
-    },
     "globalSetup": "<rootDir>/test/global-setup.js"
   },
   "volta": {

--- a/server/src/domain/activity/activity.dto.ts
+++ b/server/src/domain/activity/activity.dto.ts
@@ -1,6 +1,6 @@
-import { ActivityEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
+import { ActivityEntity } from 'src/infra/entities';
 import { Optional, ValidateUUID } from '../domain.util';
 import { UserDto, mapSimpleUser } from '../user/response-dto';
 

--- a/server/src/domain/activity/activity.service.ts
+++ b/server/src/domain/activity/activity.service.ts
@@ -1,5 +1,5 @@
-import { ActivityEntity } from '@app/infra/entities';
 import { Inject, Injectable } from '@nestjs/common';
+import { ActivityEntity } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { AuthDto } from '../auth';
 import { IAccessRepository, IActivityRepository } from '../repositories';

--- a/server/src/domain/activity/activity.spec.ts
+++ b/server/src/domain/activity/activity.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
-import { authStub, IAccessRepositoryMock, newAccessRepositoryMock } from '@test';
-import { activityStub } from '@test/fixtures/activity.stub';
-import { newActivityRepositoryMock } from '@test/repositories/activity.repository.mock';
+import { authStub, IAccessRepositoryMock, newAccessRepositoryMock } from 'test';
+import { activityStub } from 'test/fixtures/activity.stub';
+import { newActivityRepositoryMock } from 'test/repositories/activity.repository.mock';
 import { IActivityRepository } from '../repositories';
 import { ReactionType } from './activity.dto';
 import { ActivityService } from './activity.service';

--- a/server/src/domain/album/album-response.dto.spec.ts
+++ b/server/src/domain/album/album-response.dto.spec.ts
@@ -1,4 +1,4 @@
-import { albumStub } from '@test';
+import { albumStub } from 'test';
 import { mapAlbum } from './album-response.dto';
 
 describe('mapAlbum', () => {

--- a/server/src/domain/album/album-response.dto.ts
+++ b/server/src/domain/album/album-response.dto.ts
@@ -1,5 +1,5 @@
-import { AlbumEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
+import { AlbumEntity } from 'src/infra/entities';
 import { AssetResponseDto, mapAsset } from '../asset';
 import { UserResponseDto, mapUser } from '../user';
 

--- a/server/src/domain/album/album.service.spec.ts
+++ b/server/src/domain/album/album.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import _ from 'lodash';
 import {
   albumStub,
   authStub,
@@ -9,8 +10,7 @@ import {
   newJobRepositoryMock,
   newUserRepositoryMock,
   userStub,
-} from '@test';
-import _ from 'lodash';
+} from 'test';
 import { BulkIdErrorReason } from '../asset';
 import { IAlbumRepository, IAssetRepository, IJobRepository, IUserRepository } from '../repositories';
 import { AlbumService } from './album.service';

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -1,5 +1,5 @@
-import { AlbumEntity, AssetEntity, UserEntity } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { AlbumEntity, AssetEntity, UserEntity } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { BulkIdErrorReason, BulkIdResponseDto, BulkIdsDto } from '../asset';
 import { AuthDto } from '../auth';

--- a/server/src/domain/api-key/api-key.service.spec.ts
+++ b/server/src/domain/api-key/api-key.service.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { authStub, keyStub, newCryptoRepositoryMock, newKeyRepositoryMock } from '@test';
+import { authStub, keyStub, newCryptoRepositoryMock, newKeyRepositoryMock } from 'test';
 import { ICryptoRepository, IKeyRepository } from '../repositories';
 import { APIKeyService } from './api-key.service';
 

--- a/server/src/domain/api-key/api-key.service.ts
+++ b/server/src/domain/api-key/api-key.service.ts
@@ -1,5 +1,5 @@
-import { APIKeyEntity } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { APIKeyEntity } from 'src/infra/entities';
 import { AuthDto } from '../auth';
 import { ICryptoRepository, IKeyRepository } from '../repositories';
 import { APIKeyCreateDto, APIKeyCreateResponseDto, APIKeyResponseDto } from './api-key.dto';

--- a/server/src/domain/asset/asset.service.spec.ts
+++ b/server/src/domain/asset/asset.service.spec.ts
@@ -1,5 +1,6 @@
-import { AssetEntity, AssetType } from '@app/infra/entities';
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { when } from 'jest-when';
+import { AssetEntity, AssetType } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   assetStackStub,
@@ -15,8 +16,7 @@ import {
   newStorageRepositoryMock,
   newSystemConfigRepositoryMock,
   newUserRepositoryMock,
-} from '@test';
-import { when } from 'jest-when';
+} from 'test';
 import { JobName } from '../job';
 import {
   AssetStats,

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -1,10 +1,10 @@
-import { AssetEntity, LibraryType } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { BadRequestException, Inject } from '@nestjs/common';
 import _ from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { extname } from 'path';
 import sanitize from 'sanitize-filename';
+import { AssetEntity, LibraryType } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { AccessCore, Permission } from '../access';
 import { AuthDto } from '../auth';
 import { mimeTypes } from '../domain.constant';

--- a/server/src/domain/asset/dto/asset-statistics.dto.ts
+++ b/server/src/domain/asset/dto/asset-statistics.dto.ts
@@ -1,7 +1,7 @@
-import { AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
+import { AssetType } from 'src/infra/entities';
 import { Optional, toBoolean } from '../../domain.util';
 import { AssetStats } from '../../repositories';
 

--- a/server/src/domain/asset/dto/asset.dto.ts
+++ b/server/src/domain/asset/dto/asset.dto.ts
@@ -1,4 +1,3 @@
-import { AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
@@ -14,6 +13,7 @@ import {
   Min,
   ValidateIf,
 } from 'class-validator';
+import { AssetType } from 'src/infra/entities';
 import { Optional, QueryBoolean, QueryDate, ValidateUUID } from '../../domain.util';
 import { BulkIdsDto } from '../response-dto';
 

--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -1,5 +1,5 @@
-import { AssetEntity, AssetFaceEntity, AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
+import { AssetEntity, AssetFaceEntity, AssetType } from 'src/infra/entities';
 import { PersonWithFacesResponseDto, mapFacesWithoutPerson, mapPerson } from '../../person/person.dto';
 import { TagResponseDto, mapTag } from '../../tag';
 import { UserResponseDto, mapUser } from '../../user/response-dto/user-response.dto';

--- a/server/src/domain/asset/response-dto/exif-response.dto.ts
+++ b/server/src/domain/asset/response-dto/exif-response.dto.ts
@@ -1,5 +1,5 @@
-import { ExifEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
+import { ExifEntity } from 'src/infra/entities';
 
 export class ExifResponseDto {
   make?: string | null = null;

--- a/server/src/domain/asset/response-dto/smart-info-response.dto.ts
+++ b/server/src/domain/asset/response-dto/smart-info-response.dto.ts
@@ -1,4 +1,4 @@
-import { SmartInfoEntity } from '@app/infra/entities';
+import { SmartInfoEntity } from 'src/infra/entities';
 
 export class SmartInfoResponseDto {
   tags?: string[] | null;

--- a/server/src/domain/audit/audit.dto.ts
+++ b/server/src/domain/audit/audit.dto.ts
@@ -1,7 +1,7 @@
-import { AssetPathType, EntityType, PathType, PersonPathType, UserPathType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsDate, IsEnum, IsString, IsUUID, ValidateNested } from 'class-validator';
+import { AssetPathType, EntityType, PathType, PersonPathType, UserPathType } from 'src/infra/entities';
 import { Optional, ValidateUUID } from '../domain.util';
 
 const PathEnum = Object.values({ ...AssetPathType, ...PersonPathType, ...UserPathType });

--- a/server/src/domain/audit/audit.service.spec.ts
+++ b/server/src/domain/audit/audit.service.spec.ts
@@ -1,4 +1,4 @@
-import { DatabaseAction, EntityType } from '@app/infra/entities';
+import { DatabaseAction, EntityType } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   auditStub,
@@ -10,7 +10,7 @@ import {
   newPersonRepositoryMock,
   newStorageRepositoryMock,
   newUserRepositoryMock,
-} from '@test';
+} from 'test';
 import {
   IAssetRepository,
   IAuditRepository,

--- a/server/src/domain/audit/audit.service.ts
+++ b/server/src/domain/audit/audit.service.ts
@@ -1,8 +1,8 @@
-import { AssetPathType, DatabaseAction, PersonPathType, UserPathType } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { resolve } from 'node:path';
+import { AssetPathType, DatabaseAction, PersonPathType, UserPathType } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { AccessCore, Permission } from '../access';
 import { AuthDto } from '../auth';
 import { AUDIT_LOG_MAX_DURATION } from '../domain.constant';

--- a/server/src/domain/auth/auth.dto.ts
+++ b/server/src/domain/auth/auth.dto.ts
@@ -1,7 +1,7 @@
-import { APIKeyEntity, SharedLinkEntity, UserEntity, UserTokenEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { APIKeyEntity, SharedLinkEntity, UserEntity, UserTokenEntity } from 'src/infra/entities';
 
 export class AuthDto {
   user!: UserEntity;

--- a/server/src/domain/auth/auth.service.spec.ts
+++ b/server/src/domain/auth/auth.service.spec.ts
@@ -1,5 +1,8 @@
-import { UserEntity } from '@app/infra/entities';
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { IncomingHttpHeaders } from 'http';
+import { Issuer, generators } from 'openid-client';
+import { Socket } from 'socket.io';
+import { UserEntity } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   authStub,
@@ -17,10 +20,7 @@ import {
   systemConfigStub,
   userStub,
   userTokenStub,
-} from '@test';
-import { IncomingHttpHeaders } from 'http';
-import { Issuer, generators } from 'openid-client';
-import { Socket } from 'socket.io';
+} from 'test';
 import {
   ICryptoRepository,
   IKeyRepository,

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -1,5 +1,3 @@
-import { SystemConfig, UserEntity } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import {
   BadRequestException,
   Inject,
@@ -11,6 +9,8 @@ import cookieParser from 'cookie';
 import { IncomingHttpHeaders } from 'http';
 import { DateTime } from 'luxon';
 import { ClientMetadata, Issuer, UserinfoResponse, custom, generators } from 'openid-client';
+import { SystemConfig, UserEntity } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { AccessCore, Permission } from '../access';
 import {
   IAccessRepository,

--- a/server/src/domain/database/database.service.spec.ts
+++ b/server/src/domain/database/database.service.spec.ts
@@ -1,6 +1,6 @@
-import { DatabaseExtension, DatabaseService, IDatabaseRepository, Version } from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
-import { newDatabaseRepositoryMock } from '@test';
+import { DatabaseExtension, DatabaseService, IDatabaseRepository, Version } from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
+import { newDatabaseRepositoryMock } from 'test';
 
 describe(DatabaseService.name, () => {
   let sut: DatabaseService;

--- a/server/src/domain/database/database.service.ts
+++ b/server/src/domain/database/database.service.ts
@@ -1,5 +1,5 @@
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
+import { ImmichLogger } from 'src/infra/logger';
 import { QueryFailedError } from 'typeorm';
 import { Version } from '../domain.constant';
 import { DatabaseExtension, IDatabaseRepository } from '../repositories';

--- a/server/src/domain/domain.config.ts
+++ b/server/src/domain/domain.config.ts
@@ -1,7 +1,7 @@
 // TODO: remove nestjs references from domain
-import { LogLevel } from '@app/infra/entities';
 import { ConfigModuleOptions } from '@nestjs/config';
 import Joi from 'joi';
+import { LogLevel } from 'src/infra/entities';
 
 const WHEN_DB_URL_SET = Joi.when('DB_URL', {
   is: Joi.exist(),

--- a/server/src/domain/domain.constant.ts
+++ b/server/src/domain/domain.constant.ts
@@ -1,7 +1,7 @@
-import { AssetType } from '@app/infra/entities';
 import { Duration } from 'luxon';
 import { readFileSync } from 'node:fs';
 import { extname, join } from 'node:path';
+import { AssetType } from 'src/infra/entities';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 

--- a/server/src/domain/domain.module.ts
+++ b/server/src/domain/domain.module.ts
@@ -1,5 +1,5 @@
-import { ImmichLogger } from '@app/infra/logger';
 import { Global, Module, Provider } from '@nestjs/common';
+import { ImmichLogger } from 'src/infra/logger';
 import { ActivityService } from './activity';
 import { AlbumService } from './album';
 import { APIKeyService } from './api-key';

--- a/server/src/domain/download/download.service.spec.ts
+++ b/server/src/domain/download/download.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { when } from 'jest-when';
 import {
   IAccessRepositoryMock,
   assetStub,
@@ -6,8 +7,7 @@ import {
   newAccessRepositoryMock,
   newAssetRepositoryMock,
   newStorageRepositoryMock,
-} from '@test';
-import { when } from 'jest-when';
+} from 'test';
 import { Readable } from 'typeorm/platform/PlatformTools.js';
 import { CacheControl, ImmichFileResponse } from '../domain.util';
 import { IAssetRepository, IStorageRepository } from '../repositories';

--- a/server/src/domain/download/download.service.ts
+++ b/server/src/domain/download/download.service.ts
@@ -1,6 +1,6 @@
-import { AssetEntity } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { extname } from 'path';
+import { AssetEntity } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { AssetIdsDto } from '../asset';
 import { AuthDto } from '../auth';

--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -1,5 +1,5 @@
-import { SystemConfig, SystemConfigKey } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
+import { SystemConfig, SystemConfigKey } from 'src/infra/entities';
 import {
   assetStub,
   newAssetRepositoryMock,
@@ -7,7 +7,7 @@ import {
   newJobRepositoryMock,
   newPersonRepositoryMock,
   newSystemConfigRepositoryMock,
-} from '@test';
+} from 'test';
 import {
   IAssetRepository,
   ICommunicationRepository,

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -1,6 +1,6 @@
-import { AssetType } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { AssetType } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { mapAsset } from '../asset';
 import {
   ClientEvent,

--- a/server/src/domain/library/library.dto.ts
+++ b/server/src/domain/library/library.dto.ts
@@ -1,6 +1,6 @@
-import { LibraryEntity, LibraryType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { LibraryEntity, LibraryType } from 'src/infra/entities';
 import { ValidateUUID } from '../domain.util';
 
 export class CreateLibraryDto {

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -1,6 +1,7 @@
-import { AssetType, LibraryType, SystemConfig, SystemConfigKey, UserEntity } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
+import { AssetType, LibraryType, SystemConfig, SystemConfigKey, UserEntity } from 'src/infra/entities';
 
+import { Stats } from 'fs';
 import {
   assetStub,
   authStub,
@@ -15,8 +16,7 @@ import {
   newSystemConfigRepositoryMock,
   newUserRepositoryMock,
   userStub,
-} from '@test';
-import { Stats } from 'fs';
+} from 'test';
 import { ILibraryFileJob, ILibraryRefreshJob, JobName } from '../job';
 import {
   IAssetRepository,

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -1,16 +1,16 @@
-import { AssetType, LibraryType } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { R_OK } from 'node:constants';
 import { Stats } from 'node:fs';
 import path from 'node:path';
 import { basename, parse } from 'path';
+import { AssetType, LibraryType } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { AuthDto } from '../auth';
 import { mimeTypes } from '../domain.constant';
 import { usePagination, validateCronExpression } from '../domain.util';
 import { IBaseJob, IEntityJob, ILibraryFileJob, ILibraryRefreshJob, JOBS_ASSET_PAGINATION_SIZE, JobName } from '../job';
 
-import { ImmichLogger } from '@app/infra/logger';
+import { ImmichLogger } from 'src/infra/logger';
 import {
   IAccessRepository,
   IAssetRepository,

--- a/server/src/domain/media/media.service.spec.ts
+++ b/server/src/domain/media/media.service.spec.ts
@@ -7,7 +7,7 @@ import {
   TranscodeHWAccel,
   TranscodePolicy,
   VideoCodec,
-} from '@app/infra/entities';
+} from 'src/infra/entities';
 import {
   assetStub,
   faceStub,
@@ -21,7 +21,7 @@ import {
   newSystemConfigRepositoryMock,
   personStub,
   probeStub,
-} from '@test';
+} from 'test';
 import { JobName } from '../job';
 import {
   IAssetRepository,

--- a/server/src/domain/media/media.service.ts
+++ b/server/src/domain/media/media.service.ts
@@ -1,3 +1,4 @@
+import { Inject, Injectable, UnsupportedMediaTypeException } from '@nestjs/common';
 import {
   AssetEntity,
   AssetPathType,
@@ -7,9 +8,8 @@ import {
   TranscodeHWAccel,
   TranscodePolicy,
   VideoCodec,
-} from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
-import { Inject, Injectable, UnsupportedMediaTypeException } from '@nestjs/common';
+} from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { usePagination } from '../domain.util';
 import { IBaseJob, IEntityJob, JOBS_ASSET_PAGINATION_SIZE, JobName, QueueName } from '../job';
 import {

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -1,4 +1,4 @@
-import { CQMode, ToneMapping, TranscodeHWAccel, VideoCodec } from '@app/infra/entities';
+import { CQMode, ToneMapping, TranscodeHWAccel, VideoCodec } from 'src/infra/entities';
 import {
   AudioStreamInfo,
   BitrateDistribution,

--- a/server/src/domain/metadata/metadata.service.spec.ts
+++ b/server/src/domain/metadata/metadata.service.spec.ts
@@ -1,4 +1,9 @@
-import { AssetType, ExifEntity, SystemConfigKey } from '@app/infra/entities';
+import { randomBytes } from 'crypto';
+import { BinaryField } from 'exiftool-vendored';
+import { Stats } from 'fs';
+import { constants } from 'fs/promises';
+import { when } from 'jest-when';
+import { AssetType, ExifEntity, SystemConfigKey } from 'src/infra/entities';
 import {
   assetStub,
   fileStub,
@@ -15,12 +20,7 @@ import {
   newStorageRepositoryMock,
   newSystemConfigRepositoryMock,
   probeStub,
-} from '@test';
-import { randomBytes } from 'crypto';
-import { BinaryField } from 'exiftool-vendored';
-import { Stats } from 'fs';
-import { constants } from 'fs/promises';
-import { when } from 'jest-when';
+} from 'test';
 import { JobName } from '../job';
 import {
   ClientEvent,

--- a/server/src/domain/metadata/metadata.service.ts
+++ b/server/src/domain/metadata/metadata.service.ts
@@ -1,5 +1,3 @@
-import { AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
 import { ExifDateTime, Tags } from 'exiftool-vendored';
 import { firstDateTime } from 'exiftool-vendored/dist/FirstDateTime';
@@ -7,6 +5,8 @@ import { constants } from 'fs/promises';
 import _ from 'lodash';
 import { Duration } from 'luxon';
 import { Subscription } from 'rxjs';
+import { AssetEntity, AssetType, ExifEntity } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { usePagination } from '../domain.util';
 import { IBaseJob, IEntityJob, ISidecarWriteJob, JOBS_ASSET_PAGINATION_SIZE, JobName, QueueName } from '../job';
 import {

--- a/server/src/domain/partner/partner.service.spec.ts
+++ b/server/src/domain/partner/partner.service.spec.ts
@@ -1,6 +1,6 @@
-import { UserAvatarColor } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
-import { authStub, newPartnerRepositoryMock, partnerStub } from '@test';
+import { UserAvatarColor } from 'src/infra/entities';
+import { authStub, newPartnerRepositoryMock, partnerStub } from 'test';
 import { IAccessRepository, IPartnerRepository, PartnerDirection } from '../repositories';
 import { PartnerResponseDto } from './partner.dto';
 import { PartnerService } from './partner.service';

--- a/server/src/domain/partner/partner.service.ts
+++ b/server/src/domain/partner/partner.service.ts
@@ -1,5 +1,5 @@
-import { PartnerEntity } from '@app/infra/entities';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { PartnerEntity } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { AuthDto } from '../auth';
 import { IAccessRepository, IPartnerRepository, PartnerDirection, PartnerIds } from '../repositories';

--- a/server/src/domain/person/person.dto.ts
+++ b/server/src/domain/person/person.dto.ts
@@ -1,7 +1,7 @@
-import { AssetFaceEntity, PersonEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsArray, IsBoolean, IsDate, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+import { AssetFaceEntity, PersonEntity } from 'src/infra/entities';
 import { AuthDto } from '../auth';
 import { Optional, ValidateUUID, toBoolean } from '../domain.util';
 

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -1,5 +1,5 @@
-import { AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { AssetFaceEntity, Colorspace, SystemConfigKey } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   assetStub,
@@ -17,7 +17,7 @@ import {
   newStorageRepositoryMock,
   newSystemConfigRepositoryMock,
   personStub,
-} from '@test';
+} from 'test';
 import { IsNull } from 'typeorm';
 import { BulkIdErrorReason } from '../asset';
 import { CacheControl, ImmichFileResponse } from '../domain.util';

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -1,7 +1,7 @@
-import { PersonEntity } from '@app/infra/entities';
-import { PersonPathType } from '@app/infra/entities/move.entity';
-import { ImmichLogger } from '@app/infra/logger';
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { PersonEntity } from 'src/infra/entities';
+import { PersonPathType } from 'src/infra/entities/move.entity';
+import { ImmichLogger } from 'src/infra/logger';
 import { IsNull } from 'typeorm';
 import { AccessCore, Permission } from '../access';
 import { AssetResponseDto, BulkIdErrorReason, BulkIdResponseDto, mapAsset } from '../asset';

--- a/server/src/domain/repositories/activity.repository.ts
+++ b/server/src/domain/repositories/activity.repository.ts
@@ -1,5 +1,5 @@
-import { ActivityEntity } from '@app/infra/entities/activity.entity';
-import { ActivitySearch } from '@app/infra/repositories';
+import { ActivityEntity } from 'src/infra/entities/activity.entity';
+import { ActivitySearch } from 'src/infra/repositories';
 
 export const IActivityRepository = 'IActivityRepository';
 

--- a/server/src/domain/repositories/album.repository.ts
+++ b/server/src/domain/repositories/album.repository.ts
@@ -1,4 +1,4 @@
-import { AlbumEntity } from '@app/infra/entities';
+import { AlbumEntity } from 'src/infra/entities';
 
 export const IAlbumRepository = 'IAlbumRepository';
 

--- a/server/src/domain/repositories/api-key.repository.ts
+++ b/server/src/domain/repositories/api-key.repository.ts
@@ -1,4 +1,4 @@
-import { APIKeyEntity } from '@app/infra/entities';
+import { APIKeyEntity } from 'src/infra/entities';
 
 export const IKeyRepository = 'IKeyRepository';
 

--- a/server/src/domain/repositories/asset-stack.repository.ts
+++ b/server/src/domain/repositories/asset-stack.repository.ts
@@ -1,4 +1,4 @@
-import { AssetStackEntity } from '@app/infra/entities/asset-stack.entity';
+import { AssetStackEntity } from 'src/infra/entities/asset-stack.entity';
 
 export const IAssetStackRepository = 'IAssetStackRepository';
 

--- a/server/src/domain/repositories/asset.repository.ts
+++ b/server/src/domain/repositories/asset.repository.ts
@@ -1,5 +1,5 @@
-import { SearchExploreItem } from '@app/domain';
-import { AssetEntity, AssetJobStatusEntity, AssetType, ExifEntity } from '@app/infra/entities';
+import { SearchExploreItem } from 'src/domain';
+import { AssetEntity, AssetJobStatusEntity, AssetType, ExifEntity } from 'src/infra/entities';
 import { FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { Paginated, PaginationOptions } from '../domain.util';
 

--- a/server/src/domain/repositories/audit.repository.ts
+++ b/server/src/domain/repositories/audit.repository.ts
@@ -1,4 +1,4 @@
-import { AuditEntity, DatabaseAction, EntityType } from '@app/infra/entities';
+import { AuditEntity, DatabaseAction, EntityType } from 'src/infra/entities';
 
 export const IAuditRepository = 'IAuditRepository';
 

--- a/server/src/domain/repositories/library.repository.ts
+++ b/server/src/domain/repositories/library.repository.ts
@@ -1,4 +1,4 @@
-import { LibraryEntity, LibraryType } from '@app/infra/entities';
+import { LibraryEntity, LibraryType } from 'src/infra/entities';
 import { LibraryStatsResponseDto } from '../library/library.dto';
 
 export const ILibraryRepository = 'ILibraryRepository';

--- a/server/src/domain/repositories/media.repository.ts
+++ b/server/src/domain/repositories/media.repository.ts
@@ -1,4 +1,4 @@
-import { VideoCodec } from '@app/infra/entities';
+import { VideoCodec } from 'src/infra/entities';
 import { Writable } from 'stream';
 
 export const IMediaRepository = 'IMediaRepository';

--- a/server/src/domain/repositories/move.repository.ts
+++ b/server/src/domain/repositories/move.repository.ts
@@ -1,4 +1,4 @@
-import { MoveEntity, PathType } from '@app/infra/entities';
+import { MoveEntity, PathType } from 'src/infra/entities';
 
 export const IMoveRepository = 'IMoveRepository';
 

--- a/server/src/domain/repositories/partner.repository.ts
+++ b/server/src/domain/repositories/partner.repository.ts
@@ -1,4 +1,4 @@
-import { PartnerEntity } from '@app/infra/entities';
+import { PartnerEntity } from 'src/infra/entities';
 
 export interface PartnerIds {
   sharedById: string;

--- a/server/src/domain/repositories/person.repository.ts
+++ b/server/src/domain/repositories/person.repository.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, AssetFaceEntity, PersonEntity } from '@app/infra/entities';
+import { AssetEntity, AssetFaceEntity, PersonEntity } from 'src/infra/entities';
 import { FindManyOptions, FindOptionsRelations, FindOptionsSelect } from 'typeorm';
 import { Paginated, PaginationOptions } from '../domain.util';
 

--- a/server/src/domain/repositories/search.repository.ts
+++ b/server/src/domain/repositories/search.repository.ts
@@ -1,4 +1,4 @@
-import { AssetType } from '@app/infra/entities';
+import { AssetType } from 'src/infra/entities';
 
 export enum SearchStrategy {
   CLIP = 'CLIP',

--- a/server/src/domain/repositories/shared-link.repository.ts
+++ b/server/src/domain/repositories/shared-link.repository.ts
@@ -1,4 +1,4 @@
-import { SharedLinkEntity } from '@app/infra/entities';
+import { SharedLinkEntity } from 'src/infra/entities';
 
 export const ISharedLinkRepository = 'ISharedLinkRepository';
 

--- a/server/src/domain/repositories/smart-info.repository.ts
+++ b/server/src/domain/repositories/smart-info.repository.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, AssetFaceEntity, SmartInfoEntity } from '@app/infra/entities';
+import { AssetEntity, AssetFaceEntity, SmartInfoEntity } from 'src/infra/entities';
 
 export const ISmartInfoRepository = 'ISmartInfoRepository';
 

--- a/server/src/domain/repositories/system-config.repository.ts
+++ b/server/src/domain/repositories/system-config.repository.ts
@@ -1,4 +1,4 @@
-import { SystemConfigEntity } from '@app/infra/entities';
+import { SystemConfigEntity } from 'src/infra/entities';
 
 export const ISystemConfigRepository = 'ISystemConfigRepository';
 

--- a/server/src/domain/repositories/system-metadata.repository.ts
+++ b/server/src/domain/repositories/system-metadata.repository.ts
@@ -1,4 +1,4 @@
-import { SystemMetadata } from '@app/infra/entities';
+import { SystemMetadata } from 'src/infra/entities';
 
 export const ISystemMetadataRepository = 'ISystemMetadataRepository';
 

--- a/server/src/domain/repositories/tag.repository.ts
+++ b/server/src/domain/repositories/tag.repository.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, TagEntity } from '@app/infra/entities';
+import { AssetEntity, TagEntity } from 'src/infra/entities';
 
 export const ITagRepository = 'ITagRepository';
 

--- a/server/src/domain/repositories/user-token.repository.ts
+++ b/server/src/domain/repositories/user-token.repository.ts
@@ -1,4 +1,4 @@
-import { UserTokenEntity } from '@app/infra/entities';
+import { UserTokenEntity } from 'src/infra/entities';
 
 export const IUserTokenRepository = 'IUserTokenRepository';
 

--- a/server/src/domain/repositories/user.repository.ts
+++ b/server/src/domain/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-import { UserEntity } from '@app/infra/entities';
+import { UserEntity } from 'src/infra/entities';
 
 export interface UserListFilter {
   withDeleted?: boolean;

--- a/server/src/domain/search/dto/search.dto.ts
+++ b/server/src/domain/search/dto/search.dto.ts
@@ -1,6 +1,6 @@
-import { AssetType } from '@app/infra/entities';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { AssetType } from 'src/infra/entities';
 import { Optional, toBoolean } from '../../domain.util';
 
 export class SearchDto {

--- a/server/src/domain/search/search.service.spec.ts
+++ b/server/src/domain/search/search.service.spec.ts
@@ -1,4 +1,4 @@
-import { SystemConfigKey } from '@app/infra/entities';
+import { SystemConfigKey } from 'src/infra/entities';
 import {
   assetStub,
   authStub,
@@ -9,7 +9,7 @@ import {
   newSmartInfoRepositoryMock,
   newSystemConfigRepositoryMock,
   personStub,
-} from '@test';
+} from 'test';
 import { mapAsset } from '../asset';
 import {
   IAssetRepository,

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -1,6 +1,6 @@
-import { AssetEntity } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
+import { AssetEntity } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { AssetResponseDto, mapAsset } from '../asset';
 import { AuthDto } from '../auth';
 import { PersonResponseDto } from '../person';

--- a/server/src/domain/server-info/server-info.dto.ts
+++ b/server/src/domain/server-info/server-info.dto.ts
@@ -1,5 +1,5 @@
-import { FeatureFlags, IVersion } from '@app/domain';
 import { ApiProperty, ApiResponseProperty } from '@nestjs/swagger';
+import { FeatureFlags, IVersion } from 'src/domain';
 import { SystemConfigThemeDto } from '../system-config/dto/system-config-theme.dto';
 
 export class ServerPingResponse {

--- a/server/src/domain/server-info/server-info.service.spec.ts
+++ b/server/src/domain/server-info/server-info.service.spec.ts
@@ -1,4 +1,4 @@
-import { SystemMetadataKey } from '@app/infra/entities';
+import { SystemMetadataKey } from 'src/infra/entities';
 import {
   newCommunicationRepositoryMock,
   newServerInfoRepositoryMock,
@@ -6,7 +6,7 @@ import {
   newSystemConfigRepositoryMock,
   newSystemMetadataRepositoryMock,
   newUserRepositoryMock,
-} from '@test';
+} from 'test';
 import { serverVersion } from '../domain.constant';
 import {
   ICommunicationRepository,

--- a/server/src/domain/server-info/server-info.service.ts
+++ b/server/src/domain/server-info/server-info.service.ts
@@ -1,7 +1,7 @@
-import { SystemMetadataKey } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
 import { DateTime } from 'luxon';
+import { SystemMetadataKey } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { Version, isDev, mimeTypes, serverVersion } from '../domain.constant';
 import { asHumanReadable } from '../domain.util';
 import {

--- a/server/src/domain/shared-link/shared-link-response.dto.ts
+++ b/server/src/domain/shared-link/shared-link-response.dto.ts
@@ -1,6 +1,6 @@
-import { SharedLinkEntity, SharedLinkType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import _ from 'lodash';
+import { SharedLinkEntity, SharedLinkType } from 'src/infra/entities';
 import { AlbumResponseDto, mapAlbumWithoutAssets } from '../album';
 import { AssetResponseDto, mapAsset } from '../asset';
 

--- a/server/src/domain/shared-link/shared-link.dto.ts
+++ b/server/src/domain/shared-link/shared-link.dto.ts
@@ -1,7 +1,7 @@
-import { SharedLinkType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsDate, IsEnum, IsString } from 'class-validator';
+import { SharedLinkType } from 'src/infra/entities';
 import { Optional, ValidateUUID } from '../domain.util';
 
 export class SharedLinkCreateDto {

--- a/server/src/domain/shared-link/shared-link.service.spec.ts
+++ b/server/src/domain/shared-link/shared-link.service.spec.ts
@@ -1,5 +1,6 @@
-import { SharedLinkType } from '@app/infra/entities';
 import { BadRequestException, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import _ from 'lodash';
+import { SharedLinkType } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   albumStub,
@@ -10,8 +11,7 @@ import {
   newSharedLinkRepositoryMock,
   sharedLinkResponseStub,
   sharedLinkStub,
-} from '@test';
-import _ from 'lodash';
+} from 'test';
 import { AssetIdErrorReason } from '../asset';
 import { ICryptoRepository, ISharedLinkRepository } from '../repositories';
 import { SharedLinkService } from './shared-link.service';

--- a/server/src/domain/shared-link/shared-link.service.ts
+++ b/server/src/domain/shared-link/shared-link.service.ts
@@ -1,5 +1,5 @@
-import { AssetEntity, SharedLinkEntity, SharedLinkType } from '@app/infra/entities';
 import { BadRequestException, ForbiddenException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AssetEntity, SharedLinkEntity, SharedLinkType } from 'src/infra/entities';
 import { AccessCore, Permission } from '../access';
 import { AssetIdErrorReason, AssetIdsDto, AssetIdsResponseDto } from '../asset';
 import { AuthDto } from '../auth';

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, SystemConfigKey } from '@app/infra/entities';
+import { AssetEntity, SystemConfigKey } from 'src/infra/entities';
 import {
   assetStub,
   newAssetRepositoryMock,
@@ -7,7 +7,7 @@ import {
   newMachineLearningRepositoryMock,
   newSmartInfoRepositoryMock,
   newSystemConfigRepositoryMock,
-} from '@test';
+} from 'test';
 import { JobName } from '../job';
 import {
   IAssetRepository,

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -1,5 +1,5 @@
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
+import { ImmichLogger } from 'src/infra/logger';
 import { usePagination } from '../domain.util';
 import { IBaseJob, IEntityJob, JOBS_ASSET_PAGINATION_SIZE, JobName, QueueName } from '../job';
 import {

--- a/server/src/domain/storage-template/storage-template.service.spec.ts
+++ b/server/src/domain/storage-template/storage-template.service.spec.ts
@@ -1,3 +1,5 @@
+import { when } from 'jest-when';
+import { Stats } from 'node:fs';
 import {
   IAlbumRepository,
   IAssetRepository,
@@ -10,8 +12,8 @@ import {
   IUserRepository,
   StorageTemplateService,
   defaults,
-} from '@app/domain';
-import { AssetPathType, SystemConfigKey } from '@app/infra/entities';
+} from 'src/domain';
+import { AssetPathType, SystemConfigKey } from 'src/infra/entities';
 import {
   assetStub,
   newAlbumRepositoryMock,
@@ -24,9 +26,7 @@ import {
   newSystemConfigRepositoryMock,
   newUserRepositoryMock,
   userStub,
-} from '@test';
-import { when } from 'jest-when';
-import { Stats } from 'node:fs';
+} from 'test';
 import { SystemConfigCore } from '../system-config';
 
 describe(StorageTemplateService.name, () => {

--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -1,10 +1,10 @@
-import { AssetEntity, AssetPathType, AssetType, SystemConfig } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
 import handlebar from 'handlebars';
 import * as luxon from 'luxon';
 import path from 'node:path';
 import sanitize from 'sanitize-filename';
+import { AssetEntity, AssetPathType, AssetType, SystemConfig } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { getLivePhotoMotionFilename, usePagination } from '../domain.util';
 import { IEntityJob, JOBS_ASSET_PAGINATION_SIZE } from '../job';
 import {

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -1,7 +1,7 @@
-import { SystemConfigCore } from '@app/domain/system-config';
-import { AssetEntity, AssetPathType, PathType, PersonEntity, PersonPathType } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { dirname, join, resolve } from 'node:path';
+import { SystemConfigCore } from 'src/domain/system-config';
+import { AssetEntity, AssetPathType, PathType, PersonEntity, PersonPathType } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { APP_MEDIA_LOCATION } from '../domain.constant';
 import {
   IAssetRepository,

--- a/server/src/domain/storage/storage.service.spec.ts
+++ b/server/src/domain/storage/storage.service.spec.ts
@@ -1,4 +1,4 @@
-import { newStorageRepositoryMock } from '@test';
+import { newStorageRepositoryMock } from 'test';
 import { IStorageRepository } from '../repositories';
 import { StorageService } from './storage.service';
 

--- a/server/src/domain/storage/storage.service.ts
+++ b/server/src/domain/storage/storage.service.ts
@@ -1,5 +1,5 @@
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
+import { ImmichLogger } from 'src/infra/logger';
 import { IDeleteFilesJob } from '../job';
 import { IStorageRepository } from '../repositories';
 import { StorageCore, StorageFolder } from './storage.core';

--- a/server/src/domain/system-config/dto/system-config-ffmpeg.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-ffmpeg.dto.ts
@@ -1,7 +1,7 @@
-import { AudioCodec, CQMode, ToneMapping, TranscodeHWAccel, TranscodePolicy, VideoCodec } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsEnum, IsInt, IsString, Max, Min } from 'class-validator';
+import { AudioCodec, CQMode, ToneMapping, TranscodeHWAccel, TranscodePolicy, VideoCodec } from 'src/infra/entities';
 
 export class SystemConfigFFmpegDto {
   @IsInt()

--- a/server/src/domain/system-config/dto/system-config-library.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-library.dto.ts
@@ -1,4 +1,3 @@
-import { validateCronExpression } from '@app/domain';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -11,6 +10,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { validateCronExpression } from 'src/domain';
 
 const isEnabled = (config: SystemConfigLibraryScanDto) => config.enabled;
 

--- a/server/src/domain/system-config/dto/system-config-logging.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-logging.dto.ts
@@ -1,6 +1,6 @@
-import { LogLevel } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum } from 'class-validator';
+import { LogLevel } from 'src/infra/entities';
 
 export class SystemConfigLoggingDto {
   @IsBoolean()

--- a/server/src/domain/system-config/dto/system-config-machine-learning.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-machine-learning.dto.ts
@@ -1,6 +1,6 @@
-import { CLIPConfig, RecognitionConfig } from '@app/domain';
 import { Type } from 'class-transformer';
 import { IsBoolean, IsObject, IsUrl, ValidateIf, ValidateNested } from 'class-validator';
+import { CLIPConfig, RecognitionConfig } from 'src/domain';
 
 export class SystemConfigMachineLearningDto {
   @IsBoolean()

--- a/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-thumbnail.dto.ts
@@ -1,7 +1,7 @@
-import { Colorspace } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsEnum, IsInt, Max, Min } from 'class-validator';
+import { Colorspace } from 'src/infra/entities';
 
 export class SystemConfigThumbnailDto {
   @IsInt()

--- a/server/src/domain/system-config/dto/system-config.dto.ts
+++ b/server/src/domain/system-config/dto/system-config.dto.ts
@@ -1,6 +1,6 @@
-import { SystemConfig } from '@app/infra/entities';
 import { Type } from 'class-transformer';
 import { IsObject, ValidateNested } from 'class-validator';
+import { SystemConfig } from 'src/infra/entities';
 import { SystemConfigFFmpegDto } from './system-config-ffmpeg.dto';
 import { SystemConfigJobDto } from './system-config-job.dto';
 import { SystemConfigLibraryDto } from './system-config-library.dto';

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -1,7 +1,13 @@
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
+import { CronExpression } from '@nestjs/schedule';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import * as _ from 'lodash';
+import { Subject } from 'rxjs';
 import {
   AudioCodec,
-  Colorspace,
   CQMode,
+  Colorspace,
   LogLevel,
   SystemConfig,
   SystemConfigEntity,
@@ -11,14 +17,8 @@ import {
   TranscodeHWAccel,
   TranscodePolicy,
   VideoCodec,
-} from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
-import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
-import { CronExpression } from '@nestjs/schedule';
-import { plainToInstance } from 'class-transformer';
-import { validate } from 'class-validator';
-import * as _ from 'lodash';
-import { Subject } from 'rxjs';
+} from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { QueueName } from '../job/job.constants';
 import { ISystemConfigRepository } from '../repositories';
 import { SystemConfigDto } from './dto';

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -1,7 +1,8 @@
+import { BadRequestException } from '@nestjs/common';
 import {
   AudioCodec,
-  Colorspace,
   CQMode,
+  Colorspace,
   LogLevel,
   SystemConfig,
   SystemConfigEntity,
@@ -10,13 +11,12 @@ import {
   TranscodeHWAccel,
   TranscodePolicy,
   VideoCodec,
-} from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
-import { BadRequestException } from '@nestjs/common';
-import { newCommunicationRepositoryMock, newSystemConfigRepositoryMock } from '@test';
+} from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
+import { newCommunicationRepositoryMock, newSystemConfigRepositoryMock } from 'test';
 import { QueueName } from '../job';
 import { ICommunicationRepository, ISmartInfoRepository, ISystemConfigRepository, ServerEvent } from '../repositories';
-import { defaults, SystemConfigValidator } from './system-config.core';
+import { SystemConfigValidator, defaults } from './system-config.core';
 import { SystemConfigService } from './system-config.service';
 
 const updates: SystemConfigEntity[] = [

--- a/server/src/domain/system-config/system-config.service.ts
+++ b/server/src/domain/system-config/system-config.service.ts
@@ -1,8 +1,8 @@
-import { LogLevel, SystemConfig } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject, Injectable } from '@nestjs/common';
 import { instanceToPlain } from 'class-transformer';
 import _ from 'lodash';
+import { LogLevel, SystemConfig } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import {
   ClientEvent,
   ICommunicationRepository,

--- a/server/src/domain/tag/tag-response.dto.ts
+++ b/server/src/domain/tag/tag-response.dto.ts
@@ -1,5 +1,5 @@
-import { TagEntity, TagType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
+import { TagEntity, TagType } from 'src/infra/entities';
 
 export class TagResponseDto {
   id!: string;

--- a/server/src/domain/tag/tag.dto.ts
+++ b/server/src/domain/tag/tag.dto.ts
@@ -1,6 +1,6 @@
-import { TagType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { TagType } from 'src/infra/entities';
 import { Optional } from '../domain.util';
 
 export class CreateTagDto {

--- a/server/src/domain/tag/tag.service.spec.ts
+++ b/server/src/domain/tag/tag.service.spec.ts
@@ -1,7 +1,7 @@
-import { TagType } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
-import { assetStub, authStub, newTagRepositoryMock, tagResponseStub, tagStub } from '@test';
 import { when } from 'jest-when';
+import { TagType } from 'src/infra/entities';
+import { assetStub, authStub, newTagRepositoryMock, tagResponseStub, tagStub } from 'test';
 import { AssetIdErrorReason } from '../asset';
 import { ITagRepository } from '../repositories';
 import { TagService } from './tag.service';

--- a/server/src/domain/trash/trash.service.spec.ts
+++ b/server/src/domain/trash/trash.service.spec.ts
@@ -7,7 +7,7 @@ import {
   newAssetRepositoryMock,
   newCommunicationRepositoryMock,
   newJobRepositoryMock,
-} from '@test';
+} from 'test';
 import { JobName } from '..';
 import { ClientEvent, IAssetRepository, ICommunicationRepository, IJobRepository } from '../repositories';
 import { TrashService } from './trash.service';

--- a/server/src/domain/user/dto/update-user.dto.ts
+++ b/server/src/domain/user/dto/update-user.dto.ts
@@ -1,7 +1,7 @@
-import { UserAvatarColor } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsEmail, IsEnum, IsNotEmpty, IsNumber, IsPositive, IsString, IsUUID } from 'class-validator';
+import { UserAvatarColor } from 'src/infra/entities';
 import { Optional, toEmail, toSanitized } from '../../domain.util';
 
 export class UpdateUserDto {

--- a/server/src/domain/user/response-dto/user-response.dto.ts
+++ b/server/src/domain/user/response-dto/user-response.dto.ts
@@ -1,6 +1,6 @@
-import { UserAvatarColor, UserEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
+import { UserAvatarColor, UserEntity } from 'src/infra/entities';
 
 export const getRandomAvatarColor = (user: UserEntity): UserAvatarColor => {
   const values = Object.values(UserAvatarColor);

--- a/server/src/domain/user/user.core.ts
+++ b/server/src/domain/user/user.core.ts
@@ -1,7 +1,7 @@
-import { LibraryType, UserEntity } from '@app/infra/entities';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import path from 'path';
 import sanitize from 'sanitize-filename';
+import { LibraryType, UserEntity } from 'src/infra/entities';
 import { ICryptoRepository, ILibraryRepository, IUserRepository } from '../repositories';
 import { UserResponseDto } from './response-dto';
 

--- a/server/src/domain/user/user.service.spec.ts
+++ b/server/src/domain/user/user.service.spec.ts
@@ -1,10 +1,11 @@
-import { UserEntity } from '@app/infra/entities';
 import {
   BadRequestException,
   ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
+import { when } from 'jest-when';
+import { UserEntity } from 'src/infra/entities';
 import {
   authStub,
   newAlbumRepositoryMock,
@@ -15,8 +16,7 @@ import {
   newStorageRepositoryMock,
   newUserRepositoryMock,
   userStub,
-} from '@test';
-import { when } from 'jest-when';
+} from 'test';
 import { CacheControl, ImmichFileResponse } from '../domain.util';
 import { JobName } from '../job';
 import {

--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -1,7 +1,7 @@
-import { UserEntity } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { BadRequestException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { randomBytes } from 'crypto';
+import { UserEntity } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { AuthDto } from '../auth';
 import { CacheControl, ImmichFileResponse } from '../domain.util';
 import { IEntityJob, JobName } from '../job';

--- a/server/src/immich-admin/app.module.ts
+++ b/server/src/immich-admin/app.module.ts
@@ -1,6 +1,6 @@
-import { DomainModule } from '@app/domain';
-import { InfraModule } from '@app/infra';
 import { Module } from '@nestjs/common';
+import { DomainModule } from 'src/domain';
+import { InfraModule } from 'src/infra';
 import { ListUsersCommand } from './commands/list-users.command';
 import { DisablePasswordLoginCommand, EnablePasswordLoginCommand } from './commands/password-login';
 import { PromptPasswordQuestions, ResetAdminPasswordCommand } from './commands/reset-admin-password.command';

--- a/server/src/immich-admin/commands/list-users.command.ts
+++ b/server/src/immich-admin/commands/list-users.command.ts
@@ -1,5 +1,5 @@
-import { UserService } from '@app/domain';
 import { Command, CommandRunner } from 'nest-commander';
+import { UserService } from 'src/domain';
 import { CLI_USER } from '../constants';
 
 @Command({

--- a/server/src/immich-admin/commands/password-login.ts
+++ b/server/src/immich-admin/commands/password-login.ts
@@ -1,5 +1,5 @@
-import { SystemConfigService } from '@app/domain';
 import { Command, CommandRunner } from 'nest-commander';
+import { SystemConfigService } from 'src/domain';
 
 @Command({
   name: 'enable-password-login',

--- a/server/src/immich-admin/commands/reset-admin-password.command.ts
+++ b/server/src/immich-admin/commands/reset-admin-password.command.ts
@@ -1,5 +1,5 @@
-import { UserResponseDto, UserService } from '@app/domain';
 import { Command, CommandRunner, InquirerService, Question, QuestionSet } from 'nest-commander';
+import { UserResponseDto, UserService } from 'src/domain';
 
 @Command({
   name: 'reset-admin-password',

--- a/server/src/immich-admin/constants.ts
+++ b/server/src/immich-admin/constants.ts
@@ -1,5 +1,5 @@
-import { AuthDto } from '@app/domain';
-import { UserEntity } from '@app/infra/entities';
+import { AuthDto } from 'src/domain';
+import { UserEntity } from 'src/infra/entities';
 
 export const CLI_USER: AuthDto = {
   user: {

--- a/server/src/immich-admin/main.ts
+++ b/server/src/immich-admin/main.ts
@@ -1,5 +1,5 @@
-import { LogLevel } from '@app/infra/entities';
 import { CommandFactory } from 'nest-commander';
+import { LogLevel } from 'src/infra/entities';
 import { AppModule } from './app.module';
 
 export async function bootstrap() {

--- a/server/src/immich/api-v1/asset/asset-repository.ts
+++ b/server/src/immich/api-v1/asset/asset-repository.ts
@@ -1,8 +1,8 @@
-import { AssetCreate } from '@app/domain';
-import { AssetEntity, ExifEntity } from '@app/infra/entities';
-import { OptionalBetween } from '@app/infra/infra.utils';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AssetCreate } from 'src/domain';
+import { AssetEntity, ExifEntity } from 'src/infra/entities';
+import { OptionalBetween } from 'src/infra/infra.utils';
 import { In } from 'typeorm/find-options/operator/In';
 import { Repository } from 'typeorm/repository/Repository';
 import { AssetSearchDto } from './dto/asset-search.dto';

--- a/server/src/immich/api-v1/asset/asset.controller.ts
+++ b/server/src/immich/api-v1/asset/asset.controller.ts
@@ -1,4 +1,3 @@
-import { AssetResponseDto, AssetService, AuthDto } from '@app/domain';
 import {
   Body,
   Controller,
@@ -17,6 +16,7 @@ import {
 } from '@nestjs/common';
 import { ApiBody, ApiConsumes, ApiHeader, ApiTags } from '@nestjs/swagger';
 import { NextFunction, Response } from 'express';
+import { AssetResponseDto, AssetService, AuthDto } from 'src/domain';
 import { Auth, Authenticated, FileResponse, SharedLinkRoute } from '../../app.guard';
 import { UseValidation, sendFile } from '../../app.utils';
 import { UUIDParamDto } from '../../controllers/dto/uuid-param.dto';

--- a/server/src/immich/api-v1/asset/asset.core.ts
+++ b/server/src/immich/api-v1/asset/asset.core.ts
@@ -1,7 +1,7 @@
-import { AuthDto, IJobRepository, JobName, mimeTypes, UploadFile } from '@app/domain';
-import { AssetEntity } from '@app/infra/entities';
 import { BadRequestException } from '@nestjs/common';
 import { parse } from 'node:path';
+import { AuthDto, IJobRepository, JobName, mimeTypes, UploadFile } from 'src/domain';
+import { AssetEntity } from 'src/infra/entities';
 import { IAssetRepositoryV1 } from './asset-repository';
 import { CreateAssetDto } from './dto/create-asset.dto';
 

--- a/server/src/immich/api-v1/asset/asset.service.spec.ts
+++ b/server/src/immich/api-v1/asset/asset.service.spec.ts
@@ -1,5 +1,6 @@
-import { IAssetRepository, IJobRepository, ILibraryRepository, IUserRepository, JobName } from '@app/domain';
-import { ASSET_CHECKSUM_CONSTRAINT, AssetEntity, AssetType, ExifEntity } from '@app/infra/entities';
+import { when } from 'jest-when';
+import { IAssetRepository, IJobRepository, ILibraryRepository, IUserRepository, JobName } from 'src/domain';
+import { ASSET_CHECKSUM_CONSTRAINT, AssetEntity, AssetType, ExifEntity } from 'src/infra/entities';
 import {
   IAccessRepositoryMock,
   assetStub,
@@ -10,8 +11,7 @@ import {
   newJobRepositoryMock,
   newLibraryRepositoryMock,
   newUserRepositoryMock,
-} from '@test';
-import { when } from 'jest-when';
+} from 'test';
 import { QueryFailedError } from 'typeorm';
 import { IAssetRepositoryV1 } from './asset-repository';
 import { AssetService } from './asset.service';

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -1,3 +1,4 @@
+import { Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import {
   AccessCore,
   AssetResponseDto,
@@ -15,10 +16,9 @@ import {
   getLivePhotoMotionFilename,
   mapAsset,
   mimeTypes,
-} from '@app/domain';
-import { ASSET_CHECKSUM_CONSTRAINT, AssetEntity, AssetType, LibraryType } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
-import { Inject, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+} from 'src/domain';
+import { ASSET_CHECKSUM_CONSTRAINT, AssetEntity, AssetType, LibraryType } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { QueryFailedError } from 'typeorm';
 import { IAssetRepositoryV1 } from './asset-repository';
 import { AssetCore } from './asset.core';

--- a/server/src/immich/api-v1/asset/dto/asset-search.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/asset-search.dto.ts
@@ -1,7 +1,7 @@
-import { Optional, toBoolean } from '@app/domain';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsBoolean, IsDate, IsInt, IsNotEmpty, IsUUID } from 'class-validator';
+import { Optional, toBoolean } from 'src/domain';
 
 export class AssetSearchDto {
   @Optional()

--- a/server/src/immich/api-v1/asset/dto/create-asset.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/create-asset.dto.ts
@@ -1,7 +1,7 @@
-import { Optional, toBoolean, UploadFieldName, ValidateUUID } from '@app/domain';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import { IsBoolean, IsDate, IsNotEmpty, IsString } from 'class-validator';
+import { Optional, UploadFieldName, ValidateUUID, toBoolean } from 'src/domain';
 
 export class CreateAssetBase {
   @IsNotEmpty()

--- a/server/src/immich/api-v1/asset/dto/get-asset-thumbnail.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/get-asset-thumbnail.dto.ts
@@ -1,6 +1,6 @@
-import { Optional } from '@app/domain';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
+import { Optional } from 'src/domain';
 
 export enum GetAssetThumbnailFormatEnum {
   JPEG = 'JPEG',

--- a/server/src/immich/api-v1/asset/dto/serve-file.dto.ts
+++ b/server/src/immich/api-v1/asset/dto/serve-file.dto.ts
@@ -1,7 +1,7 @@
-import { Optional, toBoolean } from '@app/domain';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean } from 'class-validator';
+import { Optional, toBoolean } from 'src/domain';
 
 export class ServeFileDto {
   @Optional()

--- a/server/src/immich/app.guard.ts
+++ b/server/src/immich/app.guard.ts
@@ -1,5 +1,3 @@
-import { AuthDto, AuthService, IMMICH_API_KEY_NAME, LoginDetails } from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
 import {
   CanActivate,
   ExecutionContext,
@@ -11,6 +9,8 @@ import {
 import { Reflector } from '@nestjs/core';
 import { ApiBearerAuth, ApiCookieAuth, ApiOkResponse, ApiQuery, ApiSecurity } from '@nestjs/swagger';
 import { Request } from 'express';
+import { AuthDto, AuthService, IMMICH_API_KEY_NAME, LoginDetails } from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 import { UAParser } from 'ua-parser-js';
 
 export enum Metadata {

--- a/server/src/immich/app.module.ts
+++ b/server/src/immich/app.module.ts
@@ -1,10 +1,10 @@
-import { DomainModule } from '@app/domain';
-import { InfraModule } from '@app/infra';
-import { AssetEntity, ExifEntity } from '@app/infra/entities';
 import { Module, OnModuleInit } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { DomainModule } from 'src/domain';
+import { InfraModule } from 'src/infra';
+import { AssetEntity, ExifEntity } from 'src/infra/entities';
 import { AssetRepositoryV1, IAssetRepositoryV1 } from './api-v1/asset/asset-repository';
 import { AssetController as AssetControllerV1 } from './api-v1/asset/asset.controller';
 import { AssetService } from './api-v1/asset/asset.service';

--- a/server/src/immich/app.service.ts
+++ b/server/src/immich/app.service.ts
@@ -1,3 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression, Interval } from '@nestjs/schedule';
+import { NextFunction, Request, Response } from 'express';
+import { readFileSync } from 'fs';
 import {
   AuthService,
   DatabaseService,
@@ -10,12 +14,8 @@ import {
   StorageService,
   SystemConfigService,
   WEB_ROOT_PATH,
-} from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
-import { Injectable } from '@nestjs/common';
-import { Cron, CronExpression, Interval } from '@nestjs/schedule';
-import { NextFunction, Request, Response } from 'express';
-import { readFileSync } from 'fs';
+} from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 
 const render = (index: string, meta: OpenGraphTags) => {
   const tags = `

--- a/server/src/immich/app.utils.ts
+++ b/server/src/immich/app.utils.ts
@@ -1,14 +1,3 @@
-import {
-  CacheControl,
-  IMMICH_ACCESS_COOKIE,
-  IMMICH_API_KEY_HEADER,
-  IMMICH_API_KEY_NAME,
-  ImmichFileResponse,
-  ImmichReadStream,
-  isConnectionAborted,
-  serverVersion,
-} from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
 import { HttpException, INestApplication, StreamableFile } from '@nestjs/common';
 import {
   DocumentBuilder,
@@ -22,6 +11,17 @@ import { writeFileSync } from 'fs';
 import { access, constants } from 'fs/promises';
 import _ from 'lodash';
 import path, { isAbsolute } from 'path';
+import {
+  CacheControl,
+  IMMICH_ACCESS_COOKIE,
+  IMMICH_API_KEY_HEADER,
+  IMMICH_API_KEY_NAME,
+  ImmichFileResponse,
+  ImmichReadStream,
+  isConnectionAborted,
+  serverVersion,
+} from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 import { promisify } from 'util';
 
 import { applyDecorators, UsePipes, ValidationPipe } from '@nestjs/common';

--- a/server/src/immich/controllers/activity.controller.ts
+++ b/server/src/immich/controllers/activity.controller.ts
@@ -1,4 +1,7 @@
-import { AuthDto } from '@app/domain';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { AuthDto } from 'src/domain';
 import {
   ActivityDto,
   ActivitySearchDto,
@@ -6,10 +9,7 @@ import {
   ActivityCreateDto as CreateDto,
   ActivityResponseDto as ResponseDto,
   ActivityStatisticsResponseDto as StatsResponseDto,
-} from '@app/domain/activity';
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Query, Res } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { Response } from 'express';
+} from 'src/domain/activity';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/album.controller.ts
+++ b/server/src/immich/controllers/album.controller.ts
@@ -1,3 +1,5 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   AddUsersDto,
   AlbumCountResponseDto,
@@ -10,9 +12,7 @@ import {
   CreateAlbumDto as CreateDto,
   GetAlbumsDto,
   UpdateAlbumDto as UpdateDto,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { ParseMeUUIDPipe } from '../api-v1/validation/parse-me-uuid-pipe';
 import { Auth, Authenticated, SharedLinkRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';

--- a/server/src/immich/controllers/api-key.controller.ts
+++ b/server/src/immich/controllers/api-key.controller.ts
@@ -1,3 +1,5 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   APIKeyCreateDto,
   APIKeyCreateResponseDto,
@@ -5,9 +7,7 @@ import {
   APIKeyService,
   APIKeyUpdateDto,
   AuthDto,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/app.controller.ts
+++ b/server/src/immich/controllers/app.controller.ts
@@ -1,6 +1,6 @@
-import { SystemConfigService } from '@app/domain';
 import { Controller, Get, Header } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { SystemConfigService } from 'src/domain';
 import { PublicRoute } from '../app.guard';
 
 @Controller()

--- a/server/src/immich/controllers/asset.controller.ts
+++ b/server/src/immich/controllers/asset.controller.ts
@@ -1,4 +1,21 @@
 import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Next,
+  Param,
+  Post,
+  Put,
+  Query,
+  Res,
+  StreamableFile,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { NextFunction, Response } from 'express';
+import {
   AssetBulkDeleteDto,
   AssetBulkUpdateDto,
   AssetIdsDto,
@@ -25,24 +42,7 @@ import {
   TrashService,
   UpdateAssetDto as UpdateDto,
   UpdateStackParentDto,
-} from '@app/domain';
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  HttpCode,
-  HttpStatus,
-  Next,
-  Param,
-  Post,
-  Put,
-  Query,
-  Res,
-  StreamableFile,
-} from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { NextFunction, Response } from 'express';
+} from 'src/domain';
 import { Auth, Authenticated, FileResponse, SharedLinkRoute } from '../app.guard';
 import { UseValidation, asStreamableFile, sendFile } from '../app.utils';
 import { Route } from '../interceptors';

--- a/server/src/immich/controllers/audit.controller.ts
+++ b/server/src/immich/controllers/audit.controller.ts
@@ -1,3 +1,5 @@
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   AuditDeletesDto,
   AuditDeletesResponseDto,
@@ -7,9 +9,7 @@ import {
   FileChecksumResponseDto,
   FileReportDto,
   FileReportFixDto,
-} from '@app/domain';
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { AdminRoute, Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/auth.controller.ts
+++ b/server/src/immich/controllers/auth.controller.ts
@@ -1,3 +1,6 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
 import {
   AuthDeviceResponseDto,
   AuthDto,
@@ -13,10 +16,7 @@ import {
   UserResponseDto,
   ValidateAccessTokenResponseDto,
   mapUser,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, Res } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { Request, Response } from 'express';
+} from 'src/domain';
 import { Auth, Authenticated, GetLoginDetails, PublicRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/download.controller.ts
+++ b/server/src/immich/controllers/download.controller.ts
@@ -1,7 +1,7 @@
-import { AssetIdsDto, AuthDto, DownloadInfoDto, DownloadResponseDto, DownloadService } from '@app/domain';
 import { Body, Controller, HttpCode, HttpStatus, Next, Param, Post, Res, StreamableFile } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NextFunction, Response } from 'express';
+import { AssetIdsDto, AuthDto, DownloadInfoDto, DownloadResponseDto, DownloadService } from 'src/domain';
 import { Auth, Authenticated, FileResponse, SharedLinkRoute } from '../app.guard';
 import { UseValidation, asStreamableFile, sendFile } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/face.controller.ts
+++ b/server/src/immich/controllers/face.controller.ts
@@ -1,6 +1,6 @@
-import { AssetFaceResponseDto, AuthDto, FaceDto, PersonResponseDto, PersonService } from '@app/domain';
 import { Body, Controller, Get, Param, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { AssetFaceResponseDto, AuthDto, FaceDto, PersonResponseDto, PersonService } from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/job.controller.ts
+++ b/server/src/immich/controllers/job.controller.ts
@@ -1,6 +1,6 @@
-import { AllJobStatusResponseDto, JobCommandDto, JobIdParamDto, JobService, JobStatusDto } from '@app/domain';
 import { Body, Controller, Get, Param, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { AllJobStatusResponseDto, JobCommandDto, JobIdParamDto, JobService, JobStatusDto } from 'src/domain';
 import { Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/library.controller.ts
+++ b/server/src/immich/controllers/library.controller.ts
@@ -1,3 +1,5 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   AuthDto,
   CreateLibraryDto as CreateDto,
@@ -6,9 +8,7 @@ import {
   LibraryResponseDto as ResponseDto,
   ScanLibraryDto,
   UpdateLibraryDto as UpdateDto,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/oauth.controller.ts
+++ b/server/src/immich/controllers/oauth.controller.ts
@@ -1,3 +1,6 @@
+import { Body, Controller, Get, HttpStatus, Post, Redirect, Req, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
 import {
   AuthDto,
   AuthService,
@@ -8,10 +11,7 @@ import {
   OAuthConfigDto,
   OAuthConfigResponseDto,
   UserResponseDto,
-} from '@app/domain';
-import { Body, Controller, Get, HttpStatus, Post, Redirect, Req, Res } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { Request, Response } from 'express';
+} from 'src/domain';
 import { Auth, Authenticated, GetLoginDetails, PublicRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/partner.controller.ts
+++ b/server/src/immich/controllers/partner.controller.ts
@@ -1,7 +1,7 @@
-import { AuthDto, PartnerDirection, PartnerService } from '@app/domain';
-import { PartnerResponseDto, UpdatePartnerDto } from '@app/domain/partner/partner.dto';
 import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
+import { AuthDto, PartnerDirection, PartnerService } from 'src/domain';
+import { PartnerResponseDto, UpdatePartnerDto } from 'src/domain/partner/partner.dto';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/person.controller.ts
+++ b/server/src/immich/controllers/person.controller.ts
@@ -1,3 +1,6 @@
+import { Body, Controller, Get, Next, Param, Post, Put, Query, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { NextFunction, Response } from 'express';
 import {
   AssetFaceUpdateDto,
   AssetResponseDto,
@@ -11,10 +14,7 @@ import {
   PersonService,
   PersonStatisticsResponseDto,
   PersonUpdateDto,
-} from '@app/domain';
-import { Body, Controller, Get, Next, Param, Post, Put, Query, Res } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { NextFunction, Response } from 'express';
+} from 'src/domain';
 import { Auth, Authenticated, FileResponse } from '../app.guard';
 import { UseValidation, sendFile } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/search.controller.ts
+++ b/server/src/immich/controllers/search.controller.ts
@@ -1,3 +1,5 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   AuthDto,
   PersonResponseDto,
@@ -6,9 +8,7 @@ import {
   SearchPeopleDto,
   SearchResponseDto,
   SearchService,
-} from '@app/domain';
-import { Controller, Get, Query } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/server-info.controller.ts
+++ b/server/src/immich/controllers/server-info.controller.ts
@@ -1,3 +1,5 @@
+import { Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   ServerConfigDto,
   ServerFeaturesDto,
@@ -8,9 +10,7 @@ import {
   ServerStatsResponseDto,
   ServerThemeDto,
   ServerVersionResponseDto,
-} from '@app/domain';
-import { Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { AdminRoute, Authenticated, PublicRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/shared-link.controller.ts
+++ b/server/src/immich/controllers/shared-link.controller.ts
@@ -1,3 +1,6 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query, Req, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
 import {
   AssetIdsDto,
   AssetIdsResponseDto,
@@ -8,10 +11,7 @@ import {
   SharedLinkPasswordDto,
   SharedLinkResponseDto,
   SharedLinkService,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query, Req, Res } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
-import { Request, Response } from 'express';
+} from 'src/domain';
 import { Auth, Authenticated, SharedLinkRoute } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/system-config.controller.ts
+++ b/server/src/immich/controllers/system-config.controller.ts
@@ -1,7 +1,7 @@
-import { SystemConfigDto, SystemConfigService, SystemConfigTemplateStorageOptionDto } from '@app/domain';
-import { MapThemeDto } from '@app/domain/system-config/system-config-map-theme.dto';
 import { Body, Controller, Get, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { SystemConfigDto, SystemConfigService, SystemConfigTemplateStorageOptionDto } from 'src/domain';
+import { MapThemeDto } from 'src/domain/system-config/system-config-map-theme.dto';
 import { AdminRoute, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/tag.controller.ts
+++ b/server/src/immich/controllers/tag.controller.ts
@@ -1,3 +1,5 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import {
   AssetIdsDto,
   AssetIdsResponseDto,
@@ -7,9 +9,7 @@ import {
   TagResponseDto,
   TagService,
   UpdateTagDto,
-} from '@app/domain';
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+} from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 import { UUIDParamDto } from './dto/uuid-param.dto';

--- a/server/src/immich/controllers/trash.controller.ts
+++ b/server/src/immich/controllers/trash.controller.ts
@@ -1,6 +1,6 @@
-import { AuthDto, BulkIdsDto, TrashService } from '@app/domain';
 import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { AuthDto, BulkIdsDto, TrashService } from 'src/domain';
 import { Auth, Authenticated } from '../app.guard';
 import { UseValidation } from '../app.utils';
 

--- a/server/src/immich/controllers/user.controller.ts
+++ b/server/src/immich/controllers/user.controller.ts
@@ -1,13 +1,4 @@
 import {
-  AuthDto,
-  CreateUserDto as CreateDto,
-  CreateProfileImageDto,
-  CreateProfileImageResponseDto,
-  UpdateUserDto as UpdateDto,
-  UserResponseDto,
-  UserService,
-} from '@app/domain';
-import {
   Body,
   Controller,
   Delete,
@@ -25,6 +16,15 @@ import {
 } from '@nestjs/common';
 import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { NextFunction, Response } from 'express';
+import {
+  AuthDto,
+  CreateUserDto as CreateDto,
+  CreateProfileImageDto,
+  CreateProfileImageResponseDto,
+  UpdateUserDto as UpdateDto,
+  UserResponseDto,
+  UserService,
+} from 'src/domain';
 import { AdminRoute, Auth, Authenticated, FileResponse } from '../app.guard';
 import { UseValidation, sendFile } from '../app.utils';
 import { FileUploadInterceptor, Route } from '../interceptors';

--- a/server/src/immich/interceptors/error.interceptor.ts
+++ b/server/src/immich/interceptors/error.interceptor.ts
@@ -1,4 +1,3 @@
-import { ImmichLogger } from '@app/infra/logger';
 import {
   CallHandler,
   ExecutionContext,
@@ -8,6 +7,7 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { Observable, catchError, throwError } from 'rxjs';
+import { ImmichLogger } from 'src/infra/logger';
 import { isConnectionAborted } from '../../domain';
 import { routeToErrorMessage } from '../app.utils';
 

--- a/server/src/immich/interceptors/file-upload.interceptor.ts
+++ b/server/src/immich/interceptors/file-upload.interceptor.ts
@@ -1,5 +1,3 @@
-import { AssetService, UploadFieldName, UploadFile } from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { Reflector } from '@nestjs/core';
@@ -8,6 +6,8 @@ import { createHash, randomUUID } from 'crypto';
 import { NextFunction, RequestHandler } from 'express';
 import multer, { StorageEngine, diskStorage } from 'multer';
 import { Observable } from 'rxjs';
+import { AssetService, UploadFieldName, UploadFile } from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 import { AuthRequest } from '../app.guard';
 
 export enum Route {

--- a/server/src/immich/main.ts
+++ b/server/src/immich/main.ts
@@ -1,10 +1,10 @@
-import { envName, isDev, serverVersion } from '@app/domain';
-import { WebSocketAdapter } from '@app/infra';
-import { ImmichLogger } from '@app/infra/logger';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { json } from 'body-parser';
 import cookieParser from 'cookie-parser';
+import { envName, isDev, serverVersion } from 'src/domain';
+import { WebSocketAdapter } from 'src/infra';
+import { ImmichLogger } from 'src/infra/logger';
 import { AppModule } from './app.module';
 import { AppService } from './app.service';
 import { useSwagger } from './app.utils';

--- a/server/src/infra/entities/geodata-places.entity.ts
+++ b/server/src/infra/entities/geodata-places.entity.ts
@@ -1,5 +1,5 @@
-import { GeodataAdmin1Entity } from '@app/infra/entities/geodata-admin1.entity';
-import { GeodataAdmin2Entity } from '@app/infra/entities/geodata-admin2.entity';
+import { GeodataAdmin1Entity } from 'src/infra/entities/geodata-admin1.entity';
+import { GeodataAdmin2Entity } from 'src/infra/entities/geodata-admin2.entity';
 import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 
 @Entity('geodata_places', { synchronize: false })

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -1,4 +1,4 @@
-import { ConcurrentQueueName } from '@app/domain';
+import { ConcurrentQueueName } from 'src/domain';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('system_config')

--- a/server/src/infra/infra.config.ts
+++ b/server/src/infra/infra.config.ts
@@ -1,7 +1,7 @@
-import { QueueName } from '@app/domain';
 import { RegisterQueueOptions } from '@nestjs/bullmq';
 import { QueueOptions } from 'bullmq';
 import { RedisOptions } from 'ioredis';
+import { QueueName } from 'src/domain';
 
 function parseRedisConfig(): RedisOptions {
   const redisUrl = process.env.REDIS_URL;

--- a/server/src/infra/infra.module.ts
+++ b/server/src/infra/infra.module.ts
@@ -1,3 +1,8 @@
+import { BullModule } from '@nestjs/bullmq';
+import { Global, Module, Provider } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import {
   IAccessRepository,
   IActivityRepository,
@@ -27,12 +32,7 @@ import {
   IUserRepository,
   IUserTokenRepository,
   immichAppConfig,
-} from '@app/domain';
-import { BullModule } from '@nestjs/bullmq';
-import { Global, Module, Provider } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
-import { TypeOrmModule } from '@nestjs/typeorm';
+} from 'src/domain';
 import { databaseConfig } from './database.config';
 import { databaseEntities } from './entities';
 import { bullConfig, bullQueues } from './infra.config';

--- a/server/src/infra/infra.utils.ts
+++ b/server/src/infra/infra.utils.ts
@@ -1,5 +1,5 @@
-import { Paginated, PaginationOptions } from '@app/domain';
 import _ from 'lodash';
+import { Paginated, PaginationOptions } from 'src/domain';
 import { Between, FindManyOptions, LessThanOrEqual, MoreThanOrEqual, ObjectLiteral, Repository } from 'typeorm';
 import { chunks, setUnion } from '../domain/domain.util';
 import { DATABASE_PARAMETER_CHUNK_SIZE } from './infra.util';

--- a/server/src/infra/migrations/1700713871511-UsePgVectors.ts
+++ b/server/src/infra/migrations/1700713871511-UsePgVectors.ts
@@ -1,4 +1,4 @@
-import { getCLIPModelInfo } from '@app/domain/smart-info/smart-info.constant';
+import { getCLIPModelInfo } from 'src/domain/smart-info/smart-info.constant';
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class UsePgVectors1700713871511 implements MigrationInterface {
@@ -12,12 +12,14 @@ export class UsePgVectors1700713871511 implements MigrationInterface {
         LIMIT 1`);
     const faceDimSize = faceDimQuery?.[0]?.['dimsize'] ?? 512;
 
-    const clipModelNameQuery = await queryRunner.query(`SELECT value FROM system_config WHERE key = 'machineLearning.clip.modelName'`);
+    const clipModelNameQuery = await queryRunner.query(
+      `SELECT value FROM system_config WHERE key = 'machineLearning.clip.modelName'`,
+    );
     const clipModelName: string = clipModelNameQuery?.[0]?.['value'] ?? 'ViT-B-32__openai';
     const clipDimSize = getCLIPModelInfo(clipModelName.replace(/"/g, '')).dimSize;
 
     await queryRunner.query(`
-        ALTER TABLE asset_faces 
+        ALTER TABLE asset_faces
         ALTER COLUMN embedding SET NOT NULL,
         ALTER COLUMN embedding TYPE vector(${faceDimSize})`);
 
@@ -35,7 +37,7 @@ export class UsePgVectors1700713871511 implements MigrationInterface {
         AND array_position(si."clipEmbedding", NULL) IS NULL`);
 
     await queryRunner.query(`ALTER TABLE smart_info DROP COLUMN IF EXISTS "clipEmbedding"`);
-    }
+  }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE asset_faces ALTER COLUMN embedding TYPE real array`);

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -1,5 +1,5 @@
-import { IAccessRepository, chunks, setUnion } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IAccessRepository, chunks, setUnion } from 'src/domain';
 import { Brackets, In, Repository } from 'typeorm';
 import {
   ActivityEntity,

--- a/server/src/infra/repositories/activity.repository.ts
+++ b/server/src/infra/repositories/activity.repository.ts
@@ -1,6 +1,6 @@
-import { IActivityRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IActivityRepository } from 'src/domain';
 import { IsNull, Repository } from 'typeorm';
 import { ActivityEntity } from '../entities/activity.entity';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/album.repository.ts
+++ b/server/src/infra/repositories/album.repository.ts
@@ -1,7 +1,7 @@
-import { AlbumAsset, AlbumAssetCount, AlbumAssets, AlbumInfoOptions, IAlbumRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import _ from 'lodash';
+import { AlbumAsset, AlbumAssetCount, AlbumAssets, AlbumInfoOptions, IAlbumRepository } from 'src/domain';
 import { DataSource, FindOptionsOrder, FindOptionsRelations, In, IsNull, Not, Repository } from 'typeorm';
 import { setUnion } from '../../domain/domain.util';
 import { dataSource } from '../database.config';

--- a/server/src/infra/repositories/api-key.repository.ts
+++ b/server/src/infra/repositories/api-key.repository.ts
@@ -1,6 +1,6 @@
-import { IKeyRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IKeyRepository } from 'src/domain';
 import { Repository } from 'typeorm';
 import { APIKeyEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/asset-stack.repository.ts
+++ b/server/src/infra/repositories/asset-stack.repository.ts
@@ -1,6 +1,6 @@
-import { IAssetStackRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IAssetStackRepository } from 'src/domain';
 import { Repository } from 'typeorm';
 import { AssetStackEntity } from '../entities';
 

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -1,3 +1,8 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import _ from 'lodash';
+import { DateTime } from 'luxon';
+import path from 'path';
 import {
   AssetBuilderOptions,
   AssetCreate,
@@ -19,12 +24,7 @@ import {
   TimeBucketSize,
   WithProperty,
   WithoutProperty,
-} from '@app/domain';
-import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import _ from 'lodash';
-import { DateTime } from 'luxon';
-import path from 'path';
+} from 'src/domain';
 import {
   And,
   Brackets,

--- a/server/src/infra/repositories/audit.repository.ts
+++ b/server/src/infra/repositories/audit.repository.ts
@@ -1,5 +1,5 @@
-import { AuditSearch, IAuditRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AuditSearch, IAuditRepository } from 'src/domain';
 import { LessThan, MoreThan, Repository } from 'typeorm';
 import { AuditEntity } from '../entities';
 

--- a/server/src/infra/repositories/communication.repository.ts
+++ b/server/src/infra/repositories/communication.repository.ts
@@ -1,13 +1,4 @@
 import {
-  AuthService,
-  ClientEvent,
-  ICommunicationRepository,
-  OnConnectCallback,
-  OnServerEventCallback,
-  ServerEvent,
-} from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
-import {
   OnGatewayConnection,
   OnGatewayDisconnect,
   OnGatewayInit,
@@ -15,6 +6,15 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import {
+  AuthService,
+  ClientEvent,
+  ICommunicationRepository,
+  OnConnectCallback,
+  OnServerEventCallback,
+  ServerEvent,
+} from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 
 @WebSocketGateway({
   cors: true,

--- a/server/src/infra/repositories/crypto.repository.ts
+++ b/server/src/infra/repositories/crypto.repository.ts
@@ -1,8 +1,8 @@
-import { ICryptoRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { compareSync, hash } from 'bcrypt';
 import { createHash, randomBytes, randomUUID } from 'crypto';
 import { createReadStream } from 'fs';
+import { ICryptoRepository } from 'src/domain';
 
 @Injectable()
 export class CryptoRepository implements ICryptoRepository {

--- a/server/src/infra/repositories/database.repository.ts
+++ b/server/src/infra/repositories/database.repository.ts
@@ -1,7 +1,7 @@
-import { DatabaseExtension, DatabaseLock, IDatabaseRepository, Version } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import AsyncLock from 'async-lock';
+import { DatabaseExtension, DatabaseLock, IDatabaseRepository, Version } from 'src/domain';
 import { DataSource, QueryRunner } from 'typeorm';
 
 @Injectable()

--- a/server/src/infra/repositories/filesystem.provider.spec.ts
+++ b/server/src/infra/repositories/filesystem.provider.spec.ts
@@ -1,5 +1,5 @@
-import { CrawlOptionsDto } from '@app/domain';
 import mockfs from 'mock-fs';
+import { CrawlOptionsDto } from 'src/domain';
 import { FilesystemProvider } from './filesystem.provider';
 
 interface Test {

--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -1,17 +1,17 @@
-import {
-  CrawlOptionsDto,
-  DiskUsage,
-  ImmichReadStream,
-  ImmichZipStream,
-  IStorageRepository,
-  mimeTypes,
-} from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
 import archiver from 'archiver';
 import { constants, createReadStream, existsSync, mkdirSync } from 'fs';
 import fs, { copyFile, readdir, rename, writeFile } from 'fs/promises';
 import { glob } from 'glob';
 import path from 'path';
+import {
+  CrawlOptionsDto,
+  DiskUsage,
+  IStorageRepository,
+  ImmichReadStream,
+  ImmichZipStream,
+  mimeTypes,
+} from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 
 export class FilesystemProvider implements IStorageRepository {
   private logger = new ImmichLogger(FilesystemProvider.name);

--- a/server/src/infra/repositories/job.repository.ts
+++ b/server/src/infra/repositories/job.repository.ts
@@ -1,20 +1,20 @@
-import {
-  IJobRepository,
-  JobCounts,
-  JobItem,
-  JobName,
-  JOBS_TO_QUEUE,
-  QueueCleanType,
-  QueueName,
-  QueueStatus,
-} from '@app/domain';
-import { ImmichLogger } from '@app/infra/logger';
 import { getQueueToken } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Job, JobsOptions, Processor, Queue, Worker, WorkerOptions } from 'bullmq';
 import { CronJob, CronTime } from 'cron';
+import {
+  IJobRepository,
+  JOBS_TO_QUEUE,
+  JobCounts,
+  JobItem,
+  JobName,
+  QueueCleanType,
+  QueueName,
+  QueueStatus,
+} from 'src/domain';
+import { ImmichLogger } from 'src/infra/logger';
 import { setTimeout } from 'timers/promises';
 import { bullConfig } from '../infra.config';
 

--- a/server/src/infra/repositories/library.repository.ts
+++ b/server/src/infra/repositories/library.repository.ts
@@ -1,6 +1,6 @@
-import { ILibraryRepository, LibraryStatsResponseDto } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ILibraryRepository, LibraryStatsResponseDto } from 'src/domain';
 import { IsNull, Not } from 'typeorm';
 import { Repository } from 'typeorm/repository/Repository';
 import { LibraryEntity, LibraryType } from '../entities';

--- a/server/src/infra/repositories/machine-learning.repository.ts
+++ b/server/src/infra/repositories/machine-learning.repository.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { readFile } from 'fs/promises';
 import {
   CLIPConfig,
   CLIPMode,
@@ -8,9 +10,7 @@ import {
   RecognitionConfig,
   TextModelInput,
   VisionModelInput,
-} from '@app/domain';
-import { Injectable } from '@nestjs/common';
-import { readFile } from 'fs/promises';
+} from 'src/domain';
 
 const errorPrefix = 'Machine learning request';
 

--- a/server/src/infra/repositories/media.repository.ts
+++ b/server/src/infra/repositories/media.repository.ts
@@ -1,9 +1,9 @@
-import { CropOptions, IMediaRepository, ResizeOptions, TranscodeOptions, VideoInfo } from '@app/domain';
-import { Colorspace } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import ffmpeg, { FfprobeData } from 'fluent-ffmpeg';
 import fs from 'fs/promises';
 import sharp from 'sharp';
+import { CropOptions, IMediaRepository, ResizeOptions, TranscodeOptions, VideoInfo } from 'src/domain';
+import { Colorspace } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { Writable } from 'stream';
 import { promisify } from 'util';
 

--- a/server/src/infra/repositories/metadata.repository.ts
+++ b/server/src/infra/repositories/metadata.repository.ts
@@ -1,25 +1,25 @@
-import {
-  citiesFile,
-  geodataAdmin1Path,
-  geodataAdmin2Path,
-  geodataCitites500Path,
-  geodataDatePath,
-  GeoPoint,
-  IMetadataRepository,
-  ImmichTags,
-  ISystemMetadataRepository,
-  ReverseGeocodeResult,
-} from '@app/domain';
-import { GeodataAdmin1Entity, GeodataAdmin2Entity, GeodataPlacesEntity, SystemMetadataKey } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Inject } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DefaultReadTaskOptions, exiftool, Tags } from 'exiftool-vendored';
+import { DefaultReadTaskOptions, Tags, exiftool } from 'exiftool-vendored';
 import { createReadStream, existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import * as geotz from 'geo-tz';
 import { getName } from 'i18n-iso-countries';
 import * as readLine from 'readline';
+import {
+  GeoPoint,
+  IMetadataRepository,
+  ISystemMetadataRepository,
+  ImmichTags,
+  ReverseGeocodeResult,
+  citiesFile,
+  geodataAdmin1Path,
+  geodataAdmin2Path,
+  geodataCitites500Path,
+  geodataDatePath,
+} from 'src/domain';
+import { GeodataAdmin1Entity, GeodataAdmin2Entity, GeodataPlacesEntity, SystemMetadataKey } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { DataSource, DeepPartial, QueryRunner, Repository } from 'typeorm';
 
 type GeoEntity = GeodataPlacesEntity | GeodataAdmin1Entity | GeodataAdmin2Entity;

--- a/server/src/infra/repositories/move.repository.ts
+++ b/server/src/infra/repositories/move.repository.ts
@@ -1,6 +1,6 @@
-import { IMoveRepository, MoveCreate } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IMoveRepository, MoveCreate } from 'src/domain';
 import { Repository } from 'typeorm';
 import { MoveEntity, PathType } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/partner.repository.ts
+++ b/server/src/infra/repositories/partner.repository.ts
@@ -1,6 +1,6 @@
-import { IPartnerRepository, PartnerIds } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IPartnerRepository, PartnerIds } from 'src/domain';
 import { DeepPartial, Repository } from 'typeorm';
 import { PartnerEntity } from '../entities';
 

--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -1,3 +1,5 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import _ from 'lodash';
 import {
   AssetFaceId,
   IPersonRepository,
@@ -7,9 +9,7 @@ import {
   PersonSearchOptions,
   PersonStatistics,
   UpdateFacesData,
-} from '@app/domain';
-import { InjectRepository } from '@nestjs/typeorm';
-import _ from 'lodash';
+} from 'src/domain';
 import { FindManyOptions, FindOptionsRelations, FindOptionsSelect, In, Repository } from 'typeorm';
 import { AssetEntity, AssetFaceEntity, PersonEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/server-info.repository.ts
+++ b/server/src/infra/repositories/server-info.repository.ts
@@ -1,6 +1,6 @@
-import { GitHubRelease, IServerInfoRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
+import { GitHubRelease, IServerInfoRepository } from 'src/domain';
 
 @Injectable()
 export class ServerInfoRepository implements IServerInfoRepository {

--- a/server/src/infra/repositories/shared-link.repository.ts
+++ b/server/src/infra/repositories/shared-link.repository.ts
@@ -1,6 +1,6 @@
-import { ISharedLinkRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ISharedLinkRepository } from 'src/domain';
 import { Repository } from 'typeorm';
 import { SharedLinkEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/smart-info.repository.ts
+++ b/server/src/infra/repositories/smart-info.repository.ts
@@ -1,9 +1,9 @@
-import { Embedding, EmbeddingSearch, FaceEmbeddingSearch, FaceSearchResult, ISmartInfoRepository } from '@app/domain';
-import { getCLIPModelInfo } from '@app/domain/smart-info/smart-info.constant';
-import { AssetEntity, AssetFaceEntity, SmartInfoEntity, SmartSearchEntity } from '@app/infra/entities';
-import { ImmichLogger } from '@app/infra/logger';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Embedding, EmbeddingSearch, FaceEmbeddingSearch, FaceSearchResult, ISmartInfoRepository } from 'src/domain';
+import { getCLIPModelInfo } from 'src/domain/smart-info/smart-info.constant';
+import { AssetEntity, AssetFaceEntity, SmartInfoEntity, SmartSearchEntity } from 'src/infra/entities';
+import { ImmichLogger } from 'src/infra/logger';
 import { Repository } from 'typeorm';
 import { DummyValue, GenerateSql } from '../infra.util';
 import { asVector, isValidInteger } from '../infra.utils';

--- a/server/src/infra/repositories/system-config.repository.ts
+++ b/server/src/infra/repositories/system-config.repository.ts
@@ -1,7 +1,7 @@
-import { ISystemConfigRepository } from '@app/domain';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
 import { readFile } from 'fs/promises';
+import { ISystemConfigRepository } from 'src/domain';
 import { In, Repository } from 'typeorm';
 import { SystemConfigEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/system-metadata.repository.ts
+++ b/server/src/infra/repositories/system-metadata.repository.ts
@@ -1,5 +1,5 @@
-import { ISystemMetadataRepository } from '@app/domain/repositories/system-metadata.repository';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ISystemMetadataRepository } from 'src/domain/repositories/system-metadata.repository';
 import { Repository } from 'typeorm';
 import { SystemMetadata, SystemMetadataEntity } from '../entities';
 

--- a/server/src/infra/repositories/tag.repository.ts
+++ b/server/src/infra/repositories/tag.repository.ts
@@ -1,7 +1,7 @@
-import { ITagRepository } from '@app/domain';
-import { AssetEntity, TagEntity } from '@app/infra/entities';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ITagRepository } from 'src/domain';
+import { AssetEntity, TagEntity } from 'src/infra/entities';
 import { Repository } from 'typeorm';
 
 @Injectable()

--- a/server/src/infra/repositories/user-token.repository.ts
+++ b/server/src/infra/repositories/user-token.repository.ts
@@ -1,6 +1,6 @@
-import { IUserTokenRepository } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IUserTokenRepository } from 'src/domain';
 import { Repository } from 'typeorm';
 import { UserTokenEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/repositories/user.repository.ts
+++ b/server/src/infra/repositories/user.repository.ts
@@ -1,6 +1,6 @@
-import { IUserRepository, UserFindOptions, UserListFilter, UserStatsQueryResponse } from '@app/domain';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { IUserRepository, UserFindOptions, UserListFilter, UserStatsQueryResponse } from 'src/domain';
 import { IsNull, Not, Repository } from 'typeorm';
 import { AssetEntity, UserEntity } from '../entities';
 import { DummyValue, GenerateSql } from '../infra.util';

--- a/server/src/infra/sql-generator/index.ts
+++ b/server/src/infra/sql-generator/index.ts
@@ -1,10 +1,10 @@
-import { ISystemConfigRepository } from '@app/domain';
 import { INestApplication } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { mkdir, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { ISystemConfigRepository } from 'src/domain';
 import { databaseConfig } from '../database.config';
 import { databaseEntities } from '../entities';
 import { GENERATE_SQL_KEY, GenerateSqlQueries } from '../infra.util';

--- a/server/src/microservices/app.service.ts
+++ b/server/src/microservices/app.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import {
   AssetService,
   AuditService,
@@ -14,8 +15,7 @@ import {
   StorageTemplateService,
   SystemConfigService,
   UserService,
-} from '@app/domain';
-import { Injectable } from '@nestjs/common';
+} from 'src/domain';
 
 @Injectable()
 export class AppService {

--- a/server/src/microservices/main.ts
+++ b/server/src/microservices/main.ts
@@ -1,7 +1,7 @@
-import { envName, serverVersion } from '@app/domain';
-import { WebSocketAdapter } from '@app/infra';
-import { ImmichLogger } from '@app/infra/logger';
 import { NestFactory } from '@nestjs/core';
+import { envName, serverVersion } from 'src/domain';
+import { WebSocketAdapter } from 'src/infra';
+import { ImmichLogger } from 'src/infra/logger';
 import { MicroservicesModule } from './microservices.module';
 
 const logger = new ImmichLogger('ImmichMicroservice');

--- a/server/src/microservices/microservices.module.ts
+++ b/server/src/microservices/microservices.module.ts
@@ -1,6 +1,6 @@
-import { DomainModule } from '@app/domain';
-import { InfraModule } from '@app/infra';
 import { Module, OnModuleInit } from '@nestjs/common';
+import { DomainModule } from 'src/domain';
+import { InfraModule } from 'src/infra';
 import { AppService } from './app.service';
 
 @Module({

--- a/server/test/fixtures/activity.stub.ts
+++ b/server/test/fixtures/activity.stub.ts
@@ -1,4 +1,4 @@
-import { ActivityEntity } from '@app/infra/entities';
+import { ActivityEntity } from 'src/infra/entities';
 import { albumStub } from './album.stub';
 import { assetStub } from './asset.stub';
 import { authStub } from './auth.stub';

--- a/server/test/fixtures/album.stub.ts
+++ b/server/test/fixtures/album.stub.ts
@@ -1,4 +1,4 @@
-import { AlbumEntity } from '@app/infra/entities';
+import { AlbumEntity } from 'src/infra/entities';
 import { assetStub } from './asset.stub';
 import { authStub } from './auth.stub';
 import { userStub } from './user.stub';

--- a/server/test/fixtures/api-key.stub.ts
+++ b/server/test/fixtures/api-key.stub.ts
@@ -1,4 +1,4 @@
-import { APIKeyEntity } from '@app/infra/entities';
+import { APIKeyEntity } from 'src/infra/entities';
 import { authStub } from './auth.stub';
 import { userStub } from './user.stub';
 

--- a/server/test/fixtures/asset.stub.ts
+++ b/server/test/fixtures/asset.stub.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, AssetStackEntity, AssetType, ExifEntity } from '@app/infra/entities';
+import { AssetEntity, AssetStackEntity, AssetType, ExifEntity } from 'src/infra/entities';
 import { authStub } from './auth.stub';
 import { fileStub } from './file.stub';
 import { libraryStub } from './library.stub';

--- a/server/test/fixtures/audit.stub.ts
+++ b/server/test/fixtures/audit.stub.ts
@@ -1,4 +1,4 @@
-import { AuditEntity, DatabaseAction, EntityType } from '@app/infra/entities';
+import { AuditEntity, DatabaseAction, EntityType } from 'src/infra/entities';
 import { authStub } from './auth.stub';
 
 export const auditStub = {

--- a/server/test/fixtures/auth.stub.ts
+++ b/server/test/fixtures/auth.stub.ts
@@ -1,4 +1,4 @@
-import { AuthDto } from '@app/domain';
+import { AuthDto } from 'src/domain';
 import { SharedLinkEntity, UserEntity, UserTokenEntity } from '../../src/infra/entities';
 
 export const adminSignupStub = {

--- a/server/test/fixtures/face.stub.ts
+++ b/server/test/fixtures/face.stub.ts
@@ -1,4 +1,4 @@
-import { AssetFaceEntity } from '@app/infra/entities';
+import { AssetFaceEntity } from 'src/infra/entities';
 import { assetStub } from './asset.stub';
 import { personStub } from './person.stub';
 

--- a/server/test/fixtures/library.stub.ts
+++ b/server/test/fixtures/library.stub.ts
@@ -1,4 +1,4 @@
-import { LibraryEntity, LibraryType } from '@app/infra/entities';
+import { LibraryEntity, LibraryType } from 'src/infra/entities';
 import { userStub } from './user.stub';
 
 export const libraryStub = {

--- a/server/test/fixtures/media.stub.ts
+++ b/server/test/fixtures/media.stub.ts
@@ -1,4 +1,4 @@
-import { AudioStreamInfo, VideoFormat, VideoInfo, VideoStreamInfo } from '@app/domain';
+import { AudioStreamInfo, VideoFormat, VideoInfo, VideoStreamInfo } from 'src/domain';
 
 const probeStubDefaultFormat: VideoFormat = {
   formatName: 'mov,mp4,m4a,3gp,3g2,mj2',

--- a/server/test/fixtures/partner.stub.ts
+++ b/server/test/fixtures/partner.stub.ts
@@ -1,4 +1,4 @@
-import { PartnerEntity } from '@app/infra/entities';
+import { PartnerEntity } from 'src/infra/entities';
 import { userStub } from './user.stub';
 
 export const partnerStub = {

--- a/server/test/fixtures/person.stub.ts
+++ b/server/test/fixtures/person.stub.ts
@@ -1,4 +1,4 @@
-import { PersonEntity } from '@app/infra/entities';
+import { PersonEntity } from 'src/infra/entities';
 import { userStub } from './user.stub';
 
 export const personStub = {

--- a/server/test/fixtures/search.stub.ts
+++ b/server/test/fixtures/search.stub.ts
@@ -1,5 +1,5 @@
-import { SearchResult } from '@app/domain';
-import { AssetEntity, ExifEntity, SmartInfoEntity } from '@app/infra/entities';
+import { SearchResult } from 'src/domain';
+import { AssetEntity, ExifEntity, SmartInfoEntity } from 'src/infra/entities';
 import { assetStub } from '.';
 
 export const searchStub = {

--- a/server/test/fixtures/shared-link.stub.ts
+++ b/server/test/fixtures/shared-link.stub.ts
@@ -1,5 +1,5 @@
-import { AlbumResponseDto, AssetResponseDto, ExifResponseDto, mapUser, SharedLinkResponseDto } from '@app/domain';
-import { AssetType, SharedLinkEntity, SharedLinkType, UserEntity } from '@app/infra/entities';
+import { AlbumResponseDto, AssetResponseDto, ExifResponseDto, SharedLinkResponseDto, mapUser } from 'src/domain';
+import { AssetType, SharedLinkEntity, SharedLinkType, UserEntity } from 'src/infra/entities';
 import { assetStub } from './asset.stub';
 import { authStub } from './auth.stub';
 import { libraryStub } from './library.stub';

--- a/server/test/fixtures/system-config.stub.ts
+++ b/server/test/fixtures/system-config.stub.ts
@@ -1,4 +1,4 @@
-import { SystemConfigEntity, SystemConfigKey } from '@app/infra/entities';
+import { SystemConfigEntity, SystemConfigKey } from 'src/infra/entities';
 
 export const systemConfigStub: Record<string, SystemConfigEntity[]> = {
   defaults: [],

--- a/server/test/fixtures/tag.stub.ts
+++ b/server/test/fixtures/tag.stub.ts
@@ -1,5 +1,5 @@
-import { TagResponseDto } from '@app/domain';
-import { TagEntity, TagType } from '@app/infra/entities';
+import { TagResponseDto } from 'src/domain';
+import { TagEntity, TagType } from 'src/infra/entities';
 import { userStub } from './user.stub';
 
 export const tagStub = {

--- a/server/test/fixtures/user-token.stub.ts
+++ b/server/test/fixtures/user-token.stub.ts
@@ -1,4 +1,4 @@
-import { UserTokenEntity } from '@app/infra/entities';
+import { UserTokenEntity } from 'src/infra/entities';
 import { userStub } from './user.stub';
 
 export const userTokenStub = {

--- a/server/test/fixtures/user.stub.ts
+++ b/server/test/fixtures/user.stub.ts
@@ -1,4 +1,4 @@
-import { UserAvatarColor, UserEntity } from '@app/infra/entities';
+import { UserAvatarColor, UserEntity } from 'src/infra/entities';
 import { authStub } from './auth.stub';
 
 export const userDto = {

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -1,4 +1,4 @@
-import { AccessCore, IAccessRepository } from '@app/domain';
+import { AccessCore, IAccessRepository } from 'src/domain';
 
 export interface IAccessRepositoryMock {
   activity: jest.Mocked<IAccessRepository['activity']>;

--- a/server/test/repositories/activity.repository.mock.ts
+++ b/server/test/repositories/activity.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IActivityRepository } from '@app/domain';
+import { IActivityRepository } from 'src/domain';
 
 export const newActivityRepositoryMock = (): jest.Mocked<IActivityRepository> => {
   return {

--- a/server/test/repositories/album.repository.mock.ts
+++ b/server/test/repositories/album.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IAlbumRepository } from '@app/domain';
+import { IAlbumRepository } from 'src/domain';
 
 export const newAlbumRepositoryMock = (): jest.Mocked<IAlbumRepository> => {
   return {

--- a/server/test/repositories/api-key.repository.mock.ts
+++ b/server/test/repositories/api-key.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IKeyRepository } from '@app/domain';
+import { IKeyRepository } from 'src/domain';
 
 export const newKeyRepositoryMock = (): jest.Mocked<IKeyRepository> => {
   return {

--- a/server/test/repositories/asset-stack.repository.mock.ts
+++ b/server/test/repositories/asset-stack.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IAssetStackRepository } from '@app/domain';
+import { IAssetStackRepository } from 'src/domain';
 
 export const newAssetStackRepositoryMock = (): jest.Mocked<IAssetStackRepository> => {
   return {

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IAssetRepository } from '@app/domain';
+import { IAssetRepository } from 'src/domain';
 
 export const newAssetRepositoryMock = (): jest.Mocked<IAssetRepository> => {
   return {

--- a/server/test/repositories/audit.repository.mock.ts
+++ b/server/test/repositories/audit.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IAuditRepository } from '@app/domain';
+import { IAuditRepository } from 'src/domain';
 
 export const newAuditRepositoryMock = (): jest.Mocked<IAuditRepository> => {
   return {

--- a/server/test/repositories/communication.repository.mock.ts
+++ b/server/test/repositories/communication.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ICommunicationRepository } from '@app/domain';
+import { ICommunicationRepository } from 'src/domain';
 
 export const newCommunicationRepositoryMock = (): jest.Mocked<ICommunicationRepository> => {
   return {

--- a/server/test/repositories/crypto.repository.mock.ts
+++ b/server/test/repositories/crypto.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ICryptoRepository } from '@app/domain';
+import { ICryptoRepository } from 'src/domain';
 
 export const newCryptoRepositoryMock = (): jest.Mocked<ICryptoRepository> => {
   return {

--- a/server/test/repositories/database.repository.mock.ts
+++ b/server/test/repositories/database.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IDatabaseRepository, Version } from '@app/domain';
+import { IDatabaseRepository, Version } from 'src/domain';
 
 export const newDatabaseRepositoryMock = (): jest.Mocked<IDatabaseRepository> => {
   return {

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IJobRepository } from '@app/domain';
+import { IJobRepository } from 'src/domain';
 
 export const newJobRepositoryMock = (): jest.Mocked<IJobRepository> => {
   return {

--- a/server/test/repositories/library.repository.mock.ts
+++ b/server/test/repositories/library.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ILibraryRepository } from '@app/domain';
+import { ILibraryRepository } from 'src/domain';
 
 export const newLibraryRepositoryMock = (): jest.Mocked<ILibraryRepository> => {
   return {

--- a/server/test/repositories/machine-learning.repository.mock.ts
+++ b/server/test/repositories/machine-learning.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IMachineLearningRepository } from '@app/domain';
+import { IMachineLearningRepository } from 'src/domain';
 
 export const newMachineLearningRepositoryMock = (): jest.Mocked<IMachineLearningRepository> => {
   return {

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IMediaRepository } from '@app/domain';
+import { IMediaRepository } from 'src/domain';
 
 export const newMediaRepositoryMock = (): jest.Mocked<IMediaRepository> => {
   return {

--- a/server/test/repositories/metadata.repository.mock.ts
+++ b/server/test/repositories/metadata.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IMetadataRepository } from '@app/domain';
+import { IMetadataRepository } from 'src/domain';
 
 export const newMetadataRepositoryMock = (): jest.Mocked<IMetadataRepository> => {
   return {

--- a/server/test/repositories/move.repository.mock.ts
+++ b/server/test/repositories/move.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IMoveRepository } from '@app/domain';
+import { IMoveRepository } from 'src/domain';
 
 export const newMoveRepositoryMock = (): jest.Mocked<IMoveRepository> => {
   return {

--- a/server/test/repositories/partner.repository.mock.ts
+++ b/server/test/repositories/partner.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IPartnerRepository } from '@app/domain';
+import { IPartnerRepository } from 'src/domain';
 
 export const newPartnerRepositoryMock = (): jest.Mocked<IPartnerRepository> => {
   return {

--- a/server/test/repositories/person.repository.mock.ts
+++ b/server/test/repositories/person.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IPersonRepository } from '@app/domain';
+import { IPersonRepository } from 'src/domain';
 
 export const newPersonRepositoryMock = (): jest.Mocked<IPersonRepository> => {
   return {

--- a/server/test/repositories/shared-link.repository.mock.ts
+++ b/server/test/repositories/shared-link.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ISharedLinkRepository } from '@app/domain';
+import { ISharedLinkRepository } from 'src/domain';
 
 export const newSharedLinkRepositoryMock = (): jest.Mocked<ISharedLinkRepository> => {
   return {

--- a/server/test/repositories/smart-info.repository.mock.ts
+++ b/server/test/repositories/smart-info.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ISmartInfoRepository } from '@app/domain';
+import { ISmartInfoRepository } from 'src/domain';
 
 export const newSmartInfoRepositoryMock = (): jest.Mocked<ISmartInfoRepository> => {
   return {

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IStorageRepository, StorageCore } from '@app/domain';
+import { IStorageRepository, StorageCore } from 'src/domain';
 
 export const newStorageRepositoryMock = (reset = true): jest.Mocked<IStorageRepository> => {
   if (reset) {

--- a/server/test/repositories/system-config.repository.mock.ts
+++ b/server/test/repositories/system-config.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ISystemConfigRepository, SystemConfigCore } from '@app/domain';
+import { ISystemConfigRepository, SystemConfigCore } from 'src/domain';
 
 export const newSystemConfigRepositoryMock = (reset = true): jest.Mocked<ISystemConfigRepository> => {
   if (reset) {

--- a/server/test/repositories/system-info.repository.mock.ts
+++ b/server/test/repositories/system-info.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IServerInfoRepository } from '@app/domain';
+import { IServerInfoRepository } from 'src/domain';
 
 export const newServerInfoRepositoryMock = (): jest.Mocked<IServerInfoRepository> => {
   return {

--- a/server/test/repositories/system-metadata.repository.mock.ts
+++ b/server/test/repositories/system-metadata.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ISystemMetadataRepository } from '@app/domain';
+import { ISystemMetadataRepository } from 'src/domain';
 
 export const newSystemMetadataRepositoryMock = (): jest.Mocked<ISystemMetadataRepository> => {
   return {

--- a/server/test/repositories/tag.repository.mock.ts
+++ b/server/test/repositories/tag.repository.mock.ts
@@ -1,4 +1,4 @@
-import { ITagRepository } from '@app/domain';
+import { ITagRepository } from 'src/domain';
 
 export const newTagRepositoryMock = (): jest.Mocked<ITagRepository> => {
   return {

--- a/server/test/repositories/user-token.repository.mock.ts
+++ b/server/test/repositories/user-token.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IUserTokenRepository } from '@app/domain';
+import { IUserTokenRepository } from 'src/domain';
 
 export const newUserTokenRepositoryMock = (): jest.Mocked<IUserTokenRepository> => {
   return {

--- a/server/test/repositories/user.repository.mock.ts
+++ b/server/test/repositories/user.repository.mock.ts
@@ -1,4 +1,4 @@
-import { IUserRepository, UserCore } from '@app/domain';
+import { IUserRepository, UserCore } from 'src/domain';
 
 export const newUserRepositoryMock = (reset = true): jest.Mocked<IUserRepository> => {
   if (reset) {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,17 +16,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "preserveWatchOutput": true,
-    "baseUrl": "./",
-    "paths": {
-      "@test": ["test"],
-      "@test/*": ["test/*"],
-      "@app/immich": ["src/immich"],
-      "@app/immich/*": ["src/immich/*"],
-      "@app/infra": ["src/infra"],
-      "@app/infra/*": ["src/infra/*"],
-      "@app/domain": ["src/domain"],
-      "@app/domain/*": ["src/domain/*"]
-    }
+    "baseUrl": "./"
   },
-  "exclude": ["dist", "node_modules", "upload"]
+  "exclude": ["dist", "node_modules", "upload"],
 }


### PR DESCRIPTION
Using modules aliases can be convenient, but also make the build more complex and often frustrating to deal with. This PR replaces modules aliases with root path imports. This has several benefits, including:
- More transparency around where imports are coming from
- Less required configuration to integrate with other tools (like jest)
- Simpler migration path to ESM

Essentially the changeset comes down to removing `tsconfig.paths` settings and `jestConfig.moduleNameMapper` configuration by updating the following imports:

Before:
```typescript
import {} from '@app/domain';
import {} from '@app/infra';
import {} from '@app/immich';
import {} from '@test';
```
After:
```typescript
import {} from 'src/domain';
import {} from 'src/infra';
import {} from 'src/immich';
import {} from 'test';
```

TLDR is this is simpler and looks almost the same as before.

