### PR TITLE
fix(ml): model paths not working

### DIFF
--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel
 
 
 class StrEnum(str, Enum):
+    value: str
+
     def __str__(self) -> str:
         return self.value
 

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -6,6 +6,11 @@ import numpy.typing as npt
 from pydantic import BaseModel
 
 
+class StrEnum(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
 class TextResponse(BaseModel):
     __root__: str
 
@@ -21,12 +26,12 @@ class BoundingBox(TypedDict):
     y2: int
 
 
-class ModelType(str, Enum):
+class ModelType(StrEnum):
     CLIP = "clip"
     FACIAL_RECOGNITION = "facial-recognition"
 
 
-class ModelRuntime(str, Enum):
+class ModelRuntime(StrEnum):
     ONNX = "onnx"
     ARMNN = "armnn"
 


### PR DESCRIPTION
## Description

ML currently uses two string enums. Python 3.11 has a `StrEnum` class that we used for this in the past, but we now have to support 3.10 as well and changed `StrEnum` to `str, Enum` for compatibility. But it looks like these enums have a different string representation than the native `StrEnum`. The latter uses the value as its representation, while the former represents itself as `EnumName.VALUE`. As a result, string interpolation with model paths produces invalid paths.

This PR makes a custom `StrEnum` class to fix this behavior.