### PR TITLE
chore(dep): add intl to ignoreDeps and remove unused packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,10 +83,7 @@
   "ignorePaths": ["mobile/openapi/pubspec.yaml"],
   "ignoreDeps": [
     "http",
-    "latlong2",
-    "vector_map_tiles",
-    "flutter_map",
-    "flutter_map_heatmap"
+    "intl"
   ],
   "labels": ["dependencies", "renovate"]
 }


### PR DESCRIPTION
#### Changes made

-  `latlong2`, `vector_map_tiles`,  `flutter_map` and `flutter_map_heatmap` are not used anymore since we've migrated to maplibre
- added `intl` to `ignoreDeps` since it depends on the version used by the openapi-generator