### PR TITLE
fix(mobile): make elements scrollable to avoid overflow in landscale

### DIFF
--- a/mobile/lib/modules/album/ui/album_viewer_appbar.dart
+++ b/mobile/lib/modules/album/ui/album_viewer_appbar.dart
@@ -211,8 +211,8 @@ class AlbumViewerAppbar extends HookConsumerWidget
           return SafeArea(
             child: Padding(
               padding: const EdgeInsets.only(top: 24.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
+              child: ListView(
+                shrinkWrap: true,
                 children: [
                   ...buildBottomSheetActions(),
                   if (onAddPhotos != null) ...commonActions,

--- a/mobile/lib/modules/album/views/album_options_part.dart
+++ b/mobile/lib/modules/album/views/album_options_part.dart
@@ -142,6 +142,7 @@ class AlbumOptionsPage extends HookConsumerWidget {
 
     buildSharedUsersList() {
       return ListView.builder(
+        primary: false,
         shrinkWrap: true,
         itemCount: sharedUsers.value.length,
         itemBuilder: (context, index) {
@@ -188,9 +189,7 @@ class AlbumOptionsPage extends HookConsumerWidget {
         centerTitle: true,
         title: Text("translated_text_options".tr()),
       ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
+      body: ListView(
         children: [
           if (isOwner && album.shared)
             SwitchListTile.adaptive(

--- a/mobile/lib/modules/album/views/select_additional_user_for_sharing_page.dart
+++ b/mobile/lib/modules/album/views/select_additional_user_for_sharing_page.dart
@@ -63,8 +63,7 @@ class SelectAdditionalUserForSharingPage extends HookConsumerWidget {
           ),
         );
       }
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      return ListView(
         children: [
           Wrap(
             children: [...usersChip],
@@ -81,6 +80,7 @@ class SelectAdditionalUserForSharingPage extends HookConsumerWidget {
             ),
           ),
           ListView.builder(
+            primary: false,
             shrinkWrap: true,
             itemBuilder: ((context, index) {
               return ListTile(

--- a/mobile/lib/modules/album/views/select_user_for_sharing_page.dart
+++ b/mobile/lib/modules/album/views/select_user_for_sharing_page.dart
@@ -90,8 +90,7 @@ class SelectUserForSharingPage extends HookConsumerWidget {
           ),
         );
       }
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      return ListView(
         children: [
           Wrap(
             children: [...usersChip],
@@ -108,6 +107,7 @@ class SelectUserForSharingPage extends HookConsumerWidget {
             ).tr(),
           ),
           ListView.builder(
+            primary: false,
             shrinkWrap: true,
             itemBuilder: ((context, index) {
               return ListTile(

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -428,10 +428,8 @@ class SharedLinkEditPage extends HookConsumerWidget {
         leading: const CloseButton(),
         centerTitle: false,
       ),
-      resizeToAvoidBottomInset: false,
       body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: ListView(
           children: [
             Padding(
               padding: const EdgeInsets.all(padding),
@@ -487,7 +485,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
               Align(
                 alignment: Alignment.bottomRight,
                 child: Padding(
-                  padding: const EdgeInsets.only(right: padding + 10),
+                  padding: const EdgeInsets.only(
+                    right: padding + 10,
+                    bottom: padding,
+                  ),
                   child: ElevatedButton(
                     onPressed:
                         existingLink != null ? handleEditLink : handleNewLink,
@@ -508,6 +509,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
                 padding: const EdgeInsets.only(
                   left: padding,
                   right: padding,
+                  bottom: padding,
                 ),
                 child: buildNewLinkField(),
               ),


### PR DESCRIPTION
I noticed some issues with overflowing, non-scrollable contents and fixed them. I have a phone with a rather small screen, but I think they should be reproducible on most phones in landscape mode

| page | before | after|
| ------------- | ------------- | ------------- |
| album options  | ![album-options-before](https://github.com/immich-app/immich/assets/2041078/8e967636-c45d-4cb8-9372-2ecdfb92ac1d) | ![album-options-after](https://github.com/immich-app/immich/assets/2041078/d300514c-e6c7-4307-b207-58ad442d5270) |
| link edit  | ![link-edit-before](https://github.com/immich-app/immich/assets/2041078/7773d5df-4e4b-4b94-b7a7-3e6351492b7d) | ![link-edit-after](https://github.com/immich-app/immich/assets/2041078/25166dd3-3bed-478f-81c3-03a42eb68121) |
| add user | ![add-user-before](https://github.com/immich-app/immich/assets/2041078/99cf2039-967f-4cf1-b660-7e36562d0e9d) | ![add-user-after](https://github.com/immich-app/immich/assets/2041078/b53aeae6-9fb4-46e2-bf0f-6263ef1c6fc2) |
| album viewer | ![album-viewer-before](https://github.com/immich-app/immich/assets/2041078/78eb9b12-c7ec-4048-b286-a1c908382ded) | ![album-viewer-after](https://github.com/immich-app/immich/assets/2041078/dfa6b2f4-7521-48e4-968c-a16f772aa98a) |





