### PR TITLE
chore(mobile): Removes analysis options for openapi directory

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -34,7 +34,6 @@ linter:
 analyzer:
   exclude:
     - openapi/**
-    - openapi/test/**
     - lib/generated_plugin_registrant.dart
 
 plugins:

--- a/open-api/bin/generate-open-api.sh
+++ b/open-api/bin/generate-open-api.sh
@@ -14,6 +14,9 @@ function dart {
   # Post generate patches
   patch --no-backup-if-mismatch -u ../mobile/openapi/lib/api_client.dart <./patch/api_client.dart.patch
   patch --no-backup-if-mismatch -u ../mobile/openapi/lib/api.dart <./patch/api.dart.patch
+  # Don't include analysis_options.yaml for the generated openapi files
+  # so that language servers can properly exclude the mobile/openapi directory
+  rm ../mobile/openapi/analysis_options.yaml
 }
 
 function typescript {


### PR DESCRIPTION
The `openapi/analysis_options.yml` file was causing the analyzer to include the entire `openapi/` directory in the analyzer, which is contrary to our own analysis options.