### PR TITLE
feat(server): allow oauth claim to set 0 for no quota

### DIFF
--- a/server/src/domain/auth/auth.service.spec.ts
+++ b/server/src/domain/auth/auth.service.spec.ts
@@ -15,7 +15,6 @@ import {
   newUserTokenRepositoryMock,
   sharedLinkStub,
   systemConfigStub,
-  userDto,
   userStub,
   userTokenStub,
 } from '@test';
@@ -51,6 +50,14 @@ const fixtures = {
     email,
     password: 'password',
   },
+};
+
+const oauthUserWithDefaultQuota = {
+  email: email,
+  name: ' ',
+  oauthId: sub,
+  quotaSizeInBytes: 1_073_741_824,
+  storageLabel: null,
 };
 
 describe('AuthService', () => {
@@ -502,7 +509,7 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithDefaultStorageQuota);
+      expect(userMock.create).toHaveBeenCalledWith(oauthUserWithDefaultQuota);
     });
 
     it('should ignore an invalid storage quota', async () => {
@@ -516,8 +523,9 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithDefaultStorageQuota);
+      expect(userMock.create).toHaveBeenCalledWith(oauthUserWithDefaultQuota);
     });
+
     it('should ignore a negative quota', async () => {
       configMock.load.mockResolvedValue(systemConfigStub.withDefaultStorageQuota);
       userMock.getByEmail.mockResolvedValue(null);
@@ -529,7 +537,7 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithDefaultStorageQuota);
+      expect(userMock.create).toHaveBeenCalledWith(oauthUserWithDefaultQuota);
     });
 
     it('should not set quota for 0 quota', async () => {
@@ -543,7 +551,13 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithUnsetQuotaClaim);
+      expect(userMock.create).toHaveBeenCalledWith({
+        email: email,
+        name: ' ',
+        oauthId: sub,
+        quotaSizeInBytes: null,
+        storageLabel: null,
+      });
     });
 
     it('should use a valid storage quota', async () => {
@@ -557,7 +571,13 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithStorageQuotaClaim);
+      expect(userMock.create).toHaveBeenCalledWith({
+        email: email,
+        name: ' ',
+        oauthId: sub,
+        quotaSizeInBytes: 5_368_709_120,
+        storageLabel: null,
+      });
     });
   });
 

--- a/server/src/domain/auth/auth.service.spec.ts
+++ b/server/src/domain/auth/auth.service.spec.ts
@@ -532,7 +532,7 @@ describe('AuthService', () => {
       expect(userMock.create).toHaveBeenCalledWith(userDto.userWithDefaultStorageQuota);
     });
 
-    it('should ignore a 0 quota', async () => {
+    it('should not set quota for 0 quota', async () => {
       configMock.load.mockResolvedValue(systemConfigStub.withDefaultStorageQuota);
       userMock.getByEmail.mockResolvedValue(null);
       userMock.getAdmin.mockResolvedValue(userStub.user1);
@@ -543,7 +543,7 @@ describe('AuthService', () => {
         loginResponseStub.user1oauth,
       );
 
-      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithDefaultStorageQuota);
+      expect(userMock.create).toHaveBeenCalledWith(userDto.userWithUnsetQuotaClaim);
     });
 
     it('should use a valid storage quota', async () => {

--- a/server/src/domain/auth/auth.service.ts
+++ b/server/src/domain/auth/auth.service.ts
@@ -264,7 +264,7 @@ export class AuthService {
       const storageQuota = this.getClaim(profile, {
         key: storageQuotaClaim,
         default: defaultStorageQuota,
-        isValid: (value: unknown) => isNumber(value) && value > 0,
+        isValid: (value: unknown) => isNumber(value) && value >= 0,
       });
 
       const userName = profile.name ?? `${profile.given_name || ''} ${profile.family_name || ''}`;

--- a/server/test/fixtures/user.stub.ts
+++ b/server/test/fixtures/user.stub.ts
@@ -37,6 +37,13 @@ export const userDto = {
     quotaSizeInBytes: 5_368_709_120,
     storageLabel: null,
   },
+  userWithUnsetQuotaClaim: {
+    email: 'test@immich.com',
+    name: ' ',
+    oauthId: 'my-auth-user-sub',
+    quotaSizeInBytes: null,
+    storageLabel: null,
+  },
 };
 
 export const userStub = {

--- a/server/test/fixtures/user.stub.ts
+++ b/server/test/fixtures/user.stub.ts
@@ -23,27 +23,6 @@ export const userDto = {
     name: 'User with quota',
     quotaSizeInBytes: 42,
   },
-  userWithDefaultStorageQuota: {
-    email: 'test@immich.com',
-    name: ' ',
-    oauthId: 'my-auth-user-sub',
-    quotaSizeInBytes: 1_073_741_824,
-    storageLabel: null,
-  },
-  userWithStorageQuotaClaim: {
-    email: 'test@immich.com',
-    name: ' ',
-    oauthId: 'my-auth-user-sub',
-    quotaSizeInBytes: 5_368_709_120,
-    storageLabel: null,
-  },
-  userWithUnsetQuotaClaim: {
-    email: 'test@immich.com',
-    name: ' ',
-    oauthId: 'my-auth-user-sub',
-    quotaSizeInBytes: null,
-    storageLabel: null,
-  },
 };
 
 export const userStub = {


### PR DESCRIPTION
@jrasm91 thanks for all the help on https://github.com/immich-app/immich/pull/7548 - Do we want to support the use case of having a default quota set but setting it to unlimited for specific users via the claim? I was sticking with `0` to match the UI and default quota language.