### PR TITLE
feat(web): display age with months if age is less than 2

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -292,6 +292,8 @@
                   >
                     {#if ageInMonths <= 11}
                       Age {ageInMonths} months
+                    {:else if ageInMonths > 12 && ageInMonths <= 23}
+                      Age 1 year, {ageInMonths - 12} months
                     {:else}
                       Age {age}
                     {/if}


### PR DESCRIPTION
Piggybacking off #5961, this will show a child's age with "Age 1 year, 3 months", because development at that age is so fast. :)