### PR TITLE
fix(server): delete thumbnail for readonly asset

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -695,7 +695,7 @@ describe(AssetService.name, () => {
       });
     });
 
-    it('should not schedule delete-files job for readonly assets', async () => {
+    it('should only delete generated files for readonly assets', async () => {
       when(assetMock.getById)
         .calledWith(assetStub.readOnly.id, {
           faces: {
@@ -709,7 +709,17 @@ describe(AssetService.name, () => {
 
       await sut.handleAssetDeletion({ id: assetStub.readOnly.id });
 
-      expect(jobMock.queue.mock.calls).toEqual([]);
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.DELETE_FILES,
+        data: {
+          files: [
+            assetStub.readOnly.thumbnailPath,
+            assetStub.readOnly.previewPath,
+            assetStub.readOnly.encodedVideoPath,
+            assetStub.readOnly.sidecarPath,
+          ],
+        },
+      });
 
       expect(assetMock.remove).toHaveBeenCalledWith(assetStub.readOnly);
     });

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -715,9 +715,9 @@ describe(AssetService.name, () => {
             name: JobName.DELETE_FILES,
             data: {
               files: [
-                assetStub.external.thumbnailPath,
-                assetStub.external.previewPath,
-                assetStub.external.encodedVideoPath,
+                assetStub.readOnly.thumbnailPath,
+                assetStub.readOnly.previewPath,
+                assetStub.readOnly.encodedVideoPath,
               ],
             },
           },

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -709,17 +709,20 @@ describe(AssetService.name, () => {
 
       await sut.handleAssetDeletion({ id: assetStub.readOnly.id });
 
-      expect(jobMock.queue).toHaveBeenCalledWith({
-        name: JobName.DELETE_FILES,
-        data: {
-          files: [
-            assetStub.readOnly.thumbnailPath,
-            assetStub.readOnly.previewPath,
-            assetStub.readOnly.encodedVideoPath,
-            assetStub.readOnly.sidecarPath,
-          ],
-        },
-      });
+      expect(jobMock.queue.mock.calls).toEqual([
+        [
+          {
+            name: JobName.DELETE_FILES,
+            data: {
+              files: [
+                assetStub.external.thumbnailPath,
+                assetStub.external.previewPath,
+                assetStub.external.encodedVideoPath,
+              ],
+            },
+          },
+        ],
+      ]);
 
       expect(assetMock.remove).toHaveBeenCalledWith(assetStub.readOnly);
     });
@@ -758,7 +761,6 @@ describe(AssetService.name, () => {
                 assetStub.external.thumbnailPath,
                 assetStub.external.previewPath,
                 assetStub.external.encodedVideoPath,
-                assetStub.external.sidecarPath,
               ],
             },
           },

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -399,9 +399,9 @@ export class AssetService {
       await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.livePhotoVideoId } });
     }
 
-    const files = [asset.thumbnailPath, asset.previewPath, asset.encodedVideoPath, asset.sidecarPath];
+    const files = [asset.thumbnailPath, asset.previewPath, asset.encodedVideoPath];
     if (!fromExternal && !asset.isReadOnly) {
-      files.push(asset.originalPath);
+      files.push(asset.sidecarPath, asset.originalPath);
     }
 
     await this.jobRepository.queue({ name: JobName.DELETE_FILES, data: { files } });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -400,13 +400,11 @@ export class AssetService {
     }
 
     const files = [asset.thumbnailPath, asset.previewPath, asset.encodedVideoPath, asset.sidecarPath];
-    if (!fromExternal) {
+    if (!fromExternal && !asset.isReadOnly) {
       files.push(asset.originalPath);
     }
 
-    if (!asset.isReadOnly) {
-      await this.jobRepository.queue({ name: JobName.DELETE_FILES, data: { files } });
-    }
+    await this.jobRepository.queue({ name: JobName.DELETE_FILES, data: { files } });
 
     return JobStatus.SUCCESS;
   }

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -400,7 +400,7 @@ export class AssetService {
     }
 
     const files = [asset.thumbnailPath, asset.previewPath, asset.encodedVideoPath];
-    if (!fromExternal && !asset.isReadOnly) {
+    if (!(asset.isExternal || asset.isReadOnly)) {
       files.push(asset.sidecarPath, asset.originalPath);
     }
 


### PR DESCRIPTION
Closes #4863 
Deletes thumbnail and other generated files for read-only assets

This is safe as only external library files use the "isReadOnly" boolean
