### PR TITLE
chore(cli): clarify use of concurrency option

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -44,7 +44,7 @@ program
       .default(false),
   )
   .addOption(
-    new Option('-c, --concurrency', 'Number of assets to upload at the same time')
+    new Option('-c, --concurrency <number>', 'Number of assets to upload at the same time')
       .env('IMMICH_UPLOAD_CONCURRENCY')
       .default(4),
   )

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -144,6 +144,24 @@ describe(`immich upload`, () => {
   });
 
   describe('immich upload --concurrency <number>', () => {
+    it('should work', async () => {
+      const { stderr, stdout, exitCode } = await immichCli([
+        'upload',
+        `${testAssetDir}/albums/nature/`,
+        '--concurrency',
+        '2',
+      ]);
+
+      expect(stderr).toBe('');
+      expect(stdout.split('\n')).toEqual(
+        expect.arrayContaining([expect.stringContaining('Successfully uploaded 9 assets')]),
+      );
+      expect(exitCode).toBe(0);
+
+      const assets = await getAllAssets({}, { headers: asKeyAuth(key) });
+      expect(assets.length).toBe(9);
+    });
+
     it('should reject string argument', async () => {
       const { stderr, exitCode } = await immichCli([
         'upload',
@@ -151,16 +169,12 @@ describe(`immich upload`, () => {
         '--concurrency string',
       ]);
 
-      expect(stderr).toBe('unknown argument');
+      expect(stderr).toContain('unknown option');
       expect(exitCode).not.toBe(0);
     });
-    
+
     it('should reject command without number', async () => {
-      const { stderr, exitCode } = await immichCli([
-        'upload',
-        `${testAssetDir}/albums/nature/`,
-        '--concurrency',
-      ]);
+      const { stderr, exitCode } = await immichCli(['upload', `${testAssetDir}/albums/nature/`, '--concurrency']);
 
       expect(stderr).toContain('argument missing');
       expect(exitCode).not.toBe(0);

--- a/e2e/src/cli/specs/upload.e2e-spec.ts
+++ b/e2e/src/cli/specs/upload.e2e-spec.ts
@@ -142,4 +142,28 @@ describe(`immich upload`, () => {
       expect(assets.length).toBe(9);
     });
   });
+
+  describe('immich upload --concurrency <number>', () => {
+    it('should reject string argument', async () => {
+      const { stderr, exitCode } = await immichCli([
+        'upload',
+        `${testAssetDir}/albums/nature/`,
+        '--concurrency string',
+      ]);
+
+      expect(stderr).toBe('unknown argument');
+      expect(exitCode).not.toBe(0);
+    });
+    
+    it('should reject command without number', async () => {
+      const { stderr, exitCode } = await immichCli([
+        'upload',
+        `${testAssetDir}/albums/nature/`,
+        '--concurrency',
+      ]);
+
+      expect(stderr).toContain('argument missing');
+      expect(exitCode).not.toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Description

The concurrency option takes a number, but this isn't reflected in the help message.