### PR TITLE
fix(web): wrong month on timeline scrollbar cursor

### DIFF
--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AssetStore, AssetBucket } from '$lib/stores/assets.store';
-  import type { DateTime } from 'luxon';
+  import { DateTime } from 'luxon';
   import { fromLocalDateTime } from '$lib/utils/timeline-util';
   import { createEventDispatcher } from 'svelte';
   import { clamp } from 'lodash-es';
@@ -83,6 +83,7 @@
     hoverLabel = new Date(attr).toLocaleString($locale, {
       month: 'short',
       year: 'numeric',
+      timeZone: 'UTC',
     });
   };
 

--- a/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
+++ b/web/src/lib/components/shared-components/scrollbar/scrollbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AssetStore, AssetBucket } from '$lib/stores/assets.store';
-  import { DateTime } from 'luxon';
+  import type { DateTime } from 'luxon';
   import { fromLocalDateTime } from '$lib/utils/timeline-util';
   import { createEventDispatcher } from 'svelte';
   import { clamp } from 'lodash-es';


### PR DESCRIPTION
Timebucket return time in UTC timezone, without specifying it, the month will be incorrect with `toLocaleString` call