### PR TITLE
fix(mobile): Fixes memory lane progress indicator color in dark mode

### DIFF
--- a/mobile/lib/modules/memories/ui/memory_progress_indicator.dart
+++ b/mobile/lib/modules/memories/ui/memory_progress_indicator.dart
@@ -39,9 +39,9 @@ class MemoryProgressIndicator extends StatelessWidget {
                     decoration: BoxDecoration(
                       border: i == 0
                           ? null
-                          : Border(
+                          : const Border(
                               left: BorderSide(
-                                color: context.colorScheme.onSecondaryContainer,
+                                color: Colors.black,
                                 width: 1,
                               ),
                             ),

--- a/mobile/lib/modules/memories/ui/memory_progress_indicator.dart
+++ b/mobile/lib/modules/memories/ui/memory_progress_indicator.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/constants/immich_colors.dart';
-import 'package:immich_mobile/extensions/build_context_extensions.dart';
 
 class MemoryProgressIndicator extends StatelessWidget {
   /// The number of ticks in the progress indicator


### PR DESCRIPTION
Fixes this:

![Screenshot from 2024-02-19 08-44-22](https://github.com/immich-app/immich/assets/100457/5c7002c4-5e47-4253-9cd0-cda557c60d07)

Into this:

![image](https://github.com/immich-app/immich/assets/100457/453704e9-0604-4d17-9071-221dd3799b86)

- [x] Tested dark mode
- [x] Tested bright mode