### PR TITLE
fix(server): skip invisible assets for thumbnail generation and ml

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -225,6 +225,15 @@ describe(MediaService.name, () => {
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });
 
+    it('should skip invisible assets', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.livePhotoMotionAsset]);
+
+      expect(await sut.handleGeneratePreview({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(mediaMock.resize).not.toHaveBeenCalled();
+      expect(assetMock.update).not.toHaveBeenCalledWith();
+    });
+
     it.each(Object.values(ImageFormat))('should generate a %s preview for an image when specified', async (format) => {
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.IMAGE_PREVIEW_FORMAT, value: format }]);
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
@@ -353,6 +362,15 @@ describe(MediaService.name, () => {
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });
 
+    it('should skip invisible assets', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.livePhotoMotionAsset]);
+
+      expect(await sut.handleGenerateThumbnail({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(mediaMock.resize).not.toHaveBeenCalled();
+      expect(assetMock.update).not.toHaveBeenCalledWith();
+    });
+
     it.each(Object.values(ImageFormat))(
       'should generate a %s thumbnail for an image when specified',
       async (format) => {
@@ -408,6 +426,15 @@ describe(MediaService.name, () => {
       assetMock.getByIds.mockResolvedValue([assetStub.noResizePath]);
       await sut.handleGenerateThumbhash({ id: assetStub.noResizePath.id });
       expect(mediaMock.generateThumbhash).not.toHaveBeenCalled();
+    });
+
+    it('should skip invisible assets', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.livePhotoMotionAsset]);
+
+      expect(await sut.handleGenerateThumbhash({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(mediaMock.generateThumbhash).not.toHaveBeenCalled();
+      expect(assetMock.update).not.toHaveBeenCalledWith();
     });
 
     it('should generate a thumbhash', async () => {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -245,12 +245,16 @@ export class MediaService {
 
   async handleGenerateThumbhash({ id }: IEntityJob): Promise<JobStatus> {
     const [asset] = await this.assetRepository.getByIds([id]);
-    if (!asset?.previewPath) {
+    if (!asset) {
       return JobStatus.FAILED;
     }
 
     if (!asset.isVisible) {
       return JobStatus.SKIPPED;
+    }
+
+    if (!asset.previewPath) {
+      return JobStatus.FAILED;
     }
 
     const thumbhash = await this.mediaRepository.generateThumbhash(asset.previewPath);

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -322,6 +322,14 @@ export class PersonService {
       return JobStatus.FAILED;
     }
 
+    if (!asset.isVisible) {
+      await this.assetRepository.upsertJobStatus({
+        assetId: asset.id,
+        facesRecognizedAt: new Date(),
+      });
+      return JobStatus.SKIPPED;
+    }
+
     const faces = await this.machineLearningRepository.detectFaces(
       machineLearning.url,
       { imagePath: asset.previewPath },

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -292,7 +292,12 @@ export class PersonService {
 
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
       return force
-        ? this.assetRepository.getAll(pagination, { orderDirection: 'DESC', withFaces: true, withArchived: true })
+        ? this.assetRepository.getAll(pagination, {
+            orderDirection: 'DESC',
+            withFaces: true,
+            withArchived: true,
+            isVisible: true,
+          })
         : this.assetRepository.getWithout(pagination, WithoutProperty.FACES);
     });
 
@@ -323,10 +328,6 @@ export class PersonService {
     }
 
     if (!asset.isVisible) {
-      await this.assetRepository.upsertJobStatus({
-        assetId: asset.id,
-        facesRecognizedAt: new Date(),
-      });
       return JobStatus.SKIPPED;
     }
 

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -1,4 +1,3 @@
-import { AssetEntity } from 'src/entities/asset.entity';
 import { SystemConfigKey } from 'src/entities/system-config.entity';
 import { IAssetRepository, WithoutProperty } from 'src/interfaces/asset.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -2,7 +2,7 @@ import { AssetEntity } from 'src/entities/asset.entity';
 import { SystemConfigKey } from 'src/entities/system-config.entity';
 import { IAssetRepository, WithoutProperty } from 'src/interfaces/asset.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';
-import { IJobRepository, JobName } from 'src/interfaces/job.interface';
+import { IJobRepository, JobName, JobStatus } from 'src/interfaces/job.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { IMachineLearningRepository } from 'src/interfaces/machine-learning.interface';
 import { ISearchRepository } from 'src/interfaces/search.interface';
@@ -18,11 +18,6 @@ import { newMachineLearningRepositoryMock } from 'test/repositories/machine-lear
 import { newSearchRepositoryMock } from 'test/repositories/search.repository.mock';
 import { newSystemConfigRepositoryMock } from 'test/repositories/system-config.repository.mock';
 import { Mocked } from 'vitest';
-
-const asset = {
-  id: 'asset-1',
-  previewPath: 'path/to/resize.ext',
-} as AssetEntity;
 
 describe(SmartInfoService.name, () => {
   let sut: SmartInfoService;
@@ -44,7 +39,7 @@ describe(SmartInfoService.name, () => {
     loggerMock = newLoggerRepositoryMock();
     sut = new SmartInfoService(assetMock, databaseMock, jobMock, machineMock, searchMock, configMock, loggerMock);
 
-    assetMock.getByIds.mockResolvedValue([asset]);
+    assetMock.getByIds.mockResolvedValue([assetStub.image]);
   });
 
   it('should work', () => {
@@ -92,17 +87,16 @@ describe(SmartInfoService.name, () => {
     it('should do nothing if machine learning is disabled', async () => {
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.MACHINE_LEARNING_ENABLED, value: false }]);
 
-      await sut.handleEncodeClip({ id: '123' });
+      expect(await sut.handleEncodeClip({ id: '123' })).toEqual(JobStatus.SKIPPED);
 
       expect(assetMock.getByIds).not.toHaveBeenCalled();
       expect(machineMock.encodeImage).not.toHaveBeenCalled();
     });
 
     it('should skip assets without a resize path', async () => {
-      const asset = { previewPath: '' } as AssetEntity;
-      assetMock.getByIds.mockResolvedValue([asset]);
+      assetMock.getByIds.mockResolvedValue([assetStub.noResizePath]);
 
-      await sut.handleEncodeClip({ id: asset.id });
+      expect(await sut.handleEncodeClip({ id: assetStub.noResizePath.id })).toEqual(JobStatus.FAILED);
 
       expect(searchMock.upsert).not.toHaveBeenCalled();
       expect(machineMock.encodeImage).not.toHaveBeenCalled();
@@ -111,14 +105,23 @@ describe(SmartInfoService.name, () => {
     it('should save the returned objects', async () => {
       machineMock.encodeImage.mockResolvedValue([0.01, 0.02, 0.03]);
 
-      await sut.handleEncodeClip({ id: asset.id });
+      expect(await sut.handleEncodeClip({ id: assetStub.image.id })).toEqual(JobStatus.SUCCESS);
 
       expect(machineMock.encodeImage).toHaveBeenCalledWith(
         'http://immich-machine-learning:3003',
-        { imagePath: 'path/to/resize.ext' },
+        { imagePath: assetStub.image.previewPath },
         { enabled: true, modelName: 'ViT-B-32__openai' },
       );
-      expect(searchMock.upsert).toHaveBeenCalledWith('asset-1', [0.01, 0.02, 0.03]);
+      expect(searchMock.upsert).toHaveBeenCalledWith(assetStub.image.id, [0.01, 0.02, 0.03]);
+    });
+
+    it('should skip invisible assets', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.livePhotoMotionAsset]);
+
+      expect(await sut.handleEncodeClip({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(machineMock.encodeImage).not.toHaveBeenCalled();
+      expect(searchMock.upsert).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/smart-info.service.ts
+++ b/server/src/services/smart-info.service.ts
@@ -60,7 +60,7 @@ export class SmartInfoService {
 
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
       return force
-        ? this.assetRepository.getAll(pagination)
+        ? this.assetRepository.getAll(pagination, { isVisible: true })
         : this.assetRepository.getWithout(pagination, WithoutProperty.SMART_SEARCH);
     });
 
@@ -82,6 +82,10 @@ export class SmartInfoService {
     const [asset] = await this.assetRepository.getByIds([id]);
     if (!asset) {
       return JobStatus.FAILED;
+    }
+
+    if (!asset.isVisible) {
+      return JobStatus.SKIPPED;
     }
 
     if (!asset.previewPath) {


### PR DESCRIPTION
## Description

We currently process live photos through our image and machine learning pipelines, but this is both unnecessary and causes issues of its own (e.g. #8597 where facial recognition is matching live photos). This PR adds checks on these jobs to skip them if `isVisible` is false.

Fixes #8597