### PR TITLE
fix(web): weird Overpass font height

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -29,6 +29,7 @@
   src: url('$lib/assets/fonts/overpass/Overpass.ttf') format('truetype-variations');
   font-weight: 1 999;
   font-style: normal;
+  ascent-override: 100%;
 }
 
 @font-face {
@@ -36,6 +37,7 @@
   src: url('$lib/assets/fonts/overpass/OverpassMono.ttf') format('truetype-variations');
   font-weight: 1 999;
   font-style: monospace;
+  ascent-override: 100%;
 }
 
 @font-face {


### PR DESCRIPTION
The icon and the font is now aligned properly

Before and after

![image](https://github.com/immich-app/immich/assets/27055614/80d36aa9-1322-4e76-997c-863d3a64b8ed)
