### PR TITLE
fix(web): Share button visible when viewing album has only shared link

### DIFF
--- a/web/src/routes/(user)/albums/[albumId]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId]/+page.svelte
@@ -148,7 +148,7 @@
 
     backUrl = url || AppRoute.ALBUMS;
 
-    if (backUrl === AppRoute.SHARING && album.sharedUsers.length === 0) {
+    if (backUrl === AppRoute.SHARING && album.sharedUsers.length === 0 && !album.hasSharedLink) {
       isCreatingSharedAlbum = true;
     }
   });


### PR DESCRIPTION
Fixed the issue that an album, with only shared link i.e. no users shared, still show the Share button which only means for the creation process