### PR TITLE
feat(server): hardware HDR tonemapping for RKMPP

### DIFF
--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -38,9 +38,10 @@ services:
       - /dev/dri:/dev/dri
       - /dev/dma_heap:/dev/dma_heap
       - /dev/mpp_service:/dev/mpp_service
-      - /dev/mali0:/dev/mali0 # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
+      #- /dev/mali0:/dev/mali0 # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
     volumes:
-      - /usr/lib/aarch64-linux-gnu/libmali.so:/usr/lib/libmali.so:ro # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
+      #- /etc/OpenCL:/etc/OpenCL:ro # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
+      #- /usr/lib/aarch64-linux-gnu/libmali.so.1:/usr/lib/aarch64-linux-gnu/libmali.so.1:ro # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
 
   vaapi:
     devices:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -1,9 +1,9 @@
 version: "3.8"
 
-# Configurations for hardware-accelerated transcoding 
+# Configurations for hardware-accelerated transcoding
 
 # If using Unraid or another platform that doesn't allow multiple Compose files,
-# you can inline the config for a backend by copying its contents 
+# you can inline the config for a backend by copying its contents
 # into the immich-microservices service in the docker-compose.yml file.
 
 # See https://immich.app/docs/features/hardware-transcoding for more info on using hardware transcoding.
@@ -38,6 +38,9 @@ services:
       - /dev/dri:/dev/dri
       - /dev/dma_heap:/dev/dma_heap
       - /dev/mpp_service:/dev/mpp_service
+      - /dev/mali0:/dev/mali0 # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
+    volumes:
+      - /usr/lib/aarch64-linux-gnu/libmali.so:/usr/lib/libmali.so:ro # only required to enable OpenCL-accelerated HDR -> SDR tonemapping
 
   vaapi:
     devices:

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -42,6 +42,14 @@ You do not need to redo any transcoding jobs after enabling hardware acceleratio
   - If you have an 11th gen CPU or older, then you may need to follow [these][jellyfin-lp] instructions as Low-Power mode is required
   - Additionally, if the server specifically has an 11th gen CPU and is running kernel 5.15 (shipped with Ubuntu 22.04 LTS), then you will need to upgrade this kernel (from [Jellyfin docs][jellyfin-kernel-bug])
 
+#### RKMPP
+
+For RKMPP to work:
+
+- You must have a supported Rockchip ARM SoC.
+- Only RK3588 supports hardware tonemapping, other SoCs use slower software tonemapping while still using hardware encoding.
+- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so` to be present on your host system. Install [`libmali-valhall-g610-g6p0-gbm`][libmali-rockchip].
+
 ## Setup
 
 #### Basic Setup
@@ -106,3 +114,4 @@ Once this is done, you can continue to step 3 of "Basic Setup".
 [nvcr]: https://github.com/NVIDIA/nvidia-container-runtime/
 [jellyfin-lp]: https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#configure-and-verify-lp-mode-on-linux
 [jellyfin-kernel-bug]: https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#known-issues-and-limitations
+[libmali-rockchip]: https://github.com/tsukumijima/libmali-rockchip/releases

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -48,7 +48,11 @@ For RKMPP to work:
 
 - You must have a supported Rockchip ARM SoC.
 - Only RK3588 supports hardware tonemapping, other SoCs use slower software tonemapping while still using hardware encoding.
-- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so` to be present on your host system. Install [`libmali-valhall-g610-g6p0-gbm`][libmali-rockchip].
+- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so.1` to be present on your host system. Install [`libmali-valhall-g610-g6p0-gbm`][libmali-rockchip] and modify the [`hwaccel.transcoding.yml`][hw-file] file:
+  - under `rkmpp` uncomment the 3 lines required for OpenCL tonemapping by removing the `#` symbol at the beginning of each line
+  - `- /dev/mali0:/dev/mali0`
+  - `- /etc/OpenCL:/etc/OpenCL:ro`
+  - `- /usr/lib/aarch64-linux-gnu/libmali.so.1:/usr/lib/aarch64-linux-gnu/libmali.so.1:ro`
 
 ## Setup
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,6 +9,7 @@ RUN npm ci && \
     # they're marked as optional dependencies, so we need to copy them manually after pruning
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
+RUN mkdir --parents /etc/OpenCL/vendors && echo "/usr/lib/libmali.so" > /etc/OpenCL/vendors/mali.icd
 COPY server .
 ENV PATH="${PATH}:/usr/src/app/bin" \
     NODE_ENV=development \
@@ -22,6 +23,7 @@ FROM dev AS prod
 RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 COPY --from=dev /usr/src/app/node_modules/@img ./node_modules/@img
+COPY --from=dev /etc/OpenCL /etc/OpenCL
 
 # web build
 FROM node:iron-alpine3.18@sha256:a02826c7340c37a29179152723190bcc3044f933c925f3c2d78abb20f794de3f as web
@@ -49,6 +51,7 @@ ENV NODE_ENV=production \
 COPY --from=prod /usr/src/app/node_modules ./node_modules
 COPY --from=prod /usr/src/app/dist ./dist
 COPY --from=prod /usr/src/app/bin ./bin
+COPY --from=prod /etc/OpenCL /etc/OpenCL
 COPY --from=web /usr/src/app/build ./www
 COPY server/resources resources
 COPY server/package.json server/package-lock.json ./

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,7 +9,6 @@ RUN npm ci && \
     # they're marked as optional dependencies, so we need to copy them manually after pruning
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
-RUN mkdir --parents /etc/OpenCL/vendors && echo "/usr/lib/libmali.so" > /etc/OpenCL/vendors/mali.icd
 COPY server .
 ENV PATH="${PATH}:/usr/src/app/bin" \
     NODE_ENV=development \
@@ -23,7 +22,6 @@ FROM dev AS prod
 RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 COPY --from=dev /usr/src/app/node_modules/@img ./node_modules/@img
-COPY --from=dev /etc/OpenCL /etc/OpenCL
 
 # web build
 FROM node:iron-alpine3.18@sha256:a02826c7340c37a29179152723190bcc3044f933c925f3c2d78abb20f794de3f as web
@@ -51,7 +49,6 @@ ENV NODE_ENV=production \
 COPY --from=prod /usr/src/app/node_modules ./node_modules
 COPY --from=prod /usr/src/app/dist ./dist
 COPY --from=prod /usr/src/app/bin ./bin
-COPY --from=prod /etc/OpenCL /etc/OpenCL
 COPY --from=web /usr/src/app/build ./www
 COPY server/resources resources
 COPY server/package.json server/package-lock.json ./

--- a/server/src/domain/media/media.util.ts
+++ b/server/src/domain/media/media.util.ts
@@ -1,4 +1,5 @@
 import { CQMode, ToneMapping, TranscodeHWAccel, TranscodeTarget, VideoCodec } from '@app/infra/entities';
+import { statSync } from 'node:fs';
 import {
   AudioStreamInfo,
   BitrateDistribution,
@@ -608,6 +609,19 @@ export class VAAPIConfig extends BaseHWConfig {
 }
 
 export class RKMPPConfig extends BaseHWConfig {
+  private static hasOpenCL?: boolean = undefined;
+
+  constructor(
+    protected config: SystemConfigFFmpegDto,
+    devices: string[] = [],
+  ) {
+    super(config, devices);
+    if (RKMPPConfig.hasOpenCL === undefined) {
+      // static property to check only once
+      RKMPPConfig.hasOpenCL = statSync('/usr/lib/libmali.so').isFile() && statSync('/dev/mali0').isCharacterDevice();
+    }
+  }
+
   eligibleForTwoPass(): boolean {
     return false;
   }
@@ -616,19 +630,25 @@ export class RKMPPConfig extends BaseHWConfig {
     if (this.devices.length === 0) {
       throw new Error('No RKMPP device found');
     }
-    if (this.shouldToneMap(videoStream)) {
-      // disable hardware decoding
-      return [];
-    }
-    return ['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga'];
+    return this.shouldToneMap(videoStream) && !RKMPPConfig.hasOpenCL
+      ? [] // disable hardware decoding & filters
+      : ['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga'];
   }
 
   getFilterOptions(videoStream: VideoStreamInfo) {
     if (this.shouldToneMap(videoStream)) {
-      // use software filter options
-      return super.getFilterOptions(videoStream);
-    }
-    if (this.shouldScale(videoStream)) {
+      if (!RKMPPConfig.hasOpenCL) {
+        return super.getFilterOptions(videoStream);
+      }
+      const colors = this.getColors();
+      return [
+        `scale_rkrga=${this.getScaling(videoStream)}:format=p010:afbc=1`,
+        'hwmap=derive_device=opencl:mode=read',
+        `tonemap_opencl=format=nv12:r=pc:p=${colors.primaries}:t=${colors.transfer}:m=${colors.matrix}:tonemap=${this.config.tonemap}:desat=0`,
+        'hwmap=derive_device=rkmpp:mode=write:reverse=1',
+        'format=drm_prime',
+      ];
+    } else if (this.shouldScale(videoStream)) {
       return [`scale_rkrga=${this.getScaling(videoStream)}:format=nv12:afbc=1`];
     }
     return [];


### PR DESCRIPTION
**enables full hardware transcoding for HDR videos on Rockchip SoCs**

- pipeline: hardware decode -> scaling -> opencl tonemapping -> hardware encoding
- only RK3588 supports tonemapping, other Rockchips SoCs still use software decoding/scaling/tonemapping but retain hardware encoding
- users need to provide `libmali.so` for tonemapping
- added docs for RKMPP transcoding
- enables 4K HDR -> FHD SDR transcode at 8x realtime speed :rocket:  (in software it's 0.25x realtime...)