### PR TITLE
docs: add some details for getting started as a developer

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -18,12 +18,11 @@ Thanks for being interested in contributing 😊
 
 ### Server and web app
 
-This environment includes the following services:
+This environment includes the services below. Additional details are available in each service's README.
 
-- Core server - `/server/src/immich`
-- Machine learning - `/machine-learning`
-- Microservices - `/server/src/microservicess`
-- Web app - `/web`
+- Server - [`/server`](https://github.com/immich-app/immich/tree/main/server)
+- Web app - [`/web`](https://github.com/immich-app/immich/tree/main/web)
+- Machine learning - [`/machine-learning`](https://github.com/immich-app/immich/tree/main/machine-learning)
 - Redis
 - PostgreSQL development database with exposed port `5432` so you can use any database client to acess it
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,3 @@
+# Immich server project
+
+This project uses the [NestJS](https://nestjs.com/) web framework. Please refer to [the NestJS docs](https://docs.nestjs.com/) for information on getting started as a contributor to this project.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,5 @@
+# Immich web project
+
+This project uses the [SvelteKit](https://kit.svelte.dev/) web framework. Please refer to [the SvelteKit docs](https://kit.svelte.dev/docs) for information on getting started as a contributor to this project. In particular, it will help you navigate the project's code if you understand the basics of [SvelteKit routing](https://kit.svelte.dev/docs/routing).
+
+When developing locally, you will run a SvelteKit Node.js server. When this project is deployed to production, it is built as a SPA and deployed as part of [../server](the server project).


### PR DESCRIPTION
Letting people know that we use SvelteKit and Nest.js will hopefully help them get started a bit faster.

The developer setup instructions pointed to two server directories to that no longer exist, so I replaced those pointers with a single pointer to the top-level server project.