### PR TITLE
refactor(server): metric repo

### DIFF
--- a/server/src/interfaces/metric.interface.ts
+++ b/server/src/interfaces/metric.interface.ts
@@ -10,7 +10,7 @@ export interface IMetricGroupRepository {
   addToCounter(name: string, value: number, options?: MetricOptions): void;
   addToGauge(name: string, value: number, options?: MetricOptions): void;
   addToHistogram(name: string, value: number, options?: MetricOptions): void;
-  configure(options: MetricGroupOptions): void;
+  configure(options: MetricGroupOptions): this;
 }
 
 export interface IMetricRepository {

--- a/server/src/interfaces/metric.interface.ts
+++ b/server/src/interfaces/metric.interface.ts
@@ -1,13 +1,21 @@
 import { MetricOptions } from '@opentelemetry/api';
 
-export interface CustomMetricOptions extends MetricOptions {
-  enabled?: boolean;
-}
-
 export const IMetricRepository = 'IMetricRepository';
 
+export interface MetricGroupOptions {
+  enabled: boolean;
+}
+
+export interface IMetricGroupRepository {
+  addToCounter(name: string, value: number, options?: MetricOptions): void;
+  addToGauge(name: string, value: number, options?: MetricOptions): void;
+  addToHistogram(name: string, value: number, options?: MetricOptions): void;
+  configure(options: MetricGroupOptions): void;
+}
+
 export interface IMetricRepository {
-  addToCounter(name: string, value: number, options?: CustomMetricOptions): void;
-  updateGauge(name: string, value: number, options?: CustomMetricOptions): void;
-  updateHistogram(name: string, value: number, options?: CustomMetricOptions): void;
+  api: IMetricGroupRepository;
+  host: IMetricGroupRepository;
+  jobs: IMetricGroupRepository;
+  repo: IMetricGroupRepository;
 }

--- a/server/src/repositories/metric.repository.ts
+++ b/server/src/repositories/metric.repository.ts
@@ -1,31 +1,75 @@
-import { Inject } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { MetricOptions } from '@opentelemetry/api';
 import { MetricService } from 'nestjs-otel';
-import { CustomMetricOptions, IMetricRepository } from 'src/interfaces/metric.interface';
+import { IMetricGroupRepository, IMetricRepository, MetricGroupOptions } from 'src/interfaces/metric.interface';
+import { apiMetrics, hostMetrics, jobMetrics, repoMetrics } from 'src/utils/instrumentation';
 
+class MetricGroupRepository implements IMetricGroupRepository {
+  private enabled = false;
+  constructor(private readonly metricService: MetricService) {}
+
+  addToCounter(name: string, value: number, options?: MetricOptions): void {
+    if (this.enabled) {
+      this.metricService.getCounter(name, options).add(value);
+    }
+  }
+
+  addToGauge(name: string, value: number, options?: MetricOptions): void {
+    if (this.enabled) {
+      this.metricService.getUpDownCounter(name, options).add(value);
+    }
+  }
+
+  addToHistogram(name: string, value: number, options?: MetricOptions): void {
+    if (this.enabled) {
+      this.metricService.getHistogram(name, options).record(value);
+    }
+  }
+
+  configure(options: MetricGroupOptions): void {
+    this.enabled = options.enabled;
+  }
+}
+
+class ApiMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+  constructor(metricService: MetricService) {
+    super(metricService);
+    this.configure({ enabled: apiMetrics });
+  }
+}
+
+class HostMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+  constructor(metricService: MetricService) {
+    super(metricService);
+    this.configure({ enabled: hostMetrics });
+  }
+}
+
+class JobMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+  constructor(metricService: MetricService) {
+    super(metricService);
+    this.configure({ enabled: jobMetrics });
+  }
+}
+
+class RepoMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+  constructor(metricService: MetricService) {
+    super(metricService);
+    this.configure({ enabled: repoMetrics });
+  }
+}
+
+@Injectable()
 export class MetricRepository implements IMetricRepository {
-  constructor(@Inject(MetricService) private readonly metricService: MetricService) {}
+  api: ApiMetricRepository;
+  host: HostMetricRepository;
+  jobs: JobMetricRepository;
+  repo: RepoMetricRepository;
 
-  addToCounter(name: string, value: number, options?: CustomMetricOptions): void {
-    if (options?.enabled === false) {
-      return;
-    }
-
-    this.metricService.getCounter(name, options).add(value);
-  }
-
-  updateGauge(name: string, value: number, options?: CustomMetricOptions): void {
-    if (options?.enabled === false) {
-      return;
-    }
-
-    this.metricService.getUpDownCounter(name, options).add(value);
-  }
-
-  updateHistogram(name: string, value: number, options?: CustomMetricOptions): void {
-    if (options?.enabled === false) {
-      return;
-    }
-
-    this.metricService.getHistogram(name, options).record(value);
+  constructor(metricService: MetricService) {
+    this.api = new ApiMetricRepository(metricService);
+    this.host = new HostMetricRepository(metricService);
+    this.jobs = new JobMetricRepository(metricService);
+    this.repo = new RepoMetricRepository(metricService);
   }
 }

--- a/server/src/repositories/metric.repository.ts
+++ b/server/src/repositories/metric.repository.ts
@@ -31,28 +31,28 @@ class MetricGroupRepository implements IMetricGroupRepository {
   }
 }
 
-class ApiMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+class ApiMetricRepository extends MetricGroupRepository {
   constructor(metricService: MetricService) {
     super(metricService);
     this.configure({ enabled: apiMetrics });
   }
 }
 
-class HostMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+class HostMetricRepository extends MetricGroupRepository {
   constructor(metricService: MetricService) {
     super(metricService);
     this.configure({ enabled: hostMetrics });
   }
 }
 
-class JobMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+class JobMetricRepository extends MetricGroupRepository {
   constructor(metricService: MetricService) {
     super(metricService);
     this.configure({ enabled: jobMetrics });
   }
 }
 
-class RepoMetricRepository extends MetricGroupRepository implements IMetricGroupRepository {
+class RepoMetricRepository extends MetricGroupRepository {
   constructor(metricService: MetricService) {
     super(metricService);
     this.configure({ enabled: repoMetrics });

--- a/server/src/repositories/metric.repository.ts
+++ b/server/src/repositories/metric.repository.ts
@@ -26,50 +26,23 @@ class MetricGroupRepository implements IMetricGroupRepository {
     }
   }
 
-  configure(options: MetricGroupOptions): void {
+  configure(options: MetricGroupOptions): this {
     this.enabled = options.enabled;
-  }
-}
-
-class ApiMetricRepository extends MetricGroupRepository {
-  constructor(metricService: MetricService) {
-    super(metricService);
-    this.configure({ enabled: apiMetrics });
-  }
-}
-
-class HostMetricRepository extends MetricGroupRepository {
-  constructor(metricService: MetricService) {
-    super(metricService);
-    this.configure({ enabled: hostMetrics });
-  }
-}
-
-class JobMetricRepository extends MetricGroupRepository {
-  constructor(metricService: MetricService) {
-    super(metricService);
-    this.configure({ enabled: jobMetrics });
-  }
-}
-
-class RepoMetricRepository extends MetricGroupRepository {
-  constructor(metricService: MetricService) {
-    super(metricService);
-    this.configure({ enabled: repoMetrics });
+    return this;
   }
 }
 
 @Injectable()
 export class MetricRepository implements IMetricRepository {
-  api: ApiMetricRepository;
-  host: HostMetricRepository;
-  jobs: JobMetricRepository;
-  repo: RepoMetricRepository;
+  api: MetricGroupRepository;
+  host: MetricGroupRepository;
+  jobs: MetricGroupRepository;
+  repo: MetricGroupRepository;
 
   constructor(metricService: MetricService) {
-    this.api = new ApiMetricRepository(metricService);
-    this.host = new HostMetricRepository(metricService);
-    this.jobs = new JobMetricRepository(metricService);
-    this.repo = new RepoMetricRepository(metricService);
+    this.api = new MetricGroupRepository(metricService).configure({ enabled: apiMetrics });
+    this.host = new MetricGroupRepository(metricService).configure({ enabled: hostMetrics });
+    this.jobs = new MetricGroupRepository(metricService).configure({ enabled: jobMetrics });
+    this.repo = new MetricGroupRepository(metricService).configure({ enabled: repoMetrics });
   }
 }

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -96,7 +96,7 @@ export class JobService {
       throw new BadRequestException(`Job is already running`);
     }
 
-    this.metricRepository.addToCounter(`immich.queues.${snakeCase(name)}.started`, 1), { enabled: jobMetrics };
+    this.metricRepository.jobs.addToCounter(`immich.queues.${snakeCase(name)}.started`, 1), { enabled: jobMetrics };
 
     switch (name) {
       case QueueName.VIDEO_CONVERSION: {
@@ -163,20 +163,20 @@ export class JobService {
         const { name, data } = item;
 
         const queueMetric = `immich.queues.${snakeCase(queueName)}.active`;
-        this.metricRepository.updateGauge(queueMetric, 1, { enabled: jobMetrics });
+        this.metricRepository.jobs.addToGauge(queueMetric, 1);
 
         try {
           const handler = jobHandlers[name];
           const status = await handler(data);
           const jobMetric = `immich.jobs.${name.replaceAll('-', '_')}.${status}`;
-          this.metricRepository.addToCounter(jobMetric, 1, { enabled: jobMetrics });
+          this.metricRepository.jobs.addToCounter(jobMetric, 1);
           if (status === JobStatus.SUCCESS || status == JobStatus.SKIPPED) {
             await this.onDone(item);
           }
         } catch (error: Error | any) {
           this.logger.error(`Unable to run job handler (${queueName}/${name}): ${error}`, error?.stack, data);
         } finally {
-          this.metricRepository.updateGauge(queueMetric, -1, { enabled: jobMetrics });
+          this.metricRepository.jobs.addToGauge(queueMetric, -1);
         }
       });
     }

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -20,7 +20,6 @@ import {
 import { IMetricRepository } from 'src/interfaces/metric.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
 import { ISystemConfigRepository } from 'src/interfaces/system-config.interface';
-import { jobMetrics } from 'src/utils/instrumentation';
 import { ImmichLogger } from 'src/utils/logger';
 
 @Injectable()

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -96,7 +96,7 @@ export class JobService {
       throw new BadRequestException(`Job is already running`);
     }
 
-    this.metricRepository.jobs.addToCounter(`immich.queues.${snakeCase(name)}.started`, 1), { enabled: jobMetrics };
+    this.metricRepository.jobs.addToCounter(`immich.queues.${snakeCase(name)}.started`, 1);
 
     switch (name) {
       case QueueName.VIDEO_CONVERSION: {

--- a/server/test/repositories/metric.repository.mock.ts
+++ b/server/test/repositories/metric.repository.mock.ts
@@ -2,8 +2,29 @@ import { IMetricRepository } from 'src/interfaces/metric.interface';
 
 export const newMetricRepositoryMock = (): jest.Mocked<IMetricRepository> => {
   return {
-    addToCounter: jest.fn(),
-    updateGauge: jest.fn(),
-    updateHistogram: jest.fn(),
+    api: {
+      addToCounter: jest.fn(),
+      addToGauge: jest.fn(),
+      addToHistogram: jest.fn(),
+      configure: jest.fn(),
+    },
+    host: {
+      addToCounter: jest.fn(),
+      addToGauge: jest.fn(),
+      addToHistogram: jest.fn(),
+      configure: jest.fn(),
+    },
+    jobs: {
+      addToCounter: jest.fn(),
+      addToGauge: jest.fn(),
+      addToHistogram: jest.fn(),
+      configure: jest.fn(),
+    },
+    repo: {
+      addToCounter: jest.fn(),
+      addToGauge: jest.fn(),
+      addToHistogram: jest.fn(),
+      configure: jest.fn(),
+    },
   };
 };


### PR DESCRIPTION
## Description

This PR changes the metric repo to work more like the access repo, faceted across several metric groups. This is cleaner and moves ownership of enabling/disabling metrics to the repo rather than the caller.