### PR TITLE
fix(web): prevent navigation from overlapping video controls

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -600,7 +600,7 @@
     {/if}
 
     {#if $slideshowState === SlideshowState.None && showNavigation}
-      <div class="z-[1001] column-span-1 col-start-1 row-span-1 row-start-2 justify-self-start">
+      <div class="z-[1001] column-span-1 col-start-1 row-span-1 row-start-2 mb-[128px] justify-self-start">
         <NavigationArea onClick={(e) => navigateAsset('previous', e)} label="View previous asset">
           <Icon path={mdiChevronLeft} size="36" ariaHidden />
         </NavigationArea>
@@ -691,7 +691,7 @@
     </div>
 
     {#if $slideshowState === SlideshowState.None && showNavigation}
-      <div class="z-[1001] col-span-1 col-start-4 row-span-1 row-start-2 justify-self-end">
+      <div class="z-[1001] col-span-1 col-start-4 row-span-1 row-start-2 mb-[128px] justify-self-end">
         <NavigationArea onClick={(e) => navigateAsset('next', e)} label="View next asset">
           <Icon path={mdiChevronRight} size="36" ariaHidden />
         </NavigationArea>

--- a/web/src/lib/components/asset-viewer/navigation-area.svelte
+++ b/web/src/lib/components/asset-viewer/navigation-area.svelte
@@ -5,7 +5,7 @@
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="group flex h-full place-items-center hover:cursor-pointer" on:click={onClick}>
+<div class="group flex h-full pt-[64px] place-items-center hover:cursor-pointer" on:click={onClick}>
   <button
     class="mx-4 rounded-full p-3 text-gray-500 transition group-hover:bg-gray-500 group-hover:text-white"
     aria-label={label}

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -29,8 +29,7 @@
 
 <div
   transition:fade={{ duration: 150 }}
-  class="flex select-none place-content-center place-items-center"
-  style="height: calc(100% - 64px)"
+  class="flex h-full pb-[64px] select-none place-content-center place-items-center"
 >
   <video
     bind:this={element}


### PR DESCRIPTION
Fixes #9405, fixes #9174.

Can't really say I like how the fix is done but there are a couple challenges here:
* ActivityStatus component takes up real estate
  * it's not always shown
* To accommodate for that, video controls have to be shifted up
* Navigation areas have to account for that
* Navigation area icon should stay centered

In my opinion there are several things that could be done differently:
* ActivityStatus component should be implemented differently and not be floating in the bottom right. I'm no designer though so it stays where it is.
  * the video container wouldn't need any bottom margins
* The navigation bars shouldn't have bottom margins
  * but then how do we ensure video controls are accessible?

Then there's also mobile and video aspect ratio/viewport aspect ratio to consider. At the moment this change causes the navigation area to be even smaller (since the bottom margins have been doubled):

![image](https://github.com/immich-app/immich/assets/5608270/f46aea85-5f0f-4e69-af7d-5a4102cad496)
