### PR TITLE
feat(server): lower library scan memory usage

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -47,6 +47,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "luxon": "^3.4.2",
+        "mnemonist": "^0.39.8",
         "nest-commander": "^3.11.1",
         "nestjs-otel": "^5.1.5",
         "node-addon-api": "^7.0.0",
@@ -10426,6 +10427,14 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/mock-fs": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
@@ -10818,6 +10827,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -22037,6 +22051,14 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
+    "mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "requires": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "mock-fs": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
@@ -22348,6 +22370,11 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+    },
+    "obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "obuf": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -71,6 +71,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "luxon": "^3.4.2",
+    "mnemonist": "^0.39.8",
     "nest-commander": "^3.11.1",
     "nestjs-otel": "^5.1.5",
     "node-addon-api": "^7.0.0",

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -155,7 +155,9 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
-      storageMock.crawl.mockResolvedValue(['/data/user1/photo.jpg']);
+      storageMock.walk.mockImplementation(async function* generator() {
+        yield '/data/user1/photo.jpg';
+      });
       assetMock.getLibraryAssetPaths.mockResolvedValue({ items: [], hasNextPage: false });
 
       await sut.handleQueueAssetRefresh(mockLibraryJob);
@@ -181,7 +183,9 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
-      storageMock.crawl.mockResolvedValue(['/data/user1/photo.jpg']);
+      storageMock.walk.mockImplementation(async function* generator() {
+        yield '/data/user1/photo.jpg';
+      });
       assetMock.getLibraryAssetPaths.mockResolvedValue({ items: [], hasNextPage: false });
 
       await sut.handleQueueAssetRefresh(mockLibraryJob);
@@ -231,12 +235,11 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibraryWithImportPaths1);
-      storageMock.crawl.mockResolvedValue([]);
       assetMock.getLibraryAssetPaths.mockResolvedValue({ items: [], hasNextPage: false });
 
       await sut.handleQueueAssetRefresh(mockLibraryJob);
 
-      expect(storageMock.crawl).toHaveBeenCalledWith({
+      expect(storageMock.walk).toHaveBeenCalledWith({
         pathsToCrawl: [libraryStub.externalLibraryWithImportPaths1.importPaths[1]],
         exclusionPatterns: [],
       });
@@ -250,7 +253,6 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
-      storageMock.crawl.mockResolvedValue([]);
       assetMock.getLibraryAssetPaths.mockResolvedValue({
         items: [assetStub.image],
         hasNextPage: false,
@@ -271,7 +273,9 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
-      storageMock.crawl.mockResolvedValue([assetStub.offline.originalPath]);
+      storageMock.walk.mockImplementation(async function* generator() {
+        yield assetStub.offline.originalPath;
+      });
       assetMock.getLibraryAssetPaths.mockResolvedValue({
         items: [assetStub.offline],
         hasNextPage: false,

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -155,6 +155,7 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
+      // eslint-disable-next-line @typescript-eslint/require-await
       storageMock.walk.mockImplementation(async function* generator() {
         yield '/data/user1/photo.jpg';
       });
@@ -183,6 +184,7 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
+      // eslint-disable-next-line @typescript-eslint/require-await
       storageMock.walk.mockImplementation(async function* generator() {
         yield '/data/user1/photo.jpg';
       });
@@ -273,6 +275,7 @@ describe(LibraryService.name, () => {
       };
 
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
+      // eslint-disable-next-line @typescript-eslint/require-await
       storageMock.walk.mockImplementation(async function* generator() {
         yield assetStub.offline.originalPath;
       });

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -690,13 +690,13 @@ export class LibraryService extends EventEmitter {
         batch.push(assetPath);
 
         if (batch.length >= LIBRARY_SCAN_BATCH_SIZE) {
-          await this.scanAssets(job.id, batch, library.ownerId, false);
+          await this.scanAssets(job.id, batch, library.ownerId, job.refreshAllFiles ?? false);
           batch.length = 0;
         }
       }
 
       if (batch.length > 0) {
-        await this.scanAssets(job.id, batch, library.ownerId, false);
+        await this.scanAssets(job.id, batch, library.ownerId, job.refreshAllFiles ?? false);
       }
     }
 

--- a/server/src/domain/repositories/storage.repository.ts
+++ b/server/src/domain/repositories/storage.repository.ts
@@ -53,6 +53,7 @@ export interface IStorageRepository {
   readdir(folder: string): Promise<string[]>;
   stat(filepath: string): Promise<Stats>;
   crawl(crawlOptions: CrawlOptionsDto): Promise<string[]>;
+  walk(crawlOptions: CrawlOptionsDto): AsyncGenerator<string>;
   copyFile(source: string, target: string): Promise<void>;
   rename(source: string, target: string): Promise<void>;
   watch(paths: string[], options: WatchOptions, events: Partial<WatchEvents>): () => Promise<void>;

--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -165,7 +165,9 @@ export class FilesystemProvider implements IStorageRepository {
       ignore: exclusionPatterns,
     });
 
-    stream.on('data', (file) => yield file);
+    for await (const value of stream) {
+        yield value as string;
+    }
   }
 
   watch(paths: string[], options: WatchOptions, events: Partial<WatchEvents>) {

--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -141,7 +141,7 @@ export class FilesystemProvider implements IStorageRepository {
       return Promise.resolve([]);
     }
 
-    return glob(this.getGlob(pathsToCrawl), {
+    return glob(this.asGlob(pathsToCrawl), {
       absolute: true,
       caseSensitiveMatch: false,
       onlyFiles: true,
@@ -157,7 +157,7 @@ export class FilesystemProvider implements IStorageRepository {
       return emptyGenerator();
     }
 
-    const stream = globStream(this.getGlob(pathsToCrawl), {
+    const stream = globStream(this.asGlob(pathsToCrawl), {
       absolute: true,
       caseSensitiveMatch: false,
       onlyFiles: true,
@@ -182,7 +182,7 @@ export class FilesystemProvider implements IStorageRepository {
     return () => watcher.close();
   }
 
-  private getGlob(pathsToCrawl: string[]): string {
+  private asGlob(pathsToCrawl: string[]): string {
     const base = pathsToCrawl.length === 1 ? pathsToCrawl[0] : `{${pathsToCrawl.join(',')}}`;
     const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
     return `${base}/**/${extensions}`;

--- a/server/src/infra/repositories/filesystem.provider.ts
+++ b/server/src/infra/repositories/filesystem.provider.ts
@@ -166,7 +166,7 @@ export class FilesystemProvider implements IStorageRepository {
     });
 
     for await (const value of stream) {
-        yield value as string;
+      yield value as string;
     }
   }
 

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -56,6 +56,7 @@ export const newStorageRepositoryMock = (reset = true): jest.Mocked<IStorageRepo
     readdir: jest.fn(),
     stat: jest.fn(),
     crawl: jest.fn(),
+    walk: jest.fn().mockImplementation(async function* () {}),
     rename: jest.fn(),
     copyFile: jest.fn(),
     utimes: jest.fn(),


### PR DESCRIPTION
### Description

This PR drastically lowers RAM consumption for scans on large libraries with four optimizations:
1. Batched queueing for asset scanning
2. Trie data structure instead of set
3. Conditionally delete from trie instead of keeping a separate list for full refresh
4. Streamed glob

### How Has This Been Tested?

Successfully imported a library with 1.5 million assets and observed much lower RAM usage than described in #7373

Fixes #7373

![memory_usage](https://github.com/immich-app/immich/assets/101130780/f94412a3-92b1-4c5c-b9e8-19f5befc1c47)
