### PR TITLE
fix(ml): openvino not working with kernel 6.7.5 or later

### DIFF
--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -33,6 +33,9 @@ services:
       - /dev/dri:/dev/dri
     volumes:
       - /dev/bus/usb:/dev/bus/usb
+    environment:
+      - NEOReadDebugKeys=1
+      - OverrideGpuAddressSpace=48
 
   openvino-wsl:
     devices:
@@ -41,3 +44,6 @@ services:
     volumes:
       - /dev/bus/usb:/dev/bus/usb
       - /usr/lib/wsl:/usr/lib/wsl
+    environment:
+      - NEOReadDebugKeys=1
+      - OverrideGpuAddressSpace=48

--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -33,9 +33,6 @@ services:
       - /dev/dri:/dev/dri
     volumes:
       - /dev/bus/usb:/dev/bus/usb
-    environment:
-      - NEOReadDebugKeys=1
-      - OverrideGpuAddressSpace=48
 
   openvino-wsl:
     devices:
@@ -44,6 +41,3 @@ services:
     volumes:
       - /dev/bus/usb:/dev/bus/usb
       - /usr/lib/wsl:/usr/lib/wsl
-    environment:
-      - NEOReadDebugKeys=1
-      - OverrideGpuAddressSpace=48

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -40,6 +40,9 @@ FROM python:3.11-slim-bookworm@sha256:fc39d2e68b554c3f0a5cb8a776280c0b3d73b4c04b
 
 FROM openvino/ubuntu22_runtime:2023.3.0@sha256:176646df619032ea6c10faf842867119c393e7497b7f88b5e307e932a0fd5aa8 as prod-openvino
 USER root
+# TODO: remove this once the image has the fix for https://github.com/intel/compute-runtime/issues/710
+ENV NEOReadDebugKeys=1 \
+    OverrideGpuAddressSpace=48
 
 FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04@sha256:2d913b09e6be8387e1a10976933642c73c840c0b735f0bf3c28d97fc9bc422e0 as prod-cuda
 


### PR DESCRIPTION
## Description

There's a [bug](https://github.com/intel/compute-runtime/issues/710) in the `intel-compute-runtime` version used in the OpenVINO image. The suggested workaround is to add these environmental variables. We can remove them in the future once the image is updated with the patched release for this package.

Fixes #9523