### PR TITLE
renovate: mobile ignore *_plus plugins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,6 @@
     }
   ],
   "ignorePaths": ["mobile/openapi/pubspec.yaml"],
-  "ignoreDeps": ["http", "intl"],
+  "ignoreDeps": ["http", "intl", "package_info_plus", "share_plus", "device_info_plus", "connectivity_plus", "wakelock_plus"],
   "labels": ["dependencies", "renovate"]
 }


### PR DESCRIPTION
#### Changes made

- *_plus plugins are ignored from renovate updates until the jdk is migrated to 17