### PR TITLE
fix(docs): fix path in readme files

### DIFF
--- a/readme_i18n/README_ca_ES.md
+++ b/readme_i18n/README_ca_ES.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Iniciar sessió amb URL personalitzada">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Iniciar sessió amb URL personalitzada">
 </p>
 <h3 align="center">Immich - Solució de còpia de seguretat d'alta rendiment per a fotos i vídeos auto-allotjada</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Captura de pantalla principal">
+<img src="../design/immich-screenshots.png" title="Captura de pantalla principal">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_de_DE.md
+++ b/readme_i18n/README_de_DE.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login mit eigener URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login mit eigener URL">
 </p>
 <h3 align="center">Immich - Hoch performante, selbst gehostete Backup-Lösung für Fotos und Videos</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Haupt-Screenshot">
+<img src="../design/immich-screenshots.png" title="Haupt-Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_es_ES.md
+++ b/readme_i18n/README_es_ES.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Iniciar sesión con URL personalizada">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Iniciar sesión con URL personalizada">
 </p>
 <h3 align="center">Immich: Una solución Self-Hosted de copia de seguridad de fotos y videos de alto rendimiento</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Captura de pantalla principal">
+<img src="../design/immich-screenshots.png" title="Captura de pantalla principal">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_fr_FR.md
+++ b/readme_i18n/README_fr_FR.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - Solution de sauvegarde performante et auto-hébergée des photos et des vidéos</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_it_IT.md
+++ b/readme_i18n/README_it_IT.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - Soluzione self-hosted ad alte prestazioni per backup di foto e video</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_ja_JP.md
+++ b/readme_i18n/README_ja_JP.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - 高性能なセルフホスト 写真/ビデオバックアップソリューション</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_ko_KR.md
+++ b/readme_i18n/README_ko_KR.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - 고성능 자체 호스팅 사진 및 동영상 백업 솔루션</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_nl_NL.md
+++ b/readme_i18n/README_nl_NL.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login met aangepaste URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login met aangepaste URL">
 </p>
 <h3 align="center">Immich - Hoogwaardige, self-hosted back-up oplossing voor foto's en video's</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_ru_RU.md
+++ b/readme_i18n/README_ru_RU.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - Высокопроизводительное решение для автономоного создания фото и видео архивов</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">

--- a/readme_i18n/README_tr_TR.md
+++ b/readme_i18n/README_tr_TR.md
@@ -9,12 +9,12 @@
 </p>
 
 <p align="center">
-<img src="design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
+<img src="../design/immich-logo-stacked-light.svg" width="300" title="Login With Custom URL">
 </p>
 <h3 align="center">Immich - Yüksek performanslı, kendine ait barındırılan fotoğraf ve video yedekleme çözümü</h3>
 <br/>
 <a href="https://immich.app">
-<img src="design/immich-screenshots.png" title="Main Screenshot">
+<img src="../design/immich-screenshots.png" title="Main Screenshot">
 </a>
 <br/>
 <p align="center">


### PR DESCRIPTION
Fixes the Immich logo in the translated readme files.

Before:
![image](https://github.com/immich-app/immich/assets/65036298/d49462ea-5386-4895-aad1-7a1deb092b91)

After:
![image](https://github.com/immich-app/immich/assets/65036298/69905b75-88ae-49af-818c-69779cd46176)