### PR TITLE
fix(server): untracked thumbnail and preview images

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -251,6 +251,17 @@ describe(MediaService.name, () => {
       expect(assetMock.update).toHaveBeenCalledWith({ id: 'asset-id', previewPath });
     });
 
+    it('should delete previous preview if different path', async () => {
+      const previousPreviewPath = assetStub.image.previewPath;
+
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.IMAGE_THUMBNAIL_FORMAT, value: ImageFormat.WEBP }]);
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+
+      await sut.handleGeneratePreview({ id: assetStub.image.id });
+
+      expect(storageMock.unlink).toHaveBeenCalledWith(previousPreviewPath);
+    });
+
     it('should generate a P3 thumbnail for a wide gamut image', async () => {
       assetMock.getByIds.mockResolvedValue([
         { ...assetStub.image, exifInfo: { profileDescription: 'Adobe RGB', bitsPerSample: 14 } as ExifEntity },
@@ -390,6 +401,17 @@ describe(MediaService.name, () => {
         expect(assetMock.update).toHaveBeenCalledWith({ id: 'asset-id', thumbnailPath });
       },
     );
+
+    it('should delete previous thumbnail if different path', async () => {
+      const previousThumbnailPath = assetStub.image.thumbnailPath;
+
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.IMAGE_THUMBNAIL_FORMAT, value: ImageFormat.WEBP }]);
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+
+      await sut.handleGenerateThumbnail({ id: assetStub.image.id });
+
+      expect(storageMock.unlink).toHaveBeenCalledWith(previousThumbnailPath);
+    });
   });
 
   it('should generate a P3 thumbnail for a wide gamut image', async () => {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -234,16 +234,6 @@ describe(MediaService.name, () => {
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });
 
-    it('should delete existing preview if invisible asset', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.liveMotionWithThumb]);
-
-      expect(await sut.handleGeneratePreview({ id: assetStub.liveMotionWithThumb.id })).toEqual(JobStatus.SKIPPED);
-
-      expect(storageMock.unlink).toHaveBeenCalledWith(assetStub.liveMotionWithThumb.previewPath);
-      expect(mediaMock.resize).not.toHaveBeenCalled();
-      expect(assetMock.update).not.toHaveBeenCalledWith();
-    });
-
     it.each(Object.values(ImageFormat))('should generate a %s preview for an image when specified', async (format) => {
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.IMAGE_PREVIEW_FORMAT, value: format }]);
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
@@ -388,16 +378,6 @@ describe(MediaService.name, () => {
 
       expect(await sut.handleGenerateThumbnail({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
 
-      expect(mediaMock.resize).not.toHaveBeenCalled();
-      expect(assetMock.update).not.toHaveBeenCalledWith();
-    });
-
-    it('should delete existing thumbnail if invisible asset', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.liveMotionWithThumb]);
-
-      expect(await sut.handleGenerateThumbnail({ id: assetStub.liveMotionWithThumb.id })).toEqual(JobStatus.SKIPPED);
-
-      expect(storageMock.unlink).toHaveBeenCalledWith(assetStub.liveMotionWithThumb.thumbnailPath);
       expect(mediaMock.resize).not.toHaveBeenCalled();
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -234,6 +234,16 @@ describe(MediaService.name, () => {
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });
 
+    it('should delete existing preview if invisible asset', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.liveMotionWithThumb]);
+
+      expect(await sut.handleGeneratePreview({ id: assetStub.liveMotionWithThumb.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(storageMock.unlink).toHaveBeenCalledWith(assetStub.liveMotionWithThumb.previewPath);
+      expect(mediaMock.resize).not.toHaveBeenCalled();
+      expect(assetMock.update).not.toHaveBeenCalledWith();
+    });
+
     it.each(Object.values(ImageFormat))('should generate a %s preview for an image when specified', async (format) => {
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.IMAGE_PREVIEW_FORMAT, value: format }]);
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
@@ -378,6 +388,16 @@ describe(MediaService.name, () => {
 
       expect(await sut.handleGenerateThumbnail({ id: assetStub.livePhotoMotionAsset.id })).toEqual(JobStatus.SKIPPED);
 
+      expect(mediaMock.resize).not.toHaveBeenCalled();
+      expect(assetMock.update).not.toHaveBeenCalledWith();
+    });
+
+    it('should delete existing thumbnail if invisible asset', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.liveMotionWithThumb]);
+
+      expect(await sut.handleGenerateThumbnail({ id: assetStub.liveMotionWithThumb.id })).toEqual(JobStatus.SKIPPED);
+
+      expect(storageMock.unlink).toHaveBeenCalledWith(assetStub.liveMotionWithThumb.thumbnailPath);
       expect(mediaMock.resize).not.toHaveBeenCalled();
       expect(assetMock.update).not.toHaveBeenCalledWith();
     });

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -181,10 +181,19 @@ export class MediaService {
     }
 
     if (!asset.isVisible) {
+      if (asset.previewPath) {
+        this.logger.debug(`Asset ${asset.id} is not visible, deleting preview`);
+        await this.storageRepository.unlink(asset.previewPath);
+        await this.assetRepository.update({ id: asset.id, previewPath: null });
+      }
       return JobStatus.SKIPPED;
     }
 
     const previewPath = await this.generateThumbnail(asset, AssetPathType.PREVIEW, image.previewFormat);
+    if (asset.previewPath && asset.previewPath !== previewPath) {
+      this.logger.debug(`Deleting old preview for asset ${asset.id}`);
+      await this.storageRepository.unlink(asset.previewPath);
+    }
     await this.assetRepository.update({ id: asset.id, previewPath });
     return JobStatus.SUCCESS;
   }
@@ -249,10 +258,19 @@ export class MediaService {
     }
 
     if (!asset.isVisible) {
+      if (asset.thumbnailPath) {
+        this.logger.debug(`Asset ${asset.id} is not visible, deleting thumbnail`);
+        await this.storageRepository.unlink(asset.thumbnailPath);
+        await this.assetRepository.update({ id: asset.id, thumbnailPath: null });
+      }
       return JobStatus.SKIPPED;
     }
 
     const thumbnailPath = await this.generateThumbnail(asset, AssetPathType.THUMBNAIL, image.thumbnailFormat);
+    if (asset.thumbnailPath && asset.thumbnailPath !== thumbnailPath) {
+      this.logger.debug(`Deleting old thumbnail for asset ${asset.id}`);
+      await this.storageRepository.unlink(asset.thumbnailPath);
+    }
     await this.assetRepository.update({ id: asset.id, thumbnailPath });
     return JobStatus.SUCCESS;
   }

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -181,11 +181,6 @@ export class MediaService {
     }
 
     if (!asset.isVisible) {
-      if (asset.previewPath) {
-        this.logger.debug(`Asset ${asset.id} is not visible, deleting preview`);
-        await this.storageRepository.unlink(asset.previewPath);
-        await this.assetRepository.update({ id: asset.id, previewPath: null });
-      }
       return JobStatus.SKIPPED;
     }
 
@@ -258,11 +253,6 @@ export class MediaService {
     }
 
     if (!asset.isVisible) {
-      if (asset.thumbnailPath) {
-        this.logger.debug(`Asset ${asset.id} is not visible, deleting thumbnail`);
-        await this.storageRepository.unlink(asset.thumbnailPath);
-        await this.assetRepository.update({ id: asset.id, thumbnailPath: null });
-      }
       return JobStatus.SKIPPED;
     }
 

--- a/server/test/fixtures/asset.stub.ts
+++ b/server/test/fixtures/asset.stub.ts
@@ -471,6 +471,24 @@ export const assetStub = {
     },
   } as AssetEntity),
 
+  liveMotionWithThumb: Object.freeze({
+    id: fileStub.livePhotoMotion.uuid,
+    originalPath: fileStub.livePhotoMotion.originalPath,
+    ownerId: authStub.user1.user.id,
+    type: AssetType.VIDEO,
+    isVisible: false,
+    fileModifiedAt: new Date('2022-06-19T23:41:36.910Z'),
+    fileCreatedAt: new Date('2022-06-19T23:41:36.910Z'),
+    libraryId: 'library-id',
+    library: libraryStub.uploadLibrary1,
+    previewPath: '/uploads/user-id/thumbs/path.ext',
+    thumbnailPath: '/uploads/user-id/webp/path.ext',
+    exifInfo: {
+      fileSizeInByte: 100_000,
+      timeZone: `America/New_York`,
+    },
+  } as AssetEntity),
+
   livePhotoStillAsset: Object.freeze({
     id: 'live-photo-still-asset',
     originalPath: fileStub.livePhotoStill.originalPath,


### PR DESCRIPTION
## Description

The ability to choose the format means that it's no longer enough to overwrite a preview or thumbnail asset: in cases where the old path differs from the new, the old file will be left behind. This PR explicitly checks for this case and deletes the old path.

There is a bit of duplication here since the check is added separately for previews and thumbnails. I did this to make the behavior more transparent: the `generateThumbnail` helper should only generate an image, not have a side effect of deleting another file.

Fixes #8981

## How Has This Been Tested?

Tested by checking that there are only a few untracked assets in the repair page, changing the target thumbnail and preview formats, re-running thumbnail generation and confirming there's no explosion of untracked files after thumbnail generation is complete.