### PR TITLE
fix(server): include archived images in face detection

### DIFF
--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -292,7 +292,7 @@ export class PersonService {
 
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) => {
       return force
-        ? this.assetRepository.getAll(pagination, { orderDirection: 'DESC', withFaces: true })
+        ? this.assetRepository.getAll(pagination, { orderDirection: 'DESC', withFaces: true, withArchived: true })
         : this.assetRepository.getWithout(pagination, WithoutProperty.FACES);
     });
 
@@ -424,7 +424,7 @@ export class PersonService {
 
     this.logger.debug(`Face ${id} has ${matches.length} matches`);
 
-    const isCore = matches.length >= machineLearning.facialRecognition.minFaces;
+    const isCore = matches.length >= machineLearning.facialRecognition.minFaces && !face.asset.isArchived;
     if (!isCore && !deferred) {
       this.logger.debug(`Deferring non-core face ${id} for later processing`);
       await this.jobRepository.queue({ name: JobName.FACIAL_RECOGNITION, data: { id, deferred: true } });


### PR DESCRIPTION
## Description

Archived images are excluded from display, but they should still go through the facial recognition pipeline as normal. The only caveat is that faces in archived assets will always be considered non-core to avoid using them for thumbnails.

Fixes #6701
