### PR TITLE
fix(web): oauth login

### DIFF
--- a/web/src/api/utils.ts
+++ b/web/src/api/utils.ts
@@ -45,7 +45,7 @@ export const oauth = {
     try {
       const redirectUri = location.href.split('?')[0];
       const { data } = await api.oauthApi.startOAuth({ oAuthConfigDto: { redirectUri } });
-      goto(data.url);
+      window.location.href = data.url;
     } catch (error) {
       handleError(error, 'Unable to login with OAuth');
     }

--- a/web/src/api/utils.ts
+++ b/web/src/api/utils.ts
@@ -1,4 +1,3 @@
-import { goto } from '$app/navigation';
 import type { AxiosError, AxiosPromise } from 'axios';
 import {
   notificationController,

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -11,7 +11,7 @@
   export let data: PageData;
 
   afterNavigate(async ({ from }) => {
-    if (from?.url.pathname === AppRoute.AUTH_CHANGE_PASSWORD) {
+    if (from?.url?.pathname === AppRoute.AUTH_CHANGE_PASSWORD) {
       resetSavedUser();
       await api.authenticationApi.logout();
     }


### PR DESCRIPTION
`goto` is only for internal routes, starting in svelte-kit v2. This one got missed in the upgrade.