### PR TITLE
fix(docs): document vector extension env variable

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -60,14 +60,17 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## Database
 
-| Variable      | Description       |   Default   | Services              |
-| :------------ | :---------------- | :---------: | :-------------------- |
-| `DB_URL`      | Database URL      |             | server, microservices |
-| `DB_HOSTNAME` | Database Host     | `localhost` | server, microservices |
-| `DB_PORT`     | Database Port     |   `5432`    | server, microservices |
-| `DB_USERNAME` | Database User     | `postgres`  | server, microservices |
-| `DB_PASSWORD` | Database Password | `postgres`  | server, microservices |
-| `DB_DATABASE` | Database Name     |  `immich`   | server, microservices |
+| Variable                         | Description                                                   |   Default    | Services              |
+| :------------------------------- | :------------------------------------------------------------ | :----------: | :-------------------- |
+| `DB_URL`                         | Database URL                                                  |              | server, microservices |
+| `DB_HOSTNAME`                    | Database Host                                                 | `localhost`  | server, microservices |
+| `DB_PORT`                        | Database Port                                                 |    `5432`    | server, microservices |
+| `DB_USERNAME`                    | Database User                                                 |  `postgres`  | server, microservices |
+| `DB_PASSWORD`                    | Database Password                                             |  `postgres`  | server, microservices |
+| `DB_DATABASE`                    | Database Name                                                 |   `immich`   | server, microservices |
+| `VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`]) | `pgvecto.rs` | server, microservices |
+
+\*1: This setting cannot be changed after the server has successfully started up
 
 :::info
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -60,15 +60,15 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## Database
 
-| Variable                         | Description                                                   |   Default    | Services              |
-| :------------------------------- | :------------------------------------------------------------ | :----------: | :-------------------- |
-| `DB_URL`                         | Database URL                                                  |              | server, microservices |
-| `DB_HOSTNAME`                    | Database Host                                                 | `localhost`  | server, microservices |
-| `DB_PORT`                        | Database Port                                                 |    `5432`    | server, microservices |
-| `DB_USERNAME`                    | Database User                                                 |  `postgres`  | server, microservices |
-| `DB_PASSWORD`                    | Database Password                                             |  `postgres`  | server, microservices |
-| `DB_DATABASE`                    | Database Name                                                 |   `immich`   | server, microservices |
-| `VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`]) | `pgvecto.rs` | server, microservices |
+| Variable                            | Description                                                   |   Default    | Services              |
+| :---------------------------------- | :------------------------------------------------------------ | :----------: | :-------------------- |
+| `DB_URL`                            | Database URL                                                  |              | server, microservices |
+| `DB_HOSTNAME`                       | Database Host                                                 | `localhost`  | server, microservices |
+| `DB_PORT`                           | Database Port                                                 |    `5432`    | server, microservices |
+| `DB_USERNAME`                       | Database User                                                 |  `postgres`  | server, microservices |
+| `DB_PASSWORD`                       | Database Password                                             |  `postgres`  | server, microservices |
+| `DB_DATABASE`                       | Database Name                                                 |   `immich`   | server, microservices |
+| `DB_VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`]) | `pgvecto.rs` | server, microservices |
 
 \*1: This setting cannot be changed after the server has successfully started up
 

--- a/server/src/domain/database/database.service.ts
+++ b/server/src/domain/database/database.service.ts
@@ -72,7 +72,7 @@ export class DatabaseService {
         In this case, please run 'CREATE EXTENSION IF NOT EXISTS ${this.vectorExt}' manually as a superuser.
         See https://immich.app/docs/guides/database-queries for how to query the database.
 
-        Alternatively, if your Postgres instance has ${extName[otherExt]}, you may use this instead by setting the environment variable 'VECTOR_EXTENSION=${otherExt}'.
+        Alternatively, if your Postgres instance has ${extName[otherExt]}, you may use this instead by setting the environment variable 'DB_VECTOR_EXTENSION=${otherExt}'.
         Note that switching between the two extensions after a successful startup is not supported.
         The exception is if your version of Immich prior to upgrading was 1.90.2 or earlier.
         In this case, you may set either extension now, but you will not be able to switch to the other extension following a successful startup.

--- a/server/src/domain/domain.config.ts
+++ b/server/src/domain/domain.config.ts
@@ -18,12 +18,12 @@ export const immichAppConfig: ConfigModuleOptions = {
     DB_PASSWORD: WHEN_DB_URL_SET,
     DB_DATABASE_NAME: WHEN_DB_URL_SET,
     DB_URL: Joi.string().optional(),
+    DB_VECTOR_EXTENSION: Joi.string().optional().valid('pgvector', 'pgvecto.rs').default('pgvecto.rs'),
     LOG_LEVEL: Joi.string()
       .optional()
       .valid(...Object.values(LogLevel)),
     MACHINE_LEARNING_PORT: Joi.number().optional(),
     MICROSERVICES_PORT: Joi.number().optional(),
     SERVER_PORT: Joi.number().optional(),
-    VECTOR_EXTENSION: Joi.string().optional().valid('pgvector', 'pgvecto.rs').default('pgvecto.rs'),
   }),
 };

--- a/server/src/infra/database.config.ts
+++ b/server/src/infra/database.config.ts
@@ -30,4 +30,4 @@ export const databaseConfig: PostgresConnectionOptions = {
 export const dataSource = new DataSource(databaseConfig);
 
 export const vectorExt =
-  process.env.VECTOR_EXTENSION === 'pgvector' ? DatabaseExtension.VECTOR : DatabaseExtension.VECTORS;
+  process.env.DB_VECTOR_EXTENSION === 'pgvector' ? DatabaseExtension.VECTOR : DatabaseExtension.VECTORS;


### PR DESCRIPTION
## Description

The `VECTOR_EXTENSION` env variable isn't listed in the docs. Also changes the name of it to `DB_VECTOR_EXTENSION` for consistency.