### PR TITLE
fix(web): render failed upload buttons correctly on mobile

### DIFF
--- a/web/src/lib/components/shared-components/upload-asset-preview.svelte
+++ b/web/src/lib/components/shared-components/upload-asset-preview.svelte
@@ -24,8 +24,8 @@
   out:fade={{ duration: 100 }}
   class="flex flex-col rounded-lg bg-immich-bg text-xs dark:bg-immich-dark-bg"
 >
-  <div class="grid grid-cols-[65px_auto_auto]">
-    <div class="relative h-[65px]">
+  <div class="grid grid-cols-[65px_auto_auto] max-h-[70px]">
+    <div class="relative">
       <div in:fade={{ duration: 250 }}>
         <ImmichLogo noText class="h-[65px] w-[65px] rounded-bl-lg rounded-tl-lg object-cover p-2" />
       </div>
@@ -83,18 +83,14 @@
       </div>
     </div>
     {#if uploadAsset.state === UploadState.ERROR}
-      <div class="flex h-full flex-col place-content-center place-items-center justify-items-center pr-2">
-        <button
-          on:click={() => handleRetry(uploadAsset)}
-          title="Retry upload"
-          class="flex h-full w-full place-content-center place-items-center text-sm"
-        >
+      <div class="flex h-full flex-col place-content-evenly place-items-center justify-items-center pr-2">
+        <button on:click={() => handleRetry(uploadAsset)} title="Retry upload" class="flex text-sm">
           <span class="text-immich-dark-gray dark:text-immich-dark-fg"><Icon path={mdiRefresh} size="20" /></span>
         </button>
         <button
           on:click={() => uploadAssetsStore.removeUploadAsset(uploadAsset.id)}
           title="Dismiss error"
-          class="flex h-full w-full place-content-center place-items-center text-sm"
+          class="flex text-sm"
         >
           <span class="text-immich-error"><Icon path={mdiCancel} size="20" /></span>
         </button>
@@ -104,7 +100,7 @@
 
   {#if uploadAsset.state === UploadState.ERROR}
     <div class="flex flex-row justify-between">
-      <p class="w-full rounded-md p-1 px-2 text-justify text-[10px] text-immich-error">
+      <p class="w-full rounded-md py-1 px-2 text-justify text-[10px] text-immich-error">
         {uploadAsset.error}
       </p>
     </div>


### PR DESCRIPTION
Fixes #9055.

**Before &rarr; After**

<p>
  <img src="https://github.com/immich-app/immich/assets/73403527/6a0c108f-102c-46ac-8f13-c2766bffa18c" width="200" />
  <img src="https://github.com/immich-app/immich/assets/73403527/ab171e83-eba4-40c9-ac22-d1994b6b24f4" width="200" />
</p>

The buttons were overflowing down because their container is set to `h-full` and its closest parent with a [defined height](https://tailwindcss.com/docs/height#full-height) is 400px:

<p>
  <img src="https://github.com/immich-app/immich/assets/73403527/27664ec6-06c7-44ac-bd49-4e2e96be9475" width="200" />
</p>

I fixed it by setting the max height of the row with the thumbnail, progress/status bar, and failed upload buttons to 70px:

<p>
  <img src="https://github.com/immich-app/immich/assets/73403527/5664d5a9-5122-4265-bd20-a705e0a483bb" width="200" />
</p>

I think hardcoding this value is okay because the thumbnail is already hardcoded to a height of 65px plus 2px padding on all sides, and I believe everything in that row is intended to be the same height as the thumbnail.

I also made some minor changes to the Tailwind for the buttons. The borders in the last two screenshots were just for debugging and are not present in this PR. Let me know of any feedback.