### PR TITLE
fix(server): prevent leaking isFavorite and isArchived info

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -80,7 +80,7 @@
     },
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
-      "version": "1.97.0",
+      "version": "1.92.1",
       "dev": true,
       "license": "GNU Affero General Public License version 3",
       "devDependencies": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -80,7 +80,7 @@
     },
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
-      "version": "1.92.1",
+      "version": "1.97.0",
       "dev": true,
       "license": "GNU Affero General Public License version 3",
       "devDependencies": {

--- a/e2e/src/api/specs/album.e2e-spec.ts
+++ b/e2e/src/api/specs/album.e2e-spec.ts
@@ -122,7 +122,7 @@ describe('/album', () => {
     it("should not show other users' favorites", async () => {
       const { status, body } = await request(app)
         .get(`/album/${user1Albums[0].id}?withoutAssets=false`)
-        .set('Authorization', `Bearer ${user1.accessToken}`);
+        .set('Authorization', `Bearer ${user2.accessToken}`);
       expect(status).toEqual(200);
       expect(body).toEqual({
         ...user1Albums[0],

--- a/e2e/src/api/specs/album.e2e-spec.ts
+++ b/e2e/src/api/specs/album.e2e-spec.ts
@@ -41,7 +41,7 @@ describe('/album', () => {
     ]);
 
     [user1Asset1, user1Asset2] = await Promise.all([
-      apiUtils.createAsset(user1.accessToken),
+      apiUtils.createAsset(user1.accessToken, { isFavorite: true }),
       apiUtils.createAsset(user1.accessToken),
     ]);
 
@@ -117,6 +117,17 @@ describe('/album', () => {
         .set('Authorization', `Bearer ${user1.accessToken}`);
       expect(status).toEqual(400);
       expect(body).toEqual(errorDto.badRequest(['assetId must be a UUID']));
+    });
+
+    it("should not show other users' favorites", async () => {
+      const { status, body } = await request(app)
+        .get(`/album/${user1Albums[0].id}?withoutAssets=false`)
+        .set('Authorization', `Bearer ${user1.accessToken}`);
+      expect(status).toEqual(200);
+      expect(body).toEqual({
+        ...user1Albums[0],
+        assets: [expect.objectContaining({ isFavorite: false })],
+      });
     });
 
     it('should not return shared albums with a deleted owner', async () => {

--- a/server/src/domain/album/album-response.dto.ts
+++ b/server/src/domain/album/album-response.dto.ts
@@ -1,6 +1,7 @@
 import { AlbumEntity } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { AssetResponseDto, mapAsset } from '../asset';
+import { AuthDto } from '../auth/auth.dto';
 import { UserResponseDto, mapUser } from '../user';
 
 export class AlbumResponseDto {
@@ -24,7 +25,7 @@ export class AlbumResponseDto {
   isActivityEnabled!: boolean;
 }
 
-export const mapAlbum = (entity: AlbumEntity, withAssets: boolean): AlbumResponseDto => {
+export const mapAlbum = (entity: AlbumEntity, withAssets: boolean, auth?: AuthDto): AlbumResponseDto => {
   const sharedUsers: UserResponseDto[] = [];
 
   if (entity.sharedUsers) {
@@ -59,7 +60,7 @@ export const mapAlbum = (entity: AlbumEntity, withAssets: boolean): AlbumRespons
     hasSharedLink,
     startDate,
     endDate,
-    assets: (withAssets ? assets : []).map((asset) => mapAsset(asset)),
+    assets: (withAssets ? assets : []).map((asset) => mapAsset(asset, { auth })),
     assetCount: entity.assets?.length || 0,
     isActivityEnabled: entity.isActivityEnabled,
   };

--- a/server/src/domain/album/album.service.ts
+++ b/server/src/domain/album/album.service.ts
@@ -104,7 +104,7 @@ export class AlbumService {
     const [albumMetadataForIds] = await this.albumRepository.getMetadataForIds([album.id]);
 
     return {
-      ...mapAlbum(album, withAssets),
+      ...mapAlbum(album, withAssets, auth),
       startDate: albumMetadataForIds.startDate,
       endDate: albumMetadataForIds.endDate,
       assetCount: albumMetadataForIds.assetCount,

--- a/server/src/domain/asset/asset.service.ts
+++ b/server/src/domain/asset/asset.service.ts
@@ -180,7 +180,7 @@ export class AssetService {
 
         return {
           title: `${years} year${years > 1 ? 's' : ''} since...`,
-          asset: mapAsset(asset),
+          asset: mapAsset(asset, { auth }),
         };
       })
       .groupBy((asset) => asset.title)
@@ -230,8 +230,8 @@ export class AssetService {
     const timeBucketOptions = await this.buildTimeBucketOptions(auth, dto);
     const assets = await this.assetRepository.getTimeBucket(dto.timeBucket, timeBucketOptions);
     return !auth.sharedLink || auth.sharedLink?.showExif
-      ? assets.map((asset) => mapAsset(asset, { withStack: true }))
-      : assets.map((asset) => mapAsset(asset, { stripMetadata: true }));
+      ? assets.map((asset) => mapAsset(asset, { withStack: true, auth }))
+      : assets.map((asset) => mapAsset(asset, { stripMetadata: true, auth }));
   }
 
   async buildTimeBucketOptions(auth: AuthDto, dto: TimeBucketDto): Promise<TimeBucketOptions> {
@@ -261,7 +261,7 @@ export class AssetService {
 
   async getRandom(auth: AuthDto, count: number): Promise<AssetResponseDto[]> {
     const assets = await this.assetRepository.getRandom(auth.user.id, count);
-    return assets.map((a) => mapAsset(a));
+    return assets.map((a) => mapAsset(a, { auth }));
   }
 
   async getUserAssetsByDeviceId(auth: AuthDto, deviceId: string) {
@@ -292,10 +292,10 @@ export class AssetService {
     }
 
     if (auth.sharedLink && !auth.sharedLink.showExif) {
-      return mapAsset(asset, { stripMetadata: true, withStack: true });
+      return mapAsset(asset, { stripMetadata: true, withStack: true, auth });
     }
 
-    const data = mapAsset(asset, { withStack: true });
+    const data = mapAsset(asset, { withStack: true, auth });
 
     if (auth.sharedLink) {
       delete data.owner;
@@ -315,7 +315,7 @@ export class AssetService {
     await this.updateMetadata({ id, description, dateTimeOriginal, latitude, longitude });
 
     const asset = await this.assetRepository.save({ id, ...rest });
-    return mapAsset(asset);
+    return mapAsset(asset, { auth });
   }
 
   async updateAll(auth: AuthDto, dto: AssetBulkUpdateDto): Promise<void> {

--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -106,7 +106,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     localDateTime: entity.localDateTime,
     updatedAt: entity.updatedAt,
     isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
-    isArchived: entity.isArchived,
+    isArchived: options.auth?.user.id === entity.ownerId ? entity.isArchived : false,
     isTrashed: !!entity.deletedAt,
     duration: entity.duration ?? '0:00:00.00000',
     exifInfo: entity.exifInfo ? mapExif(entity.exifInfo) : undefined,

--- a/server/src/domain/asset/response-dto/asset-response.dto.ts
+++ b/server/src/domain/asset/response-dto/asset-response.dto.ts
@@ -1,3 +1,4 @@
+import { AuthDto } from '@app/domain/auth/auth.dto';
 import { AssetEntity, AssetFaceEntity, AssetType } from '@app/infra/entities';
 import { ApiProperty } from '@nestjs/swagger';
 import { PersonWithFacesResponseDto, mapFacesWithoutPerson, mapPerson } from '../../person/person.dto';
@@ -50,6 +51,7 @@ export class AssetResponseDto extends SanitizedAssetResponseDto {
 export type AssetMapOptions = {
   stripMetadata?: boolean;
   withStack?: boolean;
+  auth?: AuthDto;
 };
 
 const peopleWithFaces = (faces: AssetFaceEntity[]): PersonWithFacesResponseDto[] => {
@@ -103,7 +105,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     fileModifiedAt: entity.fileModifiedAt,
     localDateTime: entity.localDateTime,
     updatedAt: entity.updatedAt,
-    isFavorite: entity.isFavorite,
+    isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
     isArchived: entity.isArchived,
     isTrashed: !!entity.deletedAt,
     duration: entity.duration ?? '0:00:00.00000',
@@ -117,7 +119,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     stack: withStack
       ? entity.stack?.assets
           .filter((a) => a.id !== entity.stack?.primaryAssetId)
-          .map((a) => mapAsset(a, { stripMetadata }))
+          .map((a) => mapAsset(a, { stripMetadata, auth: options.auth }))
       : undefined,
     stackCount: entity.stack?.assets?.length ?? null,
     isExternal: entity.isExternal,


### PR DESCRIPTION
Prevent leaking the `isFavorite` data for non-owners until full support for favorites.
fixes #7577

## Screenshots

| Before | After |
| :---: | :---: |
| ![Screenshot from 2024-03-02 17-24-34](https://github.com/immich-app/immich/assets/74269598/dae51b0a-c1b8-4352-b201-c9ac8ffba208) | ![Screenshot from 2024-03-02 17-23-43](https://github.com/immich-app/immich/assets/74269598/8b07e53a-8a19-4acf-a9de-07f4ccbb6e8b) |