### PR TITLE
ci: add conventional commit validation for PR titles

### DIFF
--- a/.github/workflows/pr-require-conventional-commit.yml
+++ b/.github/workflows/pr-require-conventional-commit.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/PRConventionalCommits@1.1.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'


### PR DESCRIPTION
Validate that PR titles are the in conventional commit format before merging