### PR TITLE
docs: fix vectors grant... again

### DIFF
--- a/docs/docs/administration/postgres-standalone.md
+++ b/docs/docs/administration/postgres-standalone.md
@@ -50,8 +50,7 @@ ALTER DATABASE <immichdatabasename> OWNER TO <immichdbusername>;
 CREATE EXTENSION vectors;
 CREATE EXTENSION earthdistance CASCADE;
 ALTER DATABASE <immichdatabasename> SET search_path TO "$user", public, vectors;
-GRANT USAGE ON SCHEMA vectors TO <immichdbusername>;
-ALTER DEFAULT PRIVILEGES IN SCHEMA vectors GRANT SELECT ON TABLES TO <immichdbusername>;
+ALTER SCHEMA vectors OWNER TO <immichdbusername>;
 COMMIT;
 ```
 


### PR DESCRIPTION
@mertalev

I did some testing in my DB with two instances of Immich running. The following worked, without affecting the other Immich installation.

```
ALTER SCHEMA vectors OWNER TO immich;
ALTER TABLE pg_vector_index_stat OWNER TO immich;
```

If we alter the schema owner first, the table owner will inherit upon creation, yes? Rendering the second command unnecessary.

@VoVAllen we keep running into the error `error: permission denied for view pg_vector_index_stat`. Will changing the owner of the vectors schema to the Immich user fix this without causing other issues?