### PR TITLE
fix(mobile): appBar on home screen animates out and doesnt alter asset grid position

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/disable_multi_select_button.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/disable_multi_select_button.dart
@@ -17,7 +17,7 @@ class DisableMultiSelectButton extends ConsumerWidget {
     return Align(
       alignment: Alignment.topLeft,
       child: Padding(
-        padding: const EdgeInsets.only(left: 16.0, top: 16.0),
+        padding: const EdgeInsets.only(left: 16.0, top: 8.0),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4.0),
           child: ElevatedButton.icon(

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -252,7 +252,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
         : listWidget;
     return widget.onRefresh == null
         ? child
-        : appBarOffset() ? RefreshIndicator(onRefresh: widget.onRefresh!, child: child, edgeOffset: 30,) : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
+        : appBarOffset() ? RefreshIndicator(onRefresh: widget.onRefresh!, edgeOffset: 30, child: child, ) : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
   }
 
   @override

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -14,8 +14,10 @@ import 'package:immich_mobile/modules/home/ui/asset_grid/asset_drag_region.dart'
 import 'package:immich_mobile/modules/home/ui/asset_grid/thumbnail_image.dart';
 import 'package:immich_mobile/modules/home/ui/asset_grid/thumbnail_placeholder.dart';
 import 'package:immich_mobile/modules/home/ui/control_bottom_app_bar.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/shared/models/asset.dart';
 import 'package:immich_mobile/shared/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/shared/providers/tab.provider.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 import 'asset_grid_data_structure.dart';
@@ -215,8 +217,13 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
       }
     }
 
+    bool appBarOffset() {
+      return ref.watch(tabProvider).index == 0 && ModalRoute.of(context)?.settings.name == TabControllerRoute.name;
+    }
+
     final listWidget = ScrollablePositionedList.builder(
-      padding: const EdgeInsets.only(
+      padding: EdgeInsets.only(
+        top: appBarOffset() ? 60 : 0,
         bottom: 220,
       ),
       itemBuilder: _itemBuilder,
@@ -236,6 +243,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
             controller: _itemScrollController,
             backgroundColor: context.themeData.hintColor,
             labelTextBuilder: _labelBuilder,
+            padding: appBarOffset() ? const EdgeInsets.only(top:60) : const EdgeInsets.only(),
             labelConstraints: const BoxConstraints(maxHeight: 28),
             scrollbarAnimationDuration: const Duration(milliseconds: 300),
             scrollbarTimeToFade: const Duration(milliseconds: 1000),
@@ -244,7 +252,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
         : listWidget;
     return widget.onRefresh == null
         ? child
-        : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
+        : appBarOffset() ? RefreshIndicator(onRefresh: widget.onRefresh!, child: child, edgeOffset: 30,) : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
   }
 
   @override

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -218,7 +218,8 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
     }
 
     bool appBarOffset() {
-      return ref.watch(tabProvider).index == 0 && ModalRoute.of(context)?.settings.name == TabControllerRoute.name;
+      return ref.watch(tabProvider).index == 0 &&
+          ModalRoute.of(context)?.settings.name == TabControllerRoute.name;
     }
 
     final listWidget = ScrollablePositionedList.builder(
@@ -243,7 +244,9 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
             controller: _itemScrollController,
             backgroundColor: context.themeData.hintColor,
             labelTextBuilder: _labelBuilder,
-            padding: appBarOffset() ? const EdgeInsets.only(top:60) : const EdgeInsets.only(),
+            padding: appBarOffset()
+                ? const EdgeInsets.only(top: 60)
+                : const EdgeInsets.only(),
             labelConstraints: const BoxConstraints(maxHeight: 28),
             scrollbarAnimationDuration: const Duration(milliseconds: 300),
             scrollbarTimeToFade: const Duration(milliseconds: 1000),
@@ -252,7 +255,13 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
         : listWidget;
     return widget.onRefresh == null
         ? child
-        : appBarOffset() ? RefreshIndicator(onRefresh: widget.onRefresh!, edgeOffset: 30, child: child, ) : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
+        : appBarOffset()
+            ? RefreshIndicator(
+                onRefresh: widget.onRefresh!,
+                edgeOffset: 30,
+                child: child,
+              )
+            : RefreshIndicator(onRefresh: widget.onRefresh!, child: child);
   }
 
   @override

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/album/providers/album.provider.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
+import 'package:immich_mobile/modules/home/providers/multiselect.provider.dart';
 import 'package:immich_mobile/modules/memories/ui/memory_lane.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/server_info.provider.dart';
@@ -98,19 +99,37 @@ class HomePage extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: const ImmichAppBar(),
-      body: MultiselectGrid(
-        topWidget: (currentUser != null && currentUser.memoryEnabled)
-            ? const MemoryLane()
-            : const SizedBox(),
-        renderListProvider: timelineUsers.length > 1
-            ? multiUserAssetsProvider(timelineUsers)
-            : assetsProvider(currentUser?.isarId),
-        buildLoadingIndicator: buildLoadingIndicator,
-        onRefresh: refreshAssets,
-        stackEnabled: true,
-        archiveEnabled: true,
-        editEnabled: true,
+      body: Stack(
+        children: [
+          MultiselectGrid(
+            topWidget: (currentUser != null && currentUser.memoryEnabled)
+                ? const MemoryLane()
+                : const SizedBox(),
+            renderListProvider: timelineUsers.length > 1
+                ? multiUserAssetsProvider(timelineUsers)
+                : assetsProvider(currentUser?.isarId),
+            buildLoadingIndicator: buildLoadingIndicator,
+            onRefresh: refreshAssets,
+            stackEnabled: true,
+            archiveEnabled: true,
+            editEnabled: true,
+          ),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 300),
+            top: ref.watch(multiselectProvider)
+                ? -(kToolbarHeight + MediaQuery.of(context).padding.top)
+                : 0,
+            left: 0,
+            right: 0,
+            child: Container(
+              height: kToolbarHeight + MediaQuery.of(context).padding.top,
+              color: context.themeData.appBarTheme.backgroundColor,
+              child: const SafeArea(
+                child: ImmichAppBar(),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -99,7 +99,7 @@ class HomePage extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: ref.watch(multiselectProvider) ? null : const ImmichAppBar(),
+      appBar: const ImmichAppBar(), // ref.watch(multiselectProvider) ? null : const ImmichAppBar()
       body: MultiselectGrid(
         topWidget: (currentUser != null && currentUser.memoryEnabled)
             ? const MemoryLane()

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -8,7 +8,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/album/providers/album.provider.dart';
 import 'package:immich_mobile/modules/album/providers/shared_album.provider.dart';
-import 'package:immich_mobile/modules/home/providers/multiselect.provider.dart';
 import 'package:immich_mobile/modules/memories/ui/memory_lane.dart';
 import 'package:immich_mobile/shared/providers/asset.provider.dart';
 import 'package:immich_mobile/shared/providers/server_info.provider.dart';

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -99,7 +99,7 @@ class HomePage extends HookConsumerWidget {
     }
 
     return Scaffold(
-      appBar: const ImmichAppBar(), // ref.watch(multiselectProvider) ? null : const ImmichAppBar()
+      appBar: const ImmichAppBar(),
       body: MultiselectGrid(
         topWidget: (currentUser != null && currentUser.memoryEnabled)
             ? const MemoryLane()

--- a/mobile/lib/modules/home/views/home_page.dart
+++ b/mobile/lib/modules/home/views/home_page.dart
@@ -98,39 +98,37 @@ class HomePage extends HookConsumerWidget {
       }
     }
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          MultiselectGrid(
-            topWidget: (currentUser != null && currentUser.memoryEnabled)
-                ? const MemoryLane()
-                : const SizedBox(),
-            renderListProvider: timelineUsers.length > 1
-                ? multiUserAssetsProvider(timelineUsers)
-                : assetsProvider(currentUser?.isarId),
-            buildLoadingIndicator: buildLoadingIndicator,
-            onRefresh: refreshAssets,
-            stackEnabled: true,
-            archiveEnabled: true,
-            editEnabled: true,
-          ),
-          AnimatedPositioned(
-            duration: const Duration(milliseconds: 300),
-            top: ref.watch(multiselectProvider)
-                ? -(kToolbarHeight + MediaQuery.of(context).padding.top)
-                : 0,
-            left: 0,
-            right: 0,
-            child: Container(
-              height: kToolbarHeight + MediaQuery.of(context).padding.top,
-              color: context.themeData.appBarTheme.backgroundColor,
-              child: const SafeArea(
-                child: ImmichAppBar(),
-              ),
+    return Stack(
+      children: [
+        MultiselectGrid(
+          topWidget: (currentUser != null && currentUser.memoryEnabled)
+              ? const MemoryLane()
+              : const SizedBox(),
+          renderListProvider: timelineUsers.length > 1
+              ? multiUserAssetsProvider(timelineUsers)
+              : assetsProvider(currentUser?.isarId),
+          buildLoadingIndicator: buildLoadingIndicator,
+          onRefresh: refreshAssets,
+          stackEnabled: true,
+          archiveEnabled: true,
+          editEnabled: true,
+        ),
+        AnimatedPositioned(
+          duration: const Duration(milliseconds: 300),
+          top: ref.watch(multiselectProvider)
+              ? -(kToolbarHeight + MediaQuery.of(context).padding.top)
+              : 0,
+          left: 0,
+          right: 0,
+          child: Container(
+            height: kToolbarHeight + MediaQuery.of(context).padding.top,
+            color: context.themeData.appBarTheme.backgroundColor,
+            child: const SafeArea(
+              child: ImmichAppBar(),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Description
Fixes #9015 

~~This alters the appBar in the home page. I removed the ternary if statement which was checking if multi-selection is enabled. I see the value in removing the bar to gain space but it does make the UI feel weird. Perhaps it could be a setting that can be added later if users want.~~

This alters the `HomePage()` widget return. The `HomePage()` is now a `Stack` which allows the `MultiselectGrid()` to scroll behind it. The page no longer shifts when an asset is selected and the `ImmichAppBar()` animates out to the top as show in the example given by @waclaw66. This only affects the home page as there is a check in the  `ImmichAssetGridView()` which checks if the current tab is index 0 and the Route is one of the main tabs within the TabController. If both of those checks come up true padding is added to accommodate the AppBar adding some extra space. The `RefreshIndicator()` also has an offset added conditionally.

## How Has This Been Tested?

I ran flutter test and had no issues, I also ran it on an android device. I am unable to test IOS but I have no reason to believe anything would be different on either OS. I checked all views which use the asset grid and only saw the changes take effect on the main page.
