### PR TITLE
fix(web): prevent duplicate calls to time bucket endpoint

### DIFF
--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -207,7 +207,7 @@ export class AssetStore {
 
       bucket.position = position;
 
-      if (bucket.assets.length > 0) {
+      if (bucket.assets.length > 0 || bucket.cancelToken) {
         this.emit(false);
         return;
       }


### PR DESCRIPTION
## Description

On page load, it's possible for the asset store's `init` and the insersection handler to both try to load the same bucket. Checking for an existing cancel token prevents this and possibly other cases.

An earlier iteration also removed the `loaders` section in the asset store's `init` as the intersection handler also does the same thing. However, after testing it seems to make the page load a bit snappier compared to relying only on the intersection handler.

## How Has This Been Tested?

Loaded timeline view with network dev tools and observed that the time bucket endpoint is only called once for a particular date.