### PR TITLE
chore(web): icon consistency and improvements

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/side-bar.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar.svelte
@@ -11,8 +11,6 @@
     mdiArchiveArrowDownOutline,
     mdiHeart,
     mdiHeartOutline,
-    mdiHeartMultiple,
-    mdiHeartMultipleOutline,
     mdiImageAlbum,
     mdiImageMultiple,
     mdiImageMultipleOutline,
@@ -37,7 +35,6 @@
     }
   };
 
-  let isAlbumsSelected: boolean;
   let isArchiveSelected: boolean;
   let isFavoritesSelected: boolean;
   let isMapSelected: boolean;

--- a/web/src/lib/components/shared-components/side-bar/side-bar.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar.svelte
@@ -4,9 +4,13 @@
   import { getAlbumCount, getAssetStatistics } from '@immich/sdk';
   import {
     mdiAccount,
+    mdiAccountOutline,
     mdiAccountMultiple,
     mdiAccountMultipleOutline,
+    mdiArchiveArrowDown,
     mdiArchiveArrowDownOutline,
+    mdiHeart,
+    mdiHeartOutline,
     mdiHeartMultiple,
     mdiHeartMultipleOutline,
     mdiImageAlbum,
@@ -14,6 +18,8 @@
     mdiImageMultipleOutline,
     mdiMagnify,
     mdiMap,
+    mdiMapOutline,
+    mdiTrashCan,
     mdiTrashCanOutline,
   } from '@mdi/js';
   import LoadingSpinner from '../loading-spinner.svelte';
@@ -31,9 +37,14 @@
     }
   };
 
+  let isAlbumsSelected: boolean;
+  let isArchiveSelected: boolean;
   let isFavoritesSelected: boolean;
+  let isMapSelected: boolean;
+  let isPeopleSelected: boolean;
   let isPhotosSelected: boolean;
   let isSharingSelected: boolean;
+  let isTrashSelected: boolean;
 </script>
 
 <SideBarSection>
@@ -60,11 +71,21 @@
     {/if}
 
     {#if $featureFlags.map}
-      <SideBarLink title="Map" routeId="/(user)/map" icon={mdiMap} />
+      <SideBarLink
+        title="Map"
+        routeId="/(user)/map"
+        bind:isSelected={isMapSelected}
+        icon={isMapSelected ? mdiMap : mdiMapOutline}
+      />
     {/if}
 
     {#if $sidebarSettings.people}
-      <SideBarLink title="People" routeId="/(user)/people" icon={mdiAccount} />
+      <SideBarLink
+        title="People"
+        routeId="/(user)/people"
+        bind:isSelected={isPeopleSelected}
+        icon={isPeopleSelected ? mdiAccount : mdiAccountOutline}
+      />
     {/if}
     {#if $sidebarSettings.sharing}
       <SideBarLink
@@ -92,7 +113,7 @@
     <SideBarLink
       title="Favorites"
       routeId="/(user)/favorites"
-      icon={isFavoritesSelected ? mdiHeartMultiple : mdiHeartMultipleOutline}
+      icon={isFavoritesSelected ? mdiHeart : mdiHeartOutline}
       bind:isSelected={isFavoritesSelected}
     >
       <svelte:fragment slot="moreInformation">
@@ -118,7 +139,12 @@
       </svelte:fragment>
     </SideBarLink>
 
-    <SideBarLink title="Archive" routeId="/(user)/archive" icon={mdiArchiveArrowDownOutline}>
+    <SideBarLink
+      title="Archive"
+      routeId="/(user)/archive"
+      bind:isSelected={isArchiveSelected}
+      icon={isArchiveSelected ? mdiArchiveArrowDown : mdiArchiveArrowDownOutline}
+    >
       <svelte:fragment slot="moreInformation">
         {#await getStats({ isArchived: true })}
           <LoadingSpinner />
@@ -132,7 +158,12 @@
     </SideBarLink>
 
     {#if $featureFlags.trash}
-      <SideBarLink title="Trash" routeId="/(user)/trash" icon={mdiTrashCanOutline}>
+      <SideBarLink
+        title="Trash"
+        routeId="/(user)/trash"
+        bind:isSelected={isTrashSelected}
+        icon={isTrashSelected ? mdiTrashCan : mdiTrashCanOutline}
+      >
         <svelte:fragment slot="moreInformation">
           {#await getStats({ isTrashed: true })}
             <LoadingSpinner />


### PR DESCRIPTION
Add change from outline to regular icon in sidebar when page selected to more of the icons (previously only applied to Photos, Sharing, and Favorites). Also change Favorites to single heart consistent with mobile app. (I can change anything if y'all would like.)