### PR TITLE
chore: upgrade to Vite 5.1.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -57,7 +57,7 @@
         "tailwindcss": "^3.2.7",
         "tslib": "^2.5.0",
         "typescript": "^5.3.3",
-        "vite": "^5.0.10",
+        "vite": "^5.1.1",
         "vitest": "^1.0.4"
       }
     },
@@ -6196,9 +6196,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.33",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "dev": true,
       "funding": [
         {
@@ -8031,13 +8031,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
-      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.1.tgz",
+      "integrity": "sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.35",
         "rollup": "^4.2.0"
       },
       "bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,7 @@
     "tailwindcss": "^3.2.7",
     "tslib": "^2.5.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.10",
+    "vite": "^5.1.1",
     "vitest": "^1.0.4"
   },
   "type": "module",


### PR DESCRIPTION
I was hoping it might fix the Vite bug mentioned in https://github.com/immich-app/immich/pull/7035#discussion_r1485629157. It doesn't, but being on the latest should help with reporting an issue there