### PR TITLE
fix(web): prevent drag-n-drop upload overlay from showing when not dragging files

### DIFF
--- a/web/src/lib/components/shared-components/drag-and-drop-upload-overlay.svelte
+++ b/web/src/lib/components/shared-components/drag-and-drop-upload-overlay.svelte
@@ -6,7 +6,9 @@
   let dragStartTarget: EventTarget | null = null;
 
   const handleDragEnter = (e: DragEvent) => {
-    dragStartTarget = e.target;
+    if (e.dataTransfer && e.dataTransfer.types.includes('Files')) {
+      dragStartTarget = e.target;
+    }
   };
 </script>
 


### PR DESCRIPTION
This PR prevents the "Drop files anywhere to upload" overlay to appear when dragging anything else than files.