### PR TITLE
fix(server): face search results not always sorted

### DIFF
--- a/server/src/infra/repositories/search.repository.ts
+++ b/server/src/infra/repositories/search.repository.ts
@@ -188,6 +188,7 @@ export class SearchRepository implements ISearchRepository {
         .addCommonTableExpression(cte, 'cte')
         .from('cte', 'res')
         .where('res.distance <= :maxDistance', { maxDistance })
+        .orderBy('res.distance')
         .getRawMany();
     });
     return results.map((row) => ({

--- a/server/src/infra/sql/search.repository.sql
+++ b/server/src/infra/sql/search.repository.sql
@@ -229,6 +229,8 @@ FROM
   "cte" "res"
 WHERE
   res.distance <= $3
+ORDER BY
+  res.distance ASC
 COMMIT
 
 -- SearchRepository.searchPlaces


### PR DESCRIPTION
## Description

VBASE doesn't have a guarantee of sort order, so it's possible for the most similar face to not be the top result. This is bounded by the fact that we have a distance threshold, but it's still better to sort here to make sure we pick the most similar face every time. The overhead of this is almost nothing since the number of rows is so low.