### PR TITLE
fix(server): fix person pagination when deleting

### DIFF
--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -258,7 +258,7 @@ export class PersonService {
 
   private async deleteAllPeople() {
     const personPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
-      this.repository.getAll(pagination),
+      this.repository.getAll({ ...pagination, skip: 0 }),
     );
 
     for await (const people of personPagination) {


### PR DESCRIPTION
## Description

We delete all people when running face detection or facial recognition with "All". This is handled by fetching paginated lists of people and deleting them in batches. The issue is that as we're deleting rows from this table, the SKIP value in the pagination query becomes outdated. Once it exceeds the size of the table - the pagination size (1000), the pagination stops early and half of the table remains.

This PR sets the skip value to 0 since we delete all rows in each fetched page, meaning the next batch begins at row 0.

## How Has This Been Tested?

I removed the foreign key constraints to the person table and added 20000 randomly generated rows to it. I then started an "All" job for facial recognition and immediately paused it and observed that it deleted all rows in the table, 1000 at a time.