### PR TITLE
fix(mobile): stack entity handling

### DIFF
--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -34,7 +34,10 @@ class Asset {
         isTrashed = remote.isTrashed,
         isReadOnly = remote.isReadOnly,
         isOffline = remote.isOffline,
-        stackParentId = remote.stackParentId,
+        // workaround to nullify stackParentId for the parent asset until we refactor the mobile app
+        // stack handling to properly handle it
+        stackParentId =
+            remote.stackParentId == remote.id ? null : remote.stackParentId,
         stackCount = remote.stackCount;
 
   Asset.local(AssetEntity local, List<int> hash)
@@ -290,7 +293,6 @@ class Asset {
           width: a.width ?? width,
           height: a.height ?? height,
           exifInfo: a.exifInfo?.copyWith(id: id) ?? exifInfo,
-          stackCount: a.stackCount ?? stackCount,
         );
       } else if (isRemote) {
         return _copyWith(
@@ -305,7 +307,9 @@ class Asset {
           id: id,
           remoteId: remoteId,
           livePhotoVideoId: livePhotoVideoId,
-          stackParentId: stackParentId,
+          // workaround to nullify stackParentId for the parent asset until we refactor the mobile app
+          // stack handling to properly handle it
+          stackParentId: stackParentId == remoteId ? null : stackParentId,
           stackCount: stackCount,
           isFavorite: isFavorite,
           isArchived: isArchived,
@@ -323,8 +327,10 @@ class Asset {
           width: a.width,
           height: a.height,
           livePhotoVideoId: a.livePhotoVideoId,
-          stackParentId: a.stackParentId,
-          stackCount: a.stackCount ?? stackCount,
+          // workaround to nullify stackParentId for the parent asset until we refactor the mobile app
+          // stack handling to properly handle it
+          stackParentId: a.stackParentId == a.remoteId ? null : a.stackParentId,
+          stackCount: a.stackCount,
           // isFavorite + isArchived are not set by device-only assets
           isFavorite: a.isFavorite,
           isArchived: a.isArchived,

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -115,7 +115,7 @@ export class AssetService {
     const userId = dto.userId || auth.user.id;
     await this.access.requirePermission(auth, Permission.TIMELINE_READ, userId);
     const assets = await this.assetRepositoryV1.getAllByUserId(userId, dto);
-    return assets.map((asset) => mapAsset(asset));
+    return assets.map((asset) => mapAsset(asset, { withStack: true }));
   }
 
   async serveThumbnail(auth: AuthDto, assetId: string, dto: GetAssetThumbnailDto): Promise<ImmichFileResponse> {


### PR DESCRIPTION
Fixes #6945 

#### Changes made:

- Update the mobile app logic to handle the new stack entity related changes where the parent asset will have the `stackParentId` set to itself