### PR TITLE
docs: pg_dumpall refinements

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -110,7 +110,7 @@ No. Our golden rule is that the original assets should always be untouched, so w
 
 ### How can I move all data (photos, persons, albums) from one user to another?
 
-This is not officially supported, but can be accomplished with some database updates. You can do this on the command line (in the PostgreSQL container using the psql command), or you can add for example an [Adminer](https://www.adminer.org/) container to the `docker-compose.yml` file, so that you can use a web-interface.
+This is not officially supported, but can be accomplished with some database updates. You can do this on the command line (in the PostgreSQL container using the `psql` command), or you can add for example an [Adminer](https://www.adminer.org/) container to the `docker-compose.yml` file, so that you can use a web-interface.
 
 :::warning
 This is an advanced operation. If you can't do it with the steps described here, this is not for you.

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -21,7 +21,7 @@ The recommended way to backup and restore the Immich database is to use the `pg_
   <TabItem value="Linux system based Backup" label="Linux system based Backup" default>
 
 ```bash title='Backup'
-docker exec -t immich_postgres pg_dumpall -c -U postgres | gzip > "/path/to/backup/dump.sql.gz"
+docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | gzip > "/path/to/backup/dump.sql.gz"
 ```
 
 ```bash title='Restore'
@@ -30,7 +30,7 @@ docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
-gunzip < "/path/to/backup/dump.sql.gz" | docker exec -i immich_postgres psql -U postgres -d immich    # Restore Backup
+gunzip < "/path/to/backup/dump.sql.gz" | docker exec -i immich_postgres psql --username=postgres    # Restore Backup
 docker compose up -d    # Start remainder of Immich apps
 ```
 
@@ -38,7 +38,7 @@ docker compose up -d    # Start remainder of Immich apps
   <TabItem value="Windows system based Backup" label="Windows system based Backup">
 
 ```powershell title='Backup'
-docker exec -t immich_postgres pg_dumpall -c -U postgres > "\path\to\backup\dump.sql"
+docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres > "\path\to\backup\dump.sql"
 ```
 
 ```powershell title='Restore'
@@ -47,7 +47,7 @@ docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
-gc "C:\path\to\backup\dump.sql" | docker exec -i immich_postgres psql -U postgres -d immich    # Restore Backup
+gc "C:\path\to\backup\dump.sql" | docker exec -i immich_postgres psql --username=postgres    # Restore Backup
 docker compose up -d    # Start remainder of Immich apps
 ```
 
@@ -68,10 +68,11 @@ services:
       - .env
     environment:
       POSTGRES_HOST: database
-      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_CLUSTER: 'TRUE'
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       SCHEDULE: "@daily"
+      POSTGRES_EXTRA_OPTS: '--clean --if-exists'
       BACKUP_DIR: /db_dumps
     volumes:
       - ./db_dumps:/db_dumps
@@ -82,7 +83,7 @@ services:
 Then you can restore with the same command but pointed at the latest dump.
 
 ```bash title='Automated Restore'
-gunzip < db_dumps/last/immich-latest.sql.gz | docker exec -i immich_postgres psql -U postgres -d immich
+gunzip < db_dumps/last/immich-latest.sql.gz | docker exec -i immich_postgres psql --username=postgres
 ```
 
 ## Filesystem

--- a/docs/docs/guides/template-backup-script.md
+++ b/docs/docs/guides/template-backup-script.md
@@ -43,9 +43,9 @@ REMOTE_BACKUP_PATH="/path/to/remote/backup/directory"
 ### Local
 
 # Backup Immich database
-docker exec -t immich_postgres pg_dumpall -c -U postgres > "$UPLOAD_LOCATION"/database-backup/immich-database.sql
+docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres > "$UPLOAD_LOCATION"/database-backup/immich-database.sql
 # For deduplicating backup programs such as Borg or Restic, compressing the content can increase backup size by making it harder to deduplicate. If you are using a different program or still prefer to compress, you can use the following command instead:
-# docker exec -t immich_postgres pg_dumpall -c -U postgres | /usr/bin/gzip --rsyncable > "$UPLOAD_LOCATION"/database-backup/immich-database.sql.gz
+# docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | /usr/bin/gzip --rsyncable > "$UPLOAD_LOCATION"/database-backup/immich-database.sql.gz
 
 ### Append to local Borg repository
 borg create "$BACKUP_PATH/immich-borg::{now}" "$UPLOAD_LOCATION" --exclude "$UPLOAD_LOCATION"/thumbs/ --exclude "$UPLOAD_LOCATION"/encoded-video/


### PR DESCRIPTION
"fixes" #8459

- Switch to long-args, add --if-exists to prevent errors when dropping non-existent DB
- Switch Docker image to `pg_dumpall` to mirror behavior of given command, making sure that all information (schemas, perms, etc) is backed up.
- Do not need to specify a target database when restoring pg_dumpall
- Note that `pg_dumpall` (set by `POSTGRES_CLUSTER: true`) does not support compression, so these dumps will be larger than with the previous method. However, these are auto-rotate, and I believe that as a default we should provide a complete cluster backup as a database backup only can be harder to restore with extensions, schemas, etc.


