### PR TITLE
Allow moving in photo spheres using one touch input instead of two.

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -11,8 +11,6 @@
     viewer = new Viewer({
       container,
       panorama,
-      touchmoveTwoFingers: true,
-      mousewheelCtrlKey: false,
       navbar: false,
     });
   });


### PR DESCRIPTION
This is the standard behaviour and also more intuitive. As we don't require scrolling when displaying photo spheres this should not impede usability.

Also remove `mousewheelCtrlKey: false`, which is the default.