### PR TITLE
fix(web): the selected tab on the sidebar was not always shown as selected

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
@@ -14,7 +14,7 @@
 
   let showMoreInformation = false;
   $: routePath = resolveRoute(routeId, {});
-  $: isSelected = $page.route.id === routeId;
+  $: isSelected = ($page.route.id?.match(/^\/(admin|\(user\))\/[^/]*/) || [])[0] === routeId;
 </script>
 
 <a
@@ -24,7 +24,7 @@
   aria-current={isSelected ? 'page' : undefined}
   class="flex w-full place-items-center justify-between gap-4 rounded-r-full py-3 transition-[padding] delay-100 duration-100 hover:cursor-pointer hover:bg-immich-gray hover:text-immich-primary dark:text-immich-dark-fg dark:hover:bg-immich-dark-gray dark:hover:text-immich-dark-primary
     {isSelected
-    ? 'bg-immich-primary/10 text-immich-primary hover:bg-immich-primary/25 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary'
+    ? 'bg-immich-primary/10 text-immich-primary hover:bg-immich-primary/10 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary'
     : ''}
 		pl-5 group-hover:sm:px-5 md:px-5
   "


### PR DESCRIPTION
## Description

The sidebar sometimes did not show that the current tab was selected. This is because the check was comparing the current route and then list of route Ids. When certain tabs were selected, like the photos tab, the `$page.route.id` would return `/(user)/photos/[[assetId=id]]` while the check was looking for `/(user)/photos`. Regex was used to check for just the first portion ie. `/(user)/[anything]` as well as `/admin/[anything]`.  The regex has an or for an empty array to avoid returning null if there are no matches.

The colour when hovered and selected was also changed from `bg-immich-primary-25` to `bg-immich-primary-10` as a darker hover is not needed when on the current page, just seems redundant and doesn't look as good. 

## How has this been tested

I ran the `npm run check:all` and tested both the user and admin page within the browser.