### PR TITLE
fix(server): storage template migration not working

### DIFF
--- a/server/src/domain/storage-template/storage-template.service.ts
+++ b/server/src/domain/storage-template/storage-template.service.ts
@@ -117,7 +117,7 @@ export class StorageTemplateService {
       return true;
     }
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
-      this.assetRepository.getAll(pagination),
+      this.assetRepository.getAll(pagination, { withExif: true }),
     );
     const users = await this.userRepository.getList();
 


### PR DESCRIPTION
## Description

The asset repository's `getAll` method doesn't add exif info by default anymore. Since the storage template migration skips all assets without exif info, it effectively doesn't work. 

Fixes #7361