### PR TITLE
fix: `npm i` on Windows …

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install --no-install-recommends -yqq tini
 WORKDIR /usr/src/app
 COPY server/package.json server/package-lock.json ./
 RUN npm ci && \
-    # sharp-linux-x64 and sharp-linux-arm64 are the only ones we need
+    # exiftool-vendored.pl, sharp-linux-x64 and sharp-linux-arm64 are the only ones we need
     # they're marked as optional dependencies, so we need to copy them manually after pruning
     rm -rf node_modules/@img/sharp-libvips* && \
     rm -rf node_modules/@img/sharp-linuxmusl-x64
@@ -22,6 +22,7 @@ FROM dev AS prod
 RUN npm run build
 RUN npm prune --omit=dev --omit=optional
 COPY --from=dev /usr/src/app/node_modules/@img ./node_modules/@img
+COPY --from=dev /usr/src/app/node_modules/exiftool-vendored.pl ./node_modules/exiftool-vendored.pl
 
 # web build
 FROM node:iron-alpine3.18@sha256:fa5d3cf51725bd42d32e67917623038539dbe720dab082f590785c001eb4dfef as web

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -35,7 +35,6 @@
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
         "exiftool-vendored": "~24.6.0",
-        "exiftool-vendored.pl": "12.78",
         "fast-glob": "^3.3.2",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^8.0.0",
@@ -7774,6 +7773,7 @@
       "version": "12.78.0",
       "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.78.0.tgz",
       "integrity": "sha512-K8j9NgxRpTFskFuXEl0AGsc692yYyThe4i3SXgx7xc0fu/vwD2c7tRGljkEtvaweYnMmfrF4DhCpuTu0aux6sg==",
+      "optional": true,
       "os": [
         "!win32"
       ]
@@ -20051,7 +20051,8 @@
     "exiftool-vendored.pl": {
       "version": "12.78.0",
       "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.78.0.tgz",
-      "integrity": "sha512-K8j9NgxRpTFskFuXEl0AGsc692yYyThe4i3SXgx7xc0fu/vwD2c7tRGljkEtvaweYnMmfrF4DhCpuTu0aux6sg=="
+      "integrity": "sha512-K8j9NgxRpTFskFuXEl0AGsc692yYyThe4i3SXgx7xc0fu/vwD2c7tRGljkEtvaweYnMmfrF4DhCpuTu0aux6sg==",
+      "optional": true
     },
     "exit": {
       "version": "0.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -59,7 +59,6 @@
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
     "exiftool-vendored": "~24.6.0",
-    "exiftool-vendored.pl": "12.78",
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^8.0.0",


### PR DESCRIPTION
…by removing direct dependency on `exiftool-vendored.pl` (like in `e2e/package.json`)

As platform-specific optional dependency will be provided by `exiftool-vendored` dependency: https://github.com/photostructure/exiftool-vendored.js/blob/9d4c1543c30d1466d035edbca22475b53523c98a/README.md?plain=1#L72-L74