### PR TITLE
feat(server): fully accelerated qsv

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1496,12 +1496,10 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: expect.arrayContaining([
-            '-hwaccel qsv',
-            '-async_depth 4',
-            '-threads 1',
+          inputOptions: expect.arrayContaining(['-hwaccel qsv', '-async_depth 4', '-threads 1']),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining('scale_qsv=-1:720:async_depth=4:mode=hq:format=nv12'),
           ]),
-          outputOptions: expect.arrayContaining([expect.stringContaining('scale_qsv=-1:720:async_depth=4:mode=hq:format=nv12')]),
           twoPass: false,
         },
       );
@@ -1521,11 +1519,7 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: expect.arrayContaining([
-            '-hwaccel qsv',
-            '-async_depth 4',
-            '-threads 1',
-          ]),
+          inputOptions: expect.arrayContaining(['-hwaccel qsv', '-async_depth 4', '-threads 1']),
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
               'hwmap=derive_device=opencl,tonemap_opencl=desat=0:format=nv12:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709,hwmap=derive_device=vaapi:reverse=1',
@@ -1549,10 +1543,7 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: expect.arrayContaining([
-            '-hwaccel qsv',
-            '-qsv_device /dev/dri/renderD129',
-          ]),
+          inputOptions: expect.arrayContaining(['-hwaccel qsv', '-qsv_device /dev/dri/renderD129']),
           outputOptions: expect.any(Array),
           twoPass: false,
         },

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1482,6 +1482,83 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).not.toHaveBeenCalled();
     });
 
+    it('should use hardware decoding for qsv if enabled', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128']);
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.QSV, accelDecode: true },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining([
+            '-hwaccel qsv',
+            '-async_depth 4',
+            '-threads 1',
+          ]),
+          outputOptions: expect.arrayContaining([expect.stringContaining('scale_qsv=-1:720:async_depth=4:mode=hq:format=nv12')]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use hardware tone-mapping for qsv if hardware decoding is enabled and should tone map', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128']);
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.QSV, accelDecode: true },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining([
+            '-hwaccel qsv',
+            '-async_depth 4',
+            '-threads 1',
+          ]),
+          outputOptions: expect.arrayContaining([
+            expect.stringContaining(
+              'hwmap=derive_device=opencl,tonemap_opencl=desat=0:format=nv12:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709,hwmap=derive_device=vaapi:reverse=1',
+            ),
+          ]),
+          twoPass: false,
+        },
+      );
+    });
+
+    it('should use preferred device for qsv when hardware decoding', async () => {
+      storageMock.readdir.mockResolvedValue(['renderD128', 'renderD129', 'renderD130']);
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      systemMock.get.mockResolvedValue({
+        ffmpeg: { accel: TranscodeHWAccel.QSV, accelDecode: true, preferredHwDevice: 'renderD129' },
+      });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.arrayContaining([
+            '-hwaccel qsv',
+            '-qsv_device /dev/dri/renderD129',
+          ]),
+          outputOptions: expect.any(Array),
+          twoPass: false,
+        },
+      );
+    });
+
     it('should set options for vaapi', async () => {
       storageMock.readdir.mockResolvedValue(['renderD128']);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -38,7 +38,8 @@ import {
   HEVCConfig,
   NvencHwDecodeConfig,
   NvencSwDecodeConfig,
-  QSVConfig,
+  QsvHwDecodeConfig,
+  QsvSwDecodeConfig,
   RkmppHwDecodeConfig,
   RkmppSwDecodeConfig,
   ThumbnailConfig,
@@ -499,7 +500,9 @@ export class MediaService {
         break;
       }
       case TranscodeHWAccel.QSV: {
-        handler = new QSVConfig(config, await this.getDevices());
+        handler = config.accelDecode
+          ? new QsvHwDecodeConfig(config, await this.getDevices())
+          : new QsvSwDecodeConfig(config, await this.getDevices());
         break;
       }
       case TranscodeHWAccel.VAAPI: {

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -652,7 +652,7 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
     const options = ['-hwaccel qsv', '-async_depth 4', '-threads 1'];
     const hwDevice = this.getPreferredHardwareDevice();
     if (hwDevice) {
-      options.push(`-qsv_device ${hwDevice}`);
+      options.push(`-qsv_device /dev/dri/${hwDevice}`);
     }
 
     return options;
@@ -661,7 +661,7 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     if (this.shouldScale(videoStream) || !this.shouldToneMap(videoStream)) {
-      let scaling = `scale_qsv=${this.getScaling(videoStream)}:mode=hq:async_depth=4`;
+      let scaling = `scale_qsv=${this.getScaling(videoStream)}:async_depth=4:mode=hq`;
       if (!this.shouldToneMap(videoStream)) {
         scaling += ':format=nv12';
       }

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -703,7 +703,7 @@ export class VAAPIConfig extends BaseHWConfig {
     }
 
     let hwDevice = this.getPreferredHardwareDevice();
-    if (hwDevice === null) {
+    if (!hwDevice) {
       hwDevice = `/dev/dri/${this.devices[0]}`;
     }
 

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -313,7 +313,7 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
       throw new Error(`Device '${device}' does not exist`);
     }
 
-    return device;
+    return `/dev/dri/${deviceName}`;
   }
 }
 
@@ -652,7 +652,7 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
     const options = ['-hwaccel qsv', '-async_depth 4', '-threads 1'];
     const hwDevice = this.getPreferredHardwareDevice();
     if (hwDevice) {
-      options.push(`-qsv_device /dev/dri/${hwDevice}`);
+      options.push(`-qsv_device ${hwDevice}`);
     }
 
     return options;


### PR DESCRIPTION
### Descripion

This PR adds end-to-end acceleration for Quick Sync transcoding. Similar to NVENC and RKMPP, tone-mapping is done with OpenCL. Based on my testing, OpenCL was even faster than native VPP tone-mapping while having more features and higher quality.

### Testing

Tested with hardware decoding enabled and disabled, with tone-mapping enabled and disabled, and scaling set to either 720p or original.

Note: My processor is too new for the `intel-compute-runtime` in the server image, so I had to manually install the latest release [here](https://github.com/intel/compute-runtime/releases/tag/24.17.29377.6). I'll make a PR to apply this in the base image, but in the meantime it should only affect very new processors and only when hardware decoding is enabled.

Current transcoding time: 470s
With hardware decoding: 34s