### PR TITLE
fix(server): support special characters in library paths

### DIFF
--- a/server/src/repositories/storage.repository.spec.ts
+++ b/server/src/repositories/storage.repository.spec.ts
@@ -77,17 +77,6 @@ const tests: Test[] = [
     },
   },
   {
-    test: 'should support globbing paths',
-    options: {
-      pathsToCrawl: ['/photos*'],
-    },
-    files: {
-      '/photos1/image1.jpg': true,
-      '/photos2/image2.jpg': true,
-      '/images/image3.jpg': false,
-    },
-  },
-  {
     test: 'should crawl a single path without trailing slash',
     options: {
       pathsToCrawl: ['/photos'],
@@ -177,6 +166,15 @@ const tests: Test[] = [
       [`${cwd}/photos/1.jpg`]: true,
       [`${cwd}/photos/2.jpg`]: true,
       [`/photos/3.jpg`]: false,
+    },
+  },
+  {
+    test: 'should support special characters in paths',
+    options: {
+      pathsToCrawl: ['/photos (new)'],
+    },
+    files: {
+      ['/photos (new)/1.jpg']: true,
     },
   },
 ];

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import archiver from 'archiver';
 import chokidar, { WatchOptions } from 'chokidar';
-import { glob, globStream } from 'fast-glob';
+import { escapePath, glob, globStream } from 'fast-glob';
 import { constants, createReadStream, existsSync, mkdirSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -186,7 +186,8 @@ export class StorageRepository implements IStorageRepository {
   }
 
   private asGlob(pathsToCrawl: string[]): string {
-    const base = pathsToCrawl.length === 1 ? pathsToCrawl[0] : `{${pathsToCrawl.join(',')}}`;
+    const escapedPaths = pathsToCrawl.map((path) => escapePath(path));
+    const base = escapedPaths.length === 1 ? escapedPaths[0] : `{${escapedPaths.join(',')}}`;
     const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
     return `${base}/**/${extensions}`;
   }


### PR DESCRIPTION
Directories with special characters, like `(`, aren't properly crawled. This is fixed by escaping the provided paths before they're passed to `fast-glob`. My newly added test now passes. But, another test that uses `*` had to be deleted since we can't treat input paths as patterns and verbatim at the same time. I audited the use cases and it seems like only actual paths would be passed (please double check!). In particular, library paths are validated as real paths before being crawled.

If this behavior is intentional, the docs/UI should probably clarify that users need to escape special characters themselves. The path validation logic would also need to be tweaked to 'unescape' before checking the path. That seems a bit confusing.

cc @jrasm91 since you recently touched this and have last blame on the test that I deleted :)