### PR TITLE
fix(web): search params

### DIFF
--- a/web/src/routes/(user)/search/+page.ts
+++ b/web/src/routes/(user)/search/+page.ts
@@ -10,7 +10,11 @@ export const load = (async (data) => {
     url.searchParams.get(QueryParameter.SEARCH_TERM) || url.searchParams.get(QueryParameter.QUERY) || undefined;
   let results: SearchResponseDto | null = null;
   if (term) {
-    const response = await search({ ...data.url.searchParams });
+    let params = {};
+    for (const [key, value] of data.url.searchParams) {
+      params = {...params, [key]:value};
+    }
+    const response = await search({ ...params });
     let items: AssetResponseDto[] = (data as unknown as { results: SearchResponseDto }).results?.assets.items;
     if (items) {
       items.push(...response.assets.items);

--- a/web/src/routes/(user)/search/+page.ts
+++ b/web/src/routes/(user)/search/+page.ts
@@ -12,7 +12,7 @@ export const load = (async (data) => {
   if (term) {
     let params = {};
     for (const [key, value] of data.url.searchParams) {
-      params = {...params, [key]:value};
+      params = { ...params, [key]: value };
     }
     const response = await search({ ...params });
     let items: AssetResponseDto[] = (data as unknown as { results: SearchResponseDto }).results?.assets.items;


### PR DESCRIPTION
`...data.url.searchParams` is no longer translated into key value pair. It is now under this format and doesn't work with the API. 

![image](https://github.com/immich-app/immich/assets/27055614/3db9ae6c-dace-460c-bcd8-63cc28a7f544)

This PR reconstruct the params into an object
