### PR TITLE
fix(mobile): Fix asset selector title bar text

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -409,6 +409,7 @@
   "share_add_photos": "Add photos",
   "share_add_title": "Add a title",
   "share_create_album": "Create album",
+  "share_assets_selected": "{} selected",
   "shared_album_activities_input_disable": "Comment is disabled",
   "shared_album_activities_input_hint": "Say something",
   "shared_album_activity_remove_content": "Do you want to delete this activity?",

--- a/mobile/lib/pages/common/album_asset_selection.page.dart
+++ b/mobile/lib/pages/common/album_asset_selection.page.dart
@@ -31,10 +31,6 @@ class AlbumAssetSelectionPage extends HookConsumerWidget {
     final selected = useState<Set<Asset>>(existingAssets);
     final selectionEnabledHook = useState(true);
 
-    String buildAssetCountText() {
-      return selected.value.length.toString();
-    }
-
     Widget buildBody(RenderList renderList) {
       return ImmichAssetGrid(
         renderList: renderList,
@@ -63,10 +59,10 @@ class AlbumAssetSelectionPage extends HookConsumerWidget {
                 'share_add_photos',
                 style: TextStyle(fontSize: 18),
               ).tr()
-            : Text(
-                buildAssetCountText(),
-                style: const TextStyle(fontSize: 18),
-              ),
+            : const Text(
+                'share_assets_selected',
+                style: TextStyle(fontSize: 18),
+              ).tr(args: [selected.value.length.toString()]),
         centerTitle: false,
         actions: [
           if (selected.value.isNotEmpty || canDeselect)


### PR DESCRIPTION
`album_asset_selection.page.dart`'s title bar just showed the number of assets selected/already added. This add the correct text to show what the number means