### PR TITLE
Fix backup and restore docker compose issue

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -71,6 +71,7 @@ services:
       POSTGRES_CLUSTER: 'TRUE'
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
       SCHEDULE: "@daily"
       POSTGRES_EXTRA_OPTS: '--clean --if-exists'
       BACKUP_DIR: /db_dumps


### PR DESCRIPTION
For the backup and restore docker compose config to work, the `POSTGRES_DB` environment variable needs to be specified