### PR TITLE
feat(mobile): Adds better precaching for assets in gallery view and memory lane

### DIFF
--- a/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
+++ b/mobile/lib/modules/asset_viewer/views/gallery_viewer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 import 'dart:ui' as ui;
@@ -132,7 +133,7 @@ class GalleryViewerPage extends HookConsumerWidget {
     void toggleFavorite(Asset asset) =>
         ref.read(assetProvider.notifier).toggleFavorite([asset]);
 
-    void precacheNextImage(int index) {
+    Future<void> precacheNextImage(int index) async {
       void onError(Object exception, StackTrace? stackTrace) {
         // swallow error silently
         debugPrint('Error precaching next image: $exception, $stackTrace');
@@ -140,7 +141,7 @@ class GalleryViewerPage extends HookConsumerWidget {
 
       if (index < totalAssets && index >= 0) {
         final asset = loadAsset(index);
-        precacheImage(
+        await precacheImage(
           ImmichImage.imageProvider(asset: asset),
           context,
           onError: onError,
@@ -711,6 +712,21 @@ class GalleryViewerPage extends HookConsumerWidget {
       [],
     );
 
+    useEffect(
+      () {
+        // No need to await this
+        unawaited(
+          // Delay this a bit so we can finish loading the page
+          Future.delayed(const Duration(milliseconds: 400)).then(
+            // Precache the next image
+            (_) => precacheNextImage(currentIndex.value + 1),
+          ),
+        );
+        return null;
+      },
+      [],
+    );
+
     ref.listen(showControlsProvider, (_, show) {
       if (show) {
         SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
@@ -754,12 +770,16 @@ class GalleryViewerPage extends HookConsumerWidget {
                   ),
               itemCount: totalAssets,
               scrollDirection: Axis.horizontal,
-              onPageChanged: (value) {
+              onPageChanged: (value) async {
                 final next = currentIndex.value < value ? value + 1 : value - 1;
-                precacheNextImage(next);
+                HapticFeedback.selectionClick();
                 currentIndex.value = value;
                 stackIndex.value = -1;
-                HapticFeedback.selectionClick();
+
+                // Wait for page change animation to finish
+                await Future.delayed(const Duration(milliseconds: 400));
+                // Then precache the next image
+                unawaited(precacheNextImage(next));
               },
               builder: (context, index) {
                 final a =

--- a/mobile/lib/modules/memories/views/memory_page.dart
+++ b/mobile/lib/modules/memories/views/memory_page.dart
@@ -124,11 +124,14 @@ class MemoryPage extends HookConsumerWidget {
           .then((_) => precacheAsset(1));
     }
 
-    onAssetChanged(int otherIndex) {
+    Future<void> onAssetChanged(int otherIndex) async {
       HapticFeedback.selectionClick();
       currentAssetPage.value = otherIndex;
-      precacheAsset(otherIndex + 1);
       updateProgressText();
+      // Wait for page change animation to finish
+      await Future.delayed(const Duration(milliseconds: 400));
+      // And then precache the next asset
+      await precacheAsset(otherIndex + 1);
     }
 
     /* Notification listener is used instead of OnPageChanged callback since OnPageChanged is called


### PR DESCRIPTION
- Waits for a short delay after paging to precache next asset
- This way the page animation has time to complete before running precache image
- Preloads the next asset in the gallery view on start after a short delay