### PR TITLE
docs: clarify details of connecting to backend for development

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -66,7 +66,7 @@ The mobile app `(/mobile)` will required Flutter toolchain 3.13.x to be installe
 
 Please refer to the [Flutter's official documentation](https://flutter.dev/docs/get-started/install) for more information on setting up the toolchain on your machine.
 
-The mobile app asks you what backend to connect to. You can utilize the demo backend (https://demo.immich.app/) if you don't need to change server code or can run the server yourself per the instructions in the prior section.
+The mobile app asks you what backend to connect to. You can utilize the demo backend (https://demo.immich.app/) if you don't need to change server code or can run the server yourself per the instructions above.
 
 ## IDE setup
 

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -16,7 +16,7 @@ Thanks for being interested in contributing 😊
 
 ## Environment
 
-### Server and web app
+### Services
 
 This environment includes the services below. Additional details are available in each service's README.
 
@@ -28,7 +28,7 @@ This environment includes the services below. Additional details are available i
 
 All the services are packaged to run as with single Docker Compose command.
 
-### Instructions
+### Server and web apps
 
 1. Clone the project repo.
 2. Run `cp docker/example.env docker/.env`.
@@ -47,13 +47,7 @@ You can access the web from `http://your-machine-ip:2283` or `http://localhost:2
 
 **Note:** the "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
 
-### Mobile app
-
-The mobile app `(/mobile)` will required Flutter toolchain 3.13.x to be installed on your system.
-
-Please refer to the [Flutter's official documentation](https://flutter.dev/docs/get-started/install) for more information on setting up the toolchain on your machine.
-
-### Connect to a remote backend
+#### Connect web to a remote backend
 
 If you only want to do web development connected to an existing, remote backend, follow these steps:
 
@@ -65,6 +59,14 @@ If you only want to do web development connected to an existing, remote backend,
 ```bash
 IMMICH_SERVER_URL=https://demo.immich.app/ npm run dev
 ```
+
+### Mobile app
+
+The mobile app `(/mobile)` will required Flutter toolchain 3.13.x to be installed on your system.
+
+Please refer to the [Flutter's official documentation](https://flutter.dev/docs/get-started/install) for more information on setting up the toolchain on your machine.
+
+The mobile app asks you what backend to connect to. You can utilize the demo backend (https://demo.immich.app/) if you don't need to change server code or can run the server yourself per the instructions in the prior section.
 
 ## IDE setup
 


### PR DESCRIPTION
- improve the headings. e.g. the section talking about redis, ML, postgres, etc. is titled "Server and web app", so I changed it to "Services"
- move the section describing how to connect web to server backend to live as a sub-heading of the web setup section
- add a line describing how to connect mobile to a server backend