### PR TITLE
Localize the output of the library count to make it more readable

### DIFF
--- a/web/src/lib/components/user-settings-page/library-list.svelte
+++ b/web/src/lib/components/user-settings-page/library-list.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
   import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
+  import { locale } from '$lib/stores/preferences.store';
   import { getBytesWithUnit } from '$lib/utils/byte-units';
   import { getContextMenuPosition } from '$lib/utils/context-menu';
   import { handleError } from '$lib/utils/handle-error';
@@ -332,7 +333,7 @@
                 </td>
               {:else}
                 <td class="w-1/6 text-ellipsis px-4 text-sm">
-                  {totalCount[index]}
+                  {totalCount[index].toLocaleString($locale)}
                 </td>
                 <td class="w-1/6 text-ellipsis px-4 text-sm">{diskUsage[index]} {diskUsageUnit[index]}</td>
               {/if}


### PR DESCRIPTION
Localizes the assets counter on the personal library overview

Before:
![image](https://github.com/immich-app/immich/assets/940593/85ad60c2-0c79-451d-9328-55caa9c6053b)


After:
![image](https://github.com/immich-app/immich/assets/940593/0722aa8a-dd8c-4a88-97da-98260266afce)
