### PR TITLE
docs: document metric env variables, add job metric env

### DIFF
--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -27,8 +27,8 @@ The metrics in immich are grouped into API (endpoint calls and response times), 
 
 Immich will not expose an endpoint for metrics by default. To enable this endpoint, you can add the `IMMICH_METRICS=true` environmental variable to your `.env` file. Note that only the server and microservices containers currently use this variable.
 
-:::note
-`IMMICH_METRICS` is equivalent to enabling the following three environmental variables: `IMMICH_API_METRICS`, `IMMICH_HOST_METRICS`, and `IMMICH_IO_METRICS`. If you would like to only expose certain kinds of metrics, you can set only those environmental variables to `true`. Explicitly setting the environmental variable for a metric group overrides `IMMICH_METRICS` for that group.
+:::tip
+`IMMICH_METRICS` enables all metrics, but there are also [environmental variables](/docs/install/environment-variables.md#prometheus) to toggle specific metric groups. If you'd like to only expose certain kinds of metrics, you can set only those environmental variables to `true`. Explicitly setting the environmental variable for a metric group overrides `IMMICH_METRICS` for that group. For example, setting `IMMICH_METRICS=true` and `IMMICH_API_METRICS=false` will enable all metrics except API metrics.
 :::
 
 The next step is to configure a new or existing Prometheus instance to scrape this endpoint. The following steps assume that you do not have an existing Prometheus instance, but the steps will be similar either way.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -145,6 +145,18 @@ Other machine learning parameters can be tuned from the admin UI.
 
 :::
 
+## Prometheus
+
+| Variable                       | Description                                                        | Default | Services              |
+| :----------------------------- | :----------------------------------------------------------------- | :-----: | :-------------------- |
+| `IMMICH_METRICS`<sup>\*1</sup> | Toggle all metrics                                                 |         | server, microservices |
+| `IMMICH_API_METRICS`           | Toggle metrics for endpoints and response times                    |         | server, microservices |
+| `IMMICH_HOST_METRICS`          | Toggle metrics for CPU and memory utilization for host and process |         | server, microservices |
+| `IMMICH_IO_METRICS`            | Toggle metrics for database queries, image processing, etc.        |         | server, microservices |
+| `IMMICH_JOB_METRICS`           | Toggle metrics for jobs and queues                                 |         | server, microservices |
+
+\*1: Overridden for a metric group when its corresponding environmental variable is set.
+
 ## Docker Secrets
 
 The following variables support the use of [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) for additional security.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -147,13 +147,13 @@ Other machine learning parameters can be tuned from the admin UI.
 
 ## Prometheus
 
-| Variable                       | Description                                                        | Default | Services              |
-| :----------------------------- | :----------------------------------------------------------------- | :-----: | :-------------------- |
-| `IMMICH_METRICS`<sup>\*1</sup> | Toggle all metrics                                                 |         | server, microservices |
-| `IMMICH_API_METRICS`           | Toggle metrics for endpoints and response times                    |         | server, microservices |
-| `IMMICH_HOST_METRICS`          | Toggle metrics for CPU and memory utilization for host and process |         | server, microservices |
-| `IMMICH_IO_METRICS`            | Toggle metrics for database queries, image processing, etc.        |         | server, microservices |
-| `IMMICH_JOB_METRICS`           | Toggle metrics for jobs and queues                                 |         | server, microservices |
+| Variable                       | Description                                                                                   | Default | Services              |
+| :----------------------------- | :-------------------------------------------------------------------------------------------- | :-----: | :-------------------- |
+| `IMMICH_METRICS`<sup>\*1</sup> | Toggle all metrics (one of [`true`, `false`])                                                 |         | server, microservices |
+| `IMMICH_API_METRICS`           | Toggle metrics for endpoints and response times (one of [`true`, `false`])                    |         | server, microservices |
+| `IMMICH_HOST_METRICS`          | Toggle metrics for CPU and memory utilization for host and process (one of [`true`, `false`]) |         | server, microservices |
+| `IMMICH_IO_METRICS`            | Toggle metrics for database queries, image processing, etc. (one of [`true`, `false`])        |         | server, microservices |
+| `IMMICH_JOB_METRICS`           | Toggle metrics for jobs and queues (one of [`true`, `false`])                                 |         | server, microservices |
 
 \*1: Overridden for a metric group when its corresponding environmental variable is set.
 


### PR DESCRIPTION
### Description

The metric envs aren't listed in the env variable doc page. This PR adds a new section for them, changes the monitoring doc to reference this section, and adds an entry for job metrics.