### PR TITLE
fix(server, web): prevent reload when liking an asset

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -25,6 +25,8 @@
   let copyImageToClipboard: (source: string) => Promise<Blob>;
   let canCopyImagesToClipboard: () => boolean;
 
+  const loadOriginalByDefault = $alwaysLoadOriginalFile && isWebCompatibleImage(asset);
+
   $: if (imgElement) {
     createZoomImageWheel(imgElement, {
       maxZoom: 10,
@@ -125,7 +127,7 @@
   transition:fade={{ duration: haveFadeTransition ? 150 : 0 }}
   class="flex h-full select-none place-content-center place-items-center"
 >
-  {#await loadAssetData({ loadOriginal: $alwaysLoadOriginalFile ? isWebCompatibleImage(asset) : false })}
+  {#await loadAssetData({ loadOriginal: loadOriginalByDefault })}
     <LoadingSpinner />
   {:then}
     <div bind:this={imgElement} class="h-full w-full">


### PR DESCRIPTION
This PR prevents photo viewer from reloading when you like an asset