### PR TITLE
chore(web): remove CircleIconButton slot

### DIFF
--- a/web/src/lib/components/elements/buttons/circle-icon-button.svelte
+++ b/web/src/lib/components/elements/buttons/circle-icon-button.svelte
@@ -38,5 +38,4 @@
   on:click
 >
   <Icon path={icon} {size} ariaLabel={title} color="currentColor" />
-  <slot />
 </button>

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -459,27 +459,22 @@
 
               {#if isOwned}
                 <div use:clickOutside on:outclick={() => (viewMode = ViewMode.VIEW)}>
-                  <CircleIconButton title="Album options" on:click={handleOpenAlbumOptions} icon={mdiDotsVertical}>
-                    {#if viewMode === ViewMode.ALBUM_OPTIONS}
-                      <ContextMenu {...contextMenuPosition}>
-                        <MenuOption
-                          icon={mdiImageOutline}
-                          text="Select album cover"
-                          on:click={() => (viewMode = ViewMode.SELECT_THUMBNAIL)}
-                        />
-                        <MenuOption
-                          icon={mdiCogOutline}
-                          text="Options"
-                          on:click={() => (viewMode = ViewMode.OPTIONS)}
-                        />
-                        <MenuOption
-                          icon={mdiDeleteOutline}
-                          text="Delete album"
-                          on:click={() => (viewMode = ViewMode.CONFIRM_DELETE)}
-                        />
-                      </ContextMenu>
-                    {/if}
-                  </CircleIconButton>
+                  <CircleIconButton title="Album options" on:click={handleOpenAlbumOptions} icon={mdiDotsVertical} />
+                  {#if viewMode === ViewMode.ALBUM_OPTIONS}
+                    <ContextMenu {...contextMenuPosition}>
+                      <MenuOption
+                        icon={mdiImageOutline}
+                        text="Select album cover"
+                        on:click={() => (viewMode = ViewMode.SELECT_THUMBNAIL)}
+                      />
+                      <MenuOption icon={mdiCogOutline} text="Options" on:click={() => (viewMode = ViewMode.OPTIONS)} />
+                      <MenuOption
+                        icon={mdiDeleteOutline}
+                        text="Delete album"
+                        on:click={() => (viewMode = ViewMode.CONFIRM_DELETE)}
+                      />
+                    </ContextMenu>
+                  {/if}
                 </div>
               {/if}
             {/if}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow up for #9127 that I meant to include.

The `CircleIconButton` functionality isn't designed to take content in a slot and display it in a helpful way. This PR removes this slot to simplify future usage of the component.

## Screenshots

N/A - user interface should look the same as before.

## Checklist:

- [x] npm run lint
- [x] npm run format
- [x] npm run check:svelte
- [x] npm test