### PR TITLE
chore(ci): move e2e test to github runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
       - name: Run npm install
         run: npm ci
 
@@ -36,6 +42,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Run e2e tests
         run: make server-e2e-jobs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   server-e2e-api:
     name: Server (e2e-api)
-    runs-on: mich
+    runs-on: macos-14
     defaults:
       run:
         working-directory: ./server
@@ -29,7 +29,7 @@ jobs:
 
   server-e2e-jobs:
     name: Server (e2e-jobs)
-    runs-on: mich
+    runs-on: macos-14
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   server-e2e-api:
     name: Server (e2e-api)
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./server
@@ -20,12 +20,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Run npm install
         run: npm ci
@@ -35,19 +29,13 @@ jobs:
 
   server-e2e-jobs:
     name: Server (e2e-jobs)
-    runs-on: macos-14
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Run e2e tests
         run: make server-e2e-jobs


### PR DESCRIPTION
Moving e2e workflow to GHA ubuntu x64 runners to reduce the infra complexity