### PR TITLE
fix(server): link motion photo with existing video asset

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -412,6 +412,12 @@ export class MetadataService {
             'base64',
           )} already exists in the repository`,
         );
+
+        // Hide the motion photo video asset if it's not already hidden to prepare for linking
+        if (motionAsset.isVisible) {
+          await this.assetRepository.update({ id: motionAsset.id, isVisible: false });
+          this.logger.log(`Hid unlinked motion photo video asset (${motionAsset.id})`);
+        }
       } else {
         // We create a UUID in advance so that each extracted video can have a unique filename
         // (allowing us to delete old ones if necessary)
@@ -438,11 +444,14 @@ export class MetadataService {
         this.storageCore.ensureFolders(motionPath);
         await this.storageRepository.writeFile(motionAsset.originalPath, video);
         await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: motionAsset.id } });
-        await this.assetRepository.update({ id: asset.id, livePhotoVideoId: motionAsset.id });
+      }
 
+      if (asset.livePhotoVideoId !== motionAsset.id) {
+        await this.assetRepository.update({ id: asset.id, livePhotoVideoId: motionAsset.id });
         // If the asset already had an associated livePhotoVideo, delete it, because
         // its checksum doesn't match the checksum of the motionAsset we just extracted
-        // (if it did, getByChecksum() would've returned non-null)
+        // (if it did, getByChecksum() would've returned a motionAsset with the same ID as livePhotoVideoId)
+        // note asset.livePhotoVideoId is not motionAsset.id yet
         if (asset.livePhotoVideoId) {
           await this.jobRepository.queue({ name: JobName.ASSET_DELETION, data: { id: asset.livePhotoVideoId } });
           this.logger.log(`Removed old motion photo video asset (${asset.livePhotoVideoId})`);


### PR DESCRIPTION
Closes #8508, closes #8503.
Originally part of #8512.

Links existing video asset with motion photo if their checksum matches.

Should NOT be merged until #8719 is merged to prevent cross library linking.
