### PR TITLE
fix: docker compose pull rate limit

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,12 +40,12 @@ services:
 
   redis:
     container_name: immich_redis
-    image: redis:6.2-alpine@sha256:c0634a08e74a4bb576d02d1ee993dc05dba10e8b7b9492dfa28a7af100d46c01
+    image: docker.io/redis:6.2-alpine@sha256:c0634a08e74a4bb576d02d1ee993dc05dba10e8b7b9492dfa28a7af100d46c01
     restart: always
 
   database:
     container_name: immich_postgres
-    image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,12 +40,12 @@ services:
 
   redis:
     container_name: immich_redis
-    image: registry.hub.docker.com/library/redis:6.2-alpine@sha256:c0634a08e74a4bb576d02d1ee993dc05dba10e8b7b9492dfa28a7af100d46c01
+    image: redis:6.2-alpine@sha256:c0634a08e74a4bb576d02d1ee993dc05dba10e8b7b9492dfa28a7af100d46c01
     restart: always
 
   database:
     container_name: immich_postgres
-    image: registry.hub.docker.com/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
with `registry.hub.docker.com/` behind the image reference, there was an issue where `docker compose up -d` would throw a rate-limiting error, even when logged in using a docker account.

#### before
```bash
poweruser@debian:~/immich-app$ docker pull registry.hub.docker.com/library/redis:6.2-alpine@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672
Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```
#### after changing image reference
```bash
poweruser@debian:~/immich-app$ docker pull redis:6.2-alpine@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672
docker.io/library/redis@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672: Pulling from library/redis
4abcf2066143: Pull complete 
2c3a1d240687: Pull complete 
643f361aa308: Pull complete 
a693cf0e318c: Pull complete 
ade57efb0b22: Pull complete 
2fa2e1566407: Pull complete 
4f4fb700ef54: Pull complete 
4464e0709769: Pull complete 
Digest: sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672
Status: Downloaded newer image for redis@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672
docker.io/library/redis:6.2-alpine@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview redis:6.2-alpine@sha256:84882e87b54734154586e5f8abd4dce69fe7311315e2fc6d67c29614c8de2672
```

it doesn't really matter where the image is downloaded from as long as it has the same sha256 hash in `docker-compose.yml`