### PR TITLE
feat(web): lazy load photo sphere viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -2,40 +2,29 @@
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { api, type AssetResponseDto } from '@api';
-  import PhotoSphere from './photo-sphere-viewer-adapter.svelte';
 
   export let asset: AssetResponseDto;
 
-  let dataUrl = '';
-  let errorMessage = '';
-
   const loadAssetData = async () => {
-    try {
-      const { data } = await api.assetApi.serveFile(
-        { id: asset.id, isThumb: false, isWeb: false, key: api.getKey() },
-        { responseType: 'blob' },
-      );
-      if (data instanceof Blob) {
-        dataUrl = URL.createObjectURL(data);
-        return dataUrl;
-      } else {
-        throw new TypeError('Invalid data format');
-      }
-    } catch {
-      errorMessage = 'Failed to load asset';
-      return '';
+    const { data } = await api.assetApi.serveFile(
+      { id: asset.id, isThumb: false, isWeb: false, key: api.getKey() },
+      { responseType: 'blob' },
+    );
+    if (data instanceof Blob) {
+      return URL.createObjectURL(data);
+    } else {
+      throw new TypeError('Invalid data format');
     }
   };
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
-  {#await loadAssetData()}
+  <!-- the photo sphere viewer is quite large, so lazy load it in parallel with loading the data -->
+  {#await Promise.all([loadAssetData(), import('./photo-sphere-viewer-adapter.svelte')])}
     <LoadingSpinner />
-  {:then assetData}
-    {#if assetData}
-      <PhotoSphere panorama={assetData} />
-    {:else}
-      <p>{errorMessage}</p>
-    {/if}
+  {:then result}
+    <svelte:component this={result[1].default} panorama={result[0]} />
+  {:catch}
+    Failed to load asset
   {/await}
 </div>

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -22,8 +22,8 @@
   <!-- the photo sphere viewer is quite large, so lazy load it in parallel with loading the data -->
   {#await Promise.all([loadAssetData(), import('./photo-sphere-viewer-adapter.svelte')])}
     <LoadingSpinner />
-  {:then result}
-    <svelte:component this={result[1].default} panorama={result[0]} />
+  {:then [data, module]}
+    <svelte:component this={module.default} panorama={data} />
   {:catch}
     Failed to load asset
   {/await}


### PR DESCRIPTION
Are there any panoramas in the demo instance? I didn't see a way to search for panoramas, so wasn't sure how to find one to test and check that I didn't break anything.

Before:
```
.svelte-kit/output/client/_app/immutable/chunks/asset-viewer.bSlvLiFG.js               1,581.26 kB │ gzip: 433.21 kB
```

After:
```
.svelte-kit/output/client/_app/immutable/chunks/photo-sphere-viewer-adapter.ctx2RvS1.js     566.44 kB │ gzip: 148.17 kB
.svelte-kit/output/client/_app/immutable/chunks/asset-viewer.9FWEg5V5.js                  1,011.00 kB │ gzip: 283.47 kB
```