### PR TITLE
Feature/improve date selection

### DIFF
--- a/mobile/openapi/doc/AssetBulkUpdateDto.md
+++ b/mobile/openapi/doc/AssetBulkUpdateDto.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **ids** | **List<String>** |  | [default to const []]
 **isArchived** | **bool** |  | [optional] 
 **isFavorite** | **bool** |  | [optional] 
+**keepTimeUnchanged** | **bool** |  | [optional] 
 **latitude** | **num** |  | [optional] 
 **longitude** | **num** |  | [optional] 
 **removeParent** | **bool** |  | [optional] 

--- a/mobile/openapi/doc/UpdateAssetDto.md
+++ b/mobile/openapi/doc/UpdateAssetDto.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **description** | **String** |  | [optional] 
 **isArchived** | **bool** |  | [optional] 
 **isFavorite** | **bool** |  | [optional] 
+**keepTimeUnchanged** | **bool** |  | [optional] 
 **latitude** | **num** |  | [optional] 
 **longitude** | **num** |  | [optional] 
 

--- a/mobile/openapi/lib/model/asset_bulk_update_dto.dart
+++ b/mobile/openapi/lib/model/asset_bulk_update_dto.dart
@@ -17,6 +17,7 @@ class AssetBulkUpdateDto {
     this.ids = const [],
     this.isArchived,
     this.isFavorite,
+    this.keepTimeUnchanged,
     this.latitude,
     this.longitude,
     this.removeParent,
@@ -48,6 +49,14 @@ class AssetBulkUpdateDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isFavorite;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? keepTimeUnchanged;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -87,6 +96,7 @@ class AssetBulkUpdateDto {
     _deepEquality.equals(other.ids, ids) &&
     other.isArchived == isArchived &&
     other.isFavorite == isFavorite &&
+    other.keepTimeUnchanged == keepTimeUnchanged &&
     other.latitude == latitude &&
     other.longitude == longitude &&
     other.removeParent == removeParent &&
@@ -99,13 +109,14 @@ class AssetBulkUpdateDto {
     (ids.hashCode) +
     (isArchived == null ? 0 : isArchived!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (keepTimeUnchanged == null ? 0 : keepTimeUnchanged!.hashCode) +
     (latitude == null ? 0 : latitude!.hashCode) +
     (longitude == null ? 0 : longitude!.hashCode) +
     (removeParent == null ? 0 : removeParent!.hashCode) +
     (stackParentId == null ? 0 : stackParentId!.hashCode);
 
   @override
-  String toString() => 'AssetBulkUpdateDto[dateTimeOriginal=$dateTimeOriginal, ids=$ids, isArchived=$isArchived, isFavorite=$isFavorite, latitude=$latitude, longitude=$longitude, removeParent=$removeParent, stackParentId=$stackParentId]';
+  String toString() => 'AssetBulkUpdateDto[dateTimeOriginal=$dateTimeOriginal, ids=$ids, isArchived=$isArchived, isFavorite=$isFavorite, keepTimeUnchanged=$keepTimeUnchanged, latitude=$latitude, longitude=$longitude, removeParent=$removeParent, stackParentId=$stackParentId]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -124,6 +135,11 @@ class AssetBulkUpdateDto {
       json[r'isFavorite'] = this.isFavorite;
     } else {
     //  json[r'isFavorite'] = null;
+    }
+    if (this.keepTimeUnchanged != null) {
+      json[r'keepTimeUnchanged'] = this.keepTimeUnchanged;
+    } else {
+    //  json[r'keepTimeUnchanged'] = null;
     }
     if (this.latitude != null) {
       json[r'latitude'] = this.latitude;
@@ -162,6 +178,7 @@ class AssetBulkUpdateDto {
             : const [],
         isArchived: mapValueOfType<bool>(json, r'isArchived'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        keepTimeUnchanged: mapValueOfType<bool>(json, r'keepTimeUnchanged'),
         latitude: num.parse('${json[r'latitude']}'),
         longitude: num.parse('${json[r'longitude']}'),
         removeParent: mapValueOfType<bool>(json, r'removeParent'),

--- a/mobile/openapi/lib/model/update_asset_dto.dart
+++ b/mobile/openapi/lib/model/update_asset_dto.dart
@@ -17,6 +17,7 @@ class UpdateAssetDto {
     this.description,
     this.isArchived,
     this.isFavorite,
+    this.keepTimeUnchanged,
     this.latitude,
     this.longitude,
   });
@@ -59,6 +60,14 @@ class UpdateAssetDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
+  bool? keepTimeUnchanged;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
   num? latitude;
 
   ///
@@ -75,6 +84,7 @@ class UpdateAssetDto {
     other.description == description &&
     other.isArchived == isArchived &&
     other.isFavorite == isFavorite &&
+    other.keepTimeUnchanged == keepTimeUnchanged &&
     other.latitude == latitude &&
     other.longitude == longitude;
 
@@ -85,11 +95,12 @@ class UpdateAssetDto {
     (description == null ? 0 : description!.hashCode) +
     (isArchived == null ? 0 : isArchived!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (keepTimeUnchanged == null ? 0 : keepTimeUnchanged!.hashCode) +
     (latitude == null ? 0 : latitude!.hashCode) +
     (longitude == null ? 0 : longitude!.hashCode);
 
   @override
-  String toString() => 'UpdateAssetDto[dateTimeOriginal=$dateTimeOriginal, description=$description, isArchived=$isArchived, isFavorite=$isFavorite, latitude=$latitude, longitude=$longitude]';
+  String toString() => 'UpdateAssetDto[dateTimeOriginal=$dateTimeOriginal, description=$description, isArchived=$isArchived, isFavorite=$isFavorite, keepTimeUnchanged=$keepTimeUnchanged, latitude=$latitude, longitude=$longitude]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -112,6 +123,11 @@ class UpdateAssetDto {
       json[r'isFavorite'] = this.isFavorite;
     } else {
     //  json[r'isFavorite'] = null;
+    }
+    if (this.keepTimeUnchanged != null) {
+      json[r'keepTimeUnchanged'] = this.keepTimeUnchanged;
+    } else {
+    //  json[r'keepTimeUnchanged'] = null;
     }
     if (this.latitude != null) {
       json[r'latitude'] = this.latitude;
@@ -138,6 +154,7 @@ class UpdateAssetDto {
         description: mapValueOfType<String>(json, r'description'),
         isArchived: mapValueOfType<bool>(json, r'isArchived'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        keepTimeUnchanged: mapValueOfType<bool>(json, r'keepTimeUnchanged'),
         latitude: num.parse('${json[r'latitude']}'),
         longitude: num.parse('${json[r'longitude']}'),
       );

--- a/mobile/openapi/test/asset_bulk_update_dto_test.dart
+++ b/mobile/openapi/test/asset_bulk_update_dto_test.dart
@@ -36,6 +36,11 @@ void main() {
       // TODO
     });
 
+    // bool keepTimeUnchanged
+    test('to test the property `keepTimeUnchanged`', () async {
+      // TODO
+    });
+
     // num latitude
     test('to test the property `latitude`', () async {
       // TODO

--- a/mobile/openapi/test/update_asset_dto_test.dart
+++ b/mobile/openapi/test/update_asset_dto_test.dart
@@ -36,6 +36,11 @@ void main() {
       // TODO
     });
 
+    // bool keepTimeUnchanged
+    test('to test the property `keepTimeUnchanged`', () async {
+      // TODO
+    });
+
     // num latitude
     test('to test the property `latitude`', () async {
       // TODO

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -6883,6 +6883,9 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "keepTimeUnchanged": {
+            "type": "boolean"
+          },
           "latitude": {
             "type": "number"
           },
@@ -10622,6 +10625,9 @@
             "type": "boolean"
           },
           "isFavorite": {
+            "type": "boolean"
+          },
+          "keepTimeUnchanged": {
             "type": "boolean"
           },
           "latitude": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -230,6 +230,7 @@ export type AssetBulkUpdateDto = {
     ids: string[];
     isArchived?: boolean;
     isFavorite?: boolean;
+    keepTimeUnchanged?: boolean;
     latitude?: number;
     longitude?: number;
     removeParent?: boolean;
@@ -311,6 +312,7 @@ export type UpdateAssetDto = {
     description?: string;
     isArchived?: boolean;
     isFavorite?: boolean;
+    keepTimeUnchanged?: boolean;
     latitude?: number;
     longitude?: number;
 };

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -37,6 +37,9 @@ export class UpdateAssetBase {
   @IsDateString()
   dateTimeOriginal?: string;
 
+  @Optional()
+  keepTimeUnchanged?: boolean;
+
   @ValidateGPS()
   @IsLatitude()
   @IsNotEmpty()

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -324,8 +324,7 @@ export class AssetService {
 
     for (const id of ids) {
       const asset = await this.assetRepository.getById(id);
-      const oldCreatedAtDate = asset?.fileCreatedAt;
-      const oldDateTime = oldCreatedAtDate ? DateTime.fromJSDate(oldCreatedAtDate) : undefined;
+      const oldCreatedAtDate = asset?.fileCreatedAt && DateTime.fromJSDate(asset.fileCreatedAt);
       let newDateTimeString = dateTimeOriginal;
       if (dateTimeOriginal && keepTimeUnchanged && oldDateTime) {
         let newDateTime = DateTime.fromISO(dateTimeOriginal);

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -326,13 +326,13 @@ export class AssetService {
       const asset = await this.assetRepository.getById(id);
       const oldCreatedAtDate = asset?.fileCreatedAt && DateTime.fromJSDate(asset.fileCreatedAt);
       let newDateTimeString = dateTimeOriginal;
-      if (dateTimeOriginal && keepTimeUnchanged && oldDateTime) {
+      if (dateTimeOriginal && keepTimeUnchanged && oldCreatedAtDate) {
         let newDateTime = DateTime.fromISO(dateTimeOriginal);
 
         newDateTime = newDateTime.set({
-          hour: oldDateTime.hour,
-          minute: oldDateTime?.minute,
-          second: oldDateTime.second,
+          hour: oldCreatedAtDate.hour,
+          minute: oldCreatedAtDate?.minute,
+          second: oldCreatedAtDate.second,
         });
         const newDateTimeStringWithNull = newDateTime?.toISO();
         newDateTimeString = newDateTimeStringWithNull === null ? undefined : newDateTimeStringWithNull;

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -7,10 +7,11 @@
   import { featureFlags } from '$lib/stores/server-config.store';
   import { user } from '$lib/stores/user.store';
   import { websocketEvents } from '$lib/stores/websocket';
-  import { getAssetThumbnailUrl, getPeopleThumbnailUrl, isSharedLink, handlePromiseError } from '$lib/utils';
+  import { getAssetThumbnailUrl, getPeopleThumbnailUrl, handlePromiseError, isSharedLink } from '$lib/utils';
   import { delay } from '$lib/utils/asset-utils';
   import { autoGrowHeight } from '$lib/utils/autogrow';
   import { clickOutside } from '$lib/utils/click-outside';
+  import { shortcut } from '$lib/utils/shortcut';
   import {
     ThumbnailFormat,
     getAssetInfo,
@@ -38,10 +39,9 @@
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import PersonSidePanel from '../faces-page/person-side-panel.svelte';
   import ChangeLocation from '../shared-components/change-location.svelte';
-  import UserAvatar from '../shared-components/user-avatar.svelte';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { NotificationType, notificationController } from '../shared-components/notification/notification';
-  import { shortcut } from '$lib/utils/shortcut';
+  import UserAvatar from '../shared-components/user-avatar.svelte';
 
   export let asset: AssetResponseDto;
   export let albums: AlbumResponseDto[] = [];
@@ -145,7 +145,7 @@
 
   let isShowChangeDate = false;
 
-  async function handleConfirmChangeDate(dateTimeOriginal: string) {
+  async function handleConfirmChangeDate(dateTimeOriginal: string, keepTimeUnchanged: boolean) {
     isShowChangeDate = false;
     try {
       await updateAsset({ id: asset.id, updateAssetDto: { dateTimeOriginal } });
@@ -433,7 +433,7 @@
         : DateTime.now()}
       <ChangeDate
         initialDate={assetDateTimeOriginal}
-        on:confirm={({ detail: date }) => handleConfirmChangeDate(date)}
+        on:confirm={({ detail: data }) => handleConfirmChangeDate(data.newDateValue, data.keepTimeUnchanged)}
         on:cancel={() => (isShowChangeDate = false)}
       />
     {/if}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -148,7 +148,7 @@
   async function handleConfirmChangeDate(dateTimeOriginal: string, keepTimeUnchanged: boolean) {
     isShowChangeDate = false;
     try {
-      await updateAsset({ id: asset.id, updateAssetDto: { dateTimeOriginal } });
+      await updateAsset({ id: asset.id, updateAssetDto: { dateTimeOriginal, keepTimeUnchanged } });
     } catch (error) {
       handleError(error, 'Unable to change date');
     }

--- a/web/src/lib/components/photos-page/actions/change-date-action.svelte
+++ b/web/src/lib/components/photos-page/actions/change-date-action.svelte
@@ -4,21 +4,21 @@
   import { getSelectedAssets } from '$lib/utils/asset-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { updateAssets } from '@immich/sdk';
+  import { mdiCalendarEditOutline } from '@mdi/js';
   import { DateTime } from 'luxon';
   import MenuOption from '../../shared-components/context-menu/menu-option.svelte';
   import { getAssetControlContext } from '../asset-select-control-bar.svelte';
-  import { mdiCalendarEditOutline } from '@mdi/js';
   export let menuItem = false;
   const { clearSelect, getOwnedAssets } = getAssetControlContext();
 
   let isShowChangeDate = false;
 
-  const handleConfirm = async (dateTimeOriginal: string) => {
+  const handleConfirm = async (dateTimeOriginal: string, keepTimeUnchanged: boolean) => {
     isShowChangeDate = false;
     const ids = getSelectedAssets(getOwnedAssets(), $user);
 
     try {
-      await updateAssets({ assetBulkUpdateDto: { ids, dateTimeOriginal } });
+      await updateAssets({ assetBulkUpdateDto: { ids, dateTimeOriginal, keepTimeUnchanged } });
     } catch (error) {
       handleError(error, 'Unable to change date');
     }
@@ -38,7 +38,7 @@
 {#if isShowChangeDate}
   <ChangeDate
     initialDate={getInitialDate()}
-    on:confirm={({ detail: date }) => handleConfirm(date)}
+    on:confirm={({ detail: date }) => handleConfirm(date.newDateValue, date.keepTimeUnchanged)}
     on:cancel={() => (isShowChangeDate = false)}
   />
 {/if}

--- a/web/src/lib/components/photos-page/actions/change-date-action.svelte
+++ b/web/src/lib/components/photos-page/actions/change-date-action.svelte
@@ -24,6 +24,12 @@
     }
     clearSelect();
   };
+  const getInitialDate = () => {
+    const ids = getSelectedAssets(getOwnedAssets(), $user);
+    const selectedAsset = Array.from(getOwnedAssets()).find((asset) => ids.includes(asset.id));
+    const initialDate = selectedAsset ? DateTime.fromISO(selectedAsset.fileCreatedAt) : DateTime.now();
+    return initialDate;
+  };
 </script>
 
 {#if menuItem}
@@ -31,7 +37,7 @@
 {/if}
 {#if isShowChangeDate}
   <ChangeDate
-    initialDate={DateTime.now()}
+    initialDate={getInitialDate()}
     on:confirm={({ detail: date }) => handleConfirm(date)}
     on:cancel={() => (isShowChangeDate = false)}
   />

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Checkbox from '$lib/components/elements/checkbox.svelte';
   import { DateTime } from 'luxon';
   import { createEventDispatcher } from 'svelte';
   import DateInput from '../elements/date-input.svelte';

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
   import { DateTime } from 'luxon';
-  import ConfirmDialogue from './confirm-dialogue.svelte';
-  import Combobox from './combobox.svelte';
+  import { createEventDispatcher } from 'svelte';
   import DateInput from '../elements/date-input.svelte';
+  import Combobox from './combobox.svelte';
+  import ConfirmDialogue from './confirm-dialogue.svelte';
 
   export let initialDate: DateTime = DateTime.now();
 
@@ -29,7 +29,6 @@
   }));
 
   const initialOption = timezones.find((item) => item.value === 'UTC' + initialDate.toFormat('ZZ'));
-
   let selectedOption = initialOption && {
     label: initialOption?.label || '',
     value: initialOption?.value || '',
@@ -40,9 +39,10 @@
   // Keep local time if not it's really confusing
   $: date = DateTime.fromISO(selectedDate).setZone(selectedOption?.value, { keepLocalTime: true });
 
+  let keepTimeUnchanged = false;
   const dispatch = createEventDispatcher<{
     cancel: void;
-    confirm: string;
+    confirm: { newDateValue: string; keepTimeUnchanged: boolean };
   }>();
 
   const handleCancel = () => dispatch('cancel');
@@ -50,7 +50,7 @@
   const handleConfirm = () => {
     const value = date.toISO();
     if (value) {
-      dispatch('confirm', value);
+      dispatch('confirm', { newDateValue: value, keepTimeUnchanged });
     }
   };
 </script>
@@ -82,6 +82,9 @@
         options={timezones}
         placeholder="Search timezone..."
       />
+    </div>
+    <div class="flex flex-col w-full mt-8">
+      <Checkbox label="Keep Time unchanged?" id="keeptime" bind:checked={keepTimeUnchanged} />
     </div>
   </div>
 </ConfirmDialogue>


### PR DESCRIPTION
This PR contains two changes, the smaller one sets the initial date of the date change dialog to the date of the first selected asset.

The bigger one adds an option to ignore the Time change and sets the original time.

The idea behind this PR is that I often upload images/videos from my GoPro or Drone. But both of them have sometimes a problem with the date and or the time.

So if I bulk change all the asses from one day, where date and time are off, I want to keep the "false" time because this will keep the assets in the right order. The smaller change is pure laziness, as I think it is easier in the date picket to get to "Today" than it is to go back "3 years" to the original asset date. I picked the first asset because I think most users will use the change date on similar dated assets.