### PR TITLE
fix(server): don't return archived assets by default

### DIFF
--- a/mobile/openapi/doc/AssetApi.md
+++ b/mobile/openapi/doc/AssetApi.md
@@ -1153,7 +1153,7 @@ Name | Type | Description  | Notes
  **updatedAfter** | **DateTime**|  | [optional] 
  **updatedBefore** | **DateTime**|  | [optional] 
  **webpPath** | **String**|  | [optional] 
- **withArchived** | **bool**|  | [optional] 
+ **withArchived** | **bool**|  | [optional] [default to false]
  **withDeleted** | **bool**|  | [optional] 
  **withExif** | **bool**|  | [optional] 
  **withPeople** | **bool**|  | [optional] 

--- a/mobile/openapi/doc/MetadataSearchDto.md
+++ b/mobile/openapi/doc/MetadataSearchDto.md
@@ -46,7 +46,7 @@ Name | Type | Description | Notes
 **updatedAfter** | [**DateTime**](DateTime.md) |  | [optional] 
 **updatedBefore** | [**DateTime**](DateTime.md) |  | [optional] 
 **webpPath** | **String** |  | [optional] 
-**withArchived** | **bool** |  | [optional] 
+**withArchived** | **bool** |  | [optional] [default to false]
 **withDeleted** | **bool** |  | [optional] 
 **withExif** | **bool** |  | [optional] 
 **withPeople** | **bool** |  | [optional] 

--- a/mobile/openapi/doc/SmartSearchDto.md
+++ b/mobile/openapi/doc/SmartSearchDto.md
@@ -36,7 +36,7 @@ Name | Type | Description | Notes
 **type** | [**AssetTypeEnum**](AssetTypeEnum.md) |  | [optional] 
 **updatedAfter** | [**DateTime**](DateTime.md) |  | [optional] 
 **updatedBefore** | [**DateTime**](DateTime.md) |  | [optional] 
-**withArchived** | **bool** |  | [optional] 
+**withArchived** | **bool** |  | [optional] [default to false]
 **withDeleted** | **bool** |  | [optional] 
 **withExif** | **bool** |  | [optional] 
 

--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -51,7 +51,7 @@ class MetadataSearchDto {
     this.updatedAfter,
     this.updatedBefore,
     this.webpPath,
-    this.withArchived,
+    this.withArchived = false,
     this.withDeleted,
     this.withExif,
     this.withPeople,
@@ -356,13 +356,7 @@ class MetadataSearchDto {
   ///
   String? webpPath;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? withArchived;
+  bool withArchived;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -483,7 +477,7 @@ class MetadataSearchDto {
     (updatedAfter == null ? 0 : updatedAfter!.hashCode) +
     (updatedBefore == null ? 0 : updatedBefore!.hashCode) +
     (webpPath == null ? 0 : webpPath!.hashCode) +
-    (withArchived == null ? 0 : withArchived!.hashCode) +
+    (withArchived.hashCode) +
     (withDeleted == null ? 0 : withDeleted!.hashCode) +
     (withExif == null ? 0 : withExif!.hashCode) +
     (withPeople == null ? 0 : withPeople!.hashCode) +
@@ -680,11 +674,7 @@ class MetadataSearchDto {
     } else {
     //  json[r'webpPath'] = null;
     }
-    if (this.withArchived != null) {
       json[r'withArchived'] = this.withArchived;
-    } else {
-    //  json[r'withArchived'] = null;
-    }
     if (this.withDeleted != null) {
       json[r'withDeleted'] = this.withDeleted;
     } else {
@@ -756,7 +746,7 @@ class MetadataSearchDto {
         updatedAfter: mapDateTime(json, r'updatedAfter', r''),
         updatedBefore: mapDateTime(json, r'updatedBefore', r''),
         webpPath: mapValueOfType<String>(json, r'webpPath'),
-        withArchived: mapValueOfType<bool>(json, r'withArchived'),
+        withArchived: mapValueOfType<bool>(json, r'withArchived') ?? false,
         withDeleted: mapValueOfType<bool>(json, r'withDeleted'),
         withExif: mapValueOfType<bool>(json, r'withExif'),
         withPeople: mapValueOfType<bool>(json, r'withPeople'),

--- a/mobile/openapi/lib/model/smart_search_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_dto.dart
@@ -41,7 +41,7 @@ class SmartSearchDto {
     this.type,
     this.updatedAfter,
     this.updatedBefore,
-    this.withArchived,
+    this.withArchived = false,
     this.withDeleted,
     this.withExif,
   });
@@ -264,13 +264,7 @@ class SmartSearchDto {
   ///
   DateTime? updatedBefore;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? withArchived;
+  bool withArchived;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -353,7 +347,7 @@ class SmartSearchDto {
     (type == null ? 0 : type!.hashCode) +
     (updatedAfter == null ? 0 : updatedAfter!.hashCode) +
     (updatedBefore == null ? 0 : updatedBefore!.hashCode) +
-    (withArchived == null ? 0 : withArchived!.hashCode) +
+    (withArchived.hashCode) +
     (withDeleted == null ? 0 : withDeleted!.hashCode) +
     (withExif == null ? 0 : withExif!.hashCode);
 
@@ -498,11 +492,7 @@ class SmartSearchDto {
     } else {
     //  json[r'updatedBefore'] = null;
     }
-    if (this.withArchived != null) {
       json[r'withArchived'] = this.withArchived;
-    } else {
-    //  json[r'withArchived'] = null;
-    }
     if (this.withDeleted != null) {
       json[r'withDeleted'] = this.withDeleted;
     } else {
@@ -552,7 +542,7 @@ class SmartSearchDto {
         type: AssetTypeEnum.fromJson(json[r'type']),
         updatedAfter: mapDateTime(json, r'updatedAfter', r''),
         updatedBefore: mapDateTime(json, r'updatedBefore', r''),
-        withArchived: mapValueOfType<bool>(json, r'withArchived'),
+        withArchived: mapValueOfType<bool>(json, r'withArchived') ?? false,
         withDeleted: mapValueOfType<bool>(json, r'withDeleted'),
         withExif: mapValueOfType<bool>(json, r'withExif'),
       );

--- a/mobile/openapi/test/metadata_search_dto_test.dart
+++ b/mobile/openapi/test/metadata_search_dto_test.dart
@@ -206,7 +206,7 @@ void main() {
       // TODO
     });
 
-    // bool withArchived
+    // bool withArchived (default value: false)
     test('to test the property `withArchived`', () async {
       // TODO
     });

--- a/mobile/openapi/test/smart_search_dto_test.dart
+++ b/mobile/openapi/test/smart_search_dto_test.dart
@@ -156,7 +156,7 @@ void main() {
       // TODO
     });
 
-    // bool withArchived
+    // bool withArchived (default value: false)
     test('to test the property `withArchived`', () async {
       // TODO
     });

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -2463,6 +2463,7 @@
             "required": false,
             "in": "query",
             "schema": {
+              "default": false,
               "type": "boolean"
             }
           },
@@ -8429,6 +8430,7 @@
             "type": "string"
           },
           "withArchived": {
+            "default": false,
             "type": "boolean"
           },
           "withDeleted": {
@@ -9497,6 +9499,7 @@
             "type": "string"
           },
           "withArchived": {
+            "default": false,
             "type": "boolean"
           },
           "withDeleted": {

--- a/server/e2e/api/specs/asset.e2e-spec.ts
+++ b/server/e2e/api/specs/asset.e2e-spec.ts
@@ -50,6 +50,7 @@ describe(`${AssetController.name} (e2e)`, () => {
   let asset3: AssetResponseDto;
   let asset4: AssetResponseDto;
   let asset5: AssetResponseDto;
+  let asset6: AssetResponseDto;
 
   const createAsset = async (
     loginResponse: LoginResponseDto,
@@ -96,12 +97,11 @@ describe(`${AssetController.name} (e2e)`, () => {
   beforeEach(async () => {
     await testApp.reset({ entities: [AssetEntity, AssetStackEntity] });
 
-    [asset1, asset2, asset3, asset4, asset5] = await Promise.all([
+    [asset1, asset2, asset3, asset4, asset5, asset6] = await Promise.all([
       createAsset(user1, new Date('1970-01-01')),
       createAsset(user1, new Date('1970-02-10')),
       createAsset(user1, new Date('1970-02-11'), {
         isFavorite: true,
-        isArchived: true,
         isExternal: true,
         isReadOnly: true,
         type: AssetType.VIDEO,
@@ -117,6 +117,9 @@ describe(`${AssetController.name} (e2e)`, () => {
       createAsset(user2, new Date('1970-01-01')),
       createAsset(user1, new Date('1970-01-01'), {
         deletedAt: yesterday.toJSDate(),
+      }),
+      createAsset(user1, new Date('1970-02-11'), {
+        isArchived: true,
       }),
     ]);
 
@@ -275,14 +278,14 @@ describe(`${AssetController.name} (e2e)`, () => {
         should: 'should search by isArchived (true)',
         deferred: () => ({
           query: { isArchived: true },
-          assets: [asset3],
+          assets: [asset6],
         }),
       },
       {
         should: 'should search by isArchived (false)',
         deferred: () => ({
           query: { isArchived: false },
-          assets: [asset2, asset1],
+          assets: [asset3, asset2, asset1],
         }),
       },
       {
@@ -311,6 +314,20 @@ describe(`${AssetController.name} (e2e)`, () => {
         deferred: () => ({
           query: { type: 'VIDEO' },
           assets: [asset3],
+        }),
+      },
+      {
+        should: 'should search by withArchived (true)',
+        deferred: () => ({
+          query: { withArchived: true },
+          assets: [asset3, asset6, asset2, asset1],
+        }),
+      },
+      {
+        should: 'should search by withArchived (false)',
+        deferred: () => ({
+          query: { withArchived: false },
+          assets: [asset3, asset2, asset1],
         }),
       },
       {
@@ -902,7 +919,7 @@ describe(`${AssetController.name} (e2e)`, () => {
         .get('/asset/statistics')
         .set('Authorization', `Bearer ${user1.accessToken}`);
 
-      expect(body).toEqual({ images: 5, videos: 1, total: 6 });
+      expect(body).toEqual({ images: 6, videos: 1, total: 7 });
       expect(status).toBe(200);
     });
 
@@ -923,7 +940,7 @@ describe(`${AssetController.name} (e2e)`, () => {
         .query({ isArchived: true });
 
       expect(status).toBe(200);
-      expect(body).toEqual({ images: 2, videos: 1, total: 3 });
+      expect(body).toEqual({ images: 3, videos: 0, total: 3 });
     });
 
     it('should return stats of all favored and archived assets', async () => {
@@ -933,7 +950,7 @@ describe(`${AssetController.name} (e2e)`, () => {
         .query({ isFavorite: true, isArchived: true });
 
       expect(status).toBe(200);
-      expect(body).toEqual({ images: 1, videos: 1, total: 2 });
+      expect(body).toEqual({ images: 1, videos: 0, total: 1 });
     });
 
     it('should return stats of all assets neither favored nor archived', async () => {
@@ -1041,7 +1058,7 @@ describe(`${AssetController.name} (e2e)`, () => {
         expect.arrayContaining([
           { count: 1, timeBucket: '2023-11-01T00:00:00.000Z' },
           { count: 1, timeBucket: '1970-01-01T00:00:00.000Z' },
-          { count: 1, timeBucket: '1970-02-01T00:00:00.000Z' },
+          { count: 2, timeBucket: '1970-02-01T00:00:00.000Z' },
         ]),
       );
     });
@@ -1198,8 +1215,13 @@ describe(`${AssetController.name} (e2e)`, () => {
         .set('Authorization', `Bearer ${user1.accessToken}`);
 
       expect(status).toBe(200);
-      expect(body).toHaveLength(1);
-      expect(body).toEqual(expect.arrayContaining([expect.objectContaining({ id: asset2.id })]));
+      expect(body).toHaveLength(2);
+      expect(body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: asset2.id }),
+          expect.objectContaining({ id: asset3.id }),
+        ]),
+      );
     });
 
     it('should get all map markers', async () => {
@@ -1209,8 +1231,13 @@ describe(`${AssetController.name} (e2e)`, () => {
         .query({ isArchived: false });
 
       expect(status).toBe(200);
-      expect(body).toHaveLength(1);
-      expect(body).toEqual([expect.objectContaining({ id: asset2.id })]);
+      expect(body).toHaveLength(2);
+      expect(body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: asset2.id }),
+          expect.objectContaining({ id: asset3.id }),
+        ]),
+      );
     });
   });
 

--- a/server/src/domain/search/dto/search.dto.ts
+++ b/server/src/domain/search/dto/search.dto.ts
@@ -23,6 +23,7 @@ class BaseSearchDto {
   isArchived?: boolean;
 
   @QueryBoolean({ optional: true })
+  @ApiProperty({ default: false })
   withArchived?: boolean;
 
   @QueryBoolean({ optional: true })

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -77,7 +77,6 @@ export class SearchService {
         checksum,
         userIds,
         orderDirection: dto.order ? enumToOrder[dto.order] : 'DESC',
-        withArchived: !!dto.withArchived,
       },
     );
 
@@ -99,7 +98,7 @@ export class SearchService {
     const size = dto.size || 100;
     const { hasNextPage, items } = await this.searchRepository.searchSmart(
       { page, size },
-      { ...dto, userIds, embedding, withArchived: !!dto.withArchived },
+      { ...dto, userIds, embedding },
     );
 
     return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null);

--- a/server/src/domain/search/search.service.ts
+++ b/server/src/domain/search/search.service.ts
@@ -77,6 +77,7 @@ export class SearchService {
         checksum,
         userIds,
         orderDirection: dto.order ? enumToOrder[dto.order] : 'DESC',
+        withArchived: !!dto.withArchived,
       },
     );
 
@@ -98,7 +99,7 @@ export class SearchService {
     const size = dto.size || 100;
     const { hasNextPage, items } = await this.searchRepository.searchSmart(
       { page, size },
-      { ...dto, userIds, embedding },
+      { ...dto, userIds, embedding, withArchived: !!dto.withArchived },
     );
 
     return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null);

--- a/server/src/infra/infra.utils.ts
+++ b/server/src/infra/infra.utils.ts
@@ -183,7 +183,7 @@ export function searchAssetBuilder(
     _.omitBy(
       {
         ...status,
-        isArchived: isArchived ?? withArchived,
+        isArchived: isArchived ?? (withArchived ? undefined : false),
         encodedVideoPath: isEncoded ? Not(IsNull()) : undefined,
         livePhotoVideoId: isMotion ? Not(IsNull()) : undefined,
       },

--- a/server/src/infra/sql/asset.repository.sql
+++ b/server/src/infra/sql/asset.repository.sql
@@ -434,7 +434,7 @@ WHERE
     AND 1 = 1
     AND "asset"."ownerId" IN ($2)
     AND 1 = 1
-    AND 1 = 1
+    AND "asset"."isArchived" = $3
   )
   AND ("asset"."deletedAt" IS NULL)
 ORDER BY

--- a/server/src/infra/sql/search.repository.sql
+++ b/server/src/infra/sql/search.repository.sql
@@ -79,7 +79,10 @@ FROM
         AND "exifInfo"."lensModel" = $2
         AND 1 = 1
         AND 1 = 1
-        AND "asset"."isFavorite" = $3
+        AND (
+          "asset"."isFavorite" = $3
+          AND "asset"."isArchived" = $4
+        )
         AND (
           "stack"."primaryAssetId" = "asset"."id"
           OR "asset"."stackId" IS NULL
@@ -177,16 +180,19 @@ WHERE
     AND "exifInfo"."lensModel" = $2
     AND 1 = 1
     AND 1 = 1
-    AND "asset"."isFavorite" = $3
+    AND (
+      "asset"."isFavorite" = $3
+      AND "asset"."isArchived" = $4
+    )
     AND (
       "stack"."primaryAssetId" = "asset"."id"
       OR "asset"."stackId" IS NULL
     )
-    AND "asset"."ownerId" IN ($4)
+    AND "asset"."ownerId" IN ($5)
   )
   AND ("asset"."deletedAt" IS NULL)
 ORDER BY
-  "search"."embedding" <= > $5 ASC
+  "search"."embedding" <= > $6 ASC
 LIMIT
   101
 COMMIT


### PR DESCRIPTION
## Description

The search endpoint doesn't explicitly set `withArchived` right now, so it won't be part of the query unless the caller sets it to `false` themselves. This makes it default to false if not provided.

Fixes the behavior described in [this](https://github.com/immich-app/immich/issues/6701#issuecomment-1954813053) comment