### PR TITLE
fix: Prevent clear-text logging of sensitive information admin password

### DIFF
--- a/server/src/immich-admin/commands/reset-admin-password.command.ts
+++ b/server/src/immich-admin/commands/reset-admin-password.command.ts
@@ -24,19 +24,15 @@ export class ResetAdminPasswordCommand extends CommandRunner {
     return this.inquirer.ask<{ password: string }>('prompt-password', {}).then(({ password }) => password);
   };
 
-  async run(): Promise<void> {
-    try {
-      const { password, provided } = await this.userService.resetAdminPassword(this.ask);
+async run(): Promise<void> {
+  try {
+    const { provided } = await this.userService.resetAdminPassword(this.ask);
 
-      if (provided) {
-        console.log(`The admin password has been updated.`);
-      } else {
-        console.log(`The admin password has been updated to:\n${password}`);
-      }
-    } catch (error) {
-      console.error(error);
-      console.error('Unable to reset admin password');
-    }
+    console.log(`The admin password has been updated.`);
+
+  } catch (error) {
+    console.error(error);
+    console.error('Unable to reset admin password');
   }
 }
 


### PR DESCRIPTION
### Description
This PR addresses the clear-text logging of sensitive information in the `ResetAdminPasswordCommand` class to mitigate the risk of exposing sensitive user data to potential attackers. 

```typescript
      } else {
        console.log(`The admin password has been updated to:\n${password}`);
``` 

### Changes Made
- Modified the code to prevent clear-text logging of the new admin password.
- Updated the log message to provide a generic notification that the admin password has been updated, without revealing the actual password.

### Motivation and Context
Previously, the admin password was logged directly in the console output, which could lead to the exposure of confidential information if the logs were accessed by unauthorized parties. By implementing this fix, we reduce the risk of exposing sensitive user data and system information, thereby enhancing the overall security posture of the application.