### PR TITLE
🚧 feat(Mobile): Use client side hash to check if asset exists in remote before backup 

### DIFF
--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -330,19 +330,25 @@ class BackupNotifier extends StateNotifier<BackUpState> {
 
     // Hash all album assets, excluding assets in `assetsFromExcludedAlbums`
     for (final album in state.selectedBackupAlbums) {
-      final result = await hashService.getHashedAssets(album.albumEntity, excludedAssets: assetsFromExcludedAlbums.toList().map((e) => e.id).toSet());
+      final result = await hashService.getHashedAssets(album.albumEntity,
+          excludedAssets:
+              assetsFromExcludedAlbums.toList().map((e) => e.id).toSet());
       hashedSelectedAssets.addAll(result);
     }
 
     if (hashedSelectedAssets.isNotEmpty) {
-      final assetHashCheckResponse = await _backupService.bulkUploadCheckRequest(hashedSelectedAssets);
+      final assetHashCheckResponse =
+          await _backupService.bulkUploadCheckRequest(hashedSelectedAssets);
 
       if (assetHashCheckResponse?.results != null) {
-        final rejectedAssetIds = assetHashCheckResponse!.results.where((e) => e.action == AssetBulkUploadCheckResultActionEnum.reject).map((e) => e.id);
-        assetsFromSelectedAlbums.removeWhere((e) => rejectedAssetIds.contains(e.id));
+        final rejectedAssetIds = assetHashCheckResponse!.results
+            .where(
+                (e) => e.action == AssetBulkUploadCheckResultActionEnum.reject)
+            .map((e) => e.id);
+        assetsFromSelectedAlbums
+            .removeWhere((e) => rejectedAssetIds.contains(e.id));
       }
     }
-
 
     final Set<AssetEntity> allUniqueAssets =
         assetsFromSelectedAlbums.difference(assetsFromExcludedAlbums);

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -4,6 +4,7 @@ import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/models/backup/available_album.model.dart';
 import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/models/backup/backup_state.model.dart';
@@ -19,11 +20,13 @@ import 'package:immich_mobile/models/server_info/server_disk_info.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/providers/app_life_cycle.provider.dart';
 import 'package:immich_mobile/providers/db.provider.dart';
+import 'package:immich_mobile/services/hash.service.dart';
 import 'package:immich_mobile/services/server_info.service.dart';
 import 'package:immich_mobile/utils/backup_progress.dart';
 import 'package:immich_mobile/utils/diff.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
+import 'package:openapi/api.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -286,13 +289,15 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   ///
   /// From all the selected and albums assets
   /// Find the assets that are not overlapping between the two sets
+  /// Remove assets which are already present in remote server using SHA-1 checksum.
   /// Those assets are unique and are used as the total assets
   ///
   Future<void> _updateBackupAssetCount() async {
     final duplicatedAssetIds = await _backupService.getDuplicatedAssetIds();
     final Set<AssetEntity> assetsFromSelectedAlbums = {};
     final Set<AssetEntity> assetsFromExcludedAlbums = {};
-
+    final Set<Asset> hashedSelectedAssets = {};
+    final hashService = HashService(_db, _backgroundService);
     for (final album in state.selectedBackupAlbums) {
       final assetCount = await album.albumEntity.assetCountAsync;
 
@@ -307,6 +312,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       assetsFromSelectedAlbums.addAll(assets);
     }
 
+    // Extract all excluded assets
     for (final album in state.excludedBackupAlbums) {
       final assetCount = await album.albumEntity.assetCountAsync;
 
@@ -320,6 +326,22 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       );
       assetsFromExcludedAlbums.addAll(assets);
     }
+
+    // Hash all album assets, excluding assets in `assetsFromExcludedAlbums`
+    for (final album in state.selectedBackupAlbums) {
+      final result = await hashService.getHashedAssets(album.albumEntity, excludedAssets: assetsFromExcludedAlbums.toList().map((e) => e.id).toSet());
+      hashedSelectedAssets.addAll(result);
+    }
+
+    if (hashedSelectedAssets.isNotEmpty) {
+      final assetHashCheckResponse = await _backupService.bulkUploadCheckRequest(hashedSelectedAssets);
+
+      if (assetHashCheckResponse?.results != null) {
+        final rejectedAssetIds = assetHashCheckResponse!.results.where((e) => e.action == AssetBulkUploadCheckResultActionEnum.reject).map((e) => e.id);
+        assetsFromSelectedAlbums.removeWhere((e) => rejectedAssetIds.contains(e.id));
+      }
+    }
+
 
     final Set<AssetEntity> allUniqueAssets =
         assetsFromSelectedAlbums.difference(assetsFromExcludedAlbums);

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -298,6 +298,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     final Set<AssetEntity> assetsFromExcludedAlbums = {};
     final Set<Asset> hashedSelectedAssets = {};
     final hashService = HashService(_db, _backgroundService);
+
     for (final album in state.selectedBackupAlbums) {
       final assetCount = await album.albumEntity.assetCountAsync;
 

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -5,7 +5,8 @@ import 'dart:io';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/entities/asset.entity.dart' as immich_asset_entity;
+import 'package:immich_mobile/entities/asset.entity.dart'
+    as immich_asset_entity;
 import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/models/backup/current_upload_asset.model.dart';
 import 'package:immich_mobile/entities/duplicated_asset.entity.dart';
@@ -52,11 +53,17 @@ class BackupService {
     }
   }
 
-  Future<AssetBulkUploadCheckResponseDto?> bulkUploadCheckRequest(Set<immich_asset_entity.Asset > assets) async {
+  Future<AssetBulkUploadCheckResponseDto?> bulkUploadCheckRequest(
+      Set<immich_asset_entity.Asset> assets) async {
     try {
       final assetList = assets.toList();
-      final bulkUploadCheckRequest = assetList.map((e) => AssetBulkUploadCheckItem(checksum: e.checksum, id: e.localId != null ? e.localId! : e.id.toString())).toList();
-      return await _apiService.assetApi.checkBulkUpload(AssetBulkUploadCheckDto(assets: bulkUploadCheckRequest));
+      final bulkUploadCheckRequest = assetList
+          .map((e) => AssetBulkUploadCheckItem(
+              checksum: e.checksum,
+              id: e.localId != null ? e.localId! : e.id.toString()))
+          .toList();
+      return await _apiService.assetApi.checkBulkUpload(
+          AssetBulkUploadCheckDto(assets: bulkUploadCheckRequest));
     } catch (e) {
       debugPrint('Error [bulkUploadCheckRequest] ${e.toString()}');
       return null;

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -206,8 +206,6 @@ class BackupService {
         existing.addAll(allAssetsInDatabase);
       }
     }
-    // Checked for duplicates, check for checksum
-    _apiService.assetApi.checkBulkUpload(AssetBulkUploadCheckDto());
     return existing.isEmpty
         ? candidates
         : candidates.whereNot((e) => existing.contains(e.id)).toList();


### PR DESCRIPTION
Allows Client to check for asset existence in remote server by making use of asset SHA-1 checksum along with API implemented in #2072 

Fixes #1553 

## Problem statement:

When reinstalling immich app, or when asset backup already exists on immich server (through icloudpd and immich-cli for example) the client app uploads all the assets from the device which then get deduplicated from the server-side. Resulting in unnecessary upload of 20k+ assets, wasted bandwidth and time.

### Change:

Assets that are already on the server are ignored and not uploaded to the server

### Tests:
- [x] Tested on Android (emulator)
- [ ] Tested on iOS (physical device)

