### PR TITLE
chore: for redis, use service name as the default

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -16,5 +16,3 @@ DB_PASSWORD=postgres
 DB_HOSTNAME=immich_postgres
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
-
-REDIS_HOSTNAME=immich_redis

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -79,15 +79,15 @@ When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSW
 
 ## Redis
 
-| Variable         | Description    |    Default     | Services              |
-| :--------------- | :------------- | :------------: | :-------------------- |
-| `REDIS_URL`      | Redis URL      |                | server, microservices |
-| `REDIS_HOSTNAME` | Redis Host     | `immich_redis` | server, microservices |
-| `REDIS_PORT`     | Redis Port     |     `6379`     | server, microservices |
-| `REDIS_DBINDEX`  | Redis DB Index |      `0`       | server, microservices |
-| `REDIS_USERNAME` | Redis Username |                | server, microservices |
-| `REDIS_PASSWORD` | Redis Password |                | server, microservices |
-| `REDIS_SOCKET`   | Redis Socket   |                | server, microservices |
+| Variable         | Description    | Default | Services              |
+| :--------------- | :------------- | :-----: | :-------------------- |
+| `REDIS_URL`      | Redis URL      |         | server, microservices |
+| `REDIS_HOSTNAME` | Redis Host     | `redis` | server, microservices |
+| `REDIS_PORT`     | Redis Port     | `6379`  | server, microservices |
+| `REDIS_DBINDEX`  | Redis DB Index |   `0`   | server, microservices |
+| `REDIS_USERNAME` | Redis Username |         | server, microservices |
+| `REDIS_PASSWORD` | Redis Password |         | server, microservices |
+| `REDIS_SOCKET`   | Redis Socket   |         | server, microservices |
 
 :::info
 

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,7 +12,6 @@ x-server-build: &server-common
     - DB_USERNAME=postgres
     - DB_PASSWORD=postgres
     - DB_DATABASE_NAME=immich
-    - REDIS_HOSTNAME=redis
     - IMMICH_MACHINE_LEARNING_ENABLED=false
     - IMMICH_METRICS=true
   volumes:

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -52,7 +52,7 @@ function parseRedisConfig(): RedisOptions {
     }
   }
   return {
-    host: process.env.REDIS_HOSTNAME || 'immich_redis',
+    host: process.env.REDIS_HOSTNAME || 'redis',
     port: Number.parseInt(process.env.REDIS_PORT || '6379'),
     db: Number.parseInt(process.env.REDIS_DBINDEX || '0'),
     username: process.env.REDIS_USERNAME || undefined,


### PR DESCRIPTION
* default to service name instead of container name