### PR TITLE
feat(server): enable data page checksums

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -108,11 +108,13 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
-  
+    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", 'search_path="$$user", public, vectors', "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
+
   # set IMMICH_METRICS=true in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -66,10 +66,12 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", 'search_path="$$user", public, vectors', "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
 
   # set IMMICH_METRICS=true in .env to enable metrics
   immich-prometheus:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     volumes:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     restart: always
+    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", "search_path=\"$user\", public, vectors", "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
 
 volumes:
   model-cache:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     volumes:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     restart: always
-    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", "search_path=\"$user\", public, vectors", "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
+    command: ["postgres", "-c" ,"shared_preload_libraries=vectors.so", "-c", 'search_path="$$user", public, vectors', "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
 
 volumes:
   model-cache:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ name: immich
 
 services:
   immich-server:
-    container_name: immich_server
+    container_name: immich_server1
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     command: ['start.sh', 'immich']
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ name: immich
 
 services:
   immich-server:
-    container_name: immich_server1
+    container_name: immich_server
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     command: ['start.sh', 'immich']
     volumes:
@@ -68,6 +68,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     restart: always


### PR DESCRIPTION
# Proposal

Currently, the Immich Postgres database container does not use/enable data page checksums. Data page checksums are additional pages stored by Postgres that allow the DB to validate and detect corrupted data within the database tables. They have a minimal performance hit that I believe is more than offset by the ability to detect this type of data damage.

The official Postgres container [docs](https://hub.docker.com/_/postgres) outline how to enable checksums. I have tested deploying this using the pgvecto.rs database image, and it works as described. Adding this to an existing database doesn't do anything, as it's required to be specified on database initialization.

## Implications

Importantly, this would not be a breaking change. I believe setting this variable only has an effect during database initialization, and not after. It is possible to restore a pg_dump from a non-checksum DB into a checksum DB, as well. 

## Healthcheck

This would allow users to add a healthcheck to monitor for corruption in the Postgres container if desired. For example:

```
healthcheck:
  test: Errs=$(psql --username=postgres --dbname=immich --tuples-only --no-align --command="SELECT checksum_failures FROM pg_stat_database WHERE datname = 'immich';"); [[ $Errs == '0' ]] || { echo 'corrupted pages detected'; exit 1; }
  interval: 60m
  retries: 1
  timeout: 10s
  start_period: 5m
  start_interval: 1m
```

## Example logs

Checksums:

```
postgres=# show data_checksums;
 data_checksums
----------------
 on
(1 row)

postgres=# SELECT name, setting, category FROM pg_settings WHERE name = 'data_checksums';
      name      | setting |    category
----------------+---------+----------------
 data_checksums | on      | Preset Options
(1 row)

postgres=# SELECT datname, checksum_failures, checksum_last_failure FROM pg_stat_database WHERE datname IS NOT NULL;
  datname  | checksum_failures | checksum_last_failure
-----------+-------------------+-----------------------
 postgres  |                 0 |
 immich    |                 0 |
 template1 |                 0 |
 template0 |                 0 |
(4 rows)
```

Current setup PG message:

```
Data page checksums are disabled.
```

New PG message:

```
Data page checksums are enabled.
```

Adding this to an *existing* installation does not affect it all, checksums are not enabled:

```
PostgreSQL Database directory appears to contain a database; Skipping initialization
```