### PR TITLE
fix(server): empty/restore trash

### DIFF
--- a/server/e2e/client/asset-api.ts
+++ b/server/e2e/client/asset-api.ts
@@ -1,4 +1,4 @@
-import { AssetResponseDto } from '@app/domain';
+import { AssetBulkDeleteDto, AssetResponseDto } from '@app/domain';
 import { CreateAssetDto } from '@app/immich/api-v1/asset/dto/create-asset.dto';
 import { AssetFileUploadResponseDto } from '@app/immich/api-v1/asset/response-dto/asset-file-upload-response.dto';
 import { randomBytes } from 'node:crypto';
@@ -73,5 +73,9 @@ export const assetApi = {
       .set('Authorization', `Bearer ${accessToken}`);
     expect(status).toBe(200);
     return body;
+  },
+  delete: async (server: any, accessToken: string, dto: AssetBulkDeleteDto) => {
+    const { status } = await request(server).delete('/asset').set('Authorization', `Bearer ${accessToken}`).send(dto);
+    expect(status).toBe(204);
   },
 };

--- a/server/e2e/client/index.ts
+++ b/server/e2e/client/index.ts
@@ -7,6 +7,7 @@ import { libraryApi } from './library-api';
 import { partnerApi } from './partner-api';
 import { serverInfoApi } from './server-info-api';
 import { sharedLinkApi } from './shared-link-api';
+import { trashApi } from './trash-api';
 import { userApi } from './user-api';
 
 export const api = {
@@ -17,6 +18,7 @@ export const api = {
   libraryApi,
   serverInfoApi,
   sharedLinkApi,
+  trashApi,
   albumApi,
   userApi,
   partnerApi,

--- a/server/e2e/client/trash-api.ts
+++ b/server/e2e/client/trash-api.ts
@@ -1,0 +1,13 @@
+import request from 'supertest';
+import type { App } from 'supertest/types';
+
+export const trashApi = {
+  async empty(server: App, accessToken: string) {
+    const { status } = await request(server).post('/trash/empty').set('Authorization', `Bearer ${accessToken}`);
+    expect(status).toBe(204);
+  },
+  async restore(server: App, accessToken: string) {
+    const { status } = await request(server).post('/trash/restore').set('Authorization', `Bearer ${accessToken}`);
+    expect(status).toBe(204);
+  },
+};

--- a/server/e2e/jobs/specs/trash.e2e-spec.ts
+++ b/server/e2e/jobs/specs/trash.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { LoginResponseDto } from '@app/domain';
+import { api } from 'e2e/client';
+import { readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import type { App } from 'supertest/types';
+import { IMMICH_TEST_ASSET_PATH, testApp } from '../../../src/test-utils/utils';
+
+const assetFilePath = join(IMMICH_TEST_ASSET_PATH, 'formats/png/density_plot.png');
+
+describe(`Trash (e2e)`, () => {
+  let server: App;
+  let admin: LoginResponseDto;
+
+  beforeAll(async () => {
+    const app = await testApp.create();
+    server = app.getHttpServer();
+  });
+
+  beforeEach(async () => {
+    await testApp.reset();
+    await api.authApi.adminSignUp(server);
+    admin = await api.authApi.adminLogin(server);
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it('should move an asset to trash', async () => {
+    const content = await readFile(assetFilePath);
+    const { id: assetId } = await api.assetApi.upload(server, admin.accessToken, 'test-device-id', {
+      content,
+      filename: basename(assetFilePath),
+    });
+
+    const uploadedAsset = await api.assetApi.get(server, admin.accessToken, assetId);
+    expect(uploadedAsset.isTrashed).toBe(false);
+
+    await api.assetApi.delete(server, admin.accessToken, { ids: [assetId] });
+
+    const deletedAsset = await api.assetApi.get(server, admin.accessToken, assetId);
+    expect(deletedAsset.isTrashed).toBe(true);
+  });
+
+  it('should delete all trashed assets', async () => {
+    const content = await readFile(assetFilePath);
+    const { id: assetId } = await api.assetApi.upload(server, admin.accessToken, 'test-device-id', {
+      content,
+      filename: basename(assetFilePath),
+    });
+
+    await api.assetApi.delete(server, admin.accessToken, { ids: [assetId] });
+
+    const assetsBeforeEmpty = await api.assetApi.getAllAssets(server, admin.accessToken);
+    expect(assetsBeforeEmpty.length).toBe(1);
+
+    await api.trashApi.empty(server, admin.accessToken);
+
+    const assetsAfterEmpty = await api.assetApi.getAllAssets(server, admin.accessToken);
+    expect(assetsAfterEmpty.length).toBe(0);
+  });
+
+  it('should restore all trashed assets', async () => {
+    const content = await readFile(assetFilePath);
+    const { id: assetId } = await api.assetApi.upload(server, admin.accessToken, 'test-device-id', {
+      content,
+      filename: basename(assetFilePath),
+    });
+
+    await api.assetApi.delete(server, admin.accessToken, { ids: [assetId] });
+
+    const deletedAsset = await api.assetApi.get(server, admin.accessToken, assetId);
+    expect(deletedAsset.isTrashed).toBe(true);
+
+    await api.trashApi.restore(server, admin.accessToken);
+
+    const restoredAsset = await api.assetApi.get(server, admin.accessToken, assetId);
+    expect(restoredAsset.isTrashed).toBe(false);
+  });
+});

--- a/server/src/infra/repositories/asset.repository.ts
+++ b/server/src/infra/repositories/asset.repository.ts
@@ -176,7 +176,7 @@ export class AssetRepository implements IAssetRepository {
   }
 
   getByUserId(pagination: PaginationOptions, userId: string, options: AssetSearchOptions = {}): Paginated<AssetEntity> {
-    return this.getAll(pagination, { ...options, id: userId });
+    return this.getAll(pagination, { ...options, ownerId: userId });
   }
 
   @GenerateSql({ params: [[DummyValue.UUID]] })


### PR DESCRIPTION
Emptying or restoring all assets from trash is currently not working, because in `AssetRepository.getByUserId` the userId is incorrectly used as assetId