### PR TITLE
fix: bump version pipeline

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -47,7 +47,7 @@
     },
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
-      "version": "1.92.1",
+      "version": "1.97.0",
       "dev": true,
       "license": "GNU Affero General Public License version 3",
       "devDependencies": {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -80,7 +80,7 @@
     },
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
-      "version": "1.92.1",
+      "version": "1.97.0",
       "dev": true,
       "license": "GNU Affero General Public License version 3",
       "devDependencies": {

--- a/misc/release/pump-version.sh
+++ b/misc/release/pump-version.sh
@@ -66,8 +66,8 @@ if [ "$CURRENT_SERVER" != "$NEXT_SERVER" ]; then
   npm --prefix open-api/typescript-sdk version "$SERVER_PUMP"
   npm --prefix web version "$SERVER_PUMP"
   npm --prefix web i --package-lock-only
-  npm --prefix e2e i --package-lock-only
   npm --prefix cli i --package-lock-only
+  npm --prefix e2e i --package-lock-only
   poetry --directory machine-learning version "$SERVER_PUMP"
 fi
 

--- a/misc/release/pump-version.sh
+++ b/misc/release/pump-version.sh
@@ -62,9 +62,12 @@ fi
 if [ "$CURRENT_SERVER" != "$NEXT_SERVER" ]; then
   echo "Pumping Server: $CURRENT_SERVER => $NEXT_SERVER"
   npm --prefix server version "$SERVER_PUMP"
-  npm --prefix web version "$SERVER_PUMP"
-  npm --prefix open-api/typescript-sdk version "$SERVER_PUMP"
   make open-api
+  npm --prefix open-api/typescript-sdk version "$SERVER_PUMP"
+  npm --prefix web version "$SERVER_PUMP"
+  npm --prefix web i --package-lock-only
+  npm --prefix e2e i --package-lock-only
+  npm --prefix cli i --package-lock-only
   poetry --directory machine-learning version "$SERVER_PUMP"
 fi
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -63,7 +63,7 @@
     },
     "../open-api/typescript-sdk": {
       "name": "@immich/sdk",
-      "version": "1.92.1",
+      "version": "1.97.0",
       "license": "GNU Affero General Public License version 3",
       "devDependencies": {
         "@oazapfts/runtime": "^1.0.0",


### PR DESCRIPTION
Currently, package-lock files still have incorrect open-api version mentions. This PR fixes it so now the `pump-version` script: 
1. Update the server version
2. Update the typescript SDK
3. Update all projects that use the TypeScript SDK