### PR TITLE
feat(mobile): add labels to app bar buttons

### DIFF
--- a/mobile/lib/modules/album/views/library_page.dart
+++ b/mobile/lib/modules/album/views/library_page.dart
@@ -194,9 +194,10 @@ class LibraryPage extends HookConsumerWidget {
           ? InkWell(
               onTap: () => context.pushRoute(const TrashRoute()),
               borderRadius: const BorderRadius.all(Radius.circular(12)),
-              child: const Icon(
+              child: Icon(
                 Icons.delete_rounded,
                 size: 25,
+                semanticLabel: 'profile_drawer_trash'.tr(),
               ),
             )
           : null;

--- a/mobile/lib/modules/album/views/sharing_page.dart
+++ b/mobile/lib/modules/album/views/sharing_page.dart
@@ -212,9 +212,10 @@ class SharingPage extends HookConsumerWidget {
       return InkWell(
         onTap: () => context.pushRoute(const PartnerRoute()),
         borderRadius: const BorderRadius.all(Radius.circular(12)),
-        child: const Icon(
+        child: Icon(
           Icons.swap_horizontal_circle_rounded,
           size: 25,
+          semanticLabel: 'partner_page_title'.tr(),
         ),
       );
     }

--- a/mobile/lib/shared/ui/immich_app_bar.dart
+++ b/mobile/lib/shared/ui/immich_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
@@ -80,6 +81,7 @@ class ImmichAppBar extends ConsumerWidget implements PreferredSizeWidget {
               strokeWidth: 2,
               strokeCap: StrokeCap.round,
               valueColor: AlwaysStoppedAnimation<Color>(iconColor),
+              semanticsLabel: 'backup_controller_page_backup'.tr(),
             ),
           );
         } else if (backupState.backupProgress !=
@@ -89,6 +91,7 @@ class ImmichAppBar extends ConsumerWidget implements PreferredSizeWidget {
             Icons.check_outlined,
             size: 9,
             color: iconColor,
+            semanticLabel: 'backup_controller_page_backup'.tr(),
           );
         }
       }
@@ -98,6 +101,7 @@ class ImmichAppBar extends ConsumerWidget implements PreferredSizeWidget {
           Icons.cloud_off_rounded,
           size: 9,
           color: iconColor,
+          semanticLabel: 'backup_controller_page_backup'.tr(),
         );
       }
     }


### PR DESCRIPTION
## Description

Adds labels to some of the buttons in the top app bar for screen reader users, to provide context about where the buttons go.

**Note:** I did not modify the rightmost profile circle button, because I think new internationalization text will need to be added for this. Something like "Profile and settings" maybe, and modify the header of the resulting popup to match for predictability?

## How Has This Been Tested?

- [x] VoiceOver for iOS
- [ ] TalkBack for Android - untested, I don't have a physical Android to test with yet...

## Screenshots (if appropriate):

No visible changes

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable