### PR TITLE
fix(web): improve focus and shortcuts

### DIFF
--- a/web/src/lib/components/album-page/albums-table.svelte
+++ b/web/src/lib/components/album-page/albums-table.svelte
@@ -35,8 +35,6 @@
       <tr
         class="flex h-[50px] w-full place-items-center border-[3px] border-transparent p-2 text-center odd:bg-immich-gray even:bg-immich-bg hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75 md:p-5"
         on:click={() => goto(`${AppRoute.ALBUMS}/${album.id}`)}
-        on:keydown={(event) => event.key === 'Enter' && goto(`${AppRoute.ALBUMS}/${album.id}`)}
-        tabindex="0"
       >
         <a data-sveltekit-preload-data="hover" class="flex w-full" href="{AppRoute.ALBUMS}/{album.id}">
           <td class="text-md text-ellipsis text-left w-8/12 sm:w-4/12 md:w-4/12 xl:w-[30%] 2xl:w-[40%]"

--- a/web/src/lib/components/album-page/thumbnail-selection.svelte
+++ b/web/src/lib/components/album-page/thumbnail-selection.svelte
@@ -45,7 +45,7 @@
     <!-- Image grid -->
     <div class="flex flex-wrap gap-[2px]">
       {#each album.assets as asset (asset.id)}
-        <Thumbnail {asset} on:click={() => (selectedThumbnail = asset)} selected={isSelected(asset.id)} />
+        <Thumbnail {asset} onClick={() => (selectedThumbnail = asset)} selected={isSelected(asset.id)} />
       {/each}
     </div>
   </section>

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -646,7 +646,7 @@
                   ? 'bg-transparent border-2 border-white'
                   : 'bg-gray-700/40'} inline-block hover:bg-transparent"
                 asset={stackedAsset}
-                on:click={() => {
+                onClick={() => {
                   asset = stackedAsset;
                   preloadAssets = index + 1 >= $stackAssetsStore.length ? [] : [$stackAssetsStore[index + 1]];
                 }}

--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -178,7 +178,7 @@
               {showArchiveIcon}
               {asset}
               {groupIndex}
-              on:click={() => assetClickHandler(asset, groupAssets, groupTitle)}
+              onClick={() => assetClickHandler(asset, groupAssets, groupTitle)}
               on:select={() => assetSelectHandler(asset, groupAssets, groupTitle)}
               on:mouse-event={() => assetMouseEventHandler(groupTitle, asset)}
               selected={$selectedAssets.has(asset) || $assetStore.albumAssets.has(asset.id)}

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -220,7 +220,7 @@
 
     if (matchesShortcut(event, { key: 'Shift' })) {
       event.preventDefault();
-      shiftKeyIsDown = true;
+      shiftKeyIsDown = false;
     }
   };
 

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -8,7 +8,7 @@
   import { isSearchEnabled } from '$lib/stores/search.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { deleteAssets } from '$lib/utils/actions';
-  import { shortcuts, type ShortcutOptions } from '$lib/utils/shortcut';
+  import { shortcuts, type ShortcutOptions, matchesShortcut } from '$lib/utils/shortcut';
   import { formatGroupTitle, splitBucketIntoDateGroups } from '$lib/utils/timeline-util';
   import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
   import { DateTime } from 'luxon';
@@ -202,25 +202,25 @@
 
   let shiftKeyIsDown = false;
 
-  const onKeyDown = (e: KeyboardEvent) => {
+  const onKeyDown = (event: KeyboardEvent) => {
     if ($isSearchEnabled) {
       return;
     }
 
-    if (e.key == 'Shift') {
-      e.preventDefault();
+    if (matchesShortcut(event, { key: 'Shift' })) {
+      event.preventDefault();
       shiftKeyIsDown = true;
     }
   };
 
-  const onKeyUp = (e: KeyboardEvent) => {
+  const onKeyUp = (event: KeyboardEvent) => {
     if ($isSearchEnabled) {
       return;
     }
 
-    if (e.key == 'Shift') {
-      e.preventDefault();
-      shiftKeyIsDown = false;
+    if (matchesShortcut(event, { key: 'Shift' })) {
+      event.preventDefault();
+      shiftKeyIsDown = true;
     }
   };
 

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -26,17 +26,14 @@
   let currentViewAssetIndex = 0;
   $: isMultiSelectionMode = selectedAssets.size > 0;
 
-  const viewAssetHandler = (event: CustomEvent) => {
-    const { asset }: { asset: AssetResponseDto } = event.detail;
-
+  const viewAssetHandler = (asset: AssetResponseDto) => {
     currentViewAssetIndex = assets.findIndex((a) => a.id == asset.id);
     selectedAsset = assets[currentViewAssetIndex];
     $showAssetViewer = true;
     updateAssetState(selectedAsset.id, false);
   };
 
-  const selectAssetHandler = (event: CustomEvent) => {
-    const { asset }: { asset: AssetResponseDto } = event.detail;
+  const selectAssetHandler = (asset: AssetResponseDto) => {
     let temporary = new Set(selectedAssets);
 
     if (selectedAssets.has(asset)) {
@@ -123,8 +120,8 @@
         <Thumbnail
           {asset}
           readonly={disableAssetSelect}
-          on:click={(e) => (isMultiSelectionMode ? selectAssetHandler(e) : viewAssetHandler(e))}
-          on:select={selectAssetHandler}
+          onClick={(e) => (isMultiSelectionMode ? selectAssetHandler(e) : viewAssetHandler(e))}
+          on:select={(e) => selectAssetHandler(e.detail.asset)}
           on:intersected={(event) =>
             i === Math.max(1, assets.length - 7) ? dispatch('intersected', event.detail) : undefined}
           selected={selectedAssets.has(asset)}


### PR DESCRIPTION
- Make `<tr>` of AlbumsTable not focusable, this is already possible via `<a>`
- Use `matchesShortcut` in asset grid component
- Make thumbnails focusable via keyboard and add styling for it:

![thumbnail-focus](https://github.com/immich-app/immich/assets/59014050/79e59a09-bd14-4f57-b3cf-1650dee72a2d)
