### PR TITLE
fix(server): not in album filter show motion part of LivePhotos

### DIFF
--- a/server/src/infra/infra.utils.ts
+++ b/server/src/infra/infra.utils.ts
@@ -178,7 +178,10 @@ export function searchAssetBuilder(
   );
 
   if (options.isNotInAlbum) {
-    builder.leftJoin(`${builder.alias}.albums`, 'albums').andWhere('albums.id IS NULL');
+    builder
+      .leftJoin(`${builder.alias}.albums`, 'albums')
+      .andWhere('albums.id IS NULL')
+      .andWhere(`${builder.alias}.isVisible = true`);
   }
 
   if (options.withFaces || options.withPeople) {


### PR DESCRIPTION
Fix `notInAlbum` filter shows motion part of LivePhotos