### PR TITLE
feat(server, web): partner share persons/faces

### DIFF
--- a/mobile/openapi/doc/PersonApi.md
+++ b/mobile/openapi/doc/PersonApi.md
@@ -73,7 +73,7 @@ This endpoint does not need any parameter.
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **getAllPeople**
-> PeopleResponseDto getAllPeople(withHidden)
+> PeopleResponseDto getAllPeople(withHidden, withPartners)
 
 
 
@@ -97,9 +97,10 @@ import 'package:openapi/api.dart';
 
 final api_instance = PersonApi();
 final withHidden = true; // bool | 
+final withPartners = true; // bool | 
 
 try {
-    final result = api_instance.getAllPeople(withHidden);
+    final result = api_instance.getAllPeople(withHidden, withPartners);
     print(result);
 } catch (e) {
     print('Exception when calling PersonApi->getAllPeople: $e\n');
@@ -111,6 +112,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **withHidden** | **bool**|  | [optional] [default to false]
+ **withPartners** | **bool**|  | [optional] [default to false]
 
 ### Return type
 

--- a/mobile/openapi/doc/PersonResponseDto.md
+++ b/mobile/openapi/doc/PersonResponseDto.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **id** | **String** |  | 
 **isHidden** | **bool** |  | 
 **name** | **String** |  | 
+**ownerId** | **String** |  | 
 **thumbnailPath** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/mobile/openapi/doc/PersonWithFacesResponseDto.md
+++ b/mobile/openapi/doc/PersonWithFacesResponseDto.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **id** | **String** |  | 
 **isHidden** | **bool** |  | 
 **name** | **String** |  | 
+**ownerId** | **String** |  | 
 **thumbnailPath** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/mobile/openapi/lib/api/person_api.dart
+++ b/mobile/openapi/lib/api/person_api.dart
@@ -61,7 +61,9 @@ class PersonApi {
   /// Parameters:
   ///
   /// * [bool] withHidden:
-  Future<Response> getAllPeopleWithHttpInfo({ bool? withHidden, }) async {
+  ///
+  /// * [bool] withPartners:
+  Future<Response> getAllPeopleWithHttpInfo({ bool? withHidden, bool? withPartners, }) async {
     // ignore: prefer_const_declarations
     final path = r'/person';
 
@@ -74,6 +76,9 @@ class PersonApi {
 
     if (withHidden != null) {
       queryParams.addAll(_queryParams('', 'withHidden', withHidden));
+    }
+    if (withPartners != null) {
+      queryParams.addAll(_queryParams('', 'withPartners', withPartners));
     }
 
     const contentTypes = <String>[];
@@ -93,8 +98,10 @@ class PersonApi {
   /// Parameters:
   ///
   /// * [bool] withHidden:
-  Future<PeopleResponseDto?> getAllPeople({ bool? withHidden, }) async {
-    final response = await getAllPeopleWithHttpInfo( withHidden: withHidden, );
+  ///
+  /// * [bool] withPartners:
+  Future<PeopleResponseDto?> getAllPeople({ bool? withHidden, bool? withPartners, }) async {
+    final response = await getAllPeopleWithHttpInfo( withHidden: withHidden, withPartners: withPartners, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/person_response_dto.dart
+++ b/mobile/openapi/lib/model/person_response_dto.dart
@@ -17,6 +17,7 @@ class PersonResponseDto {
     required this.id,
     required this.isHidden,
     required this.name,
+    required this.ownerId,
     required this.thumbnailPath,
   });
 
@@ -28,6 +29,8 @@ class PersonResponseDto {
 
   String name;
 
+  String ownerId;
+
   String thumbnailPath;
 
   @override
@@ -36,6 +39,7 @@ class PersonResponseDto {
     other.id == id &&
     other.isHidden == isHidden &&
     other.name == name &&
+    other.ownerId == ownerId &&
     other.thumbnailPath == thumbnailPath;
 
   @override
@@ -45,10 +49,11 @@ class PersonResponseDto {
     (id.hashCode) +
     (isHidden.hashCode) +
     (name.hashCode) +
+    (ownerId.hashCode) +
     (thumbnailPath.hashCode);
 
   @override
-  String toString() => 'PersonResponseDto[birthDate=$birthDate, id=$id, isHidden=$isHidden, name=$name, thumbnailPath=$thumbnailPath]';
+  String toString() => 'PersonResponseDto[birthDate=$birthDate, id=$id, isHidden=$isHidden, name=$name, ownerId=$ownerId, thumbnailPath=$thumbnailPath]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -60,6 +65,7 @@ class PersonResponseDto {
       json[r'id'] = this.id;
       json[r'isHidden'] = this.isHidden;
       json[r'name'] = this.name;
+      json[r'ownerId'] = this.ownerId;
       json[r'thumbnailPath'] = this.thumbnailPath;
     return json;
   }
@@ -76,6 +82,7 @@ class PersonResponseDto {
         id: mapValueOfType<String>(json, r'id')!,
         isHidden: mapValueOfType<bool>(json, r'isHidden')!,
         name: mapValueOfType<String>(json, r'name')!,
+        ownerId: mapValueOfType<String>(json, r'ownerId')!,
         thumbnailPath: mapValueOfType<String>(json, r'thumbnailPath')!,
       );
     }
@@ -128,6 +135,7 @@ class PersonResponseDto {
     'id',
     'isHidden',
     'name',
+    'ownerId',
     'thumbnailPath',
   };
 }

--- a/mobile/openapi/lib/model/person_with_faces_response_dto.dart
+++ b/mobile/openapi/lib/model/person_with_faces_response_dto.dart
@@ -18,6 +18,7 @@ class PersonWithFacesResponseDto {
     required this.id,
     required this.isHidden,
     required this.name,
+    required this.ownerId,
     required this.thumbnailPath,
   });
 
@@ -31,6 +32,8 @@ class PersonWithFacesResponseDto {
 
   String name;
 
+  String ownerId;
+
   String thumbnailPath;
 
   @override
@@ -40,6 +43,7 @@ class PersonWithFacesResponseDto {
     other.id == id &&
     other.isHidden == isHidden &&
     other.name == name &&
+    other.ownerId == ownerId &&
     other.thumbnailPath == thumbnailPath;
 
   @override
@@ -50,10 +54,11 @@ class PersonWithFacesResponseDto {
     (id.hashCode) +
     (isHidden.hashCode) +
     (name.hashCode) +
+    (ownerId.hashCode) +
     (thumbnailPath.hashCode);
 
   @override
-  String toString() => 'PersonWithFacesResponseDto[birthDate=$birthDate, faces=$faces, id=$id, isHidden=$isHidden, name=$name, thumbnailPath=$thumbnailPath]';
+  String toString() => 'PersonWithFacesResponseDto[birthDate=$birthDate, faces=$faces, id=$id, isHidden=$isHidden, name=$name, ownerId=$ownerId, thumbnailPath=$thumbnailPath]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -66,6 +71,7 @@ class PersonWithFacesResponseDto {
       json[r'id'] = this.id;
       json[r'isHidden'] = this.isHidden;
       json[r'name'] = this.name;
+      json[r'ownerId'] = this.ownerId;
       json[r'thumbnailPath'] = this.thumbnailPath;
     return json;
   }
@@ -83,6 +89,7 @@ class PersonWithFacesResponseDto {
         id: mapValueOfType<String>(json, r'id')!,
         isHidden: mapValueOfType<bool>(json, r'isHidden')!,
         name: mapValueOfType<String>(json, r'name')!,
+        ownerId: mapValueOfType<String>(json, r'ownerId')!,
         thumbnailPath: mapValueOfType<String>(json, r'thumbnailPath')!,
       );
     }
@@ -136,6 +143,7 @@ class PersonWithFacesResponseDto {
     'id',
     'isHidden',
     'name',
+    'ownerId',
     'thumbnailPath',
   };
 }

--- a/mobile/openapi/test/person_api_test.dart
+++ b/mobile/openapi/test/person_api_test.dart
@@ -22,7 +22,7 @@ void main() {
       // TODO
     });
 
-    //Future<PeopleResponseDto> getAllPeople({ bool withHidden }) async
+    //Future<PeopleResponseDto> getAllPeople({ bool withHidden, bool withPartners }) async
     test('test getAllPeople', () async {
       // TODO
     });

--- a/mobile/openapi/test/person_response_dto_test.dart
+++ b/mobile/openapi/test/person_response_dto_test.dart
@@ -36,6 +36,11 @@ void main() {
       // TODO
     });
 
+    // String ownerId
+    test('to test the property `ownerId`', () async {
+      // TODO
+    });
+
     // String thumbnailPath
     test('to test the property `thumbnailPath`', () async {
       // TODO

--- a/mobile/openapi/test/person_with_faces_response_dto_test.dart
+++ b/mobile/openapi/test/person_with_faces_response_dto_test.dart
@@ -41,6 +41,11 @@ void main() {
       // TODO
     });
 
+    // String ownerId
+    test('to test the property `ownerId`', () async {
+      // TODO
+    });
+
     // String thumbnailPath
     test('to test the property `thumbnailPath`', () async {
       // TODO

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8676,6 +8676,9 @@
           "name": {
             "type": "string"
           },
+          "ownerId": {
+            "type": "string"
+          },
           "thumbnailPath": {
             "type": "string"
           }
@@ -8685,6 +8688,7 @@
           "id",
           "isHidden",
           "name",
+          "ownerId",
           "thumbnailPath"
         ],
         "type": "object"
@@ -8745,6 +8749,9 @@
           "name": {
             "type": "string"
           },
+          "ownerId": {
+            "type": "string"
+          },
           "thumbnailPath": {
             "type": "string"
           }
@@ -8755,6 +8762,7 @@
           "id",
           "isHidden",
           "name",
+          "ownerId",
           "thumbnailPath"
         ],
         "type": "object"

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4011,6 +4011,7 @@
             "required": false,
             "in": "query",
             "schema": {
+              "default": false,
               "type": "boolean"
             }
           }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4005,6 +4005,14 @@
               "default": false,
               "type": "boolean"
             }
+          },
+          {
+            "name": "withPartners",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/open-api/typescript-sdk/axios-client/api.ts
+++ b/open-api/typescript-sdk/axios-client/api.ts
@@ -14256,10 +14256,11 @@ export const PersonApiAxiosParamCreator = function (configuration?: Configuratio
         /**
          * 
          * @param {boolean} [withHidden] 
+         * @param {boolean} [withPartners] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getAllPeople: async (withHidden?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getAllPeople: async (withHidden?: boolean, withPartners?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/person`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -14283,6 +14284,10 @@ export const PersonApiAxiosParamCreator = function (configuration?: Configuratio
 
             if (withHidden !== undefined) {
                 localVarQueryParameter['withHidden'] = withHidden;
+            }
+
+            if (withPartners !== undefined) {
+                localVarQueryParameter['withPartners'] = withPartners;
             }
 
 
@@ -14676,11 +14681,12 @@ export const PersonApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @param {boolean} [withHidden] 
+         * @param {boolean} [withPartners] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getAllPeople(withHidden?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeopleResponseDto>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllPeople(withHidden, options);
+        async getAllPeople(withHidden?: boolean, withPartners?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeopleResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllPeople(withHidden, withPartners, options);
             const index = configuration?.serverIndex ?? 0;
             const operationBasePath = operationServerMap['PersonApi.getAllPeople']?.[index]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
@@ -14809,7 +14815,7 @@ export const PersonApiFactory = function (configuration?: Configuration, basePat
          * @throws {RequiredError}
          */
         getAllPeople(requestParameters: PersonApiGetAllPeopleRequest = {}, options?: RawAxiosRequestConfig): AxiosPromise<PeopleResponseDto> {
-            return localVarFp.getAllPeople(requestParameters.withHidden, options).then((request) => request(axios, basePath));
+            return localVarFp.getAllPeople(requestParameters.withHidden, requestParameters.withPartners, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -14898,6 +14904,13 @@ export interface PersonApiGetAllPeopleRequest {
      * @memberof PersonApiGetAllPeople
      */
     readonly withHidden?: boolean
+
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PersonApiGetAllPeople
+     */
+    readonly withPartners?: boolean
 }
 
 /**
@@ -15058,7 +15071,7 @@ export class PersonApi extends BaseAPI {
      * @memberof PersonApi
      */
     public getAllPeople(requestParameters: PersonApiGetAllPeopleRequest = {}, options?: RawAxiosRequestConfig) {
-        return PersonApiFp(this.configuration).getAllPeople(requestParameters.withHidden, options).then((request) => request(this.axios, this.basePath));
+        return PersonApiFp(this.configuration).getAllPeople(requestParameters.withHidden, requestParameters.withPartners, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/open-api/typescript-sdk/axios-client/api.ts
+++ b/open-api/typescript-sdk/axios-client/api.ts
@@ -2899,6 +2899,12 @@ export interface PersonResponseDto {
      * @type {string}
      * @memberof PersonResponseDto
      */
+    'ownerId': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof PersonResponseDto
+     */
     'thumbnailPath': string;
 }
 /**
@@ -2981,6 +2987,12 @@ export interface PersonWithFacesResponseDto {
      * @memberof PersonWithFacesResponseDto
      */
     'name': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof PersonWithFacesResponseDto
+     */
+    'ownerId': string;
     /**
      * 
      * @type {string}

--- a/open-api/typescript-sdk/fetch-client.ts
+++ b/open-api/typescript-sdk/fetch-client.ts
@@ -2020,14 +2020,16 @@ export function updatePartner({ id, updatePartnerDto }: {
         body: updatePartnerDto
     })));
 }
-export function getAllPeople({ withHidden }: {
+export function getAllPeople({ withHidden, withPartners }: {
     withHidden?: boolean;
+    withPartners?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: PeopleResponseDto;
     }>(`/person${QS.query(QS.explode({
-        withHidden
+        withHidden,
+        withPartners
     }))}`, {
         ...opts
     }));

--- a/open-api/typescript-sdk/fetch-client.ts
+++ b/open-api/typescript-sdk/fetch-client.ts
@@ -94,6 +94,7 @@ export type PersonWithFacesResponseDto = {
     id: string;
     isHidden: boolean;
     name: string;
+    ownerId: string;
     thumbnailPath: string;
 };
 export type SmartInfoResponseDto = {
@@ -395,6 +396,7 @@ export type PersonResponseDto = {
     id: string;
     isHidden: boolean;
     name: string;
+    ownerId: string;
     thumbnailPath: string;
 };
 export type AssetFaceResponseDto = {

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -28,6 +28,7 @@ www/
 *.launch
 .settings/
 *.sublime-workspace
+*.swp
 
 # IDE - VSCode
 .vscode/*

--- a/server/src/domain/access/access.core.ts
+++ b/server/src/domain/access/access.core.ts
@@ -276,7 +276,9 @@ export class AccessCore {
       }
 
       case Permission.PERSON_READ: {
-        return await this.repository.person.checkOwnerAccess(auth.user.id, ids);
+        const isOwner = await this.repository.person.checkOwnerAccess(auth.user.id, ids);
+        const isPartner = await this.repository.person.checkPartnerAccess(auth.user.id, setDifference(ids, isOwner));
+        return setUnion(isOwner, isPartner);
       }
 
       case Permission.PERSON_WRITE: {

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -241,7 +241,7 @@ export class AssetService {
     if (userId) {
       userIds = [userId];
 
-      if (dto.withPartners) {
+      if (dto.withPartners || dto.personId !== undefined) {
         const partners = await this.partnerRepository.getAll(auth.user.id);
         const partnersIds = partners
           .filter((partner) => partner.sharedBy && partner.sharedWith && partner.inTimeline)

--- a/server/src/domain/person/person.dto.ts
+++ b/server/src/domain/person/person.dto.ts
@@ -63,6 +63,11 @@ export class PersonSearchDto {
   @IsBoolean()
   @Transform(toBoolean)
   withHidden?: boolean = false;
+
+  @Optional()
+  @IsBoolean()
+  @Transform(toBoolean)
+  withPartners?: boolean = false;
 }
 
 export class PersonResponseDto {

--- a/server/src/domain/person/person.dto.ts
+++ b/server/src/domain/person/person.dto.ts
@@ -77,6 +77,7 @@ export class PersonResponseDto {
   birthDate!: Date | null;
   thumbnailPath!: string;
   isHidden!: boolean;
+  ownerId!: string;
 }
 
 export class PersonWithFacesResponseDto extends PersonResponseDto {
@@ -143,6 +144,7 @@ export function mapPerson(person: PersonEntity): PersonResponseDto {
     birthDate: person.birthDate,
     thumbnailPath: person.thumbnailPath,
     isHidden: person.isHidden,
+    ownerId: person.ownerId,
   };
 }
 

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -132,7 +132,7 @@ describe(PersonService.name, () => {
         withHidden: false,
       });
     });
-    it('should get partner\'s people when requested ', async () => {
+    it("should get partner's people when requested ", async () => {
       personMock.getAllForUsers.mockResolvedValue([personStub.withName, personStub.partnerPerson]);
       personMock.getNumberOfPeople.mockResolvedValue(2);
       partnerMock.getAll.mockResolvedValue([partnerStub.adminToUser1, partnerStub.user1ToAdmin1]);
@@ -146,7 +146,7 @@ describe(PersonService.name, () => {
             birthDate: null,
             thumbnailPath: '/path/to/thumbnail',
             isHidden: false,
-          }
+          },
         ],
       });
       expect(personMock.getAllForUsers).toHaveBeenCalledWith([authStub.admin.user.id, authStub.user1.user.id], {

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -48,6 +48,7 @@ const responseDto: PersonResponseDto = {
   birthDate: null,
   thumbnailPath: '/path/to/thumbnail.jpg',
   isHidden: false,
+  ownerId: authStub.admin.user.id,
 };
 
 const statistics = { assets: 3 };
@@ -146,6 +147,7 @@ describe(PersonService.name, () => {
             birthDate: null,
             thumbnailPath: '/path/to/thumbnail',
             isHidden: false,
+            ownerId: authStub.user1.user.id,
           },
         ],
       });
@@ -192,6 +194,7 @@ describe(PersonService.name, () => {
             birthDate: null,
             thumbnailPath: '/path/to/thumbnail.jpg',
             isHidden: true,
+            ownerId: personStub.noName.ownerId,
           },
         ],
       });
@@ -325,6 +328,7 @@ describe(PersonService.name, () => {
         birthDate: new Date('1976-06-30'),
         thumbnailPath: '/path/to/thumbnail.jpg',
         isHidden: false,
+        ownerId: personStub.noName.ownerId,
       });
       expect(personMock.getById).toHaveBeenCalledWith('person-1');
       expect(personMock.update).toHaveBeenCalledWith({ id: 'person-1', birthDate: new Date('1976-06-30') });
@@ -525,6 +529,7 @@ describe(PersonService.name, () => {
         isHidden: personStub.noName.isHidden,
         id: personStub.noName.id,
         name: personStub.noName.name,
+        ownerId: personStub.noName.ownerId,
         thumbnailPath: personStub.noName.thumbnailPath,
       });
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -80,14 +80,13 @@ export class PersonService {
 
   async getAll(auth: AuthDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
     const { machineLearning } = await this.configCore.getConfig();
-    let userIds: string[];
-    userIds = [auth.user.id];
+    const userIds: string[] = [auth.user.id];
     if (dto.withPartners) {
-        const partners = await this.partnerRepository.getAll(auth.user.id);
-        const partnersIds = partners
-        .filter((partner) => partner.sharedBy && partner.sharedWith && partner.sharedById != auth.user.id)  //TODO should && partner.inTimeline be included, as in assets?
+      const partners = await this.partnerRepository.getAll(auth.user.id);
+      const partnersIds = partners
+        .filter((partner) => partner.sharedBy && partner.sharedWith && partner.sharedById != auth.user.id) //TODO should && partner.inTimeline be included, as in assets?
         .map((partner) => partner.sharedById);
-        userIds.push(...partnersIds);
+      userIds.push(...partnersIds);
     }
     const people = await this.repository.getAllForUsers(userIds, {
       minimumFaceCount: machineLearning.facialRecognition.minFaces,

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -84,7 +84,7 @@ export class PersonService {
     if (dto.withPartners) {
       const partners = await this.partnerRepository.getAll(auth.user.id);
       const partnersIds = partners
-        .filter((partner) => partner.sharedBy && partner.sharedWith && partner.sharedById != auth.user.id) //TODO should && partner.inTimeline be included, as in assets?
+        .filter((partner) => partner.sharedBy && partner.sharedWith && partner.sharedById != auth.user.id)
         .map((partner) => partner.sharedById);
       userIds.push(...partnersIds);
     }

--- a/server/src/domain/repositories/access.repository.ts
+++ b/server/src/domain/repositories/access.repository.ts
@@ -36,6 +36,7 @@ export interface IAccessRepository {
   person: {
     checkFaceOwnerAccess(userId: string, assetFaceId: Set<string>): Promise<Set<string>>;
     checkOwnerAccess(userId: string, personIds: Set<string>): Promise<Set<string>>;
+    checkPartnerAccess(userId: string, personIds: Set<string>): Promise<Set<string>>;
   };
 
   partner: {

--- a/server/src/domain/repositories/person.repository.ts
+++ b/server/src/domain/repositories/person.repository.ts
@@ -11,6 +11,7 @@ export interface PersonSearchOptions {
 
 export interface PersonNameSearchOptions {
   withHidden?: boolean;
+  withPartners?: boolean;
 }
 
 export interface AssetFaceId {
@@ -30,7 +31,7 @@ export interface PersonStatistics {
 
 export interface IPersonRepository {
   getAll(pagination: PaginationOptions, options?: FindManyOptions<PersonEntity>): Paginated<PersonEntity>;
-  getAllForUser(userId: string, options: PersonSearchOptions): Promise<PersonEntity[]>;
+  getAllForUsers(userIds: string[], options: PersonSearchOptions): Promise<PersonEntity[]>;
   getAllWithoutFaces(): Promise<PersonEntity[]>;
   getById(personId: string): Promise<PersonEntity | null>;
   getByName(userId: string, personName: string, options: PersonNameSearchOptions): Promise<PersonEntity[]>;
@@ -54,7 +55,7 @@ export interface IPersonRepository {
   getRandomFace(personId: string): Promise<AssetFaceEntity | null>;
   getStatistics(personId: string): Promise<PersonStatistics>;
   reassignFace(assetFaceId: string, newPersonId: string): Promise<number>;
-  getNumberOfPeople(userId: string): Promise<number>;
+  getNumberOfPeople(userIds: string[]): Promise<number>;
   reassignFaces(data: UpdateFacesData): Promise<number>;
   update(entity: Partial<PersonEntity>): Promise<PersonEntity>;
 }

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -381,7 +381,7 @@ class PersonAccess implements IPersonAccess {
 
     return this.partnerRepository
       .createQueryBuilder('partner')
-      .innerJoinAndMapOne('sharedBy.persons', 'person', "person", "person.ownerId = partner.sharedById") //TODO: gives the correct SQL, but somehow feels wrong...
+      .innerJoinAndMapOne('sharedBy.persons', 'person', 'person', 'person.ownerId = partner.sharedById') //TODO: gives the correct SQL, but somehow feels wrong...
       .select('person.id', 'personId')
       .where('partner.sharedWithId = :userId', { userId })
       .andWhere('person.id IN (:...personIds)', { personIds: [...personIds] })

--- a/server/src/infra/repositories/access.repository.ts
+++ b/server/src/infra/repositories/access.repository.ts
@@ -381,7 +381,7 @@ class PersonAccess implements IPersonAccess {
 
     return this.partnerRepository
       .createQueryBuilder('partner')
-      .innerJoinAndMapOne('sharedBy.persons', 'person', 'person', 'person.ownerId = partner.sharedById') //TODO: gives the correct SQL, but somehow feels wrong...
+      .innerJoinAndMapOne('sharedBy.persons', 'person', 'person', 'person.ownerId = partner.sharedById')
       .select('person.id', 'personId')
       .where('partner.sharedWithId = :userId', { userId })
       .andWhere('person.id IN (:...personIds)', { personIds: [...personIds] })

--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -57,12 +57,12 @@ export class PersonRepository implements IPersonRepository {
     return paginate(this.personRepository, pagination, options);
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getAllForUser(userId: string, options?: PersonSearchOptions): Promise<PersonEntity[]> {
+  @GenerateSql({ params: [[DummyValue.UUID]] })
+  getAllForUsers(userIds: string[], options?: PersonSearchOptions): Promise<PersonEntity[]> {
     const queryBuilder = this.personRepository
       .createQueryBuilder('person')
       .leftJoin('person.faces', 'face')
-      .where('person.ownerId = :userId', { userId })
+      .where('person.ownerId IN (:...userIds)', { userIds })
       .innerJoin('face.asset', 'asset')
       .andWhere('asset.isArchived = false')
       .orderBy('person.isHidden', 'ASC')
@@ -206,12 +206,12 @@ export class PersonRepository implements IPersonRepository {
     });
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  async getNumberOfPeople(userId: string): Promise<number> {
+  @GenerateSql({ params: [[DummyValue.UUID]] })
+  async getNumberOfPeople(userIds: string[]): Promise<number> {
     return this.personRepository
       .createQueryBuilder('person')
       .leftJoin('person.faces', 'face')
-      .where('person.ownerId = :userId', { userId })
+      .where('person.ownerId IN (:...userIds)', { userIds })
       .having('COUNT(face.assetId) != 0')
       .groupBy('person.id')
       .withDeleted()

--- a/server/src/infra/sql/access.repository.sql
+++ b/server/src/infra/sql/access.repository.sql
@@ -206,6 +206,16 @@ WHERE
   "partner"."sharedById" IN ($1)
   AND "partner"."sharedWithId" = $2
 
+-- AccessRepository.person.checkPartnerAccess
+SELECT
+  "person"."id" AS "personId"
+FROM
+  "partners" "partner"
+  INNER JOIN "person" "person" ON "person"."ownerId" = "partner"."sharedById"
+WHERE
+  "partner"."sharedWithId" = $1
+  AND "person"."id" IN ($2)
+
 -- AccessRepository.person.checkOwnerAccess
 SELECT
   "PersonEntity"."id" AS "PersonEntity_id"

--- a/server/src/infra/sql/person.repository.sql
+++ b/server/src/infra/sql/person.repository.sql
@@ -7,7 +7,7 @@ SET
 WHERE
   "personId" = $2
 
--- PersonRepository.getAllForUser
+-- PersonRepository.getAllForUsers
 SELECT
   "person"."id" AS "person_id",
   "person"."createdAt" AS "person_createdAt",
@@ -24,7 +24,7 @@ FROM
   INNER JOIN "assets" "asset" ON "asset"."id" = "face"."assetId"
   AND ("asset"."deletedAt" IS NULL)
 WHERE
-  "person"."ownerId" = $1
+  "person"."ownerId" IN ($1)
   AND "asset"."isArchived" = false
   AND "person"."isHidden" = false
 GROUP BY
@@ -349,7 +349,7 @@ FROM
   "person" "person"
   LEFT JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
 WHERE
-  "person"."ownerId" = $1
+  "person"."ownerId" IN ($1)
 HAVING
   COUNT("face"."assetId") != 0
 

--- a/server/test/fixtures/person.stub.ts
+++ b/server/test/fixtures/person.stub.ts
@@ -142,4 +142,18 @@ export const personStub = {
     faceAsset: null,
     isHidden: false,
   }),
+  partnerPerson: Object.freeze<PersonEntity>({
+    id: 'person-4',
+    createdAt: new Date('2021-01-01'),
+    updatedAt: new Date('2021-01-01'),
+    ownerId: userStub.user1.id,
+    owner: userStub.user1,
+    name: 'Person 4',
+    birthDate: null,
+    thumbnailPath: '/path/to/thumbnail',
+    faces: [],
+    faceAssetId: null,
+    faceAsset: null,
+    isHidden: false,
+  }),
 };

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -50,6 +50,7 @@ export const newAccessRepositoryMock = (reset = true): IAccessRepositoryMock => 
     },
 
     person: {
+      checkPartnerAccess: jest.fn().mockResolvedValue(new Set()),
       checkFaceOwnerAccess: jest.fn().mockResolvedValue(new Set()),
       checkOwnerAccess: jest.fn().mockResolvedValue(new Set()),
     },

--- a/server/test/repositories/person.repository.mock.ts
+++ b/server/test/repositories/person.repository.mock.ts
@@ -4,7 +4,7 @@ export const newPersonRepositoryMock = (): jest.Mocked<IPersonRepository> => {
   return {
     getById: jest.fn(),
     getAll: jest.fn(),
-    getAllForUser: jest.fn(),
+    getAllForUsers: jest.fn(),
     getAssets: jest.fn(),
     getAllWithoutFaces: jest.fn(),
 

--- a/web/src/routes/(user)/explore/+page.ts
+++ b/web/src/routes/(user)/explore/+page.ts
@@ -4,7 +4,7 @@ import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate();
-  const [items, response] = await Promise.all([getExploreData(), getAllPeople({ withHidden: false })]);
+  const [items, response] = await Promise.all([getExploreData(), getAllPeople({ withHidden: false, withPartners: true })]);
 
   return {
     items,

--- a/web/src/routes/(user)/explore/+page.ts
+++ b/web/src/routes/(user)/explore/+page.ts
@@ -4,7 +4,10 @@ import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate();
-  const [items, response] = await Promise.all([getExploreData(), getAllPeople({ withHidden: false, withPartners: true })]);
+  const [items, response] = await Promise.all([
+    getExploreData(),
+    getAllPeople({ withHidden: false, withPartners: true }),
+  ]);
 
   return {
     items,

--- a/web/src/routes/(user)/people/+page.ts
+++ b/web/src/routes/(user)/people/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load = (async () => {
   await authenticate();
 
-  const people = await getAllPeople({ withHidden: true });
+  const people = await getAllPeople({ withHidden: true, withPartners: true });
   return {
     people,
     meta: {


### PR DESCRIPTION
This PR will bring the partner's persons/faces into the sharedTo-user's explorer UI
ref discussions: #7038 #5089 #6339 #5457 and probably more

The /person endpoint gains a _withPartners_ flag and web UI is updated to set it.

~~Remains to include _withPartners_ flag when requesting timeBuckets when _personId_ is set, but thought it would be nice to get some review going :)~~
Opportunistically including all parter ids when building time-bucket with the _personId_ option set could potentially be an overkill? 


The shared persons will still behave a bit "strange" (ref #7038) - they are read only!
