### PR TITLE
chore(server): better typing for system config key

### DIFF
--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -1,118 +1,135 @@
 import { ConcurrentQueueName } from 'src/interfaces/job.interface';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
+export type SystemConfigValue = string | string[] | number | boolean;
+
+// https://stackoverflow.com/a/47058976
+// https://stackoverflow.com/a/70692231
+type PathsToStringProps<T> = T extends SystemConfigValue
+  ? []
+  : {
+      [K in keyof T]: [K, ...PathsToStringProps<T[K]>];
+    }[keyof T];
+
+type Join<T extends string[], D extends string> = T extends []
+  ? never
+  : T extends [infer F]
+    ? F
+    : T extends [infer F, ...infer R]
+      ? F extends string
+        ? `${F}${D}${Join<Extract<R, string[]>, D>}`
+        : never
+      : string;
+
 @Entity('system_config')
 export class SystemConfigEntity<T = SystemConfigValue> {
   @PrimaryColumn()
-  key!: SystemConfigKey;
+  key!: (typeof SystemConfigKey)[keyof typeof SystemConfigKey];
 
   @Column({ type: 'varchar', nullable: true, transformer: { to: JSON.stringify, from: JSON.parse } })
-  value!: T | T[];
+  value!: T;
 }
-
-export type SystemConfigValue = string | number | boolean;
 
 // dot notation matches path in `SystemConfig`
-export enum SystemConfigKey {
-  FFMPEG_CRF = 'ffmpeg.crf',
-  FFMPEG_THREADS = 'ffmpeg.threads',
-  FFMPEG_PRESET = 'ffmpeg.preset',
-  FFMPEG_TARGET_VIDEO_CODEC = 'ffmpeg.targetVideoCodec',
-  FFMPEG_ACCEPTED_VIDEO_CODECS = 'ffmpeg.acceptedVideoCodecs',
-  FFMPEG_TARGET_AUDIO_CODEC = 'ffmpeg.targetAudioCodec',
-  FFMPEG_ACCEPTED_AUDIO_CODECS = 'ffmpeg.acceptedAudioCodecs',
-  FFMPEG_TARGET_RESOLUTION = 'ffmpeg.targetResolution',
-  FFMPEG_MAX_BITRATE = 'ffmpeg.maxBitrate',
-  FFMPEG_BFRAMES = 'ffmpeg.bframes',
-  FFMPEG_REFS = 'ffmpeg.refs',
-  FFMPEG_GOP_SIZE = 'ffmpeg.gopSize',
-  FFMPEG_NPL = 'ffmpeg.npl',
-  FFMPEG_TEMPORAL_AQ = 'ffmpeg.temporalAQ',
-  FFMPEG_CQ_MODE = 'ffmpeg.cqMode',
-  FFMPEG_TWO_PASS = 'ffmpeg.twoPass',
-  FFMPEG_PREFERRED_HW_DEVICE = 'ffmpeg.preferredHwDevice',
-  FFMPEG_TRANSCODE = 'ffmpeg.transcode',
-  FFMPEG_ACCEL = 'ffmpeg.accel',
-  FFMPEG_TONEMAP = 'ffmpeg.tonemap',
+export const SystemConfigKey: Record<string, Join<PathsToStringProps<SystemConfig>, '.'>> = {
+  FFMPEG_CRF: 'ffmpeg.crf',
+  FFMPEG_THREADS: 'ffmpeg.threads',
+  FFMPEG_PRESET: 'ffmpeg.preset',
+  FFMPEG_TARGET_VIDEO_CODEC: 'ffmpeg.targetVideoCodec',
+  FFMPEG_ACCEPTED_VIDEO_CODECS: 'ffmpeg.acceptedVideoCodecs',
+  FFMPEG_TARGET_AUDIO_CODEC: 'ffmpeg.targetAudioCodec',
+  FFMPEG_ACCEPTED_AUDIO_CODECS: 'ffmpeg.acceptedAudioCodecs',
+  FFMPEG_TARGET_RESOLUTION: 'ffmpeg.targetResolution',
+  FFMPEG_MAX_BITRATE: 'ffmpeg.maxBitrate',
+  FFMPEG_BFRAMES: 'ffmpeg.bframes',
+  FFMPEG_REFS: 'ffmpeg.refs',
+  FFMPEG_GOP_SIZE: 'ffmpeg.gopSize',
+  FFMPEG_NPL: 'ffmpeg.npl',
+  FFMPEG_TEMPORAL_AQ: 'ffmpeg.temporalAQ',
+  FFMPEG_CQ_MODE: 'ffmpeg.cqMode',
+  FFMPEG_TWO_PASS: 'ffmpeg.twoPass',
+  FFMPEG_PREFERRED_HW_DEVICE: 'ffmpeg.preferredHwDevice',
+  FFMPEG_TRANSCODE: 'ffmpeg.transcode',
+  FFMPEG_ACCEL: 'ffmpeg.accel',
+  FFMPEG_TONEMAP: 'ffmpeg.tonemap',
 
-  JOB_THUMBNAIL_GENERATION_CONCURRENCY = 'job.thumbnailGeneration.concurrency',
-  JOB_METADATA_EXTRACTION_CONCURRENCY = 'job.metadataExtraction.concurrency',
-  JOB_VIDEO_CONVERSION_CONCURRENCY = 'job.videoConversion.concurrency',
-  JOB_FACE_DETECTION_CONCURRENCY = 'job.faceDetection.concurrency',
-  JOB_CLIP_ENCODING_CONCURRENCY = 'job.smartSearch.concurrency',
-  JOB_BACKGROUND_TASK_CONCURRENCY = 'job.backgroundTask.concurrency',
-  JOB_STORAGE_TEMPLATE_MIGRATION_CONCURRENCY = 'job.storageTemplateMigration.concurrency',
-  JOB_SEARCH_CONCURRENCY = 'job.search.concurrency',
-  JOB_SIDECAR_CONCURRENCY = 'job.sidecar.concurrency',
-  JOB_LIBRARY_CONCURRENCY = 'job.library.concurrency',
-  JOB_MIGRATION_CONCURRENCY = 'job.migration.concurrency',
+  JOB_THUMBNAIL_GENERATION_CONCURRENCY: 'job.thumbnailGeneration.concurrency',
+  JOB_METADATA_EXTRACTION_CONCURRENCY: 'job.metadataExtraction.concurrency',
+  JOB_VIDEO_CONVERSION_CONCURRENCY: 'job.videoConversion.concurrency',
+  JOB_FACE_DETECTION_CONCURRENCY: 'job.faceDetection.concurrency',
+  JOB_CLIP_ENCODING_CONCURRENCY: 'job.smartSearch.concurrency',
+  JOB_BACKGROUND_TASK_CONCURRENCY: 'job.backgroundTask.concurrency',
+  JOB_SEARCH_CONCURRENCY: 'job.search.concurrency',
+  JOB_SIDECAR_CONCURRENCY: 'job.sidecar.concurrency',
+  JOB_LIBRARY_CONCURRENCY: 'job.library.concurrency',
+  JOB_MIGRATION_CONCURRENCY: 'job.migration.concurrency',
 
-  LIBRARY_SCAN_ENABLED = 'library.scan.enabled',
-  LIBRARY_SCAN_CRON_EXPRESSION = 'library.scan.cronExpression',
+  LIBRARY_SCAN_ENABLED: 'library.scan.enabled',
+  LIBRARY_SCAN_CRON_EXPRESSION: 'library.scan.cronExpression',
 
-  LIBRARY_WATCH_ENABLED = 'library.watch.enabled',
+  LIBRARY_WATCH_ENABLED: 'library.watch.enabled',
 
-  LOGGING_ENABLED = 'logging.enabled',
-  LOGGING_LEVEL = 'logging.level',
+  LOGGING_ENABLED: 'logging.enabled',
+  LOGGING_LEVEL: 'logging.level',
 
-  MACHINE_LEARNING_ENABLED = 'machineLearning.enabled',
-  MACHINE_LEARNING_URL = 'machineLearning.url',
+  MACHINE_LEARNING_ENABLED: 'machineLearning.enabled',
+  MACHINE_LEARNING_URL: 'machineLearning.url',
 
-  MACHINE_LEARNING_CLIP_ENABLED = 'machineLearning.clip.enabled',
-  MACHINE_LEARNING_CLIP_MODEL_NAME = 'machineLearning.clip.modelName',
+  MACHINE_LEARNING_CLIP_ENABLED: 'machineLearning.clip.enabled',
+  MACHINE_LEARNING_CLIP_MODEL_NAME: 'machineLearning.clip.modelName',
 
-  MACHINE_LEARNING_FACIAL_RECOGNITION_ENABLED = 'machineLearning.facialRecognition.enabled',
-  MACHINE_LEARNING_FACIAL_RECOGNITION_MODEL_NAME = 'machineLearning.facialRecognition.modelName',
-  MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_SCORE = 'machineLearning.facialRecognition.minScore',
-  MACHINE_LEARNING_FACIAL_RECOGNITION_MAX_DISTANCE = 'machineLearning.facialRecognition.maxDistance',
-  MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_FACES = 'machineLearning.facialRecognition.minFaces',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_ENABLED: 'machineLearning.facialRecognition.enabled',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_MODEL_NAME: 'machineLearning.facialRecognition.modelName',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_SCORE: 'machineLearning.facialRecognition.minScore',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_MAX_DISTANCE: 'machineLearning.facialRecognition.maxDistance',
+  MACHINE_LEARNING_FACIAL_RECOGNITION_MIN_FACES: 'machineLearning.facialRecognition.minFaces',
 
-  MAP_ENABLED = 'map.enabled',
-  MAP_LIGHT_STYLE = 'map.lightStyle',
-  MAP_DARK_STYLE = 'map.darkStyle',
+  MAP_ENABLED: 'map.enabled',
+  MAP_LIGHT_STYLE: 'map.lightStyle',
+  MAP_DARK_STYLE: 'map.darkStyle',
 
-  REVERSE_GEOCODING_ENABLED = 'reverseGeocoding.enabled',
+  REVERSE_GEOCODING_ENABLED: 'reverseGeocoding.enabled',
 
-  NEW_VERSION_CHECK_ENABLED = 'newVersionCheck.enabled',
+  NEW_VERSION_CHECK_ENABLED: 'newVersionCheck.enabled',
 
-  OAUTH_AUTO_LAUNCH = 'oauth.autoLaunch',
-  OAUTH_AUTO_REGISTER = 'oauth.autoRegister',
-  OAUTH_BUTTON_TEXT = 'oauth.buttonText',
-  OAUTH_CLIENT_ID = 'oauth.clientId',
-  OAUTH_CLIENT_SECRET = 'oauth.clientSecret',
-  OAUTH_DEFAULT_STORAGE_QUOTA = 'oauth.defaultStorageQuota',
-  OAUTH_ENABLED = 'oauth.enabled',
-  OAUTH_ISSUER_URL = 'oauth.issuerUrl',
-  OAUTH_MOBILE_OVERRIDE_ENABLED = 'oauth.mobileOverrideEnabled',
-  OAUTH_MOBILE_REDIRECT_URI = 'oauth.mobileRedirectUri',
-  OAUTH_SCOPE = 'oauth.scope',
-  OAUTH_SIGNING_ALGORITHM = 'oauth.signingAlgorithm',
-  OAUTH_STORAGE_LABEL_CLAIM = 'oauth.storageLabelClaim',
-  OAUTH_STORAGE_QUOTA_CLAIM = 'oauth.storageQuotaClaim',
+  OAUTH_AUTO_LAUNCH: 'oauth.autoLaunch',
+  OAUTH_AUTO_REGISTER: 'oauth.autoRegister',
+  OAUTH_BUTTON_TEXT: 'oauth.buttonText',
+  OAUTH_CLIENT_ID: 'oauth.clientId',
+  OAUTH_CLIENT_SECRET: 'oauth.clientSecret',
+  OAUTH_DEFAULT_STORAGE_QUOTA: 'oauth.defaultStorageQuota',
+  OAUTH_ENABLED: 'oauth.enabled',
+  OAUTH_ISSUER_URL: 'oauth.issuerUrl',
+  OAUTH_MOBILE_OVERRIDE_ENABLED: 'oauth.mobileOverrideEnabled',
+  OAUTH_MOBILE_REDIRECT_URI: 'oauth.mobileRedirectUri',
+  OAUTH_SCOPE: 'oauth.scope',
+  OAUTH_SIGNING_ALGORITHM: 'oauth.signingAlgorithm',
+  OAUTH_STORAGE_LABEL_CLAIM: 'oauth.storageLabelClaim',
+  OAUTH_STORAGE_QUOTA_CLAIM: 'oauth.storageQuotaClaim',
 
-  PASSWORD_LOGIN_ENABLED = 'passwordLogin.enabled',
+  PASSWORD_LOGIN_ENABLED: 'passwordLogin.enabled',
 
-  SERVER_EXTERNAL_DOMAIN = 'server.externalDomain',
-  SERVER_LOGIN_PAGE_MESSAGE = 'server.loginPageMessage',
+  SERVER_EXTERNAL_DOMAIN: 'server.externalDomain',
+  SERVER_LOGIN_PAGE_MESSAGE: 'server.loginPageMessage',
 
-  STORAGE_TEMPLATE_ENABLED = 'storageTemplate.enabled',
-  STORAGE_TEMPLATE_HASH_VERIFICATION_ENABLED = 'storageTemplate.hashVerificationEnabled',
-  STORAGE_TEMPLATE = 'storageTemplate.template',
+  STORAGE_TEMPLATE_ENABLED: 'storageTemplate.enabled',
+  STORAGE_TEMPLATE_HASH_VERIFICATION_ENABLED: 'storageTemplate.hashVerificationEnabled',
+  STORAGE_TEMPLATE: 'storageTemplate.template',
 
-  IMAGE_THUMBNAIL_FORMAT = 'image.thumbnailFormat',
-  IMAGE_THUMBNAIL_SIZE = 'image.thumbnailSize',
-  IMAGE_PREVIEW_FORMAT = 'image.previewFormat',
-  IMAGE_PREVIEW_SIZE = 'image.previewSize',
-  IMAGE_QUALITY = 'image.quality',
-  IMAGE_COLORSPACE = 'image.colorspace',
+  IMAGE_THUMBNAIL_FORMAT: 'image.thumbnailFormat',
+  IMAGE_THUMBNAIL_SIZE: 'image.thumbnailSize',
+  IMAGE_PREVIEW_FORMAT: 'image.previewFormat',
+  IMAGE_PREVIEW_SIZE: 'image.previewSize',
+  IMAGE_QUALITY: 'image.quality',
+  IMAGE_COLORSPACE: 'image.colorspace',
 
-  TRASH_ENABLED = 'trash.enabled',
-  TRASH_DAYS = 'trash.days',
+  TRASH_ENABLED: 'trash.enabled',
+  TRASH_DAYS: 'trash.days',
 
-  THEME_CUSTOM_CSS = 'theme.customCss',
+  THEME_CUSTOM_CSS: 'theme.customCss',
 
-  USER_DELETE_DELAY = 'user.deleteDelay',
-}
+  USER_DELETE_DELAY: 'user.deleteDelay',
+} as const;
 
 export enum TranscodePolicy {
   ALL = 'all',

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -1,11 +1,11 @@
 import { ConcurrentQueueName } from 'src/interfaces/job.interface';
 import { Column, Entity, PrimaryColumn } from 'typeorm';
 
-export type SystemConfigValue = string | number | boolean;
+export type SystemConfigValue = string | string[] | number | boolean;
 
 // https://stackoverflow.com/a/47058976
 // https://stackoverflow.com/a/70692231
-type PathsToStringProps<T> = T extends SystemConfigValue | string[]
+type PathsToStringProps<T> = T extends SystemConfigValue
   ? []
   : {
       [K in keyof T]: [K, ...PathsToStringProps<T[K]>];
@@ -22,7 +22,7 @@ type Join<T extends string[], D extends string> = T extends []
       : string;
 
 // dot notation matches path in `SystemConfig`
-export const SystemConfigKey: Record<string, Join<PathsToStringProps<SystemConfig>, '.'>> = {
+export const SystemConfigKey = {
   FFMPEG_CRF: 'ffmpeg.crf',
   FFMPEG_THREADS: 'ffmpeg.threads',
   FFMPEG_PRESET: 'ffmpeg.preset',
@@ -120,12 +120,14 @@ export const SystemConfigKey: Record<string, Join<PathsToStringProps<SystemConfi
   THEME_CUSTOM_CSS: 'theme.customCss',
 
   USER_DELETE_DELAY: 'user.deleteDelay',
-} as const;
+} as const satisfies Record<string, Join<PathsToStringProps<SystemConfig>, '.'>>;
+
+export type SystemConfigKeyPaths = (typeof SystemConfigKey)[keyof typeof SystemConfigKey];
 
 @Entity('system_config')
 export class SystemConfigEntity<T = SystemConfigValue> {
   @PrimaryColumn({ type: 'enum', enum: Object.values(SystemConfigKey), enumName: 'SystemConfigKey' })
-  key!: (typeof SystemConfigKey)[keyof typeof SystemConfigKey];
+  key!: SystemConfigKeyPaths;
 
   @Column({ type: 'varchar', nullable: true, transformer: { to: JSON.stringify, from: JSON.parse } })
   value!: T;

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -22,6 +22,7 @@ type Join<T extends string[], D extends string> = T extends []
       : string;
 
 // dot notation matches path in `SystemConfig`
+// TODO: migrate to key value per section
 export const SystemConfigKey = {
   FFMPEG_CRF: 'ffmpeg.crf',
   FFMPEG_THREADS: 'ffmpeg.threads',

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -126,7 +126,7 @@ export type SystemConfigKeyPaths = (typeof SystemConfigKey)[keyof typeof SystemC
 
 @Entity('system_config')
 export class SystemConfigEntity<T = SystemConfigValue> {
-  @PrimaryColumn({ type: 'enum', enum: Object.values(SystemConfigKey), enumName: 'SystemConfigKey' })
+  @PrimaryColumn({ type: 'varchar' })
   key!: SystemConfigKeyPaths;
 
   @Column({ type: 'varchar', nullable: true, transformer: { to: JSON.stringify, from: JSON.parse } })

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { FeatureFlag, SystemConfigCore } from 'src/cores/system-config.core';
-import { SystemConfig, SystemConfigKey } from 'src/entities/system-config.entity';
+import { SystemConfig, SystemConfigKey, SystemConfigKeyPaths } from 'src/entities/system-config.entity';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { IEventRepository } from 'src/interfaces/event.interface';
 import {
@@ -360,7 +360,7 @@ describe(JobService.name, () => {
       });
     }
 
-    const featureTests: Array<{ queue: QueueName; feature: FeatureFlag; configKey: SystemConfigKey }> = [
+    const featureTests: Array<{ queue: QueueName; feature: FeatureFlag; configKey: SystemConfigKeyPaths }> = [
       {
         queue: QueueName.SMART_SEARCH,
         feature: FeatureFlag.SMART_SEARCH,


### PR DESCRIPTION
## Description

The `SystemConfigKey` enum is a frequent source of bugs when changes are made to the config. One reason for this is because its values can be any string and don't necessarily need to be valid paths to the config object.

This PR tightens the typing for this enum such that any path not in `SystemConfig` is an error. To be able to do this, I changed it from an explicit enum to a constant object. 

This PR includes the fix in #8579.

## How Has This Been Tested?

Tested that the server starts up, that admin settings are changed successfully, and of course that invalid paths are caught by TypeScript.