### PR TITLE
chore(server): remove pre-installed cli

### DIFF
--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -1,6 +1,6 @@
 # The Immich CLI
 
-Immich has a CLI that allows you to perform certain actions from the command line. This CLI replaces the [legacy CLI](https://github.com/immich-app/CLI) that was previously available. The CLI is hosted in the [cli folder of the the main Immich github repository](https://github.com/immich-app/immich/tree/main/cli).
+Immich has a command line interface (CLI) that allows you to perform certain actions from the command line.
 
 ## Features
 

--- a/server/bin/immich
+++ b/server/bin/immich
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-node /usr/src/app/node_modules/.bin/immich "$@"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,6 @@
       "license": "GNU Affero General Public License version 3",
       "dependencies": {
         "@babel/runtime": "^7.22.11",
-        "@immich/cli": "^2.0.7",
         "@nestjs/bullmq": "^10.0.1",
         "@nestjs/common": "^10.2.2",
         "@nestjs/config": "^3.0.0",
@@ -1716,20 +1715,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@immich/cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@immich/cli/-/cli-2.1.0.tgz",
-      "integrity": "sha512-3s/8+Js1dAwibzgaRtZ+bsAL9nOtvoEX/qMlOTgbgLf/lT96M88QScqhb+YrU2l3WBugtts6xW76XQTrWGXcmw==",
-      "dependencies": {
-        "lodash-es": "^4.17.21"
-      },
-      "bin": {
-        "immich": "dist/index.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -10152,11 +10137,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -15603,14 +15583,6 @@
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.2.tgz",
       "integrity": "sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==",
       "optional": true
-    },
-    "@immich/cli": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@immich/cli/-/cli-2.1.0.tgz",
-      "integrity": "sha512-3s/8+Js1dAwibzgaRtZ+bsAL9nOtvoEX/qMlOTgbgLf/lT96M88QScqhb+YrU2l3WBugtts6xW76XQTrWGXcmw==",
-      "requires": {
-        "lodash-es": "^4.17.21"
-      }
     },
     "@ioredis/commands": {
       "version": "1.2.0",
@@ -21876,11 +21848,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.11",
-    "@immich/cli": "^2.0.7",
     "@nestjs/bullmq": "^10.0.1",
     "@nestjs/common": "^10.2.2",
     "@nestjs/config": "^3.0.0",


### PR DESCRIPTION
This removes `@immich/cli` as a dependency from the immich-server and immich-microservices container. The package was consistently outdated. The users can easily install it if they want via `npm i @immich/cli`.