### PR TITLE
feat(server): restore modified at timestamp after upload, preserve when copying

### DIFF
--- a/server/src/domain/repositories/storage.repository.ts
+++ b/server/src/domain/repositories/storage.repository.ts
@@ -42,4 +42,5 @@ export interface IStorageRepository {
   copyFile(source: string, target: string): Promise<void>;
   rename(source: string, target: string): Promise<void>;
   watch(paths: string[], options: WatchOptions): ImmichWatcher;
+  utimes(filepath: string, atime: Date, mtime: Date): Promise<void>;
 }

--- a/server/src/domain/storage-template/storage-template.service.spec.ts
+++ b/server/src/domain/storage-template/storage-template.service.spec.ts
@@ -534,6 +534,12 @@ describe(StorageTemplateService.name, () => {
         .mockResolvedValue({
           size: 5000,
         } as Stats);
+      when(storageMock.stat)
+        .calledWith(assetStub.image.originalPath)
+        .mockResolvedValue({
+          atime: new Date(),
+          mtime: new Date(),
+        } as Stats);
       when(cryptoMock.hashFile).calledWith(newPath).mockResolvedValue(assetStub.image.checksum);
 
       await sut.handleMigration();
@@ -542,6 +548,8 @@ describe(StorageTemplateService.name, () => {
       expect(storageMock.rename).toHaveBeenCalledWith('/original/path.jpg', newPath);
       expect(storageMock.copyFile).toHaveBeenCalledWith('/original/path.jpg', newPath);
       expect(storageMock.stat).toHaveBeenCalledWith(newPath);
+      expect(storageMock.stat).toHaveBeenCalledWith(assetStub.image.originalPath);
+      expect(storageMock.utimes).toHaveBeenCalledWith(newPath, expect.any(Date), expect.any(Date));
       expect(storageMock.unlink).toHaveBeenCalledWith(assetStub.image.originalPath);
       expect(storageMock.unlink).toHaveBeenCalledTimes(1);
       expect(assetMock.save).toHaveBeenCalledWith({

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -222,6 +222,9 @@ export class StorageCore {
           return;
         }
 
+        const { atime, mtime } = await this.repository.stat(move.oldPath);
+        await this.repository.utimes(newPath, atime, mtime);
+
         try {
           await this.repository.unlink(move.oldPath);
         } catch (error: any) {

--- a/server/src/immich/api-v1/asset/asset.service.ts
+++ b/server/src/immich/api-v1/asset/asset.service.ts
@@ -7,6 +7,7 @@ import {
   IAssetRepository,
   IJobRepository,
   ILibraryRepository,
+  IStorageRepository,
   IUserRepository,
   ImmichFileResponse,
   JobName,
@@ -55,6 +56,7 @@ export class AssetService {
     @Inject(IAssetRepository) private assetRepository: IAssetRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(ILibraryRepository) private libraryRepository: ILibraryRepository,
+    @Inject(IStorageRepository) private storageRepository: IStorageRepository,
     @Inject(IUserRepository) private userRepository: IUserRepository,
   ) {
     this.access = AccessCore.create(accessRepository);
@@ -358,6 +360,10 @@ export class AssetService {
       isOffline: dto.isOffline ?? false,
     });
 
+    if (sidecarPath) {
+      await this.storageRepository.utimes(sidecarPath, new Date(), new Date(dto.fileModifiedAt));
+    }
+    await this.storageRepository.utimes(file.originalPath, new Date(), new Date(dto.fileModifiedAt));
     await this.assetRepository.upsertExif({ assetId: asset.id, fileSizeInByte: file.size });
     await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: asset.id, source: 'upload' } });
 

--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -12,7 +12,7 @@ import archiver from 'archiver';
 import chokidar, { WatchOptions } from 'chokidar';
 import { glob } from 'glob';
 import { constants, createReadStream, existsSync, mkdirSync } from 'node:fs';
-import fs, { copyFile, readdir, rename, writeFile } from 'node:fs/promises';
+import fs, { copyFile, readdir, rename, utimes, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 export class FilesystemProvider implements IStorageRepository {
@@ -55,6 +55,8 @@ export class FilesystemProvider implements IStorageRepository {
   rename = rename;
 
   copyFile = copyFile;
+
+  utimes = utimes;
 
   async checkFileExists(filepath: string, mode = constants.F_OK): Promise<boolean> {
     try {

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -22,5 +22,6 @@ export const newStorageRepositoryMock = (reset = true): jest.Mocked<IStorageRepo
     rename: jest.fn(),
     copyFile: jest.fn(),
     watch: jest.fn(),
+    utimes: jest.fn(),
   };
 };


### PR DESCRIPTION
Created to address https://github.com/immich-app/immich/discussions/2581.

This change makes it so that the asset service restores the mtime of the asset file using the fileModifiedAt parameter.

Also, if renaming the file fails and the storage template service falls back to the copy and delete path instead, the filesystem provider now preserves the atime and mtime from the old file when copying.

This is my first time contributing - let me know if I missed something or what I can do to make this cleaner. Thanks!

(Also, not sure if I should be classifying this as a feature or a fix, I can change the commit message if needed)