### PR TITLE
fix(server): search duplicates of the same asset type

### DIFF
--- a/server/src/interfaces/search.interface.ts
+++ b/server/src/interfaces/search.interface.ts
@@ -155,8 +155,9 @@ export interface FaceEmbeddingSearch extends SearchEmbeddingOptions {
 export interface AssetDuplicateSearch {
   assetId: string;
   embedding: Embedding;
-  userIds: string[];
   maxDistance?: number;
+  type: AssetType;
+  userIds: string[];
 }
 
 export interface FaceSearchResult {

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -204,6 +204,7 @@ WITH
         "asset"."ownerId" IN ($2)
         AND "asset"."id" != $3
         AND "asset"."isVisible" = $4
+        AND "asset"."type" = $5
       )
       AND ("asset"."deletedAt" IS NULL)
     ORDER BY
@@ -216,7 +217,7 @@ SELECT
 FROM
   "cte" "res"
 WHERE
-  res.distance <= $5
+  res.distance <= $6
 
 -- SearchRepository.searchFaces
 START TRANSACTION

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -215,6 +215,7 @@ describe(SearchService.name, () => {
         assetId: assetStub.hasEmbedding.id,
         embedding: assetStub.hasEmbedding.smartSearch!.embedding,
         maxDistance: 0.03,
+        type: assetStub.hasEmbedding.type,
         userIds: [assetStub.hasEmbedding.ownerId],
       });
       expect(assetMock.updateDuplicates).toHaveBeenCalledWith({
@@ -240,6 +241,7 @@ describe(SearchService.name, () => {
         assetId: assetStub.hasEmbedding.id,
         embedding: assetStub.hasEmbedding.smartSearch!.embedding,
         maxDistance: 0.03,
+        type: assetStub.hasEmbedding.type,
         userIds: [assetStub.hasEmbedding.ownerId],
       });
       expect(assetMock.updateDuplicates).toHaveBeenCalledWith({

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -94,6 +94,7 @@ export class DuplicateService {
       assetId: asset.id,
       embedding: asset.smartSearch.embedding,
       maxDistance: machineLearning.duplicateDetection.maxDistance,
+      type: asset.type,
       userIds: [asset.ownerId],
     });
 


### PR DESCRIPTION
## Description

Duplicate detection currently treats images and videos as duplicates so long as their previews look similar. This is nonsensical since they're known to be different asset types. This PR filters by asset type to correct this.