### PR TITLE
fix(web): websocket reconnect

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -29,13 +29,13 @@
   }>();
 
   const logOut = async () => {
-    resetSavedUser();
     const { redirectUri } = await logout();
     if (redirectUri.startsWith('/')) {
-      goto(redirectUri);
+      await goto(redirectUri);
     } else {
       window.location.href = redirectUri;
     }
+    resetSavedUser();
   };
 </script>
 

--- a/web/src/lib/stores/user.store.ts
+++ b/web/src/lib/stores/user.store.ts
@@ -1,13 +1,12 @@
 import type { UserResponseDto } from '@immich/sdk';
 import { writable } from 'svelte/store';
 
-export const user = writable<UserResponseDto & { loggedOut?: true }>();
+export const user = writable<UserResponseDto>();
 
+/**
+ * Reset the store to its initial undefined value. Make sure to
+ * only do this _after_ redirecting to an unauthenticated page.
+ */
 export const resetSavedUser = () => {
-  user.update((value) => {
-    if (value) {
-      value.loggedOut = true;
-    }
-    return value;
-  });
+  user.set(undefined as unknown as UserResponseDto);
 };

--- a/web/src/lib/stores/user.store.ts
+++ b/web/src/lib/stores/user.store.ts
@@ -1,8 +1,13 @@
 import type { UserResponseDto } from '@immich/sdk';
 import { writable } from 'svelte/store';
 
-export let user = writable<UserResponseDto>();
+export const user = writable<UserResponseDto & { loggedOut?: true }>();
 
 export const resetSavedUser = () => {
-  user = writable<UserResponseDto>();
+  user.update((value) => {
+    if (value) {
+      value.loggedOut = true;
+    }
+    return value;
+  });
 };

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -14,7 +14,7 @@ export interface AuthOptions {
 export const loadUser = async () => {
   try {
     let loaded = get(user);
-    if ((!loaded || loaded?.loggedOut) && hasAuthCookie()) {
+    if (!loaded && hasAuthCookie()) {
       loaded = await getMyUserInfo();
       user.set(loaded);
     }

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -14,7 +14,7 @@ export interface AuthOptions {
 export const loadUser = async () => {
   try {
     let loaded = get(user);
-    if (!loaded && hasAuthCookie()) {
+    if ((!loaded || loaded?.loggedOut) && hasAuthCookie()) {
       loaded = await getMyUserInfo();
       user.set(loaded);
     }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -22,9 +22,14 @@
   let albumId: string | undefined;
 
   const isSharedLinkRoute = (route: string | null) => route?.startsWith('/(user)/share/[key]');
-  const isAuthRoute = (route?: string) => route?.startsWith('/auth');
 
   $: changeTheme($colorTheme);
+
+  $: if (!$user || $user?.loggedOut) {
+    closeWebsocketConnection();
+  } else if ($user) {
+    openWebsocketConnection();
+  }
 
   const changeTheme = (theme: ThemeSetting) => {
     if (theme.system) {
@@ -58,18 +63,7 @@
     setKey($page.params.key);
   }
 
-  beforeNavigate(({ from, to }) => {
-    const fromRoute = from?.route?.id || '';
-    const toRoute = to?.route?.id || '';
-
-    if (isAuthRoute(fromRoute) && !isAuthRoute(toRoute)) {
-      openWebsocketConnection();
-    }
-
-    if (!isAuthRoute(fromRoute) && isAuthRoute(toRoute)) {
-      closeWebsocketConnection();
-    }
-
+  beforeNavigate(() => {
     showNavigationLoadingBar = true;
   });
 
@@ -78,10 +72,6 @@
   });
 
   onMount(async () => {
-    if ($page.route.id?.startsWith('/auth') === false) {
-      openWebsocketConnection();
-    }
-
     try {
       await loadConfig();
     } catch (error) {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -25,10 +25,10 @@
 
   $: changeTheme($colorTheme);
 
-  $: if (!$user || $user?.loggedOut) {
-    closeWebsocketConnection();
-  } else if ($user) {
+  $: if ($user) {
     openWebsocketConnection();
+  } else {
+    closeWebsocketConnection();
   }
 
   const changeTheme = (theme: ThemeSetting) => {


### PR DESCRIPTION
The websocket connection doesn't properly re-establish after logging out and logging back in again. Fixed by using the `$user` store to detect whether the user is logged in. 