### PR TITLE
feat(mobile/web): add longer expirity for share link

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -439,6 +439,8 @@
   "shared_link_edit_expire_after_option_hours": "{} hours",
   "shared_link_edit_expire_after_option_minute": "1 minute",
   "shared_link_edit_expire_after_option_minutes": "{} minutes",
+  "shared_link_edit_expire_after_option_months": "{} months",
+  "shared_link_edit_expire_after_option_year": "{} year",
   "shared_link_edit_expire_after_option_never": "Never",
   "shared_link_edit_password": "Password",
   "shared_link_edit_password_hint": "Enter the share password",

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -272,8 +272,12 @@ class SharedLinkEditPage extends HookConsumerWidget {
             label: "shared_link_edit_expire_after_option_days".tr(args: ["30"]),
           ),
           DropdownMenuEntry(
-            value: 60 * 24 * 365,
-            label: "shared_link_edit_expire_after_option_days".tr(args: ["365"]),
+            value: 60 * 24 * 30 * 3,
+            label: "shared_link_edit_expire_after_option_months".tr(args: ["3"]),
+          ),
+          DropdownMenuEntry(
+            value: 60 * 24 * 30 * 12,
+            label: "shared_link_edit_expire_after_option_year".tr(args: ["1"]),
           ),
         ],
       );

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -271,6 +271,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
             value: 60 * 24 * 30,
             label: "shared_link_edit_expire_after_option_days".tr(args: ["30"]),
           ),
+          DropdownMenuEntry(
+            value: 60 * 24 * 365,
+            label: "shared_link_edit_expire_after_option_days".tr(args: ["365"]),
+          ),
         ],
       );
     }

--- a/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
+++ b/mobile/lib/modules/shared_link/views/shared_link_edit_page.dart
@@ -273,7 +273,8 @@ class SharedLinkEditPage extends HookConsumerWidget {
           ),
           DropdownMenuEntry(
             value: 60 * 24 * 30 * 3,
-            label: "shared_link_edit_expire_after_option_months".tr(args: ["3"]),
+            label:
+                "shared_link_edit_expire_after_option_months".tr(args: ["3"]),
           ),
           DropdownMenuEntry(
             value: 60 * 24 * 30 * 12,

--- a/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
+++ b/web/src/lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte
@@ -37,7 +37,7 @@
 
   const expiredDateOption: ImmichDropDownOption = {
     default: 'Never',
-    options: ['Never', '30 minutes', '1 hour', '6 hours', '1 day', '7 days', '30 days'],
+    options: ['Never', '30 minutes', '1 hour', '6 hours', '1 day', '7 days', '30 days', '3 months', '1 year'],
   };
 
   $: shareType = albumId ? SharedLinkType.Album : SharedLinkType.Individual;
@@ -104,6 +104,12 @@
       }
       case '30 days': {
         return 30 * 24 * 60 * 60 * 1000;
+      }
+      case '3 months': {
+        return 30 * 24 * 60 * 60 * 3 * 1000;
+      }
+      case '1 year': {
+        return 30 * 24 * 60 * 60 * 12 * 1000;
       }
       default: {
         return 0;


### PR DESCRIPTION
Sometimes peoples, like me, want to share an album to a longer period, but don't want to create an unlimited link.
For this option I add 1 year expirity for a share link.