### PR TITLE
fix(web): always show asset owner when viewing an asset from a shared album

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -732,7 +732,7 @@
     >
       <DetailPanel
         {asset}
-        albumId={album?.id}
+        currentAlbum={album}
         albums={appearsInAlbums}
         on:close={() => ($isShowDetail = false)}
         on:closeViewer={handleCloseViewer}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -36,7 +36,7 @@
 
   export let asset: AssetResponseDto;
   export let albums: AlbumResponseDto[] = [];
-  export let albumId: string | null = null;
+  export let currentAlbum: AlbumResponseDto | null = null;
 
   let showAssetPath = false;
   let textArea: HTMLTextAreaElement;
@@ -275,8 +275,8 @@
               on:mouseleave={() => ($boundingBoxesArray = [])}
             >
               <a
-                href="{AppRoute.PEOPLE}/{person.id}?{QueryParameter.PREVIOUS_ROUTE}={albumId
-                  ? `${AppRoute.ALBUMS}/${albumId}`
+                href="{AppRoute.PEOPLE}/{person.id}?{QueryParameter.PREVIOUS_ROUTE}={currentAlbum?.id
+                  ? `${AppRoute.ALBUMS}/${currentAlbum?.id}`
                   : AppRoute.PHOTOS}"
                 on:click={() => dispatch('closeViewer')}
               >
@@ -637,8 +637,8 @@
   </div>
 {/if}
 
-{#if asset.owner && !isOwner}
-  <section class="px-6 pt-6 dark:text-immich-dark-fg">
+{#if currentAlbum && currentAlbum.sharedUsers.length > 0 && asset.owner}
+  <section class="px-6 dark:text-immich-dark-fg">
     <p class="text-sm">SHARED BY</p>
     <div class="flex gap-4 pt-4">
       <div>


### PR DESCRIPTION
Always show who owns the asset in the detail-panel when the asset is viewed from a shared album.

## Screenshots

| | Before | After |
| :---: | :---: | :--: |
| Seeing the asset as the owner | ![Screenshot from 2024-02-14 01-47-50](https://github.com/immich-app/immich/assets/74269598/3841438c-25d9-40c8-803e-19e38c5f0341) | ![Screenshot from 2024-02-14 01-46-58](https://github.com/immich-app/immich/assets/74269598/3e73b892-9984-44ab-8954-913148a9c4fc) |
| Seeing the asset as a non-owner | ![Screenshot from 2024-02-14 01-47-28](https://github.com/immich-app/immich/assets/74269598/18c29997-8fd0-447d-8795-dd98b19da6d8) | ![Screenshot from 2024-02-14 01-47-14](https://github.com/immich-app/immich/assets/74269598/86cd80a4-7f43-4eaa-ac55-49638bce42e6) |