### PR TITLE
chore(web): remove maplibre dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,6 @@
         "justified-layout": "^4.1.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.2.1",
-        "maplibre-gl": "^3.6.0",
         "socket.io-client": "^4.6.1",
         "svelte-local-storage-store": "^0.6.0",
         "svelte-maplibre": "^0.7.0",

--- a/web/package.json
+++ b/web/package.json
@@ -68,7 +68,6 @@
     "justified-layout": "^4.1.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.2.1",
-    "maplibre-gl": "^3.6.0",
     "socket.io-client": "^4.6.1",
     "svelte-local-storage-store": "^0.6.0",
     "svelte-maplibre": "^0.7.0",


### PR DESCRIPTION
Removes maplibre-gl dependency as this dependency already exists transitively through svelte-maplibre.