### PR TITLE
fix(server): smtp certificate validation

### DIFF
--- a/server/src/repositories/notification.repository.ts
+++ b/server/src/repositories/notification.repository.ts
@@ -59,7 +59,7 @@ export class NotificationRepository implements INotificationRepository {
     return createTransport({
       host: options.host,
       port: options.port,
-      tls: { rejectUnauthorized: options.ignoreCert },
+      tls: { rejectUnauthorized: !options.ignoreCert },
       auth:
         options.username || options.password
           ? {


### PR DESCRIPTION
The `Ignore certificate errors` option for email notifications works opposite to what would be expected. By default it disables certificate verification (which is insecure) and when enabled, this option actually verifies certificates. Fixes #9493