### PR TITLE
fix(web): fix add to album modal text spacing

### DIFF
--- a/web/src/lib/components/asset-viewer/album-list-item.svelte
+++ b/web/src/lib/components/asset-viewer/album-list-item.svelte
@@ -50,8 +50,7 @@
       {#if variant === 'simple'}
         <span>{album.shared ? 'Shared' : ''}</span>
       {:else}
-        <span>{album.assetCount} items</span>
-        <span>{album.shared ? ' · Shared' : ''} </span>
+        <span>{album.assetCount} items{album.shared ? ' - Shared' : '' }</span>
       {/if}
     </span>
   </div>

--- a/web/src/lib/components/asset-viewer/album-list-item.svelte
+++ b/web/src/lib/components/asset-viewer/album-list-item.svelte
@@ -50,7 +50,7 @@
       {#if variant === 'simple'}
         <span>{album.shared ? 'Shared' : ''}</span>
       {:else}
-        <span>{album.assetCount} items{album.shared ? ' - Shared' : '' }</span>
+        <span>{album.assetCount} items{album.shared ? ' - Shared' : ''}</span>
       {/if}
     </span>
   </div>


### PR DESCRIPTION
The interpunct character doesn't work well with the Overpass font - it seems to swallow spacing.
![image](https://github.com/immich-app/immich/assets/5608270/3056c27b-c3f4-4048-be81-f7ef8251cd17)

Changed it to an hyphen.

Before:
![image](https://github.com/immich-app/immich/assets/5608270/7febcbe8-efaf-49aa-b81c-52947fbd9e64)

After:
![image](https://github.com/immich-app/immich/assets/5608270/e2b08f7a-665f-4e27-aa2b-4d58cc36ac75)
