### PR TITLE
chore(server): less rigid transcoding tests

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -633,7 +633,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -644,7 +644,7 @@ describe(MediaService.name, () => {
             '-vf format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -674,7 +674,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a aac',
             '-movflags faststart',
@@ -685,7 +685,7 @@ describe(MediaService.name, () => {
             '-vf format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -700,7 +700,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -711,7 +711,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -729,7 +729,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -742,7 +742,7 @@ describe(MediaService.name, () => {
             '-crf 23',
             '-maxrate 30M',
             '-bufsize 60M',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -760,7 +760,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a aac',
             '-movflags faststart',
@@ -771,7 +771,7 @@ describe(MediaService.name, () => {
             '-vf format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -787,7 +787,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -798,7 +798,7 @@ describe(MediaService.name, () => {
             '-vf scale=720:-2,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -817,7 +817,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a aac',
             '-movflags faststart',
@@ -828,7 +828,7 @@ describe(MediaService.name, () => {
             `-vf scale=-2:354,format=yuv420p`,
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -847,7 +847,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a aac',
             '-movflags faststart',
@@ -858,7 +858,7 @@ describe(MediaService.name, () => {
             `-vf scale=354:-2,format=yuv420p`,
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -877,7 +877,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v copy',
             '-c:a aac',
             '-movflags faststart',
@@ -888,7 +888,7 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -908,7 +908,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v copy',
             '-c:a aac',
             '-movflags faststart',
@@ -918,7 +918,7 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -938,7 +938,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v copy',
             '-c:a aac',
             '-movflags faststart',
@@ -949,7 +949,7 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -965,7 +965,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -976,7 +976,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -992,7 +992,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1003,7 +1003,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1058,7 +1058,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1071,7 +1071,7 @@ describe(MediaService.name, () => {
             '-crf 23',
             '-maxrate 4500k',
             '-bufsize 9000k',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1090,7 +1090,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1103,7 +1103,7 @@ describe(MediaService.name, () => {
             '-b:v 3104k',
             '-minrate 1552k',
             '-maxrate 4500k',
-          ],
+          ]),
           twoPass: true,
         },
       );
@@ -1119,7 +1119,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1130,7 +1130,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1150,7 +1150,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v vp9',
             '-c:a copy',
             '-movflags faststart',
@@ -1164,7 +1164,7 @@ describe(MediaService.name, () => {
             '-b:v 3104k',
             '-minrate 1552k',
             '-maxrate 4500k',
-          ],
+          ]),
           twoPass: true,
         },
       );
@@ -1184,7 +1184,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v vp9',
             '-c:a copy',
             '-movflags faststart',
@@ -1197,7 +1197,7 @@ describe(MediaService.name, () => {
             '-row-mt 1',
             '-crf 23',
             '-b:v 0',
-          ],
+          ]),
           twoPass: true,
         },
       );
@@ -1216,7 +1216,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v vp9',
             '-c:a copy',
             '-movflags faststart',
@@ -1229,7 +1229,7 @@ describe(MediaService.name, () => {
             '-row-mt 1',
             '-crf 23',
             '-b:v 0',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1248,7 +1248,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v vp9',
             '-c:a copy',
             '-movflags faststart',
@@ -1260,7 +1260,7 @@ describe(MediaService.name, () => {
             '-row-mt 1',
             '-crf 23',
             '-b:v 0',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1279,7 +1279,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v vp9',
             '-c:a copy',
             '-movflags faststart',
@@ -1293,7 +1293,7 @@ describe(MediaService.name, () => {
             '-threads 2',
             '-crf 23',
             '-b:v 0',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1309,7 +1309,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1322,7 +1322,7 @@ describe(MediaService.name, () => {
             '-threads 1',
             '-x264-params frame-threads=1:pools=none',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1338,7 +1338,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -1349,7 +1349,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1368,7 +1368,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v hevc',
             '-c:a copy',
             '-movflags faststart',
@@ -1382,7 +1382,7 @@ describe(MediaService.name, () => {
             '-threads 1',
             '-x265-params frame-threads=1:pools=none',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1401,7 +1401,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v hevc',
             '-c:a copy',
             '-movflags faststart',
@@ -1413,7 +1413,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1429,7 +1429,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v av1',
             '-c:a copy',
             '-movflags faststart',
@@ -1440,7 +1440,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset 12',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1459,7 +1459,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v av1',
             '-c:a copy',
             '-movflags faststart',
@@ -1470,7 +1470,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset 4',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1489,7 +1489,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v av1',
             '-c:a copy',
             '-movflags faststart',
@@ -1501,7 +1501,7 @@ describe(MediaService.name, () => {
             '-preset 12',
             '-crf 23',
             '-svtav1-params mbr=2M',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1520,7 +1520,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v av1',
             '-c:a copy',
             '-movflags faststart',
@@ -1532,7 +1532,7 @@ describe(MediaService.name, () => {
             '-preset 12',
             '-crf 23',
             '-svtav1-params lp=4',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1552,7 +1552,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v av1',
             '-c:a copy',
             '-movflags faststart',
@@ -1564,7 +1564,7 @@ describe(MediaService.name, () => {
             '-preset 12',
             '-crf 23',
             '-svtav1-params lp=4:mbr=2M',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1614,8 +1614,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([
             '-tune hq',
             '-qmin 0',
             '-rc-lookahead 20',
@@ -1634,7 +1634,7 @@ describe(MediaService.name, () => {
             '-maxrate 10000k',
             '-bufsize 6897k',
             '-multipass 2',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1652,8 +1652,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([
             '-tune hq',
             '-qmin 0',
             '-rc-lookahead 20',
@@ -1671,7 +1671,7 @@ describe(MediaService.name, () => {
             '-cq:v 23',
             '-maxrate 10000k',
             '-bufsize 6897k',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1686,8 +1686,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([
             '-tune hq',
             '-qmin 0',
             '-rc-lookahead 20',
@@ -1703,7 +1703,7 @@ describe(MediaService.name, () => {
             '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
             '-preset p1',
             '-cq:v 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1721,8 +1721,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([
             '-tune hq',
             '-qmin 0',
             '-rc-lookahead 20',
@@ -1737,7 +1737,7 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
             '-cq:v 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1752,8 +1752,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([
             '-tune hq',
             '-qmin 0',
             '-rc-lookahead 20',
@@ -1769,7 +1769,7 @@ describe(MediaService.name, () => {
             '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
             '-preset p1',
             '-cq:v 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1788,8 +1788,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_qsv`,
             '-c:a copy',
             '-movflags faststart',
@@ -1805,7 +1805,7 @@ describe(MediaService.name, () => {
             '-global_quality 23',
             '-maxrate 10000k',
             '-bufsize 20000k',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1825,8 +1825,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device qsv=hw,child_device=/dev/dri/renderD128', '-filter_hw_device hw'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device qsv=hw,child_device=/dev/dri/renderD128',
+            '-filter_hw_device hw',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_qsv`,
             '-c:a copy',
             '-movflags faststart',
@@ -1842,7 +1845,7 @@ describe(MediaService.name, () => {
             '-global_quality 23',
             '-maxrate 10000k',
             '-bufsize 20000k',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1861,8 +1864,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_qsv`,
             '-c:a copy',
             '-movflags faststart',
@@ -1875,7 +1878,7 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=-1:720',
             '-global_quality 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1894,8 +1897,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device qsv=hw', '-filter_hw_device hw'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
+          outputOptions: expect.arrayContaining([
             `-c:v vp9_qsv`,
             '-c:a copy',
             '-movflags faststart',
@@ -1910,7 +1913,7 @@ describe(MediaService.name, () => {
             '-vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=-1:720',
             '-preset 7',
             '-q:v 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1938,8 +1941,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD128',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -1954,7 +1960,7 @@ describe(MediaService.name, () => {
             '-maxrate 10000k',
             '-minrate 3448.5k',
             '-rc_mode 3',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -1970,8 +1976,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD128',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -1985,7 +1994,7 @@ describe(MediaService.name, () => {
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2004,8 +2013,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD128',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -2018,7 +2030,7 @@ describe(MediaService.name, () => {
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2034,8 +2046,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/card1', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/card1',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -2049,7 +2064,7 @@ describe(MediaService.name, () => {
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2065,8 +2080,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD130', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD130',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -2080,7 +2098,7 @@ describe(MediaService.name, () => {
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2099,8 +2117,11 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-init_hw_device vaapi=accel:/dev/dri/renderD128', '-filter_hw_device accel'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD128',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
             '-movflags faststart',
@@ -2114,7 +2135,7 @@ describe(MediaService.name, () => {
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2133,7 +2154,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: [],
-          outputOptions: [
+          outputOptions: expect.arrayContaining([
             '-c:v h264',
             '-c:a copy',
             '-movflags faststart',
@@ -2144,7 +2165,7 @@ describe(MediaService.name, () => {
             '-vf scale=-2:720,format=yuv420p',
             '-preset ultrafast',
             '-crf 23',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2173,8 +2194,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
+          outputOptions: expect.arrayContaining([
             `-c:v hevc_rkmpp`,
             '-c:a copy',
             '-movflags faststart',
@@ -2188,7 +2209,7 @@ describe(MediaService.name, () => {
             '-level 153',
             '-rc_mode AVBR',
             '-b:v 10000k',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2208,8 +2229,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_rkmpp`,
             '-c:a copy',
             '-movflags faststart',
@@ -2222,7 +2243,7 @@ describe(MediaService.name, () => {
             '-level 51',
             '-rc_mode CQP',
             '-qp_init 30',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2243,8 +2264,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: ['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga'],
-          outputOptions: [
+          inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
+          outputOptions: expect.arrayContaining([
             `-c:v h264_rkmpp`,
             '-c:a copy',
             '-movflags faststart',
@@ -2257,7 +2278,7 @@ describe(MediaService.name, () => {
             '-level 51',
             '-rc_mode CQP',
             '-qp_init 30',
-          ],
+          ]),
           twoPass: false,
         },
       );
@@ -2274,7 +2295,7 @@ describe(MediaService.name, () => {
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
         inputOptions: [],
-        outputOptions: [
+        outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
           '-movflags faststart',
@@ -2285,7 +2306,7 @@ describe(MediaService.name, () => {
           '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
           '-preset ultrafast',
           '-crf 23',
-        ],
+        ]),
         twoPass: false,
       },
     );
@@ -2301,7 +2322,7 @@ describe(MediaService.name, () => {
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
         inputOptions: [],
-        outputOptions: [
+        outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
           '-movflags faststart',
@@ -2312,7 +2333,7 @@ describe(MediaService.name, () => {
           '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
           '-preset ultrafast',
           '-crf 23',
-        ],
+        ]),
         twoPass: false,
       },
     );
@@ -2328,7 +2349,7 @@ describe(MediaService.name, () => {
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
         inputOptions: [],
-        outputOptions: [
+        outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
           '-movflags faststart',
@@ -2339,7 +2360,7 @@ describe(MediaService.name, () => {
           '-vf zscale=t=linear:npl=250,tonemap=mobius:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
           '-preset ultrafast',
           '-crf 23',
-        ],
+        ]),
         twoPass: false,
       },
     );

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -632,19 +632,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-map 0:0', '-map 0:1']),
           twoPass: false,
         },
       );
@@ -673,19 +662,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.any(Array),
           twoPass: false,
         },
       );
@@ -699,19 +677,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.any(Array),
           twoPass: false,
         },
       );
@@ -728,21 +695,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-            '-maxrate 30M',
-            '-bufsize 60M',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.any(Array),
           twoPass: false,
         },
       );
@@ -759,25 +713,30 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('scale')]),
           twoPass: false,
         },
       );
     });
 
-    it('should transcode with alternate scaling video is vertical', async () => {
+    it('should scale horizontally when video is horizontal', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStream2160p);
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_TRANSCODE, value: TranscodePolicy.OPTIMAL }]);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=-2:720/)]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should scale vertically when video is vertical', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.videoStreamVertical2160p);
       configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_TRANSCODE, value: TranscodePolicy.OPTIMAL }]);
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
@@ -786,19 +745,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=720:-2,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=720:-2/)]),
           twoPass: false,
         },
       );
@@ -816,19 +764,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            `-vf scale=-2:354,format=yuv420p`,
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=-2:354/)]),
           twoPass: false,
         },
       );
@@ -846,19 +783,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            `-vf scale=354:-2,format=yuv420p`,
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=354:-2/)]),
           twoPass: false,
         },
       );
@@ -876,19 +802,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v copy',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v copy', '-c:a aac']),
           twoPass: false,
         },
       );
@@ -907,18 +822,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v copy',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining(['-tag:v hvc1']),
           twoPass: false,
         },
       );
@@ -937,19 +842,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v copy',
-            '-c:a aac',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v copy', '-tag:v hvc1']),
           twoPass: false,
         },
       );
@@ -964,46 +858,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
-          twoPass: false,
-        },
-      );
-    });
-
-    it('should transcode when container doesnt match target', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_TRANSCODE, value: TranscodePolicy.OPTIMAL }]);
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264', '-c:a copy']),
           twoPass: false,
         },
       );
@@ -1057,21 +913,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-            '-maxrate 4500k',
-            '-bufsize 9000k',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264', '-maxrate 4500k', '-bufsize 9000k']),
           twoPass: false,
         },
       );
@@ -1089,21 +932,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-b:v 3104k',
-            '-minrate 1552k',
-            '-maxrate 4500k',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264', '-b:v 3104k', '-minrate 1552k', '-maxrate 4500k']),
           twoPass: true,
         },
       );
@@ -1118,19 +948,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264', '-c:a copy']),
           twoPass: false,
         },
       );
@@ -1149,22 +968,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v vp9',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-cpu-used 5',
-            '-row-mt 1',
-            '-b:v 3104k',
-            '-minrate 1552k',
-            '-maxrate 4500k',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-b:v 3104k', '-minrate 1552k', '-maxrate 4500k']),
           twoPass: true,
         },
       );
@@ -1183,21 +988,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v vp9',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-cpu-used 5',
-            '-row-mt 1',
-            '-crf 23',
-            '-b:v 0',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-maxrate')]),
           twoPass: true,
         },
       );
@@ -1215,21 +1007,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v vp9',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-cpu-used 2',
-            '-row-mt 1',
-            '-crf 23',
-            '-b:v 0',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-cpu-used 2']),
           twoPass: false,
         },
       );
@@ -1247,20 +1026,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v vp9',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-row-mt 1',
-            '-crf 23',
-            '-b:v 0',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-cpu-used')]),
           twoPass: false,
         },
       );
@@ -1278,22 +1045,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v vp9',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-cpu-used 5',
-            '-row-mt 1',
-            '-threads 2',
-            '-crf 23',
-            '-b:v 0',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-threads 2']),
           twoPass: false,
         },
       );
@@ -1308,21 +1061,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-threads 1',
-            '-x264-params frame-threads=1:pools=none',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-threads 1', '-x264-params frame-threads=1:pools=none']),
           twoPass: false,
         },
       );
@@ -1337,19 +1077,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-threads')]),
           twoPass: false,
         },
       );
@@ -1367,22 +1096,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v hevc',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-threads 1',
-            '-x265-params frame-threads=1:pools=none',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v hevc', '-threads 1', '-x265-params frame-threads=1:pools=none']),
           twoPass: false,
         },
       );
@@ -1400,20 +1115,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v hevc',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-threads')]),
           twoPass: false,
         },
       );
@@ -1428,10 +1131,9 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
+          inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([
             '-c:v av1',
-            '-c:a copy',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-map 0:0',
@@ -1458,19 +1160,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v av1',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset 4',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-preset 4']),
           twoPass: false,
         },
       );
@@ -1488,20 +1179,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v av1',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset 12',
-            '-crf 23',
-            '-svtav1-params mbr=2M',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-svtav1-params mbr=2M']),
           twoPass: false,
         },
       );
@@ -1519,20 +1198,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v av1',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset 12',
-            '-crf 23',
-            '-svtav1-params lp=4',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-svtav1-params lp=4']),
           twoPass: false,
         },
       );
@@ -1551,20 +1218,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v av1',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset 12',
-            '-crf 23',
-            '-svtav1-params lp=4:mbr=2M',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-svtav1-params lp=4:mbr=2M']),
           twoPass: false,
         },
       );
@@ -1601,13 +1256,9 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).not.toHaveBeenCalled();
     });
 
-    it('should set two pass options for nvenc when enabled', async () => {
+    it('should set options for nvenc', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      configMock.load.mockResolvedValue([
-        { key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.NVENC },
-        { key: SystemConfigKey.FFMPEG_MAX_BITRATE, value: '10000k' },
-        { key: SystemConfigKey.FFMPEG_TWO_PASS, value: true },
-      ]);
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.NVENC }]);
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await sut.handleVideoConversion({ id: assetStub.video.id });
       expect(mediaMock.transcode).toHaveBeenCalledWith(
@@ -1630,11 +1281,28 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
             '-preset p1',
-            '-b:v 6897k',
-            '-maxrate 10000k',
-            '-bufsize 6897k',
-            '-multipass 2',
+            '-cq:v 23',
           ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should set two pass options for nvenc when enabled', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.NVENC },
+        { key: SystemConfigKey.FFMPEG_MAX_BITRATE, value: '10000k' },
+        { key: SystemConfigKey.FFMPEG_TWO_PASS, value: true },
+      ]);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
+          outputOptions: expect.arrayContaining([expect.stringContaining('-multipass')]),
           twoPass: false,
         },
       );
@@ -1653,25 +1321,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
-          outputOptions: expect.arrayContaining([
-            '-tune hq',
-            '-qmin 0',
-            '-rc-lookahead 20',
-            '-i_qfactor 0.75',
-            `-c:v h264_nvenc`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
-            '-preset p1',
-            '-cq:v 23',
-            '-maxrate 10000k',
-            '-bufsize 6897k',
-          ]),
+          outputOptions: expect.arrayContaining(['-cq:v 23', '-maxrate 10000k', '-bufsize 6897k']),
           twoPass: false,
         },
       );
@@ -1679,7 +1329,10 @@ describe(MediaService.name, () => {
 
     it('should set cq options for nvenc when max bitrate is disabled', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.NVENC }]);
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.NVENC },
+        { key: SystemConfigKey.FFMPEG_MAX_BITRATE, value: '10000k' },
+      ]);
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await sut.handleVideoConversion({ id: assetStub.video.id });
       expect(mediaMock.transcode).toHaveBeenCalledWith(
@@ -1687,23 +1340,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
-          outputOptions: expect.arrayContaining([
-            '-tune hq',
-            '-qmin 0',
-            '-rc-lookahead 20',
-            '-i_qfactor 0.75',
-            `-c:v h264_nvenc`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
-            '-preset p1',
-            '-cq:v 23',
-          ]),
+          outputOptions: expect.not.stringContaining('-maxrate'),
           twoPass: false,
         },
       );
@@ -1722,22 +1359,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
-          outputOptions: expect.arrayContaining([
-            '-tune hq',
-            '-qmin 0',
-            '-rc-lookahead 20',
-            '-i_qfactor 0.75',
-            `-c:v h264_nvenc`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
-            '-cq:v 23',
-          ]),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-preset')]),
           twoPass: false,
         },
       );
@@ -1753,23 +1375,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
-          outputOptions: expect.arrayContaining([
-            '-tune hq',
-            '-qmin 0',
-            '-rc-lookahead 20',
-            '-i_qfactor 0.75',
-            `-c:v h264_nvenc`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload_cuda,scale_cuda=-2:720',
-            '-preset p1',
-            '-cq:v 23',
-          ]),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-multipass')]),
           twoPass: false,
         },
       );
@@ -1829,23 +1435,7 @@ describe(MediaService.name, () => {
             '-init_hw_device qsv=hw,child_device=/dev/dri/renderD128',
             '-filter_hw_device hw',
           ]),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_qsv`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-bf 7',
-            '-refs 5',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=-1:720',
-            '-preset 7',
-            '-global_quality 23',
-            '-maxrate 10000k',
-            '-bufsize 20000k',
-          ]),
+          outputOptions: expect.any(Array),
           twoPass: false,
         },
       );
@@ -1865,20 +1455,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_qsv`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-bf 7',
-            '-refs 5',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=-1:720',
-            '-global_quality 23',
-          ]),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-preset')]),
           twoPass: false,
         },
       );
@@ -1898,22 +1475,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
-          outputOptions: expect.arrayContaining([
-            `-c:v vp9_qsv`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-bf 7',
-            '-refs 5',
-            '-g 256',
-            '-low_power 1',
-            '-v verbose',
-            '-vf format=nv12,hwupload=extra_hw_frames=64,scale_qsv=-1:720',
-            '-preset 7',
-            '-q:v 23',
-          ]),
+          outputOptions: expect.arrayContaining(['-low_power 1']),
           twoPass: false,
         },
       );
@@ -1928,13 +1490,10 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).not.toHaveBeenCalled();
     });
 
-    it('should set vbr options for vaapi when max bitrate is enabled', async () => {
+    it('should set options for vaapi', async () => {
       storageMock.readdir.mockResolvedValue(['renderD128']);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      configMock.load.mockResolvedValue([
-        { key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.VAAPI },
-        { key: SystemConfigKey.FFMPEG_MAX_BITRATE, value: '10000k' },
-      ]);
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.VAAPI }]);
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await sut.handleVideoConversion({ id: assetStub.video.id });
       expect(mediaMock.transcode).toHaveBeenCalledWith(
@@ -1956,6 +1515,32 @@ describe(MediaService.name, () => {
             '-v verbose',
             '-vf format=nv12,hwupload,scale_vaapi=-2:720',
             '-compression_level 7',
+            '-rc_mode 1',
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should set vbr options for vaapi when max bitrate is enabled', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128']);
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      configMock.load.mockResolvedValue([
+        { key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.VAAPI },
+        { key: SystemConfigKey.FFMPEG_MAX_BITRATE, value: '10000k' },
+      ]);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining([
+            '-init_hw_device vaapi=accel:/dev/dri/renderD128',
+            '-filter_hw_device accel',
+          ]),
+          outputOptions: expect.arrayContaining([
+            `-c:v h264_vaapi`,
             '-b:v 6897k',
             '-maxrate 10000k',
             '-minrate 3448.5k',
@@ -1983,14 +1568,6 @@ describe(MediaService.name, () => {
           outputOptions: expect.arrayContaining([
             `-c:v h264_vaapi`,
             '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload,scale_vaapi=-2:720',
-            '-compression_level 7',
             '-qp 23',
             '-global_quality 23',
             '-rc_mode 1',
@@ -2017,20 +1594,7 @@ describe(MediaService.name, () => {
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
           ]),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_vaapi`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload,scale_vaapi=-2:720',
-            '-qp 23',
-            '-global_quality 23',
-            '-rc_mode 1',
-          ]),
+          outputOptions: expect.not.arrayContaining([expect.stringContaining('-compression_level')]),
           twoPass: false,
         },
       );
@@ -2050,21 +1614,7 @@ describe(MediaService.name, () => {
             '-init_hw_device vaapi=accel:/dev/dri/card1',
             '-filter_hw_device accel',
           ]),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_vaapi`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload,scale_vaapi=-2:720',
-            '-compression_level 7',
-            '-qp 23',
-            '-global_quality 23',
-            '-rc_mode 1',
-          ]),
+          outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
         },
       );
@@ -2084,21 +1634,7 @@ describe(MediaService.name, () => {
             '-init_hw_device vaapi=accel:/dev/dri/renderD130',
             '-filter_hw_device accel',
           ]),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_vaapi`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload,scale_vaapi=-2:720',
-            '-compression_level 7',
-            '-qp 23',
-            '-global_quality 23',
-            '-rc_mode 1',
-          ]),
+          outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
         },
       );
@@ -2121,21 +1657,7 @@ describe(MediaService.name, () => {
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
           ]),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_vaapi`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf format=nv12,hwupload,scale_vaapi=-2:720',
-            '-compression_level 7',
-            '-qp 23',
-            '-global_quality 23',
-            '-rc_mode 1',
-          ]),
+          outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
         },
       );
@@ -2153,19 +1675,8 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: [],
-          outputOptions: expect.arrayContaining([
-            '-c:v h264',
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-v verbose',
-            '-vf scale=-2:720,format=yuv420p',
-            '-preset ultrafast',
-            '-crf 23',
-          ]),
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264']),
           twoPass: false,
         },
       );
@@ -2178,6 +1689,36 @@ describe(MediaService.name, () => {
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await expect(sut.handleVideoConversion({ id: assetStub.video.id })).resolves.toBe(JobStatus.FAILED);
       expect(mediaMock.transcode).not.toHaveBeenCalled();
+    });
+
+    it('should set options for rkmpp', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128']);
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      configMock.load.mockResolvedValue([{ key: SystemConfigKey.FFMPEG_ACCEL, value: TranscodeHWAccel.RKMPP }]);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
+          outputOptions: expect.arrayContaining([
+            `-c:v h264_rkmpp`,
+            '-c:a copy',
+            '-movflags faststart',
+            '-fps_mode passthrough',
+            '-map 0:0',
+            '-map 0:1',
+            '-g 256',
+            '-v verbose',
+            '-vf scale_rkrga=-2:720:format=nv12:afbc=1',
+            '-level 51',
+            '-rc_mode CQP',
+            '-qp_init 23',
+          ]),
+          twoPass: false,
+        },
+      );
     });
 
     it('should set vbr options for rkmpp when max bitrate is enabled', async () => {
@@ -2195,21 +1736,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
-          outputOptions: expect.arrayContaining([
-            `-c:v hevc_rkmpp`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-tag:v hvc1',
-            '-v verbose',
-            '-vf scale_rkrga=-2:720:format=nv12:afbc=1',
-            '-level 153',
-            '-rc_mode AVBR',
-            '-b:v 10000k',
-          ]),
+          outputOptions: expect.arrayContaining([`-c:v hevc_rkmpp`, '-level 153', '-rc_mode AVBR', '-b:v 10000k']),
           twoPass: false,
         },
       );
@@ -2230,20 +1757,7 @@ describe(MediaService.name, () => {
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
-          outputOptions: expect.arrayContaining([
-            `-c:v h264_rkmpp`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf scale_rkrga=-2:720:format=nv12:afbc=1',
-            '-level 51',
-            '-rc_mode CQP',
-            '-qp_init 30',
-          ]),
+          outputOptions: expect.arrayContaining([`-c:v h264_rkmpp`, '-level 51', '-rc_mode CQP', '-qp_init 30']),
           twoPass: false,
         },
       );
@@ -2266,18 +1780,9 @@ describe(MediaService.name, () => {
         {
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
           outputOptions: expect.arrayContaining([
-            `-c:v h264_rkmpp`,
-            '-c:a copy',
-            '-movflags faststart',
-            '-fps_mode passthrough',
-            '-map 0:0',
-            '-map 0:1',
-            '-g 256',
-            '-v verbose',
-            '-vf scale_rkrga=-2:720:format=p010:afbc=1,hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:r=pc:p=bt709:t=bt709:m=bt709:tonemap=hable:desat=0,hwmap=derive_device=rkmpp:mode=write:reverse=1,format=drm_prime',
-            '-level 51',
-            '-rc_mode CQP',
-            '-qp_init 30',
+            expect.stringContaining(
+              'scale_rkrga=-2:720:format=p010:afbc=1,hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:r=pc:p=bt709:t=bt709:m=bt709:tonemap=hable:desat=0,hwmap=derive_device=rkmpp:mode=write:reverse=1,format=drm_prime',
+            ),
           ]),
           twoPass: false,
         },
@@ -2294,18 +1799,11 @@ describe(MediaService.name, () => {
       '/original/path.ext',
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
-        inputOptions: [],
+        inputOptions: expect.any(Array),
         outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
-          '-movflags faststart',
-          '-fps_mode passthrough',
-          '-map 0:0',
-          '-map 0:1',
-          '-v verbose',
           '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-          '-preset ultrafast',
-          '-crf 23',
         ]),
         twoPass: false,
       },
@@ -2321,18 +1819,11 @@ describe(MediaService.name, () => {
       '/original/path.ext',
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
-        inputOptions: [],
+        inputOptions: expect.any(Array),
         outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
-          '-movflags faststart',
-          '-fps_mode passthrough',
-          '-map 0:0',
-          '-map 0:1',
-          '-v verbose',
           '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-          '-preset ultrafast',
-          '-crf 23',
         ]),
         twoPass: false,
       },
@@ -2348,18 +1839,11 @@ describe(MediaService.name, () => {
       '/original/path.ext',
       'upload/encoded-video/user-id/as/se/asset-id.mp4',
       {
-        inputOptions: [],
+        inputOptions: expect.any(Array),
         outputOptions: expect.arrayContaining([
           '-c:v h264',
           '-c:a copy',
-          '-movflags faststart',
-          '-fps_mode passthrough',
-          '-map 0:0',
-          '-map 0:1',
-          '-v verbose',
           '-vf zscale=t=linear:npl=250,tonemap=mobius:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-          '-preset ultrafast',
-          '-crf 23',
         ]),
         twoPass: false,
       },


### PR DESCRIPTION
### Description

The transcoding tests expect not only an exact set of options, but a specific order of these options. This PR uses `arrayContaining` to focus on the relevant aspect of a given test, improving clarity of intent and reducing the number of false positives when irrelevant changes are made. It tries to strike a balance of testing each codec with a broader set of flags once and testing more specific aspects with only one or two flags elsewhere.