### PR TITLE
feat(mobile): Adds blurhash

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -243,7 +243,6 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
     if (widget.preselectedAssets != null) {
       _selectedAssets.addAll(widget.preselectedAssets!);
     }
-
     _itemPositionsListener.itemPositions.addListener(_hapticsListener);
   }
 
@@ -253,6 +252,7 @@ class ImmichAssetGridViewState extends State<ImmichAssetGridView> {
     if (widget.visibleItemsListener != null) {
       _itemPositionsListener.itemPositions.removeListener(_positionListener);
     }
+    _itemPositionsListener.itemPositions.removeListener(_hapticsListener);
     super.dispose();
   }
 
@@ -423,37 +423,50 @@ class _Section extends StatelessWidget {
                 deselectAssets: deselectAssets,
               ),
             for (int i = 0; i < rows; i++)
-              scrolling
-                  ? _PlaceholderRow(
-                      key: ValueKey(i),
-                      number: i + 1 == rows
-                          ? section.count - i * assetsPerRow
-                          : assetsPerRow,
-                      width: width,
-                      height: width,
-                      margin: margin,
-                    )
-                  : _AssetRow(
-                      key: ValueKey(i),
-                      assets: assetsToRender.nestedSlice(
-                        i * assetsPerRow,
-                        min((i + 1) * assetsPerRow, section.count),
-                      ),
-                      absoluteOffset: section.offset + i * assetsPerRow,
-                      width: width,
-                      assetsPerRow: assetsPerRow,
-                      margin: margin,
-                      dynamicLayout: dynamicLayout,
-                      renderList: renderList,
-                      selectedAssets: selectedAssets,
-                      isSelectionActive: selectionActive,
-                      showStack: showStack,
-                      heroOffset: heroOffset,
-                      showStorageIndicator: showStorageIndicator,
-                      selectionActive: selectionActive,
-                      onSelect: (asset) => selectAssets([asset]),
-                      onDeselect: (asset) => deselectAssets([asset]),
-                    ),
+              // Workaround for https://github.com/flutter/flutter/issues/80075
+              ColorFiltered(
+                colorFilter: const ColorFilter.matrix(<double>[
+                  1, 0, 0, 0, 0, // R
+                  0, 1, 0, 0, 0, // G
+                  0, 0, 1, 0, 0, // B
+                  0, 0, 0, 255, 0, // A
+                ]),
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 400),
+                  switchOutCurve: Curves.fastOutSlowIn,
+                  child: scrolling
+                      ? _PlaceholderRow(
+                          key: ValueKey(i),
+                          number: i + 1 == rows
+                              ? section.count - i * assetsPerRow
+                              : assetsPerRow,
+                          width: width,
+                          height: width,
+                          margin: margin,
+                        )
+                      : _AssetRow(
+                          key: ValueKey(i),
+                          assets: assetsToRender.nestedSlice(
+                            i * assetsPerRow,
+                            min((i + 1) * assetsPerRow, section.count),
+                          ),
+                          absoluteOffset: section.offset + i * assetsPerRow,
+                          width: width,
+                          assetsPerRow: assetsPerRow,
+                          margin: margin,
+                          dynamicLayout: dynamicLayout,
+                          renderList: renderList,
+                          selectedAssets: selectedAssets,
+                          isSelectionActive: selectionActive,
+                          showStack: showStack,
+                          heroOffset: heroOffset,
+                          showStorageIndicator: showStorageIndicator,
+                          selectionActive: selectionActive,
+                          onSelect: (asset) => selectAssets([asset]),
+                          onDeselect: (asset) => deselectAssets([asset]),
+                        ),
+                ),
+              ),
           ],
         );
       },

--- a/mobile/lib/shared/models/asset.dart
+++ b/mobile/lib/shared/models/asset.dart
@@ -523,5 +523,5 @@ List<byte>? _decodeThumbhash(String? hash) {
   if (hash == null) {
     return null;
   }
-  return base64.decode(base64.normalize(hash)).toList();
+  return base64.decode(hash);
 }

--- a/mobile/lib/shared/models/asset.g.dart
+++ b/mobile/lib/shared/models/asset.g.dart
@@ -102,19 +102,24 @@ const AssetSchema = CollectionSchema(
       name: r'stackParentId',
       type: IsarType.string,
     ),
-    r'type': PropertySchema(
+    r'thumbhash': PropertySchema(
       id: 17,
+      name: r'thumbhash',
+      type: IsarType.byteList,
+    ),
+    r'type': PropertySchema(
+      id: 18,
       name: r'type',
       type: IsarType.byte,
       enumMap: _AssettypeEnumValueMap,
     ),
     r'updatedAt': PropertySchema(
-      id: 18,
+      id: 19,
       name: r'updatedAt',
       type: IsarType.dateTime,
     ),
     r'width': PropertySchema(
-      id: 19,
+      id: 20,
       name: r'width',
       type: IsarType.int,
     )
@@ -210,6 +215,12 @@ int _assetEstimateSize(
       bytesCount += 3 + value.length * 3;
     }
   }
+  {
+    final value = object.thumbhash;
+    if (value != null) {
+      bytesCount += 3 + value.length;
+    }
+  }
   return bytesCount;
 }
 
@@ -236,9 +247,10 @@ void _assetSerialize(
   writer.writeString(offsets[14], object.remoteId);
   writer.writeLong(offsets[15], object.stackCount);
   writer.writeString(offsets[16], object.stackParentId);
-  writer.writeByte(offsets[17], object.type.index);
-  writer.writeDateTime(offsets[18], object.updatedAt);
-  writer.writeInt(offsets[19], object.width);
+  writer.writeByteList(offsets[17], object.thumbhash);
+  writer.writeByte(offsets[18], object.type.index);
+  writer.writeDateTime(offsets[19], object.updatedAt);
+  writer.writeInt(offsets[20], object.width);
 }
 
 Asset _assetDeserialize(
@@ -266,10 +278,11 @@ Asset _assetDeserialize(
     remoteId: reader.readStringOrNull(offsets[14]),
     stackCount: reader.readLongOrNull(offsets[15]),
     stackParentId: reader.readStringOrNull(offsets[16]),
-    type: _AssettypeValueEnumMap[reader.readByteOrNull(offsets[17])] ??
+    thumbhash: reader.readByteList(offsets[17]),
+    type: _AssettypeValueEnumMap[reader.readByteOrNull(offsets[18])] ??
         AssetType.other,
-    updatedAt: reader.readDateTime(offsets[18]),
-    width: reader.readIntOrNull(offsets[19]),
+    updatedAt: reader.readDateTime(offsets[19]),
+    width: reader.readIntOrNull(offsets[20]),
   );
   return object;
 }
@@ -316,11 +329,13 @@ P _assetDeserializeProp<P>(
     case 16:
       return (reader.readStringOrNull(offset)) as P;
     case 17:
+      return (reader.readByteList(offset)) as P;
+    case 18:
       return (_AssettypeValueEnumMap[reader.readByteOrNull(offset)] ??
           AssetType.other) as P;
-    case 18:
-      return (reader.readDateTime(offset)) as P;
     case 19:
+      return (reader.readDateTime(offset)) as P;
+    case 20:
       return (reader.readIntOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -2078,6 +2093,159 @@ extension AssetQueryFilter on QueryBuilder<Asset, Asset, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'thumbhash',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'thumbhash',
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashElementEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'thumbhash',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashElementGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'thumbhash',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashElementLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'thumbhash',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashElementBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'thumbhash',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashLengthEqualTo(
+      int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<Asset, Asset, QAfterFilterCondition> thumbhashLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'thumbhash',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+
   QueryBuilder<Asset, Asset, QAfterFilterCondition> typeEqualTo(
       AssetType value) {
     return QueryBuilder.apply(this, (query) {
@@ -2864,6 +3032,12 @@ extension AssetQueryWhereDistinct on QueryBuilder<Asset, Asset, QDistinct> {
     });
   }
 
+  QueryBuilder<Asset, Asset, QDistinct> distinctByThumbhash() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'thumbhash');
+    });
+  }
+
   QueryBuilder<Asset, Asset, QDistinct> distinctByType() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'type');
@@ -2989,6 +3163,12 @@ extension AssetQueryProperty on QueryBuilder<Asset, Asset, QQueryProperty> {
   QueryBuilder<Asset, String?, QQueryOperations> stackParentIdProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'stackParentId');
+    });
+  }
+
+  QueryBuilder<Asset, List<int>?, QQueryOperations> thumbhashProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'thumbhash');
     });
   }
 

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -11,8 +11,9 @@ import 'package:immich_mobile/shared/models/store.dart';
 import 'package:octo_image/octo_image.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager_image_provider/photo_manager_image_provider.dart';
+import 'package:thumbhash/thumbhash.dart' as thumbhash;
 
-class ImmichImage extends StatelessWidget {
+class ImmichImage extends StatefulWidget {
   const ImmichImage(
     this.asset, {
     this.width,
@@ -55,6 +56,9 @@ class ImmichImage extends StatelessWidget {
       thumbnailSize: thumbnailSize,
     );
   }
+
+  @override
+  State<ImmichImage> createState() => _ImmichImageState();
 
   // Helper function to return the image provider for the asset
   // either by using the asset ID or the asset itself
@@ -145,6 +149,106 @@ class ImmichImage extends StatelessWidget {
         } else {
           debugPrint(
             "Error getting thumb for assetId=${asset?.localId}: $error",
+          );
+        }
+        return Icon(
+          Icons.image_not_supported_outlined,
+          color: context.primaryColor,
+        );
+      },
+    );
+  }
+}
+
+class _ImmichImageState extends State<ImmichImage> {
+  // Creating the Uint8List from the List<bytes> during each build results in flickers during
+  // the fade transition. Calculate the hash in the initState and cache it for further builds
+  Uint8List? thumbHashBytes;
+  static const _placeholderDimension = 300.0;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.asset?.thumbhash != null) {
+      final bytes = Uint8List.fromList(widget.asset!.thumbhash!);
+      final rgbaImage = thumbhash.thumbHashToRGBA(bytes);
+      thumbHashBytes = thumbhash.rgbaToBmp(rgbaImage);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.asset == null) {
+      return Container(
+        decoration: const BoxDecoration(
+          color: Colors.grey,
+        ),
+        child: SizedBox(
+          width: widget.width,
+          height: widget.height,
+          child: const Center(
+            child: Icon(Icons.no_photography),
+          ),
+        ),
+      );
+    }
+
+    final Asset asset = widget.asset!;
+
+    return Image(
+      image: ImmichImage.imageProvider(
+        asset: asset,
+        isThumbnail: widget.isThumbnail,
+      ),
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      loadingBuilder: (_, child, loadingProgress) {
+        return AnimatedOpacity(
+          opacity: loadingProgress != null ? 0 : 1,
+          duration: const Duration(seconds: 1),
+          curve: Curves.easeOut,
+          child: child,
+        );
+      },
+      frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+        if (wasSynchronouslyLoaded || frame != null) {
+          return child;
+        }
+
+        return Stack(
+          alignment: Alignment.center,
+          children: [
+            if (widget.useGrayBoxPlaceholder)
+              const SizedBox.square(
+                dimension: _placeholderDimension,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(color: Colors.grey),
+                ),
+              ),
+            if (thumbHashBytes != null)
+              Image.memory(
+                thumbHashBytes!,
+                width: _placeholderDimension,
+                height: _placeholderDimension,
+                fit: BoxFit.cover,
+              ),
+            if (widget.useProgressIndicator)
+              const Center(
+                child: CircularProgressIndicator(),
+              ),
+          ],
+        );
+      },
+      errorBuilder: (context, error, stackTrace) {
+        if (error is PlatformException &&
+            error.code == "The asset not found!") {
+          debugPrint(
+            "Asset ${asset.localId} does not exist anymore on device!",
+          );
+        } else {
+          debugPrint(
+            "Error getting thumb for assetId=${asset.localId}: $error",
           );
         }
         return Icon(

--- a/mobile/lib/shared/ui/immich_image.dart
+++ b/mobile/lib/shared/ui/immich_image.dart
@@ -105,59 +105,6 @@ class ImmichImage extends StatefulWidget {
   static bool useLocal(Asset asset) =>
       !asset.isRemote ||
       asset.isLocal && !Store.get(StoreKey.preferRemoteImage, false);
-  @override
-  Widget build(BuildContext context) {
-    if (asset == null) {
-      return Container(
-        decoration: const BoxDecoration(
-          color: Colors.grey,
-        ),
-        child: SizedBox(
-          width: width,
-          height: height,
-          child: const Center(
-            child: Icon(Icons.no_photography),
-          ),
-        ),
-      );
-    }
-
-    return OctoImage(
-      fadeInDuration: const Duration(milliseconds: 0),
-      fadeOutDuration: const Duration(milliseconds: 200),
-      placeholderBuilder: (context) {
-        if (placeholder != null) {
-          // Use the gray box placeholder
-          return placeholder!;
-        }
-        // No placeholder
-        return const SizedBox();
-      },
-      image: ImmichImage.imageProvider(
-        asset: asset,
-        isThumbnail: isThumbnail,
-      ),
-      width: width,
-      height: height,
-      fit: fit,
-      errorBuilder: (context, error, stackTrace) {
-        if (error is PlatformException &&
-            error.code == "The asset not found!") {
-          debugPrint(
-            "Asset ${asset?.localId} does not exist anymore on device!",
-          );
-        } else {
-          debugPrint(
-            "Error getting thumb for assetId=${asset?.localId}: $error",
-          );
-        }
-        return Icon(
-          Icons.image_not_supported_outlined,
-          color: context.primaryColor,
-        );
-      },
-    );
-  }
 }
 
 /// Renders an Asset using local data if available, else remote data
@@ -196,8 +143,8 @@ class _ImmichImageState extends State<ImmichImage> {
     final Asset asset = widget.asset!;
 
     return OctoImage(
-      fadeInDuration: const Duration(milliseconds: 200),
-      fadeOutDuration: const Duration(milliseconds: 200),
+      fadeInDuration: const Duration(milliseconds: 0),
+      fadeOutDuration: const Duration(milliseconds: 400),
       placeholderBuilder: (context) {
         if (thumbHashBytes != null && widget.isThumbnail) {
           // Use the blurhash placeholder
@@ -205,13 +152,9 @@ class _ImmichImageState extends State<ImmichImage> {
             thumbHashBytes!,
             fit: BoxFit.cover,
           );
-        } else if (widget.useGrayBoxPlaceholder) {
+        } else if (widget.placeholder != null) {
           // Use the gray box placeholder
-          return const SizedBox.expand(
-            child: DecoratedBox(
-              decoration: BoxDecoration(color: Colors.grey),
-            ),
-          );
+          return widget.placeholder!;
         }
         // No placeholder
         return const SizedBox();

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1467,6 +1467,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  thumbhash:
+    dependency: "direct main"
+    description:
+      name: thumbhash
+      sha256: "5f6d31c5279ca0b5caa81ec10aae8dcaab098d82cb699ea66ada4ed09c794a37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0+1"
   time:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   wakelock_plus: ^1.1.4
   flutter_local_notifications: ^16.3.2
   timezone: ^0.9.2
+  thumbhash: 0.1.0+1
   octo_image: ^2.0.0
 
   openapi:


### PR DESCRIPTION
Adds blur hash to the thumbnails and animates them in using an AnimatedSwitcher from the asset grid.

We tried to implement thumbhash support in #7016 but it became a little unwieldy once we added in the Animated Switcher here.

This branch contains almost everything from that other PR, so it's completely dependent on that being merged in first. Once that merges in, this PR can be cleaned up significantly.