### PR TITLE
fix(web): update assets after delete

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -334,11 +334,9 @@
       }
       await deleteAsset();
       return;
-    } else {
-      await trashAsset();
     }
 
-    await navigateAsset('next');
+    await trashAsset();
     return;
   };
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -334,8 +334,7 @@
       }
       await deleteAsset();
       return;
-    }
-    else {
+    } else {
       await trashAsset();
     }
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -335,8 +335,11 @@
       await deleteAsset();
       return;
     }
+    else {
+      await trashAsset();
+    }
 
-    await trashAsset();
+    await navigateAsset('next');
     return;
   };
 

--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -67,23 +67,25 @@
     {/if}
     <div class="inline-block" bind:offsetWidth={innerWidth}>
       {#each $memoryStore as memory, index (memory.yearsAgo)}
-        <button
-          class="memory-card relative mr-8 inline-block aspect-video h-[215px] rounded-xl"
-          on:click={() => goto(`${AppRoute.MEMORY}?${QueryParameter.MEMORY_INDEX}=${index}`)}
-        >
-          <img
-            class="h-full w-full rounded-xl object-cover"
-            src={getAssetThumbnailUrl(memory.assets[0].id, ThumbnailFormat.Webp)}
-            alt={`Memory Lane ${getAltText(memory.assets[0])}`}
-            draggable="false"
-          />
-          <p class="absolute bottom-2 left-4 z-10 text-lg text-white">
-            {memoryLaneTitle(memory.yearsAgo)}
-          </p>
-          <div
-            class="absolute left-0 top-0 z-0 h-full w-full rounded-xl bg-gradient-to-t from-black/40 via-transparent to-transparent transition-all hover:bg-black/20"
-          />
-        </button>
+        {#if memory.assets.length > 0}
+          <button
+            class="memory-card relative mr-8 inline-block aspect-video h-[215px] rounded-xl"
+            on:click={() => goto(`${AppRoute.MEMORY}?${QueryParameter.MEMORY_INDEX}=${index}`)}
+          >
+            <img
+              class="h-full w-full rounded-xl object-cover"
+              src={getAssetThumbnailUrl(memory.assets[0].id, ThumbnailFormat.Webp)}
+              alt={`Memory Lane ${getAltText(memory.assets[0])}`}
+              draggable="false"
+            />
+            <p class="absolute bottom-2 left-4 z-10 text-lg text-white">
+              {memoryLaneTitle(memory.yearsAgo)}
+            </p>
+            <div
+              class="absolute left-0 top-0 z-0 h-full w-full rounded-xl bg-gradient-to-t from-black/40 via-transparent to-transparent transition-all hover:bg-black/20"
+            />
+          </button>
+        {/if}
       {/each}
     </div>
   </section>

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -66,13 +66,17 @@
     }
   };
 
-  const handleAction = async (action: AssetAction, asset: AssetResponseDto) => {
+  const handleAction = (action: AssetAction, asset: AssetResponseDto) => {
     switch (action) {
       case AssetAction.DELETE:
-      case AssetAction.TRASH:
-        assets.splice(assets.findIndex((a) => a.id === asset.id), 1);
+      case AssetAction.TRASH: {
+        assets.splice(
+          assets.findIndex((a) => a.id === asset.id),
+          1,
+        );
         assets = assets;
         break;
+      }
     }
   };
 
@@ -127,6 +131,11 @@
 <!-- Overlay Asset Viewer -->
 {#if $showAssetViewer}
   <Portal target="body">
-    <AssetViewer asset={$viewingAsset} on:action={({ detail: action }) => handleAction(action.type, action.asset)} on:previous={navigateAssetBackward} on:next={navigateAssetForward} />
+    <AssetViewer
+      asset={$viewingAsset}
+      on:action={({ detail: action }) => handleAction(action.type, action.asset)}
+      on:previous={navigateAssetBackward}
+      on:next={navigateAssetForward}
+    />
   </Portal>
 {/if}

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -68,6 +68,7 @@
 
   const handleAction = (action: AssetAction, asset: AssetResponseDto) => {
     switch (action) {
+      case AssetAction.ARCHIVE:
       case AssetAction.DELETE:
       case AssetAction.TRASH: {
         assets.splice(

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -11,6 +11,7 @@
   import { getAssetRatio } from '$lib/utils/asset-utils';
   import { calculateWidth } from '$lib/utils/timeline-util';
   import { navigate } from '$lib/utils/navigation';
+  import { AssetAction } from '$lib/constants';
 
   const dispatch = createEventDispatcher<{ intersected: { container: HTMLDivElement; position: BucketPosition } }>();
 
@@ -65,6 +66,16 @@
     }
   };
 
+  const handleAction = async (action: AssetAction, asset: AssetResponseDto) => {
+    switch (action) {
+      case AssetAction.DELETE:
+      case AssetAction.TRASH:
+        assets.splice(assets.findIndex((a) => a.id === asset.id), 1);
+        assets = assets;
+        break;
+    }
+  };
+
   onDestroy(() => {
     $showAssetViewer = false;
   });
@@ -116,6 +127,6 @@
 <!-- Overlay Asset Viewer -->
 {#if $showAssetViewer}
   <Portal target="body">
-    <AssetViewer asset={$viewingAsset} on:previous={navigateAssetBackward} on:next={navigateAssetForward} />
+    <AssetViewer asset={$viewingAsset} on:action={({ detail: action }) => handleAction(action.type, action.asset)} on:previous={navigateAssetBackward} on:next={navigateAssetForward} />
   </Portal>
 {/if}


### PR DESCRIPTION
fixes #8338 

## Current Behavior
After click the delete button on the viewer page, it will show the next photo by "navigateAsset('next')". Also, the assets shown in the gallery viewer will also filter out the deleted photo, and update itself. 