### PR TITLE
Fix for Notifications cover the upload control panel #6102

### DIFF
--- a/web/src/lib/components/shared-components/notification/notification-list.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if $notificationList.length > 0}
-  <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute left-4 top-[80px] z-[99999999]">
+  <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute right-5 top-[80px] z-[99999999]">
     {#each $notificationList as notificationInfo (notificationInfo.id)}
       <div animate:flip={{ duration: 250, easing: quintOut }}>
         <NotificationCard {notificationInfo} />

--- a/web/src/lib/components/shared-components/notification/notification-list.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if $notificationList.length > 0}
-  <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute right-5 top-[80px] z-[99999999]">
+  <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute left-4 top-[80px] z-[99999999]">
     {#each $notificationList as notificationInfo (notificationInfo.id)}
       <div animate:flip={{ duration: 250, easing: quintOut }}>
         <NotificationCard {notificationInfo} />

--- a/web/src/lib/components/shared-components/notification/notification-list.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-list.svelte
@@ -11,7 +11,7 @@
 
 {#if $notificationList.length > 0}
   <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute right-5 top-[80px] z-[99999999]">
-    {#each $notificationList as notificationInfo (notificationInfo.id)}
+    {#each $notificationList.slice(0, 3) as notificationInfo (notificationInfo.id)}
       <div animate:flip={{ duration: 250, easing: quintOut }}>
         <NotificationCard {notificationInfo} />
       </div>


### PR DESCRIPTION
The notifications for adding assets covers the upload control panel. This PR moves it those notifications to the left of the screen, where there are no controls. This allows easier access to the upload control panel on the right side of the screen. This is a potential fix for #6102