### PR TITLE
fix(web): keep notifications in view when scrolling

### DIFF
--- a/web/src/lib/components/shared-components/notification/notification-list.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if $notificationList.length > 0}
-  <section transition:fade={{ duration: 250 }} id="notification-list" class="absolute right-5 top-[80px] z-[99999999]">
+  <section transition:fade={{ duration: 250 }} id="notification-list" class="fixed right-5 top-[80px] z-[99999999]">
     {#each $notificationList as notificationInfo (notificationInfo.id)}
       <div animate:flip={{ duration: 250, easing: quintOut }}>
         <NotificationCard {notificationInfo} />


### PR DESCRIPTION
Notifications can become hidden from view when a page doesn't use `UserPageLayout` and a notification shows up while scrolled down. The notification list now uses `position: fixed` to avoid this situation.

![notification-scroll-before](https://github.com/immich-app/immich/assets/59014050/07f6e46e-1f83-48d6-9c03-b8d17de51861)
