### PR TITLE
feat(server): env variable to skip migrations on startup

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -60,6 +60,10 @@ docker compose up -d    # Start remainder of Immich apps
 
 Note that for the database restore to proceed properly, it requires a completely fresh install (i.e. the Immich server has never run since creating the Docker containers). If the Immich app has run, Postgres conflicts may be encountered upon database restoration (relation already exists, violated foreign key constraints, multiple primary keys, etc.).
 
+:::tip
+Some deployment methods make it difficult to start the database without also starting the server or microservices. In these cases, you may set the environmental variable `DB_SKIP_MIGRATIONS=true` before starting the services. This will prevent the server from running migrations that interfere with the restore process. Note that both the server and microservices must have this variable set to prevent the migrations from running. Be sure to remove this variable and restart the services after the database is restored.
+:::
+
 The database dumps can also be automated (using [this image](https://github.com/prodrigestivill/docker-postgres-backup-local)) by editing the docker compose file to match the following:
 
 ```yaml

--- a/docs/docs/administration/postgres-standalone.md
+++ b/docs/docs/administration/postgres-standalone.md
@@ -33,7 +33,7 @@ DB_URL='postgresql://immichdbusername:immichdbpassword@postgreshost:postgresport
 ```
 
 :::info
-When `DB_URL` is defined, the other database (`DB_*`) variables are ignored, with the exception of `DB_VECTOR_EXTENSION`.
+When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD` and `DB_DATABASE_NAME` database variables are ignored.
 :::
 
 ## With superuser permission

--- a/docs/docs/administration/postgres-standalone.md
+++ b/docs/docs/administration/postgres-standalone.md
@@ -32,10 +32,6 @@ DB_URL='postgresql://immichdbusername:immichdbpassword@postgreshost:postgresport
 # DB_URL='postgresql://immichdbusername:immichdbpassword@postgreshost:postgresport/immichdatabasename?sslmode=require&sslmode=no-verify'
 ```
 
-:::info
-When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD` and `DB_DATABASE_NAME` database variables are ignored.
-:::
-
 ## With superuser permission
 
 Typically Immich expects superuser permission in the database, which you can grant by running `ALTER USER <immichdbusername> WITH SUPERUSER;` at the `psql` console. If you prefer not to grant superuser permissions, follow the instructions in the next section.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -58,15 +58,16 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 
 ## Database
 
-| Variable                            | Description                                                   |   Default    | Services              |
-| :---------------------------------- | :------------------------------------------------------------ | :----------: | :-------------------- |
-| `DB_URL`                            | Database URL                                                  |              | server, microservices |
-| `DB_HOSTNAME`                       | Database Host                                                 | `localhost`  | server, microservices |
-| `DB_PORT`                           | Database Port                                                 |    `5432`    | server, microservices |
-| `DB_USERNAME`                       | Database User                                                 |  `postgres`  | server, microservices |
-| `DB_PASSWORD`                       | Database Password                                             |  `postgres`  | server, microservices |
-| `DB_DATABASE_NAME`                  | Database Name                                                 |   `immich`   | server, microservices |
-| `DB_VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`]) | `pgvecto.rs` | server, microservices |
+| Variable                            | Description                                                              |   Default    | Services              |
+| :---------------------------------- | :----------------------------------------------------------------------- | :----------: | :-------------------- |
+| `DB_URL`                            | Database URL                                                             |              | server, microservices |
+| `DB_HOSTNAME`                       | Database Host                                                            | `localhost`  | server, microservices |
+| `DB_PORT`                           | Database Port                                                            |    `5432`    | server, microservices |
+| `DB_USERNAME`                       | Database User                                                            |  `postgres`  | server, microservices |
+| `DB_PASSWORD`                       | Database Password                                                        |  `postgres`  | server, microservices |
+| `DB_DATABASE_NAME`                  | Database Name                                                            |   `immich`   | server, microservices |
+| `DB_VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`])            | `pgvecto.rs` | server, microservices |
+| `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`]) |   `false`    | server, microservices |
 
 \*1: This setting cannot be changed after the server has successfully started up
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -69,11 +69,11 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | `DB_VECTOR_EXTENSION`<sup>\*1</sup> | Database Vector Extension (one of [`pgvector`, `pgvecto.rs`])            | `pgvecto.rs` | server, microservices |
 | `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`]) |   `false`    | server, microservices |
 
-\*1: This setting cannot be changed after the server has successfully started up
+\*1: This setting cannot be changed after the server has successfully started up.
 
 :::info
 
-When `DB_URL` is defined, the other database (`DB_*`) variables are ignored, with the exception of `DB_VECTOR_EXTENSION`.
+When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD` and `DB_DATABASE_NAME` database variables are ignored.
 
 :::
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -28,6 +28,7 @@ export const immichAppConfig: ConfigModuleOptions = {
     DB_DATABASE_NAME: WHEN_DB_URL_SET,
     DB_URL: Joi.string().optional(),
     DB_VECTOR_EXTENSION: Joi.string().optional().valid('pgvector', 'pgvecto.rs').default('pgvecto.rs'),
+    DB_SKIP_MIGRATIONS: Joi.boolean().optional().default(false),
 
     MACHINE_LEARNING_PORT: Joi.number().optional(),
     MICROSERVICES_PORT: Joi.number().optional(),

--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -12,6 +12,7 @@ describe(DatabaseService.name, () => {
   let loggerMock: Mocked<ILoggerRepository>;
 
   beforeEach(() => {
+    delete process.env.DB_SKIP_MIGRATIONS;
     databaseMock = newDatabaseRepositoryMock();
     loggerMock = newLoggerRepositoryMock();
     sut = new DatabaseService(databaseMock, loggerMock);
@@ -210,5 +211,13 @@ describe(DatabaseService.name, () => {
         expect(loggerMock.fatal).not.toHaveBeenCalled();
       },
     );
+
+    it('should skip migrations if DB_SKIP_MIGRATIONS=true', async () => {
+      process.env.DB_SKIP_MIGRATIONS = 'true';
+
+      await expect(sut.init()).resolves.toBeUndefined();
+
+      expect(databaseMock.runMigrations).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -49,7 +49,9 @@ export class DatabaseService {
         throw error;
       }
 
-      await this.databaseRepository.runMigrations();
+      if (process.env.DB_SKIP_MIGRATIONS !== 'true') {
+        await this.databaseRepository.runMigrations();
+      }
     });
   }
 


### PR DESCRIPTION
## Description

Some deployment methods, like Portainer and TrueNAS SCALE, make it difficult to start the database without starting everything else as well. This makes it awkward to restore from a backup as the server will run migrations that then cause duplicate key violations, etc.

This PR adds an env variable to ease this process, skipping migrations to allow the admin to restore to a clean database.