### PR TITLE
fix: Refine Duplicate Photo Handling in Upload Component

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -27,30 +27,36 @@
   };
 
   $: $isUploading && autoHide();
+
+  function handleUploadComplete() {
+    if ($errorCounter > 0) {
+      notificationController.show({
+        message: `Upload completed with ${$errorCounter} error${$errorCounter > 1 ? 's' : ''}`,
+        type: NotificationType.Warning,
+      });
+    }
+
+    if ($duplicateCounter > 0) {
+      notificationController.show({
+        message: `Skipped ${$duplicateCounter} duplicate asset${$duplicateCounter > 1 ? 's' : ''}`,
+        type: NotificationType.Warning,
+      });
+    } else if ($successCounter > 0) {
+      notificationController.show({
+        message: 'Upload success, refresh the page to see new upload assets.',
+        type: NotificationType.Info,
+      });
+    }
+
+    uploadAssetsStore.resetStore();
+  }
 </script>
 
 {#if $hasError || $isUploading}
   <div
     in:fade={{ duration: 250 }}
     out:fade={{ duration: 250 }}
-    on:outroend={() => {
-      notificationController.show({
-        message:
-          ($errorCounter > 0
-            ? `Upload completed with ${$errorCounter} error${$errorCounter > 1 ? 's' : ''}`
-            : 'Upload success') + ', refresh the page to see new upload assets.',
-        type: $errorCounter > 0 ? NotificationType.Warning : NotificationType.Info,
-      });
-
-      if ($duplicateCounter > 0) {
-        notificationController.show({
-          message: `Skipped ${$duplicateCounter} duplicate asset${$duplicateCounter > 1 ? 's' : ''}`,
-          type: NotificationType.Warning,
-        });
-      }
-
-      uploadAssetsStore.resetStore();
-    }}
+    on:outroend={handleUploadComplete}
     class="absolute bottom-6 right-6 z-[10000]"
   >
     {#if showDetail}


### PR DESCRIPTION
This commit refines the handling of duplicate photos during the upload process within the component. The key changes focus on improving user feedback by ensuring that duplicate uploads no longer trigger unnecessary "Upload success" notifications.

From the Gif below you can see it now only shows the error/warning instead of a success message and an error/warning message:

![explorer_2BFgbyr3ss](https://github.com/immich-app/immich/assets/160616898/ab80d206-47a3-43ec-aab0-1ffd0acae23d)
