### PR TITLE
fix(web): Remove excess spacing on #asset-grid and search bar

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -387,7 +387,7 @@
 <!-- Right margin MUST be equal to the width of immich-scrubbable-scrollbar -->
 <section
   id="asset-grid"
-  class="scrollbar-hidden h-full overflow-y-auto pb-[60px] {isEmpty ? 'm-0' : 'ml-4 mr-[60px]'}"
+  class="scrollbar-hidden h-full overflow-y-auto pb-[60px] {isEmpty ? 'm-0' : 'mr-[60px]'}"
   bind:clientHeight={viewport.height}
   bind:clientWidth={viewport.width}
   bind:this={element}

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -51,7 +51,7 @@
       </h1>
     </a>
     <div class="flex justify-between gap-16 pr-6">
-      <div class="hidden w-full max-w-5xl flex-1 pl-4 sm:block">
+      <div class="hidden w-full max-w-5xl flex-1 sm:block">
         {#if $featureFlags.search}
           <SearchBar grayTheme={true} />
         {/if}


### PR DESCRIPTION
The timeline / asset-grid has a `1rem` left-margin that results in the sidebar looking larger than it actually is. Removing the margin makes the sidebar have even spacing and as bonus adds a little more room for photos. With this change photos are no longer offset from the main page titles like `Archive` and `Favorites` but those are stickied to the top anyway.  

Update: Also removed the left padding on the search bar so it's even with the timline. Pics below do not reflect this change. 

Original:
![orig](https://github.com/immich-app/immich/assets/868654/af5e37e7-869f-41da-9d00-addd695b4387)

Left margin removed:
![fixed](https://github.com/immich-app/immich/assets/868654/7ea9cdcd-9255-40fa-8e98-5e12ba23d6bc)
