### PR TITLE
chore(ml): make execution provider log info-level

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -217,7 +217,7 @@ class InferenceModel(ABC):
 
     @provider_options.setter
     def provider_options(self, provider_options: list[dict[str, Any]]) -> None:
-        log.debug(f"Setting execution provider options to {provider_options}")
+        log.info(f"Setting execution provider options to {provider_options}")
         self._provider_options = provider_options
 
     @property

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -170,7 +170,7 @@ class TestBase:
         encoder.clear_cache()
 
         mock_rmtree.assert_called_once_with(encoder.cache_dir)
-        info.assert_called_once()
+        assert info.call_count == 2
 
     def test_clear_cache_warns_if_path_does_not_exist(self, mocker: MockerFixture) -> None:
         mock_rmtree = mocker.patch("app.models.base.rmtree", autospec=True)


### PR DESCRIPTION
## Description

This one in particular is of more interest than the other configuration-related logs since it reveals what acceleration device (if any) is being used in practice.