### PR TITLE
fix(server): person thumbnails not being queued during thumbnail generation

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -115,7 +115,7 @@ export class MediaService {
             continue;
           }
 
-          await this.personRepository.update({ id: person.id, faceAssetId: face.assetId });
+          await this.personRepository.update({ id: person.id, faceAssetId: face.id });
         }
 
         jobs.push({ name: JobName.GENERATE_PERSON_THUMBNAIL, data: { id: person.id } });


### PR DESCRIPTION
## Description

During thumbnail generation queueing, we check if each person has an assigned face for use as a thumbnail. If there is none (e.g. because the associated asset has been deleted), we select a random face instead to use for the thumbnail.

We attempt to use the face's asset ID when performing this update. However, the misleadingly-named `faceAssetId` column does not expect the _face's asset_ ID, but rather the _face asset's_ ID. Since this throws an exception and we only queue jobs at the end, the result is that no people are queued for thumbnail generation.

This PR changes this behavior to instead update the face ID.

Fixes #8982