### PR TITLE
fix(server): put system config

### DIFF
--- a/e2e/src/api/specs/system-config.e2e-spec.ts
+++ b/e2e/src/api/specs/system-config.e2e-spec.ts
@@ -86,6 +86,26 @@ describe('/system-config', () => {
       expect(body).toEqual(errorDto.unauthorized);
     });
 
+    it('should always return the new config', async () => {
+      const config = await getSystemConfig(admin.accessToken);
+
+      const response1 = await request(app)
+        .put('/system-config')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .send({ ...config, newVersionCheck: { enabled: false } });
+
+      expect(response1.status).toBe(200);
+      expect(response1.body).toEqual({ ...config, newVersionCheck: { enabled: false } });
+
+      const response2 = await request(app)
+        .put('/system-config')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .send({ ...config, newVersionCheck: { enabled: true } });
+
+      expect(response2.status).toBe(200);
+      expect(response2.body).toEqual({ ...config, newVersionCheck: { enabled: true } });
+    });
+
     it('should reject an invalid config entry', async () => {
       const { status, body } = await request(app)
         .put('/system-config')

--- a/server/src/cores/system-config.core.ts
+++ b/server/src/cores/system-config.core.ts
@@ -321,7 +321,7 @@ export class SystemConfigCore {
       await this.repository.deleteKeys(deletes.map((item) => item.key));
     }
 
-    const config = await this.getConfig();
+    const config = await this.getConfig(true);
 
     this.config$.next(config);
 


### PR DESCRIPTION
Don't use/read the cached config when returning it in the update endpoint.