### PR TITLE
docs(ml): update hardware acceleration doc

### DIFF
--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -27,8 +27,6 @@ services:
               count: 1
               capabilities:
                 - gpu
-                - compute
-                - video
 
   openvino:
     device_cgroup_rules:

--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -43,6 +43,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 
 1. If you do not already have it, download the latest [`hwaccel.ml.yml`][hw-file] file and ensure it's in the same folder as the `docker-compose.yml`.
 2. In the `docker-compose.yml` under `immich-machine-learning`, uncomment the `extends` section and change `cpu` to the appropriate backend.
+2. Still in `immich-machine-learning`, add one of -[armnn, cuda, openvino] to the `image` section's tag at the end of the line.
 3. Redeploy the `immich-machine-learning` container with these updated settings.
 
 #### Single Compose File
@@ -60,8 +61,6 @@ deploy:
           count: 1
           capabilities:
             - gpu
-            - compute
-            - video
 ```
 
 You can add this to the `immich-machine-learning` service instead of extending from `hwaccel.ml.yml`:
@@ -69,6 +68,7 @@ You can add this to the `immich-machine-learning` service instead of extending f
 ```yaml
 immich-machine-learning:
   container_name: immich_machine_learning
+  # Note the `-cuda` at the end
   image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}-cuda
   # Note the lack of an `extends` section
   deploy:
@@ -79,8 +79,6 @@ immich-machine-learning:
             count: 1
             capabilities:
               - gpu
-              - compute
-              - video
   volumes:
     - model-cache:/cache
   env_file:

--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -43,8 +43,8 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 
 1. If you do not already have it, download the latest [`hwaccel.ml.yml`][hw-file] file and ensure it's in the same folder as the `docker-compose.yml`.
 2. In the `docker-compose.yml` under `immich-machine-learning`, uncomment the `extends` section and change `cpu` to the appropriate backend.
-2. Still in `immich-machine-learning`, add one of -[armnn, cuda, openvino] to the `image` section's tag at the end of the line.
-3. Redeploy the `immich-machine-learning` container with these updated settings.
+3. Still in `immich-machine-learning`, add one of -[armnn, cuda, openvino] to the `image` section's tag at the end of the line.
+4. Redeploy the `immich-machine-learning` container with these updated settings.
 
 #### Single Compose File
 


### PR DESCRIPTION
## Description

Changing the tag is a required step, but this is only noted in the Compose file comments, not in the doc's instructions.

Additionally removes `video` and `compute` from the CUDA config as there are reports of these causing issues and it works without them.
