### PR TITLE
fix(server): Properly build ML predict URL

### DIFF
--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -19,9 +19,11 @@ export class MachineLearningRepository implements IMachineLearningRepository {
   private async predict<T>(url: string, input: TextModelInput | VisionModelInput, config: ModelConfig): Promise<T> {
     const formData = await this.getFormData(input, config);
 
-    const res = await fetch(`${url}/predict`, { method: 'POST', body: formData }).catch((error: Error | any) => {
-      throw new Error(`${errorPrefix} to "${url}" failed with ${error?.cause || error}`);
-    });
+    const res = await fetch(new URL('/predict', url), { method: 'POST', body: formData }).catch(
+      (error: Error | any) => {
+        throw new Error(`${errorPrefix} to "${url}" failed with ${error?.cause || error}`);
+      },
+    );
 
     if (res.status >= 400) {
       const modelType = config.modelType ? ` for ${config.modelType.replace('-', ' ')}` : '';


### PR DESCRIPTION
#9676 - A trailing slash at the end of the machine learning URL breaks the requests to the ML endpoint.

- Created a new enum to filter for URL specific types
- Added a `validationMessage` variable to provide information to the front-end for user feedback
- Added an `isInvalid` variable to provide a state for the tailwind classes
- These changes do not prevent a user from pressing save

validation error with message:
<img width="704" alt="image" src="https://github.com/immich-app/immich/assets/65427171/1268337e-f778-4097-90c0-70dce1b485ec">

valid input:
<img width="704" alt="image" src="https://github.com/immich-app/immich/assets/65427171/629c8a0a-20a2-40de-b008-ef2f9ee562a0">
