### PR TITLE
fix(web): empty album stored

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { afterNavigate, goto } from '$app/navigation';
+  import { afterNavigate, goto, onNavigate } from '$app/navigation';
   import AlbumDescription from '$lib/components/album-page/album-description.svelte';
   import AlbumOptions from '$lib/components/album-page/album-options.svelte';
   import AlbumSummary from '$lib/components/album-page/album-summary.svelte';
@@ -405,6 +405,12 @@
       handleError(error, 'Unable to update album cover');
     }
   };
+
+  onNavigate(async () => {
+    if (album.assetCount === 0 && !album.albumName) {
+      await deleteAlbum(album);
+    }
+  });
 </script>
 
 <div class="flex overflow-hidden" bind:clientWidth={globalWidth}>
@@ -559,7 +565,7 @@
             {#if viewMode !== ViewMode.SELECT_THUMBNAIL}
               <!-- ALBUM TITLE -->
               <section class="pt-24">
-                <AlbumTitle id={album.id} albumName={album.albumName} {isOwned} />
+                <AlbumTitle id={album.id} bind:albumName={album.albumName} {isOwned} />
 
                 {#if album.assetCount > 0}
                   <AlbumSummary {album} />


### PR DESCRIPTION
 I was annoyed by #9657 so I fixed it on may local version.

The idea is to remove and empty album (without assets) when navigating back (clicking the close button) from the album create page instead of cleaning up when navigating to the albums page.
However I'm just starting to get familiar with the code, so I don't know if there are any side effects I'm not aware of...

The alternative would be to do the same cleanup when e.g. when adding a a photo to an album (in the "photos" section).
The advantage of doing it on closing is that it only needs to done once and it also avoids the flickering when opening the "albums" section (the empty album is visible just before it is deleted).

Please let me know if it is useful for you.