### PR TITLE
fix(web): emit updated date when pressing enter

### DIFF
--- a/web/src/lib/components/elements/date-input.svelte
+++ b/web/src/lib/components/elements/date-input.svelte
@@ -17,4 +17,9 @@
   {value}
   on:input={(e) => (updatedValue = e.currentTarget.value)}
   on:blur={() => (value = updatedValue)}
+  on:keydown={(e) => {
+    if (e.key === 'Enter') {
+      value = updatedValue;
+    }
+  }}
 />


### PR DESCRIPTION
Fixes a bug where submitting a form (e.g. `set-birth-date-modal`) by pressing `Enter` in the date input did not update the date value.