### PR TITLE
support livp photos

### DIFF
--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -19,6 +19,7 @@ const image: Record<string, string[]> = {
   '.gif': ['image/gif'],
   '.heic': ['image/heic'],
   '.heif': ['image/heif'],
+  '.livp': ['image/livp'],
   '.hif': ['image/hif'],
   '.iiq': ['image/iiq', 'image/x-phaseone-iiq'],
   '.insp': ['image/jpeg'],


### PR DESCRIPTION
Uploading photos in the format of livp through the iOS immich app will result in an error on the server.
```txt
[Nest] 1  - 04/08/2024, 1:22:53 PM   ERROR [AssetService] Unsupported file type IMG_4372.livp
```

I found that the code does not have the livp format here. Can you add the livp format here?