### PR TITLE
add explicit registry to docker image names

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,12 +60,12 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2-alpine@sha256:51d6c56749a4243096327e3fb964a48ed92254357108449cb6e23999c37773c5
+    image: registry.hub.docker.com/library/redis:6.2-alpine@sha256:51d6c56749a4243096327e3fb964a48ed92254357108449cb6e23999c37773c5
     restart: always
 
   database:
     container_name: immich_postgres
-    image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    image: registry.hub.docker.com/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
closes #7495

Some container engines (hello podman :wave: ) don't use registry.hub.docker.com by default and won't be able to load `redis` or `pgvecto-rs` images from the composition.

This pull request explicitly add the image name prefix needed to fix that.