### PR TITLE
chore(server): default postgres hostname to compose service name

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -13,6 +13,5 @@ DB_PASSWORD=postgres
 
 # The values below this line do not need to be changed
 ###################################################################################
-DB_HOSTNAME=immich_postgres
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -61,7 +61,7 @@ These environment variables are used by the `docker-compose.yml` file and do **N
 | Variable                            | Description                                                              |   Default    | Services              |
 | :---------------------------------- | :----------------------------------------------------------------------- | :----------: | :-------------------- |
 | `DB_URL`                            | Database URL                                                             |              | server, microservices |
-| `DB_HOSTNAME`                       | Database Host                                                            | `localhost`  | server, microservices |
+| `DB_HOSTNAME`                       | Database Host                                                            |  `database`  | server, microservices |
 | `DB_PORT`                           | Database Port                                                            |    `5432`    | server, microservices |
 | `DB_USERNAME`                       | Database User                                                            |  `postgres`  | server, microservices |
 | `DB_PASSWORD`                       | Database Password                                                        |  `postgres`  | server, microservices |

--- a/server/src/database.config.ts
+++ b/server/src/database.config.ts
@@ -6,7 +6,7 @@ const url = process.env.DB_URL;
 const urlOrParts = url
   ? { url }
   : {
-      host: process.env.DB_HOSTNAME || 'localhost',
+      host: process.env.DB_HOSTNAME || 'database',
       port: Number.parseInt(process.env.DB_PORT || '5432'),
       username: process.env.DB_USERNAME || 'postgres',
       password: process.env.DB_PASSWORD || 'postgres',
@@ -26,8 +26,12 @@ export const databaseConfig: PostgresConnectionOptions = {
   ...urlOrParts,
 };
 
-// this export is used by TypeORM commands in package.json#scripts
-export const dataSource = new DataSource(databaseConfig);
+/**
+ * @deprecated - DO NOT USE THIS
+ *
+ * this export is ONLY to be used for TypeORM commands in package.json#scripts
+ */
+export const dataSource = new DataSource({ ...databaseConfig, host: 'localhost' });
 
 export const vectorExt =
   process.env.DB_VECTOR_EXTENSION === 'pgvector' ? DatabaseExtension.VECTOR : DatabaseExtension.VECTORS;

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import _ from 'lodash';
-import { dataSource } from 'src/database.config';
 import { Chunked, ChunkedArray, DATABASE_PARAMETER_CHUNK_SIZE, DummyValue, GenerateSql } from 'src/decorators';
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AssetEntity } from 'src/entities/asset.entity';
@@ -328,7 +327,7 @@ export class AlbumRepository implements IAlbumRepository {
       .limit(1);
 
     // Using dataSource, because there is no direct access to albums_assets_assets.
-    const albumHasAssets = dataSource
+    const albumHasAssets = this.dataSource
       .createQueryBuilder()
       .select('1')
       .from('albums_assets_assets', 'albums_assets')


### PR DESCRIPTION
* change default back to `database` (reverse change made [here](https://github.com/immich-app/immich/pull/1381/files#diff-69986fee491fd46475173d3925e5d1a56cbdce049f16a5c30cf39b93d6c8c380)).
* npm run typeorm:migrations:* commands still work
* updated warning for export data source and fixed one stray usage
* number of required env variables goes down by one