### PR TITLE
perf(web): optimize date groups

### DIFF
--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -21,7 +21,7 @@
         if ($isSelectAllCancelled) {
           break;
         }
-        await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
+        await assetStore.loadBucket(bucket.date, BucketPosition.Unknown);
         for (const asset of bucket.assets) {
           assetInteractionStore.selectAsset(asset);
         }

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -112,7 +112,7 @@
 </script>
 
 <section id="asset-group-by-date" class="flex flex-wrap gap-x-12" bind:clientHeight={actualBucketHeight}>
-  {#each assetsGroupByDate.values() as groupAssets, groupIndex (groupAssets[0].id)}
+  {#each assetsGroupByDate as groupAssets, groupIndex (groupAssets[0].id)}
     {@const asset = groupAssets[0]}
     {@const groupTitle = formatGroupTitle(fromLocalDateTime(asset.localDateTime).startOf('day'))}
     <!-- Asset Group By Date -->

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -154,36 +154,34 @@
         </span>
       </p>
 
-      {#if groupAssets.length > 0}
-        <!-- Image grid -->
-        <div
-          class="relative"
-          style="height: {geometry[groupIndex].containerHeight}px;width: {geometry[groupIndex].containerWidth}px"
-        >
-          {#each groupAssets as asset, index (asset.id)}
-            {@const box = geometry[groupIndex].boxes[index]}
-            <div
-              class="absolute"
-              style="width: {box.width}px; height: {box.height}px; top: {box.top}px; left: {box.left}px"
-            >
-              <Thumbnail
-                showStackedIcon={withStacked}
-                {showArchiveIcon}
-                {asset}
-                {groupIndex}
-                on:click={() => assetClickHandler(asset, groupAssets, groupTitle)}
-                on:select={() => assetSelectHandler(asset, groupAssets, groupTitle)}
-                on:mouse-event={() => assetMouseEventHandler(groupTitle, asset)}
-                selected={$selectedAssets.has(asset) || $assetStore.albumAssets.has(asset.id)}
-                selectionCandidate={$assetSelectionCandidates.has(asset)}
-                disabled={$assetStore.albumAssets.has(asset.id)}
-                thumbnailWidth={box.width}
-                thumbnailHeight={box.height}
-              />
-            </div>
-          {/each}
-        </div>
-      {/if}
+      <!-- Image grid -->
+      <div
+        class="relative"
+        style="height: {geometry[groupIndex].containerHeight}px;width: {geometry[groupIndex].containerWidth}px"
+      >
+        {#each groupAssets as asset, index (asset.id)}
+          {@const box = geometry[groupIndex].boxes[index]}
+          <div
+            class="absolute"
+            style="width: {box.width}px; height: {box.height}px; top: {box.top}px; left: {box.left}px"
+          >
+            <Thumbnail
+              showStackedIcon={withStacked}
+              {showArchiveIcon}
+              {asset}
+              {groupIndex}
+              on:click={() => assetClickHandler(asset, groupAssets, groupTitle)}
+              on:select={() => assetSelectHandler(asset, groupAssets, groupTitle)}
+              on:mouse-event={() => assetMouseEventHandler(groupTitle, asset)}
+              selected={$selectedAssets.has(asset) || $assetStore.albumAssets.has(asset.id)}
+              selectionCandidate={$assetSelectionCandidates.has(asset)}
+              disabled={$assetStore.albumAssets.has(asset.id)}
+              thumbnailWidth={box.width}
+              thumbnailHeight={box.height}
+            />
+          </div>
+        {/each}
+      </div>
     </div>
   {/each}
 </section>

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -318,7 +318,6 @@
       for (let bucketIndex = startBucketIndex; bucketIndex <= endBucketIndex; bucketIndex++) {
         const bucket = $assetStore.buckets[bucketIndex];
 
-        // Split bucket into date groups and check each group
         for (const dateGroup of bucket.dateGroups.values()) {
           const dateGroupTitle = formatGroupTitle(DateTime.fromISO(dateGroup[0].fileCreatedAt).startOf('day'));
           if (dateGroup.every((a) => $selectedAssets.has(a))) {

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -5,15 +5,16 @@
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { BucketPosition, type AssetStore, type Viewport } from '$lib/stores/assets.store';
-  import { locale, showDeleteModal } from '$lib/stores/preferences.store';
+  import { showDeleteModal } from '$lib/stores/preferences.store';
   import { isSearchEnabled } from '$lib/stores/search.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { deleteAssets } from '$lib/utils/actions';
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
-  import { formatGroupTitle, splitBucketIntoDateGroups } from '$lib/utils/timeline-util';
+  import { formatGroupTitle } from '$lib/utils/timeline-util';
   import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
   import { DateTime } from 'luxon';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import AssetViewer from '../asset-viewer/asset-viewer.svelte';
   import IntersectionObserver from '../asset-viewer/intersection-observer.svelte';
   import Portal from '../shared-components/portal/portal.svelte';
   import Scrollbar from '../shared-components/scrollbar/scrollbar.svelte';
@@ -444,19 +445,17 @@
 
 <Portal target="body">
   {#if $showAssetViewer}
-    {#await import('../asset-viewer/asset-viewer.svelte') then AssetViewer}
-      <AssetViewer.default
-        {withStacked}
-        {assetStore}
-        asset={$viewingAsset}
-        {isShared}
-        {album}
-        on:previous={handlePrevious}
-        on:next={handleNext}
-        on:close={handleClose}
-        on:action={({ detail: action }) => handleAction(action.type, action.asset)}
-      />
-    {/await}
+    <AssetViewer
+      {withStacked}
+      {assetStore}
+      asset={$viewingAsset}
+      {isShared}
+      {album}
+      on:previous={handlePrevious}
+      on:next={handleNext}
+      on:close={handleClose}
+      on:action={({ detail: action }) => handleAction(action.type, action.asset)}
+    />
   {/if}
 </Portal>
 

--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -38,8 +38,8 @@
     return buckets.map((bucket) => {
       const segment = new Segment();
       segment.count = bucket.assets.length;
-      segment.height = toScrollY(bucket.bucketHeight);
-      segment.timeGroup = bucket.bucketDate;
+      segment.height = toScrollY(bucket.height);
+      segment.timeGroup = bucket.date;
       segment.date = fromLocalDateTime(segment.timeGroup);
 
       if (previous?.date.year !== segment.date.year && height > MIN_YEAR_LABEL_DISTANCE) {

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -80,7 +80,6 @@ export class AssetBucket {
       return;
     }
 
-    const time1 = performance.now();
     for (const asset of this.assets) {
       const curLocale = fromLocalDateTime(asset.localDateTime).toLocaleString(groupDateFormat);
       if (this.dateGroups.has(curLocale)) {
@@ -89,8 +88,6 @@ export class AssetBucket {
         this.dateGroups.set(curLocale, [asset]);
       }
     }
-    const time2 = performance.now();
-    console.log(`updateDateGroups for ${this.date}:`, time2 - time1);
   }
 }
 

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -63,14 +63,6 @@ export class AssetBucket {
       this.assets = assets;
     } else {
       this.assets.push(...assets);
-      const time1 = performance.now();
-      this.assets.sort((a, b) => {
-        const aDate = DateTime.fromISO(a.fileCreatedAt).toUTC();
-        const bDate = DateTime.fromISO(b.fileCreatedAt).toUTC();
-        return bDate.diff(aDate).milliseconds;
-      });
-      const time2 = performance.now();
-      console.log(`addAssets sorting for ${this.date}:`, time2 - time1);
     }
     this.updateDateGroups();
   }

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -1,6 +1,4 @@
 import { locale } from '$lib/stores/preferences.store';
-import type { AssetResponseDto } from '@immich/sdk';
-import { groupBy, sortBy } from 'lodash-es';
 import { DateTime, Interval } from 'luxon';
 import { get } from 'svelte/store';
 
@@ -44,20 +42,11 @@ export function formatGroupTitle(date: DateTime): string {
   return date.toLocaleString(groupDateFormat);
 }
 
-export function splitBucketIntoDateGroups(
-  assets: AssetResponseDto[],
-  locale: string | undefined,
-): AssetResponseDto[][] {
-  const grouped = groupBy(assets, (asset) =>
-    fromLocalDateTime(asset.localDateTime).toLocaleString(groupDateFormat, { locale }),
-  );
-  return sortBy(grouped, (group) => assets.indexOf(group[0]));
-}
-
 export type LayoutBox = {
   top: number;
   left: number;
   width: number;
+  height: number;
 };
 
 export function calculateWidth(boxes: LayoutBox[]): number {


### PR DESCRIPTION
## Description

The algorithm for grouping by date is inefficient and doesn't scale well. There's also no caching, so revisiting buckets re-groups again. This PR optimizes this with a more efficient algorithm and ensures that a given bucket will only ever be grouped into dates once.

## How Has This Been Tested?

Tested with a console log during grouping to check that a given bucket is only grouped once, even after scrubbing away and back to the bucket.