### PR TITLE
fix(server): do not process faces of deleted assets

### DIFF
--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -788,7 +788,7 @@ describe(PersonService.name, () => {
     });
 
     it('should return false if face does not have asset', async () => {
-      const face = { ...faceStub.face1, asset: null } as AssetFaceEntity & { asset: null};
+      const face = { ...faceStub.face1, asset: null } as AssetFaceEntity & { asset: null };
       personMock.getFaceByIdWithAssets.mockResolvedValue(face);
 
       expect(await sut.handleRecognizeFaces({ id: faceStub.face1.id })).toBe(false);

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
+import { AssetEntity, AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   IAccessRepositoryMock,
@@ -779,6 +779,17 @@ describe(PersonService.name, () => {
   describe('handleRecognizeFaces', () => {
     it('should return false if face does not exist', async () => {
       personMock.getFaceByIdWithAssets.mockResolvedValue(null);
+
+      expect(await sut.handleRecognizeFaces({ id: faceStub.face1.id })).toBe(false);
+
+      expect(personMock.reassignFaces).not.toHaveBeenCalled();
+      expect(personMock.create).not.toHaveBeenCalled();
+      expect(personMock.createFaces).not.toHaveBeenCalled();
+    });
+
+    it('should return false if face does not have asset', async () => {
+      const face = { ...faceStub.face1, asset: null } as AssetFaceEntity & { asset: null};
+      personMock.getFaceByIdWithAssets.mockResolvedValue(face);
 
       expect(await sut.handleRecognizeFaces({ id: faceStub.face1.id })).toBe(false);
 

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetEntity, AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
+import { AssetFaceEntity, Colorspace, SystemConfigKey } from '@app/infra/entities';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   IAccessRepositoryMock,

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -400,7 +400,7 @@ export class PersonService {
       { person: true, asset: true },
       { id: true, personId: true, embedding: true },
     );
-    if (!face) {
+    if (!face || !face.asset) {
       this.logger.warn(`Face ${id} not found`);
       return false;
     }


### PR DESCRIPTION
## Description

When querying for faces during recognition, a face from an asset that was deleted after queueing will throw an error. While TypeORM has a default filter for deleted entities, it still returns an entity if it has deleted relations. The quick fix is to check the asset relation. Moving forward, it may be good to switch to inner joins for relations. This is beyond the scope of this fix as it involves switching to query builders, complicates custom selects, etc.

Fixes #6709
