### PR TITLE
feat(server): optimize face re-queueing

### DIFF
--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -417,6 +417,7 @@ export class PersonService {
       numResults: machineLearning.facialRecognition.minFaces,
     });
 
+    // `matches` also includes the face itself
     if (matches.length <= 1) {
       this.logger.debug(`Face ${id} has no matches`);
       return true;
@@ -431,7 +432,7 @@ export class PersonService {
       return true;
     }
 
-    let personId = matches.find((match) => match.face.personId)?.face.personId; // `matches` also includes the face itself
+    let personId = matches.find((match) => match.face.personId)?.face.personId;
     if (!personId) {
       const matchWithPerson = await this.smartInfoRepository.searchFaces({
         userIds: [face.asset.ownerId],

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -417,7 +417,12 @@ export class PersonService {
       numResults: machineLearning.facialRecognition.minFaces,
     });
 
-    this.logger.debug(`Face ${id} has ${matches.length} match${matches.length == 1 ? '' : 'es'}`);
+    if (matches.length <= 1) {
+      this.logger.debug(`Face ${id} has no matches`);
+      return true;
+    }
+
+    this.logger.debug(`Face ${id} has ${matches.length} matches`);
 
     const isCore = matches.length >= machineLearning.facialRecognition.minFaces;
     if (!isCore && !deferred) {


### PR DESCRIPTION
## Description

This is a simple, but effective optimization that minimizes the number of faces re-queued during facial recognition.

We currently re-queue all non-core faces, but this is unnecessary when the face has no matches: it won't be clustered regardless. This is typical of background faces that can make up a significant number of faces in a library.

This optimization benefits "without" jobs the most, as these will have a higher percentage of outlier faces by nature.