### PR TITLE
chore(web): fine tuning styling for base modal

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8769,7 +8769,7 @@
             "type": "array"
           },
           "data": {
-            "$ref": "#/components/schemas/OnThisDayDto"
+            "type": "object"
           },
           "isSaved": {
             "type": "boolean"
@@ -8829,7 +8829,7 @@
             "type": "string"
           },
           "data": {
-            "$ref": "#/components/schemas/OnThisDayDto"
+            "type": "object"
           },
           "deletedAt": {
             "format": "date-time",
@@ -9107,17 +9107,6 @@
         },
         "required": [
           "redirectUri"
-        ],
-        "type": "object"
-      },
-      "OnThisDayDto": {
-        "properties": {
-          "year": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "year"
         ],
         "type": "object"
       },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8769,7 +8769,7 @@
             "type": "array"
           },
           "data": {
-            "type": "object"
+            "$ref": "#/components/schemas/OnThisDayDto"
           },
           "isSaved": {
             "type": "boolean"
@@ -8829,7 +8829,7 @@
             "type": "string"
           },
           "data": {
-            "type": "object"
+            "$ref": "#/components/schemas/OnThisDayDto"
           },
           "deletedAt": {
             "format": "date-time",
@@ -9107,6 +9107,17 @@
         },
         "required": [
           "redirectUri"
+        ],
+        "type": "object"
+      },
+      "OnThisDayDto": {
+        "properties": {
+          "year": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "year"
         ],
         "type": "object"
       },

--- a/web/src/lib/components/shared-components/base-modal.svelte
+++ b/web/src/lib/components/shared-components/base-modal.svelte
@@ -61,7 +61,7 @@
         onOutclick: () => dispatch('close'),
         onEscape: () => dispatch('close'),
       }}
-      class="max-h-[800px] min-h-[200px] w-[450px] overflow-y-auto rounded-lg bg-immich-bg shadow-md dark:bg-immich-dark-gray dark:text-immich-dark-fg immich-scrollbar"
+      class="max-h-[800px] min-h-[200px] w-[450px] overflow-y-auto rounded-3xl bg-immich-bg shadow-md dark:bg-immich-dark-gray dark:text-immich-dark-fg immich-scrollbar"
       tabindex="-1"
     >
       <div class="flex place-items-center justify-between px-5 py-3">
@@ -71,7 +71,7 @@
           {:else if icon}
             <Icon path={icon} size={32} ariaHidden={true} class="text-immich-primary dark:text-immich-dark-primary" />
           {/if}
-          <h1 id={`${id}-title`} class="text-lg mt-[2px]">
+          <h1 id={`${id}-title`}>
             {title}
           </h1>
         </div>

--- a/web/src/lib/components/shared-components/base-modal.svelte
+++ b/web/src/lib/components/shared-components/base-modal.svelte
@@ -65,15 +65,13 @@
       tabindex="-1"
     >
       <div class="flex place-items-center justify-between px-5 py-3">
-        <div class="flex items-center">
+        <div class="flex gap-2 place-items-center">
           {#if showLogo}
-            <ImmichLogo noText={true} width={24} />
-            <div class="w-2" />
+            <ImmichLogo noText={true} width={32} />
           {:else if icon}
-            <Icon path={icon} size={24} ariaHidden={true} class="text-immich-primary dark:text-immich-dark-primary" />
-            <div class="w-2" />
+            <Icon path={icon} size={32} ariaHidden={true} class="text-immich-primary dark:text-immich-dark-primary" />
           {/if}
-          <h1 id={`${id}-title`} class="text-xl font-medium text-immich-primary dark:text-immich-dark-primary mt-1">
+          <h1 id={`${id}-title`} class="text-lg mt-[2px]">
             {title}
           </h1>
         </div>

--- a/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
+++ b/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
@@ -237,11 +237,11 @@
     {#if !sharedLink}
       {#if editingLink}
         <div class="flex justify-end">
-          <Button size="sm" rounded="lg" on:click={handleEditLink}>Confirm</Button>
+          <Button size="sm" on:click={handleEditLink}>Confirm</Button>
         </div>
       {:else}
         <div class="flex justify-end">
-          <Button size="sm" rounded="lg" on:click={handleCreateSharedLink}>Create link</Button>
+          <Button size="sm" on:click={handleCreateSharedLink}>Create link</Button>
         </div>
       {/if}
     {:else}


### PR DESCRIPTION
Fine-tuning styles for base modal to make the title softer on the eyes

# Example 1

### Before

<img width="480" alt="image" src="https://github.com/immich-app/immich/assets/27055614/c45f7b67-ea7a-450f-a73d-641e2b07fb29">



### After

<img width="463" alt="image" src="https://github.com/immich-app/immich/assets/27055614/6b2c00a2-9b93-46dd-8e8a-f6bb68c61260">


# Example 2

### Before
<img width="456" alt="image" src="https://github.com/immich-app/immich/assets/27055614/42e2309f-7f41-4afa-8e55-4d989ba25ee2">

### After
<img width="454" alt="image" src="https://github.com/immich-app/immich/assets/27055614/efd6456b-fc57-4c7b-904c-809eb8eb8b82">
