### PR TITLE
fix(web): stream 360 video instead of fetching entire video

### DIFF
--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -2,7 +2,7 @@
   import { serveFile, type AssetResponseDto, AssetTypeEnum } from '@immich/sdk';
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
-  import { getKey } from '$lib/utils';
+  import { getAssetFileUrl, getKey } from '$lib/utils';
   import type { AdapterConstructor, PluginConstructor } from '@photo-sphere-viewer/core';
   export let asset: Pick<AssetResponseDto, 'id' | 'type'>;
 
@@ -19,11 +19,11 @@
       : ([undefined, [], false] as [undefined, [], false]);
 
   const loadAssetData = async () => {
+    if (asset.type === AssetTypeEnum.Video) {
+      return { source: getAssetFileUrl(asset.id, false, false) };
+    }
     const data = await serveFile({ id: asset.id, isWeb: false, isThumb: false, key: getKey() });
     const url = URL.createObjectURL(data);
-    if (asset.type === AssetTypeEnum.Video) {
-      return { source: url };
-    }
     return url;
   };
 </script>


### PR DESCRIPTION
The Immich web client fetches entire 360 videos before beginning to play them. This causes long/large 360 videos to be unplayable as the request to fetch a very large (tested with a > 30 GB video) 360 video eventually fails.

This PR fixes that issue by passing the URL to the video asset to the Photo Sphere Viewer module instead of fetching the entire video and converting it to a Blob that is then passed to the aforementioned module.