### PR TITLE
fix(mobile): allow select empty album as backup album

### DIFF
--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -294,17 +294,29 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     final Set<AssetEntity> assetsFromExcludedAlbums = {};
 
     for (final album in state.selectedBackupAlbums) {
+      final assetCount = await album.albumEntity.assetCountAsync;
+
+      if (assetCount == 0) {
+        continue;
+      }
+
       final assets = await album.albumEntity.getAssetListRange(
         start: 0,
-        end: await album.albumEntity.assetCountAsync,
+        end: assetCount,
       );
       assetsFromSelectedAlbums.addAll(assets);
     }
 
     for (final album in state.excludedBackupAlbums) {
+      final assetCount = await album.albumEntity.assetCountAsync;
+
+      if (assetCount == 0) {
+        continue;
+      }
+
       final assets = await album.albumEntity.getAssetListRange(
         start: 0,
-        end: await album.albumEntity.assetCountAsync,
+        end: assetCount,
       );
       assetsFromExcludedAlbums.addAll(assets);
     }


### PR DESCRIPTION
This PR fixes an issue of saving empty target album for backup since the internal API to get album count expect the last value to be greater than 0. 

<img width="392" alt="image" src="https://github.com/immich-app/immich/assets/27055614/2152a60e-fc3c-4467-88e1-3e37d62ff513">

