### PR TITLE
fix(mobile): restore button in asset viewer

### DIFF
--- a/mobile/lib/modules/asset_viewer/ui/gallery_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/gallery_app_bar.dart
@@ -51,9 +51,7 @@ class GalleryAppBar extends ConsumerWidget {
     }
 
     handleRestore(Asset asset) async {
-      final result = await ref
-          .read(trashProvider.notifier)
-          .restoreAsset(asset);
+      final result = await ref.read(trashProvider.notifier).restoreAsset(asset);
 
       if (result && context.mounted) {
         ImmichToast.show(

--- a/mobile/lib/modules/asset_viewer/ui/gallery_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/gallery_app_bar.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/modules/album/providers/current_album.provider.dart';
 import 'package:immich_mobile/modules/album/ui/add_to_album_bottom_sheet.dart';
@@ -7,12 +8,14 @@ import 'package:immich_mobile/modules/asset_viewer/providers/image_viewer_page_s
 import 'package:immich_mobile/modules/asset_viewer/providers/show_controls.provider.dart';
 import 'package:immich_mobile/modules/asset_viewer/ui/top_control_app_bar.dart';
 import 'package:immich_mobile/modules/backup/providers/manual_upload.provider.dart';
+import 'package:immich_mobile/modules/trash/providers/trashed_asset.provider.dart';
 import 'package:immich_mobile/modules/home/ui/upload_dialog.dart';
 import 'package:immich_mobile/modules/partner/providers/partner.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/user.provider.dart';
+import 'package:immich_mobile/shared/ui/immich_toast.dart';
 
 class GalleryAppBar extends ConsumerWidget {
   final Asset asset;
@@ -44,6 +47,20 @@ class GalleryAppBar extends ConsumerWidget {
     handleActivities() {
       if (album != null && album.shared && album.remoteId != null) {
         context.pushRoute(const ActivitiesRoute());
+      }
+    }
+
+    handleRestore(Asset asset) async {
+      final result = await ref
+          .read(trashProvider.notifier)
+          .restoreAsset(asset);
+
+      if (result && context.mounted) {
+        ImmichToast.show(
+          context: context,
+          msg: 'asset restored successfully',
+          gravity: ToastGravity.BOTTOM,
+        );
       }
     }
 
@@ -91,6 +108,7 @@ class GalleryAppBar extends ConsumerWidget {
             asset: asset,
             onMoreInfoPressed: showInfo,
             onFavorite: toggleFavorite,
+            onRestorePressed: () => handleRestore(asset),
             onUploadPressed: asset.isLocal ? () => handleUpload(asset) : null,
             onDownloadPressed: asset.isLocal
                 ? null

--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -94,7 +94,7 @@ class TopControlAppBar extends HookConsumerWidget {
       );
     }
 
-    Widget buildAddToAlbumButtom() {
+    Widget buildAddToAlbumButton() {
       return IconButton(
         onPressed: () {
           onAddToAlbumPressed();
@@ -170,7 +170,7 @@ class TopControlAppBar extends HookConsumerWidget {
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal && !asset.isOffline && isOwner)
           buildDownloadButton(),
-        if (asset.isRemote && (isOwner || isPartner)) buildAddToAlbumButtom(),
+        if (asset.isRemote && (isOwner || isPartner)) buildAddToAlbumButton(),
         if (album != null && album.shared) buildActivitiesButton(),
         buildMoreInfoButton(),
       ],

--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -13,6 +13,7 @@ class TopControlAppBar extends HookConsumerWidget {
     required this.onMoreInfoPressed,
     required this.onDownloadPressed,
     required this.onAddToAlbumPressed,
+    required this.onRestorePressed,
     required this.onToggleMotionVideo,
     required this.isPlayingMotionVideo,
     required this.onFavorite,
@@ -28,6 +29,7 @@ class TopControlAppBar extends HookConsumerWidget {
   final VoidCallback? onDownloadPressed;
   final VoidCallback onToggleMotionVideo;
   final VoidCallback onAddToAlbumPressed;
+  final VoidCallback onRestorePressed;
   final VoidCallback onActivitiesPressed;
   final Function(Asset) onFavorite;
   final bool isPlayingMotionVideo;
@@ -106,6 +108,18 @@ class TopControlAppBar extends HookConsumerWidget {
       );
     }
 
+    Widget buildRestoreButton() {
+      return IconButton(
+        onPressed: () {
+          onRestorePressed();
+        },
+        icon: Icon(
+          Icons.history_rounded,
+          color: Colors.grey[200],
+        ),
+      );
+    }
+
     Widget buildActivitiesButton() {
       return IconButton(
         onPressed: () {
@@ -170,7 +184,8 @@ class TopControlAppBar extends HookConsumerWidget {
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal && !asset.isOffline && isOwner)
           buildDownloadButton(),
-        if (asset.isRemote && (isOwner || isPartner)) buildAddToAlbumButton(),
+        if (asset.isRemote && (isOwner || isPartner) && !asset.isTrashed) buildAddToAlbumButton(),
+        if (asset.isTrashed) buildRestoreButton(),
         if (album != null && album.shared) buildActivitiesButton(),
         buildMoreInfoButton(),
       ],

--- a/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
+++ b/mobile/lib/modules/asset_viewer/ui/top_control_app_bar.dart
@@ -184,7 +184,8 @@ class TopControlAppBar extends HookConsumerWidget {
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal && !asset.isOffline && isOwner)
           buildDownloadButton(),
-        if (asset.isRemote && (isOwner || isPartner) && !asset.isTrashed) buildAddToAlbumButton(),
+        if (asset.isRemote && (isOwner || isPartner) && !asset.isTrashed)
+          buildAddToAlbumButton(),
         if (asset.isTrashed) buildRestoreButton(),
         if (album != null && album.shared) buildActivitiesButton(),
         buildMoreInfoButton(),

--- a/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
+++ b/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
@@ -75,6 +75,28 @@ class TrashNotifier extends StateNotifier<bool> {
     return false;
   }
 
+  Future<bool> restoreAsset(Asset asset) async {
+    try {
+      final result = await _trashService.restoreAsset(asset);
+
+      if (result) {
+        final remoteAsset = asset.isRemote;
+
+        asset.isTrashed = false;
+
+        if (remoteAsset) {
+        await _db.writeTxn(() async {
+          await _db.assets.put(asset);
+        });
+        }
+        return true;
+      }
+    } catch (error, stack) {
+      _log.severe("Cannot restore asset", error, stack);
+    }
+    return false;
+  }
+
   Future<bool> restoreAssets(Iterable<Asset> assetList) async {
     try {
       final result = await _trashService.restoreAssets(assetList);

--- a/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
+++ b/mobile/lib/modules/trash/providers/trashed_asset.provider.dart
@@ -85,9 +85,9 @@ class TrashNotifier extends StateNotifier<bool> {
         asset.isTrashed = false;
 
         if (remoteAsset) {
-        await _db.writeTxn(() async {
-          await _db.assets.put(asset);
-        });
+          await _db.writeTxn(() async {
+            await _db.assets.put(asset);
+          });
         }
         return true;
       }

--- a/mobile/lib/modules/trash/services/trash.service.dart
+++ b/mobile/lib/modules/trash/services/trash.service.dart
@@ -30,6 +30,20 @@ class TrashService {
     }
   }
 
+  Future<bool> restoreAsset(Asset asset) async {
+    try {
+      if (asset.isRemote) {
+        List<String> remoteId = [asset.remoteId!];
+
+        await _apiService.trashApi.restoreAssets(BulkIdsDto(ids: remoteId));
+      }
+      return true;
+    } catch (error, stack) {
+      _log.severe("Cannot restore assets", error, stack);
+      return false;
+    }
+  }
+
   Future<void> emptyTrash() async {
     try {
       await _apiService.trashApi.emptyTrash();


### PR DESCRIPTION
## Description

Fixes #8861
This fixes the mobile version of this issue. This pull request #8935 fixed the web version.
This works for both images and videos.

Apologies if something is done wrong, this is my first opensource contribution.

## How Has This Been Tested?

- ran  `flutter test` and all tests passed successfully.
- Inserted an image from the web client and deleted it, restored on device.
- Deleted image on device and restored on device.

## Screenshots (if appropriate):

![Screenshot_1713537107](https://github.com/immich-app/immich/assets/46903591/f29c225d-3116-4c15-81a8-d15de09f82fb)
![Screenshot_1713537111](https://github.com/immich-app/immich/assets/46903591/330436e3-9033-47bb-bf74-27aca7875dcd)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable