### PR TITLE
feat(server,web,mobile): Add external upload endpoint

### DIFF
--- a/mobile/lib/models/server_info/server_config.model.dart
+++ b/mobile/lib/models/server_info/server_config.model.dart
@@ -4,33 +4,38 @@ class ServerConfig {
   final int trashDays;
   final String oauthButtonText;
   final String externalDomain;
+  final String uploadEndpoint;
 
   const ServerConfig({
     required this.trashDays,
     required this.oauthButtonText,
     required this.externalDomain,
+    required this.uploadEndpoint,
   });
 
   ServerConfig copyWith({
     int? trashDays,
     String? oauthButtonText,
     String? externalDomain,
+    String? uploadEndpoint,
   }) {
     return ServerConfig(
       trashDays: trashDays ?? this.trashDays,
       oauthButtonText: oauthButtonText ?? this.oauthButtonText,
       externalDomain: externalDomain ?? this.externalDomain,
+      uploadEndpoint: uploadEndpoint ?? this.uploadEndpoint,
     );
   }
 
   @override
   String toString() =>
-      'ServerConfig(trashDays: $trashDays, oauthButtonText: $oauthButtonText, externalDomain: $externalDomain)';
+      'ServerConfig(trashDays: $trashDays, oauthButtonText: $oauthButtonText, externalDomain: $externalDomain, uploadEndpoint: $uploadEndpoint)';
 
   ServerConfig.fromDto(ServerConfigDto dto)
       : trashDays = dto.trashDays,
         oauthButtonText = dto.oauthButtonText,
-        externalDomain = dto.externalDomain;
+        externalDomain = dto.externalDomain,
+        uploadEndpoint = dto.uploadEndpoint;
 
   @override
   bool operator ==(covariant ServerConfig other) {
@@ -38,10 +43,14 @@ class ServerConfig {
 
     return other.trashDays == trashDays &&
         other.oauthButtonText == oauthButtonText &&
-        other.externalDomain == externalDomain;
+        other.externalDomain == externalDomain &&
+        other.uploadEndpoint == uploadEndpoint;
   }
 
   @override
   int get hashCode =>
-      trashDays.hashCode ^ oauthButtonText.hashCode ^ externalDomain.hashCode;
+      trashDays.hashCode ^
+      oauthButtonText.hashCode ^
+      externalDomain.hashCode ^
+      uploadEndpoint.hashCode;
 }

--- a/mobile/lib/models/server_info/server_config.model.dart
+++ b/mobile/lib/models/server_info/server_config.model.dart
@@ -4,38 +4,38 @@ class ServerConfig {
   final int trashDays;
   final String oauthButtonText;
   final String externalDomain;
-  final String uploadEndpoint;
+  final String uploadDomain;
 
   const ServerConfig({
     required this.trashDays,
     required this.oauthButtonText,
     required this.externalDomain,
-    required this.uploadEndpoint,
+    required this.uploadDomain,
   });
 
   ServerConfig copyWith({
     int? trashDays,
     String? oauthButtonText,
     String? externalDomain,
-    String? uploadEndpoint,
+    String? uploadDomain,
   }) {
     return ServerConfig(
       trashDays: trashDays ?? this.trashDays,
       oauthButtonText: oauthButtonText ?? this.oauthButtonText,
       externalDomain: externalDomain ?? this.externalDomain,
-      uploadEndpoint: uploadEndpoint ?? this.uploadEndpoint,
+      uploadDomain: uploadDomain ?? this.uploadDomain,
     );
   }
 
   @override
   String toString() =>
-      'ServerConfig(trashDays: $trashDays, oauthButtonText: $oauthButtonText, externalDomain: $externalDomain, uploadEndpoint: $uploadEndpoint)';
+      'ServerConfig(trashDays: $trashDays, oauthButtonText: $oauthButtonText, externalDomain: $externalDomain, uploadDomain: $uploadDomain)';
 
   ServerConfig.fromDto(ServerConfigDto dto)
       : trashDays = dto.trashDays,
         oauthButtonText = dto.oauthButtonText,
         externalDomain = dto.externalDomain,
-        uploadEndpoint = dto.uploadEndpoint;
+        uploadDomain = dto.uploadDomain;
 
   @override
   bool operator ==(covariant ServerConfig other) {
@@ -44,7 +44,7 @@ class ServerConfig {
     return other.trashDays == trashDays &&
         other.oauthButtonText == oauthButtonText &&
         other.externalDomain == externalDomain &&
-        other.uploadEndpoint == uploadEndpoint;
+        other.uploadDomain == uploadDomain;
   }
 
   @override
@@ -52,5 +52,5 @@ class ServerConfig {
       trashDays.hashCode ^
       oauthButtonText.hashCode ^
       externalDomain.hashCode ^
-      uploadEndpoint.hashCode;
+      uploadDomain.hashCode;
 }

--- a/mobile/openapi/doc/SystemConfigServerDto.md
+++ b/mobile/openapi/doc/SystemConfigServerDto.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **externalDomain** | **String** |  | 
 **loginPageMessage** | **String** |  | 
-**uploadEndpoint** | **String** |  | 
+**uploadDomain** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/doc/SystemConfigServerDto.md
+++ b/mobile/openapi/doc/SystemConfigServerDto.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **externalDomain** | **String** |  | 
 **loginPageMessage** | **String** |  | 
+**uploadEndpoint** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/mobile/openapi/lib/model/system_config_server_dto.dart
+++ b/mobile/openapi/lib/model/system_config_server_dto.dart
@@ -15,36 +15,37 @@ class SystemConfigServerDto {
   SystemConfigServerDto({
     required this.externalDomain,
     required this.loginPageMessage,
-    required this.uploadEndpoint,
+    required this.uploadDomain,
   });
 
   String externalDomain;
 
   String loginPageMessage;
 
-  String uploadEndpoint;
+  String uploadDomain;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigServerDto &&
     other.externalDomain == externalDomain &&
     other.loginPageMessage == loginPageMessage &&
-    other.uploadEndpoint == uploadEndpoint;
+          other.uploadDomain == uploadDomain;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (externalDomain.hashCode) +
     (loginPageMessage.hashCode) +
-    (uploadEndpoint.hashCode);
+      (uploadDomain.hashCode);
 
   @override
-  String toString() => 'SystemConfigServerDto[externalDomain=$externalDomain, loginPageMessage=$loginPageMessage, uploadEndpoint=$uploadEndpoint]';
+  String toString() =>
+      'SystemConfigServerDto[externalDomain=$externalDomain, loginPageMessage=$loginPageMessage, uploadDomain=$uploadDomain]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'externalDomain'] = this.externalDomain;
       json[r'loginPageMessage'] = this.loginPageMessage;
-      json[r'uploadEndpoint'] = this.uploadEndpoint;
+    json[r'uploadDomain'] = this.uploadDomain;
     return json;
   }
 
@@ -58,7 +59,7 @@ class SystemConfigServerDto {
       return SystemConfigServerDto(
         externalDomain: mapValueOfType<String>(json, r'externalDomain')!,
         loginPageMessage: mapValueOfType<String>(json, r'loginPageMessage')!,
-        uploadEndpoint: mapValueOfType<String>(json, r'uploadEndpoint')!,
+        uploadDomain: mapValueOfType<String>(json, r'uploadDomain')!,
       );
     }
     return null;
@@ -108,7 +109,7 @@ class SystemConfigServerDto {
   static const requiredKeys = <String>{
     'externalDomain',
     'loginPageMessage',
-    'uploadEndpoint',
+    'uploadDomain',
   };
 }
 

--- a/mobile/openapi/lib/model/system_config_server_dto.dart
+++ b/mobile/openapi/lib/model/system_config_server_dto.dart
@@ -15,30 +15,36 @@ class SystemConfigServerDto {
   SystemConfigServerDto({
     required this.externalDomain,
     required this.loginPageMessage,
+    required this.uploadEndpoint,
   });
 
   String externalDomain;
 
   String loginPageMessage;
 
+  String uploadEndpoint;
+
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigServerDto &&
     other.externalDomain == externalDomain &&
-    other.loginPageMessage == loginPageMessage;
+    other.loginPageMessage == loginPageMessage &&
+    other.uploadEndpoint == uploadEndpoint;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (externalDomain.hashCode) +
-    (loginPageMessage.hashCode);
+    (loginPageMessage.hashCode) +
+    (uploadEndpoint.hashCode);
 
   @override
-  String toString() => 'SystemConfigServerDto[externalDomain=$externalDomain, loginPageMessage=$loginPageMessage]';
+  String toString() => 'SystemConfigServerDto[externalDomain=$externalDomain, loginPageMessage=$loginPageMessage, uploadEndpoint=$uploadEndpoint]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'externalDomain'] = this.externalDomain;
       json[r'loginPageMessage'] = this.loginPageMessage;
+      json[r'uploadEndpoint'] = this.uploadEndpoint;
     return json;
   }
 
@@ -52,6 +58,7 @@ class SystemConfigServerDto {
       return SystemConfigServerDto(
         externalDomain: mapValueOfType<String>(json, r'externalDomain')!,
         loginPageMessage: mapValueOfType<String>(json, r'loginPageMessage')!,
+        uploadEndpoint: mapValueOfType<String>(json, r'uploadEndpoint')!,
       );
     }
     return null;
@@ -101,6 +108,7 @@ class SystemConfigServerDto {
   static const requiredKeys = <String>{
     'externalDomain',
     'loginPageMessage',
+    'uploadEndpoint',
   };
 }
 

--- a/mobile/openapi/test/system_config_server_dto_test.dart
+++ b/mobile/openapi/test/system_config_server_dto_test.dart
@@ -26,6 +26,11 @@ void main() {
       // TODO
     });
 
+    // String uploadEndpoint
+    test('to test the property `uploadEndpoint`', () async {
+      // TODO
+    });
+
 
   });
 

--- a/mobile/openapi/test/system_config_server_dto_test.dart
+++ b/mobile/openapi/test/system_config_server_dto_test.dart
@@ -26,8 +26,8 @@ void main() {
       // TODO
     });
 
-    // String uploadEndpoint
-    test('to test the property `uploadEndpoint`', () async {
+    // String uploadDomain
+    test('to test the property `uploadDomain`', () async {
       // TODO
     });
 

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -9347,7 +9347,7 @@
           "trashDays": {
             "type": "integer"
           },
-          "uploadEndpoint": {
+          "uploadDomain": {
             "type": "string"
           },
           "userDeleteDelay": {
@@ -9361,7 +9361,7 @@
           "loginPageMessage",
           "oauthButtonText",
           "trashDays",
-          "uploadEndpoint",
+          "uploadDomain",
           "userDeleteDelay"
         ],
         "type": "object"
@@ -10392,14 +10392,14 @@
           "loginPageMessage": {
             "type": "string"
           },
-          "uploadEndpoint": {
+          "uploadDomain": {
             "type": "string"
           }
         },
         "required": [
           "externalDomain",
           "loginPageMessage",
-          "uploadEndpoint"
+          "uploadDomain"
         ],
         "type": "object"
       },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -9347,6 +9347,9 @@
           "trashDays": {
             "type": "integer"
           },
+          "uploadEndpoint": {
+            "type": "string"
+          },
           "userDeleteDelay": {
             "type": "integer"
           }
@@ -9358,6 +9361,7 @@
           "loginPageMessage",
           "oauthButtonText",
           "trashDays",
+          "uploadEndpoint",
           "userDeleteDelay"
         ],
         "type": "object"
@@ -10387,11 +10391,15 @@
           },
           "loginPageMessage": {
             "type": "string"
+          },
+          "uploadEndpoint": {
+            "type": "string"
           }
         },
         "required": [
           "externalDomain",
-          "loginPageMessage"
+          "loginPageMessage",
+          "uploadEndpoint"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -985,6 +985,7 @@ export type SystemConfigReverseGeocodingDto = {
 export type SystemConfigServerDto = {
     externalDomain: string;
     loginPageMessage: string;
+    uploadEndpoint: string;
 };
 export type SystemConfigStorageTemplateDto = {
     enabled: boolean;

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -983,9 +983,9 @@ export type SystemConfigReverseGeocodingDto = {
     enabled: boolean;
 };
 export type SystemConfigServerDto = {
-    externalDomain: string;
-    loginPageMessage: string;
-    uploadEndpoint: string;
+  externalDomain: string;
+  loginPageMessage: string;
+  uploadDomain: string;
 };
 export type SystemConfigStorageTemplateDto = {
     enabled: boolean;

--- a/server/src/controllers/app.controller.ts
+++ b/server/src/controllers/app.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Header } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import e from 'express';
 import { PublicRoute } from 'src/middleware/auth.guard';
 import { SystemConfigService } from 'src/services/system-config.service';
 
@@ -10,11 +11,16 @@ export class AppController {
   @ApiExcludeEndpoint()
   @Get('.well-known/immich')
   getImmichWellKnown() {
-    return {
-      api: {
-        endpoint: '/api',
-      },
-    };
+    return this.service.getConfig().then((config) => {
+      return {
+        api: {
+          endpoint: '/api',
+        },
+        upload: {
+          endpoint: config.server.uploadEndpoint,
+        },
+      };
+    });
   }
 
   @ApiExcludeEndpoint()

--- a/server/src/controllers/app.controller.ts
+++ b/server/src/controllers/app.controller.ts
@@ -17,7 +17,7 @@ export class AppController {
           endpoint: '/api',
         },
         upload: {
-          endpoint: config.server.uploadEndpoint,
+          domain: config.server.uploadDomain,
         },
       };
     });

--- a/server/src/cores/system-config.core.ts
+++ b/server/src/cores/system-config.core.ts
@@ -144,7 +144,7 @@ export const defaults = Object.freeze<SystemConfig>({
   },
   server: {
     externalDomain: '',
-    uploadEndpoint: '',
+    uploadDomain: '',
     loginPageMessage: '',
   },
   notifications: {

--- a/server/src/cores/system-config.core.ts
+++ b/server/src/cores/system-config.core.ts
@@ -144,6 +144,7 @@ export const defaults = Object.freeze<SystemConfig>({
   },
   server: {
     externalDomain: '',
+    uploadEndpoint: '',
     loginPageMessage: '',
   },
   notifications: {

--- a/server/src/dtos/server-info.dto.ts
+++ b/server/src/dtos/server-info.dto.ts
@@ -94,7 +94,7 @@ export class ServerConfigDto {
   isInitialized!: boolean;
   isOnboarded!: boolean;
   externalDomain!: string;
-  uploadEndpoint!: string;
+  uploadDomain!: string;
 }
 
 export class ServerFeaturesDto implements FeatureFlags {

--- a/server/src/dtos/server-info.dto.ts
+++ b/server/src/dtos/server-info.dto.ts
@@ -94,6 +94,7 @@ export class ServerConfigDto {
   isInitialized!: boolean;
   isOnboarded!: boolean;
   externalDomain!: string;
+  uploadEndpoint!: string;
 }
 
 export class ServerFeaturesDto implements FeatureFlags {

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -363,7 +363,7 @@ class SystemConfigServerDto {
   externalDomain!: string;
 
   @IsString()
-  uploadEndpoint!: string;
+  uploadDomain!: string;
 
   @IsString()
   loginPageMessage!: string;

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -363,6 +363,9 @@ class SystemConfigServerDto {
   externalDomain!: string;
 
   @IsString()
+  uploadEndpoint!: string;
+
+  @IsString()
   loginPageMessage!: string;
 }
 

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -111,6 +111,7 @@ export const SystemConfigKey = {
   PASSWORD_LOGIN_ENABLED: 'passwordLogin.enabled',
 
   SERVER_EXTERNAL_DOMAIN: 'server.externalDomain',
+  SERVER_UPLOAD_ENDPOINT: 'server.uploadEndpoint',
   SERVER_LOGIN_PAGE_MESSAGE: 'server.loginPageMessage',
 
   STORAGE_TEMPLATE_ENABLED: 'storageTemplate.enabled',

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -111,7 +111,7 @@ export const SystemConfigKey = {
   PASSWORD_LOGIN_ENABLED: 'passwordLogin.enabled',
 
   SERVER_EXTERNAL_DOMAIN: 'server.externalDomain',
-  SERVER_UPLOAD_ENDPOINT: 'server.uploadEndpoint',
+  SERVER_UPLOAD_DOMAIN: 'server.uploadDomain',
   SERVER_LOGIN_PAGE_MESSAGE: 'server.loginPageMessage',
 
   STORAGE_TEMPLATE_ENABLED: 'storageTemplate.enabled',
@@ -332,7 +332,7 @@ export interface SystemConfig {
   };
   server: {
     externalDomain: string;
-    uploadEndpoint: string;
+    uploadDomain: string;
     loginPageMessage: string;
   };
   user: {

--- a/server/src/entities/system-config.entity.ts
+++ b/server/src/entities/system-config.entity.ts
@@ -331,6 +331,7 @@ export interface SystemConfig {
   };
   server: {
     externalDomain: string;
+    uploadEndpoint: string;
     loginPageMessage: string;
   };
   user: {

--- a/server/src/services/server-info.service.ts
+++ b/server/src/services/server-info.service.ts
@@ -104,7 +104,7 @@ export class ServerInfoService {
       isInitialized,
       isOnboarded: onboarding?.isOnboarded || false,
       externalDomain: config.server.externalDomain,
-      uploadEndpoint: config.server.uploadEndpoint,
+      uploadDomain: config.server.uploadDomain,
     };
   }
 

--- a/server/src/services/server-info.service.ts
+++ b/server/src/services/server-info.service.ts
@@ -104,6 +104,7 @@ export class ServerInfoService {
       isInitialized,
       isOnboarded: onboarding?.isOnboarded || false,
       externalDomain: config.server.externalDomain,
+      uploadEndpoint: config.server.uploadEndpoint,
     };
   }
 

--- a/web/src/lib/components/admin-page/settings/server/server-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/server/server-settings.svelte
@@ -31,10 +31,10 @@
 
         <SettingInputField
         inputType={SettingInputFieldType.TEXT}
-        label="UPLOAD ENDPOINT"
-        desc="Endpoint for asset uploads, including http(s)://. Useful for only exposing the upload endpoint to the internet."
-        bind:value={config.server.uploadEndpoint}
-        isEdited={config.server.uploadEndpoint !== savedConfig.server.uploadEndpoint}
+        label="UPLOAD DOMAIN"
+        desc="Domain for asset uploads, including http(s)://. Useful for only exposing the upload endpoints to the internet."
+        bind:value={config.server.uploadDomain}
+        isEdited={config.server.uploadDomain !== savedConfig.server.uploadDomain}
       />
 
         <SettingInputField

--- a/web/src/lib/components/admin-page/settings/server/server-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/server/server-settings.svelte
@@ -30,6 +30,14 @@
         />
 
         <SettingInputField
+        inputType={SettingInputFieldType.TEXT}
+        label="UPLOAD ENDPOINT"
+        desc="Endpoint for asset uploads, including http(s)://. Useful for only exposing the upload endpoint to the internet."
+        bind:value={config.server.uploadEndpoint}
+        isEdited={config.server.uploadEndpoint !== savedConfig.server.uploadEndpoint}
+      />
+
+        <SettingInputField
           inputType={SettingInputFieldType.TEXT}
           label="WELCOME MESSAGE"
           desc="A message that is displayed on the login page."

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -65,6 +65,7 @@ export const uploadRequest = async <T>(options: UploadRequestOptions): Promise<{
     }
 
     xhr.open('POST', url);
+    xhr.withCredentials = true;
     xhr.responseType = 'json';
     xhr.send(data);
   });

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -80,9 +80,9 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
   uploadAssetsStore.markStarted(deviceAssetId);
 
-  let uploadEndpoint = (await getServerConfig()).uploadEndpoint || defaults.baseUrl;
-  if (!uploadEndpoint.endsWith('/')) {
-    uploadEndpoint += '/';
+  let uploadDomain = (await getServerConfig()).uploadDomain || defaults.baseUrl;
+  if (!uploadDomain.endsWith('/')) {
+    uploadDomain += '/';
   }
 
   try {
@@ -118,7 +118,7 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
             assetBulkUploadCheckDto: { assets: [{ id: asset.name, checksum }] },
           },
           {
-            baseUrl: uploadEndpoint,
+            baseUrl: uploadDomain,
           },
         );
         if (checkUploadResult.action === Action.Reject && checkUploadResult.assetId) {
@@ -131,7 +131,7 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
     if (!responseData) {
       uploadAssetsStore.updateAsset(deviceAssetId, { message: 'Uploading...' });
-      const url = uploadEndpoint + 'asset/upload' + (key ? `?key=${key}` : '');
+      const url = uploadDomain + 'asset/upload' + (key ? `?key=${key}` : '');
       const response = await uploadRequest<AssetFileUploadResponseDto>({
         url,
         data: formData,

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -118,7 +118,9 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
             assetBulkUploadCheckDto: { assets: [{ id: asset.name, checksum }] },
           },
           {
-            baseUrl: uploadDomain,
+            baseUrl: defaults.baseUrl,
+            redirect: 'follow',
+            credentials: 'include',
           },
         );
         if (checkUploadResult.action === Action.Reject && checkUploadResult.assetId) {

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -7,6 +7,7 @@ import {
   Action,
   checkBulkUpload,
   defaults,
+  getServerConfig,
   getSupportedMediaTypes,
   type AssetFileUploadResponseDto,
 } from '@immich/sdk';
@@ -118,11 +119,14 @@ async function fileUploader(asset: File, albumId: string | undefined = undefined
 
     if (!responseData) {
       uploadAssetsStore.updateAsset(deviceAssetId, { message: 'Uploading...' });
+      const url =
+        ((await getServerConfig()).uploadEndpoint || defaults.baseUrl) + '/asset/upload' + (key ? `?key=${key}` : '');
       const response = await uploadRequest<AssetFileUploadResponseDto>({
-        url: defaults.baseUrl + '/asset/upload' + (key ? `?key=${key}` : ''),
+        url,
         data: formData,
         onUploadProgress: (event) => uploadAssetsStore.updateProgress(deviceAssetId, event.loaded, event.total),
       });
+
       if (![200, 201].includes(response.status)) {
         throw new Error('Failed to upload file');
       }


### PR DESCRIPTION
Adding setting for external upload endpoint.

See more on my own FR: https://github.com/immich-app/immich/discussions/9125

Creating a draft PR if it were to get considered to be merged - otherwise just to get help with some components in server code and I'll keep the changes to my local version.

The `.well_known` and the `uploadDomain` URL would be the only two URL which would need to be publicly accessible.

- [x] Add `uploadDomain` support to server backend code
- [x] Add `uploadDomain` to `.well_known` to allow clients to find and use the correct endpoint.
- [x] Add `uploadDomain` setting to web UI
- [ ] Find a solution to forward main domain cookies to `uploadDomain` so it can authenticate and upload
- [x] Add `uploadDomain` usage to web upload
- [ ] Add `uploadDomain` usage to mobile app
- [ ] Add docs

Users should expose:
```
/asset/exist
/asset/device/{deviceId}
/asset/upload
/.well-known/immich or /server-info/config
```