### PR TITLE
fix(web): show history search box only when needed

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -106,7 +106,9 @@
         name="q"
         class="w-full {grayTheme
           ? 'dark:bg-immich-dark-gray'
-          : 'dark:bg-immich-dark-bg'} px-14 py-4 text-immich-fg/75 dark:text-immich-dark-fg {showHistory || showFilter
+          : 'dark:bg-immich-dark-bg'} px-14 py-4 text-immich-fg/75 dark:text-immich-dark-fg {(showHistory &&
+          $savedSearchTerms.length > 0) ||
+        showFilter
           ? 'rounded-t-3xl border  border-gray-200 bg-white dark:border-gray-800'
           : 'rounded-3xl border border-transparent bg-gray-200'}"
         placeholder="Search your photos"
@@ -138,7 +140,7 @@
     {/if}
 
     <!-- SEARCH HISTORY BOX -->
-    {#if showHistory}
+    {#if showHistory && $savedSearchTerms.length > 0}
       <SearchHistoryBox
         on:clearAllSearchTerms={clearAllSearchTerms}
         on:clearSearchTerm={({ detail: searchTerm }) => clearSearchTerm(searchTerm)}


### PR DESCRIPTION
Show the history box only when needed

## Screenshots

| Before | After |
| :---: | :---: |
| ![Screenshot from 2024-03-01 00-30-02](https://github.com/immich-app/immich/assets/74269598/6b506e99-2f31-4a73-9f32-546048e7d195) | ![Screenshot from 2024-03-01 00-29-50](https://github.com/immich-app/immich/assets/74269598/2551f143-9944-4e6c-8610-2b78c24ed583) |
