### PR TITLE
perf(server): optimize mapAsset

### DIFF
--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -73,23 +73,21 @@ const peopleWithFaces = (faces: AssetFaceEntity[]): PersonWithFacesResponseDto[]
 export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): AssetResponseDto {
   const { stripMetadata = false, withStack = false } = options;
 
-  const sanitizedAssetResponse: SanitizedAssetResponseDto = {
-    id: entity.id,
-    type: entity.type,
-    thumbhash: entity.thumbhash?.toString('base64') ?? null,
-    localDateTime: entity.localDateTime,
-    resized: !!entity.resizePath,
-    duration: entity.duration ?? '0:00:00.00000',
-    livePhotoVideoId: entity.livePhotoVideoId,
-    hasMetadata: false,
-  };
-
   if (stripMetadata) {
+    const sanitizedAssetResponse: SanitizedAssetResponseDto = {
+      id: entity.id,
+      type: entity.type,
+      thumbhash: entity.thumbhash?.toString('base64') ?? null,
+      localDateTime: entity.localDateTime,
+      resized: !!entity.resizePath,
+      duration: entity.duration ?? '0:00:00.00000',
+      livePhotoVideoId: entity.livePhotoVideoId,
+      hasMetadata: false,
+    };
     return sanitizedAssetResponse as AssetResponseDto;
   }
 
   return {
-    ...sanitizedAssetResponse,
     id: entity.id,
     deviceAssetId: entity.deviceAssetId,
     ownerId: entity.ownerId,


### PR DESCRIPTION
Noticed the `mapAsset` function was taking way too long. This seems to be caused by the object spread syntax, after removing it performance got much better.

Tested using `AssetService.getTimeBuckets`, specifically when the `mapAsset(asset, { withStack: true })` case gets returned. It would be useful to know if someone else can replicate these results (only includes calls to mapAsset function, nothing else).

| Assets     | Before   | After |
|------------|----------|-------|
| 100        | 3ms      | <1ms  |
| 1000       | 26ms     | 1ms   |
| 10000      | 397ms    | 6ms   |
