### PR TITLE
feat(server): Add emergency stop for library watcher

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -92,7 +92,7 @@ If your photos are on a network drive, automatic file watching likely won't work
 
 #### Troubleshooting
 
-If you encounter an `ENOSPC` error, you need to increase your file watcher limit. In sysctl, this key is called fs.inotify.max_user_watched and has a default value of 8192. Increase this number to a suitable value greater than the number of files you will be watching. Note that Immich has to watch all files in your import paths including any ignored files.
+If you encounter an `ENOSPC` error, you need to increase your file watcher limit. In sysctl, this key is called `fs.inotify.max_user_watched` and has a default value of 8192. Increase this number to a suitable value greater than the number of files you will be watching. Note that Immich has to watch all files in your import paths including any ignored files.
 
 ```
 ERROR [LibraryService] Library watcher for library c69faf55-f96d-4aa0-b83b-2d80cbc27d98 encountered error: Error: ENOSPC: System limit for number of file watchers reached, watch '/media/photo.jpg'

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -90,6 +90,16 @@ This feature - currently hidden in the config file - is considered experimental 
 
 If your photos are on a network drive, automatic file watching likely won't work. In that case, you will have to rely on a periodic library refresh to pull in your changes.
 
+#### Troubleshooting
+
+If you encounter an `ENOSPC` error, you need to increase your file watcher limit. In sysctl, this key is called fs.inotify.max_user_watched and has a default value of 8192. Increase this number to a suitable value greater than the number of files you will be watching. Note that Immich has to watch all files in your import paths including any ignored files.
+
+```
+ERROR [LibraryService] Library watcher for library c69faf55-f96d-4aa0-b83b-2d80cbc27d98 encountered error: Error: ENOSPC: System limit for number of file watchers reached, watch '/media/photo.jpg'
+```
+
+In rare cases, the library watcher can hang, preventing Immich from starting up. Unless a configuration file is used, this will prevent the user from disabling the library watcher. In that case, we have an emergency stop environment variable, `IMMICH_STOP_LIBRARY_WATCHER` that can be set to `true`. In the standard docker deployment, put this variable in the `.env` file. When Immich boots with this variable set, it will disable the library watcher configuration and exit. Remove the environment variable, and Immich can be started normally.
+
 ### Nightly job
 
 There is an automatic job that's run once a day and refreshes all modified files in all libraries as well as cleans up any libraries stuck in deletion.

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -67,6 +67,17 @@ export class LibraryService extends EventEmitter {
 
   async init() {
     const config = await this.configCore.getConfig();
+
+    if (process.env.IMMICH_STOP_LIBRARY_WATCHER === 'true') {
+      this.logger.warn('Initiating emergency stop of library watcher');
+      config.library.watch.enabled = false;
+      await this.configCore.updateConfig(config);
+      this.logger.error(
+        'Library watcher configuration has been disabled, remove IMMICH_STOP_LIBRARY_WATCHER env variable and restart immich',
+      );
+      process.exit(1);
+    }
+
     const { watch, scan } = config.library;
     this.watchLibraries = watch.enabled;
     this.jobRepository.addCronJob(


### PR DESCRIPTION
Fixes #6833 and related issues.

In some cases, the library watcher can hang, preventing immich from starting. Then the user has no way of disabling the watcher again.

This adds an env variable, IMMICH_STOP_LIBRARY_WATCHER, that causes the server container to change the configuration and then exit. After that, the env variable can be removed and Immich can start again.