### PR TITLE
fix(mobile): sync all album properties

### DIFF
--- a/mobile/lib/shared/models/album.dart
+++ b/mobile/lib/shared/models/album.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/models/store.dart';
 import 'package:immich_mobile/shared/models/user.dart';
+import 'package:immich_mobile/utils/datetime_comparison.dart';
 import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -72,21 +73,18 @@ class Album {
   @override
   bool operator ==(other) {
     if (other is! Album) return false;
-
-    final lastModifiedAssetTimestampIsSetAndEqual =
-        lastModifiedAssetTimestamp != null &&
-                other.lastModifiedAssetTimestamp != null
-            ? lastModifiedAssetTimestamp!
-                .isAtSameMomentAs(other.lastModifiedAssetTimestamp!)
-            : true;
-
     return id == other.id &&
         remoteId == other.remoteId &&
         localId == other.localId &&
         name == other.name &&
         createdAt.isAtSameMomentAs(other.createdAt) &&
         modifiedAt.isAtSameMomentAs(other.modifiedAt) &&
-        lastModifiedAssetTimestampIsSetAndEqual &&
+        isAtSameMomentAs(startDate, other.startDate) &&
+        isAtSameMomentAs(endDate, other.endDate) &&
+        isAtSameMomentAs(
+          lastModifiedAssetTimestamp,
+          other.lastModifiedAssetTimestamp,
+        ) &&
         shared == other.shared &&
         activityEnabled == other.activityEnabled &&
         owner.value == other.owner.value &&
@@ -104,6 +102,8 @@ class Album {
       name.hashCode ^
       createdAt.hashCode ^
       modifiedAt.hashCode ^
+      startDate.hashCode ^
+      endDate.hashCode ^
       lastModifiedAssetTimestamp.hashCode ^
       shared.hashCode ^
       activityEnabled.hashCode ^

--- a/mobile/lib/shared/services/sync.service.dart
+++ b/mobile/lib/shared/services/sync.service.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/shared/providers/db.provider.dart';
 import 'package:immich_mobile/shared/services/hash.service.dart';
 import 'package:immich_mobile/utils/async_mutex.dart';
 import 'package:immich_mobile/extensions/collection_extensions.dart';
+import 'package:immich_mobile/utils/datetime_comparison.dart';
 import 'package:immich_mobile/utils/diff.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
@@ -343,8 +344,13 @@ class SyncService {
 
     album.name = dto.albumName;
     album.shared = dto.shared;
+    album.createdAt = dto.createdAt;
     album.modifiedAt = dto.updatedAt;
+    album.startDate = dto.startDate;
+    album.endDate = dto.endDate;
     album.lastModifiedAssetTimestamp = originalDto.lastModifiedAssetTimestamp;
+    album.shared = dto.shared;
+    album.activityEnabled = dto.isActivityEnabled;
     if (album.thumbnail.value?.remoteId != dto.albumThumbnailAssetId) {
       album.thumbnail.value = await _db.assets
           .where()
@@ -863,12 +869,10 @@ bool _hasAlbumResponseDtoChanged(AlbumResponseDto dto, Album a) {
       dto.shared != a.shared ||
       dto.sharedUsers.length != a.sharedUsers.length ||
       !dto.updatedAt.isAtSameMomentAs(a.modifiedAt) ||
-      (dto.lastModifiedAssetTimestamp == null &&
-          a.lastModifiedAssetTimestamp != null) ||
-      (dto.lastModifiedAssetTimestamp != null &&
-          a.lastModifiedAssetTimestamp == null) ||
-      (dto.lastModifiedAssetTimestamp != null &&
-          a.lastModifiedAssetTimestamp != null &&
-          !dto.lastModifiedAssetTimestamp!
-              .isAtSameMomentAs(a.lastModifiedAssetTimestamp!));
+      !isAtSameMomentAs(dto.startDate, a.startDate) ||
+      !isAtSameMomentAs(dto.endDate, a.endDate) ||
+      !isAtSameMomentAs(
+        dto.lastModifiedAssetTimestamp,
+        a.lastModifiedAssetTimestamp,
+      );
 }

--- a/mobile/lib/utils/datetime_comparison.dart
+++ b/mobile/lib/utils/datetime_comparison.dart
@@ -1,0 +1,3 @@
+bool isAtSameMomentAs(DateTime? a, DateTime? b) =>
+    (a == null && b == null) ||
+    ((a != null && b != null) && a.isAtSameMomentAs(b));


### PR DESCRIPTION
Currently some album properties are not synced to the Isar database when an album is updated. This PR adds the missing properties to be synced.