### PR TITLE
fix(web): click on face in detail-panel

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -250,7 +250,6 @@
               on:blur={() => ($boundingBoxesArray = [])}
               on:mouseover={() => ($boundingBoxesArray = people[index].faces)}
               on:mouseleave={() => ($boundingBoxesArray = [])}
-              on:click={() => dispatch('closeViewer')}
             >
               <div class="relative">
                 <ImageThumbnail


### PR DESCRIPTION
fixes #9270. 

This PR removes the event `on:click` to only use `<a>` tag