### PR TITLE
fix(web): uploading directly to album spams notification feed

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -41,7 +41,7 @@
         });
       } else if ($successCounter > 0) {
         notificationController.show({
-          message: 'Upload success, refresh the page to see new upload assets.',
+          message: `Uploaded ${$successCounter} assets successfully, refresh the page to see new upload assets.`,
           type: NotificationType.Info,
         });
       }

--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -41,7 +41,7 @@
         });
       } else if ($successCounter > 0) {
         notificationController.show({
-          message: `Uploaded ${$successCounter} assets successfully, refresh the page to see new upload assets.`,
+          message: `Uploaded ${$successCounter} asset${$successCounter > 1 ? 's' : ''} successfully, refresh the page to see new upload assets.`,
           type: NotificationType.Info,
         });
       }

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -25,27 +25,12 @@ import { get } from 'svelte/store';
 import { handleError } from './handle-error';
 
 export const addAssetsToAlbum = async (albumId: string, assetIds: string[]) => {
-  const result = await addAssets({
+  await addAssets({
     id: albumId,
     bulkIdsDto: {
       ids: assetIds,
     },
     key: getKey(),
-  });
-  const count = result.filter(({ success }) => success).length;
-  notificationController.show({
-    type: NotificationType.Info,
-    timeout: 5000,
-    message:
-      count > 0
-        ? `Added ${count} asset${count === 1 ? '' : 's'} to the album`
-        : `Asset${assetIds.length === 1 ? ' was' : 's were'} already part of the album`,
-    button: {
-      text: 'View Album',
-      onClick() {
-        return goto(`${AppRoute.ALBUMS}/${albumId}`);
-      },
-    },
   });
 };
 

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -25,12 +25,27 @@ import { get } from 'svelte/store';
 import { handleError } from './handle-error';
 
 export const addAssetsToAlbum = async (albumId: string, assetIds: string[]) => {
-  await addAssets({
+  const result = await addAssets({
     id: albumId,
     bulkIdsDto: {
       ids: assetIds,
     },
     key: getKey(),
+  });
+  const count = result.filter(({ success }) => success).length;
+  notificationController.show({
+    type: NotificationType.Info,
+    timeout: 5000,
+    message:
+      count > 0
+        ? `Added ${count} asset${count === 1 ? '' : 's'} to the album`
+        : `Asset${assetIds.length === 1 ? ' was' : 's were'} already part of the album`,
+    button: {
+      text: 'View Album',
+      onClick() {
+        return goto(`${AppRoute.ALBUMS}/${albumId}`);
+      },
+    },
   });
 };
 

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -291,7 +291,7 @@
       const count = results.filter(({ success }) => success).length;
       notificationController.show({
         type: NotificationType.Info,
-        message: `Added ${count} asset${count === 1 ? '' : 's'}`,
+        message: `Added ${count} asset${count > 1 ? 's' : ''} successfully, refresh the page to see newly added asset${count > 1 ? 's' : ''}.`,
       });
 
       await refreshAlbum();


### PR DESCRIPTION
Fix for https://github.com/immich-app/immich/issues/6102 

- Removed multiple invocations of notification.
- Added count to final notification which appears at the end of upload process.
- Retained the (in my opinion) more useful popup bottom right which displays individual item progress.


Used a few assets from [here](https://github.com/loganmarchione/homelab-svg-assets) for the gif below.

Gif shows adding assets both during new gallery creation and adding assets to existing album.

![immich-album](https://github.com/immich-app/immich/assets/91856576/6755f452-c6bd-4054-8916-84a6cc48ab54)
