### PR TITLE
fix(web): albums dark mode contrast + a11y issue

### DIFF
--- a/web/src/lib/components/album-page/album-card-group.svelte
+++ b/web/src/lib/components/album-page/album-card-group.svelte
@@ -29,17 +29,19 @@
 
 {#if group}
   <div class="grid">
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-    <p on:click={() => toggleAlbumGroupCollapsing(group.id)} class="w-fit mt-2 pt-2 pr-2 mb-2 hover:cursor-pointer">
+    <button
+      on:click={() => toggleAlbumGroupCollapsing(group.id)}
+      class="w-fit mt-2 pt-2 pr-2 mb-2 dark:text-immich-dark-fg"
+      aria-expanded={!isCollapsed}
+    >
       <Icon
         path={mdiChevronRight}
         size="24"
         class="inline-block -mt-2.5 transition-all duration-[250ms] {iconRotation}"
       />
       <span class="font-bold text-3xl text-black dark:text-white">{group.name}</span>
-      <span class="ml-1.5 dark:text-immich-dark-fg">({albums.length} {albums.length > 1 ? 'albums' : 'album'})</span>
-    </p>
+      <span class="ml-1.5">({albums.length} {albums.length > 1 ? 'albums' : 'album'})</span>
+    </button>
     <hr class="dark:border-immich-dark-gray" />
   </div>
 {/if}

--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -61,7 +61,7 @@
       </p>
     {/if}
 
-    <span class="flex gap-2 text-sm" data-testid="album-details">
+    <span class="flex gap-2 text-sm dark:text-immich-dark-fg" data-testid="album-details">
       {#if showItemCount}
         <p>
           {album.assetCount.toLocaleString($locale)}

--- a/web/src/lib/components/album-page/albums-table.svelte
+++ b/web/src/lib/components/album-page/albums-table.svelte
@@ -40,24 +40,30 @@
     {#each groupedAlbums as albumGroup (albumGroup.id)}
       {@const isCollapsed = isAlbumGroupCollapsed($albumViewSettings, albumGroup.id)}
       {@const iconRotation = isCollapsed ? 'rotate-0' : 'rotate-90'}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-      <tbody
-        class="block w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg mt-4 hover:cursor-pointer"
+      <button
         on:click={() => toggleAlbumGroupCollapsing(albumGroup.id)}
+        class="flex w-full mt-4 rounded-md"
+        aria-expanded={!isCollapsed}
       >
-        <tr class="flex w-full place-items-center p-2 md:pl-5 md:pr-5 md:pt-3 md:pb-3">
-          <td class="text-md text-left -mb-1">
-            <Icon
-              path={mdiChevronRight}
-              size="20"
-              class="inline-block -mt-2 transition-all duration-[250ms] {iconRotation}"
-            />
-            <span class="font-bold text-2xl">{albumGroup.name}</span>
-            <span class="ml-1.5">({albumGroup.albums.length} {albumGroup.albums.length > 1 ? 'albums' : 'album'})</span>
-          </td>
-        </tr>
-      </tbody>
+        <tbody
+          class="block w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
+        >
+          <tr class="flex w-full place-items-center p-2 md:pl-5 md:pr-5 md:pt-3 md:pb-3">
+            <td class="text-md text-left -mb-1">
+              <Icon
+                path={mdiChevronRight}
+                size="20"
+                class="inline-block -mt-2 transition-all duration-[250ms] {iconRotation}"
+              />
+              <span class="font-bold text-2xl">{albumGroup.name}</span>
+              <span class="ml-1.5">
+                ({albumGroup.albums.length}
+                {albumGroup.albums.length > 1 ? 'albums' : 'album'})
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </button>
       {#if !isCollapsed}
         <tbody
           class="block w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg mt-4"


### PR DESCRIPTION
- Use `<button>` element to resolve a11y issues and add `aria-expanded`
- Improve color contrast in dark mode for grouped list view:

![album-group-before](https://github.com/immich-app/immich/assets/59014050/2aa3881c-f181-4f33-8b38-5e21f86edb3a) ![album-group-after](https://github.com/immich-app/immich/assets/59014050/96ffd684-9f97-4b74-a782-50e7d1b07474)
