### PR TITLE
Feature/hide play bar for single image

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -112,7 +112,7 @@
         </p>
       </svelte:fragment>
 
-      {#if !galleryInView}
+      {#if currentMemory.assets.length > 1} <!-- Display play bar only if there's more than 1 image -->
         <div class="flex place-content-center place-items-center gap-2 overflow-hidden">
           <CircleIconButton icon={paused ? mdiPlay : mdiPause} forceDark on:click={() => (paused = !paused)} />
 
@@ -268,7 +268,7 @@
       </div>
     </section>
 
-    <!-- GALERY VIEWER -->
+    <!-- GALLERY VIEWER -->
 
     <section class="bg-immich-dark-gray m-4">
       <div

--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -27,30 +27,36 @@
   };
 
   $: $isUploading && autoHide();
+
+  function handleUploadComplete() {
+    if ($errorCounter > 0) {
+      notificationController.show({
+        message: `Upload completed with ${$errorCounter} error${$errorCounter > 1 ? 's' : ''}`,
+        type: NotificationType.Warning,
+      });
+    }
+
+    if ($duplicateCounter > 0) {
+      notificationController.show({
+        message: `Skipped ${$duplicateCounter} duplicate asset${$duplicateCounter > 1 ? 's' : ''}`,
+        type: NotificationType.Warning,
+      });
+    } else if ($successCounter > 0) {
+      notificationController.show({
+        message: 'Upload success, refresh the page to see new upload assets.',
+        type: NotificationType.Info,
+      });
+    }
+
+    uploadAssetsStore.resetStore();
+  }
 </script>
 
 {#if $hasError || $isUploading}
   <div
     in:fade={{ duration: 250 }}
     out:fade={{ duration: 250 }}
-    on:outroend={() => {
-      notificationController.show({
-        message:
-          ($errorCounter > 0
-            ? `Upload completed with ${$errorCounter} error${$errorCounter > 1 ? 's' : ''}`
-            : 'Upload success') + ', refresh the page to see new upload assets.',
-        type: $errorCounter > 0 ? NotificationType.Warning : NotificationType.Info,
-      });
-
-      if ($duplicateCounter > 0) {
-        notificationController.show({
-          message: `Skipped ${$duplicateCounter} duplicate asset${$duplicateCounter > 1 ? 's' : ''}`,
-          type: NotificationType.Warning,
-        });
-      }
-
-      uploadAssetsStore.resetStore();
-    }}
+    on:outroend={handleUploadComplete}
     class="absolute bottom-6 right-6 z-[10000]"
   >
     {#if showDetail}


### PR DESCRIPTION
This commit introduces a feature to hide the play bar at the top of the memory viewer when there's only one image in the memory. Previously, the play bar was displayed regardless of the number of images, leading to unnecessary UI elements for single-image memories.
