### PR TITLE
Fix: Disable 'As profile picture' option for videos in context menu a…

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -186,7 +186,9 @@
                 on:click={() => dispatch('toggleArchive')}
                 text={asset.isArchived ? 'Unarchive' : 'Archive'}
               />
-              <MenuOption on:click={() => onMenuClick('asProfileImage')} text="As profile picture" />
+              {#if asset.type !== AssetTypeEnum.Video}
+                <MenuOption on:click={() => onMenuClick('asProfileImage')} text="As profile picture" />
+              {/if}
 
               {#if hasStackChildren}
                 <MenuOption on:click={() => onMenuClick('unstack')} text="Un-Stack" />


### PR DESCRIPTION
This commit modifies the context menu behavior to disable the "As profile picture" option when interacting with video assets. Previously, the option was available for all asset types, including videos, which could lead to confusion when this displayed an error.

With this change, the "As profile picture" option is conditionally rendered based on the asset type. If the asset is a video, the option is not displayed in the context menu.

This adjustment enhances the web experience by preventing users from attempting to set a video as their profile picture, which is not supported by the system.

Suggested Changes Gif:

![firefox_UTeLNKhfeK(1)](https://github.com/immich-app/immich/assets/160616898/e78f52f3-04ea-40a3-aca4-49471f61b158)

Fixes: #7724