### PR TITLE
fix(docs): add microservices to IMMICH_CONFIG_FILE env var documentation

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -36,7 +36,7 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | `NODE_ENV`                      | Environment (production, development)        |     `production`     | server, microservices, machine learning, web |
 | `LOG_LEVEL`                     | Log Level (verbose, debug, log, warn, error) |        `log`         | server, microservices                        |
 | `IMMICH_MEDIA_LOCATION`         | Media Location                               |      `./upload`      | server, microservices                        |
-| `IMMICH_CONFIG_FILE`            | Path to config file                          |                      | server                                       |
+| `IMMICH_CONFIG_FILE`            | Path to config file                          |                      | server, microservices                        |
 | `IMMICH_WEB_ROOT`               | Path of root index.html                      |  `/usr/src/app/www`  | server                                       |
 | `IMMICH_REVERSE_GEOCODING_ROOT` | Path of reverse geocoding dump directory     | `/usr/src/resources` | microservices                                |
 


### PR DESCRIPTION
Without adding a volume mapping for the config file for the microservices container, I was getting the following error. This was preventing any of the normal functions of the Immich microservices, e.g. couldn't scan library, etc.

```
Node.js v20.11.1
[Nest] 7  - 03/17/2024, 12:44:59 AM     LOG [CommunicationRepository] Initialized websocket server
[Nest] 7  - 03/17/2024, 12:44:59 AM   ERROR [SystemConfigCore] Unable to load configuration file: /config/immich-config.json
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENOENT: no such file or directory, open '/config/immich-config.json'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/config/immich-config.json'
}
```