### PR TITLE
feat(web): add ctrl+a / ctrl+d shortcuts to select / deselect all assets

### DIFF
--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -1,42 +1,24 @@
 <script lang="ts">
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
-  import { BucketPosition, type AssetStore, isSelectAllCancelled } from '$lib/stores/assets.store';
-  import { handleError } from '$lib/utils/handle-error';
-  import { get } from 'svelte/store';
-  import { mdiTimerSand, mdiSelectAll } from '@mdi/js';
+  import { type AssetStore, isSelectingAllAssets } from '$lib/stores/assets.store';
+  import { mdiSelectAll, mdiTimerSand } from '@mdi/js';
+  import { selectAllAssets } from '$lib/utils/asset-utils';
 
   export let assetStore: AssetStore;
   export let assetInteractionStore: AssetInteractionStore;
 
-  let selecting = false;
-
   const handleSelectAll = async () => {
-    try {
-      $isSelectAllCancelled = false;
-      selecting = true;
+    await selectAllAssets(assetStore, assetInteractionStore);
+  };
 
-      const assetGridState = get(assetStore);
-      for (const bucket of assetGridState.buckets) {
-        if ($isSelectAllCancelled) {
-          break;
-        }
-        await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
-        for (const asset of bucket.assets) {
-          assetInteractionStore.selectAsset(asset);
-        }
-      }
-
-      selecting = false;
-    } catch (error) {
-      handleError(error, 'Error selecting all assets');
-    }
+  const handleCancel = () => {
+    $isSelectingAllAssets = false;
   };
 </script>
 
-{#if selecting}
-  <CircleIconButton title="Delete" icon={mdiTimerSand} />
-{/if}
-{#if !selecting}
+{#if $isSelectingAllAssets}
+  <CircleIconButton title="Cancel" icon={mdiTimerSand} on:click={handleCancel} />
+{:else}
   <CircleIconButton title="Select all" icon={mdiSelectAll} on:click={handleSelectAll} />
 {/if}

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -3,12 +3,12 @@
   import { AppRoute, AssetAction } from '$lib/constants';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import { BucketPosition, type AssetStore, type Viewport } from '$lib/stores/assets.store';
+  import { BucketPosition, isSelectingAllAssets, type AssetStore, type Viewport } from '$lib/stores/assets.store';
   import { locale, showDeleteModal } from '$lib/stores/preferences.store';
   import { isSearchEnabled } from '$lib/stores/search.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { deleteAssets } from '$lib/utils/actions';
-  import { shortcuts, type ShortcutOptions, matchesShortcut } from '$lib/utils/shortcut';
+  import { matchesShortcut, type ShortcutOptions, shortcuts } from '$lib/utils/shortcut';
   import { formatGroupTitle, splitBucketIntoDateGroups } from '$lib/utils/timeline-util';
   import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
   import { DateTime } from 'luxon';
@@ -20,6 +20,7 @@
   import AssetDateGroup from './asset-date-group.svelte';
   import DeleteAssetDialog from './delete-asset-dialog.svelte';
   import { handlePromiseError } from '$lib/utils';
+  import { selectAllAssets } from '$lib/utils/asset-utils';
 
   export let isSelectionMode = false;
   export let singleSelect = false;
@@ -202,12 +203,24 @@
 
   let shiftKeyIsDown = false;
 
-  const onKeyDown = (event: KeyboardEvent) => {
+  const onKeyDown = async (event: KeyboardEvent) => {
     if ($isSearchEnabled) {
       return;
     }
 
-    if (matchesShortcut(event, { key: 'Shift', shift: true })) {
+    // Select All
+    if (matchesShortcut(event, { key: 'A', ctrl: true })) {
+      event.preventDefault();
+      await selectAllAssets(assetStore, assetInteractionStore);
+    }
+    // Deselect All
+    else if (matchesShortcut(event, { key: 'D', ctrl: true })) {
+      event.preventDefault();
+      $isSelectingAllAssets = false;
+      assetInteractionStore.clearMultiselect();
+    }
+    // Start Multi-Selection
+    else if (event.key === 'Shift') {
       event.preventDefault();
       shiftKeyIsDown = true;
     }
@@ -218,7 +231,7 @@
       return;
     }
 
-    if (matchesShortcut(event, { key: 'Shift', shift: false })) {
+    if (event.key === 'Shift') {
       event.preventDefault();
       shiftKeyIsDown = false;
     }

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -8,7 +8,7 @@
   import { isSearchEnabled } from '$lib/stores/search.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { deleteAssets } from '$lib/utils/actions';
-  import { matchesShortcut, type ShortcutOptions, shortcuts } from '$lib/utils/shortcut';
+  import { type ShortcutOptions, shortcuts } from '$lib/utils/shortcut';
   import { formatGroupTitle, splitBucketIntoDateGroups } from '$lib/utils/timeline-util';
   import type { AlbumResponseDto, AssetResponseDto } from '@immich/sdk';
   import { DateTime } from 'luxon';
@@ -94,12 +94,14 @@
       { shortcut: { key: 'Escape' }, onShortcut: () => dispatch('escape') },
       { shortcut: { key: '?', shift: true }, onShortcut: () => (showShortcuts = !showShortcuts) },
       { shortcut: { key: '/' }, onShortcut: () => goto(AppRoute.EXPLORE) },
+      { shortcut: { key: 'A', ctrl: true }, onShortcut: () => selectAllAssets(assetStore, assetInteractionStore) },
     ];
 
     if ($isMultiSelectState) {
       shortcuts.push(
         { shortcut: { key: 'Delete' }, onShortcut: onDelete },
         { shortcut: { key: 'Delete', shift: true }, onShortcut: onForceDelete },
+        { shortcut: { key: 'D', ctrl: true }, onShortcut: () => deselectAllAssets() },
       );
     }
 
@@ -203,24 +205,17 @@
 
   let shiftKeyIsDown = false;
 
-  const onKeyDown = async (event: KeyboardEvent) => {
+  const deselectAllAssets = () => {
+    $isSelectingAllAssets = false;
+    assetInteractionStore.clearMultiselect();
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
     if ($isSearchEnabled) {
       return;
     }
 
-    // Select All
-    if (matchesShortcut(event, { key: 'A', ctrl: true })) {
-      event.preventDefault();
-      await selectAllAssets(assetStore, assetInteractionStore);
-    }
-    // Deselect All
-    else if (matchesShortcut(event, { key: 'D', ctrl: true })) {
-      event.preventDefault();
-      $isSelectingAllAssets = false;
-      assetInteractionStore.clearMultiselect();
-    }
-    // Start Multi-Selection
-    else if (event.key === 'Shift') {
+    if (event.key === 'Shift') {
       event.preventDefault();
       shiftKeyIsDown = true;
     }

--- a/web/src/lib/components/shared-components/control-app-bar.svelte
+++ b/web/src/lib/components/shared-components/control-app-bar.svelte
@@ -5,7 +5,7 @@
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import { fly } from 'svelte/transition';
   import { mdiClose } from '@mdi/js';
-  import { isSelectAllCancelled } from '$lib/stores/assets.store';
+  import { isSelectingAllAssets } from '$lib/stores/assets.store';
 
   export let showBackButton = true;
   export let backIcon = mdiClose;
@@ -31,7 +31,7 @@
   };
 
   const handleClose = () => {
-    $isSelectAllCancelled = true;
+    $isSelectingAllAssets = false;
     dispatch('close');
   };
 

--- a/web/src/lib/stores/asset-interaction.store.ts
+++ b/web/src/lib/stores/asset-interaction.store.ts
@@ -3,6 +3,7 @@ import { derived, writable } from 'svelte/store';
 
 export interface AssetInteractionStore {
   selectAsset: (asset: AssetResponseDto) => void;
+  selectAssets: (assets: AssetResponseDto[]) => void;
   removeAssetFromMultiselectGroup: (asset: AssetResponseDto) => void;
   addGroupToMultiselectGroup: (group: string) => void;
   removeGroupFromMultiselectGroup: (group: string) => void;
@@ -76,6 +77,13 @@ export function createAssetInteractionStore(): AssetInteractionStore {
     selectedAssets.set(_selectedAssets);
   };
 
+  const selectAssets = (assets: AssetResponseDto[]) => {
+    for (const asset of assets) {
+      _selectedAssets.add(asset);
+    }
+    selectedAssets.set(_selectedAssets);
+  };
+
   const removeAssetFromMultiselectGroup = (asset: AssetResponseDto) => {
     _selectedAssets.delete(asset);
     selectedAssets.set(_selectedAssets);
@@ -123,6 +131,7 @@ export function createAssetInteractionStore(): AssetInteractionStore {
 
   return {
     selectAsset,
+    selectAssets,
     removeAssetFromMultiselectGroup,
     addGroupToMultiselectGroup,
     removeGroupFromMultiselectGroup,

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -517,4 +517,4 @@ export class AssetStore {
   }
 }
 
-export const isSelectAllCancelled = writable(false);
+export const isSelectingAllAssets = writable(false);

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -236,7 +236,7 @@ export const selectAllAssets = async (assetStore: AssetStore, assetInteractionSt
 
   try {
     let selectedAssetCount = 1;
-    loadBuckets: for (const bucket of get(assetStore).buckets) {
+    loadBuckets: for (const bucket of assetStore.buckets) {
       await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
 
       if (!get(isSelectingAllAssets)) {

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -235,28 +235,19 @@ export const selectAllAssets = async (assetStore: AssetStore, assetInteractionSt
   isSelectingAllAssets.set(true);
 
   try {
-    let selectedAssetCount = 1;
-    loadBuckets: for (const bucket of assetStore.buckets) {
+    for (const bucket of assetStore.buckets) {
       await assetStore.loadBucket(bucket.bucketDate, BucketPosition.Unknown);
 
       if (!get(isSelectingAllAssets)) {
         break; // Cancelled
       }
-      for (let i = 0; i < bucket.assets.length; ++i, ++selectedAssetCount) {
-        assetInteractionStore.selectAsset(bucket.assets[i]);
+      assetInteractionStore.selectAssets(bucket.assets);
 
-        if (selectedAssetCount % 2500 === 0) {
-          // Each 2500 assets selected, we use setTimeout to allow the UI to
-          // update. Otherwise, this may cause a long delay between the start of
-          // 'select all' and the effective update of the UI, depending on the
-          // number of assets to select.
-          await delay(0);
-
-          if (!get(isSelectingAllAssets)) {
-            break loadBuckets; // Cancelled
-          }
-        }
-      }
+      // We use setTimeout to allow the UI to update. Otherwise, this may
+      // cause a long delay between the start of 'select all' and the
+      // effective update of the UI, depending on the number of assets
+      // to select
+      await delay(0);
     }
   } catch (error) {
     handleError(error, 'Error selecting all assets');


### PR DESCRIPTION
This PR adds:

- Ctrl+A shortcut to select all assets.
- Ctrl+D shortcut to deselect all previously selected assets. It also cancels the ongoing "select all".
- "Select all" cancellation now works properly.
- "Select all" does not "freeze" the UI anymore if there is too many cached assets to select.