### PR TITLE
fix(server): on_asset_update event sends varying data types

### DIFF
--- a/mobile/lib/shared/providers/websocket.provider.dart
+++ b/mobile/lib/shared/providers/websocket.provider.dart
@@ -161,6 +161,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
         socket.on('on_asset_trash', _handleServerUpdates);
         socket.on('on_asset_restore', _handleServerUpdates);
         socket.on('on_asset_update', _handleServerUpdates);
+        socket.on('on_asset_stack_update', _handleServerUpdates);
         socket.on('on_asset_hidden', _handleOnAssetHidden);
         socket.on('on_new_release', _handleReleaseUpdates);
       } catch (e) {

--- a/server/src/domain/asset/asset.service.spec.ts
+++ b/server/src/domain/asset/asset.service.spec.ts
@@ -706,7 +706,7 @@ describe(AssetService.name, () => {
         stackParentId: 'parent',
       });
 
-      expect(communicationMock.send).toHaveBeenCalledWith(ClientEvent.ASSET_UPDATE, authStub.user1.user.id, [
+      expect(communicationMock.send).toHaveBeenCalledWith(ClientEvent.ASSET_STACK_UPDATE, authStub.user1.user.id, [
         'asset-1',
         'parent',
       ]);

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -381,7 +381,7 @@ export class AssetService {
       .flatMap((stack) => (stack ? [stack] : []))
       .filter((stack) => stack.assets.length < 2);
     await Promise.all(stacksToDelete.map((as) => this.assetStackRepository.delete(as.id)));
-    this.communicationRepository.send(ClientEvent.ASSET_UPDATE, auth.user.id, ids);
+    this.communicationRepository.send(ClientEvent.ASSET_STACK_UPDATE, auth.user.id, ids);
   }
 
   async handleAssetDeletionCheck() {
@@ -499,7 +499,11 @@ export class AssetService {
       primaryAssetId: newParentId,
     });
 
-    this.communicationRepository.send(ClientEvent.ASSET_UPDATE, auth.user.id, [...childIds, newParentId, oldParentId]);
+    this.communicationRepository.send(ClientEvent.ASSET_STACK_UPDATE, auth.user.id, [
+      ...childIds,
+      newParentId,
+      oldParentId,
+    ]);
     await this.assetRepository.updateAll([oldParentId, newParentId, ...childIds], { updatedAt: new Date() });
   }
 

--- a/server/src/domain/repositories/communication.repository.ts
+++ b/server/src/domain/repositories/communication.repository.ts
@@ -1,3 +1,5 @@
+import { AssetResponseDto, ReleaseNotification, ServerVersionResponseDto } from '@app/domain';
+
 export const ICommunicationRepository = 'ICommunicationRepository';
 
 export enum ClientEvent {
@@ -7,6 +9,7 @@ export enum ClientEvent {
   ASSET_UPDATE = 'on_asset_update',
   ASSET_HIDDEN = 'on_asset_hidden',
   ASSET_RESTORE = 'on_asset_restore',
+  ASSET_STACK_UPDATE = 'on_asset_stack_update',
   PERSON_THUMBNAIL = 'on_person_thumbnail',
   SERVER_VERSION = 'on_server_version',
   CONFIG_UPDATE = 'on_config_update',
@@ -17,12 +20,26 @@ export enum ServerEvent {
   CONFIG_UPDATE = 'config:update',
 }
 
+export interface ClientEventMap {
+  [ClientEvent.UPLOAD_SUCCESS]: AssetResponseDto;
+  [ClientEvent.ASSET_DELETE]: string;
+  [ClientEvent.ASSET_TRASH]: string[];
+  [ClientEvent.ASSET_UPDATE]: AssetResponseDto;
+  [ClientEvent.ASSET_HIDDEN]: string;
+  [ClientEvent.ASSET_RESTORE]: string[];
+  [ClientEvent.ASSET_STACK_UPDATE]: string[];
+  [ClientEvent.PERSON_THUMBNAIL]: string;
+  [ClientEvent.SERVER_VERSION]: ServerVersionResponseDto;
+  [ClientEvent.CONFIG_UPDATE]: Record<string, never>;
+  [ClientEvent.NEW_RELEASE]: ReleaseNotification;
+}
+
 export type OnConnectCallback = (userId: string) => Promise<void>;
 export type OnServerEventCallback = () => Promise<void>;
 
 export interface ICommunicationRepository {
-  send(event: ClientEvent, userId: string, data: any): void;
-  broadcast(event: ClientEvent, data: any): void;
+  send<E extends keyof ClientEventMap>(event: E, userId: string, data: ClientEventMap[E]): void;
+  broadcast<E extends keyof ClientEventMap>(event: E, data: ClientEventMap[E]): void;
   on(event: 'connect', callback: OnConnectCallback): void;
   on(event: ServerEvent, callback: OnServerEventCallback): void;
   sendServerEvent(event: ServerEvent): void;

--- a/server/src/domain/server-info/server-info.dto.ts
+++ b/server/src/domain/server-info/server-info.dto.ts
@@ -1,5 +1,6 @@
-import { FeatureFlags, IVersion } from '@app/domain';
+import { FeatureFlags, IVersion, type VersionType } from '@app/domain';
 import { ApiProperty, ApiResponseProperty } from '@nestjs/swagger';
+import type { DateTime } from 'luxon';
 import { SystemConfigThemeDto } from '../system-config/dto/system-config-theme.dto';
 
 export class ServerPingResponse {
@@ -104,4 +105,11 @@ export class ServerFeaturesDto implements FeatureFlags {
   passwordLogin!: boolean;
   sidecar!: boolean;
   search!: boolean;
+}
+
+export interface ReleaseNotification {
+  isAvailable: VersionType;
+  checkedAt: DateTime<boolean> | null;
+  serverVersion: ServerVersionResponseDto;
+  releaseVersion: ServerVersionResponseDto;
 }

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -17,6 +17,7 @@ export interface Events {
   on_asset_update: (asset: AssetResponseDto) => void;
   on_asset_hidden: (assetId: string) => void;
   on_asset_restore: (assetIds: string[]) => void;
+  on_asset_stack_update: (assetIds: string[]) => void;
   on_person_thumbnail: (personId: string) => void;
   on_server_version: (serverVersion: ServerVersionResponseDto) => void;
   on_config_update: () => void;


### PR DESCRIPTION
The websocket `on_asset_update` event sends `AssetResponseDto` and `string[]` as the same event. This doesn't lead to any errors currently, but that could easily happen in the future.

Fixed by adding type safety to sending events and introducing a new `on_asset_stack_update` to separate the two data types.