### PR TITLE
test: temporarily disable flaky audit e2e test until #7436 is fixed

### DIFF
--- a/e2e/src/api/specs/audit.e2e-spec.ts
+++ b/e2e/src/api/specs/audit.e2e-spec.ts
@@ -12,7 +12,8 @@ describe('/audit', () => {
     admin = await utils.adminSetup();
   });
 
-  describe('GET :/file-report', () => {
+  // TODO: Enable these tests again once #7436 is resolved as these were flaky
+  describe.skip('GET :/file-report', () => {
     it('excludes assets without issues from report', async () => {
       const [trashedAsset, archivedAsset] = await Promise.all([
         utils.createAsset(admin.accessToken),


### PR DESCRIPTION
Audit service has a bug #7436 that shows files as untracked when it shouldn't. This behaviour seems flaky and is causing the audit e2e test to sporadically fail. Disabling the test until we fix that bug