### PR TITLE
fix(server): show partners archived photos on mobile timeline

### DIFF
--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -108,7 +108,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     localDateTime: entity.localDateTime,
     updatedAt: entity.updatedAt,
     isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
-    isArchived: options.auth?.user.id === entity.ownerId ? entity.isArchived : false,
+    isArchived: entity.isArchived,
     isTrashed: !!entity.deletedAt,
     duration: entity.duration ?? '0:00:00.00000',
     exifInfo: entity.exifInfo ? mapExif(entity.exifInfo) : undefined,


### PR DESCRIPTION
Regression from #7580. The mobile app needs this property to not render partners' archived photos on the timeline

Fixes #9190 
