### PR TITLE
refactor(web): websocket events

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@faker-js/faker": "^8.0.0",
         "@floating-ui/dom": "^1.5.1",
+        "@socket.io/component-emitter": "^3.1.0",
         "@sveltejs/adapter-static": "^3.0.1",
         "@sveltejs/kit": "^2.0.6",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.0.0",
     "@floating-ui/dom": "^1.5.1",
+    "@socket.io/component-emitter": "^3.1.0",
     "@sveltejs/adapter-static": "^3.0.1",
     "@sveltejs/kit": "^2.0.6",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -6,7 +6,7 @@
   import { locale } from '$lib/stores/preferences.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { user } from '$lib/stores/user.store';
-  import { websocketStore } from '$lib/stores/websocket';
+  import { websocketEvents } from '$lib/stores/websocket';
   import { getAssetThumbnailUrl, getPeopleThumbnailUrl, isSharedLink } from '$lib/utils';
   import { getAssetFilename } from '$lib/utils/asset-utils';
   import { autoGrowHeight } from '$lib/utils/autogrow';
@@ -30,7 +30,7 @@
     mdiPencil,
   } from '@mdi/js';
   import { DateTime } from 'luxon';
-  import { createEventDispatcher, onDestroy } from 'svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
   import { slide } from 'svelte/transition';
   import { asByteUnitString } from '../../utils/byte-units';
   import { handleError } from '../../utils/handle-error';
@@ -91,14 +91,12 @@
   $: people = asset.people || [];
   $: showingHiddenPeople = false;
 
-  const unsubscribe = websocketStore.onAssetUpdate.subscribe((assetUpdate) => {
-    if (assetUpdate && assetUpdate.id === asset.id) {
-      asset = assetUpdate;
-    }
-  });
-
-  onDestroy(() => {
-    unsubscribe();
+  onMount(() => {
+    return websocketEvents.on('on_asset_update', (assetUpdate) => {
+      if (assetUpdate.id === asset.id) {
+        asset = assetUpdate;
+      }
+    });
   });
 
   const dispatch = createEventDispatcher<{

--- a/web/src/lib/components/shared-components/update-panel.svelte
+++ b/web/src/lib/components/shared-components/update-panel.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
-  import { websocketStore } from '$lib/stores/websocket';
+  import { websocketEvents } from '$lib/stores/websocket';
   import type { AssetStore } from '$lib/stores/assets.store';
+  import { onMount } from 'svelte';
 
   export let assetStore: AssetStore | null;
 
-  websocketStore.onAssetUpdate.subscribe((asset) => {
-    if (asset && asset.originalFileName && assetStore) {
-      assetStore.updateAsset(asset, true);
+  onMount(() => {
+    return websocketEvents.on('on_asset_update', (asset) => {
+      if (asset.originalFileName && assetStore) {
+        assetStore.updateAsset(asset, true);
 
-      assetStore.removeAsset(asset.id); // Update timeline
-      assetStore.addAsset(asset);
-    }
+        assetStore.removeAsset(asset.id); // Update timeline
+        assetStore.addAsset(asset);
+      }
+    });
   });
 </script>

--- a/web/src/lib/components/shared-components/version-announcement-box.svelte
+++ b/web/src/lib/components/shared-components/version-announcement-box.svelte
@@ -6,13 +6,13 @@
 
   let showModal = false;
 
-  const { onRelease } = websocketStore;
+  const { release } = websocketStore;
 
   const semverToName = ({ major, minor, patch }: ServerVersionResponseDto) => `v${major}.${minor}.${patch}`;
 
-  $: releaseVersion = $onRelease && semverToName($onRelease.releaseVersion);
-  $: serverVersion = $onRelease && semverToName($onRelease.serverVersion);
-  $: $onRelease?.isAvailable && handleRelease();
+  $: releaseVersion = $release && semverToName($release.releaseVersion);
+  $: serverVersion = $release && semverToName($release.serverVersion);
+  $: $release?.isAvailable && handleRelease();
 
   const onAcknowledge = () => {
     localStorage.setItem('appVersion', releaseVersion);

--- a/web/src/lib/utils/eventemitter.ts
+++ b/web/src/lib/utils/eventemitter.ts
@@ -1,0 +1,42 @@
+import type {
+  DefaultEventsMap,
+  EventsMap,
+  ReservedOrUserEventNames,
+  ReservedOrUserListener,
+} from '@socket.io/component-emitter';
+import type { Socket } from 'socket.io-client';
+
+export function createEventEmitter<
+  ListenEvents extends EventsMap = DefaultEventsMap,
+  EmitEvents extends EventsMap = ListenEvents,
+  ReservedEvents extends EventsMap = NonNullable<unknown>,
+>(socket: Socket<ListenEvents, EmitEvents>) {
+  function on<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
+    ev: Ev,
+    listener: ReservedOrUserListener<ReservedEvents, ListenEvents, Ev>,
+  ) {
+    socket.on(ev, listener);
+    return () => {
+      socket.off(ev, listener);
+    };
+  }
+
+  function once<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
+    ev: Ev,
+    listener: ReservedOrUserListener<ReservedEvents, ListenEvents, Ev>,
+  ) {
+    socket.once(ev, listener);
+    return () => {
+      socket.off(ev, listener);
+    };
+  }
+
+  function off<Ev extends ReservedOrUserEventNames<ReservedEvents, ListenEvents>>(
+    ev: Ev,
+    listener: ReservedOrUserListener<ReservedEvents, ListenEvents, Ev>,
+  ) {
+    socket.off(ev, listener);
+  }
+
+  return { on, once, off };
+}

--- a/web/src/routes/(user)/people/[personId]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/+page.svelte
@@ -30,7 +30,7 @@
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { AssetStore } from '$lib/stores/assets.store';
-  import { websocketStore } from '$lib/stores/websocket';
+  import { websocketEvents } from '$lib/stores/websocket';
   import { getPeopleThumbnailUrl } from '$lib/utils';
   import { clickOutside } from '$lib/utils/click-outside';
   import { handleError } from '$lib/utils/handle-error';
@@ -68,7 +68,6 @@
   });
   const assetInteractionStore = createAssetInteractionStore();
   const { selectedAssets, isMultiSelectState } = assetInteractionStore;
-  const { onPersonThumbnail } = websocketStore;
 
   let viewMode: ViewMode = ViewMode.VIEW_ASSETS;
   let isEditingName = false;
@@ -119,8 +118,6 @@
 
   $: isAllArchive = [...$selectedAssets].every((asset) => asset.isArchived);
   $: isAllFavorite = [...$selectedAssets].every((asset) => asset.isFavorite);
-  $: $onPersonThumbnail === data.person.id &&
-    (thumbnailData = getPeopleThumbnailUrl(data.person.id) + `?now=${Date.now()}`);
 
   $: {
     if (people) {
@@ -138,6 +135,12 @@
     if (action == 'merge') {
       viewMode = ViewMode.MERGE_PEOPLE;
     }
+
+    return websocketEvents.on('on_person_thumbnail', (personId: string) => {
+      if (data.person.id === personId) {
+        thumbnailData = getPeopleThumbnailUrl(data.person.id) + `?now=${Date.now()}`;
+      }
+    });
   });
 
   const handleKeyboardPress = (event: KeyboardEvent) => {


### PR DESCRIPTION
Refactors the Websocket functionality by implementing a new event bus for real-time communication. The current implementation relies on stores for this purpose, but I don't think they're the right tool for the job. While stores are suitable for scenarios where a value needs to persist in memory and be updated, they are not the best choice for real-time events.

The `on_upload_success` event has been re-enabled to show uploaded assets without refreshing the page. Previously, this event was commented out but the reason for that isn't clear. Additionally, several small bugs are fixed related to using stores, including issues with unsubscribing and multiple updates not working as expected.