### PR TITLE
feat(web): better UX when creating a new album

### DIFF
--- a/web/src/lib/components/asset-viewer/album-list-item.svelte
+++ b/web/src/lib/components/asset-viewer/album-list-item.svelte
@@ -2,6 +2,7 @@
   import { getAssetThumbnailUrl } from '$lib/utils';
   import { ThumbnailFormat, type AlbumResponseDto } from '@immich/sdk';
   import { createEventDispatcher } from 'svelte';
+  import { normalizeSearchString } from '$lib/utils/string-utils.js';
 
   const dispatch = createEventDispatcher<{
     album: void;
@@ -16,7 +17,7 @@
   // It is used to highlight the search query in the album name
   $: {
     let { albumName } = album;
-    let findIndex = albumName.toLowerCase().indexOf(searchQuery.toLowerCase());
+    let findIndex = normalizeSearchString(albumName).indexOf(normalizeSearchString(searchQuery));
     let findLength = searchQuery.length;
     albumNameArray = [
       albumName.slice(0, findIndex),

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import Icon from '$lib/components/elements/icon.svelte';
-  import { AppRoute, AssetAction, ProjectionType } from '$lib/constants';
+  import { AssetAction, ProjectionType } from '$lib/constants';
   import { updateNumberOfComments } from '$lib/stores/activity.store';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import type { AssetStore } from '$lib/stores/assets.store';
@@ -11,7 +10,7 @@
   import { stackAssetsStore } from '$lib/stores/stacked-asset.store';
   import { user } from '$lib/stores/user.store';
   import { getAssetJobMessage, isSharedLink, handlePromiseError } from '$lib/utils';
-  import { addAssetsToAlbum, downloadFile } from '$lib/utils/asset-utils';
+  import { addAssetsToAlbum, addAssetsToNewAlbum, downloadFile } from '$lib/utils/asset-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { shortcuts } from '$lib/utils/shortcut';
   import { SlideshowHistory } from '$lib/utils/slideshow-history';
@@ -20,7 +19,6 @@
     AssetTypeEnum,
     ReactionType,
     createActivity,
-    createAlbum,
     deleteActivity,
     deleteAssets,
     getActivities,
@@ -390,8 +388,7 @@
   const handleAddToNewAlbum = async (albumName: string) => {
     isShowAlbumPicker = false;
 
-    const album = await createAlbum({ createAlbumDto: { albumName, assetIds: [asset.id] } });
-    await goto(`${AppRoute.ALBUMS}/${album.id}`);
+    await addAssetsToNewAlbum(albumName, [asset.id]);
   };
 
   const handleAddToAlbum = async (album: AlbumResponseDto) => {

--- a/web/src/lib/components/photos-page/actions/add-to-album.svelte
+++ b/web/src/lib/components/photos-page/actions/add-to-album.svelte
@@ -1,23 +1,15 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import AlbumSelectionModal from '$lib/components/shared-components/album-selection-modal.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
-  import {
-    NotificationType,
-    notificationController,
-  } from '$lib/components/shared-components/notification/notification';
-  import { AppRoute } from '$lib/constants';
-  import { addAssetsToAlbum } from '$lib/utils/asset-utils';
-  import { createAlbum, type AlbumResponseDto } from '@immich/sdk';
+  import { addAssetsToAlbum, addAssetsToNewAlbum } from '$lib/utils/asset-utils';
+  import type { AlbumResponseDto } from '@immich/sdk';
   import { getMenuContext } from '../asset-select-context-menu.svelte';
   import { getAssetControlContext } from '../asset-select-control-bar.svelte';
   import { mdiImageAlbum, mdiShareVariantOutline } from '@mdi/js';
-  import ConfirmDialogue from '$lib/components/shared-components/confirm-dialogue.svelte';
 
   export let shared = false;
 
   let showAlbumPicker = false;
-  let createdAlbum: AlbumResponseDto | null = null;
 
   const { getAssets, clearSelect } = getAssetControlContext();
   const closeMenu = getMenuContext();
@@ -29,33 +21,10 @@
 
   const handleAddToNewAlbum = async (albumName: string) => {
     showAlbumPicker = false;
+    closeMenu();
 
     const assetIds = [...getAssets()].map((asset) => asset.id);
-
-    try {
-      const album = await createAlbum({ createAlbumDto: { albumName, assetIds } });
-
-      notificationController.show({
-        message: `Added ${assetIds.length} to ${album.albumName}`,
-        type: NotificationType.Info,
-      });
-
-      createdAlbum = album;
-    } catch (error) {
-      console.error(`[add-to-album.svelte]:handleAddToNewAlbum ${error}`, error);
-    }
-  };
-
-  const goToNewAlbum = async () => {
-    clearSelect();
-    if (createdAlbum) {
-      await goto(`${AppRoute.ALBUMS}/${createdAlbum.id}`);
-    }
-  };
-
-  const closeNewAlbumDialog = () => {
-    createdAlbum = null;
-    clearSelect();
+    await addAssetsToNewAlbum(albumName, assetIds);
   };
 
   const handleAddToAlbum = async (album: AlbumResponseDto) => {
@@ -79,21 +48,4 @@
     on:album={({ detail }) => handleAddToAlbum(detail)}
     on:close={handleHideAlbumPicker}
   />
-{/if}
-
-{#if createdAlbum}
-  <ConfirmDialogue
-    title="Album Created"
-    confirmText="Go To Album"
-    confirmColor="primary"
-    cancelText="Stay Here"
-    cancelColor="secondary"
-    onConfirm={() => goToNewAlbum()}
-    onClose={() => closeNewAlbumDialog()}
-  >
-    <svelte:fragment slot="prompt">
-      <p>The album <b>{createdAlbum.albumName}</b> has been created.</p>
-      <p>What would you like to do?</p>
-    </svelte:fragment>
-  </ConfirmDialogue>
 {/if}

--- a/web/src/lib/components/shared-components/album-selection-modal.svelte
+++ b/web/src/lib/components/shared-components/album-selection-modal.svelte
@@ -5,6 +5,7 @@
   import { createEventDispatcher, onMount } from 'svelte';
   import AlbumListItem from '../asset-viewer/album-list-item.svelte';
   import BaseModal from './base-modal.svelte';
+  import { normalizeSearchString } from '$lib/utils/string-utils';
 
   let albums: AlbumResponseDto[] = [];
   let recentAlbums: AlbumResponseDto[] = [];
@@ -30,7 +31,7 @@
     filteredAlbums =
       search.length > 0 && albums.length > 0
         ? albums.filter((album) => {
-            return album.albumName.toLowerCase().includes(search.toLowerCase());
+            return normalizeSearchString(album.albumName).includes(normalizeSearchString(search));
           })
         : albums;
   }
@@ -84,7 +85,7 @@
             <Icon path={mdiPlus} size="30" />
           </div>
           <p class="">
-            New {shared ? 'Shared ' : ''}Album {#if search.length > 0}<b>{search}</b>{/if}
+            New Album {#if search.length > 0}<b>{search}</b>{/if}
           </p>
         </button>
         {#if filteredAlbums.length > 0}

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -98,7 +98,12 @@
   </div>
 
   <p class="whitespace-pre-wrap pl-[28px] pr-[16px] text-sm" data-testid="message">
-    {notification.message}
+    {#if notification.html}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+      {@html notification.message}
+    {:else}
+      {notification.message}
+    {/if}
   </p>
 
   {#if button}

--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -2,20 +2,17 @@
   import { fade } from 'svelte/transition';
   import Icon from '$lib/components/elements/icon.svelte';
   import {
-    type LinkAction,
     type Notification,
     notificationController,
     NotificationType,
   } from '$lib/components/shared-components/notification/notification';
   import { onMount } from 'svelte';
   import { mdiCloseCircleOutline, mdiInformationOutline, mdiWindowClose } from '@mdi/js';
-  import { goto } from '$app/navigation';
 
   export let notification: Notification;
 
   $: icon = notification.type === NotificationType.Error ? mdiCloseCircleOutline : mdiInformationOutline;
-
-  $: button = notification.action?.type === 'link' && notification.action.button ? notification.action.button : null;
+  $: hoverStyle = notification.action.type === 'discard' ? 'hover:cursor-pointer' : '';
 
   const backgroundColor: Record<NotificationType, string> = {
     [NotificationType.Info]: '#E0E2F0',
@@ -50,28 +47,17 @@
     notificationController.removeNotificationById(notification.id);
   };
 
-  const handleClick = async () => {
-    const action = notification.action;
-    if (action.type === 'discard') {
+  const handleClick = () => {
+    if (notification.action.type === 'discard') {
       discard();
-    } else if (action.type == 'link' && !action.button) {
-      await goToLink(action);
     }
   };
 
-  const handleButtonClick = async () => {
-    const action = notification.action;
-    if (action.type === 'link') {
-      await goToLink(action);
-    }
-  };
-
-  const goToLink = async (action: LinkAction) => {
-    if (action.newTab) {
-      window.open(action.target);
-    } else {
+  const handleButtonClick = () => {
+    const button = notification.button;
+    if (button) {
       discard();
-      await goto(action.target);
+      return notification.button?.onClick();
     }
   };
 </script>
@@ -81,7 +67,7 @@
   transition:fade={{ duration: 250 }}
   style:background-color={backgroundColor[notification.type]}
   style:border-color={borderColor[notification.type]}
-  class="border z-[999999] mb-4 min-h-[80px] w-[300px] rounded-2xl p-4 shadow-md {button ? '' : 'hover:cursor-pointer'}"
+  class="border z-[999999] mb-4 min-h-[80px] w-[300px] rounded-2xl p-4 shadow-md {hoverStyle}"
   on:click={handleClick}
   on:keydown={handleClick}
 >
@@ -106,13 +92,13 @@
     {/if}
   </p>
 
-  {#if button}
+  {#if notification.button}
     <p class="pl-[28px] mt-2.5 text-sm">
       <button
         class="{buttonStyle[notification.type]} rounded px-3 pt-1.5 pb-1 transition-all duration-200"
         on:click={handleButtonClick}
       >
-        {button}
+        {notification.button.text}
       </button>
     </p>
   {/if}

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -30,13 +30,6 @@ export type Notification = {
 type DiscardAction = { type: 'discard' };
 type NoopAction = { type: 'noop' };
 
-export type LinkAction = {
-  type: 'link';
-  target: string;
-  newTab?: boolean;
-  button?: string;
-};
-
 export type NotificationAction = DiscardAction | NoopAction;
 
 export type NotificationOptions = Partial<Exclude<Notification, 'id'>> & { message: string };

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -18,7 +18,14 @@ export type Notification = {
 
 type DiscardAction = { type: 'discard' };
 type NoopAction = { type: 'noop' };
-type LinkAction = { type: 'link'; target: string };
+
+export type LinkAction = {
+  type: 'link';
+  target: string;
+  newTab?: boolean;
+  button?: string;
+};
+
 export type NotificationAction = DiscardAction | NoopAction | LinkAction;
 
 export type NotificationOptions = Partial<Exclude<Notification, 'id'>> & { message: string };

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -10,6 +10,11 @@ export type Notification = {
   id: number;
   type: NotificationType;
   message: string;
+  /**
+   * Allow HTML to be inserted within the message. Make sure to verify/encode
+   * variables that may be interpoalted into 'message'
+   */
+  html?: boolean;
   /** The action to take when the notification is clicked */
   action: NotificationAction;
   /** Timeout in miliseconds */

--- a/web/src/lib/components/shared-components/notification/notification.ts
+++ b/web/src/lib/components/shared-components/notification/notification.ts
@@ -6,6 +6,11 @@ export enum NotificationType {
   Warning = 'Warning',
 }
 
+export type NotificationButton = {
+  text: string;
+  onClick: () => unknown;
+};
+
 export type Notification = {
   id: number;
   type: NotificationType;
@@ -17,6 +22,7 @@ export type Notification = {
   html?: boolean;
   /** The action to take when the notification is clicked */
   action: NotificationAction;
+  button?: NotificationButton;
   /** Timeout in miliseconds */
   timeout: number;
 };
@@ -31,7 +37,7 @@ export type LinkAction = {
   button?: string;
 };
 
-export type NotificationAction = DiscardAction | NoopAction | LinkAction;
+export type NotificationAction = DiscardAction | NoopAction;
 
 export type NotificationOptions = Partial<Exclude<Notification, 'id'>> & { message: string };
 
@@ -44,7 +50,9 @@ function createNotificationList() {
       currentList.push({
         id: count++,
         type: NotificationType.Info,
-        action: { type: 'discard' },
+        action: {
+          type: options.button ? 'noop' : 'discard',
+        },
         timeout: 3000,
         ...options,
       });

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -38,7 +38,7 @@ export const addAssetsToAlbum = async (albumId: string, assetIds: string[]) => {
         : `Asset${assetIds.length === 1 ? ' was' : 's were'} already part of the album`,
     action: {
       type: 'link',
-      button: 'Show Album',
+      button: 'View Album',
       target: `${AppRoute.ALBUMS}/${albumId}`,
     },
   });
@@ -60,7 +60,7 @@ export const addAssetsToNewAlbum = async (albumName: string, assetIds: string[])
       html: true,
       action: {
         type: 'link',
-        button: 'Show Album',
+        button: 'View Album',
         target: `${AppRoute.ALBUMS}/${album.id}`,
       },
     });

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -1,3 +1,4 @@
+import { goto } from '$app/navigation';
 import { NotificationType, notificationController } from '$lib/components/shared-components/notification/notification';
 import { AppRoute } from '$lib/constants';
 import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
@@ -36,10 +37,11 @@ export const addAssetsToAlbum = async (albumId: string, assetIds: string[]) => {
       count > 0
         ? `Added ${count} asset${count === 1 ? '' : 's'} to the album`
         : `Asset${assetIds.length === 1 ? ' was' : 's were'} already part of the album`,
-    action: {
-      type: 'link',
-      button: 'View Album',
-      target: `${AppRoute.ALBUMS}/${albumId}`,
+    button: {
+      text: 'View Album',
+      onClick() {
+        return goto(`${AppRoute.ALBUMS}/${albumId}`);
+      },
     },
   });
 };
@@ -58,10 +60,11 @@ export const addAssetsToNewAlbum = async (albumName: string, assetIds: string[])
       timeout: 5000,
       message: `Added ${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} to ${displayName}`,
       html: true,
-      action: {
-        type: 'link',
-        button: 'View Album',
-        target: `${AppRoute.ALBUMS}/${album.id}`,
+      button: {
+        text: 'View Album',
+        onClick() {
+          return goto(`${AppRoute.ALBUMS}/${album.id}`);
+        },
       },
     });
     return album;

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -4,6 +4,7 @@ import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store'
 import { BucketPosition, isSelectingAllAssets, type AssetStore } from '$lib/stores/assets.store';
 import { downloadManager } from '$lib/stores/download';
 import { downloadRequest, getKey } from '$lib/utils';
+import { encodeHTMLSpecialChars } from '$lib/utils/string-utils';
 import {
   addAssetsToAlbum as addAssets,
   createAlbum,
@@ -51,10 +52,12 @@ export const addAssetsToNewAlbum = async (albumName: string, assetIds: string[])
         assetIds,
       },
     });
+    const displayName = albumName ? `<b>${encodeHTMLSpecialChars(albumName)}</b>` : 'new album';
     notificationController.show({
       type: NotificationType.Info,
       timeout: 5000,
-      message: `Added ${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} to new album`,
+      message: `Added ${assetIds.length} asset${assetIds.length === 1 ? '' : 's'} to ${displayName}`,
+      html: true,
       action: {
         type: 'link',
         button: 'Show Album',

--- a/web/src/lib/utils/string-utils.ts
+++ b/web/src/lib/utils/string-utils.ts
@@ -5,3 +5,12 @@ export const removeAccents = (str: string) => {
 export const normalizeSearchString = (str: string) => {
   return removeAccents(str.toLocaleLowerCase());
 };
+
+export const encodeHTMLSpecialChars = (str: string) => {
+  return str
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+};

--- a/web/src/lib/utils/string-utils.ts
+++ b/web/src/lib/utils/string-utils.ts
@@ -1,0 +1,7 @@
+export const removeAccents = (str: string) => {
+  return str.normalize('NFD').replaceAll(/[\u0300-\u036F]/g, '');
+};
+
+export const normalizeSearchString = (str: string) => {
+  return removeAccents(str.toLocaleLowerCase());
+};


### PR DESCRIPTION
This PR fixes something if find annoying:

Imagine you are sorting your thousands of photos into albums. You select `Add to... > Album`, then using the modal, you create a new album. You will be redirected to this album without being prompted. Now you have to go back and find yourself at the top of the "Photos" page, and have scroll again thousands of photos to where you previously were.

To fix this, a notification is now sent when adding assets to a new album, with a "View Album" button:

![ViewAlbum](https://github.com/immich-app/immich/assets/9944639/16901ab6-48d0-4922-9003-7cbb6cb0ad23)

I also updated the search function to ignore accents:

![SearchAccents](https://github.com/immich-app/immich/assets/9944639/2cfb1321-79c5-4a05-992b-640f9edfd48b)
