### PR TITLE
fix(server): prevent feedback loop during library scan

### DIFF
--- a/server/src/domain/library/library.dto.ts
+++ b/server/src/domain/library/library.dto.ts
@@ -89,7 +89,7 @@ export class ValidateLibraryResponseDto {
 
 export class ValidateLibraryImportPathResponseDto {
   importPath!: string;
-  isValid?: boolean = false;
+  isValid: boolean = false;
   message?: string;
 }
 

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -304,9 +304,9 @@ describe(LibraryService.name, () => {
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
       // eslint-disable-next-line @typescript-eslint/require-await
       storageMock.walk.mockImplementation(async function* generator() {
-        yield join(THUMBNAIL_DIR, 'photo.jpg');
+        yield join(THUMBNAIL_DIR, 'ph', 'ot', 'photo.jpg');
         yield assetStub.image.originalPath;
-        yield join(ENCODED_VIDEO_DIR, 'video.mp4');
+        yield join(ENCODED_VIDEO_DIR, 'vi', 'de', 'video.mp4');
       });
       assetMock.getLibraryAssetPaths.mockResolvedValue({
         items: [assetStub.image],

--- a/server/src/domain/library/library.service.spec.ts
+++ b/server/src/domain/library/library.service.spec.ts
@@ -304,9 +304,9 @@ describe(LibraryService.name, () => {
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
       // eslint-disable-next-line @typescript-eslint/require-await
       storageMock.walk.mockImplementation(async function* generator() {
-        yield join(THUMBNAIL_DIR, 'ph', 'ot', 'photo.jpg');
+        yield join(THUMBNAIL_DIR, 'path', 'to', 'photo.jpg');
         yield assetStub.image.originalPath;
-        yield join(ENCODED_VIDEO_DIR, 'vi', 'de', 'video.mp4');
+        yield join(ENCODED_VIDEO_DIR, 'path', 'to', 'video.mp4');
       });
       assetMock.getLibraryAssetPaths.mockResolvedValue({
         items: [assetStub.image],

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -26,6 +26,7 @@ import {
   StorageEventType,
   WithProperty,
 } from '../repositories';
+import { StorageCore } from '../storage';
 import { SystemConfigCore } from '../system-config';
 import {
   CreateLibraryDto,
@@ -720,6 +721,11 @@ export class LibraryService extends EventEmitter {
 
     const trie = new Trie<string>();
     for await (const filePath of generator) {
+      // avoid feedback loop
+      if (StorageCore.isGeneratedAsset(filePath)) {
+        continue;
+      }
+
       trie.add(filePath);
     }
 

--- a/server/src/domain/library/library.service.ts
+++ b/server/src/domain/library/library.service.ts
@@ -328,9 +328,13 @@ export class LibraryService extends EventEmitter {
     const validation = new ValidateLibraryImportPathResponseDto();
     validation.importPath = importPath;
 
+    if (StorageCore.isImmichPath(importPath)) {
+      validation.message = 'Cannot use media upload folder for external libraries';
+      return validation;
+    }
+
     try {
       const stat = await this.storageRepository.stat(importPath);
-
       if (!stat.isDirectory()) {
         validation.message = 'Not a directory';
         return validation;
@@ -679,13 +683,13 @@ export class LibraryService extends EventEmitter {
         this.logger.debug(`Will import ${crawledAssetPaths.size} new asset(s)`);
       }
 
-      const batch = [];
+      let batch = [];
       for (const assetPath of crawledAssetPaths) {
         batch.push(assetPath);
 
         if (batch.length >= LIBRARY_SCAN_BATCH_SIZE) {
           await this.scanAssets(job.id, batch, library.ownerId, job.refreshAllFiles ?? false);
-          batch.length = 0;
+          batch = [];
         }
       }
 
@@ -721,11 +725,6 @@ export class LibraryService extends EventEmitter {
 
     const trie = new Trie<string>();
     for await (const filePath of generator) {
-      // avoid feedback loop
-      if (StorageCore.isGeneratedAsset(filePath)) {
-        continue;
-      }
-
       trie.add(filePath);
     }
 

--- a/server/src/domain/storage/storage.core.ts
+++ b/server/src/domain/storage/storage.core.ts
@@ -20,6 +20,9 @@ export enum StorageFolder {
   THUMBNAILS = 'thumbs',
 }
 
+export const THUMBNAIL_DIR = resolve(join(APP_MEDIA_LOCATION, StorageFolder.THUMBNAILS));
+export const ENCODED_VIDEO_DIR = resolve(join(APP_MEDIA_LOCATION, StorageFolder.ENCODED_VIDEO));
+
 export interface MoveRequest {
   entityId: string;
   pathType: PathType;
@@ -113,6 +116,10 @@ export class StorageCore {
 
   static isImmichPath(path: string) {
     return resolve(path).startsWith(resolve(APP_MEDIA_LOCATION));
+  }
+
+  static isGeneratedAsset(path: string) {
+    return path.startsWith(THUMBNAIL_DIR) || path.startsWith(ENCODED_VIDEO_DIR);
   }
 
   async moveAssetFile(asset: AssetEntity, pathType: GeneratedAssetPath) {

--- a/server/test/fixtures/library.stub.ts
+++ b/server/test/fixtures/library.stub.ts
@@ -1,4 +1,6 @@
+import { APP_MEDIA_LOCATION, THUMBNAIL_DIR } from '@app/domain';
 import { LibraryEntity, LibraryType } from '@app/infra/entities';
+import { join } from 'node:path';
 import { userStub } from './user.stub';
 
 export const libraryStub = {
@@ -94,6 +96,20 @@ export const libraryStub = {
     ownerId: 'user-id',
     type: LibraryType.EXTERNAL,
     importPaths: ['/xyz', '/asdf'],
+    createdAt: new Date('2023-01-01'),
+    updatedAt: new Date('2023-01-01'),
+    refreshedAt: null,
+    isVisible: true,
+    exclusionPatterns: ['**/dir1/**'],
+  }),
+  hasImmichPaths: Object.freeze<LibraryEntity>({
+    id: 'library-id1337',
+    name: 'importpath-exclusion-library1',
+    assets: [],
+    owner: userStub.admin,
+    ownerId: 'user-id',
+    type: LibraryType.EXTERNAL,
+    importPaths: [join(THUMBNAIL_DIR, 'library'), '/xyz', join(APP_MEDIA_LOCATION, 'library')],
     createdAt: new Date('2023-01-01'),
     updatedAt: new Date('2023-01-01'),
     refreshedAt: null,


### PR DESCRIPTION
## Description

We don't handle the case where the library path contains the thumbs or encoded-videos folders, leading to a nasty feedback loop. This adds that check during the scan.

Fixes #7864