### PR TITLE
fix(web): fetch error reporting

### DIFF
--- a/open-api/typescript-sdk/fetch-errors.ts
+++ b/open-api/typescript-sdk/fetch-errors.ts
@@ -1,0 +1,15 @@
+import { HttpError } from '@oazapfts/runtime';
+
+export interface ApiExceptionResponse {
+  message: string;
+  error?: string;
+  statusCode: number;
+}
+
+export interface ApiHttpError extends HttpError {
+  data: ApiExceptionResponse;
+}
+
+export function isHttpError(error: unknown): error is ApiHttpError {
+  return error instanceof HttpError;
+}

--- a/open-api/typescript-sdk/fetch.ts
+++ b/open-api/typescript-sdk/fetch.ts
@@ -1,1 +1,2 @@
 export * from './fetch-client';
+export * from './fetch-errors';

--- a/web/src/hooks.client.ts
+++ b/web/src/hooks.client.ts
@@ -1,34 +1,22 @@
+import { isHttpError } from '@immich/sdk';
 import type { HandleClientError } from '@sveltejs/kit';
-import type { AxiosError, AxiosResponse } from 'axios';
 
 const LOG_PREFIX = '[hooks.client.ts]';
 const DEFAULT_MESSAGE = 'Hmm, not sure about that. Check the logs or open a ticket?';
 
 const parseError = (error: unknown) => {
-  const httpError = error as AxiosError;
-  const request = httpError?.request as Request & { path: string };
-  const response = httpError?.response as AxiosResponse<{
-    message: string;
-    statusCode: number;
-    error: string;
-  }>;
+  const httpError = isHttpError(error) ? error : undefined;
+  const statusCode = httpError?.status || httpError?.data?.statusCode || 500;
+  const message = httpError?.data?.message || (httpError?.data && String(httpError.data)) || httpError?.message;
 
-  let code = response?.data?.statusCode || response?.status || httpError.code || '500';
-  if (response) {
-    code += ` - ${response.data?.error || response.statusText}`;
-  }
-
-  if (request && response) {
-    console.log({
-      status: response.status,
-      url: `${request.method} ${request.path}`,
-      response: response.data || 'No data',
-    });
-  }
+  console.log({
+    status: statusCode,
+    response: httpError?.data || 'No data',
+  });
 
   return {
-    message: response?.data?.message || httpError?.message || DEFAULT_MESSAGE,
-    code,
+    message: message || DEFAULT_MESSAGE,
+    code: statusCode,
     stack: httpError?.stack,
   };
 };

--- a/web/src/lib/utils/handle-error.ts
+++ b/web/src/lib/utils/handle-error.ts
@@ -1,18 +1,25 @@
-import type { HttpError } from '@sveltejs/kit';
+import { isHttpError } from '@immich/sdk';
+import { isAxiosError } from 'axios';
 import { notificationController, NotificationType } from '../components/shared-components/notification/notification';
 
 export async function getServerErrorMessage(error: unknown) {
-  let data = (error as HttpError)?.body;
-  if (data instanceof Blob) {
-    const response = await data.text();
-    try {
-      data = JSON.parse(response);
-    } catch {
-      data = { message: response };
-    }
+  if (isHttpError(error)) {
+    return error.data?.message || error.data;
   }
 
-  return data?.message || null;
+  if (isAxiosError(error)) {
+    let data = error.response?.data;
+    if (data instanceof Blob) {
+      const response = await data.text();
+      try {
+        data = JSON.parse(response);
+      } catch {
+        data = { message: response };
+      }
+    }
+
+    return data?.message;
+  }
 }
 
 export async function handleError(error: unknown, message: string) {


### PR DESCRIPTION
Fetch errors don't show the error message returned from API responses, because it only expects axios errors. Fixed by handling both fetch and axios errors in the `handleError` function. The client hook has been changed to only handle fetch errors, because we don't use axios in any page load functions.