### PR TITLE
chore(server): open-api generation and add example.dev.env with default IMMICH_ENV to development

### DIFF
--- a/docker/example.dev.env
+++ b/docker/example.dev.env
@@ -1,0 +1,19 @@
+IMMICH_ENV=development
+
+# You can find documentation for all the supported env variables at https://immich.app/docs/install/environment-variables
+
+# The location where your uploaded files are stored
+UPLOAD_LOCATION=./library
+# The location where your database files are stored
+DB_DATA_LOCATION=./postgres
+
+# The Immich version to use. You can pin this to a specific version like "v1.71.0"
+IMMICH_VERSION=release
+
+# Connection secret for postgres. You should change it to a random password
+DB_PASSWORD=postgres
+
+# The values below this line do not need to be changed
+###################################################################################
+DB_USERNAME=postgres
+DB_DATABASE_NAME=immich

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -31,7 +31,7 @@ All the services are packaged to run as with single Docker Compose command.
 ### Server and web apps
 
 1. Clone the project repo.
-2. Run `cp docker/example.env docker/.env`.
+2. Run `cp docker/example.dev.env docker/.env`.
 3. Edit `docker/.env` to provide values for the required variable `UPLOAD_LOCATION`.
 4. From the root directory, run:
 

--- a/mobile/openapi/.openapi-generator/FILES
+++ b/mobile/openapi/.openapi-generator/FILES
@@ -70,6 +70,7 @@ doc/DownloadInfoDto.md
 doc/DownloadResponseDto.md
 doc/DuplicateApi.md
 doc/DuplicateDetectionConfig.md
+doc/DuplicateResponseDto.md
 doc/EntityType.md
 doc/ExifResponseDto.md
 doc/FaceApi.md
@@ -312,6 +313,7 @@ lib/model/download_archive_info.dart
 lib/model/download_info_dto.dart
 lib/model/download_response_dto.dart
 lib/model/duplicate_detection_config.dart
+lib/model/duplicate_response_dto.dart
 lib/model/entity_type.dart
 lib/model/exif_response_dto.dart
 lib/model/face_dto.dart
@@ -507,6 +509,7 @@ test/download_info_dto_test.dart
 test/download_response_dto_test.dart
 test/duplicate_api_test.dart
 test/duplicate_detection_config_test.dart
+test/duplicate_response_dto_test.dart
 test/entity_type_test.dart
 test/exif_response_dto_test.dart
 test/face_api_test.dart

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -284,6 +284,7 @@ Class | Method | HTTP request | Description
  - [DownloadInfoDto](doc//DownloadInfoDto.md)
  - [DownloadResponseDto](doc//DownloadResponseDto.md)
  - [DuplicateDetectionConfig](doc//DuplicateDetectionConfig.md)
+ - [DuplicateResponseDto](doc//DuplicateResponseDto.md)
  - [EntityType](doc//EntityType.md)
  - [ExifResponseDto](doc//ExifResponseDto.md)
  - [FaceDto](doc//FaceDto.md)

--- a/mobile/openapi/doc/AssetResponseDto.md
+++ b/mobile/openapi/doc/AssetResponseDto.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **checksum** | **String** | base64 encoded sha1 hash | 
 **deviceAssetId** | **String** |  | 
 **deviceId** | **String** |  | 
+**duplicateId** | **String** |  | [optional] 
 **duration** | **String** |  | 
 **exifInfo** | [**ExifResponseDto**](ExifResponseDto.md) |  | [optional] 
 **fileCreatedAt** | [**DateTime**](DateTime.md) |  | 

--- a/mobile/openapi/doc/DuplicateApi.md
+++ b/mobile/openapi/doc/DuplicateApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **getAssetDuplicates**
-> List<AssetResponseDto> getAssetDuplicates()
+> List<DuplicateResponseDto> getAssetDuplicates()
 
 
 
@@ -50,7 +50,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**List<AssetResponseDto>**](AssetResponseDto.md)
+[**List<DuplicateResponseDto>**](DuplicateResponseDto.md)
 
 ### Authorization
 

--- a/mobile/openapi/doc/DuplicateResponseDto.md
+++ b/mobile/openapi/doc/DuplicateResponseDto.md
@@ -1,0 +1,16 @@
+# openapi.model.DuplicateResponseDto
+
+## Load the model package
+```dart
+import 'package:openapi/api.dart';
+```
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**assets** | [**List<AssetResponseDto>**](AssetResponseDto.md) |  | [default to const []]
+**duplicateId** | **String** |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -116,6 +116,7 @@ part 'model/download_archive_info.dart';
 part 'model/download_info_dto.dart';
 part 'model/download_response_dto.dart';
 part 'model/duplicate_detection_config.dart';
+part 'model/duplicate_response_dto.dart';
 part 'model/entity_type.dart';
 part 'model/exif_response_dto.dart';
 part 'model/face_dto.dart';

--- a/mobile/openapi/lib/api/duplicate_api.dart
+++ b/mobile/openapi/lib/api/duplicate_api.dart
@@ -42,7 +42,7 @@ class DuplicateApi {
     );
   }
 
-  Future<List<AssetResponseDto>?> getAssetDuplicates() async {
+  Future<List<DuplicateResponseDto>?> getAssetDuplicates() async {
     final response = await getAssetDuplicatesWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
@@ -52,8 +52,8 @@ class DuplicateApi {
     // FormatException when trying to decode an empty string.
     if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
       final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<AssetResponseDto>') as List)
-        .cast<AssetResponseDto>()
+      return (await apiClient.deserializeAsync(responseBody, 'List<DuplicateResponseDto>') as List)
+        .cast<DuplicateResponseDto>()
         .toList(growable: false);
 
     }

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -300,6 +300,8 @@ class ApiClient {
           return DownloadResponseDto.fromJson(value);
         case 'DuplicateDetectionConfig':
           return DuplicateDetectionConfig.fromJson(value);
+        case 'DuplicateResponseDto':
+          return DuplicateResponseDto.fromJson(value);
         case 'EntityType':
           return EntityTypeTypeTransformer().decode(value);
         case 'ExifResponseDto':

--- a/mobile/openapi/lib/model/asset_response_dto.dart
+++ b/mobile/openapi/lib/model/asset_response_dto.dart
@@ -16,6 +16,7 @@ class AssetResponseDto {
     required this.checksum,
     required this.deviceAssetId,
     required this.deviceId,
+    this.duplicateId,
     required this.duration,
     this.exifInfo,
     required this.fileCreatedAt,
@@ -53,6 +54,8 @@ class AssetResponseDto {
   String deviceAssetId;
 
   String deviceId;
+
+  String? duplicateId;
 
   String duration;
 
@@ -149,6 +152,7 @@ class AssetResponseDto {
     other.checksum == checksum &&
     other.deviceAssetId == deviceAssetId &&
     other.deviceId == deviceId &&
+    other.duplicateId == duplicateId &&
     other.duration == duration &&
     other.exifInfo == exifInfo &&
     other.fileCreatedAt == fileCreatedAt &&
@@ -185,6 +189,7 @@ class AssetResponseDto {
     (checksum.hashCode) +
     (deviceAssetId.hashCode) +
     (deviceId.hashCode) +
+    (duplicateId == null ? 0 : duplicateId!.hashCode) +
     (duration.hashCode) +
     (exifInfo == null ? 0 : exifInfo!.hashCode) +
     (fileCreatedAt.hashCode) +
@@ -216,13 +221,18 @@ class AssetResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'AssetResponseDto[checksum=$checksum, deviceAssetId=$deviceAssetId, deviceId=$deviceId, duration=$duration, exifInfo=$exifInfo, fileCreatedAt=$fileCreatedAt, fileModifiedAt=$fileModifiedAt, hasMetadata=$hasMetadata, id=$id, isArchived=$isArchived, isExternal=$isExternal, isFavorite=$isFavorite, isOffline=$isOffline, isReadOnly=$isReadOnly, isTrashed=$isTrashed, libraryId=$libraryId, livePhotoVideoId=$livePhotoVideoId, localDateTime=$localDateTime, originalFileName=$originalFileName, originalPath=$originalPath, owner=$owner, ownerId=$ownerId, people=$people, resized=$resized, smartInfo=$smartInfo, stack=$stack, stackCount=$stackCount, stackParentId=$stackParentId, tags=$tags, thumbhash=$thumbhash, type=$type, updatedAt=$updatedAt]';
+  String toString() => 'AssetResponseDto[checksum=$checksum, deviceAssetId=$deviceAssetId, deviceId=$deviceId, duplicateId=$duplicateId, duration=$duration, exifInfo=$exifInfo, fileCreatedAt=$fileCreatedAt, fileModifiedAt=$fileModifiedAt, hasMetadata=$hasMetadata, id=$id, isArchived=$isArchived, isExternal=$isExternal, isFavorite=$isFavorite, isOffline=$isOffline, isReadOnly=$isReadOnly, isTrashed=$isTrashed, libraryId=$libraryId, livePhotoVideoId=$livePhotoVideoId, localDateTime=$localDateTime, originalFileName=$originalFileName, originalPath=$originalPath, owner=$owner, ownerId=$ownerId, people=$people, resized=$resized, smartInfo=$smartInfo, stack=$stack, stackCount=$stackCount, stackParentId=$stackParentId, tags=$tags, thumbhash=$thumbhash, type=$type, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'checksum'] = this.checksum;
       json[r'deviceAssetId'] = this.deviceAssetId;
       json[r'deviceId'] = this.deviceId;
+    if (this.duplicateId != null) {
+      json[r'duplicateId'] = this.duplicateId;
+    } else {
+    //  json[r'duplicateId'] = null;
+    }
       json[r'duration'] = this.duration;
     if (this.exifInfo != null) {
       json[r'exifInfo'] = this.exifInfo;
@@ -302,6 +312,7 @@ class AssetResponseDto {
         checksum: mapValueOfType<String>(json, r'checksum')!,
         deviceAssetId: mapValueOfType<String>(json, r'deviceAssetId')!,
         deviceId: mapValueOfType<String>(json, r'deviceId')!,
+        duplicateId: mapValueOfType<String>(json, r'duplicateId'),
         duration: mapValueOfType<String>(json, r'duration')!,
         exifInfo: ExifResponseDto.fromJson(json[r'exifInfo']),
         fileCreatedAt: mapDateTime(json, r'fileCreatedAt', r'')!,

--- a/mobile/openapi/lib/model/duplicate_response_dto.dart
+++ b/mobile/openapi/lib/model/duplicate_response_dto.dart
@@ -1,0 +1,106 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class DuplicateResponseDto {
+  /// Returns a new [DuplicateResponseDto] instance.
+  DuplicateResponseDto({
+    this.assets = const [],
+    required this.duplicateId,
+  });
+
+  List<AssetResponseDto> assets;
+
+  String duplicateId;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is DuplicateResponseDto &&
+    _deepEquality.equals(other.assets, assets) &&
+    other.duplicateId == duplicateId;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (assets.hashCode) +
+    (duplicateId.hashCode);
+
+  @override
+  String toString() => 'DuplicateResponseDto[assets=$assets, duplicateId=$duplicateId]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'assets'] = this.assets;
+      json[r'duplicateId'] = this.duplicateId;
+    return json;
+  }
+
+  /// Returns a new [DuplicateResponseDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static DuplicateResponseDto? fromJson(dynamic value) {
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return DuplicateResponseDto(
+        assets: AssetResponseDto.listFromJson(json[r'assets']),
+        duplicateId: mapValueOfType<String>(json, r'duplicateId')!,
+      );
+    }
+    return null;
+  }
+
+  static List<DuplicateResponseDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <DuplicateResponseDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = DuplicateResponseDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, DuplicateResponseDto> mapFromJson(dynamic json) {
+    final map = <String, DuplicateResponseDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = DuplicateResponseDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of DuplicateResponseDto-objects as value to a dart map
+  static Map<String, List<DuplicateResponseDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<DuplicateResponseDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = DuplicateResponseDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'assets',
+    'duplicateId',
+  };
+}
+

--- a/mobile/openapi/test/asset_response_dto_test.dart
+++ b/mobile/openapi/test/asset_response_dto_test.dart
@@ -32,6 +32,11 @@ void main() {
       // TODO
     });
 
+    // String duplicateId
+    test('to test the property `duplicateId`', () async {
+      // TODO
+    });
+
     // String duration
     test('to test the property `duration`', () async {
       // TODO

--- a/mobile/openapi/test/duplicate_api_test.dart
+++ b/mobile/openapi/test/duplicate_api_test.dart
@@ -17,7 +17,7 @@ void main() {
   // final instance = DuplicateApi();
 
   group('tests for DuplicateApi', () {
-    //Future<List<AssetResponseDto>> getAssetDuplicates() async
+    //Future<List<DuplicateResponseDto>> getAssetDuplicates() async
     test('test getAssetDuplicates', () async {
       // TODO
     });

--- a/mobile/openapi/test/duplicate_response_dto_test.dart
+++ b/mobile/openapi/test/duplicate_response_dto_test.dart
@@ -1,0 +1,32 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+import 'package:openapi/api.dart';
+import 'package:test/test.dart';
+
+// tests for DuplicateResponseDto
+void main() {
+  // final instance = DuplicateResponseDto();
+
+  group('test DuplicateResponseDto', () {
+    // List<AssetResponseDto> assets (default value: const [])
+    test('to test the property `assets`', () async {
+      // TODO
+    });
+
+    // String duplicateId
+    test('to test the property `duplicateId`', () async {
+      // TODO
+    });
+
+
+  });
+
+}

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -2231,7 +2231,7 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/AssetResponseDto"
+                    "$ref": "#/components/schemas/DuplicateResponseDto"
                   },
                   "type": "array"
                 }
@@ -7318,6 +7318,10 @@
           "deviceId": {
             "type": "string"
           },
+          "duplicateId": {
+            "nullable": true,
+            "type": "string"
+          },
           "duration": {
             "type": "string"
           },
@@ -7927,6 +7931,24 @@
         "required": [
           "enabled",
           "maxDistance"
+        ],
+        "type": "object"
+      },
+      "DuplicateResponseDto": {
+        "properties": {
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/AssetResponseDto"
+            },
+            "type": "array"
+          },
+          "duplicateId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "assets",
+          "duplicateId"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -115,6 +115,7 @@ export type AssetResponseDto = {
     checksum: string;
     deviceAssetId: string;
     deviceId: string;
+    duplicateId?: string | null;
     duration: string;
     exifInfo?: ExifResponseDto;
     fileCreatedAt: string;
@@ -371,6 +372,10 @@ export type DownloadArchiveInfo = {
 export type DownloadResponseDto = {
     archives: DownloadArchiveInfo[];
     totalSize: number;
+};
+export type DuplicateResponseDto = {
+    assets: AssetResponseDto[];
+    duplicateId: string;
 };
 export type PersonResponseDto = {
     birthDate: string | null;
@@ -1698,7 +1703,7 @@ export function getDownloadInfo({ key, downloadInfoDto }: {
 export function getAssetDuplicates(opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
-        data: AssetResponseDto[];
+        data: DuplicateResponseDto[];
     }>("/duplicates", {
         ...opts
     }));


### PR DESCRIPTION
With the change in #9561, developers and contributors need to add `IMMICH_ENV=development` to their `.env` to get open-api spec file generated according to code change