### PR TITLE
fix(web): date input on chrome

### DIFF
--- a/web/src/lib/components/elements/date-input.svelte
+++ b/web/src/lib/components/elements/date-input.svelte
@@ -6,19 +6,15 @@
   }
 
   export let value: $$Props['value'] = undefined;
+
+  // Updating `value` directly causes the date input to reset itself or
+  // interfere with user changes.
   $: updatedValue = value;
 </script>
 
 <input
   {...$$restProps}
   {value}
-  on:input={(e) => {
-    updatedValue = e.currentTarget.value;
-
-    // Only update when value is not empty to prevent resetting the input
-    if (updatedValue !== '') {
-      value = updatedValue;
-    }
-  }}
+  on:input={(e) => (updatedValue = e.currentTarget.value)}
   on:blur={() => (value = updatedValue)}
 />


### PR DESCRIPTION
In Chrome, date inputs only allow 1 digit for year/month/day as long as the date is valid. Fixes #7659 by only updating `value` after the input loses focus.