### PR TITLE
chore(web): specify that HDR videos will always be transcoded

### DIFF
--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -179,7 +179,7 @@
         <SettingSelect
           label="TRANSCODE POLICY"
           {disabled}
-          desc="Policy for when a video should be transcoded."
+          desc="Policy for when a video should be transcoded. HDR videos will always be transcoded (expect if transcoding is disabled)."
           bind:value={config.ffmpeg.transcode}
           name="transcode"
           options={[


### PR DESCRIPTION
I spent quite a bit of time understanding why my videos were getting transcoded despite 'respecting' the transcoding policy.
I didn't see that written anywhere else so I thought it was a good place to inform users of that.
