### PR TITLE
feat(server): use wildcard search for originalFileName and originalPath

### DIFF
--- a/e2e/src/api/specs/search.e2e-spec.ts
+++ b/e2e/src/api/specs/search.e2e-spec.ts
@@ -308,14 +308,14 @@ describe('/search', () => {
       {
         should: 'should search by originalFilename',
         deferred: () => ({
-          dto: { originalFileName: 'rocks' },
+          dto: { originalFileName: '*rocks*' },
           assets: [assetRocks],
         }),
       },
       {
         should: 'should search by originalFilename with spaces',
         deferred: () => ({
-          dto: { originalFileName: 'Samsung One', type: 'IMAGE' },
+          dto: { originalFileName: '*Samsung One*', type: 'IMAGE' },
           assets: [assetOneJpg5, assetOneJpg6, assetOneHeic6],
         }),
       },

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -58,12 +58,18 @@ export function searchAssetBuilder(
     builder.andWhere(`${builder.alias}.ownerId IN (:...userIds)`, { userIds: options.userIds });
   }
 
-  const path = _.pick(options, ['encodedVideoPath', 'originalPath', 'previewPath', 'thumbnailPath']);
+  const path = _.pick(options, ['encodedVideoPath', 'previewPath', 'thumbnailPath']);
   builder.andWhere(_.omitBy(path, _.isUndefined));
 
   if (options.originalFileName) {
     builder.andWhere(`f_unaccent(${builder.alias}.originalFileName) ILIKE f_unaccent(:originalFileName)`, {
-      originalFileName: `%${options.originalFileName}%`,
+      originalFileName: options.originalFileName.replaceAll('*', '%'),
+    });
+  }
+
+  if (options.originalPath) {
+    builder.andWhere(`f_unaccent(${builder.alias}.originalPath) ILIKE f_unaccent(:originalPath)`, {
+      originalPath: options.originalPath.replaceAll('*', '%'),
     });
   }
 

--- a/web/src/lib/components/shared-components/search-bar/search-text-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-text-section.svelte
@@ -57,7 +57,7 @@
     type="text"
     id="file-name-input"
     name="file-name"
-    placeholder="i.e. IMG_1234.JPG or PNG"
+    placeholder="i.e. IMG_1234.JPG or *.PNG"
     bind:value={filename}
     aria-labelledby="file-name-label"
   />


### PR DESCRIPTION
* support wildcard search for `originalPath` (relevant for external libraries with custom folder structures)
* don't add wildcard before and after the search term for `originalFileName`
* replace `*` with `%` for use with SQL `ILIKE`

Should we add a section for path in the search form, next to context and filename?