### PR TITLE
feat(server): add immich cli to container

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -53,7 +53,7 @@ COPY --from=web /usr/src/app/build ./www
 COPY server/resources resources
 COPY server/package.json server/package-lock.json ./
 COPY server/start*.sh ./
-RUN npm link && npm cache clean --force
+RUN npm link && npm install -g @immich/cli && npm cache clean --force
 COPY LICENSE /licenses/LICENSE.txt
 COPY LICENSE /LICENSE
 ENV PATH="${PATH}:/usr/src/app/bin"


### PR DESCRIPTION
In contrary to what was removed in #8224, this will always install the latest version from npm. By this, the cli will actually always be up to date (with the latest published version)