### PR TITLE
fix(web): prevent duplicate time bucket loads

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -27,7 +27,7 @@ interface UploadRequestOptions {
   onUploadProgress?: (event: ProgressEvent<XMLHttpRequestEventTarget>) => void;
 }
 
-class AbortError extends Error {
+export class AbortError extends Error {
   name = 'AbortError';
 }
 


### PR DESCRIPTION
This was fixed before, but got reverted in #7644. The original implementation had a bug, where loading a canceled bucket wasn't possible. This has been fixed and unit tests to verify correct behavior are added.