### PR TITLE
chore: update lockfiles

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -44,7 +44,7 @@
       "name": "@immich/sdk",
       "version": "1.92.1",
       "dev": true,
-      "license": "MIT",
+      "license": "GNU Affero General Public License version 3",
       "devDependencies": {
         "@types/node": "^20.11.0",
         "oazapfts": "^5.1.4",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -65,7 +65,7 @@
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
       "version": "1.92.1",
-      "license": "MIT",
+      "license": "GNU Affero General Public License version 3",
       "devDependencies": {
         "@types/node": "^20.11.0",
         "oazapfts": "^5.1.4",


### PR DESCRIPTION
Running `npm install` automatically updates these