### PR TITLE
chore(mobile): Corrects FVM gitignore and sets Flutter version to 3.16.9

### DIFF
--- a/mobile/.fvm/fvm_config.json
+++ b/mobile/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "3.16.9",
+  "flavors": {}
+}

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -55,4 +55,4 @@ default.isar.lock
 libisar.so
 
 # FVM Version Cache
-.fvm/
+.fvm/flutter_sdk


### PR DESCRIPTION
We should only have `.fvm/flutter_sdk` in our gitignore by the [fvm configuration](https://fvm.app/docs/getting_started/configuration) docs.