### PR TITLE
fix(mobile) timeline slider no longer dissapears

### DIFF
--- a/mobile/lib/modules/home/ui/asset_grid/draggable_scrollbar_custom.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/draggable_scrollbar_custom.dart
@@ -36,6 +36,8 @@ class DraggableScrollbar extends StatefulWidget {
   /// The amount of padding that should surround the thumb
   final EdgeInsetsGeometry? padding;
 
+  final double? heightOffset;
+
   /// Determines how quickly the scrollbar will animate in and out
   final Duration scrollbarAnimationDuration;
 
@@ -67,6 +69,7 @@ class DraggableScrollbar extends StatefulWidget {
     this.heightScrollThumb = 48.0,
     this.backgroundColor = Colors.white,
     this.padding,
+    this.heightOffset,
     this.scrollbarAnimationDuration = const Duration(milliseconds: 300),
     this.scrollbarTimeToFade = const Duration(milliseconds: 600),
     this.labelTextBuilder,
@@ -247,7 +250,7 @@ class DraggableScrollbarState extends State<DraggableScrollbar>
   }
 
   double get barMaxScrollExtent =>
-      (context.size?.height ?? 0) - widget.heightScrollThumb;
+      (context.size?.height ?? 0) - widget.heightScrollThumb - (widget.heightOffset ?? 0);
 
   double get barMinScrollExtent => 0;
 

--- a/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/modules/home/ui/asset_grid/immich_asset_grid_view.dart
@@ -91,6 +91,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
   int _hapticFeedbackTS = 0;
   DateTime? _prevItemTime;
   bool _scrolling = false;
+  bool _offset = true;
   final Set<Asset> _selectedAssets =
       LinkedHashSet(equals: (a, b) => a.id == b.id, hashCode: (a) => a.id);
 
@@ -267,6 +268,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
             padding: appBarOffset()
                 ? const EdgeInsets.only(top: 60)
                 : const EdgeInsets.only(),
+            heightOffset: 60,
             labelConstraints: const BoxConstraints(maxHeight: 28),
             scrollbarAnimationDuration: const Duration(milliseconds: 300),
             scrollbarTimeToFade: const Duration(milliseconds: 1000),


### PR DESCRIPTION
## Description
Fixes  #9286

I added a parameter to the scrollbar which will add a height offset if it is set. This accounts for the padding added to the top to allow the appBar to slide away when in multi select mode

