### PR TITLE
mount postgres folder to local directory by default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,9 +69,8 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     restart: always
 
 volumes:
-  pgdata:
   model-cache:

--- a/docker/example.env
+++ b/docker/example.env
@@ -14,5 +14,6 @@ DB_PASSWORD=postgres
 DB_HOSTNAME=immich_postgres
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
+DB_DATA_LOCATION=./postgres
 
 REDIS_HOSTNAME=immich_redis


### PR DESCRIPTION
> [!Caution]
> For people always pulling the latest compose file this is a *breaking change*!
> Disregarding the notes will result in (temporary) data loss!

## Background
In the past we've seen many cases where people accidentally deleted their postgres data by (unintentionally) deleting the docker volume (e.g. `docker compose down -v`).
This is unfortunate as there is *no* way to recover that data (if you don't have a backup; **MAKE BACKUPS!**).
We have been thinking about mounting the postgres data to a local folder for a while but always hesitated as this will break existing instances due to people not reading the change logs carefully. However, there have simply been too many issues with it that we ultimately decided we should make that change.

## What do I have to do?
Nothing. You shouldn't copy the compose file with every new release and generally, we don't recommend making changes to existing instances. If you never had issues before, attempting to migrate the data will put it at (an unnecessary) risk.

## I want to migrate my docker volume to a local folder
Unfortunately there isn't a "proper" way to export a docker volume.
The recommended method is to mount the volume and the directory (you want to copy your data to) to an arbitrary container, get a shell inside that container and copy the folder manually.

> [!Caution]
> Take backups before attempting this. Especially make sure you have a current database dump (`pg_dump`)

> [!Warning]
> Do *not* use a directory under `/mnt` for the postgres location if you are using WSL.
> Generally (on all operating systems) we recommend against using a network share for your database location. This is bound to break and cause all sorts of weird issues. 