### PR TITLE
fix(mobile): Stop advancing to next memory on video ended

### DIFF
--- a/mobile/lib/modules/memories/views/memory_page.dart
+++ b/mobile/lib/modules/memories/views/memory_page.dart
@@ -256,9 +256,6 @@ class MemoryPage extends HookConsumerWidget {
                                     asset: asset,
                                     title: memories[mIndex].title,
                                     showTitle: index == 0,
-                                    onVideoEnded: () {
-                                      toNextAsset(index);
-                                    },
                                   ),
                                 ),
                               );


### PR DESCRIPTION
Many video assets are motion photos and we should not auto advance to the next asset when a very short video is completed. We should have a minimum duration to stay on a particular asset in the memory lane.

I would like to re-add this functionality in while working on the autoplay feature.