### PR TITLE
chore(docs): Update docker compose readme with wget download option

### DIFF
--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -21,7 +21,7 @@ cd ./immich-app
 Download [`docker-compose.yml`][compose-file] and [`example.env`][env-file], either by running the following commands:
 
 ```bash title="Get docker-compose.yml file"
-wget https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+wget -O docker-compose.yml https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
 ```
 
 ```bash title="Get .env file"
@@ -29,11 +29,11 @@ wget -O .env https://github.com/immich-app/immich/releases/latest/download/examp
 ```
 
 ```bash title="(Optional) Get hwaccel.transcoding.yml file"
-wget https://github.com/immich-app/immich/releases/latest/download/hwaccel.transcoding.yml
+wget -O hwaccel.transcoding.yml https://github.com/immich-app/immich/releases/latest/download/hwaccel.transcoding.yml
 ```
 
 ```bash title="(Optional) Get hwaccel.ml.yml file"
-wget https://github.com/immich-app/immich/releases/latest/download/hwaccel.ml.yml
+wget -O hwaccel.ml.yml https://github.com/immich-app/immich/releases/latest/download/hwaccel.ml.yml
 ```
 
 or by downloading from your browser and moving the files to the directory that you created.


### PR DESCRIPTION
## Description
This pull request updates the docker documentation to use the [download option](https://www.gnu.org/software/wget/manual/html_node/Download-Options.html#Download-Options) (`-O`) with `wget` to download the files with the appropriate names and making them consistent with the other commands.

This change makes the document more consistent and easier to follow by downloading the files with the correct names as needed by the `docker-compose` commands.

Fixes # (issue)
Inconsistency in `wget` commands in the docker compose documentation

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):
N/A

## Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable