### PR TITLE
fix(web): prevent asset grid dates from being truncated

### DIFF
--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -153,7 +153,7 @@
           </div>
         {/if}
 
-        <span class="truncate first-letter:capitalize" title={groupTitle}>
+        <span class="w-full truncate first-letter:capitalize" title={groupTitle}>
           {groupTitle}
         </span>
       </div>


### PR DESCRIPTION
Fixes #9582.