### PR TITLE
fix(mobile): don't crop memories in landscape mode

### DIFF
--- a/mobile/lib/modules/memories/ui/memory_card.dart
+++ b/mobile/lib/modules/memories/ui/memory_card.dart
@@ -55,9 +55,9 @@ class MemoryCard extends StatelessWidget {
           LayoutBuilder(
             builder: (context, constraints) {
               // Determine the fit using the aspect ratio
-              BoxFit fit = BoxFit.fitWidth;
+              BoxFit fit = BoxFit.contain;
               if (asset.width != null && asset.height != null) {
-                final aspectRatio = asset.height! / asset.width!;
+                final aspectRatio = asset.width! / asset.height!;
                 final phoneAspectRatio =
                     constraints.maxWidth / constraints.maxHeight;
                 // Look for a 25% difference in either direction


### PR DESCRIPTION
Fix #6890 