### PR TITLE
Update reverse-proxy.md - Apache

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -44,22 +44,13 @@ Below is an example config for Apache2 site configuration.
 
 ```
 <VirtualHost *:80>
-    ServerName <snip>
+   ServerName <snip>
+   ProxyRequests Off
+   ProxyPass / http://127.0.0.1:2283/ timeout=600 upgrade=websocket
+   ProxyPassReverse / http://127.0.0.1:2283/
+   ProxyPreserveHost On
 
-    ProxyRequests off
-    ProxyVia on
-
-    RewriteEngine On
-    RewriteCond %{REQUEST_URI}  ^/api/socket.io            [NC]
-    RewriteCond %{QUERY_STRING} transport=websocket    [NC]
-    RewriteRule /(.*)           ws://localhost:2283/$1 [P,L]
-
-    ProxyPass        /api/socket.io ws://localhost:2283/api/socket.io
-    ProxyPassReverse /api/socket.io ws://localhost:2283/api/socket.io
-
-    <Location />
-        ProxyPass http://localhost:2283/
-        ProxyPassReverse http://localhost:2283/
-    </Location>
 </VirtualHost>
 ```
+
+**timeout:** is measured in seconds, and it is particularly useful when long operations are triggered (i.e. Repair), so the server doesn't return an error.


### PR DESCRIPTION
Update to the Apache's proxy script.

The documented configuration wasn't working, so I have corrected the script based on [Apache docs](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html).

This is the correct way to handle websockets in Apache 2.4.47  and later.