### PR TITLE
chore: remove watcher polling option

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -88,10 +88,7 @@ Some basic examples:
 
 This feature - currently hidden in the config file - is considered experimental and for advanced users only. If enabled, it will allow automatic watching of the filesystem which means new assets are automatically imported to Immich without needing to rescan. Deleted assets are, as always, marked as offline and can be removed with the "Remove offline files" button.
 
-If your photos are on a network drive you will likely have to enable filesystem polling. The performance hit for polling large libraries is currently unknown, feel free to test this feature and report back. In addition to the boolean feature flag, the configuration file allows customization of the following parameters, please see the [chokidar documentation](https://github.com/paulmillr/chokidar?tab=readme-ov-file#performance) for reference.
-
-- `usePolling` (default: `false`).
-- `interval`. (default: 10000). When using polling, this is how often (in milliseconds) the filesystem is polled.
+If your photos are on a network drive, automatic file watching likely won't work. In that case, you will have to rely on a periodic library refresh to pull in your changes.
 
 ### Nightly job
 

--- a/mobile/openapi/doc/SystemConfigLibraryWatchDto.md
+++ b/mobile/openapi/doc/SystemConfigLibraryWatchDto.md
@@ -9,8 +9,6 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **enabled** | **bool** |  | 
-**interval** | **int** |  | 
-**usePolling** | **bool** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/system_config_library_watch_dto.dart
+++ b/mobile/openapi/lib/model/system_config_library_watch_dto.dart
@@ -14,37 +14,25 @@ class SystemConfigLibraryWatchDto {
   /// Returns a new [SystemConfigLibraryWatchDto] instance.
   SystemConfigLibraryWatchDto({
     required this.enabled,
-    required this.interval,
-    required this.usePolling,
   });
 
   bool enabled;
 
-  int interval;
-
-  bool usePolling;
-
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigLibraryWatchDto &&
-    other.enabled == enabled &&
-    other.interval == interval &&
-    other.usePolling == usePolling;
+    other.enabled == enabled;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (enabled.hashCode) +
-    (interval.hashCode) +
-    (usePolling.hashCode);
+    (enabled.hashCode);
 
   @override
-  String toString() => 'SystemConfigLibraryWatchDto[enabled=$enabled, interval=$interval, usePolling=$usePolling]';
+  String toString() => 'SystemConfigLibraryWatchDto[enabled=$enabled]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'enabled'] = this.enabled;
-      json[r'interval'] = this.interval;
-      json[r'usePolling'] = this.usePolling;
     return json;
   }
 
@@ -57,8 +45,6 @@ class SystemConfigLibraryWatchDto {
 
       return SystemConfigLibraryWatchDto(
         enabled: mapValueOfType<bool>(json, r'enabled')!,
-        interval: mapValueOfType<int>(json, r'interval')!,
-        usePolling: mapValueOfType<bool>(json, r'usePolling')!,
       );
     }
     return null;
@@ -107,8 +93,6 @@ class SystemConfigLibraryWatchDto {
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
     'enabled',
-    'interval',
-    'usePolling',
   };
 }
 

--- a/mobile/openapi/test/system_config_library_watch_dto_test.dart
+++ b/mobile/openapi/test/system_config_library_watch_dto_test.dart
@@ -21,16 +21,6 @@ void main() {
       // TODO
     });
 
-    // int interval
-    test('to test the property `interval`', () async {
-      // TODO
-    });
-
-    // bool usePolling
-    test('to test the property `usePolling`', () async {
-      // TODO
-    });
-
 
   });
 

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -9831,18 +9831,10 @@
         "properties": {
           "enabled": {
             "type": "boolean"
-          },
-          "interval": {
-            "type": "integer"
-          },
-          "usePolling": {
-            "type": "boolean"
           }
         },
         "required": [
-          "enabled",
-          "interval",
-          "usePolling"
+          "enabled"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/axios-client/api.ts
+++ b/open-api/typescript-sdk/axios-client/api.ts
@@ -4401,18 +4401,6 @@ export interface SystemConfigLibraryWatchDto {
      * @memberof SystemConfigLibraryWatchDto
      */
     'enabled': boolean;
-    /**
-     * 
-     * @type {number}
-     * @memberof SystemConfigLibraryWatchDto
-     */
-    'interval': number;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SystemConfigLibraryWatchDto
-     */
-    'usePolling': boolean;
 }
 /**
  * 

--- a/open-api/typescript-sdk/fetch-client.ts
+++ b/open-api/typescript-sdk/fetch-client.ts
@@ -835,8 +835,6 @@ export type SystemConfigLibraryScanDto = {
 };
 export type SystemConfigLibraryWatchDto = {
     enabled: boolean;
-    interval: number;
-    usePolling: boolean;
 };
 export type SystemConfigLibraryDto = {
     scan: SystemConfigLibraryScanDto;

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -113,9 +113,6 @@ export class LibraryService extends EventEmitter {
     });
 
     const config = await this.configCore.getConfig();
-    const { usePolling, interval } = config.library.watch;
-
-    this.logger.debug(`Settings for watcher: usePolling: ${usePolling}, interval: ${interval}`);
 
     let _resolve: () => void;
     const ready$ = new Promise<void>((resolve) => (_resolve = resolve));
@@ -123,9 +120,7 @@ export class LibraryService extends EventEmitter {
     this.watchers[id] = this.storageRepository.watch(
       library.importPaths,
       {
-        usePolling,
-        interval,
-        binaryInterval: interval,
+        usePolling: false,
         ignoreInitial: true,
       },
       {

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -112,8 +112,6 @@ export class LibraryService extends EventEmitter {
       ignore: library.exclusionPatterns,
     });
 
-    const config = await this.configCore.getConfig();
-
     let _resolve: () => void;
     const ready$ = new Promise<void>((resolve) => (_resolve = resolve));
 

--- a/server/src/domain/system-config/dto/system-config-library.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-library.dto.ts
@@ -1,12 +1,9 @@
 import { validateCronExpression } from '@app/domain';
-import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
-  IsInt,
   IsNotEmpty,
   IsObject,
-  IsPositive,
   IsString,
   Validate,
   ValidateIf,

--- a/server/src/domain/system-config/dto/system-config-library.dto.ts
+++ b/server/src/domain/system-config/dto/system-config-library.dto.ts
@@ -38,14 +38,6 @@ export class SystemConfigLibraryScanDto {
 export class SystemConfigLibraryWatchDto {
   @IsBoolean()
   enabled!: boolean;
-
-  @IsBoolean()
-  usePolling!: boolean;
-
-  @IsInt()
-  @IsPositive()
-  @ApiProperty({ type: 'integer' })
-  interval!: number;
 }
 
 export class SystemConfigLibraryDto {

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -132,8 +132,6 @@ export const defaults = Object.freeze<SystemConfig>({
     },
     watch: {
       enabled: false,
-      usePolling: false,
-      interval: 10_000,
     },
   },
   server: {

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -136,8 +136,6 @@ const updatedConfig = Object.freeze<SystemConfig>({
     },
     watch: {
       enabled: false,
-      usePolling: false,
-      interval: 10_000,
     },
   },
 });

--- a/server/src/infra/entities/system-config.entity.ts
+++ b/server/src/infra/entities/system-config.entity.ts
@@ -51,8 +51,6 @@ export enum SystemConfigKey {
   LIBRARY_SCAN_CRON_EXPRESSION = 'library.scan.cronExpression',
 
   LIBRARY_WATCH_ENABLED = 'library.watch.enabled',
-  LIBRARY_WATCH_USE_POLLING = 'library.watch.usePolling',
-  LIBRARY_WATCH_INTERVAL = 'library.watch.interval',
 
   LOGGING_ENABLED = 'logging.enabled',
   LOGGING_LEVEL = 'logging.level',
@@ -268,8 +266,6 @@ export interface SystemConfig {
     };
     watch: {
       enabled: boolean;
-      usePolling: boolean;
-      interval: number;
     };
   };
   server: {

--- a/server/src/infra/migrations/1709150004123-RemoveLibraryWatchPollingOption.ts
+++ b/server/src/infra/migrations/1709150004123-RemoveLibraryWatchPollingOption.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveLibraryWatchPollingOption1709150004123 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "system_config" WHERE key = 'library.watch.usePolling'`);
+    await queryRunner.query(`DELETE FROM "system_config" WHERE key = 'library.watch.interval'`);
+  }
+
+  public async down(): Promise<void> {
+    // noop
+  }
+}

--- a/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
@@ -42,28 +42,6 @@
             subtitle="Watch external libraries for file changes"
             bind:checked={config.library.watch.enabled}
           />
-
-          <SettingSwitch
-            title="Use filesystem polling (EXPERIMENTAL)"
-            disabled={disabled || !config.library.watch.enabled}
-            subtitle="Use polling instead of native filesystem watching. This is required for network shares but can be very resource intensive. Use with care!"
-            bind:checked={config.library.watch.usePolling}
-          />
-
-          <SettingInputField
-            inputType={SettingInputFieldType.NUMBER}
-            required={config.library.watch.usePolling}
-            disabled={disabled || !config.library.watch.usePolling || !config.library.watch.enabled}
-            label="Polling interval"
-            bind:value={config.library.watch.interval}
-            isEdited={config.library.watch.interval !== savedConfig.library.watch.interval}
-          >
-            <svelte:fragment slot="desc">
-              <p class="text-sm dark:text-immich-dark-fg">
-                Interval of filesystem polling, in milliseconds. Lower values will result in higher CPU usage.
-              </p>
-            </svelte:fragment>
-          </SettingInputField>
         </div>
 
         <div class="ml-4">


### PR DESCRIPTION
Polling for the library watcher only seems to bring problems. If users want to rescan libraries automatically we should probably have them use the cron feature instead.