### PR TITLE
chore: added 'logs' field to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -93,6 +93,16 @@ body:
       description: >
         If you have any additional information for us, use the field below.
 
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant logs below. (code formatting is
+        enabled, no need for backticks)
+      render: shell
+    validations:
+      required: false
+      
   - type: markdown
     attributes:
       value: Thank you for submitting the form

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -88,12 +88,6 @@ body:
       required: true
 
   - type: textarea
-    attributes:
-      label: Additional information
-      description: >
-        If you have any additional information for us, use the field below.
-
-  - type: textarea
     id: logs
     attributes:
       label: Relevant log output
@@ -103,6 +97,12 @@ body:
     validations:
       required: false
       
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: >
+        If you have any additional information for us, use the field below.
+
   - type: markdown
     attributes:
       value: Thank you for submitting the form


### PR DESCRIPTION
Lots of issues are missing logs, people are not submitting them proactively, making things hard to debug, so a new field is added