### PR TITLE
fix(mobile): remove log message counter

### DIFF
--- a/mobile/lib/shared/views/app_log_page.dart
+++ b/mobile/lib/shared/views/app_log_page.dart
@@ -69,9 +69,9 @@ class AppLogPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          "Logs - ${logMessages.value.length}",
-          style: const TextStyle(
+        title: const Text(
+          "Logs",
+          style: TextStyle(
             fontWeight: FontWeight.bold,
             fontSize: 16.0,
           ),
@@ -135,26 +135,12 @@ class AppLogPage extends HookConsumerWidget {
             dense: true,
             tileColor: getTileColor(logMessage.level),
             minLeadingWidth: 10,
-            title: Text.rich(
-              TextSpan(
-                children: [
-                  TextSpan(
-                    text: "#$index ",
-                    style: TextStyle(
-                      color: isDarkTheme ? Colors.white70 : Colors.grey[600],
-                      fontSize: 14.0,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextSpan(
-                    text: truncateLogMessage(logMessage.message, 4),
-                    style: const TextStyle(
-                      fontSize: 14.0,
-                    ),
-                  ),
-                ],
+            title: Text(
+              truncateLogMessage(logMessage.message, 4),
+              style: const TextStyle(
+                fontSize: 14.0,
+                fontFamily: "Inconsolata",
               ),
-              style: const TextStyle(fontSize: 14.0, fontFamily: "Inconsolata"),
             ),
             subtitle: Text(
               "[${logMessage.context1}] Logged on ${DateFormat("HH:mm:ss.SSS").format(logMessage.createdAt)}",

--- a/mobile/lib/shared/views/app_log_page.dart
+++ b/mobile/lib/shared/views/app_log_page.dart
@@ -143,7 +143,7 @@ class AppLogPage extends HookConsumerWidget {
               ),
             ),
             subtitle: Text(
-              "[${logMessage.context1}] Logged on ${DateFormat("HH:mm:ss.SSS").format(logMessage.createdAt)}",
+              "at ${DateFormat("HH:mm:ss.SSS").format(logMessage.createdAt)} in ${logMessage.context1}",
               style: TextStyle(
                 fontSize: 12.0,
                 color: Colors.grey[600],


### PR DESCRIPTION
Previously, the items in the log page were numbered starting with `#0` and increasing from top (newest) to bottom (oldest). Being new to the app, this confused me because I would have expected that newer messages have a higher number than older messages.

Initially, I had planned to just start counting from the bottom (i.e. the oldest message would be `#0`), but I guess the auto-increment ID of the message would be even better as it isn't reused after clearing the logs. That is, if a number is needed at all...

Since the numbers are no longer related to the total log count, I removed the same from the title. Instead, I added the message ID to the details page title.