### PR TITLE
chore: remove `form-data` dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Run setup typescript-sdk
         run: npm ci && npm run build
         working-directory: ./open-api/typescript-sdk
@@ -142,6 +147,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Run setup typescript-sdk
         run: npm ci && npm run build

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -14,7 +14,6 @@
         "byte-size": "^8.1.1",
         "cli-progress": "^3.12.0",
         "commander": "^11.0.0",
-        "form-data": "^4.0.0",
         "glob": "^10.3.1",
         "yaml": "^2.3.1"
       },
@@ -27,8 +26,8 @@
         "@types/cli-progress": "^3.11.0",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^20.3.1",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.1",
+        "@typescript-eslint/parser": "^6.4.1",
         "@vitest/coverage-v8": "^1.2.2",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -56,7 +55,7 @@
     },
     "../server": {
       "name": "immich",
-      "version": "1.93.3",
+      "version": "1.94.1",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {
@@ -79,6 +78,7 @@
         "axios": "^1.5.0",
         "bcrypt": "^5.1.1",
         "bullmq": "^4.8.0",
+        "chokidar": "^3.5.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
@@ -129,7 +129,6 @@
         "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
         "@typescript-eslint/parser": "^6.4.1",
-        "chokidar": "^3.5.3",
         "dotenv": "^16.3.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -149,7 +148,7 @@
         "ts-loader": "^9.4.4",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.2.2",
+        "typescript": "^5.3.3",
         "utimes": "^5.2.1"
       }
     },
@@ -8828,7 +8827,7 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typeorm": "^0.3.17",
-        "typescript": "^5.2.2",
+        "typescript": "^5.3.3",
         "ua-parser-js": "^1.0.35",
         "utimes": "^5.2.1"
       }

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,7 +18,6 @@
     "byte-size": "^8.1.1",
     "cli-progress": "^3.12.0",
     "commander": "^11.0.0",
-    "form-data": "^4.0.0",
     "glob": "^10.3.1",
     "yaml": "^2.3.1"
   },
@@ -58,5 +57,8 @@
     "type": "git",
     "url": "github:immich-app/immich",
     "directory": "cli"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -1,8 +1,7 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import byteSize from 'byte-size';
 import cliProgress from 'cli-progress';
-import FormData from 'form-data';
-import fs, { ReadStream, createReadStream } from 'node:fs';
+import fs, { createReadStream } from 'node:fs';
 import { CrawlService } from '../services/crawl.service';
 import { BaseCommand } from './base-command';
 import { basename } from 'node:path';
@@ -47,14 +46,14 @@ class Asset {
 
     // TODO: doesn't xmp replace the file extension? Will need investigation
     const sideCarPath = `${this.path}.xmp`;
-    let sidecarData: ReadStream | undefined = undefined;
+    let sidecarData: Blob | undefined = undefined;
     try {
       await access(sideCarPath, constants.R_OK);
-      sidecarData = createReadStream(sideCarPath);
+      sidecarData = new File([await fs.openAsBlob(sideCarPath)], basename(sideCarPath));
     } catch {}
 
     const data: any = {
-      assetData: createReadStream(this.path),
+      assetData: new File([await fs.openAsBlob(this.path)], basename(this.path)),
       deviceAssetId: this.deviceAssetId,
       deviceId: 'CLI',
       fileCreatedAt: this.fileCreatedAt,
@@ -269,7 +268,6 @@ export class UploadCommand extends BaseCommand {
       url,
       headers: {
         'x-api-key': this.immichApi.apiKey,
-        ...data.getHeaders(),
       },
       maxContentLength: Number.POSITIVE_INFINITY,
       maxBodyLength: Number.POSITIVE_INFINITY,


### PR DESCRIPTION
This uses the standard built-in class for `FormData` vs an external package. It will also let us remove `axios` as a dependency in a follow-up (https://github.com/immich-app/immich/issues/6647).