### PR TITLE
feat(web): Implemented device last seen date and time with user locale support

### DIFF
--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -12,7 +12,7 @@
     mdiMicrosoftWindows,
     mdiTrashCanOutline,
   } from '@mdi/js';
-  import { DateTime, type ToRelativeCalendarOptions } from 'luxon';
+  import { DateTime } from 'luxon';
   import { createEventDispatcher } from 'svelte';
 
   export let device: AuthDeviceResponseDto;
@@ -20,11 +20,6 @@
   const dispatcher = createEventDispatcher<{
     delete: void;
   }>();
-
-  const options: ToRelativeCalendarOptions = {
-    unit: 'days',
-    locale: $locale,
-  };
 </script>
 
 <div class="flex w-full flex-row">

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -20,10 +20,24 @@
   const dispatcher = createEventDispatcher<{
     delete: void;
   }>();
+
+  // Calculate difference in hours
+  const hoursAgo = DateTime.now().diff(DateTime.fromISO(device.updatedAt), 'hours').hours;
+
+  // Determine the display format
+  let displayText = 'Last seen today';
+
+  if (hoursAgo >= 24) {
+    // Check if it's older than yesterday
+    const daysAgo = Math.ceil(hoursAgo / 24); // Calculate days
+    displayText = `${daysAgo} days ago`;
+  } else if (hoursAgo >= 8) {
+    // Special check for yesterday (~8 to 24 hours old)
+    displayText = '1 day ago';
+  }
 </script>
 
 <div class="flex w-full flex-row">
-  <!-- TODO: Device Image -->
   <div class="hidden items-center justify-center pr-2 text-immich-primary dark:text-immich-dark-primary sm:flex">
     {#if device.deviceOS === 'Android'}
       <Icon path={mdiAndroid} size="40" />
@@ -52,8 +66,15 @@
       </span>
       <div class="text-sm">
         <span class="">Last seen</span>
-        <span>
-          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED)}
+        <span
+          class="text-underline cursor-pointer"
+          on:mouseover={(e) =>
+            (e.target.textContent = DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(
+              DateTime.DATETIME_MED,
+            ))}
+          on:mouseout={(e) => (e.target.textContent = displayText)}
+        >
+          {displayText}
         </span>
       </div>
     </div>

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -57,8 +57,10 @@
       </span>
       <div class="text-sm">
         <span class="">Last seen</span>
-        <span>{DateTime.fromISO(device.updatedAt, { locale: $locale }).toRelativeCalendar(options)}</span>
-      </div>
+        <span>
+          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED)}
+        </span>
+      </div>           
     </div>
     {#if !device.current}
       <div class="flex flex-col justify-center text-sm">

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -12,7 +12,7 @@
     mdiMicrosoftWindows,
     mdiTrashCanOutline,
   } from '@mdi/js';
-  import { DateTime } from 'luxon';
+  import { DateTime, type ToRelativeCalendarOptions } from 'luxon';
   import { createEventDispatcher } from 'svelte';
 
   export let device: AuthDeviceResponseDto;
@@ -21,20 +21,10 @@
     delete: void;
   }>();
 
-  // Calculate difference in hours
-  const hoursAgo = DateTime.now().diff(DateTime.fromISO(device.updatedAt), 'hours').hours;
-
-  // Determine the display format
-  let displayText = 'Last seen today';
-
-  if (hoursAgo >= 24) {
-    // Check if it's older than yesterday
-    const daysAgo = Math.ceil(hoursAgo / 24); // Calculate days
-    displayText = `${daysAgo} days ago`;
-  } else if (hoursAgo >= 8) {
-    // Special check for yesterday (~8 to 24 hours old)
-    displayText = '1 day ago';
-  }
+  const options: ToRelativeCalendarOptions = {
+    unit: 'days',
+    locale: $locale,
+  };
 </script>
 
 <div class="flex w-full flex-row">
@@ -66,15 +56,10 @@
       </span>
       <div class="text-sm">
         <span class="">Last seen</span>
-        <span
-          class="text-underline cursor-pointer"
-          on:mouseover={(e) =>
-            (e.target.textContent = DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(
-              DateTime.DATETIME_MED,
-            ))}
-          on:mouseout={(e) => (e.target.textContent = displayText)}
-        >
-          {displayText}
+        <span>{DateTime.fromISO(device.updatedAt, { locale: $locale }).toRelativeCalendar(options)}</span>
+        <span class="text-xs text-gray-500 dark:text-gray-400"> - </span>
+        <span class="text-xs text-gray-500 dark:text-gray-400">
+          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED)}
         </span>
       </div>
     </div>

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -60,7 +60,7 @@
         <span>
           {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED)}
         </span>
-      </div>           
+      </div>
     </div>
     {#if !device.current}
       <div class="flex flex-col justify-center text-sm">


### PR DESCRIPTION
This pull request introduces enhancements to the last seen functionality in our application. Previously, the last seen information displayed only the time elapsed since the device was last seen. However, with this update, I have implemented support for displaying the date and time of the last seen event, enhancing the user experience.

Before:
![image](https://github.com/immich-app/immich/assets/160616898/33ecc10e-2ba1-479e-ad02-ab7468e16545)

After:
![image](https://github.com/immich-app/immich/assets/160616898/90f2d3f0-d4e4-48f9-a1a6-2ea1bb74195f)

Totally open to suggestions for this in terms of how its displayed