### PR TITLE
docs: default to sed pg_catalog for Linux, document restore/reset for PG bind mount

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -267,6 +267,9 @@ The initial backup is the most intensive due to the number of jobs running. The 
 
 By default, a container has no resource constraints and can use as much of a given resource as the host's kernel scheduler allows. To limit this, you can add the following to the `docker-compose.yml` block of any containers that you want to have limited resources.
 
+<details>
+<summary>docker-compose.yml</summary>
+
 ```yaml
 deploy:
   resources:
@@ -276,7 +279,7 @@ deploy:
       # Gigabytes of memory
       memory: '1G'
 ```
-
+</summary>
 For more details, you can look at the [original docker docs](https://docs.docker.com/config/containers/resource_constraints/) or use this [guide](https://www.baeldung.com/ops/docker-memory-limit).
 
 ### How can I boost machine learning speed?

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -232,7 +232,10 @@ to increase the bar for what the algorithm considers a "core face" for that pers
 
 ### The immich_model-cache volume takes up a lot of space, what could be the problem?
 
-If you installed several models and chose not to use some of them, it might be worth deleting the old models that are in immich_model-cache. To do this you can mount the model cache and remove the undesired models:
+If you installed several models and chose not to use some of them, it might be worth deleting the old models that are in immich_model-cache. To do this you can mount the model cache and remove the undesired models.
+
+<details>
+<summary>Steps</summary>
 
 ```bash
 docker run -it --rm -v immich_model-cache:/mnt-models alpine sh
@@ -240,6 +243,7 @@ cd /mnt-models
 ls
 # delete unused models with 'rm -r <model_name>'
 ```
+</details>
 
 ---
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -240,8 +240,8 @@ If you installed several models and chose not to use some of them, it might be w
 ```bash
 docker run -it --rm -v immich_model-cache:/mnt-models alpine sh
 cd /mnt-models
-ls
-# delete unused models with 'rm -r <model_name>'
+ls clip/ facial-recognition/
+# rm -r clip/ABC facial-recognition/DEF # delete unused models
 ```
 
 </details>

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -230,14 +230,14 @@ to increase the bar for what the algorithm considers a "core face" for that pers
 
 ### The immich_model-cache volume takes up a lot of space, what could be the problem?
 
-If you installed several models and chose not to use some of them, it might be worth deleting the old models that are in immich_model-cache.
+If you installed several models and chose not to use some of them, it might be worth deleting the old models that are in immich_model-cache. To do this you can mount the model cache and remove the undesired models:
 
-To do this you can run:
-
-- `docker run -it --rm -v immich_model-cache:/mnt ubuntu bash`
-- `cd mnt`
-- `ls`
-- and delete unused models with `rm -r <model_name>`.
+```bash
+docker run -it --rm -v immich_model-cache:/mnt-models alpine sh
+cd /mnt-models
+ls
+# delete unused models with 'rm -r <model_name>'
+```
 
 ---
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -243,6 +243,7 @@ cd /mnt-models
 ls
 # delete unused models with 'rm -r <model_name>'
 ```
+
 </details>
 
 ---
@@ -279,6 +280,7 @@ deploy:
       # Gigabytes of memory
       memory: '1G'
 ```
+
 </details>
 For more details, you can look at the [original docker docs](https://docs.docker.com/config/containers/resource_constraints/) or use this [guide](https://www.baeldung.com/ops/docker-memory-limit).
 
@@ -327,6 +329,7 @@ You may need to add mount points or docker volumes for the following internal co
 The non-root user/group needs read/write access to the volume mounts, including `UPLOAD_LOCATION`.
 
 For a further hardened system, you can add the following block to every container except for `immich_postgres`.
+
 <details>
 <summary>docker-compose.yml</summary>
 
@@ -338,6 +341,7 @@ cap_drop:
   # Prevent access to raw network traffic
   - NET_RAW
 ```
+
 </details>
 
 ### How can I **purge** data from Immich?

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -131,6 +131,7 @@ This is not officially supported but can be accomplished with some database upda
 3. Four tables need to be updated:
 
 ```sql
+BEGIN;
 -- reassign albums
 UPDATE albums SET "ownerId" = '<destinationId>' WHERE "ownerId" = '<sourceId>';
 
@@ -143,6 +144,7 @@ UPDATE assets SET "ownerId" = '<destinationId>' WHERE "ownerId" = '<sourceId>'
 
 -- reassign external libraries
 UPDATE libraries SET "ownerId" = '<destinationId>' WHERE "ownerId" = '<sourceId>';
+COMMIT;
 ```
 
 4. There might be left-over assets in the 'source' user's library if they are skipped by the last query because of duplicate checksums. These are probably duplicates anyway, and can probably be removed.

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -344,14 +344,12 @@ cap_drop:
 
 </details>
 
-### How can I **purge** data from Immich?
+### How can I purge data from Immich?
 
 Data for Immich comes in two forms:
 
-1. **Metadata** stored in a Postgres database, persisted via the `pg_data` volume
+1. **Metadata** stored in a Postgres database, stored in the `DB_DATA_LOCATION` folder (previously `pg_data` Docker volume).
 2. **Files** (originals, thumbs, profile, etc.), stored in the `UPLOAD_LOCATION` folder, more [info](/docs/administration/backup-and-restore#asset-types-and-storage-locations).
-
-To remove the **Metadata** you can stop Immich and delete the volume.
 
 :::warning
 This will destroy your database and reset your instance, meaning that you start from scratch.
@@ -361,12 +359,15 @@ This will destroy your database and reset your instance, meaning that you start 
 docker compose down -v
 ```
 
+After removing the containers and volumes, there are a few directories that need to be deleted to reset Immich to a new installation. Once they are deleted, Immich can be started back up and will be a fresh installation.
+
+- `DB_DATA_LOCATION` contains the database, media info, and settings.
+- `UPLOAD_LOCATION` contains all the media uploaded to Immich.
+
 :::note Portainer
 If you use portainer, bring down the stack in portainer. Go into the volumes section  
 and remove all the volumes related to immich then restart the stack.
 :::
-
-After removing the containers and volumes, the **Files** should be removed from the `UPLOAD_LOCATION` to provide a clean start.
 
 ### Why does the machine learning service report workers crashing?
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -279,7 +279,7 @@ deploy:
       # Gigabytes of memory
       memory: '1G'
 ```
-</summary>
+</details>
 For more details, you can look at the [original docker docs](https://docs.docker.com/config/containers/resource_constraints/) or use this [guide](https://www.baeldung.com/ops/docker-memory-limit).
 
 ### How can I boost machine learning speed?

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -327,6 +327,8 @@ You may need to add mount points or docker volumes for the following internal co
 The non-root user/group needs read/write access to the volume mounts, including `UPLOAD_LOCATION`.
 
 For a further hardened system, you can add the following block to every container except for `immich_postgres`.
+<details>
+<summary>docker-compose.yml</summary>
 
 ```yaml
 security_opt:
@@ -336,6 +338,7 @@ cap_drop:
   # Prevent access to raw network traffic
   - NET_RAW
 ```
+</details>
 
 ### How can I **purge** data from Immich?
 

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -30,7 +30,9 @@ docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
-gunzip < "/path/to/backup/dump.sql.gz" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | docker exec -i immich_postgres psql --username=postgres    # Restore Backup
+gunzip < "/path/to/backup/dump.sql.gz" \
+| sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
+| docker exec -i immich_postgres psql --username=postgres    # Restore Backup
 docker compose up -d    # Start remainder of Immich apps
 ```
 
@@ -83,7 +85,9 @@ services:
 Then you can restore with the same command but pointed at the latest dump.
 
 ```bash title='Automated Restore'
-gunzip < db_dumps/last/immich-latest.sql.gz | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | docker exec -i immich_postgres psql --username=postgres
+gunzip < db_dumps/last/immich-latest.sql.gz \
+| sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
+| docker exec -i immich_postgres psql --username=postgres
 ```
 
 :::note

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -15,7 +15,7 @@ Immich saves [file paths in the database](https://github.com/immich-app/immich/d
 Refer to the official [postgres documentation](https://www.postgresql.org/docs/current/backup.html) for details about backing up and restoring a postgres database.
 :::
 
-The recommended way to backup and restore the Immich database is to use the `pg_dumpall` command. When restoring, you need to delete the `DB_DATA_LOCATION` folder (if exists) to reset the database.
+The recommended way to backup and restore the Immich database is to use the `pg_dumpall` command. When restoring, you need to delete the `DB_DATA_LOCATION` folder (if it exists) to reset the database.
 
 <Tabs>
   <TabItem value="Linux system based Backup" label="Linux system based Backup" default>

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -30,7 +30,7 @@ docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
-gunzip < "/path/to/backup/dump.sql.gz" | docker exec -i immich_postgres psql --username=postgres    # Restore Backup
+gunzip < "/path/to/backup/dump.sql.gz" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | docker exec -i immich_postgres psql --username=postgres    # Restore Backup
 docker compose up -d    # Start remainder of Immich apps
 ```
 
@@ -83,7 +83,7 @@ services:
 Then you can restore with the same command but pointed at the latest dump.
 
 ```bash title='Automated Restore'
-gunzip < db_dumps/last/immich-latest.sql.gz | docker exec -i immich_postgres psql --username=postgres
+gunzip < db_dumps/last/immich-latest.sql.gz | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | docker exec -i immich_postgres psql --username=postgres
 ```
 
 :::note

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -15,7 +15,7 @@ Immich saves [file paths in the database](https://github.com/immich-app/immich/d
 Refer to the official [postgres documentation](https://www.postgresql.org/docs/current/backup.html) for details about backing up and restoring a postgres database.
 :::
 
-The recommended way to backup and restore the Immich database is to use the `pg_dumpall` command.
+The recommended way to backup and restore the Immich database is to use the `pg_dumpall` command. When restoring, you need to delete the `DB_DATA_LOCATION` folder (if exists) to reset the database.
 
 <Tabs>
   <TabItem value="Linux system based Backup" label="Linux system based Backup" default>

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -26,6 +26,7 @@ docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgre
 
 ```bash title='Restore'
 docker compose down -v  # CAUTION! Deletes all Immich data to start from scratch.
+# rm -rf DB_DATA_LOCATION # CAUTION! Deletes all Immich data to start from scratch.
 docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server
@@ -45,6 +46,7 @@ docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgre
 
 ```powershell title='Restore'
 docker compose down -v  # CAUTION! Deletes all Immich data to start from scratch.
+# Remove-Item -Recurse -Force DB_DATA_LOCATION # CAUTION! Deletes all Immich data to start from scratch.
 docker compose pull     # Update to latest version of Immich (if desired)
 docker compose create   # Create Docker containers for Immich apps without running them.
 docker start immich_postgres    # Start Postgres server


### PR DESCRIPTION
- Add `sed` as default for restore - multiple issues of people trying to restore recently and having geocoding issues or errors.
  - I do not know the equivalent command for Windows, would welcome someone adding it
- Collapse some code blocks in the FAQ
- Wrap the library-change instructions in a transaction
- Update docs to explain how to reset the DB now that Docker volumes are no longer used