### PR TITLE
feat(server): enable AV1 encoding for NVENC

### DIFF
--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -436,7 +436,7 @@ export class AV1Config extends BaseConfig {
 
 export class NVENCConfig extends BaseHWConfig {
   getSupportedCodecs() {
-    return [VideoCodec.H264, VideoCodec.HEVC];
+    return [VideoCodec.H264, VideoCodec.HEVC, VideoCodec.AV1];
   }
 
   getBaseInputOptions() {


### PR DESCRIPTION
### Description

Similar to #8942, allows the use of NVENC when targeting AV1.

### Testing

Tested with a 4090 and it works without any errors, both transcoding and viewing the transcode.