### PR TITLE
fix(web): prevent scroll reset on search page

### DIFF
--- a/web/src/routes/(user)/search/+page.svelte
+++ b/web/src/routes/(user)/search/+page.svelte
@@ -286,11 +286,7 @@
       </section>
     {/if}
     <section id="search-content" class="relative bg-immich-bg dark:bg-immich-dark-bg">
-      {#if isLoading}
-        <div class="flex justify-center py-16 items-center">
-          <LoadingSpinner size="48" />
-        </div>
-      {:else if searchResultAssets.length > 0}
+      {#if searchResultAssets.length > 0}
         <GalleryViewer
           assets={searchResultAssets}
           bind:selectedAssets
@@ -298,13 +294,19 @@
           showArchiveIcon={true}
           {viewport}
         />
-      {:else}
+      {:else if !isLoading}
         <div class="flex min-h-[calc(66vh_-_11rem)] w-full place-content-center items-center dark:text-white">
           <div class="flex flex-col content-center items-center text-center">
             <Icon path={mdiImageOffOutline} size="3.5em" />
             <p class="mt-5 text-3xl font-medium">No results</p>
             <p class="text-base font-normal">Try a synonym or more general keyword</p>
           </div>
+        </div>
+      {/if}
+
+      {#if isLoading}
+        <div class="flex justify-center py-16 items-center">
+          <LoadingSpinner size="48" />
         </div>
       {/if}
     </section>


### PR DESCRIPTION
Loading new results causes `GalleryViewer` to unmount which resets the scroll position. Fixed by never unmounting the component.