### PR TITLE
POC of short asset ids

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8159,6 +8159,7 @@
         "properties": {
           "assetIds": {
             "items": {
+              "format": "uuid",
               "type": "string"
             },
             "type": "array"
@@ -8416,7 +8417,6 @@
             "type": "string"
           },
           "entityId": {
-            "format": "uuid",
             "type": "string"
           },
           "entityType": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -47,6 +47,7 @@
         "lodash": "^4.17.21",
         "luxon": "^3.4.2",
         "mnemonist": "^0.39.8",
+        "nanoid": "^3.3.5",
         "nest-commander": "^3.11.1",
         "nestjs-otel": "^5.1.5",
         "openid-client": "^5.4.3",
@@ -10601,6 +10602,23 @@
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.5.tgz",
+      "integrity": "sha512-nvgaJGpIANf4+VWJAaDGORQyMzhFkze8aXVdrHq+BaSvzfpOuponEysaVFKV/0Bca5V+3SBiDvRabEPbpalEBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -22207,6 +22225,11 @@
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.5.tgz",
+      "integrity": "sha512-nvgaJGpIANf4+VWJAaDGORQyMzhFkze8aXVdrHq+BaSvzfpOuponEysaVFKV/0Bca5V+3SBiDvRabEPbpalEBg=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -71,6 +71,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.4.2",
     "mnemonist": "^0.39.8",
+    "nanoid": "^3.3.5",
     "nest-commander": "^3.11.1",
     "nestjs-otel": "^5.1.5",
     "openid-client": "^5.4.3",

--- a/server/src/dtos/activity.dto.ts
+++ b/server/src/dtos/activity.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNotEmpty, IsString, ValidateIf } from 'class-validator';
 import { UserDto, mapSimpleUser } from 'src/dtos/user.dto';
 import { ActivityEntity } from 'src/entities/activity.entity';
-import { Optional, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateUUID } from 'src/validation';
 
 export enum ReactionType {
   COMMENT = 'comment',
@@ -34,7 +34,7 @@ export class ActivityDto {
   @ValidateUUID()
   albumId!: string;
 
-  @ValidateUUID({ optional: true })
+  @ValidateAssetId({ optional: true })
   assetId?: string;
 }
 

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -4,7 +4,7 @@ import { AssetResponseDto, mapAsset } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { UserResponseDto, mapUser } from 'src/dtos/user.dto';
 import { AlbumEntity, AssetOrder } from 'src/entities/album.entity';
-import { Optional, ValidateBoolean, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateBoolean, ValidateUUID } from 'src/validation';
 
 export class AlbumInfoDto {
   @ValidateBoolean({ optional: true })
@@ -29,7 +29,7 @@ export class CreateAlbumDto {
   @ValidateUUID({ optional: true, each: true })
   sharedWithUserIds?: string[];
 
-  @ValidateUUID({ optional: true, each: true })
+  @ValidateAssetId({ optional: true, each: true })
   assetIds?: string[];
 }
 
@@ -42,7 +42,7 @@ export class UpdateAlbumDto {
   @IsString()
   description?: string;
 
-  @ValidateUUID({ optional: true })
+  @ValidateAssetId({ optional: true })
   albumThumbnailAssetId?: string;
 
   @ValidateBoolean({ optional: true })
@@ -68,7 +68,7 @@ export class GetAlbumsDto {
    * Ignores the shared parameter
    * undefined: get all albums
    */
-  @ValidateUUID({ optional: true })
+  @ValidateAssetId({ optional: true })
   assetId?: string;
 }
 

--- a/server/src/dtos/asset-ids.response.dto.ts
+++ b/server/src/dtos/asset-ids.response.dto.ts
@@ -1,4 +1,4 @@
-import { ValidateUUID } from 'src/validation';
+import { ValidateAssetId, ValidateUUID } from 'src/validation';
 
 /** @deprecated Use `BulkIdResponseDto` instead */
 export enum AssetIdErrorReason {
@@ -22,7 +22,7 @@ export enum BulkIdErrorReason {
 }
 
 export class BulkIdsDto {
-  @ValidateUUID({ each: true })
+  @ValidateAssetId({ each: true })
   ids!: string[];
 }
 

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -14,7 +14,7 @@ import {
 import { BulkIdsDto } from 'src/dtos/asset-ids.response.dto';
 import { AssetType } from 'src/entities/asset.entity';
 import { AssetStats } from 'src/interfaces/asset.interface';
-import { Optional, ValidateBoolean, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateBoolean, ValidateUUID } from 'src/validation';
 
 export class DeviceIdDto {
   @IsNotEmpty()
@@ -49,10 +49,10 @@ export class UpdateAssetBase {
 }
 
 export class AssetBulkUpdateDto extends UpdateAssetBase {
-  @ValidateUUID({ each: true })
+  @ValidateAssetId({ each: true })
   ids!: string[];
 
-  @ValidateUUID({ optional: true })
+  @ValidateAssetId({ optional: true })
   stackParentId?: string;
 
   @ValidateBoolean({ optional: true })
@@ -79,7 +79,7 @@ export class AssetBulkDeleteDto extends BulkIdsDto {
 }
 
 export class AssetIdsDto {
-  @ValidateUUID({ each: true })
+  @ValidateAssetId({ each: true })
   assetIds!: string[];
 }
 

--- a/server/src/dtos/audit.dto.ts
+++ b/server/src/dtos/audit.dto.ts
@@ -56,7 +56,6 @@ export class FileReportFixDto {
 
 // used both as request and response dto
 export class FileReportItemDto {
-  @ValidateUUID()
   entityId!: string;
 
   @ApiProperty({ enumName: 'PathEntityType', enum: PathEntityType })

--- a/server/src/dtos/download.dto.ts
+++ b/server/src/dtos/download.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsPositive } from 'class-validator';
-import { Optional, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateUUID } from 'src/validation';
 
 export class DownloadInfoDto {
-  @ValidateUUID({ each: true, optional: true })
+  @ValidateAssetId({ each: true, optional: true })
   assetIds?: string[];
 
   @ValidateUUID({ optional: true })
@@ -28,5 +28,6 @@ export class DownloadResponseDto {
 export class DownloadArchiveInfo {
   @ApiProperty({ type: 'integer' })
   size!: number;
+  @ValidateAssetId({ optional: true, each: true })
   assetIds!: string[];
 }

--- a/server/src/dtos/memory.dto.ts
+++ b/server/src/dtos/memory.dto.ts
@@ -3,7 +3,7 @@ import { Type } from 'class-transformer';
 import { IsEnum, IsInt, IsObject, IsPositive, ValidateNested } from 'class-validator';
 import { AssetResponseDto, mapAsset } from 'src/dtos/asset-response.dto';
 import { MemoryEntity, MemoryType } from 'src/entities/memory.entity';
-import { ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
+import { ValidateAssetId, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
 
 class MemoryBaseDto {
   @ValidateBoolean({ optional: true })
@@ -49,7 +49,7 @@ export class MemoryCreateDto extends MemoryBaseDto {
   @ValidateDate()
   memoryAt!: Date;
 
-  @ValidateUUID({ optional: true, each: true })
+  @ValidateAssetId({ optional: true, each: true })
   assetIds?: string[];
 }
 

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -4,7 +4,7 @@ import { IsArray, IsNotEmpty, IsString, MaxDate, ValidateNested } from 'class-va
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { PersonEntity } from 'src/entities/person.entity';
-import { Optional, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
 
 export class PersonCreateDto {
   /**
@@ -55,7 +55,7 @@ export class PeopleUpdateItem extends PersonUpdateDto {
 }
 
 export class MergePersonDto {
-  @ValidateUUID({ each: true })
+  @ValidateAssetId({ each: true })
   ids!: string[];
 }
 
@@ -114,7 +114,7 @@ export class AssetFaceUpdateItem {
   @ValidateUUID()
   personId!: string;
 
-  @ValidateUUID()
+  @ValidateAssetId()
   assetId!: string;
 }
 

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -6,7 +6,7 @@ import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { AssetOrder } from 'src/entities/album.entity';
 import { AssetType } from 'src/entities/asset.entity';
 import { GeodataPlacesEntity } from 'src/entities/geodata-places.entity';
-import { Optional, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
+import { Optional, ValidateAssetId, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
 
 class BaseSearchDto {
   @ValidateUUID({ optional: true })
@@ -131,7 +131,7 @@ class BaseSearchDto {
 }
 
 export class MetadataSearchDto extends BaseSearchDto {
-  @ValidateUUID({ optional: true })
+  @ValidateAssetId({ optional: true })
   id?: string;
 
   @IsString()

--- a/server/src/dtos/stack.dto.ts
+++ b/server/src/dtos/stack.dto.ts
@@ -1,9 +1,9 @@
-import { ValidateUUID } from 'src/validation';
+import { ValidateAssetId, ValidateUUID } from 'src/validation';
 
 export class UpdateStackParentDto {
-  @ValidateUUID()
+  @ValidateAssetId()
   oldParentId!: string;
 
-  @ValidateUUID()
+  @ValidateAssetId()
   newParentId!: string;
 }

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
@@ -10,6 +11,7 @@ import { SmartSearchEntity } from 'src/entities/smart-search.entity';
 import { TagEntity } from 'src/entities/tag.entity';
 import { UserEntity } from 'src/entities/user.entity';
 import {
+  BeforeInsert,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -21,10 +23,11 @@ import {
   ManyToOne,
   OneToMany,
   OneToOne,
+  PrimaryColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-
+export const ID_SIZE = 12;
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_library_checksum';
 
 @Entity('assets')
@@ -39,7 +42,12 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_library_checksum';
 @Index('idx_originalFileName_trigram', { synchronize: false })
 // For all assets, each originalpath must be unique per user and library
 export class AssetEntity {
-  @PrimaryGeneratedColumn('uuid')
+  @BeforeInsert()
+  updateDates() {
+    // generate the object id
+    this.id = nanoid(ID_SIZE);
+  }
+  @PrimaryColumn('varchar', { length: 16 })
   id!: string;
 
   @Column()

--- a/server/src/migrations/1713131136153-nanoid.ts
+++ b/server/src/migrations/1713131136153-nanoid.ts
@@ -1,0 +1,293 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Nanoid1713131136153 implements MigrationInterface {
+  name = 'Nanoid1713131136153';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "asset_job_status" DROP CONSTRAINT "FK_420bec36fc02813bddf5c8b73d4"`);
+    await queryRunner.query(`ALTER TABLE "asset_job_status" DROP CONSTRAINT "PK_420bec36fc02813bddf5c8b73d4"`);
+    await queryRunner.query(`ALTER TABLE "asset_job_status" ALTER COLUMN "assetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "asset_job_status" ALTER COLUMN "assetId" SET NOT NULL`);
+
+    await queryRunner.query(
+      `ALTER TABLE "asset_job_status" ADD CONSTRAINT "PK_420bec36fc02813bddf5c8b73d4" PRIMARY KEY ("assetId")`,
+    );
+    await queryRunner.query(`ALTER TABLE "asset_stack" DROP CONSTRAINT "FK_91704e101438fd0653f582426dc"`);
+    await queryRunner.query(`ALTER TABLE "asset_stack" DROP CONSTRAINT "REL_91704e101438fd0653f582426d"`);
+    await queryRunner.query(`ALTER TABLE "asset_stack" ALTER COLUMN "primaryAssetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "asset_stack" ALTER COLUMN "primaryAssetId" SET NOT NULL`);
+
+    await queryRunner.query(
+      `ALTER TABLE "asset_stack" ADD CONSTRAINT "UQ_91704e101438fd0653f582426dc" UNIQUE ("primaryAssetId")`,
+    );
+    await queryRunner.query(`ALTER TABLE "exif" DROP CONSTRAINT "FK_c0117fdbc50b917ef9067740c44"`);
+    await queryRunner.query(`ALTER TABLE "exif" DROP CONSTRAINT "PK_c0117fdbc50b917ef9067740c44"`);
+    await queryRunner.query(`ALTER TABLE "exif" ALTER COLUMN "assetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "exif" ALTER COLUMN "assetId" SET NOT NULL`);
+
+    await queryRunner.query(
+      `ALTER TABLE "exif" ADD CONSTRAINT "PK_c0117fdbc50b917ef9067740c44" PRIMARY KEY ("assetId")`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "FK_6942ecf52d75d4273de19d2c16f"`);
+    await queryRunner.query(`ALTER TABLE "memories_assets_assets" ALTER COLUMN "assetsId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "memories_assets_assets" ALTER COLUMN "assetsId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "FK_5b7decce6c8d3db9593d6111a66"`);
+    await queryRunner.query(`ALTER TABLE "albums_assets_assets" DROP CONSTRAINT "FK_4bd1303d199f4e72ccdf998c621"`);
+    await queryRunner.query(`ALTER TABLE "albums_assets_assets" ALTER COLUMN "assetsId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "albums_assets_assets" ALTER COLUMN "assetsId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "activity" DROP CONSTRAINT "FK_8091ea76b12338cb4428d33d782"`);
+    await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "FK_16294b83fa8c0149719a1f631ef"`);
+    await queryRunner.query(`ALTER TABLE "albums" DROP CONSTRAINT "FK_05895aa505a670300d4816debce"`);
+
+    await queryRunner.query(`DROP INDEX "public"."IDX_asset_id_stackId"`);
+
+    await queryRunner.query(`ALTER TABLE "tag_asset" DROP CONSTRAINT "PK_ef5346fe522b5fb3bc96454747e"`);
+    await queryRunner.query(`ALTER TABLE "tag_asset" DROP CONSTRAINT "FK_f8e8a9e893cb5c54907f1b798e9"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_tag_asset_assetsId_tagsId"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_f8e8a9e893cb5c54907f1b798e"`);
+
+    await queryRunner.query(`ALTER TABLE "tag_asset" ALTER COLUMN "assetsId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "tag_asset" ALTER COLUMN "assetsId" SET NOT NULL`);
+
+    await queryRunner.query(
+      `ALTER TABLE "tag_asset" ADD CONSTRAINT "PK_ef5346fe522b5fb3bc96454747e" PRIMARY KEY ("assetsId", "tagsId")`,
+    );
+
+    await queryRunner.query(`CREATE INDEX "IDX_tag_asset_assetsId_tagsId" on tag_asset ("assetsId", "tagsId")`);
+
+    await queryRunner.query(`ALTER TABLE "smart_info" DROP CONSTRAINT "PK_5e3753aadd956110bf3ec0244ac"`);
+    await queryRunner.query(`ALTER TABLE "smart_info" DROP CONSTRAINT "FK_5e3753aadd956110bf3ec0244ac"`);
+    await queryRunner.query(`ALTER TABLE "smart_info" ALTER COLUMN "assetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "smart_info" ALTER COLUMN "assetId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "smart_search" DROP CONSTRAINT "smart_search_assetId_fkey"`);
+    await queryRunner.query(`ALTER TABLE "smart_search" ALTER COLUMN "assetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "smart_search" ALTER COLUMN "assetId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "asset_faces" DROP CONSTRAINT "FK_02a43fd0b3c50fb6d7f0cb7282c"`);
+    await queryRunner.query(`ALTER TABLE "asset_faces" ALTER COLUMN "assetId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "asset_faces" ALTER COLUMN "assetId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "PK_da96729a8b113377cfb6a62439c"`);
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "id" TYPE character varying(36)`);
+    await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN "id" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "assets" ADD CONSTRAINT "PK_da96729a8b113377cfb6a62439c" PRIMARY KEY ("id")`);
+    await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "UQ_16294b83fa8c0149719a1f631ef"`);
+    await queryRunner.query(`ALTER TABLE "assets" DROP COLUMN "livePhotoVideoId"`);
+    await queryRunner.query(`ALTER TABLE "assets" ADD "livePhotoVideoId" character varying`);
+    await queryRunner.query(
+      `ALTER TABLE "assets" ADD CONSTRAINT "UQ_16294b83fa8c0149719a1f631ef" UNIQUE ("livePhotoVideoId")`,
+    );
+    await queryRunner.query(`ALTER TABLE "albums" DROP COLUMN "albumThumbnailAssetId"`);
+    await queryRunner.query(`ALTER TABLE "albums" ADD "albumThumbnailAssetId" character varying`);
+    await queryRunner.query(`COMMENT ON COLUMN "albums"."albumThumbnailAssetId" IS 'Asset ID to be used as thumbnail'`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_activity_like"`);
+    await queryRunner.query(`ALTER TABLE "activity" ALTER COLUMN "assetId" TYPE character varying`);
+
+    await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "PK_9b4f3687f9b31d1e311336b05e3"`);
+    await queryRunner.query(
+      `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "PK_c9fab4aa97ffd1b034f3d6581ab" PRIMARY KEY ("sharedLinksId")`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_5b7decce6c8d3db9593d6111a6"`);
+    await queryRunner.query(`ALTER TABLE "shared_link__asset" ALTER COLUMN "assetsId" TYPE character varying`);
+    await queryRunner.query(`ALTER TABLE "shared_link__asset" ALTER COLUMN "assetsId" SET NOT NULL`);
+
+    await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "PK_c9fab4aa97ffd1b034f3d6581ab"`);
+    await queryRunner.query(
+      `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "PK_9b4f3687f9b31d1e311336b05e3" PRIMARY KEY ("sharedLinksId", "assetsId")`,
+    );
+
+    await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "PK_fcaf7112a013d1703c011c6793d"`);
+    await queryRunner.query(
+      `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "PK_984e5c9ab1f04d34538cd32334e" PRIMARY KEY ("memoriesId")`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_6942ecf52d75d4273de19d2c16"`);
+
+    await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "PK_984e5c9ab1f04d34538cd32334e"`);
+    await queryRunner.query(
+      `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "PK_fcaf7112a013d1703c011c6793d" PRIMARY KEY ("memoriesId", "assetsId")`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_asset_id_stackId" ON "assets" ("id", "stackId") `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_activity_like" ON "activity" ("assetId", "userId", "albumId") WHERE ("isLiked" = true)`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_5b7decce6c8d3db9593d6111a6" ON "shared_link__asset" ("assetsId") `);
+    await queryRunner.query(`CREATE INDEX "IDX_6942ecf52d75d4273de19d2c16" ON "memories_assets_assets" ("assetsId") `);
+    await queryRunner.query(
+      `ALTER TABLE "asset_job_status" ADD CONSTRAINT "FK_420bec36fc02813bddf5c8b73d4" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "asset_stack" ADD CONSTRAINT "FK_91704e101438fd0653f582426dc" FOREIGN KEY ("primaryAssetId") REFERENCES "assets"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "exif" ADD CONSTRAINT "FK_c0117fdbc50b917ef9067740c44" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "assets" ADD CONSTRAINT "FK_16294b83fa8c0149719a1f631ef" FOREIGN KEY ("livePhotoVideoId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "albums" ADD CONSTRAINT "FK_05895aa505a670300d4816debce" FOREIGN KEY ("albumThumbnailAssetId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "activity" ADD CONSTRAINT "FK_8091ea76b12338cb4428d33d782" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "FK_5b7decce6c8d3db9593d6111a66" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "albums_assets_assets" ADD CONSTRAINT "FK_4bd1303d199f4e72ccdf998c621" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "FK_6942ecf52d75d4273de19d2c16f" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(`CREATE INDEX "IDX_f8e8a9e893cb5c54907f1b798e" ON "tag_asset" ("assetsId") `);
+    await queryRunner.query(
+      `ALTER TABLE "tag_asset" ADD CONSTRAINT "FK_f8e8a9e893cb5c54907f1b798e9" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "smart_info" ADD CONSTRAINT "PK_5e3753aadd956110bf3ec0244ac" PRIMARY KEY ("assetId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "smart_info" ADD CONSTRAINT "FK_5e3753aadd956110bf3ec0244ac" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "smart_search" ADD CONSTRAINT "smart_search_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "asset_faces" ADD CONSTRAINT "FK_02a43fd0b3c50fb6d7f0cb7282c" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN id TYPE uuid `);
+    // await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN id SET DEFUALT uuid_generate_v4()`);
+    // await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN id SET NOT NULL `);
+    // await queryRunner.query(`ALTER TABLE "assets" ALTER COLUMN id TYPE uuid `);
+    // await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "FK_6942ecf52d75d4273de19d2c16f"`);
+    // await queryRunner.query(`ALTER TABLE "albums_assets_assets" DROP CONSTRAINT "FK_4bd1303d199f4e72ccdf998c621"`);
+    // await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "FK_5b7decce6c8d3db9593d6111a66"`);
+    // await queryRunner.query(`ALTER TABLE "activity" DROP CONSTRAINT "FK_8091ea76b12338cb4428d33d782"`);
+    // await queryRunner.query(`ALTER TABLE "albums" DROP CONSTRAINT "FK_05895aa505a670300d4816debce"`);
+    // await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "FK_16294b83fa8c0149719a1f631ef"`);
+    // await queryRunner.query(`ALTER TABLE "exif" DROP CONSTRAINT "FK_c0117fdbc50b917ef9067740c44"`);
+    // await queryRunner.query(`ALTER TABLE "asset_stack" DROP CONSTRAINT "FK_91704e101438fd0653f582426dc"`);
+    // await queryRunner.query(`ALTER TABLE "asset_job_status" DROP CONSTRAINT "FK_420bec36fc02813bddf5c8b73d4"`);
+    // await queryRunner.query(`DROP INDEX "public"."IDX_6942ecf52d75d4273de19d2c16"`);
+    // await queryRunner.query(`DROP INDEX "public"."IDX_4bd1303d199f4e72ccdf998c62"`);
+    // await queryRunner.query(`DROP INDEX "public"."IDX_5b7decce6c8d3db9593d6111a6"`);
+    // await queryRunner.query(`DROP INDEX "public"."IDX_activity_like"`);
+    // await queryRunner.query(`DROP INDEX "public"."IDX_asset_id_stackId"`);
+    // await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "PK_fcaf7112a013d1703c011c6793d"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "PK_984e5c9ab1f04d34538cd32334e" PRIMARY KEY ("memoriesId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP COLUMN "assetsId"`);
+    // await queryRunner.query(`ALTER TABLE "memories_assets_assets" ADD "assetsId" uuid NOT NULL`);
+    // await queryRunner.query(`CREATE INDEX "IDX_6942ecf52d75d4273de19d2c16" ON "memories_assets_assets" ("assetsId") `);
+    // await queryRunner.query(`ALTER TABLE "memories_assets_assets" DROP CONSTRAINT "PK_984e5c9ab1f04d34538cd32334e"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "PK_fcaf7112a013d1703c011c6793d" PRIMARY KEY ("memoriesId", "assetsId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "albums_assets_assets" DROP CONSTRAINT "PK_c67bc36fa845fb7b18e0e398180"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "albums_assets_assets" ADD CONSTRAINT "PK_c67bc36fa845fb7b18e0e398180" PRIMARY KEY ("albumsId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "albums_assets_assets" DROP COLUMN "assetsId"`);
+    // await queryRunner.query(`ALTER TABLE "albums_assets_assets" ADD "assetsId" uuid NOT NULL`);
+    // await queryRunner.query(`CREATE INDEX "IDX_4bd1303d199f4e72ccdf998c62" ON "albums_assets_assets" ("assetsId") `);
+    // await queryRunner.query(`ALTER TABLE "albums_assets_assets" DROP CONSTRAINT "PK_c67bc36fa845fb7b18e0e398180"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "albums_assets_assets" ADD CONSTRAINT "PK_c67bc36fa845fb7b18e0e398180" PRIMARY KEY ("albumsId", "assetsId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "PK_9b4f3687f9b31d1e311336b05e3"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "PK_c9fab4aa97ffd1b034f3d6581ab" PRIMARY KEY ("sharedLinksId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP COLUMN "assetsId"`);
+    // await queryRunner.query(`ALTER TABLE "shared_link__asset" ADD "assetsId" uuid NOT NULL`);
+    // await queryRunner.query(`CREATE INDEX "IDX_5b7decce6c8d3db9593d6111a6" ON "shared_link__asset" ("assetsId") `);
+    // await queryRunner.query(`ALTER TABLE "shared_link__asset" DROP CONSTRAINT "PK_c9fab4aa97ffd1b034f3d6581ab"`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "PK_9b4f3687f9b31d1e311336b05e3" PRIMARY KEY ("assetsId", "sharedLinksId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "activity" DROP COLUMN "assetId"`);
+    // await queryRunner.query(`ALTER TABLE "activity" ADD "assetId" uuid`);
+    // await queryRunner.query(
+    //   `CREATE UNIQUE INDEX "IDX_activity_like" ON "activity" ("albumId", "userId", "assetId") WHERE ("isLiked" = true)`,
+    // );
+    // await queryRunner.query(`COMMENT ON COLUMN "albums"."albumThumbnailAssetId" IS 'Asset ID to be used as thumbnail'`);
+    // await queryRunner.query(`ALTER TABLE "albums" DROP COLUMN "albumThumbnailAssetId"`);
+    // await queryRunner.query(`ALTER TABLE "albums" ADD "albumThumbnailAssetId" uuid`);
+    // await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "UQ_16294b83fa8c0149719a1f631ef"`);
+    // await queryRunner.query(`ALTER TABLE "assets" DROP COLUMN "livePhotoVideoId"`);
+    // await queryRunner.query(`ALTER TABLE "assets" ADD "livePhotoVideoId" uuid`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "assets" ADD CONSTRAINT "UQ_16294b83fa8c0149719a1f631ef" UNIQUE ("livePhotoVideoId")`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "assets" DROP CONSTRAINT "PK_da96729a8b113377cfb6a62439c"`);
+    // await queryRunner.query(`ALTER TABLE "assets" DROP COLUMN "id"`);
+    // await queryRunner.query(`ALTER TABLE "assets" ADD "id" uuid NOT NULL DEFAULT uuid_generate_v4()`);
+    // await queryRunner.query(`ALTER TABLE "assets" ADD CONSTRAINT "PK_da96729a8b113377cfb6a62439c" PRIMARY KEY ("id")`);
+    // await queryRunner.query(`CREATE INDEX "IDX_asset_id_stackId" ON "assets" ("id", "stackId") `);
+    // await queryRunner.query(
+    //   `ALTER TABLE "albums" ADD CONSTRAINT "FK_05895aa505a670300d4816debce" FOREIGN KEY ("albumThumbnailAssetId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "assets" ADD CONSTRAINT "FK_16294b83fa8c0149719a1f631ef" FOREIGN KEY ("livePhotoVideoId") REFERENCES "assets"("id") ON DELETE SET NULL ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "activity" ADD CONSTRAINT "FK_8091ea76b12338cb4428d33d782" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "albums_assets_assets" ADD CONSTRAINT "FK_4bd1303d199f4e72ccdf998c621" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "shared_link__asset" ADD CONSTRAINT "FK_5b7decce6c8d3db9593d6111a66" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "memories_assets_assets" ADD CONSTRAINT "FK_6942ecf52d75d4273de19d2c16f" FOREIGN KEY ("assetsId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    // );
+    // await queryRunner.query(
+    //   `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "database" = $3 AND "schema" = $4 AND "table" = $5`,
+    //   ['GENERATED_COLUMN', 'exifTextSearchableColumn', 'immich-test', 'public', 'exif'],
+    // );
+    // await queryRunner.query(`ALTER TABLE "exif" DROP COLUMN "exifTextSearchableColumn"`);
+    // await queryRunner.query(
+    //   `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES ($1, $2, $3, $4, $5, $6)`,
+    //   ['immich-test', 'public', 'exif', 'GENERATED_COLUMN', 'exifTextSearchableColumn', ''],
+    // );
+    // await queryRunner.query(`ALTER TABLE "exif" ADD "exifTextSearchableColumn" tsvector NOT NULL`);
+    // await queryRunner.query(`ALTER TABLE "exif" DROP CONSTRAINT "PK_c0117fdbc50b917ef9067740c44"`);
+    // await queryRunner.query(`ALTER TABLE "exif" DROP COLUMN "assetId"`);
+    // await queryRunner.query(`ALTER TABLE "exif" ADD "assetId" uuid NOT NULL`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "exif" ADD CONSTRAINT "PK_c0117fdbc50b917ef9067740c44" PRIMARY KEY ("assetId")`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "exif" ADD CONSTRAINT "FK_c0117fdbc50b917ef9067740c44" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "asset_stack" DROP CONSTRAINT "UQ_91704e101438fd0653f582426dc"`);
+    // await queryRunner.query(`ALTER TABLE "asset_stack" DROP COLUMN "primaryAssetId"`);
+    // await queryRunner.query(`ALTER TABLE "asset_stack" ADD "primaryAssetId" uuid NOT NULL`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "asset_stack" ADD CONSTRAINT "REL_91704e101438fd0653f582426d" UNIQUE ("primaryAssetId")`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "asset_stack" ADD CONSTRAINT "FK_91704e101438fd0653f582426dc" FOREIGN KEY ("primaryAssetId") REFERENCES "assets"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    // );
+    // await queryRunner.query(`ALTER TABLE "asset_job_status" DROP CONSTRAINT "PK_420bec36fc02813bddf5c8b73d4"`);
+    // await queryRunner.query(`ALTER TABLE "asset_job_status" DROP COLUMN "assetId"`);
+    // await queryRunner.query(`ALTER TABLE "asset_job_status" ADD "assetId" uuid NOT NULL`);
+    // await queryRunner.query(
+    //   `ALTER TABLE "asset_job_status" ADD CONSTRAINT "PK_420bec36fc02813bddf5c8b73d4" PRIMARY KEY ("assetId")`,
+    // );
+    // await queryRunner.query(
+    //   `ALTER TABLE "asset_job_status" ADD CONSTRAINT "FK_420bec36fc02813bddf5c8b73d4" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    // );
+  }
+}

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -72,7 +72,11 @@ export class AssetRepository implements IAssetRepository {
   }
 
   create(asset: AssetCreate): Promise<AssetEntity> {
-    return this.repository.save(asset);
+    // @BeforeInsert listeners do not fire if arg to
+    // .save is not an instance of AssetEntity
+    const newAsset = new AssetEntity();
+    Object.assign(newAsset, asset);
+    return this.repository.save(newAsset);
   }
 
   @GenerateSql({ params: [[DummyValue.UUID], { day: 1, month: 1 }] })

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -16,12 +16,14 @@ import {
   IsOptional,
   IsString,
   IsUUID,
+  MinLength,
   ValidateIf,
   ValidationOptions,
   isDateString,
 } from 'class-validator';
 import { CronJob } from 'cron';
 import sanitize from 'sanitize-filename';
+import { ID_SIZE } from 'src/entities/asset.entity';
 
 @Injectable()
 export class ParseMeUUIDPipe extends ParseUUIDPipe {
@@ -54,8 +56,8 @@ export class FileNotEmptyValidator extends FileValidator {
 }
 
 export class UUIDParamDto {
+  @MinLength(ID_SIZE)
   @IsNotEmpty()
-  @IsUUID('4')
   @ApiProperty({ format: 'uuid' })
   id!: string;
 }
@@ -85,6 +87,17 @@ export const ValidateUUID = (options?: UUIDOptions) => {
   const { optional, each } = { optional: false, each: false, ...options };
   return applyDecorators(
     IsUUID('4', { each }),
+    ApiProperty({ format: 'uuid' }),
+    optional ? Optional() : IsNotEmpty(),
+    each ? IsArray() : IsString(),
+  );
+};
+
+type IdOptions = { optional?: boolean; each?: boolean };
+export const ValidateAssetId = (options?: IdOptions) => {
+  const { optional, each } = { optional: false, each: false, ...options };
+  return applyDecorators(
+    MinLength(ID_SIZE),
     ApiProperty({ format: 'uuid' }),
     optional ? Optional() : IsNotEmpty(),
     each ? IsArray() : IsString(),


### PR DESCRIPTION
This is a proof of concept of what it would take to implement short asset ids using nanoid, as mentioned in https://github.com/immich-app/immich/pull/8532#issuecomment-2054087850. 

Its currently set to use nanoid(12), which gives approximately 9B (9,000,000,000) records. Its not in the POC, but when/if this runs out, or if there is a collision with the random ID generator (rare), the operation could be retried, or the length of the id could be increased, which will exponentially (probably) grow the number of records. 

As you can see, most of the work is in updating the validation of input to loosen the UUID format checks to be just length based, and the migration script. 

Also not implemented, is the down() part of the migration, and a way to "upgrade" the old 36 char ids to be 12 chars long. I did a quick skim, and it looks like most foreign keys have a `ON UPDATE CASCADE` clause, so this could be as simple as just updating all the records to a nanoid(12) id. 

All of the not-implemented things ought to be finished if the thought of "saving" 67% of the characters of an asset. 

This was only done for assetIds, but could also be done for albumIds, and maybe all uuids? 

 