### PR TITLE
fix: memory lane assets in ascending order

### DIFF
--- a/mobile/openapi/doc/MemoryLaneResponseDto.md
+++ b/mobile/openapi/doc/MemoryLaneResponseDto.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **assets** | [**List<AssetResponseDto>**](AssetResponseDto.md) |  | [default to const []]
 **title** | **String** |  | 
-**years** | **num** |  | 
+**yearsAgo** | **num** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/doc/MemoryLaneResponseDto.md
+++ b/mobile/openapi/doc/MemoryLaneResponseDto.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **assets** | [**List<AssetResponseDto>**](AssetResponseDto.md) |  | [default to const []]
 **title** | **String** |  | 
+**years** | **num** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/memory_lane_response_dto.dart
+++ b/mobile/openapi/lib/model/memory_lane_response_dto.dart
@@ -15,30 +15,36 @@ class MemoryLaneResponseDto {
   MemoryLaneResponseDto({
     this.assets = const [],
     required this.title,
+    required this.years,
   });
 
   List<AssetResponseDto> assets;
 
   String title;
 
+  num years;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is MemoryLaneResponseDto &&
     _deepEquality.equals(other.assets, assets) &&
-    other.title == title;
+    other.title == title &&
+    other.years == years;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (assets.hashCode) +
-    (title.hashCode);
+    (title.hashCode) +
+    (years.hashCode);
 
   @override
-  String toString() => 'MemoryLaneResponseDto[assets=$assets, title=$title]';
+  String toString() => 'MemoryLaneResponseDto[assets=$assets, title=$title, years=$years]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'assets'] = this.assets;
       json[r'title'] = this.title;
+      json[r'years'] = this.years;
     return json;
   }
 
@@ -52,6 +58,7 @@ class MemoryLaneResponseDto {
       return MemoryLaneResponseDto(
         assets: AssetResponseDto.listFromJson(json[r'assets']),
         title: mapValueOfType<String>(json, r'title')!,
+        years: num.parse('${json[r'years']}'),
       );
     }
     return null;
@@ -101,6 +108,7 @@ class MemoryLaneResponseDto {
   static const requiredKeys = <String>{
     'assets',
     'title',
+    'years',
   };
 }
 

--- a/mobile/openapi/lib/model/memory_lane_response_dto.dart
+++ b/mobile/openapi/lib/model/memory_lane_response_dto.dart
@@ -15,36 +15,36 @@ class MemoryLaneResponseDto {
   MemoryLaneResponseDto({
     this.assets = const [],
     required this.title,
-    required this.years,
+    required this.yearsAgo,
   });
 
   List<AssetResponseDto> assets;
 
   String title;
 
-  num years;
+  num yearsAgo;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is MemoryLaneResponseDto &&
     _deepEquality.equals(other.assets, assets) &&
     other.title == title &&
-    other.years == years;
+    other.yearsAgo == yearsAgo;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (assets.hashCode) +
     (title.hashCode) +
-    (years.hashCode);
+    (yearsAgo.hashCode);
 
   @override
-  String toString() => 'MemoryLaneResponseDto[assets=$assets, title=$title, years=$years]';
+  String toString() => 'MemoryLaneResponseDto[assets=$assets, title=$title, yearsAgo=$yearsAgo]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'assets'] = this.assets;
       json[r'title'] = this.title;
-      json[r'years'] = this.years;
+      json[r'yearsAgo'] = this.yearsAgo;
     return json;
   }
 
@@ -58,7 +58,7 @@ class MemoryLaneResponseDto {
       return MemoryLaneResponseDto(
         assets: AssetResponseDto.listFromJson(json[r'assets']),
         title: mapValueOfType<String>(json, r'title')!,
-        years: num.parse('${json[r'years']}'),
+        yearsAgo: num.parse('${json[r'yearsAgo']}'),
       );
     }
     return null;
@@ -108,7 +108,7 @@ class MemoryLaneResponseDto {
   static const requiredKeys = <String>{
     'assets',
     'title',
-    'years',
+    'yearsAgo',
   };
 }
 

--- a/mobile/openapi/test/memory_lane_response_dto_test.dart
+++ b/mobile/openapi/test/memory_lane_response_dto_test.dart
@@ -26,8 +26,8 @@ void main() {
       // TODO
     });
 
-    // num years
-    test('to test the property `years`', () async {
+    // num yearsAgo
+    test('to test the property `yearsAgo`', () async {
       // TODO
     });
 

--- a/mobile/openapi/test/memory_lane_response_dto_test.dart
+++ b/mobile/openapi/test/memory_lane_response_dto_test.dart
@@ -26,6 +26,11 @@ void main() {
       // TODO
     });
 
+    // num years
+    test('to test the property `years`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8427,12 +8427,17 @@
             "type": "array"
           },
           "title": {
+            "deprecated": true,
             "type": "string"
+          },
+          "years": {
+            "type": "number"
           }
         },
         "required": [
           "assets",
-          "title"
+          "title",
+          "years"
         ],
         "type": "object"
       },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8430,14 +8430,14 @@
             "deprecated": true,
             "type": "string"
           },
-          "years": {
+          "yearsAgo": {
             "type": "number"
           }
         },
         "required": [
           "assets",
           "title",
-          "years"
+          "yearsAgo"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -273,7 +273,7 @@ export type MapMarkerResponseDto = {
 export type MemoryLaneResponseDto = {
     assets: AssetResponseDto[];
     title: string;
-    years: number;
+    yearsAgo: number;
 };
 export type UpdateStackParentDto = {
     newParentId: string;

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -273,6 +273,7 @@ export type MapMarkerResponseDto = {
 export type MemoryLaneResponseDto = {
     assets: AssetResponseDto[];
     title: string;
+    years: number;
 };
 export type UpdateStackParentDto = {
     newParentId: string;

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -131,7 +131,9 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
 }
 
 export class MemoryLaneResponseDto {
+  @ApiProperty({ deprecated: true })
   title!: string;
+  years!: number;
   assets!: AssetResponseDto[];
 }
 

--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -133,7 +133,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
 export class MemoryLaneResponseDto {
   @ApiProperty({ deprecated: true })
   title!: string;
-  years!: number;
+  yearsAgo!: number;
   assets!: AssetResponseDto[];
 }
 

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -93,7 +93,7 @@ export class AssetRepository implements IAssetRepository {
         },
       )
       .leftJoinAndSelect('entity.exifInfo', 'exifInfo')
-      .orderBy('entity.localDateTime', 'DESC')
+      .orderBy('entity.localDateTime', 'ASC')
       .getMany();
   }
 

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -308,12 +308,16 @@ describe(AssetService.name, () => {
     });
 
     it('should set the title correctly', async () => {
+      const image1 = { ...assetStub.image, localDateTime: new Date(2023, 1, 15, 0, 0, 0) };
+      const image2 = { ...assetStub.image, localDateTime: new Date(2023, 1, 15, 1, 0, 0) };
+      const image3 = { ...assetStub.image, localDateTime: new Date(2015, 1, 15) };
+
       partnerMock.getAll.mockResolvedValue([]);
-      assetMock.getByDayOfYear.mockResolvedValue([assetStub.image, assetStub.imageFrom2015]);
+      assetMock.getByDayOfYear.mockResolvedValue([image1, image2, image3]);
 
       await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1 })).resolves.toEqual([
-        { title: '1 year since...', assets: [mapAsset(assetStub.image)] },
-        { title: '9 years since...', assets: [mapAsset(assetStub.imageFrom2015)] },
+        { title: '1 year since...', assets: [mapAsset(image1), mapAsset(image2)] },
+        { title: '9 years since...', assets: [mapAsset(image3)] },
       ]);
 
       expect(assetMock.getByDayOfYear.mock.calls).toEqual([[[authStub.admin.user.id], { day: 15, month: 1 }]]);
@@ -321,6 +325,7 @@ describe(AssetService.name, () => {
 
     it('should get memories with partners with inTimeline enabled', async () => {
       partnerMock.getAll.mockResolvedValue([partnerStub.user1ToAdmin1]);
+      assetMock.getByDayOfYear.mockResolvedValue([]);
 
       await sut.getMemoryLane(authStub.admin, { day: 15, month: 1 });
 

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -316,8 +316,8 @@ describe(AssetService.name, () => {
       assetMock.getByDayOfYear.mockResolvedValue([image1, image2, image3]);
 
       await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1 })).resolves.toEqual([
-        { title: '1 year since...', assets: [mapAsset(image1), mapAsset(image2)] },
-        { title: '9 years since...', assets: [mapAsset(image3)] },
+        { years: 1, title: '1 year since...', assets: [mapAsset(image1), mapAsset(image2)] },
+        { years: 9, title: '9 years since...', assets: [mapAsset(image3)] },
       ]);
 
       expect(assetMock.getByDayOfYear.mock.calls).toEqual([[[authStub.admin.user.id], { day: 15, month: 1 }]]);

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -307,7 +307,7 @@ describe(AssetService.name, () => {
       jest.useRealTimers();
     });
 
-    it('should set the title correctly', async () => {
+    it('should group the assets correctly', async () => {
       const image1 = { ...assetStub.image, localDateTime: new Date(2023, 1, 15, 0, 0, 0) };
       const image2 = { ...assetStub.image, localDateTime: new Date(2023, 1, 15, 1, 0, 0) };
       const image3 = { ...assetStub.image, localDateTime: new Date(2015, 1, 15) };
@@ -316,8 +316,8 @@ describe(AssetService.name, () => {
       assetMock.getByDayOfYear.mockResolvedValue([image1, image2, image3]);
 
       await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1 })).resolves.toEqual([
-        { years: 1, title: '1 year since...', assets: [mapAsset(image1), mapAsset(image2)] },
-        { years: 9, title: '9 years since...', assets: [mapAsset(image3)] },
+        { yearsAgo: 1, title: '1 year since...', assets: [mapAsset(image1), mapAsset(image2)] },
+        { yearsAgo: 9, title: '9 years since...', assets: [mapAsset(image3)] },
       ]);
 
       expect(assetMock.getByDayOfYear.mock.calls).toEqual([[[authStub.admin.user.id], { day: 15, month: 1 }]]);

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -188,6 +188,8 @@ export class AssetService {
       .sort()
       .filter((years) => years > 0)
       .map((years) => ({
+        years,
+        // TODO move this to clients
         title: `${years} year${years > 1 ? 's' : ''} since...`,
         assets: groups[years].map((asset) => mapAsset(asset, { auth })),
       }));

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -176,22 +176,22 @@ export class AssetService {
     const assets = await this.assetRepository.getByDayOfYear(userIds, dto);
     const groups: Record<number, AssetEntity[]> = {};
     for (const asset of assets) {
-      const years = currentYear - asset.localDateTime.getFullYear();
-      if (!groups[years]) {
-        groups[years] = [];
+      const yearsAgo = currentYear - asset.localDateTime.getFullYear();
+      if (!groups[yearsAgo]) {
+        groups[yearsAgo] = [];
       }
-      groups[years].push(asset);
+      groups[yearsAgo].push(asset);
     }
 
     return Object.keys(groups)
       .map(Number)
       .sort()
-      .filter((years) => years > 0)
-      .map((years) => ({
-        years,
+      .filter((yearsAgo) => yearsAgo > 0)
+      .map((yearsAgo) => ({
+        yearsAgo,
         // TODO move this to clients
-        title: `${years} year${years > 1 ? 's' : ''} since...`,
-        assets: groups[years].map((asset) => mapAsset(asset, { auth })),
+        title: `${yearsAgo} year${yearsAgo > 1 ? 's' : ''} since...`,
+        assets: groups[yearsAgo].map((asset) => mapAsset(asset, { auth })),
       }));
   }
 

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -8,7 +8,7 @@
   import { AppRoute, QueryParameter } from '$lib/constants';
   import type { Viewport } from '$lib/stores/assets.store';
   import { memoryStore } from '$lib/stores/memory.store';
-  import { getAssetThumbnailUrl, handlePromiseError } from '$lib/utils';
+  import { getAssetThumbnailUrl, handlePromiseError, memoryLaneTitle } from '$lib/utils';
   import { shortcuts } from '$lib/utils/shortcut';
   import { fromLocalDateTime } from '$lib/utils/timeline-util';
   import { ThumbnailFormat, getMemoryLane } from '@immich/sdk';
@@ -102,7 +102,7 @@
     <ControlAppBar on:close={() => goto(AppRoute.PHOTOS)} forceDark>
       <svelte:fragment slot="leading">
         <p class="text-lg">
-          {currentMemory.title}
+          {memoryLaneTitle(currentMemory.yearsAgo)}
         </p>
       </svelte:fragment>
 
@@ -181,7 +181,7 @@
             {#if previousMemory}
               <div class="absolute bottom-4 right-4 text-left text-white">
                 <p class="text-xs font-semibold text-gray-200">PREVIOUS</p>
-                <p class="text-xl">{previousMemory.title}</p>
+                <p class="text-xl">{memoryLaneTitle(previousMemory.yearsAgo)}</p>
               </div>
             {/if}
           </button>
@@ -254,7 +254,7 @@
             {#if nextMemory}
               <div class="absolute bottom-4 left-4 text-left text-white">
                 <p class="text-xs font-semibold text-gray-200">UP NEXT</p>
-                <p class="text-xl">{nextMemory.title}</p>
+                <p class="text-xl">{memoryLaneTitle(nextMemory.yearsAgo)}</p>
               </div>
             {/if}
           </button>

--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -66,7 +66,7 @@
       </div>
     {/if}
     <div class="inline-block" bind:offsetWidth={innerWidth}>
-      {#each $memoryStore as memory, index (memory.title)}
+      {#each $memoryStore as memory, index (memory.years)}
         <button
           class="memory-card relative mr-8 inline-block aspect-video h-[215px] rounded-xl"
           on:click={() => goto(`${AppRoute.MEMORY}?${QueryParameter.MEMORY_INDEX}=${index}`)}
@@ -77,7 +77,10 @@
             alt={`Memory Lane ${getAltText(memory.assets[0])}`}
             draggable="false"
           />
-          <p class="absolute bottom-2 left-4 z-10 text-lg text-white">{memory.title}</p>
+          <p class="absolute bottom-2 left-4 z-10 text-lg text-white">
+            {memory.years}
+            {memory.years ? 'years' : 'year'} since...
+          </p>
           <div
             class="absolute left-0 top-0 z-0 h-full w-full rounded-xl bg-gradient-to-t from-black/40 via-transparent to-transparent transition-all hover:bg-black/20"
           />

--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -3,7 +3,7 @@
   import Icon from '$lib/components/elements/icon.svelte';
   import { AppRoute, QueryParameter } from '$lib/constants';
   import { memoryStore } from '$lib/stores/memory.store';
-  import { getAssetThumbnailUrl } from '$lib/utils';
+  import { getAssetThumbnailUrl, memoryLaneTitle } from '$lib/utils';
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { ThumbnailFormat, getMemoryLane } from '@immich/sdk';
   import { mdiChevronLeft, mdiChevronRight } from '@mdi/js';
@@ -66,7 +66,7 @@
       </div>
     {/if}
     <div class="inline-block" bind:offsetWidth={innerWidth}>
-      {#each $memoryStore as memory, index (memory.years)}
+      {#each $memoryStore as memory, index (memory.yearsAgo)}
         <button
           class="memory-card relative mr-8 inline-block aspect-video h-[215px] rounded-xl"
           on:click={() => goto(`${AppRoute.MEMORY}?${QueryParameter.MEMORY_INDEX}=${index}`)}
@@ -78,8 +78,7 @@
             draggable="false"
           />
           <p class="absolute bottom-2 left-4 z-10 text-lg text-white">
-            {memory.years}
-            {memory.years ? 'years' : 'year'} since...
+            {memoryLaneTitle(memory.yearsAgo)}
           </p>
           <div
             class="absolute left-0 top-0 z-0 h-full w-full rounded-xl bg-gradient-to-t from-black/40 via-transparent to-transparent transition-all hover:bg-black/20"

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -277,3 +277,5 @@ export const asyncTimeout = (ms: number) => {
 export const handlePromiseError = <T>(promise: Promise<T>): void => {
   promise.catch((error) => console.error(`[utils.ts]:handlePromiseError ${error}`, error));
 };
+
+export const memoryLaneTitle = (yearsAgo: number) => `${yearsAgo} ${yearsAgo ? 'years' : 'year'} since...`;


### PR DESCRIPTION
* fixes #8275 
* return assets in ascending order
* return groups in ascending order (1 year, 2 years, etc.)
* refactor group logic to use a map instead of lodash chaining (easier to read)
* map asset and generate year string as the last operation
* deprecate the `response.title` (client can do this using translations and `yearsAgo`)