### PR TITLE
chore(web): fix eslint setup in VS Code

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -13,6 +13,7 @@ module.exports = {
     sourceType: 'module',
     ecmaVersion: 2022,
     extraFileExtensions: ['.svelte'],
+    tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
   env: {


### PR DESCRIPTION
This fixes eslint in VS Code for me. The other `.eslintrc.cjs` files already had this line