### PR TITLE
fix(web): allow deselecting all assets from select bar

### DIFF
--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -2,7 +2,7 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { type AssetStore, isSelectingAllAssets } from '$lib/stores/assets.store';
-  import { mdiSelectAll, mdiTimerSand } from '@mdi/js';
+  import { mdiSelectAll, mdiSelectOff } from '@mdi/js';
   import { selectAllAssets } from '$lib/utils/asset-utils';
 
   export let assetStore: AssetStore;
@@ -19,7 +19,7 @@
 </script>
 
 {#if $isSelectingAllAssets}
-  <CircleIconButton title="Cancel" icon={mdiTimerSand} on:click={handleCancel} />
+  <CircleIconButton title="Cancel" icon={mdiSelectOff} on:click={handleCancel} />
 {:else}
   <CircleIconButton title="Select all" icon={mdiSelectAll} on:click={handleSelectAll} />
 {/if}

--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -14,6 +14,7 @@
 
   const handleCancel = () => {
     $isSelectingAllAssets = false;
+    assetInteractionStore.clearMultiselect();
   };
 </script>
 

--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -2,7 +2,7 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { type AssetStore, isSelectingAllAssets } from '$lib/stores/assets.store';
-  import { mdiSelectAll, mdiSelectOff } from '@mdi/js';
+  import { mdiSelectAll, mdiSelectRemove } from '@mdi/js';
   import { selectAllAssets } from '$lib/utils/asset-utils';
 
   export let assetStore: AssetStore;
@@ -19,7 +19,7 @@
 </script>
 
 {#if $isSelectingAllAssets}
-  <CircleIconButton title="Cancel" icon={mdiSelectOff} on:click={handleCancel} />
+  <CircleIconButton title="Unselect all" icon={mdiSelectRemove} on:click={handleCancel} />
 {:else}
   <CircleIconButton title="Select all" icon={mdiSelectAll} on:click={handleSelectAll} />
 {/if}

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -370,7 +370,6 @@ export const selectAllAssets = async (assetStore: AssetStore, assetInteractionSt
     }
   } catch (error) {
     handleError(error, 'Error selecting all assets');
-  } finally {
     isSelectingAllAssets.set(false);
   }
 };


### PR DESCRIPTION
Fixes #9308.

There are further issues that should probably be addressed in subsequent PRs where deselecting an asset not using the selection bar still causes the `isSelectingAllAssets` store to be true (causing the 'Cancel' button to appear).