### PR TITLE
fix(server): out of memory when unstacking assets

### DIFF
--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -326,7 +326,7 @@ export class AssetService {
     const stackIdsToCheckForDelete: string[] = [];
     if (removeParent) {
       (options as Partial<AssetEntity>).stack = null;
-      const assets = await this.assetRepository.getByIds(ids);
+      const assets = await this.assetRepository.getByIds(ids, { stack: true });
       stackIdsToCheckForDelete.push(...new Set(assets.filter((a) => !!a.stackId).map((a) => a.stackId!)));
       // This updates the updatedAt column of the parents to indicate that one of its children is removed
       // All the unique parent's -> parent is set to null


### PR DESCRIPTION
After unstacking 1000 assets the server ran out of memory. The `assetRepository.getByIds` includes the `{ stack: { assets: true } }` relation by default, which means it will retrieve all assets included in the stack again. Basically trying to load 1000 * 1000 = 1 million assets in memory. Fixed by only loading the needed relation.