### PR TITLE
feat(server):  trusted header authentication

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -43,6 +43,7 @@
         "handlebars": "^4.7.8",
         "i18n-iso-countries": "^7.6.0",
         "ioredis": "^5.3.2",
+        "ipaddr.js": "^2.1.0",
         "joi": "^17.10.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -8968,11 +8969,11 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -11600,6 +11601,14 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -20945,9 +20954,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -22955,6 +22964,13 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+        }
       }
     },
     "pump": {

--- a/server/package.json
+++ b/server/package.json
@@ -67,6 +67,7 @@
     "handlebars": "^4.7.8",
     "i18n-iso-countries": "^7.6.0",
     "ioredis": "^5.3.2",
+    "ipaddr.js": "^2.1.0",
     "joi": "^17.10.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",

--- a/server/src/middleware/auth.guard.ts
+++ b/server/src/middleware/auth.guard.ts
@@ -99,7 +99,7 @@ export class AuthGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<AuthRequest>();
 
-    const authDto = await this.authService.validate(request.headers, request.query as Record<string, string>);
+    const authDto = await this.authService.validate(request.headers, request.query as Record<string, string>, request.socket.remoteAddress);
     if (authDto.sharedLink && !isSharedRoute) {
       this.logger.warn(`Denied access to non-shared route: ${request.path}`);
       return false;

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -33,7 +33,7 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
   constructor(
     private authService: AuthService,
     private eventEmitter: EventEmitter2,
-  ) {}
+  ) { }
 
   afterInit(server: Server) {
     this.logger.log('Initialized websocket server');
@@ -53,7 +53,7 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
   async handleConnection(client: Socket) {
     try {
       this.logger.log(`Websocket Connect:    ${client.id}`);
-      const auth = await this.authService.validate(client.request.headers, {});
+      const auth = await this.authService.validate(client.request.headers, {}, client.request.socket.remoteAddress);
       await client.join(auth.user.id);
       this.serverSend(ServerEvent.WEBSOCKET_CONNECT, { userId: auth.user.id });
     } catch (error: Error | any) {

--- a/web/src/routes/auth/login/+page.server.ts
+++ b/web/src/routes/auth/login/+page.server.ts
@@ -1,0 +1,25 @@
+import { AppRoute } from '$lib/constants';
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { env } from '$env/dynamic/private';
+
+export const load = (async ({ cookies }) => {
+  if (env.IMMICH_TRUSTED_REMOTE_NETWORKS) {
+    [
+      ['immich_auth_type', 'trusted-header-auth'],
+      ['immich_is_authenticated', 'true']
+    ].forEach(([key, value]) => {
+      cookies.set(
+        key, value,
+        {
+          path: '/',
+          httpOnly: false,
+          sameSite: 'lax',
+          secure: false,
+          maxAge: 60 * 60 * 24 * 30
+        },
+      )
+    });
+    redirect(302, AppRoute.PHOTOS);
+  }
+}) satisfies PageServerLoad;


### PR DESCRIPTION
This PR implements trusted header authentication

To quote from https://www.authelia.com/integration/trusted-header-sso/introduction/

> This authentication method is referred to by many names; notably trusted header authentication, header authentication, header sso, and probably many more.

API test included.

To use it:
- `IMMICH_TRUSTED_REMOTE_NETWORKS` must be set, for example "10.3.3.0/24, fd00:3::/32, 172.3.4.0/24, 172.3.2.0/24"
- `remote-email` (note, email, not user) must exist in the HTTP request.

