### PR TITLE
chore(deps): bump sanitize-html, fixing CVE-2024-21501

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12231,7 +12231,7 @@
         "mime-format": "2.0.0",
         "mime-types": "2.1.27",
         "postman-url-encoder": "2.1.3",
-        "sanitize-html": "^2.11.0",
+        "sanitize-html": "^2.12.1",
         "semver": "^7.5.4",
         "uuid": "3.4.0"
       }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14762,9 +14762,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanitize-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.11.0.tgz",
-      "integrity": "sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.12.1.tgz",
+      "integrity": "sha512-Plh+JAn0UVDpBRP/xEjsk+xDCoOvMBwQUf/K+/cBAVuTbtX8bj2VB7S1sL1dssVpykqp0/KPSesHrqXtokVBpA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
Versions of the package sanitize-html before 2.12.1 are vulnerable to Information Exposure when used on the backend and with the style attribute allowed, allowing enumeration of files in the system (including project dependencies). An attacker could exploit this vulnerability to gather details about the file system structure and dependencies of the targeted server.

Bumps sanitize-html to 2.12.1