### PR TITLE
fix(mobile): Reset dropdown values in search by location on mobile

### DIFF
--- a/mobile/lib/modules/search/ui/search_filter/location_picker.dart
+++ b/mobile/lib/modules/search/ui/search_filter/location_picker.dart
@@ -87,11 +87,16 @@ class LocationPicker extends HookConsumerWidget {
           trailingIcon: const Icon(Icons.arrow_drop_down_rounded),
           selectedTrailingIcon: const Icon(Icons.arrow_drop_up_rounded),
           onSelected: (value) {
+            if(value.toString() == selectedCountry.value) {
+              return;
+            }
             selectedCountry.value = value.toString();
+            stateTextController.value = TextEditingValue.empty;
+            cityTextController.value = TextEditingValue.empty;
             onSelected({
               'country': selectedCountry.value,
-              'state': selectedState.value,
-              'city': selectedCity.value,
+              'state': null,
+              'city': null,
             });
           },
         ),
@@ -120,11 +125,15 @@ class LocationPicker extends HookConsumerWidget {
           trailingIcon: const Icon(Icons.arrow_drop_down_rounded),
           selectedTrailingIcon: const Icon(Icons.arrow_drop_up_rounded),
           onSelected: (value) {
+            if (value.toString() == selectedState.value) {
+              return;
+            }
             selectedState.value = value.toString();
+            cityTextController.value = TextEditingValue.empty;
             onSelected({
               'country': selectedCountry.value,
               'state': selectedState.value,
-              'city': selectedCity.value,
+              'city': null,
             });
           },
         ),

--- a/mobile/lib/modules/search/ui/search_filter/location_picker.dart
+++ b/mobile/lib/modules/search/ui/search_filter/location_picker.dart
@@ -87,7 +87,7 @@ class LocationPicker extends HookConsumerWidget {
           trailingIcon: const Icon(Icons.arrow_drop_down_rounded),
           selectedTrailingIcon: const Icon(Icons.arrow_drop_up_rounded),
           onSelected: (value) {
-            if(value.toString() == selectedCountry.value) {
+            if (value.toString() == selectedCountry.value) {
               return;
             }
             selectedCountry.value = value.toString();


### PR DESCRIPTION
Fixes #8940 

We set cityTextController value to empty on state value change. and also propagate this change upwards to search_input_page.dart -> showLocationPicker().
