### PR TITLE
fix: set default thumbnail aspect ratio to square

### DIFF
--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -47,6 +47,7 @@
   class:rounded-xl={curve}
   class:shadow-lg={shadow}
   class:rounded-full={circle}
+  class:aspect-square={circle || !heightStyle}
   class:opacity-0={!thumbhash && !complete}
   draggable="false"
 />


### PR DESCRIPTION
Prevents overlapping people names on `/people` and some other layout shifts like circles with height 0.

I also considered adding a `square` prop, but since all but one current `ImageThumbnail` usages are square or circles anyways, I decided to use `!heightStyle` instead.

Sadly no example screenshot since the demo environment doesn't have images atm :confused: 