### PR TITLE
fix(web): solve error starting docker for local development

### DIFF
--- a/web/src/lib/__mocks__/sdk.mock.ts
+++ b/web/src/lib/__mocks__/sdk.mock.ts
@@ -1,4 +1,4 @@
-import sdk from '@immich/sdk';
+import * as sdk from '@immich/sdk';
 import type { Mock, MockedObject } from 'vitest';
 
 vi.mock('@immich/sdk', async (originalImport) => {


### PR DESCRIPTION
I've been getting the error below whenever I run `make dev update`. The error doesn't stop the app from running, but it is pretty ugly, clutters up the logs, and makes you think something is wrong. This fixes it
```
immich_web               |   ✘ [ERROR] No matching export in "../open-api/typescript-sdk/build/index.js" for import "default"
immich_web               | 
immich_web               |     src/lib/__mocks__/sdk.mock.ts:1:7:
immich_web               |       1 │ import sdk from '@immich/sdk';
immich_web               |         │        ~~~
immich_web               |         ╵        defaults
immich_web               | 
immich_web               |   Did you mean to import "defaults" instead?
immich_web               | 
immich_web               |     ../open-api/typescript-sdk/build/fetch-client.js:9:13:
immich_web               |       9 │ export const defaults = {
immich_web               |         ╵              ~~~~~~~~
```