### PR TITLE
fix(server): search with same face multiple times

### DIFF
--- a/server/src/infra/infra.utils.ts
+++ b/server/src/infra/infra.utils.ts
@@ -213,9 +213,9 @@ export function searchAssetBuilder(
   if (personIds && personIds.length > 0) {
     builder
       .leftJoin(`${builder.alias}.faces`, 'faces')
-      .andWhere('faces.personId IN (:...personIds)', { personIds: personIds })
+      .andWhere('faces.personId IN (:...personIds)', { personIds })
       .addGroupBy(`${builder.alias}.id`)
-      .having('COUNT(faces.id) = :personCount', { personCount: personIds.length });
+      .having('COUNT(DISTINCT faces.personId) = :personCount', { personCount: personIds.length });
 
     if (withExif) {
       builder.addGroupBy('exifInfo.assetId');


### PR DESCRIPTION
Whan an asset contains a face multiple times, the search has wrong behavior. Let's say the asset contains the face of person A two times:
- Search for person A --> no results
- Search for person A + B --> 1 result, even though it doesn't have person B

Fixed by counting distinct persons instead of counting faces