### PR TITLE
fix(mobile): use correct Focus Node for latitude and longitude

### DIFF
--- a/mobile/lib/widgets/common/location_picker.dart
+++ b/mobile/lib/widgets/common/location_picker.dart
@@ -215,7 +215,7 @@ class _ManualPicker extends HookWidget {
           decorationText: "location_picker_longitude",
           hintText: "location_picker_longitude_hint",
           errorText: "location_picker_longitude_error",
-          focusNode: latitiudeFocusNode,
+          focusNode: longitudeFocusNode,
           validator: _validateLong,
           onUpdated: onLongitudeEditingCompleted,
         ),


### PR DESCRIPTION
Today on the mobile app, we can't change the location of pictures due to a bug in setting latitude and longitude : 
![CleanShot 2024-05-23 at 16 35 52](https://github.com/immich-app/immich/assets/246550/0806e93a-96cf-48a2-ab34-6d7a0a65099f)

This PR fixes that bug by assigning the correct focus nodes to latitude and longitude Picker Input