### PR TITLE
docs: Nginx config update

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -62,6 +62,5 @@ Below is an example config for Apache2 site configuration.
    ProxyPass / http://127.0.0.1:2283/ timeout=600 upgrade=websocket
    ProxyPassReverse / http://127.0.0.1:2283/
    ProxyPreserveHost On
-
 </VirtualHost>
 ```

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -54,7 +54,7 @@ immich.example.org {
 
 Below is an example config for Apache2 site configuration.
 
-```
+```ApacheConf
 <VirtualHost *:80>
    ServerName <snip>
    ProxyRequests Off

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -1,6 +1,6 @@
 # Reverse Proxy
 
-Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
+Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Real-IP`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
 
 :::note
 The Repair page can take a long time to load. To avoid server timeouts or errors, we recommend specifying a timeout of at least 10 minutes on your proxy server.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -4,11 +4,11 @@ Users can deploy a custom reverse proxy that forwards requests to Immich. This w
 
 ### Nginx example config
 
-Below is an example config for nginx. Make sure to include `client_max_body_size 50000M;` also in a `http` block in `/etc/nginx/nginx.conf`.
+Below is an example config for nginx. Make sure to set `public_url` to the front-facing URL of your instance, and `backend_url` to the path of the Immich server.
 
 ```nginx
 server {
-    server_name <snip>;
+    server_name <public_url>;
 
     # allow large file uploads
     client_max_body_size 50000M;
@@ -31,7 +31,7 @@ server {
     send_timeout       600s;
 
     location / {
-        proxy_pass http://<snip>:2283;
+        proxy_pass http://<backend_url>:2283;
     }
 }
 ```

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -8,22 +8,30 @@ Below is an example config for nginx. Make sure to include `client_max_body_size
 
 ```nginx
 server {
-    server_name <snip>
+    server_name <snip>;
 
+    # allow large file uploads
     client_max_body_size 50000M;
+
+    # Set headers
+    proxy_set_header Host              $http_host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # enable websockets: http://nginx.org/en/docs/http/websocket.html
+    proxy_http_version 1.1;
+    proxy_set_header   Upgrade    $http_upgrade;
+    proxy_set_header   Connection "upgrade";
+    proxy_redirect     off;
+
+    # Wait for longer before timeout, for Repair page
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    send_timeout       600s;
 
     location / {
         proxy_pass http://<snip>:2283;
-        proxy_set_header Host              $http_host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        # http://nginx.org/en/docs/http/websocket.html
-        proxy_http_version 1.1;
-        proxy_set_header   Upgrade    $http_upgrade;
-        proxy_set_header   Connection "upgrade";
-        proxy_redirect off;
     }
 }
 ```

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -1,6 +1,6 @@
 # Reverse Proxy
 
-Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
+Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
 
 :::note
 The Repair page can take a long time to load. To avoid server timeouts or errors, we recommend specifying a timeout of at least 10 minutes on your proxy server.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -2,6 +2,10 @@
 
 Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
 
+:::note
+Certain Immich operations, especially the repair page, can take a long time to load. To avoid server timeouts or errors, we recommend specifying a timeout of at least 10 minutes on your proxy server.
+:::
+
 ### Nginx example config
 
 Below is an example config for nginx. Make sure to set `public_url` to the front-facing URL of your instance, and `backend_url` to the path of the Immich server.
@@ -25,7 +29,7 @@ server {
     proxy_set_header   Connection "upgrade";
     proxy_redirect     off;
 
-    # Wait for longer before timeout, for Repair page
+    # set timeout
     proxy_read_timeout 600s;
     proxy_send_timeout 600s;
     send_timeout       600s;
@@ -54,11 +58,10 @@ Below is an example config for Apache2 site configuration.
 <VirtualHost *:80>
    ServerName <snip>
    ProxyRequests Off
+   # set timeout in seconds
    ProxyPass / http://127.0.0.1:2283/ timeout=600 upgrade=websocket
    ProxyPassReverse / http://127.0.0.1:2283/
    ProxyPreserveHost On
 
 </VirtualHost>
 ```
-
-**timeout:** is measured in seconds, and it is particularly useful when long operations are triggered (i.e. Repair), so the server doesn't return an error.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -3,7 +3,7 @@
 Users can deploy a custom reverse proxy that forwards requests to Immich. This way, the reverse proxy can handle TLS termination, load balancing, or other advanced features. All reverse proxies between Immich and the user must forward all headers and set the `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto` and `X-Forwarded-For` headers to their appropriate values. Additionally, your reverse proxy should allow for big enough uploads. By following these practices, you ensure that all custom reverse proxies are fully compatible with Immich.
 
 :::note
-Certain Immich operations, especially the repair page, can take a long time to load. To avoid server timeouts or errors, we recommend specifying a timeout of at least 10 minutes on your proxy server.
+The Repair page can take a long time to load. To avoid server timeouts or errors, we recommend specifying a timeout of at least 10 minutes on your proxy server.
 :::
 
 ### Nginx example config


### PR DESCRIPTION
- Specify timeout of 600s to match Apache config and decrease timeouts on Repair page
- Move most settings to the `server` block to allow for multiple `location` blocks that share the same upstream settings.
- [Not necessary](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) to specify `client_max_body_size` in `http` block (I don't have it, and I have uploaded multi-gigabyte files)