### PR TITLE
feat(server): fully accelerated nvenc

### DIFF
--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -1,9 +1,7 @@
-version: "3.8"
-
 # Configurations for hardware-accelerated machine learning
 
 # If using Unraid or another platform that doesn't allow multiple Compose files,
-# you can inline the config for a backend by copying its contents 
+# you can inline the config for a backend by copying its contents
 # into the immich-machine-learning service in the docker-compose.yml file.
 
 # See https://immich.app/docs/features/ml-hardware-acceleration for info on usage.
@@ -30,7 +28,7 @@ services:
 
   openvino:
     device_cgroup_rules:
-      - "c 189:* rmw"
+      - 'c 189:* rmw'
     devices:
       - /dev/dri:/dev/dri
     volumes:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: '3.8'
 
 # Configurations for hardware-accelerated transcoding
 
@@ -12,6 +12,9 @@ services:
   cpu: {}
 
   nvenc:
+    runtime: nvidia
+    environment:
+      - DISPLAY:$DISPLAY
     deploy:
       resources:
         reservations:
@@ -22,6 +25,8 @@ services:
                 - gpu
                 - compute
                 - video
+                - display
+                - graphics
 
   quicksync:
     devices:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -10,9 +10,6 @@ services:
   cpu: {}
 
   nvenc:
-    runtime: nvidia
-    environment:
-      - DISPLAY:$DISPLAY
     deploy:
       resources:
         reservations:
@@ -23,8 +20,6 @@ services:
                 - gpu
                 - compute
                 - video
-                - display
-                - graphics
 
   quicksync:
     devices:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Configurations for hardware-accelerated transcoding
 
 # If using Unraid or another platform that doesn't allow multiple Compose files,

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -22,7 +22,8 @@ You do not need to redo any transcoding jobs after enabling hardware acceleratio
 - WSL2 does not support Quick Sync.
 - Raspberry Pi is currently not supported.
 - Two-pass mode is only supported for NVENC. Other APIs will ignore this setting.
-- Only encoding is currently hardware accelerated, so the CPU is still used for software decoding and tone-mapping.
+- By default, only encoding is currently hardware accelerated. This means the CPU is still used for software decoding and tone-mapping.
+  - NVENC and RKMPP can be fully accelerated by enabling hardware decoding in the video transcoding settings.
 - Hardware dependent
   - Codec support varies, but H.264 and HEVC are usually supported.
     - Notably, NVIDIA and AMD GPUs do not support VP9 encoding.
@@ -65,6 +66,7 @@ For RKMPP to work:
 
 3. Redeploy the `immich-microservices` container with these updated settings.
 4. In the Admin page under `Video transcoding settings`, change the hardware acceleration setting to the appropriate option and save.
+5. (Optional) If using a compatible backend, you may enable hardware decoding for optimal performance.
 
 #### Single Compose File
 

--- a/mobile/openapi/doc/SystemConfigFFmpegDto.md
+++ b/mobile/openapi/doc/SystemConfigFFmpegDto.md
@@ -9,6 +9,7 @@ import 'package:openapi/api.dart';
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **accel** | [**TranscodeHWAccel**](TranscodeHWAccel.md) |  | 
+**accelDecode** | **bool** |  | 
 **acceptedAudioCodecs** | [**List<AudioCodec>**](AudioCodec.md) |  | [default to const []]
 **acceptedVideoCodecs** | [**List<VideoCodec>**](VideoCodec.md) |  | [default to const []]
 **bframes** | **int** |  | 

--- a/mobile/openapi/lib/model/system_config_f_fmpeg_dto.dart
+++ b/mobile/openapi/lib/model/system_config_f_fmpeg_dto.dart
@@ -14,6 +14,7 @@ class SystemConfigFFmpegDto {
   /// Returns a new [SystemConfigFFmpegDto] instance.
   SystemConfigFFmpegDto({
     required this.accel,
+    required this.accelDecode,
     this.acceptedAudioCodecs = const [],
     this.acceptedVideoCodecs = const [],
     required this.bframes,
@@ -36,6 +37,8 @@ class SystemConfigFFmpegDto {
   });
 
   TranscodeHWAccel accel;
+
+  bool accelDecode;
 
   List<AudioCodec> acceptedAudioCodecs;
 
@@ -87,6 +90,7 @@ class SystemConfigFFmpegDto {
   @override
   bool operator ==(Object other) => identical(this, other) || other is SystemConfigFFmpegDto &&
     other.accel == accel &&
+    other.accelDecode == accelDecode &&
     _deepEquality.equals(other.acceptedAudioCodecs, acceptedAudioCodecs) &&
     _deepEquality.equals(other.acceptedVideoCodecs, acceptedVideoCodecs) &&
     other.bframes == bframes &&
@@ -111,6 +115,7 @@ class SystemConfigFFmpegDto {
   int get hashCode =>
     // ignore: unnecessary_parenthesis
     (accel.hashCode) +
+    (accelDecode.hashCode) +
     (acceptedAudioCodecs.hashCode) +
     (acceptedVideoCodecs.hashCode) +
     (bframes.hashCode) +
@@ -132,11 +137,12 @@ class SystemConfigFFmpegDto {
     (twoPass.hashCode);
 
   @override
-  String toString() => 'SystemConfigFFmpegDto[accel=$accel, acceptedAudioCodecs=$acceptedAudioCodecs, acceptedVideoCodecs=$acceptedVideoCodecs, bframes=$bframes, cqMode=$cqMode, crf=$crf, gopSize=$gopSize, maxBitrate=$maxBitrate, npl=$npl, preferredHwDevice=$preferredHwDevice, preset=$preset, refs=$refs, targetAudioCodec=$targetAudioCodec, targetResolution=$targetResolution, targetVideoCodec=$targetVideoCodec, temporalAQ=$temporalAQ, threads=$threads, tonemap=$tonemap, transcode=$transcode, twoPass=$twoPass]';
+  String toString() => 'SystemConfigFFmpegDto[accel=$accel, accelDecode=$accelDecode, acceptedAudioCodecs=$acceptedAudioCodecs, acceptedVideoCodecs=$acceptedVideoCodecs, bframes=$bframes, cqMode=$cqMode, crf=$crf, gopSize=$gopSize, maxBitrate=$maxBitrate, npl=$npl, preferredHwDevice=$preferredHwDevice, preset=$preset, refs=$refs, targetAudioCodec=$targetAudioCodec, targetResolution=$targetResolution, targetVideoCodec=$targetVideoCodec, temporalAQ=$temporalAQ, threads=$threads, tonemap=$tonemap, transcode=$transcode, twoPass=$twoPass]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'accel'] = this.accel;
+      json[r'accelDecode'] = this.accelDecode;
       json[r'acceptedAudioCodecs'] = this.acceptedAudioCodecs;
       json[r'acceptedVideoCodecs'] = this.acceptedVideoCodecs;
       json[r'bframes'] = this.bframes;
@@ -168,6 +174,7 @@ class SystemConfigFFmpegDto {
 
       return SystemConfigFFmpegDto(
         accel: TranscodeHWAccel.fromJson(json[r'accel'])!,
+        accelDecode: mapValueOfType<bool>(json, r'accelDecode')!,
         acceptedAudioCodecs: AudioCodec.listFromJson(json[r'acceptedAudioCodecs']),
         acceptedVideoCodecs: VideoCodec.listFromJson(json[r'acceptedVideoCodecs']),
         bframes: mapValueOfType<int>(json, r'bframes')!,
@@ -235,6 +242,7 @@ class SystemConfigFFmpegDto {
   /// The list of required keys that must be present in a JSON.
   static const requiredKeys = <String>{
     'accel',
+    'accelDecode',
     'acceptedAudioCodecs',
     'acceptedVideoCodecs',
     'bframes',

--- a/mobile/openapi/test/system_config_f_fmpeg_dto_test.dart
+++ b/mobile/openapi/test/system_config_f_fmpeg_dto_test.dart
@@ -21,6 +21,11 @@ void main() {
       // TODO
     });
 
+    // bool accelDecode
+    test('to test the property `accelDecode`', () async {
+      // TODO
+    });
+
     // List<AudioCodec> acceptedAudioCodecs (default value: const [])
     test('to test the property `acceptedAudioCodecs`', () async {
       // TODO

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -9999,6 +9999,9 @@
           "accel": {
             "$ref": "#/components/schemas/TranscodeHWAccel"
           },
+          "accelDecode": {
+            "type": "boolean"
+          },
           "acceptedAudioCodecs": {
             "items": {
               "$ref": "#/components/schemas/AudioCodec"
@@ -10074,6 +10077,7 @@
         },
         "required": [
           "accel",
+          "accelDecode",
           "acceptedAudioCodecs",
           "acceptedVideoCodecs",
           "bframes",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -861,6 +861,7 @@ export type AssetFullSyncDto = {
 };
 export type SystemConfigFFmpegDto = {
     accel: TranscodeHWAccel;
+    accelDecode: boolean;
     acceptedAudioCodecs: AudioCodec[];
     acceptedVideoCodecs: VideoCodec[];
     bframes: number;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -97,7 +97,7 @@ export interface SystemConfig {
     preferredHwDevice: string;
     transcode: TranscodePolicy;
     accel: TranscodeHWAccel;
-    accelDecode: false;
+    accelDecode: boolean;
     tonemap: ToneMapping;
   };
   job: Record<ConcurrentQueueName, { concurrency: number }>;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -97,6 +97,7 @@ export interface SystemConfig {
     preferredHwDevice: string;
     transcode: TranscodePolicy;
     accel: TranscodeHWAccel;
+    accelDecode: false;
     tonemap: ToneMapping;
   };
   job: Record<ConcurrentQueueName, { concurrency: number }>;
@@ -224,6 +225,7 @@ export const defaults = Object.freeze<SystemConfig>({
     transcode: TranscodePolicy.REQUIRED,
     tonemap: ToneMapping.HABLE,
     accel: TranscodeHWAccel.DISABLED,
+    accelDecode: false,
   },
   job: {
     [QueueName.BACKGROUND_TASK]: { concurrency: 5 },

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -132,6 +132,9 @@ export class SystemConfigFFmpegDto {
   @ApiProperty({ enumName: 'TranscodeHWAccel', enum: TranscodeHWAccel })
   accel!: TranscodeHWAccel;
 
+  @ValidateBoolean()
+  accelDecode!: boolean;
+
   @IsEnum(ToneMapping)
   @ApiProperty({ enumName: 'ToneMapping', enum: ToneMapping })
   tonemap!: ToneMapping;

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1335,6 +1335,94 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should use hardware decoding for nvenc if enabled', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'hwupload=derive_device=vulkan,scale_vulkan=w=1280:h=720,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:tonemapping=clip:upscaler=none,hwupload=derive_device=cuda',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use hardware tone-mapping for nvenc if hardware decoding is enabled and should tone map', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:tonemapping=hable:upscaler=none,hwupload=derive_device=cuda',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use hardware decoding for nvenc if enabled', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true, crf: 30 },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'hwupload=derive_device=vulkan,scale_vulkan=w=1280:h=720,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:tonemapping=clip:upscaler=none,hwupload=derive_device=cuda',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use hardware tone-mapping for nvenc if hardware decoding is enabled and should tone map', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true, crf: 30 },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:tonemapping=hable:upscaler=none,hwupload=derive_device=cuda',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
     it('should set options for qsv', async () => {
       storageMock.readdir.mockResolvedValue(['renderD128']);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
@@ -1634,7 +1722,7 @@ describe(MediaService.name, () => {
     it('should set options for rkmpp', async () => {
       storageMock.readdir.mockResolvedValue(['renderD128']);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      systemMock.get.mockResolvedValue({ ffmpeg: { accel: TranscodeHWAccel.RKMPP } });
+      systemMock.get.mockResolvedValue({ ffmpeg: { accel: TranscodeHWAccel.RKMPP, accelDecode: true } });
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await sut.handleVideoConversion({ id: assetStub.video.id });
       expect(mediaMock.transcode).toHaveBeenCalledWith(
@@ -1667,6 +1755,7 @@ describe(MediaService.name, () => {
       systemMock.get.mockResolvedValue({
         ffmpeg: {
           accel: TranscodeHWAccel.RKMPP,
+          accelDecode: true,
           maxBitrate: '10000k',
           targetVideoCodec: VideoCodec.HEVC,
         },
@@ -1718,6 +1807,30 @@ describe(MediaService.name, () => {
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
               'scale_rkrga=-2:720:format=p010:afbc=1,hwmap=derive_device=opencl:mode=read,tonemap_opencl=format=nv12:r=pc:p=bt709:t=bt709:m=bt709:tonemap=hable:desat=0,hwmap=derive_device=rkmpp:mode=write:reverse=1,format=drm_prime',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use software decoding and tone-mapping if hardware decoding is disabled', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128']);
+      storageMock.stat.mockResolvedValue({ ...new Stats(), isFile: () => true, isCharacterDevice: () => true });
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.RKMPP, accelDecode: false, crf: 30, maxBitrate: '0' },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: [],
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
             ),
           ]),
           twoPass: false,

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1384,50 +1384,6 @@ describe(MediaService.name, () => {
       );
     });
 
-    it('should use hardware decoding for nvenc if enabled', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
-      systemMock.get.mockResolvedValue({
-        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true },
-      });
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
-          outputOptions: expect.arrayContaining([
-            expect.stringContaining(
-              'scale_cuda=-2:720,hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:peak_detect=true:tonemapping=clip:upscaler=none,hwupload=derive_device=cuda',
-            ),
-          ]),
-          twoPass: false,
-        },
-      );
-    });
-
-    it('should use hardware tone-mapping for nvenc if hardware decoding is enabled and should tone map', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
-      systemMock.get.mockResolvedValue({
-        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true },
-      });
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
-          outputOptions: expect.arrayContaining([
-            expect.stringContaining(
-              'hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:peak_detect=true:tonemapping=hable:upscaler=none,hwupload=derive_device=cuda',
-            ),
-          ]),
-          twoPass: false,
-        },
-      );
-    });
-
     it('should use disable peak detection for nvenc when tone mapping and temporal AQ is enabled', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
       systemMock.get.mockResolvedValue({

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1352,11 +1352,7 @@ describe(MediaService.name, () => {
             '-noautorotate',
             '-threads 1',
           ]),
-          outputOptions: expect.arrayContaining([
-            expect.stringContaining(
-              'scale_cuda=-2:720,hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:peak_detect=true:tonemapping=clip:upscaler=none,hwupload=derive_device=cuda',
-            ),
-          ]),
+          outputOptions: expect.arrayContaining([expect.stringContaining('scale_cuda=-2:720:format=nv12')]),
           twoPass: false,
         },
       );
@@ -1376,27 +1372,9 @@ describe(MediaService.name, () => {
           inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
-              'hwupload=derive_device=vulkan,libplacebo=color_primaries=bt709:color_trc=bt709:colorspace=bt709:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6:downscaler=none:format=yuv420p:peak_detect=true:tonemapping=hable:upscaler=none,hwupload=derive_device=cuda',
+              'tonemap_cuda=desat=0:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709:format=nv12',
             ),
           ]),
-          twoPass: false,
-        },
-      );
-    });
-
-    it('should use disable peak detection for nvenc when tone mapping and temporal AQ is enabled', async () => {
-      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
-      systemMock.get.mockResolvedValue({
-        ffmpeg: { accel: TranscodeHWAccel.NVENC, accelDecode: true, temporalAQ: true },
-      });
-      assetMock.getByIds.mockResolvedValue([assetStub.video]);
-      await sut.handleVideoConversion({ id: assetStub.video.id });
-      expect(mediaMock.transcode).toHaveBeenCalledWith(
-        '/original/path.ext',
-        'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
-          inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
-          outputOptions: expect.arrayContaining([expect.stringContaining('peak_detect=false')]),
           twoPass: false,
         },
       );

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -362,8 +362,7 @@ export class MediaService {
           `Error occurred during transcoding. Retrying with ${config.accel.toUpperCase()} acceleration disabled.`,
         );
       }
-      config.accel = TranscodeHWAccel.DISABLED;
-      transcodeOptions = await this.getCodecConfig(config).then((c) =>
+      transcodeOptions = await this.getCodecConfig({ ...config, accel: TranscodeHWAccel.DISABLED }).then((c) =>
         c.getOptions(target, mainVideoStream, mainAudioStream),
       );
       await this.mediaRepository.transcode(input, output, transcodeOptions);

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -36,9 +36,11 @@ import {
   AV1Config,
   H264Config,
   HEVCConfig,
-  NVENCConfig,
+  NvencHwDecodeConfig,
+  NvencSwDecodeConfig,
   QSVConfig,
-  RKMPPConfig,
+  RkmppHwDecodeConfig,
+  RkmppSwDecodeConfig,
   ThumbnailConfig,
   VAAPIConfig,
   VP9Config,
@@ -494,7 +496,7 @@ export class MediaService {
     let handler: VideoCodecHWConfig;
     switch (config.accel) {
       case TranscodeHWAccel.NVENC: {
-        handler = new NVENCConfig(config);
+        handler = config.accelDecode ? new NvencHwDecodeConfig(config) : new NvencSwDecodeConfig(config);
         break;
       }
       case TranscodeHWAccel.QSV: {
@@ -506,7 +508,10 @@ export class MediaService {
         break;
       }
       case TranscodeHWAccel.RKMPP: {
-        handler = new RKMPPConfig(config, await this.getDevices(), await this.hasOpenCL());
+        handler =
+          config.accelDecode && (await this.hasOpenCL())
+            ? new RkmppHwDecodeConfig(config, await this.getDevices())
+            : new RkmppSwDecodeConfig(config, await this.getDevices());
         break;
       }
       default: {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -66,6 +66,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     preferredHwDevice: 'auto',
     transcode: TranscodePolicy.REQUIRED,
     accel: TranscodeHWAccel.DISABLED,
+    accelDecode: false,
     tonemap: ToneMapping.HABLE,
   },
   logging: {

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -466,7 +466,7 @@ export class NVENCConfig extends BaseHWConfig {
 
     return [
       'hwupload=derive_device=vulkan',
-      `libplacebo=tonemapping=${this.config.tonemap}:colorspace=${colors.matrix}:color_primaries=${colors.primaries}:color_trc=${colors.transfer}:format=yuv420p:range=pc:downscaler=lanczos:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6`,
+      `libplacebo=tonemapping=${this.config.tonemap}:colorspace=${colors.matrix}:color_primaries=${colors.primaries}:color_trc=${colors.transfer}:format=yuv420p:upscaler=none:downscaler=none:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6`,
       'hwupload=derive_device=cuda',
     ];
   }

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -440,7 +440,7 @@ export class NVENCConfig extends BaseHWConfig {
   }
 
   getBaseInputOptions() {
-    return ['-hwaccel cuda', '-hwaccel_output_format cuda'];
+    return ['-hwaccel cuda', '-hwaccel_output_format cuda', ...this.getThreadOptions()];
   }
 
   getBaseOutputOptions(target: TranscodeTarget, videoStream: VideoStreamInfo, audioStream?: AudioStreamInfo) {
@@ -464,10 +464,9 @@ export class NVENCConfig extends BaseHWConfig {
   getToneMapping() {
     const colors = this.getColors();
 
-    // https://stackoverflow.com/a/65542002
     return [
       'hwupload=derive_device=vulkan',
-      `libplacebo=tonemapping=${this.config.tonemap}:colorspace=${colors.matrix}:color_primaries=${colors.primaries}:color_trc=${colors.transfer}:format=yuv420p:preset=high_quality:downscaler=lanczos`,
+      `libplacebo=tonemapping=${this.config.tonemap}:colorspace=${colors.matrix}:color_primaries=${colors.primaries}:color_trc=${colors.transfer}:format=yuv420p:range=pc:downscaler=lanczos:deband=true:deband_iterations=3:deband_radius=8:deband_threshold=6`,
       'hwupload=derive_device=cuda',
     ];
   }

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -476,7 +476,7 @@ export class NVENCConfig extends BaseHWConfig {
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     if (!this.config.accelDecode) {
-      options.push('format=nv12', 'hwupload_cuda');
+      options.push(...this.getToneMapping(videoStream), 'format=nv12', 'hwupload_cuda');
       if (this.shouldScale(videoStream)) {
         options.push(`scale_cuda=${this.getScaling(videoStream)}`);
       }

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -547,6 +547,7 @@ export class NvencHwDecodeConfig extends NvencSwDecodeConfig {
       'deband_threshold=6',
       'downscaler=none',
       'format=yuv420p',
+      `peak_detect=${this.config.temporalAQ ? 'false' : 'true'}`, // colors are distorted before a scene change when both temporal AQ and peak detection are enabled
       `tonemapping=${this.shouldToneMap(videoStream) ? this.config.tonemap : 'clip'}`,
       'upscaler=none',
     ];

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -280,7 +280,7 @@
               id="hardware-decoding"
               title="HARDWARE DECODING"
               {disabled}
-              subtitle="Applies only to NVENC and RKMPP. Whether to use hardware decoding for transcoding. May not work on all devices or videos."
+              subtitle="Applies only to NVENC and RKMPP. Enables end-to-end acceleration instead of only accelerating encoding. May not work on all videos."
               bind:checked={config.ffmpeg.accelDecode}
               isEdited={config.ffmpeg.accelDecode !== savedConfig.ffmpeg.accelDecode}
             />

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -276,6 +276,15 @@
               isEdited={config.ffmpeg.accel !== savedConfig.ffmpeg.accel}
             />
 
+            <SettingSwitch
+              id="hardware-decoding"
+              title="HARDWARE DECODING"
+              {disabled}
+              subtitle="Applies only to NVENC and RKMPP. Whether to use hardware decoding for transcoding. May not work on all devices or videos."
+              bind:checked={config.ffmpeg.accelDecode}
+              isEdited={config.ffmpeg.accelDecode !== savedConfig.ffmpeg.accelDecode}
+            />
+
             <SettingSelect
               label="CONSTANT QUALITY MODE"
               desc="ICQ is better than CQP, but some hardware acceleration devices do not support this mode. Setting this option will prefer the specified mode when using quality-based encoding. Ignored by NVENC as it does not support ICQ."
@@ -297,6 +306,7 @@
               bind:checked={config.ffmpeg.temporalAQ}
               isEdited={config.ffmpeg.temporalAQ !== savedConfig.ffmpeg.temporalAQ}
             />
+
             <SettingInputField
               inputType={SettingInputFieldType.TEXT}
               label="PREFERRED HARDWARE DEVICE"


### PR DESCRIPTION
### Description

Edit: An earlier version of this PR elected to make a breaking change here, but after some consideration I decided against it. The PR now makes hardware decoding opt-in and existing setups will continue to work. There is a new toggle for whether to use hardware decoding, applicable to NVENC and RKMPP. Since it defaults to false, the behavior is the same as current for NVENC. RKMPP will be downgraded to software decoding until the admin enables hardware decoding.

This is a smaller version of #9402 that only changes the behavior for NVENC. That PR aimed to streamline the decoding and filtering process to one pipeline by leveraging libplacebo and Vulkan's cross-device capabilities. However, this is premature due to the following reasons:

1. Vulkan is not supported on RKMPP, so a separate pipeline is still necessary for end-to-end acceleration.
2. There is a roughly 30% speed penalty on CPU compared to the more traditional pipeline, likely overhead from uploading frames to and from Vulkan.
3. Vulkan on FFmpeg is a very active area of development, and we are not able to upgrade to the newest and most feature-complete versions of FFmpeg while Jellyfin is still on 6.0. This limits the APIs and devices that can use Vulkan.
4. After speaking with Jellyfin devs, they strongly recommended against relying on it too heavily due to an above-average rate of breaking changes and poor backwards compatibility (hitting Windows primarily, but also affecting some Intel devices on Linux).

Vulkan works very well with Nvidia from my testing and has reasonable backwards compatibility (9xx series onward), so it's fine to use it here. Maybe someday it can be used more extensively, but in the meantime it's similar to this [XKCD](https://xkcd.com/927/).

### Testing

Tested transcoding a video on NVENC and CPU with tone-mapping enabled and disabled, confirming success logs and confirming the video plays (with browser caching disabled to ensure the video is up-to-date).