### PR TITLE
docs: Pin to Postgres v14 in postgres-backup-local

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -63,7 +63,7 @@ services:
   ...
   backup:
     container_name: immich_db_dumper
-    image: prodrigestivill/postgres-backup-local
+    image: prodrigestivill/postgres-backup-local:14
     env_file:
       - .env
     environment:


### PR DESCRIPTION
We currently don't pin to a Docker image with the database dumper, which means they are created using PG v16. This is not good as Immich uses v14. We now pin to PG v14.