### PR TITLE
fix(web): Selected face in search filter doesn't show border highlight when hovered in light theme

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
@@ -63,11 +63,11 @@
         {#each peopleList as person (person.id)}
           <button
             type="button"
-            class="flex flex-col items-center w-20 rounded-3xl border-2 border-transparent hover:bg-immich-gray dark:hover:bg-immich-dark-primary/20 p-2 transition-all {selectedPeople.has(
+            class="flex flex-col items-center w-20 rounded-3xl border-2 hover:bg-immich-gray dark:hover:bg-immich-dark-primary/20 p-2 transition-all {selectedPeople.has(
               person.id,
             )
               ? 'dark:border-slate-500 border-slate-400 bg-slate-200 dark:bg-slate-800 dark:text-white'
-              : ''}"
+              : 'border-transparent'}"
             on:click={() => togglePersonSelection(person.id)}
           >
             <ImageThumbnail


### PR DESCRIPTION
Fixes: #8747 

PREVIOUS: face didn't have border immediately when selected. border was visible after moving mouse away from face.
NOW: face has border when selected regardless if person is hovered or not.

![image](https://github.com/immich-app/immich/assets/30742945/b5b5b365-bbfd-4a38-8de8-d39d08a331fb)
