### PR TITLE
fix(web): detail panel asset description

### DIFF
--- a/e2e/src/web/specs/asset-viewer/detail-panel.e2e-spec.ts
+++ b/e2e/src/web/specs/asset-viewer/detail-panel.e2e-spec.ts
@@ -43,4 +43,18 @@ test.describe('Detail Panel', () => {
     await page.keyboard.press('i');
     await expect(page.locator('#detail-panel')).toHaveCount(0);
   });
+
+  test('description is visible for owner on shared links', async ({ context, page }) => {
+    const sharedLink = await utils.createSharedLink(admin.accessToken, {
+      type: SharedLinkType.Individual,
+      assetIds: [asset.id],
+    });
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(`/share/${sharedLink.key}/photos/${asset.id}`);
+
+    const textarea = page.getByRole('textbox', { name: 'Add a description' });
+    await page.getByRole('button', { name: 'Info' }).click();
+    await expect(textarea).toBeVisible();
+    await expect(textarea).not.toBeDisabled();
+  });
 });

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { autoGrowHeight } from '$lib/actions/autogrow';
+  import { clickOutside } from '$lib/actions/click-outside';
+  import { shortcut } from '$lib/actions/shortcut';
+  import {
+    NotificationType,
+    notificationController,
+  } from '$lib/components/shared-components/notification/notification';
+  import { handleError } from '$lib/utils/handle-error';
+  import { updateAsset, type AssetResponseDto } from '@immich/sdk';
+  import { tick } from 'svelte';
+
+  export let asset: AssetResponseDto;
+  export let isOwner: boolean;
+
+  let textarea: HTMLTextAreaElement;
+  $: description = asset.exifInfo?.description || '';
+  $: newDescription = description;
+
+  $: if (textarea) {
+    newDescription;
+    void tick().then(() => autoGrowHeight(textarea));
+  }
+
+  const handleFocusOut = async () => {
+    if (description === newDescription) {
+      return;
+    }
+
+    try {
+      await updateAsset({ id: asset.id, updateAssetDto: { description: newDescription } });
+      notificationController.show({
+        type: NotificationType.Info,
+        message: 'Asset description has been updated',
+      });
+    } catch (error) {
+      handleError(error, 'Cannot update the description');
+    }
+  };
+</script>
+
+{#if isOwner}
+  <section class="px-4 mt-10">
+    <textarea
+      bind:this={textarea}
+      class="max-h-[500px] w-full resize-none border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary immich-scrollbar"
+      placeholder="Add a description"
+      on:focusout={handleFocusOut}
+      on:input={(e) => (newDescription = e.currentTarget.value)}
+      value={description}
+      use:clickOutside={{ onOutclick: void handleFocusOut }}
+      use:shortcut={{
+        shortcut: { key: 'Enter', ctrl: true },
+        onShortcut: (e) => e.currentTarget.blur(),
+      }}
+    />
+  </section>
+{:else if description}
+  <section class="px-4 mt-6">
+    <p class="break-words whitespace-pre-line w-full text-black dark:text-white text-base">{description}</p>
+  </section>
+{/if}


### PR DESCRIPTION
Use a separate component for the asset description and fixed:
- Spacing above textarea when description is readonly
- Textarea is disabled/invisible for owners visiting a shared link
- On shared links `use:autoGrowHeight` sometimes sets `height: 0px` for the textarea