### PR TITLE
fix(mobile): sync issue

### DIFF
--- a/mobile/lib/shared/ui/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/shared/ui/app_bar_dialog/app_bar_dialog.dart
@@ -35,7 +35,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
         ref.read(currentUserProvider.notifier).refresh();
         return null;
       },
-      [user],
+      [],
     );
 
     buildTopRow() {
@@ -115,12 +115,12 @@ class ImmichAppBarDialog extends HookConsumerWidget {
                 content: "app_bar_signout_dialog_content",
                 ok: "app_bar_signout_dialog_ok",
                 onOk: () async {
-                  await ref.watch(authenticationProvider.notifier).logout();
+                  await ref.read(authenticationProvider.notifier).logout();
 
                   ref.read(manualUploadProvider.notifier).cancelBackup();
-                  ref.watch(backupProvider.notifier).cancelBackup();
-                  ref.watch(assetProvider.notifier).clearAllAsset();
-                  ref.watch(websocketProvider.notifier).disconnect();
+                  ref.read(backupProvider.notifier).cancelBackup();
+                  ref.read(assetProvider.notifier).clearAllAsset();
+                  ref.read(websocketProvider.notifier).disconnect();
                   context.replaceRoute(const LoginRoute());
                 },
               );

--- a/mobile/lib/shared/ui/app_bar_dialog/app_bar_profile_info.dart
+++ b/mobile/lib/shared/ui/app_bar_dialog/app_bar_profile_info.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/modules/home/providers/upload_profile_image.provider.dart';
 import 'package:immich_mobile/shared/models/store.dart';
+import 'package:immich_mobile/shared/providers/user.provider.dart';
 import 'package:immich_mobile/shared/ui/user_circle_avatar.dart';
 import 'package:immich_mobile/modules/login/models/authentication_state.model.dart';
 import 'package:immich_mobile/modules/login/providers/authentication.provider.dart';
@@ -67,6 +68,7 @@ class AppBarProfileInfoBox extends HookConsumerWidget {
           if (user != null) {
             user.profileImagePath = profileImagePath;
             Store.put(StoreKey.currentUser, user);
+            ref.read(currentUserProvider.notifier).refresh();
           }
         }
       }


### PR DESCRIPTION
`useEffect` does what it is supposed to do, which is to rerun the function body when the target property changes, i.e., `user`. So when we log out and invalidate the user, it runs again and saves the current user ID back to the storage while the user information is deleted. That causes the sync mechanism, which uses the userId to look for the User's information, now, not exist in the database any more after being logged out and hasn't been populated yet from the login success call, ultimately returning error and aborting the sync mechanism, leading to the user doesn't see the applicable changes they suppose to see on the phone.

Tested by logout and log back in while monitoring the Isar database for a couple dozen times to make sure that the current user id and user information are deleted when logging out

Fixes #9065