### PR TITLE
fix(server): add extension to filename migration

### DIFF
--- a/server/src/infra/migrations/1709763765506-AddExtensionToOriginalFileName.ts
+++ b/server/src/infra/migrations/1709763765506-AddExtensionToOriginalFileName.ts
@@ -10,7 +10,7 @@ export class AddExtensionToOriginalFileName1709763765506 implements MigrationInt
       UPDATE assets
       SET "originalFileName" = assets."originalFileName" || '.' || extension."ext"
       FROM extension
-      INNER JOIN assets a ON a.id = extension.id;
+      WHERE assets.id = extension.id;
       `);
   }
 


### PR DESCRIPTION
All my assets have become .jpg with this query, even though I have non jpg assets. The used inner join doesn't work as expected, because inner join cannot be used with `UPDATE` in postgres.