### PR TITLE
fix(docs): add cuda tag to ml hwaccel example

### DIFF
--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -69,7 +69,7 @@ You can add this to the `immich-machine-learning` service instead of extending f
 ```yaml
 immich-machine-learning:
   container_name: immich_machine_learning
-  image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+  image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-cuda
   # Note the lack of an `extends` section
   deploy:
     resources:


### PR DESCRIPTION
## Description

This example was just meant to show how "inlining" the `hwaccel.ml.yml` contents works, but if copy/pasted it can cause confusion due to the lack of `-cuda` in the tag.