### PR TITLE
feat: Improve error handling for Install Script

### DIFF
--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -4,7 +4,7 @@ To alleviate [performance issues on low-memory systems](/docs/FAQ.mdx#why-is-imm
 
 - Set the URL in Machine Learning Settings on the Admin Settings page to point to the designated ML system, e.g. `http://workstation:3003`.
 - Copy the following `docker-compose.yml` to your ML system.
-- Start the container by running `docker-compose up -d` or `docker compose up -d` (depending on your Docker version).
+- Start the container by running `docker compose up -d`.
 
 :::note Info
 Starting with version v1.93.0 face detection work and face recognize were split. From now on face detection is done in the immich_machine_learning service, but facial recognition is done in the immich_microservices service.

--- a/docs/docs/install/requirements.md
+++ b/docs/docs/install/requirements.md
@@ -15,7 +15,6 @@ Hardware and software requirements for Immich
 Immich requires the command `docker compose` - the similarly named `docker-compose` is [deprecated](https://docs.docker.com/compose/migrate/) and is no longer compatible with Immich.
 :::
 
-:::
 :::info Podman
 You can also use Podman to run the application. However, additional configuration might be required.
 :::

--- a/docs/docs/install/requirements.md
+++ b/docs/docs/install/requirements.md
@@ -11,6 +11,11 @@ Hardware and software requirements for Immich
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
+:::note
+Immich requires the command `docker compose` - the similarly named `docker-compose` is [deprecated](https://docs.docker.com/compose/migrate/) and is no longer compatible with Immich.
+:::
+
+:::
 :::info Podman
 You can also use Podman to run the application. However, additional configuration might be required.
 :::

--- a/docs/docs/install/script.md
+++ b/docs/docs/install/script.md
@@ -17,12 +17,11 @@ curl -o- https://raw.githubusercontent.com/immich-app/immich/main/install.sh | b
 The script will perform the following actions:
 
 1. Download [docker-compose.yml](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml), and the [.env](https://github.com/immich-app/immich/releases/latest/download/example.env) file from the main branch of the [repository](https://github.com/immich-app/immich).
-2. Populate the `.env` file with necessary information based on the current directory path.
-3. Start the containers.
+2. Start the containers.
 
 The web application will be available at `http://<machine-ip-address>:2283`, and the server URL for the mobile app will be `http://<machine-ip-address>:2283/api`
 
-The directory which is used to store the library files is `./immich-data` relative to the current directory.
+The directory which is used to store the library files is `./immich-app` relative to the current directory.
 
 :::tip
 For common next steps, see [Post Install Steps](/docs/install/post-install.mdx).

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,12 @@
 
 create_immich_directory() { local -r Tgt='./immich-app'
   echo "Creating Immich directory..."
-  mkdir -p "$Tgt"
-  cd "$Tgt" || exit
+  if [[ -e "$Tgt" ]]; then
+    echo "Found existing directory $Tgt, will overwrite YAML files"
+  else
+    mkdir -p "$Tgt" || return
+  fi 
+  cd "$Tgt" || return
 }
 
 download_docker_compose_file() {
@@ -25,30 +29,29 @@ start_docker_compose() { local -a docker_bin
     docker_bin=(docker-compose)
   else
     echo "Cannot find \`docker compose\` or \`docker-compose\`."
-    exit 1
+    return 1
   fi
 
-  if "${docker_bin[@]}" up --remove-orphans -d; then
-    show_friendly_message
-    exit 0
-  else
+  if ! "${docker_bin[@]}" up --remove-orphans -d; then
     echo "Could not start. Check for errors above."
-    exit 1
+    return 1
   fi
+  show_friendly_message
 }
 
 show_friendly_message() {
-  echo "Successfully deployed Immich!"
-  echo "You can access the website at http://$ip_address:2283 and the server URL for the mobile app is http://$ip_address:2283/api"
-  echo "---------------------------------------------------"
-  echo "If you want to configure custom information of the server, including the database, Redis information, or the backup (or upload) location, etc. 
+  cat << EOF
+Successfully deployed Immich!
+You can access the website at http://$ip_address:2283 and the server URL for the mobile app is http://$ip_address:2283/api
+---------------------------------------------------
+If you want to configure custom information of the server, including the database, Redis information, or the backup (or upload) location, etc. 
   
   1. First bring down the containers with the command 'docker-compose down' in the immich-app directory, 
   
   2. Then change the information that fits your needs in the '.env' file, 
   
-  3. Finally, bring the containers back up with the command 'docker-compose up --remove-orphans -d' in the immich-app directory"
-
+  3. Finally, bring the containers back up with the command 'docker-compose up --remove-orphans -d' in the immich-app directory
+EOF
 }
 
 # MAIN

--- a/install.sh
+++ b/install.sh
@@ -50,11 +50,11 @@ You can access the website at http://$ip_address:2283 and the server URL for the
 ---------------------------------------------------
 If you want to configure custom information of the server, including the database, Redis information, or the backup (or upload) location, etc. 
   
-  1. First bring down the containers with the command 'docker-compose down' in the immich-app directory, 
+  1. First bring down the containers with the command '${docker_bin[@]} down' in the immich-app directory, 
   
   2. Then change the information that fits your needs in the '.env' file, 
   
-  3. Finally, bring the containers back up with the command 'docker-compose up --remove-orphans -d' in the immich-app directory
+  3. Finally, bring the containers back up with the command '${docker_bin[@]} up --remove-orphans -d' in the immich-app directory
 EOF
 }
 

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ EOF
 main() {
   echo "Starting Immich installation..."
   local -ra Curl=(curl -fsSL)
+  ! command -v curl >/dev/null && { echo 'no curl binary found; please install curl and try again'; return 1; }
   local -r RepoUrl='https://github.com/immich-app/immich/releases/latest/download'
   local ip_address
   ip_address=$(hostname -I | awk '{print $1}')

--- a/install.sh
+++ b/install.sh
@@ -57,15 +57,22 @@ EOF
 # MAIN
 main() {
   echo "Starting Immich installation..."
-  local -ra Curl=(curl -fsSL)
-  command -v curl >/dev/null || { echo 'no curl binary found; please install curl and try again'; return 14; }
   local -r RepoUrl='https://github.com/immich-app/immich/releases/latest/download'
+  local -a Curl
+  if command -v curl >/dev/null; then
+    Curl=(curl -fsSL)
+  else
+    echo 'no curl binary found; please install curl and try again'
+    return 14
+  fi
 
   create_immich_directory || { echo 'error creating Immich directory'; return 10; }
   download_docker_compose_file || { echo 'error downloading Docker Compose file'; return 11; }
   download_dot_env_file || { echo 'error downloading .env'; return 12; }
-  start_docker_compose || return 13
+  start_docker_compose || { echo 'error starting Docker'; return 13; }
   return 0; }
 
 main
-exit
+Exit=$?
+[[ $Exit == 0 ]] || echo "There was an error installing Immich. Exit code: $Exit. Please provide these logs when asking for assistance."
+exit "$Exit"

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ EOF
 main() {
   echo "Starting Immich installation..."
   local -ra Curl=(curl -fsSL)
-  command -v curl >/dev/null || { echo 'no curl binary found; please install curl and try again'; return 1; }
+  command -v curl >/dev/null || { echo 'no curl binary found; please install curl and try again'; return 14; }
   local -r RepoUrl='https://github.com/immich-app/immich/releases/latest/download'
 
   create_immich_directory || { echo 'error creating Immich directory'; return 10; }

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -o nounset
+set -o pipefail
 
 create_immich_directory() { local -r Tgt='./immich-app'
   echo "Creating Immich directory..."

--- a/install.sh
+++ b/install.sh
@@ -28,12 +28,6 @@ start_docker_compose() {
   if ! docker compose >/dev/null 2>&1; then
     echo "failed to find 'docker compose'"
     return 1
-    # docker_bin=(docker compose)
-#  elif docker-compose >/dev/null 2>&1; then
-#    docker_bin=(docker-compose)
-#  else
-#    echo "Cannot find 'docker compose'." # or \`docker-compose\`."
-#    return 1
   fi
 
   if ! docker compose up --remove-orphans -d; then

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,8 @@ start_docker_compose() { local -a docker_bin
 }
 
 show_friendly_message() {
+  local ip_address
+  ip_address=$(hostname -I | awk '{print $1}')
   cat << EOF
 Successfully deployed Immich!
 You can access the website at http://$ip_address:2283 and the server URL for the mobile app is http://$ip_address:2283/api
@@ -62,8 +64,6 @@ main() {
   local -ra Curl=(curl -fsSL)
   ! command -v curl >/dev/null && { echo 'no curl binary found; please install curl and try again'; return 1; }
   local -r RepoUrl='https://github.com/immich-app/immich/releases/latest/download'
-  local ip_address
-  ip_address=$(hostname -I | awk '{print $1}')
 
   create_immich_directory || { echo 'error creating Immich directory'; return 10; }
   download_docker_compose_file || { echo 'error downloading Docker Compose file'; return 11; }

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 create_immich_directory() { local -r Tgt='./immich-app'
   echo "Creating Immich directory..."
-  if [[ -e "$Tgt" ]]; then
+  if [[ -e $Tgt ]]; then
     echo "Found existing directory $Tgt, will overwrite YAML files"
   else
     mkdir "$Tgt" || return
@@ -22,19 +22,21 @@ download_dot_env_file() {
   "${Curl[@]}" "$RepoUrl"/example.env -o ./.env
 }
 
-start_docker_compose() { local -a docker_bin
+start_docker_compose() {
   echo "Starting Immich's docker containers"
 
-  if docker compose >/dev/null 2>&1; then
-    docker_bin=(docker compose)
-  elif docker-compose >/dev/null 2>&1; then
-    docker_bin=(docker-compose)
-  else
-    echo "Cannot find \`docker compose\` or \`docker-compose\`."
+  if ! docker compose >/dev/null 2>&1; then
+    echo "failed to find 'docker compose'"
     return 1
+    # docker_bin=(docker compose)
+#  elif docker-compose >/dev/null 2>&1; then
+#    docker_bin=(docker-compose)
+#  else
+#    echo "Cannot find 'docker compose'." # or \`docker-compose\`."
+#    return 1
   fi
 
-  if ! "${docker_bin[@]}" up --remove-orphans -d; then
+  if ! docker compose up --remove-orphans -d; then
     echo "Could not start. Check for errors above."
     return 1
   fi
@@ -50,11 +52,11 @@ You can access the website at http://$ip_address:2283 and the server URL for the
 ---------------------------------------------------
 If you want to configure custom information of the server, including the database, Redis information, or the backup (or upload) location, etc. 
   
-  1. First bring down the containers with the command '${docker_bin[@]} down' in the immich-app directory, 
+  1. First bring down the containers with the command 'docker compose down' in the immich-app directory, 
   
   2. Then change the information that fits your needs in the '.env' file, 
   
-  3. Finally, bring the containers back up with the command '${docker_bin[@]} up --remove-orphans -d' in the immich-app directory
+  3. Finally, bring the containers back up with the command 'docker compose up --remove-orphans -d' in the immich-app directory
 EOF
 }
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ create_immich_directory() { local -r Tgt='./immich-app'
   if [[ -e "$Tgt" ]]; then
     echo "Found existing directory $Tgt, will overwrite YAML files"
   else
-    mkdir -p "$Tgt" || return
+    mkdir "$Tgt" || return
   fi 
   cd "$Tgt" || return
 }

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ EOF
 main() {
   echo "Starting Immich installation..."
   local -ra Curl=(curl -fsSL)
-  ! command -v curl >/dev/null && { echo 'no curl binary found; please install curl and try again'; return 1; }
+  command -v curl >/dev/null || { echo 'no curl binary found; please install curl and try again'; return 1; }
   local -r RepoUrl='https://github.com/immich-app/immich/releases/latest/download'
 
   create_immich_directory || { echo 'error creating Immich directory'; return 10; }


### PR DESCRIPTION
- Improve error detection for `cd`, `mkdir`
- Add check that `curl` exists and downloads are successful
- Notify when overwriting an existing immich-app folder - may want to prompt for a warning in the future?
- Remove deprecated references to `docker-compose`