### PR TITLE
fix(server): x264/x265 params not being set correctly

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1120,35 +1120,6 @@ describe(MediaService.name, () => {
       );
     });
 
-    it('should set frame threads for h264 if thread limit is above 1', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_THREADS, value: 2 }]);
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: [],
-          outputOptions: [
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-threads 2',
-            '-x264-params frame-threads=2',
-            '-crf 23',
-          ],
-          twoPass: false,
-        },
-      );
-    });
-
     it('should omit thread flags for h264 if thread limit is at or below 0', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_THREADS, value: 0 }]);
@@ -1202,39 +1173,6 @@ describe(MediaService.name, () => {
             '-preset ultrafast',
             '-threads 1',
             '-x265-params frame-threads=1:pools=none',
-            '-crf 23',
-          ],
-          twoPass: false,
-        },
-      );
-    });
-
-    it('should set frame threads for hevc if thread limit is above 1', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.videoStreamVp9);
-      configMock.load.mockResolvedValue([
-        { key: SystemConfigKey.FFMPEG_THREADS, value: 2 },
-        { key: SystemConfigKey.FFMPEG_TARGET_VIDEO_CODEC, value: VideoCodec.HEVC },
-      ]);
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: [],
-          outputOptions: [
-            '-c:v hevc',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-threads 2',
-            '-x265-params frame-threads=2',
             '-crf 23',
           ],
           twoPass: false,

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -343,31 +343,23 @@ export class ThumbnailConfig extends BaseConfig {
 
 export class H264Config extends BaseConfig {
   getThreadOptions() {
-    if (this.config.threads <= 0) {
-      return [];
-    }
-
-    const params = [`frame-threads=${this.config.threads}`];
+    const options = super.getThreadOptions();
     if (this.config.threads === 1) {
-      params.push('pools=none');
+      options.push('-x264-params frame-threads=1:pools=none');
     }
 
-    return [...super.getThreadOptions(), `-x264-params ${params.join(':')}`];
+    return options;
   }
 }
 
 export class HEVCConfig extends BaseConfig {
   getThreadOptions() {
-    if (this.config.threads <= 0) {
-      return [];
-    }
-
-    const params = [`frame-threads=${this.config.threads}`];
+    const options = super.getThreadOptions();
     if (this.config.threads === 1) {
-      params.push('pools=none');
+      options.push('-x265-params frame-threads=1:pools=none');
     }
 
-    return [...super.getThreadOptions(), `-x265-params ${params.join(':')}`];
+    return options;
   }
 }
 

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -346,11 +346,13 @@ export class H264Config extends BaseConfig {
     if (this.config.threads <= 0) {
       return [];
     }
-    return [
-      ...super.getThreadOptions(),
-      '-x264-params "pools=none"',
-      `-x264-params "frame-threads=${this.config.threads}"`,
-    ];
+
+    const params = [`frame-threads=${this.config.threads}`];
+    if (this.config.threads === 1) {
+      params.push('pools=none');
+    }
+
+    return [...super.getThreadOptions(), `-x264-params ${params.join(':')}`];
   }
 }
 
@@ -359,11 +361,13 @@ export class HEVCConfig extends BaseConfig {
     if (this.config.threads <= 0) {
       return [];
     }
-    return [
-      ...super.getThreadOptions(),
-      '-x265-params "pools=none"',
-      `-x265-params "frame-threads=${this.config.threads}"`,
-    ];
+
+    const params = [`frame-threads=${this.config.threads}`];
+    if (this.config.threads === 1) {
+      params.push('pools=none');
+    }
+
+    return [...super.getThreadOptions(), `-x265-params ${params.join(':')}`];
   }
 }
 


### PR DESCRIPTION
## Description

Passing `-x264-params` multiple times overwrites the full set of parameters, so this PR changes the logic here to pass it once with all relevant parameters.

Of note, the intent behind setting these flags is to lower CPU usage in constrained environments. Disabling the thread pool is highly detrimental to performance, so it's only passed when specifying 1 thread.

Fixes #8494

## How Has This Been Tested?

Tested that transcoding H.264 works when the thread count is set to 0 as well as 1, and that the latter shows much more mild CPU usage