### PR TITLE
fix(server): activity with deleted assets / users

### DIFF
--- a/server/src/queries/activity.repository.sql
+++ b/server/src/queries/activity.repository.sql
@@ -32,8 +32,28 @@ FROM
   AND (
     "ActivityEntity__ActivityEntity_user"."deletedAt" IS NULL
   )
+  LEFT JOIN "assets" "ActivityEntity__ActivityEntity_asset" ON "ActivityEntity__ActivityEntity_asset"."id" = "ActivityEntity"."assetId"
+  AND (
+    "ActivityEntity__ActivityEntity_asset"."deletedAt" IS NULL
+  )
 WHERE
-  (("ActivityEntity"."albumId" = $1))
+  (
+    ("ActivityEntity"."albumId" = $1)
+    AND (
+      (
+        (
+          "ActivityEntity__ActivityEntity_asset"."deletedAt" IS NULL
+        )
+      )
+    )
+    AND (
+      (
+        (
+          "ActivityEntity__ActivityEntity_user"."deletedAt" IS NULL
+        )
+      )
+    )
+  )
 ORDER BY
   "ActivityEntity"."createdAt" ASC
 
@@ -43,12 +63,24 @@ SELECT
 FROM
   "activity" "ActivityEntity"
   LEFT JOIN "users" "ActivityEntity__ActivityEntity_user" ON "ActivityEntity__ActivityEntity_user"."id" = "ActivityEntity"."userId"
-  AND (
-    "ActivityEntity__ActivityEntity_user"."deletedAt" IS NULL
-  )
+  LEFT JOIN "assets" "ActivityEntity__ActivityEntity_asset" ON "ActivityEntity__ActivityEntity_asset"."id" = "ActivityEntity"."assetId"
 WHERE
   (
     ("ActivityEntity"."assetId" = $1)
     AND ("ActivityEntity"."albumId" = $2)
     AND ("ActivityEntity"."isLiked" = $3)
+    AND (
+      (
+        (
+          "ActivityEntity__ActivityEntity_asset"."deletedAt" IS NULL
+        )
+      )
+    )
+    AND (
+      (
+        (
+          "ActivityEntity__ActivityEntity_user"."deletedAt" IS NULL
+        )
+      )
+    )
   )

--- a/server/src/repositories/activity.repository.ts
+++ b/server/src/repositories/activity.repository.ts
@@ -27,6 +27,12 @@ export class ActivityRepository implements IActivityRepository {
         assetId: assetId === null ? IsNull() : assetId,
         albumId,
         isLiked,
+        asset: {
+          deletedAt: IsNull(),
+        },
+        user: {
+          deletedAt: IsNull(),
+        },
       },
       relations: {
         user: true,
@@ -48,10 +54,21 @@ export class ActivityRepository implements IActivityRepository {
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   getStatistics(assetId: string, albumId: string): Promise<number> {
     return this.repository.count({
-      where: { assetId, albumId, isLiked: false },
+      where: {
+        assetId,
+        albumId,
+        isLiked: false,
+        asset: {
+          deletedAt: IsNull(),
+        },
+        user: {
+          deletedAt: IsNull(),
+        },
+      },
       relations: {
         user: true,
       },
+      withDeleted: true,
     });
   }
 

--- a/web/src/lib/components/asset-viewer/activity-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/activity-viewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
-  import { timeBeforeShowLoadingSpinner } from '$lib/constants';
+  import { AppRoute, timeBeforeShowLoadingSpinner } from '$lib/constants';
   import { getAssetThumbnailUrl, handlePromiseError } from '$lib/utils';
   import { getAssetType } from '$lib/utils/asset-utils';
   import { autoGrowHeight } from '$lib/utils/autogrow';
@@ -184,13 +184,13 @@
 
               <div class="w-full leading-4 overflow-hidden self-center break-words text-sm">{reaction.comment}</div>
               {#if assetId === undefined && reaction.assetId}
-                <div class="aspect-square w-[75px] h-[75px]">
+                <a class="aspect-square w-[75px] h-[75px]" href="{AppRoute.ALBUMS}/{albumId}/photos/{reaction.assetId}">
                   <img
                     class="rounded-lg w-[75px] h-[75px] object-cover"
                     src={getAssetThumbnailUrl(reaction.assetId, ThumbnailFormat.Webp)}
                     alt="Profile picture of {reaction.user.name}, who commented on this asset"
                   />
-                </div>
+                </a>
               {/if}
               {#if reaction.user.id === user.id || albumOwnerId === user.id}
                 <div class="flex items-start w-fit pt-[5px]" title="Delete comment">
@@ -230,13 +230,16 @@
                   {`${reaction.user.name} liked ${assetType ? `this ${getAssetType(assetType).toLowerCase()}` : 'it'}`}
                 </div>
                 {#if assetId === undefined && reaction.assetId}
-                  <div class="aspect-square w-[75px] h-[75px]">
+                  <a
+                    class="aspect-square w-[75px] h-[75px]"
+                    href="{AppRoute.ALBUMS}/{albumId}/photos/{reaction.assetId}"
+                  >
                     <img
                       class="rounded-lg w-[75px] h-[75px] object-cover"
                       src={getAssetThumbnailUrl(reaction.assetId, ThumbnailFormat.Webp)}
                       alt="Profile picture of {reaction.user.name}, who liked this asset"
                     />
-                  </div>
+                  </a>
                 {/if}
                 {#if reaction.user.id === user.id || albumOwnerId === user.id}
                   <div class="flex items-start w-fit" title="Delete like">


### PR DESCRIPTION
Currently, you get an error if a deleted user have commented / liked an asset in the album and there's still the comments of a trashed asset.

This PR adds the ability to navigate to an asset by clicking on the thumbnail of a reaction

## Screenshots

### Errors

Trashed asset:
![Screenshot from 2024-04-24 23-51-17](https://github.com/immich-app/immich/assets/74269598/80c4b5bd-1ffd-400e-8691-7c2878d59bb6)

Deleted user commented one asset :
![Screenshot from 2024-04-24 23-53-42](https://github.com/immich-app/immich/assets/74269598/2a67a23e-c37f-48c1-a6b8-e9de6761e5e4)


### Feature

https://github.com/immich-app/immich/assets/74269598/44cb907c-34ff-4f85-a888-9205b6e8cddd

