### PR TITLE
perf(server): use queries to refresh library assets

### DIFF
--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -144,6 +144,7 @@ describe(LibraryService.name, () => {
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
       storageMock.crawl.mockResolvedValue(['/data/user1/photo.jpg']);
+      assetMock.getPathsNotInLibrary.mockResolvedValue(['/data/user1/photo.jpg']);
       assetMock.getByLibraryId.mockResolvedValue([]);
       userMock.get.mockResolvedValue(userStub.admin);
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -617,12 +617,11 @@ export class LibraryService extends EventEmitter {
       .filter((validation) => validation.isValid)
       .map((validation) => validation.importPath);
 
-    const crawledAssetPaths = (
-      await this.storageRepository.crawl({
-        pathsToCrawl: validImportPaths,
-        exclusionPatterns: library.exclusionPatterns,
-      })
-    ).map((filePath) => path.normalize(filePath));
+    const rawPaths = await this.storageRepository.crawl({
+      pathsToCrawl: validImportPaths,
+      exclusionPatterns: library.exclusionPatterns,
+    });
+    const crawledAssetPaths = rawPaths.map((filePath) => path.normalize(filePath));
 
     this.logger.debug(`Found ${crawledAssetPaths.length} asset(s) when crawling import paths ${library.importPaths}`);
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -626,7 +626,7 @@ export class LibraryService extends EventEmitter {
 
     this.logger.debug(`Found ${crawledAssetPaths.length} asset(s) when crawling import paths ${library.importPaths}`);
 
-    this.assetRepository.updateOfflineLibraryAssets(library.id, crawledAssetPaths);
+    await this.assetRepository.updateOfflineLibraryAssets(library.id, crawledAssetPaths);
 
     if (crawledAssetPaths.length > 0) {
       let filteredPaths: string[] = [];

--- a/server/src/domain/repositories/asset.repository.ts
+++ b/server/src/domain/repositories/asset.repository.ts
@@ -136,6 +136,8 @@ export interface IAssetRepository {
   getLastUpdatedAssetForAlbumId(albumId: string): Promise<AssetEntity | null>;
   getByLibraryId(libraryIds: string[]): Promise<AssetEntity[]>;
   getByLibraryIdAndOriginalPath(libraryId: string, originalPath: string): Promise<AssetEntity | null>;
+  getPathsNotInLibrary(libraryId: string, originalPaths: string[]): Promise<string[]>;
+  updateOfflineLibraryAssets(libraryId: string, originalPaths: string[]): Promise<void>;
   deleteAll(ownerId: string): Promise<void>;
   getAll(pagination: PaginationOptions, options?: AssetSearchOptions): Paginated<AssetEntity>;
   getAllByFileCreationDate(

--- a/server/src/infra/sql/asset.repository.sql
+++ b/server/src/infra/sql/asset.repository.sql
@@ -395,6 +395,39 @@ ORDER BY
 LIMIT
   1
 
+-- AssetRepository.getPathsNotInLibrary
+WITH
+  paths AS (
+    SELECT
+      unnest($2::text []) AS path
+  )
+SELECT
+  path
+FROM
+  paths
+WHERE
+  NOT EXISTS (
+    SELECT
+      1
+    FROM
+      assets
+    WHERE
+      "libraryId" = $1
+      AND "originalPath" = path
+  );
+
+-- AssetRepository.updateOfflineLibraryAssets
+UPDATE "assets"
+SET
+  "isOffline" = $1,
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE
+  (
+    "libraryId" = $2
+    AND NOT ("originalPath" IN ($3))
+    AND "isOffline" = $4
+  )
+
 -- AssetRepository.getAllByFileCreationDate
 SELECT
   "asset"."id" AS "asset_id",

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -23,6 +23,8 @@ export const newAssetRepositoryMock = (): jest.Mocked<IAssetRepository> => {
     updateAll: jest.fn(),
     getByLibraryId: jest.fn(),
     getByLibraryIdAndOriginalPath: jest.fn(),
+    updateOfflineLibraryAssets: jest.fn(),
+    getPathsNotInLibrary: jest.fn(),
     deleteAll: jest.fn(),
     save: jest.fn(),
     remove: jest.fn(),


### PR DESCRIPTION
## Description

The current implementation fetches all assets for a library, which is slow and uses a substantial amount of memory. This PR moves this logic to optimized queries instead.

Fixes #7373