### PR TITLE
fix(docs): allow no release specified for milestone

### DIFF
--- a/docs/src/components/timeline.tsx
+++ b/docs/src/components/timeline.tsx
@@ -7,7 +7,7 @@ export interface Item {
   icon: string;
   title: string;
   description?: string;
-  release: string;
+  release?: string;
   tag?: string;
   date: Date;
   dateType: DateType;
@@ -70,10 +70,10 @@ export default function Timeline({ items }: Props): JSX.Element {
                       target="_blank"
                       rel="noopener"
                     >
-                      [{item.release}]{' '}
+                      [{item.release ?? item.tag}]{' '}
                     </a>
                   ) : (
-                    <span>[{item.release}]</span>
+                    item.release && <span>[{item.release}]</span>
                   )}
                 </span>
               </div>


### PR DESCRIPTION
Allows us to not specify a release for a milestone

Release becomes optional which (if no tag is specified) will remove the top right element of the milestone
![image](https://github.com/immich-app/immich/assets/1313578/df4eb35a-cbfd-4088-95dd-e21f2bb66e53)
