### PR TITLE
fix(server): use qsv format for hwmap

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1496,7 +1496,12 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: expect.arrayContaining(['-hwaccel qsv', '-async_depth 4', '-threads 1']),
+          inputOptions: expect.arrayContaining([
+            '-hwaccel qsv',
+            '-hwaccel_output_format qsv',
+            '-async_depth 4',
+            '-threads 1',
+          ]),
           outputOptions: expect.arrayContaining([
             expect.stringContaining('scale_qsv=-1:720:async_depth=4:mode=hq:format=nv12'),
           ]),
@@ -1519,10 +1524,15 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
         {
-          inputOptions: expect.arrayContaining(['-hwaccel qsv', '-async_depth 4', '-threads 1']),
+          inputOptions: expect.arrayContaining([
+            '-hwaccel qsv',
+            '-hwaccel_output_format qsv',
+            '-async_depth 4',
+            '-threads 1',
+          ]),
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
-              'hwmap=derive_device=opencl,tonemap_opencl=desat=0:format=nv12:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709,hwmap=derive_device=vaapi:reverse=1',
+              'hwmap=derive_device=opencl,tonemap_opencl=desat=0:format=nv12:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709,hwmap=derive_device=qsv:reverse=1,format=qsv',
             ),
           ]),
           twoPass: false,

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -649,7 +649,7 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
       throw new Error('No QSV device found');
     }
 
-    const options = ['-hwaccel qsv', '-async_depth 4', '-threads 1'];
+    const options = ['-hwaccel qsv', '-hwaccel_output_format qsv', '-async_depth 4', '-threads 1'];
     const hwDevice = this.getPreferredHardwareDevice();
     if (hwDevice) {
       options.push(`-qsv_device ${hwDevice}`);
@@ -691,7 +691,7 @@ export class QsvHwDecodeConfig extends QsvSwDecodeConfig {
     return [
       'hwmap=derive_device=opencl',
       `tonemap_opencl=${tonemapOptions.join(':')}`,
-      'hwmap=derive_device=vaapi:reverse=1',
+      'hwmap=derive_device=qsv:reverse=1,format=qsv',
     ];
   }
 }


### PR DESCRIPTION
## Description

Following the discussion in #9689, this PR changes the filter in the QSV command to output frames in QSV format rather than VAAPI.

Also adds `-hwaccel_output_format qsv` to the command since FFmpeg warns that omitting this is only allowed for backward compatibility reasons.

## How Has This Been Tested?

Tested that transcoding an HDR video was successful and that the performance is the same.