### PR TITLE
docs: Update backup script example

### DIFF
--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -47,6 +47,8 @@ REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 
 # Backup Immich database
 docker exec -t immich_postgres pg_dumpall -c -U postgres > "$UPLOAD_LOCATION"/database-backup/immich-database.sql
+# For deduplicating backup programs such as Borg or Restic, compressing the content can increase backup size by making it harder to deduplicate. If you are using a different program or still prefer to compress, you can use the following command instead:
+# docker exec -t immich_postgres pg_dumpall -c -U postgres | /usr/bin/gzip --rsyncable > "$UPLOAD_LOCATION"/database-backup/immich-database.sql.gz
 
 ### Append to local Borg repository
 borg create $BACKUP_PATH/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -32,6 +32,7 @@ ssh "$REMOTE_HOST" "borg init --encryption=none \"$REMOTE_BACKUP_PATH\"/immich-b
 ```
 
 Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no `:`, `@`, or `"` characters in your paths. If these characters exist, you will need to escape and/or rename the paths.
+
 ```bash title='Borg backup template'
 #!/bin/sh
 

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -50,13 +50,13 @@ docker exec -t immich_postgres pg_dumpall -c -U postgres > "$UPLOAD_LOCATION"/da
 # docker exec -t immich_postgres pg_dumpall -c -U postgres | /usr/bin/gzip --rsyncable > "$UPLOAD_LOCATION"/database-backup/immich-database.sql.gz
 
 ### Append to local Borg repository
-borg create "$BACKUP_PATH"/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
+borg create "$BACKUP_PATH/immich-borg::{now}" "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
 borg prune --keep-weekly=4 --keep-monthly=3 "$BACKUP_PATH"/immich-borg
 borg compact "$BACKUP_PATH"/immich-borg
 
 
 ### Append to remote Borg repository
-borg create "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
+borg create "$REMOTE_HOST:$REMOTE_BACKUP_PATH/immich-borg::{now}" "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
 borg prune --keep-weekly=4 --keep-monthly=3 "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg
 borg compact "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg
 ```

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -31,8 +31,7 @@ ssh "$REMOTE_HOST" "mkdir \"$REMOTE_BACKUP_PATH\"/immich-borg"
 ssh "$REMOTE_HOST" "borg init --encryption=none \"$REMOTE_BACKUP_PATH\"/immich-borg"
 ```
 
-Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no spaces in your paths. If there are spaces, enclose the paths in double quotes.
-
+Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no `:` or `"` characters in your paths. If these characters exist, you will need to escape and/or rename the paths.
 ```bash title='Borg backup template'
 #!/bin/sh
 

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -31,7 +31,7 @@ ssh "$REMOTE_HOST" "mkdir \"$REMOTE_BACKUP_PATH\"/immich-borg"
 ssh "$REMOTE_HOST" "borg init --encryption=none \"$REMOTE_BACKUP_PATH\"/immich-borg"
 ```
 
-Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no `:` or `"` characters in your paths. If these characters exist, you will need to escape and/or rename the paths.
+Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no `:`, `@`, or `"` characters in your paths. If these characters exist, you will need to escape and/or rename the paths.
 ```bash title='Borg backup template'
 #!/bin/sh
 
@@ -50,7 +50,7 @@ docker exec -t immich_postgres pg_dumpall -c -U postgres > "$UPLOAD_LOCATION"/da
 # docker exec -t immich_postgres pg_dumpall -c -U postgres | /usr/bin/gzip --rsyncable > "$UPLOAD_LOCATION"/database-backup/immich-database.sql.gz
 
 ### Append to local Borg repository
-borg create $BACKUP_PATH/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
+borg create "$BACKUP_PATH"/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
 borg prune --keep-weekly=4 --keep-monthly=3 "$BACKUP_PATH"/immich-borg
 borg compact "$BACKUP_PATH"/immich-borg
 

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -46,7 +46,7 @@ REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 ### Local
 
 # Backup Immich database
-docker exec -t immich_postgres pg_dumpall -c -U postgres | /usr/bin/gzip > $UPLOAD_LOCATION/database-backup/immich-database.sql.gz
+docker exec -t immich_postgres pg_dumpall -c -U postgres > $UPLOAD_LOCATION/database-backup/immich-database.sql
 
 ### Append to local Borg repository
 borg create $BACKUP_PATH/immich-borg::{now} $UPLOAD_LOCATION --exclude $UPLOAD_LOCATION/thumbs/ --exclude $UPLOAD_LOCATION/encoded-video/

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -27,8 +27,8 @@ borg init --encryption=none "$BACKUP_PATH/immich-borg"
 REMOTE_HOST="remote_host@IP"
 REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 
-ssh "$REMOTE_HOST" "mkdir $REMOTE_BACKUP_PATH/immich-borg"
-ssh "$REMOTE_HOST" "borg init --encryption=none $REMOTE_BACKUP_PATH/immich-borg"
+ssh "$REMOTE_HOST" "mkdir \"$REMOTE_BACKUP_PATH\"/immich-borg"
+ssh "$REMOTE_HOST" "borg init --encryption=none \"$REMOTE_BACKUP_PATH\"/immich-borg"
 ```
 
 Edit the following script as necessary and add it to your crontab. Note that this script assumes there are no spaces in your paths. If there are spaces, enclose the paths in double quotes.
@@ -46,18 +46,18 @@ REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 ### Local
 
 # Backup Immich database
-docker exec -t immich_postgres pg_dumpall -c -U postgres > $UPLOAD_LOCATION/database-backup/immich-database.sql
+docker exec -t immich_postgres pg_dumpall -c -U postgres > "$UPLOAD_LOCATION"/database-backup/immich-database.sql
 
 ### Append to local Borg repository
-borg create $BACKUP_PATH/immich-borg::{now} $UPLOAD_LOCATION --exclude $UPLOAD_LOCATION/thumbs/ --exclude $UPLOAD_LOCATION/encoded-video/
-borg prune --keep-weekly=4 --keep-monthly=3 $BACKUP_PATH/immich-borg
-borg compact $BACKUP_PATH/immich-borg
+borg create $BACKUP_PATH/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
+borg prune --keep-weekly=4 --keep-monthly=3 "$BACKUP_PATH"/immich-borg
+borg compact "$BACKUP_PATH"/immich-borg
 
 
 ### Append to remote Borg repository
-borg create $REMOTE_HOST:$REMOTE_BACKUP_PATH/immich-borg::{now} $UPLOAD_LOCATION --exclude $UPLOAD_LOCATION/thumbs/ --exclude $UPLOAD_LOCATION/encoded-video/
-borg prune --keep-weekly=4 --keep-monthly=3 $REMOTE_HOST:$REMOTE_BACKUP_PATH/immich-borg
-borg compact $REMOTE_HOST:$REMOTE_BACKUP_PATH/immich-borg
+borg create "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg::{now} "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/
+borg prune --keep-weekly=4 --keep-monthly=3 "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg
+borg compact "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg
 ```
 
 ### Restoring
@@ -67,7 +67,7 @@ To restore from a backup, use the `borg mount` command.
 ```bash title='Restore from local backup'
 BACKUP_PATH="/path/to/local/backup/directory"
 mkdir /tmp/immich-mountpoint
-borg mount $BACKUP_PATH/immich-borg /tmp/immich-mountpoint
+borg mount "$BACKUP_PATH"/immich-borg /tmp/immich-mountpoint
 cd /tmp/immich-mountpoint
 ```
 
@@ -75,7 +75,7 @@ cd /tmp/immich-mountpoint
 REMOTE_HOST="remote_host@IP"
 REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 mkdir /tmp/immich-mountpoint
-borg mount $REMOTE_HOST:$REMOTE_BACKUP_PATH/immich-borg /tmp/immich-mountpoint
+borg mount "$REMOTE_HOST:$REMOTE_BACKUP_PATH"/immich-borg /tmp/immich-mountpoint
 cd /tmp/immich-mountpoint
 ```
 


### PR DESCRIPTION
When using a deduplicating backup program (Borg, Restic, etc), using gzip is counter-productive because small changes in the input data stream can lead to much larger changes in the compressed data to backup.

As an alternative, some programs advise that you can use `gzip --rsyncable`, but uncompressed data is typically still preferred as it has a better chance of matching up with the existing chunks from prior backups.

I propose that we update the docs to make Borg more space efficient as Immich will often have small daily changes to the database.

Also fixed some unquoted vars