### PR TITLE
feat(docs): removed deprecated version line in docker compose files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,8 +2,6 @@
 # - https://immich.app/docs/developer/setup
 # - https://immich.app/docs/developer/troubleshooting
 
-version: '3.8'
-
 name: immich-dev
 
 x-server-build: &server-common

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 name: immich-prod
 
 x-server-build: &server-common

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 #
 # WARNING: Make sure to use the docker-compose.yml of the current release:
 #


### PR DESCRIPTION
This PR removes the ``version: '3.8'`` lines in all docker-compose files.

It also removes this warning message shown in the console.
![image](https://github.com/immich-app/immich/assets/65036298/8e844f4c-ddeb-4989-af0e-30d9fd623417)


Closes #8256 

More information can be found here: https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md
And here: https://github.com/mailcow/mailcow-dockerized/issues/5797