### PR TITLE
fix(web): multiple fixes for people

### DIFF
--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -30,9 +30,7 @@
   }>();
 
   $: hasSelection = selectedPeople.length > 0;
-  $: unselectedPeople = people.filter(
-    (source) => !selectedPeople.some((selected) => selected.id === source.id) && source.id !== person.id,
-  );
+  $: peopleToNotShow = [...selectedPeople, person];
 
   onMount(async () => {
     const data = await getAllPeople({ withHidden: false });
@@ -150,13 +148,7 @@
         </div>
       </div>
 
-      <PeopleList
-        people={unselectedPeople}
-        peopleCopy={unselectedPeople}
-        unselectedPeople={selectedPeople}
-        {screenHeight}
-        on:select={({ detail }) => onSelect(detail)}
-      />
+      <PeopleList {people} {peopleToNotShow} {screenHeight} on:select={({ detail }) => onSelect(detail)} />
     </section>
 
     {#if isShowConfirmation}

--- a/web/src/lib/components/faces-page/people-list.svelte
+++ b/web/src/lib/components/faces-page/people-list.svelte
@@ -6,8 +6,8 @@
 
   export let screenHeight: number;
   export let people: PersonResponseDto[];
-  export let peopleCopy: PersonResponseDto[];
-  export let unselectedPeople: PersonResponseDto[];
+  export let peopleToNotShow: PersonResponseDto[];
+  let searchedPeopleLocal: PersonResponseDto[] = [];
 
   let name = '';
   let showPeople: PersonResponseDto[];
@@ -17,20 +17,15 @@
   }>();
 
   $: {
-    showPeople = people.filter(
-      (person) => !unselectedPeople.some((unselectedPerson) => unselectedPerson.id === person.id),
+    showPeople = name ? searchedPeopleLocal : people;
+    showPeople = showPeople.filter(
+      (person) => !peopleToNotShow.some((unselectedPerson) => unselectedPerson.id === person.id),
     );
   }
 </script>
 
 <div class=" w-40 sm:w-48 md:w-96 h-14 mb-8">
-  <SearchPeople
-    type="searchBar"
-    placeholder="Search people"
-    bind:searchName={name}
-    bind:searchedPeopleLocal={people}
-    onReset={() => (people = peopleCopy)}
-  />
+  <SearchPeople type="searchBar" placeholder="Search people" bind:searchName={name} bind:searchedPeopleLocal />
 </div>
 
 <div

--- a/web/src/lib/components/faces-page/unmerge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/unmerge-face-selector.svelte
@@ -31,9 +31,7 @@
   let hasSelection = false;
   let screenHeight: number;
 
-  $: unselectedPeople = selectedPerson
-    ? people.filter((person) => selectedPerson && person.id !== selectedPerson.id && personAssets.id !== person.id)
-    : people;
+  $: peopleToNotShow = selectedPerson ? [personAssets, selectedPerson] : [personAssets];
 
   let dispatch = createEventDispatcher<{
     confirm: void;
@@ -178,13 +176,7 @@
           </div>
         </div>
       {/if}
-      <PeopleList
-        people={unselectedPeople}
-        peopleCopy={unselectedPeople}
-        unselectedPeople={selectedPerson ? [selectedPerson, personAssets] : [personAssets]}
-        {screenHeight}
-        on:select={({ detail }) => handleSelectedPerson(detail)}
-      />
+      <PeopleList {people} {peopleToNotShow} {screenHeight} on:select={({ detail }) => handleSelectedPerson(detail)} />
     </section>
   </section>
 </section>

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -60,14 +60,23 @@
   let edittingPerson: PersonResponseDto | null = null;
   let searchedPeopleLocal: PersonResponseDto[] = [];
   let handleSearchPeople: (force?: boolean, name?: string) => Promise<void>;
+  let showPeople: PersonResponseDto[] = [];
+  let countVisiblePeople: number;
 
   let innerHeight: number;
 
   for (const person of people) {
     initialHiddenValues[person.id] = person.isHidden;
   }
-  $: showPeople = searchName ? searchedPeopleLocal : people.filter((person) => !person.isHidden);
-  $: countVisiblePeople = countTotalPeople - countHiddenPeople;
+  $: {
+    if (searchName) {
+      showPeople = searchedPeopleLocal;
+      countVisiblePeople = searchedPeopleLocal.length;
+    } else {
+      showPeople = people.filter((person) => !person.isHidden);
+      countVisiblePeople = countTotalPeople - countHiddenPeople;
+    }
+  }
 
   onMount(async () => {
     const getSearchedPeople = $page.url.searchParams.get(QueryParameter.SEARCHED_PEOPLE);
@@ -382,7 +391,7 @@
 
 <UserPageLayout
   title="People"
-  description={countVisiblePeople === 0 ? undefined : `(${countVisiblePeople.toLocaleString($locale)})`}
+  description={countVisiblePeople === 0 && !searchName ? undefined : `(${countVisiblePeople.toLocaleString($locale)})`}
 >
   <svelte:fragment slot="buttons">
     {#if countTotalPeople > 0}


### PR DESCRIPTION
This PR includes multiple fixes for the webUI related to the people feature:
- fixes  #9338
- fixes and simplify the search for the merge modal
- on the /people page, show the number of people when searching for a person instead of the fixed number of people