### PR TITLE
fix(mobile): do not show hidden people

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/exif_sheet/exif_people.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_sheet/exif_people.dart
@@ -22,8 +22,8 @@ class ExifPeople extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final peopleProvider =
         ref.watch(assetPeopleNotifierProvider(asset).notifier);
-    final people = ref.watch(assetPeopleNotifierProvider(asset));
-    final double imageSize = math.min(context.width / 3, 150);
+    final people = ref.watch(assetPeopleNotifierProvider(asset)).value?.where((p) => !p.isHidden);
+    final double imageSize = math.min(context.width / 3, 120);
 
     showPersonNameEditModel(
       String personId,
@@ -40,12 +40,12 @@ class ExifPeople extends ConsumerWidget {
       });
     }
 
-    if (people.value?.isEmpty ?? true) {
+    if (people?.isEmpty ?? true) {
       // Empty list or loading
       return Container();
     }
 
-    final curatedPeople = people.value
+    final curatedPeople = people
             ?.map((p) => CuratedContent(id: p.id, label: p.name))
             .toList() ??
         [];

--- a/mobile/lib/modules/asset_viewer/ui/exif_sheet/exif_people.dart
+++ b/mobile/lib/modules/asset_viewer/ui/exif_sheet/exif_people.dart
@@ -22,7 +22,10 @@ class ExifPeople extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final peopleProvider =
         ref.watch(assetPeopleNotifierProvider(asset).notifier);
-    final people = ref.watch(assetPeopleNotifierProvider(asset)).value?.where((p) => !p.isHidden);
+    final people = ref
+        .watch(assetPeopleNotifierProvider(asset))
+        .value
+        ?.where((p) => !p.isHidden);
     final double imageSize = math.min(context.width / 3, 120);
 
     showPersonNameEditModel(
@@ -45,10 +48,9 @@ class ExifPeople extends ConsumerWidget {
       return Container();
     }
 
-    final curatedPeople = people
-            ?.map((p) => CuratedContent(id: p.id, label: p.name))
-            .toList() ??
-        [];
+    final curatedPeople =
+        people?.map((p) => CuratedContent(id: p.id, label: p.name)).toList() ??
+            [];
 
     return Column(
       children: [

--- a/mobile/lib/modules/search/ui/curated_people_row.dart
+++ b/mobile/lib/modules/search/ui/curated_people_row.dart
@@ -23,7 +23,7 @@ class CuratedPeopleRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const imageSize = 85.0;
+    const imageSize = 80.0;
 
     // Guard empty [content]
     if (content.isEmpty) {


### PR DESCRIPTION
This PR makes hidden people not visible in asset details (same on web) and makes people thumbnails bit more compact.