### PR TITLE
refactor: no experimental vm modules

### DIFF
--- a/docs/docs/developer/testing.md
+++ b/docs/docs/developer/testing.md
@@ -20,8 +20,3 @@ The API e2e tests spin up a test database and execute http requests against the 
 #### Jobs (e2e)
 
 The Jobs e2e tests spin up a docker test environment where thumbnail generation, library scanning, and other _job_ workflows are validated.
-
-:::note
-Note that there is a bug in nodejs \<20.8 that causes segmentation faults when running these tests. If you run into segfaults, ensure you are using at least version 20.8.
-:::
-/follow

--- a/server/bin/immich-test
+++ b/server/bin/immich-test
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-NODE_OPTIONS='--experimental-vm-modules' node /usr/src/app/node_modules/.bin/jest --config e2e/$1/jest-e2e.json --runInBand
+node /usr/src/app/node_modules/.bin/jest --config e2e/$1/jest-e2e.json --runInBand

--- a/server/e2e/jobs/utils.ts
+++ b/server/e2e/jobs/utils.ts
@@ -1,6 +1,7 @@
-import { IJobRepository, JobItem, JobItemHandler, QueueName } from '@app/domain';
+import { IJobRepository, IMediaRepository, JobItem, JobItemHandler, QueueName } from '@app/domain';
 import { AppModule } from '@app/immich';
 import { InfraModule, InfraTestModule, dataSource } from '@app/infra';
+import { MediaRepository } from '@app/infra/repositories';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { DateTime } from 'luxon';
@@ -53,7 +54,42 @@ export const db = {
   },
 };
 
-let _handler: JobItemHandler = () => Promise.resolve();
+class JobMock implements IJobRepository {
+  private _handler: JobItemHandler = () => Promise.resolve();
+  addHandler(_queueName: QueueName, _concurrency: number, handler: JobItemHandler) {
+    this._handler = handler;
+  }
+  addCronJob() {}
+  updateCronJob() {}
+  deleteCronJob() {}
+  validateCronExpression() {}
+  queue(item: JobItem) {
+    return this._handler(item);
+  }
+  queueAll(items: JobItem[]) {
+    return Promise.all(items.map(this._handler)).then(() => Promise.resolve());
+  }
+  async resume() {}
+  async empty() {}
+  async setConcurrency() {}
+  async getQueueStatus() {
+    return null as any;
+  }
+  async getJobCounts() {
+    return null as any;
+  }
+  async pause() {}
+  async clear() {
+    return [];
+  }
+  async waitForQueueCompletion() {}
+}
+
+class MediaMockRepository extends MediaRepository {
+  async generateThumbhash() {
+    return Buffer.from('mock-thumbhash');
+  }
+}
 
 let app: INestApplication;
 
@@ -63,23 +99,9 @@ export const testApp = {
       .overrideModule(InfraModule)
       .useModule(InfraTestModule)
       .overrideProvider(IJobRepository)
-      .useValue({
-        addHandler: (_queueName: QueueName, _concurrency: number, handler: JobItemHandler) => (_handler = handler),
-        addCronJob: jest.fn(),
-        updateCronJob: jest.fn(),
-        deleteCronJob: jest.fn(),
-        validateCronExpression: jest.fn(),
-        queue: (item: JobItem) => _handler(item),
-        queueAll: (items: JobItem[]) => Promise.all(items.map(_handler)).then(() => Promise.resolve()),
-        resume: jest.fn(),
-        empty: jest.fn(),
-        setConcurrency: jest.fn(),
-        getQueueStatus: jest.fn(),
-        getJobCounts: jest.fn(),
-        pause: jest.fn(),
-        clear: jest.fn(),
-        waitForQueueCompletion: jest.fn(),
-      } as IJobRepository)
+      .useClass(JobMock)
+      .overrideProvider(IMediaRepository)
+      .useClass(MediaMockRepository)
       .compile();
 
     app = await moduleFixture.createNestApplication().init();

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "e2e:jobs": "NODE_OPTIONS='--experimental-vm-modules' jest --config e2e/jobs/jest-e2e.json --runInBand",
+    "e2e:jobs": "jest --config e2e/jobs/jest-e2e.json --runInBand",
     "e2e:api": "jest --config e2e/api/jest-e2e.json --runInBand",
     "typeorm": "typeorm",
     "typeorm:migrations:create": "typeorm migration:create",


### PR DESCRIPTION
Remove the need for using `--experimental-vm-modules` due to dynamic import (for es module) by mocking the thumbhash implementation.