### PR TITLE
fix(server): truncate embedding tables

### DIFF
--- a/server/src/domain/repositories/search.repository.ts
+++ b/server/src/domain/repositories/search.repository.ts
@@ -187,4 +187,5 @@ export interface ISearchRepository {
   searchFaces(search: FaceEmbeddingSearch): Promise<FaceSearchResult[]>;
   upsert(smartInfo: Partial<SmartInfoEntity>, embedding?: Embedding): Promise<void>;
   searchPlaces(placeName: string): Promise<GeodataPlacesEntity[]>;
+  deleteAllSearchEmbeddings(): Promise<void>;
 }

--- a/server/src/domain/smart-info/smart-info.service.spec.ts
+++ b/server/src/domain/smart-info/smart-info.service.spec.ts
@@ -71,6 +71,7 @@ describe(SmartInfoService.name, () => {
 
       expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.SMART_SEARCH, data: { id: assetStub.image.id } }]);
       expect(assetMock.getWithout).toHaveBeenCalledWith({ skip: 0, take: 1000 }, WithoutProperty.SMART_SEARCH);
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
     });
 
     it('should queue all the assets', async () => {
@@ -83,6 +84,7 @@ describe(SmartInfoService.name, () => {
 
       expect(jobMock.queueAll).toHaveBeenCalledWith([{ name: JobName.SMART_SEARCH, data: { id: assetStub.image.id } }]);
       expect(assetMock.getAll).toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).toHaveBeenCalled();
     });
   });
 

--- a/server/src/domain/smart-info/smart-info.service.ts
+++ b/server/src/domain/smart-info/smart-info.service.ts
@@ -50,6 +50,10 @@ export class SmartInfoService {
       return true;
     }
 
+    if (force) {
+      await this.repository.deleteAllSearchEmbeddings();
+    }
+
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
       return force
         ? this.assetRepository.getAll(pagination)

--- a/server/src/infra/repositories/person.repository.ts
+++ b/server/src/infra/repositories/person.repository.ts
@@ -40,11 +40,11 @@ export class PersonRepository implements IPersonRepository {
   }
 
   async deleteAll(): Promise<void> {
-    await this.personRepository.delete({});
+    await this.personRepository.clear();
   }
 
   async deleteAllFaces(): Promise<void> {
-    await this.assetFaceRepository.delete({});
+    await this.assetFaceRepository.query('TRUNCATE TABLE asset_faces CASCADE');
   }
 
   getAllFaces(

--- a/server/test/repositories/search.repository.mock.ts
+++ b/server/test/repositories/search.repository.mock.ts
@@ -8,5 +8,6 @@ export const newSearchRepositoryMock = (): jest.Mocked<ISearchRepository> => {
     searchFaces: jest.fn(),
     upsert: jest.fn(),
     searchPlaces: jest.fn(),
+    deleteAllSearchEmbeddings: jest.fn(),
   };
 };


### PR DESCRIPTION
## Description

Re-running smart search or face detection destroys the HNSW index because of the number of dead tuples it creates. Truncating is appropriate here since it also purges dead tuples and indexes. We avoided truncation before because it didn't work on pgvecto.rs 0.1.11, but we can safely do it on 0.2.0 now.

Fixes #7313

## How Has This Been Tested?

Tested with running "all" jobs on smart search and face detection, as well as by changing the smart search model.