### PR TITLE
feat(mobile): show more errors in the app log

### DIFF
--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -52,8 +52,8 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       // Resolve API server endpoint from user provided serverUrl
       await _apiService.resolveAndSetEndpoint(serverUrl);
       await _apiService.serverInfoApi.pingServer();
-    } catch (e) {
-      debugPrint('Invalid Server Endpoint Url $e');
+    } catch (error, stack) {
+      _log.severe("Error logging in: ${error.toString()}", error, stack);
       return false;
     }
 
@@ -91,9 +91,9 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         accessToken: loginResponse.accessToken,
         serverUrl: serverUrl,
       );
-    } catch (e) {
+    } catch (error, stack) {
       HapticFeedback.vibrate();
-      debugPrint("Error logging in $e");
+      _log.severe("Error logging in ${error.toString()}", error, stack);
       return false;
     }
   }
@@ -151,8 +151,8 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
       state = state.copyWith(shouldChangePassword: false);
 
       return true;
-    } catch (e) {
-      debugPrint("Error changing password $e");
+    } catch (error, stack) {
+      _log.severe("Error changing password: ${error.toString()}", error, stack);
       return false;
     }
   }

--- a/mobile/lib/shared/services/api.service.dart
+++ b/mobile/lib/shared/services/api.service.dart
@@ -7,8 +7,10 @@ import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:openapi/api.dart';
 import 'package:http/http.dart';
+import 'package:logging/logging.dart';
 
 class ApiService {
+  final _log = Logger("ApiService");
   late ApiClient _apiClient;
 
   late UserApi userApi;
@@ -126,8 +128,8 @@ class ApiService {
         }
         return endpoint;
       }
-    } catch (e) {
-      debugPrint("Could not locate /.well-known/immich at $baseUrl");
+    } catch (error, stack) {
+      _log.severe("Could not locate /.well-known/immich at $baseUrl", error, stack);
     }
 
     return "";

--- a/mobile/lib/shared/services/server_info.service.dart
+++ b/mobile/lib/shared/services/server_info.service.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/shared/models/server_info/server_features.model.da
 import 'package:immich_mobile/shared/models/server_info/server_version.model.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
+import 'package:logging/logging.dart';
 
 final serverInfoServiceProvider = Provider(
   (ref) => ServerInfoService(
@@ -14,6 +15,7 @@ final serverInfoServiceProvider = Provider(
 );
 
 class ServerInfoService {
+  final _log = Logger("ServerInfoService");
   final ApiService _apiService;
 
   ServerInfoService(this._apiService);
@@ -24,8 +26,8 @@ class ServerInfoService {
       if (dto != null) {
         return ServerDiskInfo.fromDto(dto);
       }
-    } catch (e) {
-      debugPrint("Error [getServerInfo] ${e.toString()}");
+    } catch (error, stack) {
+      _log.severe("Cannot get server info: ${error.toString()}", error, stack);
     }
     return null;
   }
@@ -36,8 +38,8 @@ class ServerInfoService {
       if (dto != null) {
         return ServerVersion.fromDto(dto);
       }
-    } catch (e) {
-      debugPrint("Error [getServerVersion] ${e.toString()}");
+    } catch (error, stack) {
+      _log.severe("Cannot get server version: ${error.toString()}", error, stack);
     }
     return null;
   }
@@ -48,8 +50,8 @@ class ServerInfoService {
       if (dto != null) {
         return ServerFeatures.fromDto(dto);
       }
-    } catch (e) {
-      debugPrint("Error [getServerFeatures] ${e.toString()}");
+    } catch (error, stack) {
+      _log.severe("Cannot get server features: ${error.toString()}", error, stack);
     }
     return null;
   }
@@ -60,8 +62,8 @@ class ServerInfoService {
       if (dto != null) {
         return ServerConfig.fromDto(dto);
       }
-    } catch (e) {
-      debugPrint("Error [getServerConfig] ${e.toString()}");
+    } catch (error, stack) {
+      _log.severe("Cannot get server config: ${error.toString()}", error, stack);
     }
     return null;
   }


### PR DESCRIPTION
Many helpful errors are sent to `debugPrint()` (i.e. logcat on Android) which requires additional efforts to read them.

Use the app's own logging mechanism instead to make them appear in the builtin log viewer, making them easily available to end-users.