### PR TITLE
feat(server): job metrics

### DIFF
--- a/server/e2e/docker-compose.server-e2e.yml
+++ b/server/e2e/docker-compose.server-e2e.yml
@@ -19,6 +19,7 @@ services:
       - DB_PASSWORD=postgres
       - DB_DATABASE_NAME=e2e_test
       - IMMICH_METRICS=true
+      - IMMICH_JOB_METRICS=false
     depends_on:
       - database
 

--- a/server/e2e/docker-compose.server-e2e.yml
+++ b/server/e2e/docker-compose.server-e2e.yml
@@ -19,7 +19,6 @@ services:
       - DB_PASSWORD=postgres
       - DB_DATABASE_NAME=e2e_test
       - IMMICH_METRICS=true
-      - IMMICH_JOB_METRICS=false
     depends_on:
       - database
 

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -51,6 +51,7 @@ import { ILibraryRepository } from 'src/interfaces/library.interface';
 import { IMachineLearningRepository } from 'src/interfaces/machine-learning.interface';
 import { IMediaRepository } from 'src/interfaces/media.interface';
 import { IMetadataRepository } from 'src/interfaces/metadata.interface';
+import { IMetricRepository } from 'src/interfaces/metric.interface';
 import { IMoveRepository } from 'src/interfaces/move.interface';
 import { IPartnerRepository } from 'src/interfaces/partner.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
@@ -83,6 +84,7 @@ import { LibraryRepository } from 'src/repositories/library.repository';
 import { MachineLearningRepository } from 'src/repositories/machine-learning.repository';
 import { MediaRepository } from 'src/repositories/media.repository';
 import { MetadataRepository } from 'src/repositories/metadata.repository';
+import { MetricRepository } from 'src/repositories/metric.repository';
 import { MoveRepository } from 'src/repositories/move.repository';
 import { PartnerRepository } from 'src/repositories/partner.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
@@ -123,8 +125,6 @@ import { TrashService } from 'src/services/trash.service';
 import { UserService } from 'src/services/user.service';
 import { otelConfig } from 'src/utils/instrumentation';
 import { ImmichLogger } from 'src/utils/logger';
-import { IMetricRepository } from 'src/interfaces/metric.interface';
-import { MetricRepository } from 'src/repositories/metric.repository';
 
 const commands = [
   ResetAdminPasswordCommand,

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -123,6 +123,8 @@ import { TrashService } from 'src/services/trash.service';
 import { UserService } from 'src/services/user.service';
 import { otelConfig } from 'src/utils/instrumentation';
 import { ImmichLogger } from 'src/utils/logger';
+import { IMetricRepository } from 'src/interfaces/metric.interface';
+import { MetricRepository } from 'src/repositories/metric.repository';
 
 const commands = [
   ResetAdminPasswordCommand,
@@ -208,6 +210,7 @@ const repositories: Provider[] = [
   { provide: IKeyRepository, useClass: ApiKeyRepository },
   { provide: IMachineLearningRepository, useClass: MachineLearningRepository },
   { provide: IMetadataRepository, useClass: MetadataRepository },
+  { provide: IMetricRepository, useClass: MetricRepository },
   { provide: IMoveRepository, useClass: MoveRepository },
   { provide: IPartnerRepository, useClass: PartnerRepository },
   { provide: IPersonRepository, useClass: PersonRepository },

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -279,6 +279,7 @@ export class ImmichAdminModule {}
     EventEmitterModule.forRoot(),
     TypeOrmModule.forRoot(databaseConfig),
     TypeOrmModule.forFeature(databaseEntities),
+    OpenTelemetryModule.forRoot(otelConfig),
   ],
   controllers: [...controllers],
   providers: [...services, ...repositories, ...middleware, SchedulerRegistry],

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -165,7 +165,6 @@ const controllers = [
 const services: Provider[] = [
   ApiService,
   MicroservicesService,
-
   APIKeyService,
   ActivityService,
   AlbumService,

--- a/server/src/interfaces/metric.interface.ts
+++ b/server/src/interfaces/metric.interface.ts
@@ -1,0 +1,13 @@
+import { MetricOptions } from '@opentelemetry/api';
+
+export interface CustomMetricOptions extends MetricOptions {
+  enabled?: boolean;
+}
+
+export const IMetricRepository = 'IMetricRepository';
+
+export interface IMetricRepository {
+  addToCounter(name: string, value: number, options?: CustomMetricOptions): void;
+  updateGauge(name: string, value: number, options?: CustomMetricOptions): void;
+  updateHistogram(name: string, value: number, options?: CustomMetricOptions): void;
+}

--- a/server/src/repositories/metric.repository.ts
+++ b/server/src/repositories/metric.repository.ts
@@ -1,8 +1,9 @@
+import { Inject } from '@nestjs/common';
 import { MetricService } from 'nestjs-otel';
 import { CustomMetricOptions, IMetricRepository } from 'src/interfaces/metric.interface';
 
 export class MetricRepository implements IMetricRepository {
-  constructor(private readonly metricService: MetricService) {}
+  constructor(@Inject(MetricService) private readonly metricService: MetricService) {}
 
   addToCounter(name: string, value: number, options?: CustomMetricOptions): void {
     if (options?.enabled === false) {

--- a/server/src/repositories/metric.repository.ts
+++ b/server/src/repositories/metric.repository.ts
@@ -1,0 +1,30 @@
+import { MetricService } from 'nestjs-otel';
+import { CustomMetricOptions, IMetricRepository } from 'src/interfaces/metric.interface';
+
+export class MetricRepository implements IMetricRepository {
+  constructor(private readonly metricService: MetricService) {}
+
+  addToCounter(name: string, value: number, options?: CustomMetricOptions): void {
+    if (options?.enabled === false) {
+      return;
+    }
+
+    this.metricService.getCounter(name, options).add(value);
+  }
+
+  updateGauge(name: string, value: number, options?: CustomMetricOptions): void {
+    if (options?.enabled === false) {
+      return;
+    }
+
+    this.metricService.getUpDownCounter(name, options).add(value);
+  }
+
+  updateHistogram(name: string, value: number, options?: CustomMetricOptions): void {
+    if (options?.enabled === false) {
+      return;
+    }
+
+    this.metricService.getHistogram(name, options).record(value);
+  }
+}

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,5 +1,4 @@
 import { BadRequestException } from '@nestjs/common';
-import { MetricService } from 'nestjs-otel';
 import { FeatureFlag, SystemConfigCore } from 'src/cores/system-config.core';
 import { SystemConfig, SystemConfigKey } from 'src/entities/system-config.entity';
 import { IAssetRepository } from 'src/interfaces/asset.interface';

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { MetricService } from 'nestjs-otel';
 import { FeatureFlag, SystemConfigCore } from 'src/cores/system-config.core';
 import { SystemConfig, SystemConfigKey } from 'src/entities/system-config.entity';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
@@ -12,6 +13,7 @@ import {
   JobStatus,
   QueueName,
 } from 'src/interfaces/job.interface';
+import { IMetricRepository } from 'src/interfaces/metric.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
 import { ISystemConfigRepository } from 'src/interfaces/system-config.interface';
 import { JobService } from 'src/services/job.service';
@@ -19,6 +21,7 @@ import { assetStub } from 'test/fixtures/asset.stub';
 import { newAssetRepositoryMock } from 'test/repositories/asset.repository.mock';
 import { newEventRepositoryMock } from 'test/repositories/event.repository.mock';
 import { newJobRepositoryMock } from 'test/repositories/job.repository.mock';
+import { newMetricRepositoryMock } from 'test/repositories/metric.repository.mock';
 import { newPersonRepositoryMock } from 'test/repositories/person.repository.mock';
 import { newSystemConfigRepositoryMock } from 'test/repositories/system-config.repository.mock';
 
@@ -37,6 +40,7 @@ describe(JobService.name, () => {
   let eventMock: jest.Mocked<IEventRepository>;
   let jobMock: jest.Mocked<IJobRepository>;
   let personMock: jest.Mocked<IPersonRepository>;
+  let metricMock: jest.Mocked<IMetricRepository>;
 
   beforeEach(() => {
     assetMock = newAssetRepositoryMock();
@@ -44,7 +48,8 @@ describe(JobService.name, () => {
     eventMock = newEventRepositoryMock();
     jobMock = newJobRepositoryMock();
     personMock = newPersonRepositoryMock();
-    sut = new JobService(assetMock, eventMock, jobMock, configMock, personMock);
+    metricMock = newMetricRepositoryMock();
+    sut = new JobService(assetMock, eventMock, jobMock, configMock, personMock, metricMock);
   });
 
   it('should work', () => {

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { snakeCase } from 'lodash';
-import { MetricService } from 'nestjs-otel';
 import { FeatureFlag, SystemConfigCore } from 'src/cores/system-config.core';
 import { mapAsset } from 'src/dtos/asset-response.dto';
 import { AllJobStatusResponseDto, JobCommandDto, JobStatusDto } from 'src/dtos/job.dto';

--- a/server/src/utils/instrumentation.ts
+++ b/server/src/utils/instrumentation.ts
@@ -17,12 +17,16 @@ import { excludePaths, serverVersion } from 'src/constants';
 import { DecorateAll } from 'src/decorators';
 
 let metricsEnabled = process.env.IMMICH_METRICS === 'true';
-const hostMetrics =
+export const hostMetrics =
   process.env.IMMICH_HOST_METRICS == null ? metricsEnabled : process.env.IMMICH_HOST_METRICS === 'true';
-const apiMetrics = process.env.IMMICH_API_METRICS == null ? metricsEnabled : process.env.IMMICH_API_METRICS === 'true';
-const repoMetrics = process.env.IMMICH_IO_METRICS == null ? metricsEnabled : process.env.IMMICH_IO_METRICS === 'true';
+export const apiMetrics =
+  process.env.IMMICH_API_METRICS == null ? metricsEnabled : process.env.IMMICH_API_METRICS === 'true';
+export const repoMetrics =
+  process.env.IMMICH_IO_METRICS == null ? metricsEnabled : process.env.IMMICH_IO_METRICS === 'true';
+export const jobMetrics =
+  process.env.IMMICH_JOB_METRICS == null ? metricsEnabled : process.env.IMMICH_JOB_METRICS === 'true';
 
-metricsEnabled ||= hostMetrics || apiMetrics || repoMetrics;
+metricsEnabled ||= hostMetrics || apiMetrics || repoMetrics || jobMetrics;
 if (!metricsEnabled && process.env.OTEL_SDK_DISABLED === undefined) {
   process.env.OTEL_SDK_DISABLED = 'true';
 }

--- a/server/test/repositories/metric.repository.mock.ts
+++ b/server/test/repositories/metric.repository.mock.ts
@@ -1,0 +1,9 @@
+import { IMetricRepository } from 'src/interfaces/metric.interface';
+
+export const newMetricRepositoryMock = (): jest.Mocked<IMetricRepository> => {
+  return {
+    addToCounter: jest.fn(),
+    updateGauge: jest.fn(),
+    updateHistogram: jest.fn(),
+  };
+};


### PR DESCRIPTION
## Description

This PR adds observability for jobs and queues. Specifically, it tracks job successes, skips and failures as well as the current number of active jobs in each queue. This is implemented in the job service through a new metric repository.

## How Has This Been Tested?

Tested that the active jobs in the queue show up in Prometheus and respond to changes in concurrency.

![thumbnail-generation-active](https://github.com/immich-app/immich/assets/101130780/35b20223-2418-48b2-9e2a-002f47d1edf1)
