### PR TITLE
feat(web): determine duplication of upload on client

### DIFF
--- a/web/src/lib/stores/upload.ts
+++ b/web/src/lib/stores/upload.ts
@@ -1,4 +1,4 @@
-import { derived, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import { UploadState, type UploadAsset } from '../models/upload-asset';
 
 function createUploadStore() {
@@ -22,17 +22,23 @@ function createUploadStore() {
   );
 
   const addNewUploadAsset = (newAsset: UploadAsset) => {
-    totalUploadCounter.update((c) => c + 1);
-    uploadAssets.update((assets) => [
-      ...assets,
-      {
-        ...newAsset,
-        speed: 0,
-        state: UploadState.PENDING,
-        progress: 0,
-        eta: 0,
-      },
-    ]);
+    const assets = get(uploadAssets);
+    const duplicate = assets.find((asset) => asset.id === newAsset.id);
+    if (duplicate) {
+      uploadAssets.update((assets) => assets.map((asset) => (asset.id === newAsset.id ? newAsset : asset)));
+    } else {
+      totalUploadCounter.update((c) => c + 1);
+      uploadAssets.update((assets) => [
+        ...assets,
+        {
+          ...newAsset,
+          speed: 0,
+          state: UploadState.PENDING,
+          progress: 0,
+          eta: 0,
+        },
+      ]);
+    }
   };
 
   const updateProgress = (id: string, loaded: number, total: number) => {

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -3,7 +3,13 @@ import { uploadAssetsStore } from '$lib/stores/upload';
 import { getKey, uploadRequest } from '$lib/utils';
 import { addAssetsToAlbum } from '$lib/utils/asset-utils';
 import { ExecutorQueue } from '$lib/utils/executor-queue';
-import { Action, checkBulkUpload, defaults, getSupportedMediaTypes, type AssetFileUploadResponseDto } from '@immich/sdk';
+import {
+  Action,
+  checkBulkUpload,
+  defaults,
+  getSupportedMediaTypes,
+  type AssetFileUploadResponseDto,
+} from '@immich/sdk';
 import { getServerErrorMessage, handleError } from './handle-error';
 
 let _extensions: string[];
@@ -70,8 +76,6 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
   const fileCreatedAt = new Date(asset.lastModified).toISOString();
   const deviceAssetId = getDeviceAssetId(asset);
 
-
-
   uploadAssetsStore.markStarted(deviceAssetId);
 
   {
@@ -92,7 +96,6 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
       const key = getKey();
 
       const res: AssetFileUploadResponseDto = await (async () => {
-
         const checksum = await getSha1Checksum(asset);
         if (checksum) {
           // TODO: 2 roundtrips to the servers have performance and functionality problems
@@ -104,13 +107,15 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
           // but the assets belong to another user, we can do hardlink or copy --reflink=always
           // and create record, instead of uploading the whole file again.
           // It would save both bandwidth and storage.
-          const { results: [checkUploadResult] } = await checkBulkUpload({ assetBulkUploadCheckDto: { assets: [{ id: asset.name, checksum }] } });
+          const {
+            results: [checkUploadResult],
+          } = await checkBulkUpload({ assetBulkUploadCheckDto: { assets: [{ id: asset.name, checksum }] } });
           if (checkUploadResult.action === Action.Reject && checkUploadResult.assetId) {
             // Always because of duplicate
             return {
               duplicate: true,
               id: checkUploadResult.assetId,
-            }
+            };
           }
         }
         const response = await uploadRequest<AssetFileUploadResponseDto>({
@@ -125,7 +130,6 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
       })();
 
       {
-
         if (res.duplicate) {
           uploadAssetsStore.duplicateCounter.update((count) => count + 1);
         } else {
@@ -159,38 +163,30 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
 // TODO: should probably move this to @immach/sdk as well
 async function getSha1Checksum(file: File): Promise<string | null> {
-  return new Promise((resolve, reject) => {
-    // Step 0: Check if the Crypto API is supported
-    if (!crypto || !crypto.subtle || !crypto.subtle.digest) {
-      // how do we use logger here?
-      console.warn("crypto.subtle.digest API is not available. Client side duplicate checks cannot be used. Ensure you're using a secure context (HTTPS) or a supported browser.");
-      resolve(null);
-      return;
-    }
-    // Step 1: Read the file as an ArrayBuffer
-    const reader = new FileReader();
-    reader.onload = function (event) {
-      const arrayBuffer = event.target?.result;
-      if (!(arrayBuffer instanceof ArrayBuffer)) {
-        reject('Failed to read file');
-        return;
-      }
-      // Step 2: Compute the SHA-1 hash
-      crypto.subtle.digest('SHA-1', arrayBuffer)
-        .then(hashBuffer => {
-          // Step 3: Convert ArrayBuffer to Hex String
-          const hashArray = Array.from(new Uint8Array(hashBuffer));
-          const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-          // Step 4: Resolve the promise with the SHA-1 checksum
-          resolve(hashHex);
-        })
-        .catch(err => reject(err));
-    };
-    reader.onerror = function (err) {
-      reader.abort();
-      console.warn("crypto.subtle.digest API read error. Skipping client side duplicate checks.");
-      resolve(null);
-    };
-    reader.readAsArrayBuffer(file);
-  });
+  // Step 0: Check if the Crypto API is supported
+  if (!crypto || !crypto.subtle || !crypto.subtle.digest) {
+    // how do we use logger here?
+    console.warn(
+      "crypto.subtle.digest API is not available. Client side duplicate checks cannot be used. Ensure you're using a secure context (HTTPS) or a supported browser.",
+    );
+    return null;
+  }
+
+  try {
+    // Step 1: Convert the Blob to an ArrayBuffer directly
+    const arrayBuffer = await file.arrayBuffer();
+
+    // Step 2: Compute the SHA-1 hash
+    const hashBuffer = await crypto.subtle.digest('SHA-1', arrayBuffer);
+
+    // Step 3: Convert ArrayBuffer to Hex String
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+
+    // Step 4: Return the SHA-1 checksum
+    return hashHex;
+  } catch (error) {
+    console.warn('Error processing the file for checksum generation:', error);
+    return null;
+  }
 }

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -3,7 +3,7 @@ import { uploadAssetsStore } from '$lib/stores/upload';
 import { getKey, uploadRequest } from '$lib/utils';
 import { addAssetsToAlbum } from '$lib/utils/asset-utils';
 import { ExecutorQueue } from '$lib/utils/executor-queue';
-import { defaults, getSupportedMediaTypes, type AssetFileUploadResponseDto } from '@immich/sdk';
+import { Action, checkBulkUpload, defaults, getSupportedMediaTypes, type AssetFileUploadResponseDto } from '@immich/sdk';
 import { getServerErrorMessage, handleError } from './handle-error';
 
 let _extensions: string[];
@@ -70,8 +70,12 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
   const fileCreatedAt = new Date(asset.lastModified).toISOString();
   const deviceAssetId = getDeviceAssetId(asset);
 
-  return new Promise((resolve) => resolve(uploadAssetsStore.markStarted(deviceAssetId)))
-    .then(() => {
+
+
+  uploadAssetsStore.markStarted(deviceAssetId);
+
+  {
+    try {
       const formData = new FormData();
       for (const [key, value] of Object.entries({
         deviceAssetId,
@@ -87,15 +91,38 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
       const key = getKey();
 
-      return uploadRequest<AssetFileUploadResponseDto>({
-        url: defaults.baseUrl + '/asset/upload' + (key ? `?key=${key}` : ''),
-        data: formData,
-        onUploadProgress: (event) => uploadAssetsStore.updateProgress(deviceAssetId, event.loaded, event.total),
-      });
-    })
-    .then(async (response) => {
-      if (response.status == 200 || response.status == 201) {
-        const res: AssetFileUploadResponseDto = response.data;
+      const checksum = await getSha1Checksum(asset);
+
+      const res: AssetFileUploadResponseDto = await (async () => {
+        // TODO: 2 roundtrips to the servers have performance and functionality problems
+        // We can have a single endpoint that does both checks and uploads using headers
+        // for example, `x-immich-checksum`. Server can then process headers first,
+        // and determine whether to consume body stream, or not at all, and return 201.
+        // With that approach, we can saves bandwidth for duplicated assets even from different users/owners.
+        // That is, on server, we can check the whole DB for the checksum. If checksum is found
+        // but the assets belong to another user, we can do hardlink or copy --reflink=always
+        // and create record, instead of uploading the whole file again.
+        // It would save both bandwidth and storage.
+        const { results: [checkUploadResult] } = await checkBulkUpload({ assetBulkUploadCheckDto: { assets: [{ id: asset.name, checksum }] } });
+        if (checkUploadResult.action === Action.Reject && checkUploadResult.assetId) {
+          // Always because of duplicate
+          return {
+            duplicate: true,
+            id: checkUploadResult.assetId,
+          }
+        }
+        const response = await uploadRequest<AssetFileUploadResponseDto>({
+          url: defaults.baseUrl + '/asset/upload' + (key ? `?key=${key}` : ''),
+          data: formData,
+          onUploadProgress: (event) => uploadAssetsStore.updateProgress(deviceAssetId, event.loaded, event.total),
+        });
+        if (![200, 201].includes(response.status)) {
+          throw new Error('Failed to upload file');
+        }
+        return response.data;
+      })();
+
+      {
 
         if (res.duplicate) {
           uploadAssetsStore.duplicateCounter.update((count) => count + 1);
@@ -119,11 +146,48 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
         return res.id;
       }
-    })
-    .catch((error) => {
+    } catch (error) {
       handleError(error, 'Unable to upload file');
       const reason = getServerErrorMessage(error) || error;
       uploadAssetsStore.updateAsset(deviceAssetId, { state: UploadState.ERROR, error: reason });
       return undefined;
-    });
+    }
+  }
+}
+
+// TODO: should probably move this to @immach/sdk as well
+async function getSha1Checksum(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Step 0: Check if the Crypto API is supported
+    if (!crypto || !crypto.subtle || !crypto.subtle.digest) {
+      // how do we use logger here?
+      console.warn("crypto.subtle.digest API is not available. Client side duplicate checks cannot be used. Ensure you're using a secure context (HTTPS) or a supported browser.");
+      resolve("");
+      return;
+    }
+    // Step 1: Read the file as an ArrayBuffer
+    const reader = new FileReader();
+    reader.onload = function (event) {
+      const arrayBuffer = event.target?.result;
+      if (!(arrayBuffer instanceof ArrayBuffer)) {
+        reject('Failed to read file');
+        return;
+      }
+      // Step 2: Compute the SHA-1 hash
+      crypto.subtle.digest('SHA-1', arrayBuffer)
+        .then(hashBuffer => {
+          // Step 3: Convert ArrayBuffer to Hex String
+          const hashArray = Array.from(new Uint8Array(hashBuffer));
+          const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+          // Step 4: Resolve the promise with the SHA-1 checksum
+          resolve(hashHex);
+        })
+        .catch(err => reject(err));
+    };
+    reader.onerror = function (err) {
+      reader.abort();
+      reject(err);
+    };
+    reader.readAsArrayBuffer(file);
+  });
 }


### PR DESCRIPTION
This PR brings feature parity of determining asset duplicates to web (only via HTTPS, not HTTP, due to availability `crypto` API).

That being said, the whole design of `checkBulkUpload` followed by `upload` requiring 2 roundtrips to the servers has performance and functionality problems. We instead can have a single endpoint that does both checks and uploads using headers for example, `x-immich-checksum`. Server can then process headers first, and determine whether to consume body stream, or not at all, and return 201. With that approach, we can save bandwidth for duplicated assets even from different users/owners. That is, on server, we can check the whole DB for the checksum. If checksum is found, but the assets belong to another user, we can do hardlink or copy --reflink=always (instead of uploading the whole file again), and create DB record. It would save both bandwidth and storage.