### PR TITLE
fix(web): restore button in asset viewer 

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -20,6 +20,7 @@
     mdiFolderDownloadOutline,
     mdiHeart,
     mdiHeartOutline,
+    mdiHistory,
     mdiImageAlbum,
     mdiImageMinusOutline,
     mdiImageOutline,
@@ -52,6 +53,7 @@
 
   type MenuItemEvent =
     | 'addToAlbum'
+    | 'restoreAsset'
     | 'addToSharedAlbum'
     | 'asProfileImage'
     | 'setAsAlbumCover'
@@ -70,6 +72,7 @@
     delete: void;
     toggleArchive: void;
     addToAlbum: void;
+    restoreAsset: void;
     addToSharedAlbum: void;
     asProfileImage: void;
     setAsAlbumCover: void;
@@ -208,12 +211,16 @@
             {#if showDownloadButton}
               <MenuOption icon={mdiFolderDownloadOutline} on:click={() => onMenuClick('download')} text="Download" />
             {/if}
-            <MenuOption icon={mdiImageAlbum} on:click={() => onMenuClick('addToAlbum')} text="Add to album" />
-            <MenuOption
-              icon={mdiShareVariantOutline}
-              on:click={() => onMenuClick('addToSharedAlbum')}
-              text="Add to shared album"
-            />
+            {#if asset.isTrashed}
+              <MenuOption icon={mdiHistory} on:click={() => onMenuClick('restoreAsset')} text="Restore" />
+            {:else}
+              <MenuOption icon={mdiImageAlbum} on:click={() => onMenuClick('addToAlbum')} text="Add to album" />
+              <MenuOption
+                icon={mdiShareVariantOutline}
+                on:click={() => onMenuClick('addToSharedAlbum')}
+                text="Add to shared album"
+              />
+            {/if}
 
             {#if isOwner}
               {#if hasStackChildren}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -27,6 +27,7 @@
     getActivityStatistics,
     getAllAlbums,
     runAssetJobs,
+    restoreAssets,
     updateAsset,
     updateAlbumInfo,
     type ActivityResponseDto,
@@ -403,6 +404,21 @@
     await handleGetAllAlbums();
   };
 
+  const handleRestoreAsset = async () => {
+    try {
+      await restoreAssets({ bulkIdsDto: { ids: [asset.id] } });
+
+      dispatch('action', { type: AssetAction.RESTORE, asset });
+
+      notificationController.show({
+        type: NotificationType.Info,
+        message: `Restored Asset. Refresh the page to see the changes`,
+      });
+    } catch (error) {
+      handleError(error, 'Error restoring asset');
+    }
+  };
+
   const toggleArchive = async () => {
     try {
       const data = await updateAsset({
@@ -556,6 +572,7 @@
           on:delete={() => trashOrDelete()}
           on:favorite={toggleFavorite}
           on:addToAlbum={() => openAlbumPicker(false)}
+          on:restoreAsset={() => handleRestoreAsset()}
           on:addToSharedAlbum={() => openAlbumPicker(true)}
           on:playMotionPhoto={() => (shouldPlayMotionPhoto = true)}
           on:stopMotionPhoto={() => (shouldPlayMotionPhoto = false)}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -413,7 +413,7 @@
 
       notificationController.show({
         type: NotificationType.Info,
-        message: `Restored Asset. Refresh the page to see the changes`,
+        message: `Restored asset`,
       });
     } catch (error) {
       handleError(error, 'Error restoring asset');

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -407,6 +407,7 @@
   const handleRestoreAsset = async () => {
     try {
       await restoreAssets({ bulkIdsDto: { ids: [asset.id] } });
+      asset.isTrashed = false;
 
       dispatch('action', { type: AssetAction.RESTORE, asset });
 

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -181,8 +181,8 @@
       case AssetAction.ARCHIVE:
       case AssetAction.UNARCHIVE:
       case AssetAction.FAVORITE:
-      case AssetAction.UNFAVORITE: 
-      case AssetAction.RESTORE:  {
+      case AssetAction.UNFAVORITE:
+      case AssetAction.RESTORE: {
         assetStore.updateAssets([asset]);
         break;
       }

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -181,7 +181,8 @@
       case AssetAction.ARCHIVE:
       case AssetAction.UNARCHIVE:
       case AssetAction.FAVORITE:
-      case AssetAction.UNFAVORITE: {
+      case AssetAction.UNFAVORITE: 
+      case AssetAction.RESTORE:  {
         assetStore.updateAssets([asset]);
         break;
       }

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -169,6 +169,7 @@
     switch (action) {
       case removeAction:
       case AssetAction.TRASH:
+      case AssetAction.RESTORE:
       case AssetAction.DELETE: {
         // find the next asset to show or close the viewer
         (await handleNext()) || (await handlePrevious()) || handleClose();
@@ -181,8 +182,7 @@
       case AssetAction.ARCHIVE:
       case AssetAction.UNARCHIVE:
       case AssetAction.FAVORITE:
-      case AssetAction.UNFAVORITE:
-      case AssetAction.RESTORE: {
+      case AssetAction.UNFAVORITE: {
         assetStore.updateAssets([asset]);
         break;
       }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,13 +1,14 @@
-export enum AssetAction {
-  ARCHIVE = 'archive',
-  UNARCHIVE = 'unarchive',
-  FAVORITE = 'favorite',
-  UNFAVORITE = 'unfavorite',
-  TRASH = 'trash',
-  DELETE = 'delete',
-  // RESTORE = 'restore',
-  ADD = 'add',
-}
+  export enum AssetAction {
+    ARCHIVE = 'archive',
+    UNARCHIVE = 'unarchive',
+    FAVORITE = 'favorite',
+    UNFAVORITE = 'unfavorite',
+    TRASH = 'trash',
+    DELETE = 'delete',
+    RESTORE = 'restore',
+    ADD = 'add',
+    
+  }
 
 export enum AppRoute {
   ADMIN_USER_MANAGEMENT = '/admin/user-management',

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,14 +1,13 @@
-  export enum AssetAction {
-    ARCHIVE = 'archive',
-    UNARCHIVE = 'unarchive',
-    FAVORITE = 'favorite',
-    UNFAVORITE = 'unfavorite',
-    TRASH = 'trash',
-    DELETE = 'delete',
-    RESTORE = 'restore',
-    ADD = 'add',
-    
-  }
+export enum AssetAction {
+  ARCHIVE = 'archive',
+  UNARCHIVE = 'unarchive',
+  FAVORITE = 'favorite',
+  UNFAVORITE = 'unfavorite',
+  TRASH = 'trash',
+  DELETE = 'delete',
+  RESTORE = 'restore',
+  ADD = 'add',
+}
 
 export enum AppRoute {
   ADMIN_USER_MANAGEMENT = '/admin/user-management',


### PR DESCRIPTION
## Description
Fixes #8861 

This fixes the web version of this issue. This pull request #8919 fixed the mobile version.

## How Has This Been Tested?

- ran  `npm run check:all` and all tests passed successfully.
- Inserted an image from the web client and deleted it, restored from the trash.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable