### PR TITLE
fix(mobile): Fixes double video auto initialize issue, placeholder for videos

### DIFF
--- a/mobile/lib/modules/asset_viewer/hooks/chewiew_controller_hook.dart
+++ b/mobile/lib/modules/asset_viewer/hooks/chewiew_controller_hook.dart
@@ -20,7 +20,6 @@ ChewieController? useChewieController(
   bool showOptions = true,
   bool showControlsOnInitialize = false,
   bool autoPlay = true,
-  bool autoInitialize = true,
   bool allowFullScreen = false,
   bool allowedScreenSleep = false,
   bool showControls = true,
@@ -43,7 +42,6 @@ ChewieController? useChewieController(
       hideControlsTimer: hideControlsTimer,
       showControlsOnInitialize: showControlsOnInitialize,
       showControls: showControls,
-      autoInitialize: autoInitialize,
       allowedScreenSleep: allowedScreenSleep,
       onPlaying: onPlaying,
       onPaused: onPaused,
@@ -58,7 +56,6 @@ class _ChewieControllerHook extends Hook<ChewieController?> {
   final bool showOptions;
   final bool showControlsOnInitialize;
   final bool autoPlay;
-  final bool autoInitialize;
   final bool allowFullScreen;
   final bool allowedScreenSleep;
   final bool showControls;
@@ -77,7 +74,6 @@ class _ChewieControllerHook extends Hook<ChewieController?> {
     this.showOptions = true,
     this.showControlsOnInitialize = false,
     this.autoPlay = true,
-    this.autoInitialize = true,
     this.allowFullScreen = false,
     this.allowedScreenSleep = false,
     this.showControls = true,
@@ -166,7 +162,6 @@ class _ChewieControllerHookState
         showOptions: hook.showOptions,
         showControlsOnInitialize: hook.showControlsOnInitialize,
         autoPlay: hook.autoPlay,
-        autoInitialize: hook.autoInitialize,
         allowFullScreen: hook.allowFullScreen,
         allowedScreenSleep: hook.allowedScreenSleep,
         showControls: hook.showControls,

--- a/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
+++ b/mobile/lib/modules/asset_viewer/views/video_viewer_page.dart
@@ -40,7 +40,7 @@ class VideoViewerPage extends HookWidget {
       controlsSafeAreaMinimum: const EdgeInsets.only(
         bottom: 100,
       ),
-      placeholder: placeholder,
+      placeholder: SizedBox.expand(child: placeholder),
       showControls: showControls && !isMotionVideo,
       hideControlsTimer: hideControlsTimer,
       customControls: const VideoPlayerControls(),


### PR DESCRIPTION
- Video auto initialize wasn't being respected so I removed it in favor of manual initialization
- Fixes video placeholder not expanding to fill the space