### PR TITLE
deployment: pin .env to current version

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -3,11 +3,12 @@
 # The location where your uploaded files are stored
 UPLOAD_LOCATION=./library
 
-# The Immich version to use. You can pin this to a specific version like "v1.71.0"
-IMMICH_VERSION=release
+# The version of Immich to use. To always use the latest version, specify IMMICH_VERSION=release
+# Before upgrading, always review the breaking changes at https://github.com/immich-app/immich/discussions?discussions_q=label%3Abreaking-change+sort%3Adate_created
+IMMICH_VERSION=v1.101.0
 
 # Connection secret for postgres. You should change it to a random password
-DB_PASSWORD=postgres
+DB_PASSWORD=postgres_immich_7890
 
 # The values below this line do not need to be changed
 ###################################################################################


### PR DESCRIPTION
Moving from Discord for discussion/conversation. I know this is a controversial change and may not be wanted at this time.

We discourage use of watchtower/similar, but it's almost a daily occurrence now that someone updates their Immich by just running `docker compose pull` without fixing the docker compose. This way people would have to take an extra step to switch to the bleeding edge release.

In the same light, I see tons of env files with the default `postgres` password. Obviously any publicly available password is not a good idea, but at least specifying something unique to Immich has the potential to decrease botnet Postgres takeovers (have seen a few threads with this happening in some projects with the `postgres` password).