### PR TITLE
fix(server): re-add mimalloc

### DIFF
--- a/server/start.sh
+++ b/server/start.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
+export LD_PRELOAD="$lib_path"
+
 read_file_and_export() {
 	if [ -n "${!1}" ]; then
 		content="$(cat "${!1}")"


### PR DESCRIPTION
mimalloc reduces RAM usage and increases performance. The `LD_PRELOAD`  line for it in `start.sh` got removed in #7189, so this PR adds it back. 