### PR TITLE
refactor(mobile): move error details to separate DB column

### DIFF
--- a/mobile/lib/extensions/asyncvalue_extensions.dart
+++ b/mobile/lib/extensions/asyncvalue_extensions.dart
@@ -30,7 +30,7 @@ extension LogOnError<T> on AsyncValue<T> {
     }
 
     if (hasError && !hasValue) {
-      _asyncErrorLogger.severe("$error", error, stackTrace);
+      _asyncErrorLogger.severe('Could not load value', error, stackTrace);
       return onError?.call(error, stackTrace) ??
           ScaffoldErrorBody(errorMsg: error?.toString());
     }

--- a/mobile/lib/extensions/response_extensions.dart
+++ b/mobile/lib/extensions/response_extensions.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart';
 
 extension LoggerExtension on Response {
-  String toLoggerString() =>
-      "Status: $statusCode $reasonPhrase\n\n$body";
+  String toLoggerString() => "Status: $statusCode $reasonPhrase\n\n$body";
 }

--- a/mobile/lib/extensions/response_extensions.dart
+++ b/mobile/lib/extensions/response_extensions.dart
@@ -1,0 +1,6 @@
+import 'package:http/http.dart';
+
+extension LoggerExtension on Response {
+  String toLoggerString() =>
+      "Status: ${statusCode} ${reasonPhrase}\n\n${body}";
+}

--- a/mobile/lib/extensions/response_extensions.dart
+++ b/mobile/lib/extensions/response_extensions.dart
@@ -2,5 +2,5 @@ import 'package:http/http.dart';
 
 extension LoggerExtension on Response {
   String toLoggerString() =>
-      "Status: ${statusCode} ${reasonPhrase}\n\n${body}";
+      "Status: $statusCode $reasonPhrase\n\n$body";
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -73,15 +73,14 @@ Future<void> initApp() async {
   FlutterError.onError = (details) {
     FlutterError.presentError(details);
     log.severe(
-      'FlutterError - Catch all error: ${details.toString()} - ${details.exception} - ${details.library} - ${details.context} - ${details.stack}',
-      details,
+      'FlutterError - Catch all',
+      "${details.toString()}\nException: ${details.exception}\nLibrary: ${details.library}\nContext: ${details.context}",
       details.stack,
     );
   };
 
   PlatformDispatcher.instance.onError = (error, stack) {
-    log.severe('PlatformDispatcher - Catch all error: $error', error, stack);
-    debugPrint("PlatformDispatcher - Catch all error: $error $stack");
+    log.severe('PlatformDispatcher - Catch all', error, stack);
     return true;
   };
 

--- a/mobile/lib/mixins/error_logger.mixin.dart
+++ b/mobile/lib/mixins/error_logger.mixin.dart
@@ -10,13 +10,14 @@ mixin ErrorLoggerMixin {
   /// Else, logs the error to the overrided logger and returns an AsyncError<>
   AsyncFuture<T> guardError<T>(
     Future<T> Function() fn, {
+    required String errorMessage,
     Level logLevel = Level.SEVERE,
   }) async {
     try {
       final result = await fn();
       return AsyncData(result);
     } catch (error, stackTrace) {
-      logger.log(logLevel, "$error", error, stackTrace);
+      logger.log(logLevel, errorMessage, error, stackTrace);
       return AsyncError(error, stackTrace);
     }
   }
@@ -26,12 +27,13 @@ mixin ErrorLoggerMixin {
   Future<T> logError<T>(
     Future<T> Function() fn, {
     required T defaultValue,
+    required String errorMessage,
     Level logLevel = Level.SEVERE,
   }) async {
     try {
       return await fn();
     } catch (error, stackTrace) {
-      logger.log(logLevel, "$error", error, stackTrace);
+      logger.log(logLevel, errorMessage, error, stackTrace);
     }
     return defaultValue;
   }

--- a/mobile/lib/modules/activities/services/activity.service.dart
+++ b/mobile/lib/modules/activities/services/activity.service.dart
@@ -24,6 +24,7 @@ class ActivityService with ErrorLoggerMixin {
         return list != null ? list.map(Activity.fromDto).toList() : [];
       },
       defaultValue: [],
+      errorMessage: "Failed to get all activities for album $albumId",
     );
   }
 
@@ -35,6 +36,7 @@ class ActivityService with ErrorLoggerMixin {
         return dto?.comments ?? 0;
       },
       defaultValue: 0,
+      errorMessage: "Failed to statistics for album $albumId",
     );
   }
 
@@ -45,6 +47,7 @@ class ActivityService with ErrorLoggerMixin {
         return true;
       },
       defaultValue: false,
+      errorMessage: "Failed to delete activity",
     );
   }
 
@@ -54,21 +57,24 @@ class ActivityService with ErrorLoggerMixin {
     String? assetId,
     String? comment,
   }) async {
-    return guardError(() async {
-      final dto = await _apiService.activityApi.createActivity(
-        ActivityCreateDto(
-          albumId: albumId,
-          type: type == ActivityType.comment
-              ? ReactionType.comment
-              : ReactionType.like,
-          assetId: assetId,
-          comment: comment,
-        ),
-      );
-      if (dto != null) {
-        return Activity.fromDto(dto);
-      }
-      throw NoResponseDtoError();
-    });
+    return guardError(
+      () async {
+        final dto = await _apiService.activityApi.createActivity(
+          ActivityCreateDto(
+            albumId: albumId,
+            type: type == ActivityType.comment
+                ? ReactionType.comment
+                : ReactionType.like,
+            assetId: assetId,
+            comment: comment,
+          ),
+        );
+        if (dto != null) {
+          return Activity.fromDto(dto);
+        }
+        throw NoResponseDtoError();
+      },
+      errorMessage: "Failed to create $type for album $albumId",
+    );
   }
 }

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -39,7 +39,8 @@ class ImageViewerService {
           final failedResponse =
               imageResponse.statusCode != 200 ? imageResponse : motionReponse;
           _log.severe(
-            "Motion asset download failed with status - ${failedResponse.statusCode} and response - ${failedResponse.body}",
+            "Motion asset download failed",
+            "Status: ${failedResponse.statusCode}\nResponse: ${failedResponse.body}",
           );
           return false;
         }
@@ -76,7 +77,8 @@ class ImageViewerService {
 
         if (res.statusCode != 200) {
           _log.severe(
-            "Asset download failed with status - ${res.statusCode} and response - ${res.body}",
+            "Asset download failed",
+            "Status: ${res.statusCode}\nResponse: ${res.body}",
           );
           return false;
         }
@@ -98,7 +100,7 @@ class ImageViewerService {
         return entity != null;
       }
     } catch (error, stack) {
-      _log.severe("Error saving file ${error.toString()}", error, stack);
+      _log.severe("Error saving downloaded asset", error, stack);
       return false;
     } finally {
       // Clear temp files

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:immich_mobile/shared/services/api.service.dart';
@@ -38,10 +39,7 @@ class ImageViewerService {
             motionReponse.statusCode != 200) {
           final failedResponse =
               imageResponse.statusCode != 200 ? imageResponse : motionReponse;
-          _log.severe(
-            "Motion asset download failed",
-            "Status: ${failedResponse.statusCode}\nResponse: ${failedResponse.body}",
-          );
+          _log.severe("Motion asset download failed", failedResponse.toLoggerString());
           return false;
         }
 
@@ -76,10 +74,7 @@ class ImageViewerService {
             .downloadFileWithHttpInfo(asset.remoteId!);
 
         if (res.statusCode != 200) {
-          _log.severe(
-            "Asset download failed",
-            "Status: ${res.statusCode}\nResponse: ${res.body}",
-          );
+          _log.severe("Asset download failed", res.toLoggerString());
           return false;
         }
 

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -40,7 +40,9 @@ class ImageViewerService {
           final failedResponse =
               imageResponse.statusCode != 200 ? imageResponse : motionReponse;
           _log.severe(
-              "Motion asset download failed", failedResponse.toLoggerString());
+            "Motion asset download failed",
+            failedResponse.toLoggerString(),
+          );
           return false;
         }
 

--- a/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
+++ b/mobile/lib/modules/asset_viewer/services/image_viewer.service.dart
@@ -39,7 +39,8 @@ class ImageViewerService {
             motionReponse.statusCode != 200) {
           final failedResponse =
               imageResponse.statusCode != 200 ? imageResponse : motionReponse;
-          _log.severe("Motion asset download failed", failedResponse.toLoggerString());
+          _log.severe(
+              "Motion asset download failed", failedResponse.toLoggerString());
           return false;
         }
 

--- a/mobile/lib/modules/asset_viewer/ui/description_input.dart
+++ b/mobile/lib/modules/asset_viewer/ui/description_input.dart
@@ -48,7 +48,7 @@ class DescriptionInput extends HookConsumerWidget {
         );
       } catch (error, stack) {
         hasError.value = true;
-        _log.severe("Error updating description $error", error, stack);
+        _log.severe("Error updating description", error, stack);
         ImmichToast.show(
           context: context,
           msg: "description_input_submit_error".tr(),

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -243,7 +243,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
           availableAlbum =
               availableAlbum.copyWith(thumbnailData: thumbnailData);
         } catch (e, stack) {
-          log.severe("Failed to get thumbnail for album ${album.name}", e, stack);
+          log.severe(
+              "Failed to get thumbnail for album ${album.name}", e, stack);
         }
 
         availableAlbums.add(availableAlbum);

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -243,11 +243,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
           availableAlbum =
               availableAlbum.copyWith(thumbnailData: thumbnailData);
         } catch (e, stack) {
-          log.severe(
-            "Failed to get thumbnail for album ${album.name}",
-            e.toString(),
-            stack,
-          );
+          log.severe("Failed to get thumbnail for album ${album.name}", e, stack);
         }
 
         availableAlbums.add(availableAlbum);

--- a/mobile/lib/modules/backup/providers/backup.provider.dart
+++ b/mobile/lib/modules/backup/providers/backup.provider.dart
@@ -244,7 +244,10 @@ class BackupNotifier extends StateNotifier<BackUpState> {
               availableAlbum.copyWith(thumbnailData: thumbnailData);
         } catch (e, stack) {
           log.severe(
-              "Failed to get thumbnail for album ${album.name}", e, stack);
+            "Failed to get thumbnail for album ${album.name}",
+            e,
+            stack,
+          );
         }
 
         availableAlbums.add(availableAlbum);

--- a/mobile/lib/modules/login/providers/authentication.provider.dart
+++ b/mobile/lib/modules/login/providers/authentication.provider.dart
@@ -108,7 +108,7 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
           .then((_) => log.info("Logout was successful for $userEmail"))
           .onError(
             (error, stackTrace) =>
-                log.severe("Error logging out $userEmail", error, stackTrace),
+                log.severe("Logout failed for $userEmail", error, stackTrace),
           );
 
       await Future.wait([
@@ -129,8 +129,8 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
         shouldChangePassword: false,
         isAuthenticated: false,
       );
-    } catch (e) {
-      log.severe("Error logging out $e");
+    } catch (e, stack) {
+      log.severe('Logout failed', e, stack);
     }
   }
 

--- a/mobile/lib/modules/login/services/oauth.service.dart
+++ b/mobile/lib/modules/login/services/oauth.service.dart
@@ -36,7 +36,7 @@ class OAuthService {
         ),
       );
     } catch (e, stack) {
-      log.severe("Error performing oAuthLogin: ${e.toString()}", e, stack);
+      log.severe("OAuth login failed", e, stack);
       return null;
     }
   }

--- a/mobile/lib/modules/map/providers/map_state.provider.dart
+++ b/mobile/lib/modules/map/providers/map_state.provider.dart
@@ -51,7 +51,8 @@ class MapStateNotifier extends _$MapStateNotifier {
         lightStyleFetched: AsyncError(lightResponse.body, StackTrace.current),
       );
       _log.severe(
-        "Cannot fetch map light style with status - ${lightResponse.statusCode} and response - ${lightResponse.body}",
+        "Cannot fetch map light style",
+        "Status: ${lightResponse.statusCode}\nResponse: ${lightResponse.body}",
       );
       return;
     }
@@ -78,7 +79,8 @@ class MapStateNotifier extends _$MapStateNotifier {
         darkStyleFetched: AsyncError(darkResponse.body, StackTrace.current),
       );
       _log.severe(
-        "Cannot fetch map dark style with status - ${darkResponse.statusCode} and response - ${darkResponse.body}",
+        "Cannot fetch map dark style",
+        "Status: ${darkResponse.statusCode}\nResponse: ${darkResponse.body}",
       );
       return;
     }

--- a/mobile/lib/modules/map/providers/map_state.provider.dart
+++ b/mobile/lib/modules/map/providers/map_state.provider.dart
@@ -51,7 +51,8 @@ class MapStateNotifier extends _$MapStateNotifier {
       state = state.copyWith(
         lightStyleFetched: AsyncError(lightResponse.body, StackTrace.current),
       );
-      _log.severe("Cannot fetch map light style", lightResponse.toLoggerString());
+      _log.severe(
+          "Cannot fetch map light style", lightResponse.toLoggerString());
       return;
     }
 

--- a/mobile/lib/modules/map/providers/map_state.provider.dart
+++ b/mobile/lib/modules/map/providers/map_state.provider.dart
@@ -52,7 +52,9 @@ class MapStateNotifier extends _$MapStateNotifier {
         lightStyleFetched: AsyncError(lightResponse.body, StackTrace.current),
       );
       _log.severe(
-          "Cannot fetch map light style", lightResponse.toLoggerString());
+        "Cannot fetch map light style",
+        lightResponse.toLoggerString(),
+      );
       return;
     }
 

--- a/mobile/lib/modules/map/providers/map_state.provider.dart
+++ b/mobile/lib/modules/map/providers/map_state.provider.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/modules/map/models/map_state.model.dart';
 import 'package:immich_mobile/modules/settings/providers/app_settings.provider.dart';
 import 'package:immich_mobile/modules/settings/services/app_settings.service.dart';
@@ -50,10 +51,7 @@ class MapStateNotifier extends _$MapStateNotifier {
       state = state.copyWith(
         lightStyleFetched: AsyncError(lightResponse.body, StackTrace.current),
       );
-      _log.severe(
-        "Cannot fetch map light style",
-        "Status: ${lightResponse.statusCode}\nResponse: ${lightResponse.body}",
-      );
+      _log.severe("Cannot fetch map light style", lightResponse.toLoggerString());
       return;
     }
 
@@ -78,10 +76,7 @@ class MapStateNotifier extends _$MapStateNotifier {
       state = state.copyWith(
         darkStyleFetched: AsyncError(darkResponse.body, StackTrace.current),
       );
-      _log.severe(
-        "Cannot fetch map dark style",
-        "Status: ${darkResponse.statusCode}\nResponse: ${darkResponse.body}",
-      );
+      _log.severe("Cannot fetch map dark style", darkResponse.toLoggerString());
       return;
     }
 

--- a/mobile/lib/modules/map/services/map.service.dart
+++ b/mobile/lib/modules/map/services/map.service.dart
@@ -28,6 +28,7 @@ class MapSerivce with ErrorLoggerMixin {
         return markers?.map(MapMarker.fromDto) ?? [];
       },
       defaultValue: [],
+      errorMessage: "Failed to get map markers",
     );
   }
 }

--- a/mobile/lib/modules/map/utils/map_utils.dart
+++ b/mobile/lib/modules/map/utils/map_utils.dart
@@ -105,10 +105,8 @@ class MapUtils {
         timeLimit: const Duration(seconds: 5),
       );
       return (currentUserLocation, null);
-    } catch (error) {
-      _log.severe(
-        "Cannot get user's current location due to ${error.toString()}",
-      );
+    } catch (error, stack) {
+      _log.severe("Cannot get user's current location", error, stack);
       return (null, LocationPermission.unableToDetermine);
     }
   }

--- a/mobile/lib/modules/map/widgets/map_asset_grid.dart
+++ b/mobile/lib/modules/map/widgets/map_asset_grid.dart
@@ -147,7 +147,7 @@ class MapAssetGrid extends HookConsumerWidget {
                         },
                         error: (error, stackTrace) {
                           log.warning(
-                            "Cannot get assets in the current map bounds $error",
+                            "Cannot get assets in the current map bounds",
                             error,
                             stackTrace,
                           );

--- a/mobile/lib/modules/memories/services/memory.service.dart
+++ b/mobile/lib/modules/memories/services/memory.service.dart
@@ -47,7 +47,7 @@ class MemoryService {
 
       return memories.isNotEmpty ? memories : null;
     } catch (error, stack) {
-      log.severe("Cannot get memories ${error.toString()}", error, stack);
+      log.severe("Cannot get memories", error, stack);
       return null;
     }
   }

--- a/mobile/lib/modules/partner/services/partner.service.dart
+++ b/mobile/lib/modules/partner/services/partner.service.dart
@@ -40,7 +40,7 @@ class PartnerService {
         return userDtos.map((u) => User.fromPartnerDto(u)).toList();
       }
     } catch (e) {
-      _log.warning("failed to get partners for direction $direction:\n$e");
+      _log.warning("Failed to get partners for direction $direction", e);
     }
     return null;
   }
@@ -51,7 +51,7 @@ class PartnerService {
       partner.isPartnerSharedBy = false;
       await _db.writeTxn(() => _db.users.put(partner));
     } catch (e) {
-      _log.warning("failed to remove partner ${partner.id}:\n$e");
+      _log.warning("Failed to remove partner ${partner.id}", e);
       return false;
     }
     return true;
@@ -66,7 +66,7 @@ class PartnerService {
         return true;
       }
     } catch (e) {
-      _log.warning("failed to add partner ${partner.id}:\n$e");
+      _log.warning("Failed to add partner ${partner.id}", e);
     }
     return false;
   }
@@ -81,7 +81,7 @@ class PartnerService {
         return true;
       }
     } catch (e) {
-      _log.warning("failed to update partner ${partner.id}:\n$e");
+      _log.warning("Failed to update partner ${partner.id}", e);
     }
     return false;
   }

--- a/mobile/lib/modules/shared_link/services/shared_link.service.dart
+++ b/mobile/lib/modules/shared_link/services/shared_link.service.dart
@@ -22,7 +22,7 @@ class SharedLinkService {
           ? AsyncData(list.map(SharedLink.fromDto).toList())
           : const AsyncData([]);
     } catch (e, stack) {
-      _log.severe("failed to fetch shared links - $e");
+      _log.severe("Failed to fetch shared links", e, stack);
       return AsyncError(e, stack);
     }
   }
@@ -31,7 +31,7 @@ class SharedLinkService {
     try {
       return await _apiService.sharedLinkApi.removeSharedLink(id);
     } catch (e) {
-      _log.severe("failed to delete shared link id - $id with error - $e");
+      _log.severe("Failed to delete shared link id - $id", e);
     }
   }
 
@@ -81,7 +81,7 @@ class SharedLinkService {
         }
       }
     } catch (e) {
-      _log.severe("failed to create shared link with error - $e");
+      _log.severe("Failed to create shared link", e);
     }
     return null;
   }
@@ -113,7 +113,7 @@ class SharedLinkService {
         return SharedLink.fromDto(responseDto);
       }
     } catch (e) {
-      _log.severe("failed to update shared link id - $id with error - $e");
+      _log.severe("Failed to update shared link id - $id", e);
     }
     return null;
   }

--- a/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
+++ b/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
@@ -44,7 +44,7 @@ class TrashNotifier extends StateNotifier<bool> {
           .read(syncServiceProvider)
           .handleRemoteAssetRemoval(idsToRemove.cast<String>().toList());
     } catch (error, stack) {
-      _log.severe("Cannot empty trash ${error.toString()}", error, stack);
+      _log.severe("Cannot empty trash", error, stack);
     }
   }
 
@@ -70,7 +70,7 @@ class TrashNotifier extends StateNotifier<bool> {
 
       return isRemoved;
     } catch (error, stack) {
-      _log.severe("Cannot empty trash ${error.toString()}", error, stack);
+      _log.severe("Cannot remove assets", error, stack);
     }
     return false;
   }
@@ -93,7 +93,7 @@ class TrashNotifier extends StateNotifier<bool> {
         return true;
       }
     } catch (error, stack) {
-      _log.severe("Cannot restore trash ${error.toString()}", error, stack);
+      _log.severe("Cannot restore assets", error, stack);
     }
     return false;
   }
@@ -123,7 +123,7 @@ class TrashNotifier extends StateNotifier<bool> {
         await _db.assets.putAll(updatedAssets);
       });
     } catch (error, stack) {
-      _log.severe("Cannot restore trash ${error.toString()}", error, stack);
+      _log.severe("Cannot restore trash", error, stack);
     }
   }
 }

--- a/mobile/lib/modules/trash/services/trash.service.dart
+++ b/mobile/lib/modules/trash/services/trash.service.dart
@@ -25,7 +25,7 @@ class TrashService {
       await _apiService.trashApi.restoreAssets(BulkIdsDto(ids: remoteIds));
       return true;
     } catch (error, stack) {
-      _log.severe("Cannot restore assets ${error.toString()}", error, stack);
+      _log.severe("Cannot restore assets", error, stack);
       return false;
     }
   }
@@ -34,7 +34,7 @@ class TrashService {
     try {
       await _apiService.trashApi.emptyTrash();
     } catch (error, stack) {
-      _log.severe("Cannot empty trash ${error.toString()}", error, stack);
+      _log.severe("Cannot empty trash", error, stack);
     }
   }
 
@@ -42,7 +42,7 @@ class TrashService {
     try {
       await _apiService.trashApi.restoreTrash();
     } catch (error, stack) {
-      _log.severe("Cannot restore trash ${error.toString()}", error, stack);
+      _log.severe("Cannot restore trash", error, stack);
     }
   }
 }

--- a/mobile/lib/shared/models/logger_message.model.dart
+++ b/mobile/lib/shared/models/logger_message.model.dart
@@ -9,6 +9,7 @@ part 'logger_message.model.g.dart';
 class LoggerMessage {
   Id id = Isar.autoIncrement;
   String message;
+  String? details;
   @Enumerated(EnumType.ordinal)
   LogLevel level = LogLevel.INFO;
   DateTime createdAt;
@@ -17,6 +18,7 @@ class LoggerMessage {
 
   LoggerMessage({
     required this.message,
+    required this.details,
     required this.level,
     required this.createdAt,
     required this.context1,

--- a/mobile/lib/shared/models/logger_message.model.g.dart
+++ b/mobile/lib/shared/models/logger_message.model.g.dart
@@ -32,14 +32,19 @@ const LoggerMessageSchema = CollectionSchema(
       name: r'createdAt',
       type: IsarType.dateTime,
     ),
-    r'level': PropertySchema(
+    r'details': PropertySchema(
       id: 3,
+      name: r'details',
+      type: IsarType.string,
+    ),
+    r'level': PropertySchema(
+      id: 4,
       name: r'level',
       type: IsarType.byte,
       enumMap: _LoggerMessagelevelEnumValueMap,
     ),
     r'message': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'message',
       type: IsarType.string,
     )
@@ -76,6 +81,12 @@ int _loggerMessageEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  {
+    final value = object.details;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
   bytesCount += 3 + object.message.length * 3;
   return bytesCount;
 }
@@ -89,8 +100,9 @@ void _loggerMessageSerialize(
   writer.writeString(offsets[0], object.context1);
   writer.writeString(offsets[1], object.context2);
   writer.writeDateTime(offsets[2], object.createdAt);
-  writer.writeByte(offsets[3], object.level.index);
-  writer.writeString(offsets[4], object.message);
+  writer.writeString(offsets[3], object.details);
+  writer.writeByte(offsets[4], object.level.index);
+  writer.writeString(offsets[5], object.message);
 }
 
 LoggerMessage _loggerMessageDeserialize(
@@ -103,9 +115,10 @@ LoggerMessage _loggerMessageDeserialize(
     context1: reader.readStringOrNull(offsets[0]),
     context2: reader.readStringOrNull(offsets[1]),
     createdAt: reader.readDateTime(offsets[2]),
-    level: _LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offsets[3])] ??
+    details: reader.readStringOrNull(offsets[3]),
+    level: _LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offsets[4])] ??
         LogLevel.ALL,
-    message: reader.readString(offsets[4]),
+    message: reader.readString(offsets[5]),
   );
   object.id = id;
   return object;
@@ -125,9 +138,11 @@ P _loggerMessageDeserializeProp<P>(
     case 2:
       return (reader.readDateTime(offset)) as P;
     case 3:
+      return (reader.readStringOrNull(offset)) as P;
+    case 4:
       return (_LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offset)] ??
           LogLevel.ALL) as P;
-    case 4:
+    case 5:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -619,6 +634,160 @@ extension LoggerMessageQueryFilter
     });
   }
 
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'details',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'details',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'details',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'details',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'details',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'details',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition>
+      detailsIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'details',
+        value: '',
+      ));
+    });
+  }
+
   QueryBuilder<LoggerMessage, LoggerMessage, QAfterFilterCondition> idEqualTo(
       Id value) {
     return QueryBuilder.apply(this, (query) {
@@ -913,6 +1082,18 @@ extension LoggerMessageQuerySortBy
     });
   }
 
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByDetails() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'details', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByDetailsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'details', Sort.desc);
+    });
+  }
+
   QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> sortByLevel() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'level', Sort.asc);
@@ -979,6 +1160,18 @@ extension LoggerMessageQuerySortThenBy
     });
   }
 
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByDetails() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'details', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenByDetailsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'details', Sort.desc);
+    });
+  }
+
   QueryBuilder<LoggerMessage, LoggerMessage, QAfterSortBy> thenById() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'id', Sort.asc);
@@ -1038,6 +1231,13 @@ extension LoggerMessageQueryWhereDistinct
     });
   }
 
+  QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByDetails(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'details', caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<LoggerMessage, LoggerMessage, QDistinct> distinctByLevel() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'level');
@@ -1075,6 +1275,12 @@ extension LoggerMessageQueryProperty
   QueryBuilder<LoggerMessage, DateTime, QQueryOperations> createdAtProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<LoggerMessage, String?, QQueryOperations> detailsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'details');
     });
   }
 

--- a/mobile/lib/shared/services/asset.service.dart
+++ b/mobile/lib/shared/services/asset.service.dart
@@ -90,7 +90,7 @@ class AssetService {
       return allAssets;
     } catch (error, stack) {
       log.severe(
-        'Error while getting remote assets: ${error.toString()}',
+        'Error while getting remote assets',
         error,
         stack,
       );
@@ -117,7 +117,7 @@ class AssetService {
       );
       return true;
     } catch (error, stack) {
-      log.severe("Error deleteAssets  ${error.toString()}", error, stack);
+      log.severe("Error while deleting assets", error, stack);
     }
     return false;
   }

--- a/mobile/lib/shared/services/immich_logger.service.dart
+++ b/mobile/lib/shared/services/immich_logger.service.dart
@@ -12,7 +12,7 @@ import 'package:share_plus/share_plus.dart';
 /// [ImmichLogger] is a custom logger that is built on top of the [logging] package.
 /// The logs are written to the database and onto console, using `debugPrint` method.
 ///
-/// The logs are deleted when exceeding the `maxLogEntries` (default 200) property
+/// The logs are deleted when exceeding the `maxLogEntries` (default 500) property
 /// in the class.
 ///
 /// Logs can be shared by calling the `shareLogs` method, which will open a share dialog
@@ -58,6 +58,7 @@ class ImmichLogger {
     debugPrint('[${record.level.name}] [${record.time}] ${record.message}');
     final lm = LoggerMessage(
       message: record.message,
+      details: record.error?.toString(),
       level: record.level.toLogLevel(),
       createdAt: record.time,
       context1: record.loggerName,

--- a/mobile/lib/shared/services/share.service.dart
+++ b/mobile/lib/shared/services/share.service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/api.provider.dart';
 import 'package:logging/logging.dart';
@@ -40,10 +41,7 @@ class ShareService {
               .downloadFileWithHttpInfo(asset.remoteId!);
 
           if (res.statusCode != 200) {
-            _log.severe(
-              "Asset download for ${asset.fileName} failed",
-              "Status: ${res.statusCode}\nResponse: ${res.body}",
-            );
+            _log.severe("Asset download for ${asset.fileName} failed", res.toLoggerString());
             continue;
           }
 

--- a/mobile/lib/shared/services/share.service.dart
+++ b/mobile/lib/shared/services/share.service.dart
@@ -41,8 +41,10 @@ class ShareService {
               .downloadFileWithHttpInfo(asset.remoteId!);
 
           if (res.statusCode != 200) {
-            _log.severe("Asset download for ${asset.fileName} failed",
-                res.toLoggerString());
+            _log.severe(
+              "Asset download for ${asset.fileName} failed",
+              res.toLoggerString(),
+            );
             continue;
           }
 

--- a/mobile/lib/shared/services/share.service.dart
+++ b/mobile/lib/shared/services/share.service.dart
@@ -41,7 +41,8 @@ class ShareService {
 
           if (res.statusCode != 200) {
             _log.severe(
-              "Asset download failed with status - ${res.statusCode} and response - ${res.body}",
+              "Asset download for ${asset.fileName} failed",
+              "Status: ${res.statusCode}\nResponse: ${res.body}",
             );
             continue;
           }
@@ -68,7 +69,7 @@ class ShareService {
       );
       return true;
     } catch (error) {
-      _log.severe("Share failed with error $error");
+      _log.severe("Share failed", error);
     }
     return false;
   }

--- a/mobile/lib/shared/services/share.service.dart
+++ b/mobile/lib/shared/services/share.service.dart
@@ -41,7 +41,8 @@ class ShareService {
               .downloadFileWithHttpInfo(asset.remoteId!);
 
           if (res.statusCode != 200) {
-            _log.severe("Asset download for ${asset.fileName} failed", res.toLoggerString());
+            _log.severe("Asset download for ${asset.fileName} failed",
+                res.toLoggerString());
             continue;
           }
 

--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -140,7 +140,7 @@ class SyncService {
     try {
       await _db.writeTxn(() => a.put(_db));
     } on IsarError catch (e) {
-      _log.severe("Failed to put new asset into db: $e");
+      _log.severe("Failed to put new asset into db", e);
       return false;
     }
     return true;
@@ -173,7 +173,7 @@ class SyncService {
       }
       return false;
     } on IsarError catch (e) {
-      _log.severe("Failed to sync remote assets to db: $e");
+      _log.severe("Failed to sync remote assets to db", e);
     }
     return null;
   }
@@ -232,7 +232,7 @@ class SyncService {
       await _db.writeTxn(() => _db.assets.deleteAll(idsToDelete));
       await upsertAssetsWithExif(toAdd + toUpdate);
     } on IsarError catch (e) {
-      _log.severe("Failed to sync remote assets to db: $e");
+      _log.severe("Failed to sync remote assets to db", e);
     }
     await _updateUserAssetsETag(user, now);
     return true;
@@ -364,7 +364,7 @@ class SyncService {
       });
       _log.info("Synced changes of remote album ${album.name} to DB");
     } on IsarError catch (e) {
-      _log.severe("Failed to sync remote album to database $e");
+      _log.severe("Failed to sync remote album to database", e);
     }
 
     if (album.shared || dto.shared) {
@@ -441,7 +441,7 @@ class SyncService {
       assert(ok);
       _log.info("Removed local album $album from DB");
     } catch (e) {
-      _log.severe("Failed to remove local album $album from DB");
+      _log.severe("Failed to remove local album $album from DB", e);
     }
   }
 
@@ -577,7 +577,7 @@ class SyncService {
       });
       _log.info("Synced changes of local album ${ape.name} to DB");
     } on IsarError catch (e) {
-      _log.severe("Failed to update synced album ${ape.name} in DB: $e");
+      _log.severe("Failed to update synced album ${ape.name} in DB", e);
     }
 
     return true;
@@ -623,7 +623,7 @@ class SyncService {
       });
       _log.info("Fast synced local album ${ape.name} to DB");
     } on IsarError catch (e) {
-      _log.severe("Failed to fast sync local album ${ape.name} to DB: $e");
+      _log.severe("Failed to fast sync local album ${ape.name} to DB", e);
       return false;
     }
 
@@ -656,7 +656,7 @@ class SyncService {
       await _db.writeTxn(() => _db.albums.store(a));
       _log.info("Added a new local album to DB: ${ape.name}");
     } on IsarError catch (e) {
-      _log.severe("Failed to add new local album ${ape.name} to DB: $e");
+      _log.severe("Failed to add new local album ${ape.name} to DB", e);
     }
   }
 
@@ -706,9 +706,7 @@ class SyncService {
       });
       _log.info("Upserted ${assets.length} assets into the DB");
     } on IsarError catch (e) {
-      _log.severe(
-        "Failed to upsert ${assets.length} assets into the DB: ${e.toString()}",
-      );
+      _log.severe("Failed to upsert ${assets.length} assets into the DB", e);
       // give details on the errors
       assets.sort(Asset.compareByOwnerChecksum);
       final inDb = await _db.assets.getAllByOwnerIdChecksum(
@@ -776,7 +774,7 @@ class SyncService {
       });
       return true;
     } catch (e) {
-      _log.severe("Failed to remove all local albums and assets: $e");
+      _log.severe("Failed to remove all local albums and assets", e);
       return false;
     }
   }

--- a/mobile/lib/shared/services/user.service.dart
+++ b/mobile/lib/shared/services/user.service.dart
@@ -42,7 +42,7 @@ class UserService {
       final dto = await _apiService.userApi.getAllUsers(isAll);
       return dto?.map(User.fromUserDto).toList();
     } catch (e) {
-      _log.warning("Failed get all users:\n$e");
+      _log.warning("Failed get all users", e);
       return null;
     }
   }
@@ -65,7 +65,7 @@ class UserService {
         ),
       );
     } catch (e) {
-      _log.warning("Failed to upload profile image:\n$e");
+      _log.warning("Failed to upload profile image", e);
       return null;
     }
   }

--- a/mobile/lib/shared/views/app_log_detail_page.dart
+++ b/mobile/lib/shared/views/app_log_detail_page.dart
@@ -134,7 +134,9 @@ class AppLogDetailPage extends HookConsumerWidget {
               buildLogContext1(logMessage.context1.toString()),
             if (logMessage.context2 != null)
               buildTextWithCopyButton(
-                  "STACK TRACE", logMessage.context2.toString()),
+                "STACK TRACE",
+                logMessage.context2.toString(),
+              ),
           ],
         ),
       ),

--- a/mobile/lib/shared/views/app_log_detail_page.dart
+++ b/mobile/lib/shared/views/app_log_detail_page.dart
@@ -133,7 +133,8 @@ class AppLogDetailPage extends HookConsumerWidget {
             if (logMessage.context1 != null)
               buildLogContext1(logMessage.context1.toString()),
             if (logMessage.context2 != null)
-              buildTextWithCopyButton("STACK TRACE", logMessage.context2.toString()),
+              buildTextWithCopyButton(
+                  "STACK TRACE", logMessage.context2.toString()),
           ],
         ),
       ),

--- a/mobile/lib/shared/views/app_log_detail_page.dart
+++ b/mobile/lib/shared/views/app_log_detail_page.dart
@@ -15,7 +15,7 @@ class AppLogDetailPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     var isDarkTheme = context.isDarkTheme;
 
-    buildStackMessage(String stackTrace) {
+    buildTextWithCopyButton(String header, String text) {
       return Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(
@@ -28,7 +28,7 @@ class AppLogDetailPage extends HookConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8.0),
                   child: Text(
-                    "STACK TRACES",
+                    header,
                     style: TextStyle(
                       fontSize: 12.0,
                       color: context.primaryColor,
@@ -38,8 +38,7 @@ class AppLogDetailPage extends HookConsumerWidget {
                 ),
                 IconButton(
                   onPressed: () {
-                    Clipboard.setData(ClipboardData(text: stackTrace))
-                        .then((_) {
+                    Clipboard.setData(ClipboardData(text: text)).then((_) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text(
@@ -68,73 +67,7 @@ class AppLogDetailPage extends HookConsumerWidget {
               child: Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: SelectableText(
-                  stackTrace,
-                  style: const TextStyle(
-                    fontSize: 12.0,
-                    fontWeight: FontWeight.bold,
-                    fontFamily: "Inconsolata",
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    buildLogMessage(String message) {
-      return Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8.0),
-                  child: Text(
-                    "MESSAGE",
-                    style: TextStyle(
-                      fontSize: 12.0,
-                      color: context.primaryColor,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-                IconButton(
-                  onPressed: () {
-                    Clipboard.setData(ClipboardData(text: message)).then((_) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(
-                            "Copied to clipboard",
-                            style: context.textTheme.bodyLarge?.copyWith(
-                              color: context.primaryColor,
-                            ),
-                          ),
-                        ),
-                      );
-                    });
-                  },
-                  icon: Icon(
-                    Icons.copy,
-                    size: 16.0,
-                    color: context.primaryColor,
-                  ),
-                ),
-              ],
-            ),
-            Container(
-              decoration: BoxDecoration(
-                color: isDarkTheme ? Colors.grey[900] : Colors.grey[200],
-                borderRadius: BorderRadius.circular(15.0),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: SelectableText(
-                  message,
+                  text,
                   style: const TextStyle(
                     fontSize: 12.0,
                     fontWeight: FontWeight.bold,
@@ -194,11 +127,13 @@ class AppLogDetailPage extends HookConsumerWidget {
       body: SafeArea(
         child: ListView(
           children: [
-            buildLogMessage(logMessage.message),
+            buildTextWithCopyButton("MESSAGE", logMessage.message),
+            if (logMessage.details != null)
+              buildTextWithCopyButton("DETAILS", logMessage.details.toString()),
             if (logMessage.context1 != null)
               buildLogContext1(logMessage.context1.toString()),
             if (logMessage.context2 != null)
-              buildStackMessage(logMessage.context2.toString()),
+              buildTextWithCopyButton("STACK TRACE", logMessage.context2.toString()),
           ],
         ),
       ),

--- a/mobile/lib/shared/views/splash_screen.dart
+++ b/mobile/lib/shared/views/splash_screen.dart
@@ -35,10 +35,10 @@ class SplashScreenPage extends HookConsumerWidget {
             deviceIsOffline = true;
             log.fine("Device seems to be offline upon launch");
           } else {
-            log.severe(e);
+            log.severe("Failed to resolve endpoint", e);
           }
         } catch (e) {
-          log.severe(e);
+          log.severe("Failed to resolve endpoint", e);
         }
 
         try {
@@ -53,7 +53,7 @@ class SplashScreenPage extends HookConsumerWidget {
           ref.read(authenticationProvider.notifier).logout();
 
           log.severe(
-            'Cannot set success login info: $error',
+            'Cannot set success login info',
             error,
             stackTrace,
           );


### PR DESCRIPTION
As discussed in #6866, `logRecord.error` previously wasn't stored in the DB. Instead, a string copy of it was merged into the `message` in most places. Separate the two, so the log overview shows a brief description of the error while the details (usually an exception, but could be any string) can be found in the details page.

I adjusted many places to split the log message into its headline and the details, but for sure there will be some that I've missed. It shouldn't be a problem to adjust those later. There might also be places where adding further details as string could be helpful, like a few statistics when the upload has finished.