### PR TITLE
fix(server): penalize null geodata fields when searching places

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -254,15 +254,15 @@ WHERE
   OR f_unaccent ("admin1Name") %>> f_unaccent ($1)
   OR f_unaccent ("alternateNames") %>> f_unaccent ($1)
 ORDER BY
-  COALESCE(f_unaccent (name) <->>> f_unaccent ($1), 0) + COALESCE(
+  COALESCE(f_unaccent (name) <->>> f_unaccent ($1), 0.1) + COALESCE(
     f_unaccent ("admin2Name") <->>> f_unaccent ($1),
-    0
+    0.1
   ) + COALESCE(
     f_unaccent ("admin1Name") <->>> f_unaccent ($1),
-    0
+    0.1
   ) + COALESCE(
     f_unaccent ("alternateNames") <->>> f_unaccent ($1),
-    0
+    0.1
   ) ASC
 LIMIT
   20

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -214,10 +214,10 @@ export class SearchRepository implements ISearchRepository {
       .orWhere(`f_unaccent("alternateNames") %>> f_unaccent(:placeName)`)
       .orderBy(
         `
-        COALESCE(f_unaccent(name) <->>> f_unaccent(:placeName), 0) +
-        COALESCE(f_unaccent("admin2Name") <->>> f_unaccent(:placeName), 0) +
-        COALESCE(f_unaccent("admin1Name") <->>> f_unaccent(:placeName), 0) +
-        COALESCE(f_unaccent("alternateNames") <->>> f_unaccent(:placeName), 0)
+        COALESCE(f_unaccent(name) <->>> f_unaccent(:placeName), 0.1) +
+        COALESCE(f_unaccent("admin2Name") <->>> f_unaccent(:placeName), 0.1) +
+        COALESCE(f_unaccent("admin1Name") <->>> f_unaccent(:placeName), 0.1) +
+        COALESCE(f_unaccent("alternateNames") <->>> f_unaccent(:placeName), 0.1)
         `,
       )
       .setParameters({ placeName })


### PR DESCRIPTION
### Description

The test for `/search/places` was recently made stricter by checking that the top result is the most relevant. However, it's actually not guaranteed to be the first result as Paris and Paris Leona are tied in score. The reason for this is that the latter has null for `admin2Name`, which gets coalesced to 0 (a perfect match). This PR sets null values to have a score of 0.1 to avoid rewarding a lack of data.

### How Has This Been Tested?

Tested that the order for this is now deterministic and the test does not flake.