### PR TITLE
fix(server): prevent cross-library motion photo linking, made getByChecksum library specific

### DIFF
--- a/server/src/interfaces/asset.interface.ts
+++ b/server/src/interfaces/asset.interface.ts
@@ -146,7 +146,7 @@ export interface IAssetRepository {
   ): Promise<AssetEntity[]>;
   getByIdsWithAllRelations(ids: string[]): Promise<AssetEntity[]>;
   getByDayOfYear(ownerIds: string[], monthDay: MonthDay): Promise<AssetEntity[]>;
-  getByChecksum(userId: string, checksum: Buffer): Promise<AssetEntity | null>;
+  getByChecksum(libraryId: string, checksum: Buffer): Promise<AssetEntity | null>;
   getByAlbumId(pagination: PaginationOptions, albumId: string): Paginated<AssetEntity>;
   getByUserId(pagination: PaginationOptions, userId: string, options?: AssetSearchOptions): Paginated<AssetEntity>;
   getById(id: string, relations?: FindOptionsRelations<AssetEntity>): Promise<AssetEntity | null>;

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -464,7 +464,7 @@ FROM
 WHERE
   (
     (
-      ("AssetEntity"."ownerId" = $1)
+      ("AssetEntity"."libraryId" = $1)
       AND ("AssetEntity"."checksum" = $2)
     )
   )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -265,8 +265,8 @@ export class AssetRepository implements IAssetRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.BUFFER] })
-  getByChecksum(userId: string, checksum: Buffer): Promise<AssetEntity | null> {
-    return this.repository.findOne({ where: { ownerId: userId, checksum } });
+  getByChecksum(libraryId: string, checksum: Buffer): Promise<AssetEntity | null> {
+    return this.repository.findOne({ where: { libraryId, checksum } });
   }
 
   findLivePhotoMatch(options: LivePhotoSearchOptions): Promise<AssetEntity | null> {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -405,7 +405,7 @@ export class MetadataService {
       }
       const checksum = this.cryptoRepository.hashSha1(video);
 
-      let motionAsset = await this.assetRepository.getByChecksum(asset.ownerId, checksum);
+      let motionAsset = await this.assetRepository.getByChecksum(asset.libraryId, checksum);
       if (motionAsset) {
         this.logger.debug(
           `Asset ${asset.id}'s motion photo video with checksum ${checksum.toString(


### PR DESCRIPTION
Closes #8718

Changed `getByChecksum` used during motion photo extraction and linking to take `libraryId` instead of `ownerId`.

This PRs was part of #8512 and is preparation for fixing #8718 and #8503

This should be a safe nonbreaking change.
Most motion photos should be in the same library as their video asset.
