### PR TITLE
fix: when using old script args, just set the workers include var

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -32,22 +32,21 @@ function bootstrap() {
       return bootstrapImmichAdmin();
     }
     case 'immich': {
-      process.title = 'immich_server';
       if (!process.env.IMMICH_WORKERS_INCLUDE) {
         process.env.IMMICH_WORKERS_INCLUDE = 'api';
       }
+      break;
     }
     case 'microservices': {
-      process.title = 'immich_microservices';
       if (!process.env.IMMICH_WORKERS_INCLUDE) {
         process.env.IMMICH_WORKERS_INCLUDE = 'microservices';
       }
+      break;
     }
-    default: {
-      for (const worker of getWorkers()) {
-        bootstrapWorker(worker);
-      }
-    }
+  }
+  process.title = 'immich';
+  for (const worker of getWorkers()) {
+    bootstrapWorker(worker);
   }
 }
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -33,11 +33,15 @@ function bootstrap() {
     }
     case 'immich': {
       process.title = 'immich_server';
-      return bootstrapWorker('api');
+      if (!process.env.IMMICH_WORKERS_INCLUDE) {
+        process.env.IMMICH_WORKERS_INCLUDE = 'api';
+      }
     }
     case 'microservices': {
       process.title = 'immich_microservices';
-      return bootstrapWorker('microservices');
+      if (!process.env.IMMICH_WORKERS_INCLUDE) {
+        process.env.IMMICH_WORKERS_INCLUDE = 'microservices';
+      }
     }
     default: {
       for (const worker of getWorkers()) {


### PR DESCRIPTION
Instead of directly booting a specific worker when using the old script vars, just set the IMMICH_WORKERS_INCLUDE variable if it isn't set already.
Also sets a process title when just bootstrapping workers