### PR TITLE
chore(mobile):  Put the real delete button before other delete variants

### DIFF
--- a/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
+++ b/mobile/lib/modules/home/ui/control_bottom_app_bar.dart
@@ -125,6 +125,19 @@ class ControlBottomAppBar extends ConsumerWidget {
                 .tr(),
             onPressed: enabled ? onFavorite : null,
           ),
+        if (hasLocal && hasRemote && onDelete != null)
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 90),
+            child: ControlBoxButton(
+              iconData: Icons.delete_sweep_outlined,
+              label: "control_bottom_app_bar_delete".tr(),
+              onPressed: enabled
+                  ? () => handleRemoteDelete(!trashEnabled, onDelete!)
+                  : null,
+              onLongPressed:
+                  enabled ? () => showForceDeleteDialog(onDelete!) : null,
+            ),
+          ),
         if (hasRemote && onDeleteServer != null)
           ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 85),
@@ -170,19 +183,6 @@ class ControlBottomAppBar extends ConsumerWidget {
                       );
                     }
                   : null,
-            ),
-          ),
-        if (hasLocal && hasRemote && onDelete != null)
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 90),
-            child: ControlBoxButton(
-              iconData: Icons.delete_sweep_outlined,
-              label: "control_bottom_app_bar_delete".tr(),
-              onPressed: enabled
-                  ? () => handleRemoteDelete(!trashEnabled, onDelete!)
-                  : null,
-              onLongPressed:
-                  enabled ? () => showForceDeleteDialog(onDelete!) : null,
             ),
           ),
         if (hasRemote && onEditTime != null)


### PR DESCRIPTION
Hi!
After recent update that split the trash action into 3 buttons (https://github.com/immich-app/immich/pull/4505) the most frequently used button - actual delete from the phone and remote - requires scrolling to access.
I moved it before its 2 cousins so that it is visible right away.
I believe that this is the primary delete action so it should be first.