### PR TITLE
feat(cli): concurrent upload

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@immich/cli",
       "version": "2.0.8",
       "license": "GNU Affero General Public License version 3",
+      "dependencies": {
+        "@types/lodash": "^4.14.202",
+        "lodash": "^4.17.21"
+      },
       "bin": {
         "immich": "dist/index.js"
       },
@@ -1295,6 +1299,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.4",
@@ -3538,6 +3547,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -6432,6 +6446,11 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+    },
     "@types/mock-fs": {
       "version": "4.13.4",
       "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.4.tgz",
@@ -8079,6 +8098,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.0.8",
       "license": "GNU Affero General Public License version 3",
       "dependencies": {
-        "@types/lodash": "^4.14.202"
+        "@types/lodash-es": "^4.17.12",
+        "lodash-es": "^4.17.21"
       },
       "bin": {
         "immich": "dist/index.js"
@@ -1303,6 +1304,14 @@
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.4",
@@ -3546,6 +3555,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -6445,6 +6459,14 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
+    "@types/lodash-es": {
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mock-fs": {
       "version": "4.13.4",
       "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.4.tgz",
@@ -8092,6 +8114,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,8 +9,7 @@
       "version": "2.0.8",
       "license": "GNU Affero General Public License version 3",
       "dependencies": {
-        "@types/lodash": "^4.14.202",
-        "lodash": "^4.17.21"
+        "@types/lodash": "^4.14.202"
       },
       "bin": {
         "immich": "dist/index.js"
@@ -3547,11 +3546,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -8098,11 +8092,6 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.8",
       "license": "GNU Affero General Public License version 3",
       "dependencies": {
-        "@types/lodash-es": "^4.17.12",
         "lodash-es": "^4.17.21"
       },
       "bin": {
@@ -20,6 +19,7 @@
         "@testcontainers/postgresql": "^10.7.1",
         "@types/byte-size": "^8.1.0",
         "@types/cli-progress": "^3.11.0",
+        "@types/lodash-es": "^4.17.12",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^20.3.1",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -1303,12 +1303,14 @@
     "node_modules/@types/lodash": {
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "dev": true
     },
     "node_modules/@types/lodash-es": {
       "version": "4.17.12",
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -6457,12 +6459,14 @@
     "@types/lodash": {
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "dev": true
     },
     "@types/lodash-es": {
       "version": "4.17.12",
       "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+      "dev": true,
       "requires": {
         "@types/lodash": "*"
       }

--- a/cli/package.json
+++ b/cli/package.json
@@ -58,6 +58,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.202"
+    "@types/lodash-es": "^4.17.12",
+    "lodash-es": "^4.17.21"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -56,5 +56,9 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@types/lodash": "^4.14.202",
+    "lodash": "^4.17.21"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -58,7 +58,6 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.202",
-    "lodash": "^4.17.21"
+    "@types/lodash": "^4.14.202"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,7 @@
     "@testcontainers/postgresql": "^10.7.1",
     "@types/byte-size": "^8.1.0",
     "@types/cli-progress": "^3.11.0",
+    "@types/lodash-es": "^4.17.12",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^20.3.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -58,7 +59,6 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@types/lodash-es": "^4.17.12",
     "lodash-es": "^4.17.21"
   }
 }

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -8,7 +8,7 @@ import { basename } from 'node:path';
 import { ImmichApi } from 'src/services/api.service';
 import { CrawlService } from '../services/crawl.service';
 import { BaseCommand } from './base-command';
-import { chunk, zip } from 'lodash';
+import { chunk, zip } from 'lodash-es';
 import { AssetBulkUploadCheckResult } from '@immich/sdk';
 
 const zipDefined = zip as <T, U>(a: T[], b: U[]) => [T, U][];

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -339,7 +339,7 @@ export class UploadCommand extends BaseCommand {
 
     try {
       for (const [albumId, assets] of albumToAssets.entries()) {
-        for (const assetBatch of chunk(assets, Math.min(1000 * options.concurrency, 65000))) {
+        for (const assetBatch of chunk(assets, Math.min(1000 * options.concurrency, 65_000))) {
           await this.api.addAssetsToAlbum(albumId, { ids: assetBatch });
           albumUpdateProgress.increment(assetBatch.length);
         }
@@ -373,21 +373,21 @@ export class UploadCommand extends BaseCommand {
   private async getStatus(assets: Asset[]): Promise<{ asset: Asset; status: CheckResponseStatus }[]> {
     const checkResponse = await this.checkHashes(assets);
 
-    const res = [];
+    const responses = [];
     for (const [check, asset] of zipDefined(checkResponse, assets)) {
       if (check.action === 'reject') {
-        res.push({ asset, status: CheckResponseStatus.REJECT });
+        responses.push({ asset, status: CheckResponseStatus.REJECT });
       } else if (check.reason === 'duplicate') {
         if (check.assetId) {
           asset.id = check.assetId;
         }
-        res.push({ asset, status: CheckResponseStatus.DUPLICATE });
+        responses.push({ asset, status: CheckResponseStatus.DUPLICATE });
       } else {
-        res.push({ asset, status: CheckResponseStatus.ACCEPT });
+        responses.push({ asset, status: CheckResponseStatus.ACCEPT });
       }
     }
 
-    return res;
+    return responses;
   }
 
   private async checkHashes(assetsToCheck: Asset[]): Promise<AssetBulkUploadCheckResult[]> {
@@ -401,7 +401,7 @@ export class UploadCommand extends BaseCommand {
 
   private async uploadAssets(assets: Asset[]): Promise<string[]> {
     const fileRequests = await Promise.all(assets.map((asset) => asset.getUploadFormData()));
-    return Promise.all(fileRequests.map((req) => this.uploadAsset(req).then((res) => res.id)));
+    return Promise.all(fileRequests.map((request) => this.uploadAsset(request).then((response) => response.id)));
   }
 
   private async crawl(paths: string[], options: UploadOptionsDto): Promise<string[]> {

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -107,15 +107,15 @@ class Asset {
 }
 
 export class UploadOptionsDto {
-  recursive = false;
-  exclusionPatterns: string[] = [];
-  dryRun = false;
-  skipHash = false;
-  delete = false;
-  album = false;
-  albumName = '';
-  includeHidden = false;
-  concurrency = 4;
+  recursive? = false;
+  exclusionPatterns?: string[] = [];
+  dryRun? = false;
+  skipHash? = false;
+  delete? = false;
+  album? = false;
+  albumName? = '';
+  includeHidden? = false;
+  concurrency? = 4;
 }
 
 export class UploadCommand extends BaseCommand {
@@ -135,7 +135,7 @@ export class UploadCommand extends BaseCommand {
 
     const assetsToCheck = files.map((path) => new Asset(path));
 
-    const { newAssets, duplicateAssets } = await this.checkAssets(assetsToCheck, options.concurrency);
+    const { newAssets, duplicateAssets } = await this.checkAssets(assetsToCheck, options.concurrency ?? 4);
 
     const totalSizeUploaded = await this.upload(newAssets, options);
     const messageStart = options.dryRun ? 'Would have' : 'Successfully';
@@ -339,7 +339,7 @@ export class UploadCommand extends BaseCommand {
 
     try {
       for (const [albumId, assets] of albumToAssets.entries()) {
-        for (const assetBatch of chunk(assets, Math.min(1000 * options.concurrency, 65_000))) {
+        for (const assetBatch of chunk(assets, Math.min(1000 * (options.concurrency ?? 4), 65_000))) {
           await this.api.addAssetsToAlbum(albumId, { ids: assetBatch });
           albumUpdateProgress.increment(assetBatch.length);
         }

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -261,7 +261,7 @@ export class UploadCommand extends BaseCommand {
   }
 
   public async getAlbums(): Promise<Map<string, string>> {
-    const { data: existingAlbums } = await this.immichApi.albumApi.getAllAlbums();
+    const existingAlbums = await this.immichApi.albumApi.getAllAlbums();
 
     const albumMapping = new Map<string, string>();
     for (const album of existingAlbums) {
@@ -305,7 +305,7 @@ export class UploadCommand extends BaseCommand {
       for (const albumNames of chunk(newAlbums, options.concurrency)) {
         const newAlbumIds = await Promise.all(
           albumNames.map((albumName: string) =>
-            this.immichApi.albumApi.createAlbum({ createAlbumDto: { albumName } }).then((r) => r.data.id),
+            this.immichApi.albumApi.createAlbum({ createAlbumDto: { albumName } }).then((r) => r.id),
           ),
         );
 
@@ -400,7 +400,7 @@ export class UploadCommand extends BaseCommand {
       assets: zipDefined(assetsToCheck, checksums).map(([asset, checksum]) => ({ id: asset.path, checksum })),
     };
     const checkResponse = await this.immichApi.assetApi.checkBulkUpload({ assetBulkUploadCheckDto });
-    return checkResponse.data.results;
+    return checkResponse.results;
   }
 
   private async uploadAssets(assets: Asset[]): Promise<string[]> {
@@ -410,7 +410,7 @@ export class UploadCommand extends BaseCommand {
 
   private async crawl(paths: string[], options: UploadOptionsDto): Promise<string[]> {
     const formatResponse = await this.immichApi.serverInfoApi.getSupportedMediaTypes();
-    const crawlService = new CrawlService(formatResponse.data.image, formatResponse.data.video);
+    const crawlService = new CrawlService(formatResponse.image, formatResponse.video);
 
     return crawlService.crawl({
       pathsToCrawl: paths,

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -134,10 +134,7 @@ export class UploadCommand extends BaseCommand {
 
     const assetsToCheck = files.map((path) => new Asset(path));
 
-    const { newAssets, duplicateAssets } = await this.checkAssets(
-      assetsToCheck,
-      options.concurrency ?? 4,
-    );
+    const { newAssets, duplicateAssets } = await this.checkAssets(assetsToCheck, options.concurrency ?? 4);
 
     const totalSizeUploaded = await this.upload(newAssets, options);
     const messageStart = options.dryRun ? 'Would have' : 'Successfully';

--- a/cli/src/commands/upload.command.ts
+++ b/cli/src/commands/upload.command.ts
@@ -141,7 +141,9 @@ export class UploadCommand extends BaseCommand {
     if (newAssets.length === 0) {
       console.log('All assets were already uploaded, nothing to do.');
     } else {
-      console.log(`${messageStart} uploaded ${newAssets.length} assets (${byteSize(totalSizeUploaded)})`);
+      console.log(
+        `${messageStart} uploaded ${newAssets.length} asset${newAssets.length === 1 ? '' : 's'} (${byteSize(totalSizeUploaded)})`,
+      );
     }
 
     if (options.album || options.albumName) {
@@ -149,8 +151,8 @@ export class UploadCommand extends BaseCommand {
         [...newAssets, ...duplicateAssets],
         options,
       );
-      console.log(`${messageStart} created ${createdAlbumCount} new albums`);
-      console.log(`${messageStart} updated ${updatedAssetCount} assets`);
+      console.log(`${messageStart} created ${createdAlbumCount} new album${createdAlbumCount === 1 ? '' : 's'}`);
+      console.log(`${messageStart} updated ${updatedAssetCount} asset${updatedAssetCount === 1 ? '' : 's'}`);
     }
 
     if (!options.delete) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -43,6 +43,11 @@ program
       .env('IMMICH_DRY_RUN')
       .default(false),
   )
+  .addOption(
+    new Option('-c, --concurrency', 'Number of assets to upload at the same time')
+      .env('IMMICH_UPLOAD_CONCURRENCY')
+      .default(4),
+  )
   .addOption(new Option('--delete', 'Delete local assets after upload').env('IMMICH_DELETE_ASSETS'))
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action(async (paths, options) => {

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -99,6 +99,7 @@ describe(`immich upload`, () => {
           expect.stringContaining(
             'All assets were already uploaded, nothing to do.'
           ),
+          expect.stringContaining('Successfully updated 9 assets'),
         ])
       );
       expect(response2.stderr).toBe('');

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -30,8 +30,10 @@ describe(`immich upload`, () => {
         '--recursive',
       ]);
       expect(stderr).toBe('');
-      expect(stdout).toEqual(
-        expect.stringContaining('Successfully uploaded 9 assets')
+      expect(stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining('Successfully uploaded 9 assets')]
+        )
       );
       expect(exitCode).toBe(0);
 
@@ -48,8 +50,10 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album',
       ]);
-      expect(stdout).toEqual(
-        expect.stringContaining('Successfully uploaded 9 assets')
+      expect(stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining('Successfully uploaded 9 assets')]
+        )
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
@@ -68,8 +72,10 @@ describe(`immich upload`, () => {
         `${testAssetDir}/albums/nature/`,
         '--recursive',
       ]);
-      expect(response1.stdout).toEqual(
-        expect.stringContaining('Successfully uploaded 9 assets')
+      expect(response1.stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining('Successfully uploaded 9 assets')]
+        )
       );
       expect(response1.stderr).toBe('');
       expect(response1.exitCode).toBe(0);
@@ -86,9 +92,11 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album',
       ]);
-      expect(response2.stdout).toEqual(
-        expect.stringContaining(
-          'All assets were already uploaded, nothing to do.'
+      expect(response2.stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining(
+            'All assets were already uploaded, nothing to do.'
+          )]
         )
       );
       expect(response2.stderr).toBe('');
@@ -111,8 +119,10 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album-name=e2e',
       ]);
-      expect(stdout).toEqual(
-        expect.stringContaining('Successfully uploaded 9 assets')
+      expect(stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining('Successfully uploaded 9 assets')]
+        )
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
@@ -147,8 +157,10 @@ describe(`immich upload`, () => {
       await rm(`/tmp/albums/nature`, { recursive: true });
       expect(files).toEqual([]);
 
-      expect(stdout).toEqual(
-        expect.stringContaining('Successfully uploaded 9 assets')
+      expect(stdout.split('\n')).toEqual(
+        expect.arrayContaining(
+          [expect.stringContaining('Successfully uploaded 9 assets')]
+        )
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -31,9 +31,9 @@ describe(`immich upload`, () => {
       ]);
       expect(stderr).toBe('');
       expect(stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining('Successfully uploaded 9 assets')]
-        )
+        expect.arrayContaining([
+          expect.stringContaining('Successfully uploaded 9 assets'),
+        ])
       );
       expect(exitCode).toBe(0);
 
@@ -51,9 +51,11 @@ describe(`immich upload`, () => {
         '--album',
       ]);
       expect(stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining('Successfully uploaded 9 assets')]
-        )
+        expect.arrayContaining([
+          expect.stringContaining('Successfully uploaded 9 assets'),
+          expect.stringContaining('Successfully created 1 new album'),
+          expect.stringContaining('Successfully updated 9 assets'),
+        ])
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
@@ -73,9 +75,9 @@ describe(`immich upload`, () => {
         '--recursive',
       ]);
       expect(response1.stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining('Successfully uploaded 9 assets')]
-        )
+        expect.arrayContaining([
+          expect.stringContaining('Successfully uploaded 9 assets'),
+        ])
       );
       expect(response1.stderr).toBe('');
       expect(response1.exitCode).toBe(0);
@@ -93,11 +95,11 @@ describe(`immich upload`, () => {
         '--album',
       ]);
       expect(response2.stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining(
+        expect.arrayContaining([
+          expect.stringContaining(
             'All assets were already uploaded, nothing to do.'
-          )]
-        )
+          ),
+        ])
       );
       expect(response2.stderr).toBe('');
       expect(response2.exitCode).toBe(0);
@@ -120,9 +122,11 @@ describe(`immich upload`, () => {
         '--album-name=e2e',
       ]);
       expect(stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining('Successfully uploaded 9 assets')]
-        )
+        expect.arrayContaining([
+          expect.stringContaining('Successfully uploaded 9 assets'),
+          expect.stringContaining('Successfully created 1 new album'),
+          expect.stringContaining('Successfully updated 9 assets'),
+        ])
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
@@ -158,9 +162,10 @@ describe(`immich upload`, () => {
       expect(files).toEqual([]);
 
       expect(stdout.split('\n')).toEqual(
-        expect.arrayContaining(
-          [expect.stringContaining('Successfully uploaded 9 assets')]
-        )
+        expect.arrayContaining([
+          expect.stringContaining('Successfully uploaded 9 assets'),
+          expect.stringContaining('Deleting assets that have been uploaded'),
+        ])
       );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -30,9 +30,9 @@ describe(`immich upload`, () => {
         '--recursive',
       ]);
       expect(stderr).toBe('');
-      expect(stdout.split('\n')).toEqual([
-        expect.stringContaining('Successfully uploaded 9 assets'),
-      ]);
+      expect(stdout).toEqual(
+        expect.stringContaining('Successfully uploaded 9 assets')
+      );
       expect(exitCode).toBe(0);
 
       const assets = await getAllAssets({}, { headers: asKeyAuth(key) });
@@ -48,9 +48,9 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album',
       ]);
-      expect(stdout.split('\n')).toEqual([
-        expect.stringContaining('Successfully uploaded 9 assets'),
-      ]);
+      expect(stdout).toEqual(
+        expect.stringContaining('Successfully uploaded 9 assets')
+      );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
 
@@ -68,9 +68,9 @@ describe(`immich upload`, () => {
         `${testAssetDir}/albums/nature/`,
         '--recursive',
       ]);
-      expect(response1.stdout.split('\n')).toEqual([
-        expect.stringContaining('Successfully uploaded 9 assets'),
-      ]);
+      expect(response1.stdout).toEqual(
+        expect.stringContaining('Successfully uploaded 9 assets')
+      );
       expect(response1.stderr).toBe('');
       expect(response1.exitCode).toBe(0);
 
@@ -86,11 +86,11 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album',
       ]);
-      expect(response2.stdout.split('\n')).toEqual([
+      expect(response2.stdout).toEqual(
         expect.stringContaining(
           'All assets were already uploaded, nothing to do.'
-        ),
-      ]);
+        )
+      );
       expect(response2.stderr).toBe('');
       expect(response2.exitCode).toBe(0);
 
@@ -111,9 +111,9 @@ describe(`immich upload`, () => {
         '--recursive',
         '--album-name=e2e',
       ]);
-      expect(stdout.split('\n')).toEqual([
-        expect.stringContaining('Successfully uploaded 9 assets'),
-      ]);
+      expect(stdout).toEqual(
+        expect.stringContaining('Successfully uploaded 9 assets')
+      );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
 
@@ -147,9 +147,9 @@ describe(`immich upload`, () => {
       await rm(`/tmp/albums/nature`, { recursive: true });
       expect(files).toEqual([]);
 
-      expect(stdout.split('\n')).toEqual([
-        expect.stringContaining('Successfully uploaded 9 assets'),
-      ]);
+      expect(stdout).toEqual(
+        expect.stringContaining('Successfully uploaded 9 assets')
+      );
       expect(stderr).toBe('');
       expect(exitCode).toBe(0);
 


### PR DESCRIPTION
### Description

When doing bulk uploads, I noticed that uploading through web was much faster than through the CLI (specifically when the upload component is minimized to avoid rendering slowdown). The former is able to upload files concurrently, while the latter currently does everything sequentially.

This PR addresses this limitation by refactoring the upload command to be "batch"-oriented - it runs a given number of promises at a time, finishing one step for all files before moving to the next step. Besides faster uploads, a benefit of this change is that it visualizes the progress of each step. In particular, this means users can now see how many of their assets were duplicates.