### PR TITLE
fix(web): updating asset store after remove

### DIFF
--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -429,7 +429,6 @@ export class AssetStore {
 
   removeAssets(ids: string[]) {
     const idSet = new Set(ids);
-    this.assets = this.assets.filter((asset) => !idSet.has(asset.id));
 
     // Iterate in reverse to allow array splicing.
     for (let index = this.buckets.length - 1; index >= 0; index--) {
@@ -441,16 +440,13 @@ export class AssetStore {
         }
 
         bucket.assets.splice(index_, 1);
-        bucket.bucketCount = bucket.assets.length;
-        if (bucket.bucketCount === 0) {
+        if (bucket.assets.length === 0) {
           this.buckets.splice(index, 1);
         }
-
-        delete this.assetToBucket[asset.id];
       }
     }
 
-    this.emit(false);
+    this.emit(true);
   }
 
   async getPreviousAssetId(assetId: string): Promise<string | null> {


### PR DESCRIPTION
The `assetToBucket` object isn't updated correctly after calling `removeAssets`, causing index lookups to fail. Fixed by using `emit(true)` to reconstruct the object. Fixes #4954