### PR TITLE
Feat Implement upload confirmation for external users

### DIFF
--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -28,6 +28,12 @@ export const openFileUploadDialog = async (albumId?: string | undefined) => {
       fileSelector.type = 'file';
       fileSelector.multiple = true;
       fileSelector.accept = extensions.join(',');
+
+      // External User Check and Warning 
+      if (isExternalUser()) {
+        alert("Please note uploaded files can only be deleted by Immich users. Please upload at your own risk");
+      }
+
       fileSelector.addEventListener('change', (e: Event) => {
         const target = e.target as HTMLInputElement;
         if (!target.files) {
@@ -126,4 +132,8 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
       uploadAssetsStore.updateAsset(deviceAssetId, { state: UploadState.ERROR, error: reason });
       return undefined;
     });
+}
+
+function isExternalUser() {
+  return window.location.href.includes('/share/');
 }


### PR DESCRIPTION
This PR introduces changes to display a warning message when users attempt to upload files using both the upload button or drag-and-drop feature in external album views where the upload feature is enabled. 

### Changes Made
- Added a warning message for external users when using the upload button to upload files.
- Modified the drag-and-drop functionality to display a warning message for external users before uploading files.

### New Behaviour
![firefox_Pw9LOc44Yl](https://github.com/immich-app/immich/assets/160616898/376d9db3-c873-45bf-99a3-f27614e0627a)


Fixes: #7956 