### PR TITLE
fix(server): partner can view archived assets

### DIFF
--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -13,6 +13,7 @@ import {
   createAlbum,
   createApiKey,
   createLibrary,
+  createPartner,
   createPerson,
   createSharedLink,
   createUser,
@@ -384,6 +385,8 @@ export const utils = {
 
   validateLibrary: (accessToken: string, id: string, dto: ValidateLibraryDto) =>
     validate({ id, validateLibraryDto: dto }, { headers: asBearerAuth(accessToken) }),
+
+  createPartner: (accessToken: string, id: string) => createPartner({ id }, { headers: asBearerAuth(accessToken) }),
 
   setAuthCookies: async (context: BrowserContext, accessToken: string) =>
     await context.addCookies([

--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -153,6 +153,7 @@ FROM
   AND ("asset"."deletedAt" IS NULL)
 WHERE
   "partner"."sharedWithId" = $1
+  AND "asset"."isArchived" = false
   AND "asset"."id" IN ($2)
 
 -- AccessRepository.asset.checkSharedLinkAccess

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -240,6 +240,7 @@ class AssetAccess implements IAssetAccess {
       .innerJoin('sharedBy.assets', 'asset')
       .select('asset.id', 'assetId')
       .where('partner.sharedWithId = :userId', { userId })
+      .andWhere('asset.isArchived = false')
       .andWhere('asset.id IN (:...assetIds)', { assetIds: [...assetIds] })
       .getRawMany()
       .then((rows) => new Set(rows.map((row) => row.assetId)));


### PR DESCRIPTION
Partners can view archived assets when the asset uuid is known, even though the description for partner sharing says:

![Screenshot 2024-05-25 at 11-14-47 Settings](https://github.com/immich-app/immich/assets/59014050/1a412620-07ef-4ecb-99a0-33906379294c)
