### PR TITLE
feat(web): use lib/utils/copyToClipboard for share link

### DIFF
--- a/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
+++ b/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import Button from '$lib/components/elements/buttons/button.svelte';
+  import LinkButton from '$lib/components/elements/buttons/link-button.svelte';
   import Icon from '$lib/components/elements/icon.svelte';
   import { serverConfig } from '$lib/stores/server-config.store';
   import { copyToClipboard, makeSharedLinkUrl } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { SharedLinkType, createSharedLink, updateSharedLink, type SharedLinkResponseDto } from '@immich/sdk';
-  import { mdiLink } from '@mdi/js';
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { mdiContentCopy, mdiLink } from '@mdi/js';
+  import { createEventDispatcher } from 'svelte';
   import BaseModal from '../base-modal.svelte';
   import type { ImmichDropDownOption } from '../dropdown-button.svelte';
   import DropdownButton from '../dropdown-button.svelte';
@@ -26,7 +27,6 @@
   let expirationTime = '';
   let password = '';
   let shouldChangeExpirationTime = false;
-  let canCopyImagesToClipboard = true;
   let enablePassword = false;
 
   const dispatch = createEventDispatcher<{
@@ -41,27 +41,22 @@
 
   $: shareType = albumId ? SharedLinkType.Album : SharedLinkType.Individual;
 
-  onMount(async () => {
-    if (editingLink) {
-      if (editingLink.description) {
-        description = editingLink.description;
-      }
-      if (editingLink.password) {
-        password = editingLink.password;
-      }
-      allowUpload = editingLink.allowUpload;
-      allowDownload = editingLink.allowDownload;
-      showMetadata = editingLink.showMetadata;
-
-      albumId = editingLink.album?.id;
-      assetIds = editingLink.assets.map(({ id }) => id);
-
-      enablePassword = !!editingLink.password;
+  if (editingLink) {
+    if (editingLink.description) {
+      description = editingLink.description;
     }
+    if (editingLink.password) {
+      password = editingLink.password;
+    }
+    allowUpload = editingLink.allowUpload;
+    allowDownload = editingLink.allowDownload;
+    showMetadata = editingLink.showMetadata;
 
-    const module = await import('copy-image-clipboard');
-    canCopyImagesToClipboard = module.canCopyImagesToClipboard();
-  });
+    albumId = editingLink.album?.id;
+    assetIds = editingLink.assets.map(({ id }) => id);
+
+    enablePassword = !!editingLink.password;
+  }
 
   const handleCreateSharedLink = async () => {
     const expirationTime = getExpirationTimeInMillisecond();
@@ -86,14 +81,6 @@
     } catch (error) {
       handleError(error, 'Failed to create shared link');
     }
-  };
-
-  const handleCopy = async () => {
-    if (!sharedLink) {
-      return;
-    }
-
-    await copyToClipboard(sharedLink);
   };
 
   const getExpirationTimeInMillisecond = () => {
@@ -265,9 +252,11 @@
       <div class="flex w-full gap-4">
         <input class="immich-form-input w-full" bind:value={sharedLink} disabled />
 
-        {#if canCopyImagesToClipboard}
-          <Button on:click={() => handleCopy()}>Copy</Button>
-        {/if}
+        <LinkButton on:click={() => (sharedLink ? copyToClipboard(sharedLink) : '')}>
+          <div class="flex place-items-center gap-2 text-sm">
+            <Icon path={mdiContentCopy} size="18" />
+          </div>
+        </LinkButton>
       </div>
     {/if}
   </section>


### PR DESCRIPTION
Using Firefox, I noticed there was no button to copy the link on the create share modal. Upon looking to add it, I noticed there was some logic around if it should be shown or not. I removed `module.canCopyImagesToClipboard` and used the function in lib which was working in Firefox for me on the system settings page.

**before**
![before firefox](https://github.com/immich-app/immich/assets/3507151/c2b74140-2a22-496f-9b8c-80d8b0e97044)
![before chrome](https://github.com/immich-app/immich/assets/3507151/ef5be17d-7e84-4ab8-84d7-8eee04070f45)

**after**
![after chrome](https://github.com/immich-app/immich/assets/3507151/2d57993f-48bd-471d-b246-77c013e152fd)
![after firefox](https://github.com/immich-app/immich/assets/3507151/cbfd527c-dd9f-431e-9a97-f9404052bae3)
