### PR TITLE
fix(server): Disable duplicate detection when smart search disabled

### DIFF
--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -63,7 +63,7 @@ export const isSmartSearchEnabled = (machineLearning: SystemConfig['machineLearn
 export const isFacialRecognitionEnabled = (machineLearning: SystemConfig['machineLearning']) =>
   isMachineLearningEnabled(machineLearning) && machineLearning.facialRecognition.enabled;
 export const isDuplicateDetectionEnabled = (machineLearning: SystemConfig['machineLearning']) =>
-  isMachineLearningEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
+  isMachineLearningEnabled(machineLearning) && isSmartSearchEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
 
 export const isConnectionAborted = (error: Error | any) => error.code === 'ECONNABORTED';
 

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -63,7 +63,7 @@ export const isSmartSearchEnabled = (machineLearning: SystemConfig['machineLearn
 export const isFacialRecognitionEnabled = (machineLearning: SystemConfig['machineLearning']) =>
   isMachineLearningEnabled(machineLearning) && machineLearning.facialRecognition.enabled;
 export const isDuplicateDetectionEnabled = (machineLearning: SystemConfig['machineLearning']) =>
-  isMachineLearningEnabled(machineLearning) && isSmartSearchEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
+  isSmartSearchEnabled(machineLearning) && machineLearning.duplicateDetection.enabled;
 
 export const isConnectionAborted = (error: Error | any) => error.code === 'ECONNABORTED';
 


### PR DESCRIPTION
While testing #9540, I noticed that after some changes to #8228, before it was merged, Duplicate Detection stays enabled with Smart Search disabled and Machine Learning enabled and Duplicate Detection enabled.

It was intended that any cobination of Machine Learning is disabled and/or Smart Search is disabled and/or Duplicate Detection is disabled that Duplicate Detection would be disabled. This PR accomplishes this intent.

To test this PR, I borrowed the functioning Duplicate Detection Job UI which is part of the work-in-progress Duplicate Detection UI to confirm that the change in this PR works.