### PR TITLE
Fix typos: immcih -> immich

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -337,7 +337,7 @@ docker compose down -v
 
 :::note Portainer
 If you use portainer, bring down the stack in portainer. Go into the volumes section  
-and remove all the volumes related to immcih then restart the stack.
+and remove all the volumes related to immich then restart the stack.
 :::
 
 After removing the containers and volumes, the **Files** should be removed from the `UPLOAD_LOCATION` to provide a clean start.

--- a/mobile/assets/i18n/ja-JP.json
+++ b/mobile/assets/i18n/ja-JP.json
@@ -320,7 +320,7 @@
   "profile_drawer_client_out_of_date_major": "アプリが更新されてません。最新のバージョンに更新してください",
   "profile_drawer_client_out_of_date_minor": "アプリが更新されてません。最新のマイナーバージョンに更新してください",
   "profile_drawer_client_server_up_to_date": "すべて最新です",
-  "profile_drawer_documentation": "Immcihの説明書",
+  "profile_drawer_documentation": "Immichの説明書",
   "profile_drawer_github": "GitHub",
   "profile_drawer_server_out_of_date_major": "サーバーが更新されてません。最新のバージョンに更新してください",
   "profile_drawer_server_out_of_date_minor": "サーバーが更新されてません。最新のマイナーバージョンに更新してください",


### PR DESCRIPTION
Fix a typo in the Android app's Japanese translation.
Fix the same typo in the FAQ,