### PR TITLE
chore: rename "Library" to "External Library" in system settings

### DIFF
--- a/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
@@ -69,7 +69,7 @@
           >
             <p slot="desc" class="immich-form-label pb-2 text-sm">
               The name of a CLIP model listed <a href="https://huggingface.co/immich-app"><u>here</u></a>. Note that you
-              must re-run the 'Encode CLIP' job for all images upon changing a model.
+              must re-run the 'Smart Search' job for all images upon changing a model.
             </p>
           </SettingInputField>
         </div>

--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -72,8 +72,8 @@
     },
     {
       item: LibrarySettings,
-      title: 'Library',
-      subtitle: 'Manage library settings',
+      title: 'External Library',
+      subtitle: 'Manage external library settings',
       key: 'library',
     },
     {

--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -74,7 +74,7 @@
       item: LibrarySettings,
       title: 'External Library',
       subtitle: 'Manage external library settings',
-      key: 'library',
+      key: 'external-library',
     },
     {
       item: LoggingSettings,


### PR DESCRIPTION
This is intended to assist with any confusion regarding standard libraries.