### PR TITLE
fix(server): only queue ml / transcoding jobs after thumbnail generation on upload

### DIFF
--- a/server/src/domain/job/job.service.spec.ts
+++ b/server/src/domain/job/job.service.spec.ts
@@ -286,12 +286,7 @@ describe(JobService.name, () => {
       },
       {
         item: { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1' } },
-        jobs: [
-          JobName.GENERATE_WEBP_THUMBNAIL,
-          JobName.GENERATE_THUMBHASH_THUMBNAIL,
-          JobName.SMART_SEARCH,
-          JobName.FACE_DETECTION,
-        ],
+        jobs: [JobName.GENERATE_WEBP_THUMBNAIL, JobName.GENERATE_THUMBHASH_THUMBNAIL],
       },
       {
         item: { name: JobName.GENERATE_JPEG_THUMBNAIL, data: { id: 'asset-1', source: 'upload' } },

--- a/server/src/domain/job/job.service.ts
+++ b/server/src/domain/job/job.service.ts
@@ -248,16 +248,18 @@ export class JobService {
         const jobs: JobItem[] = [
           { name: JobName.GENERATE_WEBP_THUMBNAIL, data: item.data },
           { name: JobName.GENERATE_THUMBHASH_THUMBNAIL, data: item.data },
-          { name: JobName.SMART_SEARCH, data: item.data },
-          { name: JobName.FACE_DETECTION, data: item.data },
         ];
 
-        const [asset] = await this.assetRepository.getByIds([item.data.id]);
-        if (asset) {
-          if (asset.type === AssetType.VIDEO) {
-            jobs.push({ name: JobName.VIDEO_CONVERSION, data: item.data });
-          } else if (asset.livePhotoVideoId) {
-            jobs.push({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
+        if (item.data.source === 'upload') {
+          jobs.push({ name: JobName.SMART_SEARCH, data: item.data }, { name: JobName.FACE_DETECTION, data: item.data });
+
+          const [asset] = await this.assetRepository.getByIds([item.data.id]);
+          if (asset) {
+            if (asset.type === AssetType.VIDEO) {
+              jobs.push({ name: JobName.VIDEO_CONVERSION, data: item.data });
+            } else if (asset.livePhotoVideoId) {
+              jobs.push({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
+            }
           }
         }
 


### PR DESCRIPTION
### Description

Re-running thumbnail generation has the side effect of queueing all ML tasks as well as transcoding. This is unnecessary and can be detrimental in the case of ML due to the indices being degraded. There's currently no way to *just* re-generate thumbnails (such as with a different quality setting, or after a [certain PR](https://github.com/immich-app/immich/pull/7513)).

This PR addresses this by selectively queueing ML and transcoding only on upload.