### PR TITLE
fix: auth sub override

### DIFF
--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -201,7 +201,7 @@ export class AuthService {
     // link existing user
     if (!user) {
       const emailUser = await this.userRepository.getByEmail(profile.email);
-      if (emailUser) {
+      if (emailUser && !emailUser.oauthId) {
         user = await this.userRepository.update(emailUser.id, { oauthId: profile.sub });
       }
     }

--- a/server/test/fixtures/system-config.stub.ts
+++ b/server/test/fixtures/system-config.stub.ts
@@ -15,7 +15,7 @@ export const systemConfigStub = {
       enabled: false,
     },
   },
-  noAutoRegister: {
+  oauthEnabled: {
     oauth: {
       enabled: true,
       autoRegister: false,
@@ -23,7 +23,15 @@ export const systemConfigStub = {
       buttonText: 'OAuth',
     },
   },
-  override: {
+  oauthWithAutoRegister: {
+    oauth: {
+      enabled: true,
+      autoRegister: true,
+      autoLaunch: false,
+      buttonText: 'OAuth',
+    },
+  },
+  oauthWithMobileOverride: {
     oauth: {
       enabled: true,
       autoRegister: true,
@@ -32,7 +40,7 @@ export const systemConfigStub = {
       buttonText: 'OAuth',
     },
   },
-  withDefaultStorageQuota: {
+  oauthWithStorageQuota: {
     oauth: {
       enabled: true,
       autoRegister: true,


### PR DESCRIPTION
Do not override a previously linked user's oauthId, even if the email matches.