### PR TITLE
fix(server): places page not working with partner sharing

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -278,7 +278,7 @@ WITH RECURSIVE
         exif
         INNER JOIN assets ON exif."assetId" = assets.id
       WHERE
-        "ownerId" IN ($1)
+        "ownerId" = ANY ('$1'::uuid [])
         AND "isVisible" = $2
         AND "isArchived" = $3
         AND type = $4
@@ -302,7 +302,7 @@ WITH RECURSIVE
           INNER JOIN assets ON exif."assetId" = assets.id
         WHERE
           city > c.city
-          AND "ownerId" IN ($1)
+          AND "ownerId" = ANY ('$1'::uuid [])
           AND "isVisible" = $2
           AND "isArchived" = $3
           AND type = $4

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -227,7 +227,7 @@ export class SearchRepository implements ISearchRepository {
 
   @GenerateSql({ params: [[DummyValue.UUID]] })
   async getAssetsByCity(userIds: string[]): Promise<AssetEntity[]> {
-    const parameters = [userIds.join(', '), true, false, AssetType.IMAGE];
+    const parameters = [userIds, true, false, AssetType.IMAGE];
     const rawRes = await this.repository.query(this.assetsByCityQuery, parameters);
 
     const items: AssetEntity[] = [];
@@ -315,7 +315,7 @@ WITH RECURSIVE cte AS (
     SELECT city, "assetId"
     FROM exif
     INNER JOIN assets ON exif."assetId" = assets.id
-    WHERE "ownerId" IN ($1) AND "isVisible" = $2 AND "isArchived" = $3 AND type = $4
+    WHERE "ownerId" = ANY('$1'::uuid[]) AND "isVisible" = $2 AND "isArchived" = $3 AND type = $4
     ORDER BY city
     LIMIT 1
   )
@@ -328,7 +328,7 @@ WITH RECURSIVE cte AS (
     SELECT city, "assetId"
     FROM exif
     INNER JOIN assets ON exif."assetId" = assets.id
-    WHERE city > c.city AND "ownerId" IN ($1) AND "isVisible" = $2 AND "isArchived" = $3 AND type = $4
+    WHERE city > c.city AND "ownerId" = ANY('$1'::uuid[]) AND "isVisible" = $2 AND "isArchived" = $3 AND type = $4
     ORDER BY city
     LIMIT 1
     ) l

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -225,7 +225,7 @@ export class SearchRepository implements ISearchRepository {
       .getMany();
   }
 
-  @GenerateSql({ params: [[DummyValue.UUID]] })
+  @GenerateSql({ params: [[DummyValue.UUID, DummyValue.UUID]] })
   async getAssetsByCity(userIds: string[]): Promise<AssetEntity[]> {
     const parameters = [userIds, true, false, AssetType.IMAGE];
     const rawRes = await this.repository.query(this.assetsByCityQuery, parameters);


### PR DESCRIPTION
## Description

The user IDs are concatenated for the query, but this doesn't work since they're interpreted as a single invalid UUID rather than multiple UUIDs (if it did work, it would imply SQL injection). This PR changes the query to allow the array of user IDs to be passed directly.

Fixes #8241


## How Has This Been Tested?

Tested that the query still works when visiting the Places page.