### PR TITLE
 fix(mobile): timeline slider no longer disappears

### DIFF
--- a/mobile/lib/widgets/asset_grid/draggable_scrollbar_custom.dart
+++ b/mobile/lib/widgets/asset_grid/draggable_scrollbar_custom.dart
@@ -36,6 +36,9 @@ class DraggableScrollbar extends StatefulWidget {
   /// The amount of padding that should surround the thumb
   final EdgeInsetsGeometry? padding;
 
+  /// The height offset of the thumb/bar from the bottom of the page
+  final double? heightOffset;
+
   /// Determines how quickly the scrollbar will animate in and out
   final Duration scrollbarAnimationDuration;
 
@@ -67,6 +70,7 @@ class DraggableScrollbar extends StatefulWidget {
     this.heightScrollThumb = 48.0,
     this.backgroundColor = Colors.white,
     this.padding,
+    this.heightOffset,
     this.scrollbarAnimationDuration = const Duration(milliseconds: 300),
     this.scrollbarTimeToFade = const Duration(milliseconds: 600),
     this.labelTextBuilder,
@@ -247,7 +251,9 @@ class DraggableScrollbarState extends State<DraggableScrollbar>
   }
 
   double get barMaxScrollExtent =>
-      (context.size?.height ?? 0) - widget.heightScrollThumb;
+      (context.size?.height ?? 0) -
+      widget.heightScrollThumb -
+      (widget.heightOffset ?? 0);
 
   double get barMinScrollExtent => 0;
 

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -267,6 +267,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
             padding: appBarOffset()
                 ? const EdgeInsets.only(top: 60)
                 : const EdgeInsets.only(),
+            heightOffset: appBarOffset() ? 60 : 0,
             labelConstraints: const BoxConstraints(maxHeight: 28),
             scrollbarAnimationDuration: const Duration(milliseconds: 300),
             scrollbarTimeToFade: const Duration(milliseconds: 1000),


### PR DESCRIPTION
## Description
Fixes #9286

I added a parameter to the scrollbar which will add a height offset if it is set. This accounts for the padding added to the top to allow the appBar to slide away when in multi select mode