### PR TITLE
chore: refactor transcode config routing

### DIFF
--- a/server/src/interfaces/media.interface.ts
+++ b/server/src/interfaces/media.interface.ts
@@ -83,5 +83,5 @@ export interface IMediaRepository {
 
   // video
   probe(input: string): Promise<VideoInfo>;
-  transcode(input: string, output: string | Writable, options: TranscodeCommand): Promise<void>;
+  transcode(input: string, output: string | Writable, command: TranscodeCommand): Promise<void>;
 }

--- a/server/src/interfaces/media.interface.ts
+++ b/server/src/interfaces/media.interface.ts
@@ -53,7 +53,7 @@ export interface VideoInfo {
   audioStreams: AudioStreamInfo[];
 }
 
-export interface TranscodeOptions {
+export interface TranscodeCommand {
   inputOptions: string[];
   outputOptions: string[];
   twoPass: boolean;
@@ -67,7 +67,7 @@ export interface BitrateDistribution {
 }
 
 export interface VideoCodecSWConfig {
-  getOptions(target: TranscodeTarget, videoStream: VideoStreamInfo, audioStream: AudioStreamInfo): TranscodeOptions;
+  getCommand(target: TranscodeTarget, videoStream: VideoStreamInfo, audioStream: AudioStreamInfo): TranscodeCommand;
 }
 
 export interface VideoCodecHWConfig extends VideoCodecSWConfig {
@@ -83,5 +83,5 @@ export interface IMediaRepository {
 
   // video
   probe(input: string): Promise<VideoInfo>;
-  transcode(input: string, output: string | Writable, options: TranscodeOptions): Promise<void>;
+  transcode(input: string, output: string | Writable, options: TranscodeCommand): Promise<void>;
 }

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -11,7 +11,7 @@ import {
   IMediaRepository,
   ImageDimensions,
   ThumbnailOptions,
-  TranscodeOptions,
+  TranscodeCommand,
   VideoInfo,
 } from 'src/interfaces/media.interface';
 import { Instrumentation } from 'src/utils/instrumentation';
@@ -97,7 +97,7 @@ export class MediaRepository implements IMediaRepository {
     };
   }
 
-  transcode(input: string, output: string | Writable, options: TranscodeOptions): Promise<void> {
+  transcode(input: string, output: string | Writable, options: TranscodeCommand): Promise<void> {
     if (!options.twoPass) {
       return new Promise((resolve, reject) => {
         this.configureFfmpegCall(input, output, options).on('error', reject).on('end', resolve).run();
@@ -150,7 +150,7 @@ export class MediaRepository implements IMediaRepository {
     return { width, height };
   }
 
-  private configureFfmpegCall(input: string, output: string | Writable, options: TranscodeOptions) {
+  private configureFfmpegCall(input: string, output: string | Writable, options: TranscodeCommand) {
     return ffmpeg(input, { niceness: 10 })
       .inputOptions(options.inputOptions)
       .outputOptions(options.outputOptions)

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -488,7 +488,12 @@ export class MediaService {
 
   private async getDevices() {
     if (!this.devices) {
-      this.devices = await this.storageRepository.readdir('/dev/dri');
+      try {
+        this.devices = await this.storageRepository.readdir('/dev/dri');
+      } catch {
+        this.logger.debug('No devices found in /dev/dri.');
+        this.devices = [];
+      }
     }
 
     return this.devices;

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -3,22 +3,84 @@ import { SystemConfigFFmpegDto } from 'src/dtos/system-config.dto';
 import {
   AudioStreamInfo,
   BitrateDistribution,
-  TranscodeOptions,
+  TranscodeCommand,
   VideoCodecHWConfig,
   VideoCodecSWConfig,
   VideoStreamInfo,
 } from 'src/interfaces/media.interface';
 
-class BaseConfig implements VideoCodecSWConfig {
-  presets = ['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'];
-  constructor(protected config: SystemConfigFFmpegDto) {}
+export class BaseConfig implements VideoCodecSWConfig {
+  readonly presets = ['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'];
+  protected constructor(protected config: SystemConfigFFmpegDto) {}
 
-  getOptions(target: TranscodeTarget, videoStream: VideoStreamInfo, audioStream?: AudioStreamInfo) {
+  static create(config: SystemConfigFFmpegDto, devices: string[] = [], hasOpenCL = false): VideoCodecSWConfig {
+    if (config.accel === TranscodeHWAccel.DISABLED) {
+      return this.getSWCodecConfig(config);
+    }
+    return this.getHWCodecConfig(config, devices, hasOpenCL);
+  }
+
+  private static getSWCodecConfig(config: SystemConfigFFmpegDto) {
+    switch (config.targetVideoCodec) {
+      case VideoCodec.H264: {
+        return new H264Config(config);
+      }
+      case VideoCodec.HEVC: {
+        return new HEVCConfig(config);
+      }
+      case VideoCodec.VP9: {
+        return new VP9Config(config);
+      }
+      case VideoCodec.AV1: {
+        return new AV1Config(config);
+      }
+      default: {
+        throw new Error(`Codec '${config.targetVideoCodec}' is unsupported`);
+      }
+    }
+  }
+
+  private static getHWCodecConfig(config: SystemConfigFFmpegDto, devices: string[] = [], hasOpenCL = false) {
+    let handler: VideoCodecHWConfig;
+    switch (config.accel) {
+      case TranscodeHWAccel.NVENC: {
+        handler = config.accelDecode ? new NvencHwDecodeConfig(config) : new NvencSwDecodeConfig(config);
+        break;
+      }
+      case TranscodeHWAccel.QSV: {
+        handler = config.accelDecode ? new QsvHwDecodeConfig(config, devices) : new QsvSwDecodeConfig(config, devices);
+        break;
+      }
+      case TranscodeHWAccel.VAAPI: {
+        handler = new VAAPIConfig(config, devices);
+        break;
+      }
+      case TranscodeHWAccel.RKMPP: {
+        handler =
+          config.accelDecode && hasOpenCL
+            ? new RkmppHwDecodeConfig(config, devices)
+            : new RkmppSwDecodeConfig(config, devices);
+        break;
+      }
+      default: {
+        throw new Error(`${config.accel.toUpperCase()} acceleration is unsupported`);
+      }
+    }
+    if (!handler.getSupportedCodecs().includes(config.targetVideoCodec)) {
+      throw new Error(
+        `${config.accel.toUpperCase()} acceleration does not support codec '${config.targetVideoCodec.toUpperCase()}'. Supported codecs: ${handler.getSupportedCodecs()}`,
+      );
+    }
+
+    return handler;
+  }
+
+  getCommand(target: TranscodeTarget, videoStream: VideoStreamInfo, audioStream?: AudioStreamInfo) {
     const options = {
       inputOptions: this.getBaseInputOptions(videoStream),
       outputOptions: [...this.getBaseOutputOptions(target, videoStream, audioStream), '-v verbose'],
       twoPass: this.eligibleForTwoPass(),
-    } as TranscodeOptions;
+    } as TranscodeCommand;
     if ([TranscodeTarget.ALL, TranscodeTarget.VIDEO].includes(target)) {
       const filters = this.getFilterOptions(videoStream);
       if (filters.length > 0) {
@@ -318,6 +380,10 @@ export class BaseHWConfig extends BaseConfig implements VideoCodecHWConfig {
 }
 
 export class ThumbnailConfig extends BaseConfig {
+  static create(config: SystemConfigFFmpegDto): VideoCodecSWConfig {
+    return new ThumbnailConfig(config);
+  }
+
   getBaseInputOptions(): string[] {
     return ['-skip_frame nokey', '-sws_flags accurate_rnd+full_chroma_int'];
   }

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -13,11 +13,11 @@ export class BaseConfig implements VideoCodecSWConfig {
   readonly presets = ['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'];
   protected constructor(protected config: SystemConfigFFmpegDto) {}
 
-  static create(config: SystemConfigFFmpegDto, devices: string[] = [], hasOpenCL = false): VideoCodecSWConfig {
+  static create(config: SystemConfigFFmpegDto, devices: string[] = [], hasMaliOpenCL = false): VideoCodecSWConfig {
     if (config.accel === TranscodeHWAccel.DISABLED) {
       return this.getSWCodecConfig(config);
     }
-    return this.getHWCodecConfig(config, devices, hasOpenCL);
+    return this.getHWCodecConfig(config, devices, hasMaliOpenCL);
   }
 
   private static getSWCodecConfig(config: SystemConfigFFmpegDto) {
@@ -40,7 +40,7 @@ export class BaseConfig implements VideoCodecSWConfig {
     }
   }
 
-  private static getHWCodecConfig(config: SystemConfigFFmpegDto, devices: string[] = [], hasOpenCL = false) {
+  private static getHWCodecConfig(config: SystemConfigFFmpegDto, devices: string[] = [], hasMaliOpenCL = false) {
     let handler: VideoCodecHWConfig;
     switch (config.accel) {
       case TranscodeHWAccel.NVENC: {
@@ -57,7 +57,7 @@ export class BaseConfig implements VideoCodecSWConfig {
       }
       case TranscodeHWAccel.RKMPP: {
         handler =
-          config.accelDecode && hasOpenCL
+          config.accelDecode && hasMaliOpenCL
             ? new RkmppHwDecodeConfig(config, devices)
             : new RkmppSwDecodeConfig(config, devices);
         break;


### PR DESCRIPTION
## Description

The transcode config to use is currently handled in the media service. This PR moves it to the util instead as the routing is somewhat complex and should be considered an implementation detail. Creating a config is now declarative, without the service needing to care about what config it really is.

Also renames `TranscodeOptions` to `TranscodeCommand` and `getOptions` to `getCommand`. This is to better distinguish it from the admin config.

Lastly, it removes some uses of `null` in the service.