### PR TITLE
fix(web): bypass the onStackAssets shortcut when only one is selected

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -87,10 +87,12 @@
   };
 
   const onStackAssets = async () => {
-    await stackAssets(Array.from($selectedAssets), (ids) => {
-      assetStore.removeAssets(ids);
-      dispatch('escape');
-    });
+    if ($selectedAssets.size > 1) {
+      await stackAssets(Array.from($selectedAssets), (ids) => {
+        assetStore.removeAssets(ids);
+        dispatch('escape');
+      });
+    }
   };
 
   $: shortcutList = (() => {


### PR DESCRIPTION
Selecting one asset and pressing 's' would show 'Stacked 1 assets' and result in a noop. This change prevents the notification and exiting the select mode.