### PR TITLE
fix(web): album state after removing assets

### DIFF
--- a/web/src/lib/components/album-page/album-summary.svelte
+++ b/web/src/lib/components/album-page/album-summary.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
   import { dateFormats } from '$lib/constants';
   import { locale } from '$lib/stores/preferences.store';
-  import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
+  import type { AlbumResponseDto } from '@immich/sdk';
 
-  export let assetCount: number;
   export let album: AlbumResponseDto;
-  export let oldestAsset: AssetResponseDto | undefined = undefined;
-  export let newestAsset: AssetResponseDto | undefined = undefined;
 
-  $: startDate = formatDate(oldestAsset?.fileCreatedAt || album.startDate);
-  $: endDate = formatDate(newestAsset?.fileCreatedAt || album.endDate);
+  $: startDate = formatDate(album.startDate);
+  $: endDate = formatDate(album.endDate);
 
   const formatDate = (date?: string) => {
     return date ? new Date(date).toLocaleDateString($locale, dateFormats.album) : undefined;
@@ -28,10 +25,8 @@
   };
 </script>
 
-{#if assetCount > 0}
-  <span class="my-2 flex gap-2 text-sm font-medium text-gray-500" data-testid="album-details">
-    <p>{getDateRange(startDate, endDate)}</p>
-    <p>·</p>
-    <p>{assetCount} items</p>
-  </span>
-{/if}
+<span class="my-2 flex gap-2 text-sm font-medium text-gray-500" data-testid="album-details">
+  <p>{getDateRange(startDate, endDate)}</p>
+  <p>·</p>
+  <p>{album.assetCount} items</p>
+</span>

--- a/web/src/lib/components/album-page/album-summary.svelte
+++ b/web/src/lib/components/album-page/album-summary.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { dateFormats } from '$lib/constants';
+  import { locale } from '$lib/stores/preferences.store';
+  import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
+
+  export let assetCount: number;
+  export let album: AlbumResponseDto;
+  export let oldestAsset: AssetResponseDto | undefined = undefined;
+  export let newestAsset: AssetResponseDto | undefined = undefined;
+
+  $: startDate = formatDate(oldestAsset?.fileCreatedAt || album.startDate);
+  $: endDate = formatDate(newestAsset?.fileCreatedAt || album.endDate);
+
+  const formatDate = (date?: string) => {
+    return date ? new Date(date).toLocaleDateString($locale, dateFormats.album) : undefined;
+  };
+
+  const getDateRange = (start?: string, end?: string) => {
+    if (start && end && start !== end) {
+      return `${start} - ${end}`;
+    }
+
+    if (start) {
+      return start;
+    }
+
+    return '';
+  };
+</script>
+
+{#if assetCount > 0}
+  <span class="my-2 flex gap-2 text-sm font-medium text-gray-500" data-testid="album-details">
+    <p>{getDateRange(startDate, endDate)}</p>
+    <p>·</p>
+    <p>{assetCount} items</p>
+  </span>
+{/if}

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -3,11 +3,9 @@
   import SelectAllAssets from '$lib/components/photos-page/actions/select-all-assets.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { dragAndDropFilesStore } from '$lib/stores/drag-and-drop-files.store';
-  import { locale } from '$lib/stores/preferences.store';
   import { fileUploadHandler, openFileUploadDialog } from '$lib/utils/file-uploader';
   import type { AlbumResponseDto, SharedLinkResponseDto, UserResponseDto } from '@immich/sdk';
   import { onDestroy, onMount } from 'svelte';
-  import { dateFormats } from '../../constants';
   import { createAssetInteractionStore } from '../../stores/asset-interaction.store';
   import { AssetStore } from '../../stores/assets.store';
   import { downloadArchive } from '../../utils/asset-utils';
@@ -21,6 +19,7 @@
   import { shouldIgnoreShortcut } from '$lib/utils/shortcut';
   import { mdiFileImagePlusOutline, mdiFolderDownloadOutline } from '@mdi/js';
   import { handlePromiseError } from '$lib/utils';
+  import AlbumSummary from './album-summary.svelte';
 
   export let sharedLink: SharedLinkResponseDto;
   export let user: UserResponseDto | undefined = undefined;
@@ -39,31 +38,6 @@
       dragAndDropFilesStore.set({ isDragging: false, files: [] });
     }
   });
-
-  const getDateRange = () => {
-    const { startDate, endDate } = album;
-
-    let start = '';
-    let end = '';
-
-    if (startDate) {
-      start = new Date(startDate).toLocaleDateString($locale, dateFormats.album);
-    }
-
-    if (endDate) {
-      end = new Date(endDate).toLocaleDateString($locale, dateFormats.album);
-    }
-
-    if (startDate && endDate && start !== end) {
-      return `${start} - ${end}`;
-    }
-
-    if (start) {
-      return start;
-    }
-
-    return '';
-  };
 
   const onKeyboardPress = (event: KeyboardEvent) => handleKeyboardPress(event);
 
@@ -148,14 +122,7 @@
         {album.albumName}
       </h1>
 
-      <!-- ALBUM SUMMARY -->
-      {#if album.assetCount > 0}
-        <span class="my-4 flex gap-2 text-sm font-medium text-gray-500" data-testid="album-details">
-          <p class="">{getDateRange()}</p>
-          <p>·</p>
-          <p>{album.assetCount} items</p>
-        </span>
-      {/if}
+      <AlbumSummary assetCount={album.assetCount} {album} />
 
       <!-- ALBUM DESCRIPTION -->
       {#if album.description}

--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -122,7 +122,9 @@
         {album.albumName}
       </h1>
 
-      <AlbumSummary assetCount={album.assetCount} {album} />
+      {#if album.assetCount > 0}
+        <AlbumSummary {album} />
+      {/if}
 
       <!-- ALBUM DESCRIPTION -->
       {#if album.description}

--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -114,7 +114,6 @@
   let textArea: HTMLTextAreaElement;
 
   $: assetStore = new AssetStore({ albumId });
-  $: assetCount = $assetStore.initialized ? assetStore.assets.length : album.assetCount;
   const assetInteractionStore = createAssetInteractionStore();
   const { isMultiSelectState, selectedAssets } = assetInteractionStore;
 
@@ -366,6 +365,11 @@
     }
   };
 
+  const handleRemoveAssets = async (assetIds: string[]) => {
+    assetStore.removeAssets(assetIds);
+    await refreshAlbum();
+  };
+
   const handleUpdateThumbnail = async (assetId: string) => {
     if (viewMode !== ViewMode.SELECT_THUMBNAIL) {
       return;
@@ -406,10 +410,10 @@
           {/if}
           <DownloadAction menuItem filename="{album.albumName}.zip" />
           {#if isOwned || isAllUserOwned}
-            <RemoveFromAlbum menuItem bind:album onRemove={(assetIds) => assetStore.removeAssets(assetIds)} />
+            <RemoveFromAlbum menuItem bind:album onRemove={handleRemoveAssets} />
           {/if}
           {#if isAllUserOwned}
-            <DeleteAssets menuItem onAssetDelete={(assetIds) => assetStore.removeAssets(assetIds)} />
+            <DeleteAssets menuItem onAssetDelete={handleRemoveAssets} />
             <ChangeDate menuItem />
             <ChangeLocation menuItem />
           {/if}
@@ -438,7 +442,7 @@
               />
             {/if}
 
-            {#if assetCount > 0}
+            {#if album.assetCount > 0}
               <CircleIconButton title="Download" on:click={handleDownloadAlbum} icon={mdiFolderDownloadOutline} />
 
               {#if isOwned}
@@ -460,7 +464,7 @@
               <Button
                 size="sm"
                 rounded="lg"
-                disabled={assetCount === 0}
+                disabled={album.assetCount === 0}
                 on:click={() => (viewMode = ViewMode.SELECT_USERS)}
               >
                 Share
@@ -532,12 +536,9 @@
               <section class="pt-24">
                 <AlbumTitle id={album.id} albumName={album.albumName} {isOwned} />
 
-                <AlbumSummary
-                  {assetCount}
-                  {album}
-                  oldestAsset={$assetStore.assets.at(-1)}
-                  newestAsset={$assetStore.assets.at(0)}
-                />
+                {#if album.assetCount > 0}
+                  <AlbumSummary {album} />
+                {/if}
 
                 <!-- ALBUM SHARING -->
                 {#if album.sharedUsers.length > 0 || (album.hasSharedLink && isOwned)}
@@ -582,7 +583,7 @@
               </section>
             {/if}
 
-            {#if assetCount === 0}
+            {#if album.assetCount === 0}
               <section id="empty-album" class=" mt-[200px] flex place-content-center place-items-center">
                 <div class="w-[300px]">
                   <p class="text-xs dark:text-immich-dark-fg">ADD PHOTOS</p>


### PR DESCRIPTION
The album summary (date range + asset count) isn't updated after removing assets and when removing all assets from an album, the page doesn't return to the initial 'empty state'. Fixed by making asset count reactive and creating a new `AlbumSummary` component, which also eliminates code duplication.