### PR TITLE
fix: Make DB_DATA_LOCATION more prominent in .env file

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -2,6 +2,8 @@
 
 # The location where your uploaded files are stored
 UPLOAD_LOCATION=./library
+# The location where your database files are stored
+DB_DATA_LOCATION=./postgres
 
 # The Immich version to use. You can pin this to a specific version like "v1.71.0"
 IMMICH_VERSION=release
@@ -14,6 +16,5 @@ DB_PASSWORD=postgres
 DB_HOSTNAME=immich_postgres
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
-DB_DATA_LOCATION=./postgres
 
 REDIS_HOSTNAME=immich_redis


### PR DESCRIPTION
We've already had a case in #9033 of someone forgetting to change it and losing the data on reboot.