### PR TITLE
fix(server): recognize faces when min. faces is set to 1

### DIFF
--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -867,7 +867,9 @@ describe(PersonService.name, () => {
     });
 
     it('should not queue face with no matches', async () => {
-      searchMock.searchFaces.mockResolvedValue([]);
+      const faces = [{ face: faceStub.noPerson1, distance: 0 }] as FaceSearchResult[];
+
+      searchMock.searchFaces.mockResolvedValue(faces);
       personMock.getFaceByIdWithAssets.mockResolvedValue(faceStub.noPerson1);
       personMock.create.mockResolvedValue(personStub.withName);
 

--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -867,9 +867,7 @@ describe(PersonService.name, () => {
     });
 
     it('should not queue face with no matches', async () => {
-      const faces = [{ face: faceStub.noPerson1, distance: 0 }] as FaceSearchResult[];
-
-      searchMock.searchFaces.mockResolvedValue(faces);
+      searchMock.searchFaces.mockResolvedValue([]);
       personMock.getFaceByIdWithAssets.mockResolvedValue(faceStub.noPerson1);
       personMock.create.mockResolvedValue(personStub.withName);
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -411,7 +411,7 @@ export class PersonService {
 
     // `matches` also includes the face itself
     if (machineLearning.facialRecognition.minFaces > 1 && matches.length <= 1) {
-      this.logger.debug(`Face ${id} has fewer matches than required`);
+      this.logger.debug(`Face ${id} only matched the face itself, skipping`);
       return true;
     }
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -410,8 +410,8 @@ export class PersonService {
     });
 
     // `matches` also includes the face itself
-    if (matches.length === 0) {
-      this.logger.debug(`Face ${id} has no matches`);
+    if (machineLearning.facialRecognition.minFaces > 1 && matches.length <= 1) {
+      this.logger.debug(`Face ${id} has fewer matches than required`);
       return true;
     }
 

--- a/server/src/domain/person/person.service.ts
+++ b/server/src/domain/person/person.service.ts
@@ -410,7 +410,7 @@ export class PersonService {
     });
 
     // `matches` also includes the face itself
-    if (matches.length <= 1) {
+    if (matches.length === 0) {
       this.logger.debug(`Face ${id} has no matches`);
       return true;
     }


### PR DESCRIPTION
In #6961 there was an optimization to face recognition, but it overlooks the scenario where `machineLearning.facialRecognition.minFaces` is set to `1`, resulting in no person being created.

Has been tested in an empty instance by setting MIN RECOGNIZED FACES to 1 and then uploading an image with a single face and match
