### PR TITLE
feat(ml): add cache_dir option to OpenVINO EP

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -186,7 +186,7 @@ class InferenceModel(ABC):
                 case "CPUExecutionProvider" | "CUDAExecutionProvider":
                     option = {"arena_extend_strategy": "kSameAsRequested"}
                 case "OpenVINOExecutionProvider":
-                    option = {"device_type": "GPU_FP32"}
+                    option = {"device_type": "GPU_FP32", "cache_dir": f"{self.cache_dir}/openvino"}
                 case _:
                     option = {}
             options.append(option)

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -186,7 +186,7 @@ class InferenceModel(ABC):
                 case "CPUExecutionProvider" | "CUDAExecutionProvider":
                     option = {"arena_extend_strategy": "kSameAsRequested"}
                 case "OpenVINOExecutionProvider":
-                    option = {"device_type": "GPU_FP32", "cache_dir": f"{self.cache_dir}/openvino"}
+                    option = {"device_type": "GPU_FP32", "cache_dir": (self.cache_dir / "openvino").as_posix()}
                 case _:
                     option = {}
             options.append(option)

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -88,9 +88,8 @@ class TestBase:
         encoder = OpenCLIPEncoder("ViT-B-32__openai", providers=["OpenVINOExecutionProvider", "CPUExecutionProvider"])
 
         assert encoder.provider_options == [
-            {"device_type": "GPU_FP32"},
+            {"device_type": "GPU_FP32", "cache_dir": (encoder.cache_dir / "openvino").as_posix()},
             {"arena_extend_strategy": "kSameAsRequested"},
-            {"cache_dir": f"{encoder.cache_dir}/openvino"},
         ]
 
     def test_sets_provider_options_kwarg(self) -> None:

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -90,6 +90,7 @@ class TestBase:
         assert encoder.provider_options == [
             {"device_type": "GPU_FP32"},
             {"arena_extend_strategy": "kSameAsRequested"},
+            {"cache_dir": f"{encoder.cache_dir}/openvino"},
         ]
 
     def test_sets_provider_options_kwarg(self) -> None:


### PR DESCRIPTION
## Description

This PR enables caching for the OpenVINO EP by adding a `cache_dir` option to the provider config as documented [here](https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#summary-of-options) and suggested by @mertalev in https://github.com/immich-app/immich/pull/7854#issuecomment-2002035826

This greatly reduced memory consumption during smart search in my tests: using the model `XLM-Roberta-Large-Vit-B-32`, I saw a memory usage of ~2.5 GB during search instead of the ~7-8 GB without caching.