### PR TITLE
refactor(web): Moved global video player mute status control from the video player mute button to a user preference

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -52,9 +52,9 @@
     class="h-full object-contain"
     on:canplay={handleCanPlay}
     on:ended={() => dispatch('onVideoEnded')}
-    bind:muted={$videoViewerMuted}
     bind:volume={$videoViewerVolume}
     poster={getAssetThumbnailUrl(assetId, ThumbnailFormat.Jpeg, checksum)}
+    muted={$videoViewerMuted}
   >
     <source src={assetFileUrl} type="video/mp4" />
     <track kind="captions" />

--- a/web/src/lib/components/user-settings-page/app-settings.svelte
+++ b/web/src/lib/components/user-settings-page/app-settings.svelte
@@ -11,6 +11,7 @@
     playVideoThumbnailOnHover,
     showDeleteModal,
     sidebarSettings,
+    videoViewerMuted,
   } from '$lib/stores/preferences.store';
   import { findLocale } from '$lib/utils';
   import { onMount } from 'svelte';
@@ -130,6 +131,15 @@
           subtitle="Enable to automatically loop a video in the detail viewer."
           bind:checked={$loopVideo}
           on:toggle={() => ($loopVideo = !$loopVideo)}
+        />
+      </div>
+
+      <div class="ml-4">
+        <SettingSwitch
+          id="video-viewer-muted"
+          title="Muted video player"
+          subtitle="Mute the video viewer by default"
+          bind:checked={$videoViewerMuted}
         />
       </div>
 

--- a/web/src/lib/components/user-settings-page/app-settings.svelte
+++ b/web/src/lib/components/user-settings-page/app-settings.svelte
@@ -138,7 +138,7 @@
         <SettingSwitch
           id="video-viewer-muted"
           title="Muted video player"
-          subtitle="Mute the video viewer by default"
+          subtitle="Mute the video player by default"
           bind:checked={$videoViewerMuted}
         />
       </div>


### PR DESCRIPTION
Added an option in the user preferences to mute the video player by default as there was no way of setting this currently.

I believe that the video player should be muted by default, but I understand that someone else might not want this, so I think a setting is the best way to handle this

Maybe it would make sense to create another section for the video player, but I thought that for now that isn't necessary and would simply pollute the page