### PR TITLE
fix(web): trash page now auto refreshes 

### DIFF
--- a/web/src/routes/(user)/trash/+page.svelte
+++ b/web/src/routes/(user)/trash/+page.svelte
@@ -39,7 +39,7 @@
     try {
       await emptyTrash();
 
-      const deletedAssetIds = assetStore.assets.map(a => a.id);
+      const deletedAssetIds = assetStore.assets.map((a) => a.id);
       const numberOfAssets = deletedAssetIds.length;
       assetStore.removeAssets(deletedAssetIds);
 
@@ -56,7 +56,7 @@
     try {
       await restoreTrash();
 
-      const restoredAssetIds = assetStore.assets.map(a => a.id);
+      const restoredAssetIds = assetStore.assets.map((a) => a.id);
       const numberOfAssets = restoredAssetIds.length;
       assetStore.removeAssets(restoredAssetIds);
 

--- a/web/src/routes/(user)/trash/+page.svelte
+++ b/web/src/routes/(user)/trash/+page.svelte
@@ -39,8 +39,12 @@
     try {
       await emptyTrash();
 
+      const deletedAssetIds = assetStore.assets.map(a => a.id);
+      const numberOfAssets = deletedAssetIds.length;
+      assetStore.removeAssets(deletedAssetIds);
+
       notificationController.show({
-        message: `Empty trash initiated. Refresh the page to see the changes`,
+        message: `Permanently deleted ${numberOfAssets} ${numberOfAssets == 1 ? 'asset' : 'assets'}`,
         type: NotificationType.Info,
       });
     } catch (error) {
@@ -52,8 +56,12 @@
     try {
       await restoreTrash();
 
+      const restoredAssetIds = assetStore.assets.map(a => a.id);
+      const numberOfAssets = restoredAssetIds.length;
+      assetStore.removeAssets(restoredAssetIds);
+
       notificationController.show({
-        message: `Restore trash initiated. Refresh the page to see the changes`,
+        message: `Restored ${numberOfAssets} ${numberOfAssets == 1 ? 'asset' : 'assets'}`,
         type: NotificationType.Info,
       });
     } catch (error) {


### PR DESCRIPTION
## Description

When the 'Restore All' or 'Empty Trash' buttons are pressed the page no longer needs to be refreshed for the changes to take visual effect.

## How Has This Been Tested?

- ran `npm run check:all`
- inserted images and permanently deleted them as well as restoring them. Tested all intended functionality.