### PR TITLE
chore(server): lower default max recognition distance for facial recognition

### DIFF
--- a/server/src/domain/person/person.service.spec.ts
+++ b/server/src/domain/person/person.service.spec.ts
@@ -709,7 +709,7 @@ describe(PersonService.name, () => {
         },
         {
           enabled: true,
-          maxDistance: 0.6,
+          maxDistance: 0.5,
           minScore: 0.7,
           minFaces: 3,
           modelName: 'buffalo_l',

--- a/server/src/domain/system-config/system-config.core.ts
+++ b/server/src/domain/system-config/system-config.core.ts
@@ -75,7 +75,7 @@ export const defaults = Object.freeze<SystemConfig>({
       enabled: true,
       modelName: 'buffalo_l',
       minScore: 0.7,
-      maxDistance: 0.6,
+      maxDistance: 0.5,
       minFaces: 3,
     },
   },

--- a/server/src/domain/system-config/system-config.service.spec.ts
+++ b/server/src/domain/system-config/system-config.service.spec.ts
@@ -76,7 +76,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
       enabled: true,
       modelName: 'buffalo_l',
       minScore: 0.7,
-      maxDistance: 0.6,
+      maxDistance: 0.5,
       minFaces: 3,
     },
   },


### PR DESCRIPTION
## Description

The feedback we've been receiving is more often that multiple people are recognized as the same person as opposed to duplicating the same person. The current algorithm is more effective at connecting faces than the previous one, so it seems appropriate to lower this default a touch.