### PR TITLE
fix(server): regular version check

### DIFF
--- a/server/src/domain/server-info/server-info.service.ts
+++ b/server/src/domain/server-info/server-info.service.ts
@@ -149,7 +149,7 @@ export class ServerInfoService {
       }
 
       // check once per hour (max)
-      if (this.releaseVersionCheckedAt && this.releaseVersionCheckedAt.diffNow().as('minutes') < 60) {
+      if (this.releaseVersionCheckedAt && DateTime.now().diff(this.releaseVersionCheckedAt).as('minutes') < 60) {
         return true;
       }
 


### PR DESCRIPTION
`dt.diffNow()` equals `dt.diff(DateTime.now())`, so it returns a negative number when `dt` is in the past (which it always is in this case).

Therefore we could only get over the condition during startup (when `this.releaseVersionCheckedAt` isn't set yet), effectively breaking update notifications while the server is running.

There are different ways to write this, e.g. 
```javascript
1: DateTime.now().diff(this.releaseVersionCheckedAt).as('minutes') < 60
2: -this.releaseVersionCheckedAt.diffNow().as('minutes') < 60
3: Math.abs(this.releaseVersionCheckedAt.diffNow().as('minutes')) < 60
4: this.releaseVersionCheckedAt.diffNow().as('minutes') > -60
```

I prefer the first one because it feels most readable. Second is basically reversing the timestamps, third does the same (assuming that time only moves forward). I don't like the fourth way, hard to read from my point of view.