### PR TITLE
chore(web): auto sort imports

### DIFF
--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -3,6 +3,7 @@
   "trailingComma": "all",
   "printWidth": 120,
   "semi": true,
-  "plugins": ["prettier-plugin-svelte"],
+  "plugins": ["prettier-plugin-organize-imports", "prettier-plugin-svelte"],
+  "organizeImportsSkipDestructiveCodeActions": true,
   "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -50,6 +50,7 @@
         "identity-obj-proxy": "^3.0.0",
         "postcss": "^8.4.21",
         "prettier": "^3.1.0",
+        "prettier-plugin-organize-imports": "^3.2.4",
         "prettier-plugin-svelte": "^3.1.2",
         "rollup-plugin-visualizer": "^5.12.0",
         "svelte": "^4.0.5",
@@ -6396,6 +6397,26 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz",
+      "integrity": "sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==",
+      "dev": true,
+      "peerDependencies": {
+        "@volar/vue-language-plugin-pug": "^1.0.4",
+        "@volar/vue-typescript": "^1.0.4",
+        "prettier": ">=2.0",
+        "typescript": ">=2.9"
+      },
+      "peerDependenciesMeta": {
+        "@volar/vue-language-plugin-pug": {
+          "optional": true
+        },
+        "@volar/vue-typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prettier-plugin-svelte": {

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "identity-obj-proxy": "^3.0.0",
     "postcss": "^8.4.21",
     "prettier": "^3.1.0",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-svelte": "^3.1.2",
     "rollup-plugin-visualizer": "^5.12.0",
     "svelte": "^4.0.5",

--- a/web/src/lib/components/shared-components/notification/__tests__/notification-list.spec.ts
+++ b/web/src/lib/components/shared-components/notification/__tests__/notification-list.spec.ts
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
-import { render, type RenderResult, waitFor } from '@testing-library/svelte';
+import { render, waitFor, type RenderResult } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-import { notificationController, NotificationType } from '../notification';
+import { NotificationType, notificationController } from '../notification';
 import NotificationList from '../notification-list.svelte';
 
 function _getNotificationListElement(sut: RenderResult<NotificationList>): HTMLAnchorElement | null {

--- a/web/src/routes/(user)/search/+page.ts
+++ b/web/src/routes/(user)/search/+page.ts
@@ -1,7 +1,7 @@
+import { QueryParameter } from '$lib/constants';
 import { authenticate } from '$lib/utils/auth';
 import { search, type AssetResponseDto, type SearchResponseDto } from '@immich/sdk';
 import type { PageLoad } from './$types';
-import { QueryParameter } from '$lib/constants';
 
 export const load = (async (data) => {
   await authenticate();

--- a/web/src/routes/auth/change-password/+page.ts
+++ b/web/src/routes/auth/change-password/+page.ts
@@ -1,9 +1,9 @@
 import { AppRoute } from '$lib/constants';
+import { user } from '$lib/stores/user.store';
 import { authenticate } from '$lib/utils/auth';
 import { redirect } from '@sveltejs/kit';
-import type { PageLoad } from './$types';
 import { get } from 'svelte/store';
-import { user } from '$lib/stores/user.store';
+import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate();

--- a/web/src/routes/auth/onboarding/+page.ts
+++ b/web/src/routes/auth/onboarding/+page.ts
@@ -1,6 +1,6 @@
-import type { PageLoad } from './$types';
-import { authenticate } from '$lib/utils/auth';
 import { loadConfig } from '$lib/stores/server-config.store';
+import { authenticate } from '$lib/utils/auth';
+import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate({ admin: true });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,7 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig } from 'vite';
-import path from 'node:path';
 
 const upstream = {
   target: process.env.IMMICH_SERVER_URL || 'http://immich-server:3001/',


### PR DESCRIPTION
Doesn't look like this plugin supports `.svelte` files yet, but it'll require and auto-fix `.ts` ones.