### PR TITLE
fix(server): quote database name in migration

### DIFF
--- a/server/src/infra/migrations/1707000751533-AddVectorsToSearchPath.ts
+++ b/server/src/infra/migrations/1707000751533-AddVectorsToSearchPath.ts
@@ -4,11 +4,11 @@ export class AddVectorsToSearchPath1707000751533 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const res = await queryRunner.query(`SELECT current_database() as db`);
     const databaseName = res[0]['db'];
-    await queryRunner.query(`ALTER DATABASE ${databaseName} SET search_path TO "$user", public, vectors`);
+    await queryRunner.query(`ALTER DATABASE "${databaseName}" SET search_path TO "$user", public, vectors`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     const databaseName = await queryRunner.query(`SELECT current_database()`);
-    await queryRunner.query(`ALTER DATABASE ${databaseName} SET search_path TO "$user", public`);
+    await queryRunner.query(`ALTER DATABASE "${databaseName}" SET search_path TO "$user", public`);
   }
 }


### PR DESCRIPTION
## Description

The migration doesn't take into account "atypical" database names that can cause a syntax error if unquoted.

Fixes #7276