### PR TITLE
chore: build API with esnext target

### DIFF
--- a/open-api/typescript-sdk/tsconfig.axios.json
+++ b/open-api/typescript-sdk/tsconfig.axios.json
@@ -1,6 +1,7 @@
 {
   "include": ["axios.ts", "axios-client/**/*"],
   "compilerOptions": {
+    "target": "esnext",
     "strict": true,
     "skipLibCheck": true,
     "declaration": true,

--- a/open-api/typescript-sdk/tsconfig.fetch.json
+++ b/open-api/typescript-sdk/tsconfig.fetch.json
@@ -1,6 +1,7 @@
 {
   "include": ["fetch.ts", "fetch-client/**/*"],
   "compilerOptions": {
+    "target": "esnext",
     "strict": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
Removes a bunch of polyfill code from the API that's unnecessary. The CLI and web projects are built with Vite and support for any newer features will already be added at that time if needed.

This should make the web frontend load a bit faster. I didn't benchmark the web project, but for reference here's the output difference for the CLI

Size of the CLI on `main`:
dist/index.js  1,088.98 kB

Size of CLI with this PR:
dist/index.js  760.50 kB
