### PR TITLE
feat(server): [WIP] migration endpoints from google photos

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1194,30 +1194,6 @@
         ]
       }
     },
-    "/asset/duplicates": {
-      "get": {
-        "operationId": "getAssetDuplicates",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/AssetResponseDto"
-                  },
-                  "type": "array"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "tags": [
-          "Asset"
-        ]
-      }
-    },
     "/asset/exist": {
       "post": {
         "description": "Checks if multiple assets exist on the server and returns all existing - used by background backup",
@@ -3113,6 +3089,57 @@
         ],
         "tags": [
           "Memory"
+        ]
+      }
+    },
+    "/migrate/upload": {
+      "post": {
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "format": "binary",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Upload ZIP file",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Migrate"
         ]
       }
     },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3092,6 +3092,88 @@
         ]
       }
     },
+    "/migrate/begin": {
+      "post": {
+        "operationId": "beginMigration",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrationBegin"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Migrate"
+        ]
+      }
+    },
+    "/migrate/status": {
+      "get": {
+        "operationId": "getMigrationStatus",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MigrationStatus"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Migrate"
+        ]
+      }
+    },
     "/migrate/upload": {
       "post": {
         "operationId": "uploadFile",
@@ -8800,6 +8882,38 @@
             "type": "boolean"
           }
         },
+        "type": "object"
+      },
+      "MigrationBegin": {
+        "properties": {
+          "success": {
+            "example": true,
+            "readOnly": true,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ],
+        "type": "object"
+      },
+      "MigrationStatus": {
+        "properties": {
+          "res": {
+            "example": [
+              "file1.zip",
+              "file2.zip"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true,
+            "type": "array"
+          }
+        },
+        "required": [
+          "res"
+        ],
         "type": "object"
       },
       "ModelType": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3092,7 +3092,7 @@
         ]
       }
     },
-    "/migrate/begin": {
+    "/migrate/google/begin": {
       "post": {
         "operationId": "beginMigration",
         "parameters": [
@@ -3133,7 +3133,7 @@
         ]
       }
     },
-    "/migrate/status": {
+    "/migrate/google/status": {
       "get": {
         "operationId": "getMigrationStatus",
         "parameters": [
@@ -3174,7 +3174,7 @@
         ]
       }
     },
-    "/migrate/upload": {
+    "/migrate/google/upload": {
       "post": {
         "operationId": "uploadFile",
         "parameters": [

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,7 +38,7 @@
         "fast-glob": "^3.3.2",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^8.0.0",
-        "google-photos-migrate": "^2.7.1",
+        "google-photos-migrate": "^2.7.2",
         "handlebars": "^4.7.8",
         "i18n-iso-countries": "^7.6.0",
         "ioredis": "^5.3.2",
@@ -9983,9 +9983,9 @@
       }
     },
     "node_modules/google-photos-migrate": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.1.tgz",
-      "integrity": "sha512-bDc+aeVgfAelBsp2BSxZ2/dHCClFRAOInTns1Veqza/7r6sAVS11t1lp5KJ1fqHFdfMXb5TUjoOXCqJB82rXoQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.2.tgz",
+      "integrity": "sha512-V5H7aAQXFsswO78O8fAF9kPOPgb/M3TwD1iB0ev5S7cf1lVsCpcMP6eTnySCC0njWYprzBrO4jI/Q3P1wKR+iQ==",
       "license": "MIT",
       "dependencies": {
         "cmd-ts": "^0.13.0",
@@ -23344,9 +23344,9 @@
       }
     },
     "google-photos-migrate": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.1.tgz",
-      "integrity": "sha512-bDc+aeVgfAelBsp2BSxZ2/dHCClFRAOInTns1Veqza/7r6sAVS11t1lp5KJ1fqHFdfMXb5TUjoOXCqJB82rXoQ==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.2.tgz",
+      "integrity": "sha512-V5H7aAQXFsswO78O8fAF9kPOPgb/M3TwD1iB0ev5S7cf1lVsCpcMP6eTnySCC0njWYprzBrO4jI/Q3P1wKR+iQ==",
       "requires": {
         "cmd-ts": "^0.13.0",
         "exiftool-vendored": "^26.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -38,6 +38,7 @@
         "fast-glob": "^3.3.2",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^8.0.0",
+        "google-photos-migrate": "^2.7.1",
         "handlebars": "^4.7.8",
         "i18n-iso-countries": "^7.6.0",
         "ioredis": "^5.3.2",
@@ -61,7 +62,8 @@
         "sirv": "^2.0.4",
         "thumbhash": "^0.1.1",
         "typeorm": "^0.3.17",
-        "ua-parser-js": "^1.0.35"
+        "ua-parser-js": "^1.0.35",
+        "unzipper": "^0.11.6"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.1.16",
@@ -85,6 +87,7 @@
         "@types/picomatch": "^2.3.3",
         "@types/supertest": "^6.0.0",
         "@types/ua-parser-js": "^0.7.36",
+        "@types/unzipper": "^0.10.9",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitest/coverage-v8": "^1.5.0",
@@ -5976,6 +5979,16 @@
       "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
       "dev": true
     },
+    "node_modules/@types/unzipper": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.9.tgz",
+      "integrity": "sha512-vHbmFZAw8emNAOVkHVbS3qBnbr0x/qHQZ+ei1HE7Oy6Tyrptl+jpqnOX+BF5owcu/HZLOV0nJK+K9sjs1Ox2JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/validator": {
       "version": "13.11.8",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
@@ -7050,6 +7063,15 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -7075,6 +7097,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -7627,6 +7655,18 @@
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmd-ts": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/cmd-ts/-/cmd-ts-0.13.0.tgz",
+      "integrity": "sha512-nsnxf6wNIM/JAS7T/x/1JmbEsjH0a8tezXqqpaL0O6+eV0/aDEnRxwjxpu0VzDdRcaC1ixGSbRlUuf/IU59I4g==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "didyoumean": "^1.2.2",
+        "strip-ansi": "^6.0.0"
       }
     },
     "node_modules/color": {
@@ -8360,6 +8400,45 @@
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -9570,6 +9649,54 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -9853,6 +9980,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-photos-migrate": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.1.tgz",
+      "integrity": "sha512-bDc+aeVgfAelBsp2BSxZ2/dHCClFRAOInTns1Veqza/7r6sAVS11t1lp5KJ1fqHFdfMXb5TUjoOXCqJB82rXoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cmd-ts": "^0.13.0",
+        "exiftool-vendored": "^26.0.0",
+        "fs-extra": "^11.2.0",
+        "sanitize-filename": "^1.6.3"
+      },
+      "bin": {
+        "google-photos-migrate": "esm/cli.js"
+      }
+    },
+    "node_modules/google-photos-migrate/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/gopd": {
@@ -10633,7 +10789,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -15886,7 +16041,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -15926,6 +16080,19 @@
       },
       "peerDependencies": {
         "@swc/core": "^1.2.108"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.11.6.tgz",
+      "integrity": "sha512-anERl79akvqLbAxfjIFe4hK0wsi0fH4uGLwNEl4QEnG+KKs3QQeApYgOS/f6vH2EdACUlZg35psmd/3xL2duFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "bluebird": "~3.4.1",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -20256,6 +20423,15 @@
       "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
       "dev": true
     },
+    "@types/unzipper": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.9.tgz",
+      "integrity": "sha512-vHbmFZAw8emNAOVkHVbS3qBnbr0x/qHQZ+ei1HE7Oy6Tyrptl+jpqnOX+BF5owcu/HZLOV0nJK+K9sjs1Ox2JA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/validator": {
       "version": "13.11.8",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.8.tgz",
@@ -21043,6 +21219,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="
+    },
     "bignumber.js": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
@@ -21062,6 +21243,11 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "body-parser": {
       "version": "1.20.2",
@@ -21443,6 +21629,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
+    "cmd-ts": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/cmd-ts/-/cmd-ts-0.13.0.tgz",
+      "integrity": "sha512-nsnxf6wNIM/JAS7T/x/1JmbEsjH0a8tezXqqpaL0O6+eV0/aDEnRxwjxpu0VzDdRcaC1ixGSbRlUuf/IU59I4g==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "didyoumean": "^1.2.2",
+        "strip-ansi": "^6.0.0"
+      }
     },
     "color": {
       "version": "4.2.3",
@@ -21976,6 +22173,43 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
       "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A=="
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "eastasianwidth": {
       "version": "0.2.0",
@@ -22876,6 +23110,40 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -23073,6 +23341,29 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "google-photos-migrate": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/google-photos-migrate/-/google-photos-migrate-2.7.1.tgz",
+      "integrity": "sha512-bDc+aeVgfAelBsp2BSxZ2/dHCClFRAOInTns1Veqza/7r6sAVS11t1lp5KJ1fqHFdfMXb5TUjoOXCqJB82rXoQ==",
+      "requires": {
+        "cmd-ts": "^0.13.0",
+        "exiftool-vendored": "^26.0.0",
+        "fs-extra": "^11.2.0",
+        "sanitize-filename": "^1.6.3"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "gopd": {
@@ -23630,7 +23921,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -27220,8 +27510,7 @@
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -27249,6 +27538,18 @@
         "@rollup/pluginutils": "^5.1.0",
         "load-tsconfig": "^0.2.5",
         "unplugin": "^1.10.1"
+      }
+    },
+    "unzipper": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.11.6.tgz",
+      "integrity": "sha512-anERl79akvqLbAxfjIFe4hK0wsi0fH4uGLwNEl4QEnG+KKs3QQeApYgOS/f6vH2EdACUlZg35psmd/3xL2duFQ==",
+      "requires": {
+        "big-integer": "^1.6.17",
+        "bluebird": "~3.4.1",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2"
       }
     },
     "update-browserslist-db": {

--- a/server/package.json
+++ b/server/package.json
@@ -62,7 +62,7 @@
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^8.0.0",
-    "google-photos-migrate": "^2.7.1",
+    "google-photos-migrate": "^2.7.2",
     "handlebars": "^4.7.8",
     "i18n-iso-countries": "^7.6.0",
     "ioredis": "^5.3.2",

--- a/server/package.json
+++ b/server/package.json
@@ -62,6 +62,7 @@
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^8.0.0",
+    "google-photos-migrate": "^2.7.1",
     "handlebars": "^4.7.8",
     "i18n-iso-countries": "^7.6.0",
     "ioredis": "^5.3.2",
@@ -85,7 +86,8 @@
     "sirv": "^2.0.4",
     "thumbhash": "^0.1.1",
     "typeorm": "^0.3.17",
-    "ua-parser-js": "^1.0.35"
+    "ua-parser-js": "^1.0.35",
+    "unzipper": "^0.11.6"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.1.16",
@@ -109,6 +111,7 @@
     "@types/picomatch": "^2.3.3",
     "@types/supertest": "^6.0.0",
     "@types/ua-parser-js": "^0.7.36",
+    "@types/unzipper": "^0.10.9",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/coverage-v8": "^1.5.0",

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -12,6 +12,7 @@ import { ReportController } from 'src/controllers/file-report.controller';
 import { JobController } from 'src/controllers/job.controller';
 import { LibraryController } from 'src/controllers/library.controller';
 import { MemoryController } from 'src/controllers/memory.controller';
+import { MigrateController } from 'src/controllers/migrate.controller';
 import { OAuthController } from 'src/controllers/oauth.controller';
 import { PartnerController } from 'src/controllers/partner.controller';
 import { PersonController } from 'src/controllers/person.controller';
@@ -41,6 +42,7 @@ export const controllers = [
   JobController,
   LibraryController,
   MemoryController,
+  MigrateController,
   OAuthController,
   PartnerController,
   PersonController,

--- a/server/src/controllers/migrate.controller.ts
+++ b/server/src/controllers/migrate.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  HttpStatus,
+  Inject,
+  ParseFilePipe,
+  Post,
+  Res,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { AuthDto } from 'src/dtos/auth.dto';
+import { ILoggerRepository } from 'src/interfaces/logger.interface';
+import { Auth, Authenticated } from 'src/middleware/auth.guard';
+import { MigrateService } from 'src/services/migrate.service';
+
+@ApiTags('Migrate')
+@Controller('migrate')
+export class MigrateController {
+  constructor(
+    private service: MigrateService,
+    @Inject(ILoggerRepository) private logger: ILoggerRepository,
+  ) {}
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Upload ZIP file',
+    schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } } },
+  })
+  @Authenticated({ sharedLink: true })
+  async uploadFile(
+    @Auth() auth: AuthDto,
+    @UploadedFile(new ParseFilePipe()) file: Express.Multer.File,
+    @Res() res: Response,
+  ): Promise<void> {
+    try {
+      await this.service.uploadFile(auth, file);
+      res.status(HttpStatus.OK).send({ message: 'File uploaded successfully' });
+    } catch (error) {
+      this.logger.error('Error uploading file', error);
+      res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ message: 'Failed to upload file' });
+    }
+  }
+}

--- a/server/src/controllers/migrate.controller.ts
+++ b/server/src/controllers/migrate.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   HttpStatus,
   Inject,
   ParseFilePipe,
@@ -12,6 +13,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { AuthDto } from 'src/dtos/auth.dto';
+import { MigrationBegin, MigrationStatus } from 'src/dtos/migrate.dto';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { Auth, Authenticated } from 'src/middleware/auth.guard';
 import { MigrateService } from 'src/services/migrate.service';
@@ -44,5 +46,17 @@ export class MigrateController {
       this.logger.error('Error uploading file', error);
       res.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ message: 'Failed to upload file' });
     }
+  }
+
+  @Get('status')
+  @Authenticated({ sharedLink: true })
+  getMigrationStatus(): Promise<MigrationStatus> {
+    return this.service.getMigrationStatus();
+  }
+
+  @Post('begin')
+  @Authenticated({ sharedLink: true })
+  async beginMigration(): Promise<MigrationBegin> {
+    return await this.service.beginMigration();
   }
 }

--- a/server/src/controllers/migrate.controller.ts
+++ b/server/src/controllers/migrate.controller.ts
@@ -28,7 +28,7 @@ export class MigrateController {
     @Inject(ILoggerRepository) private logger: ILoggerRepository,
   ) {}
 
-  @Post('upload')
+  @Post('google/upload')
   @UseInterceptors(FileInterceptor('file'))
   @ApiConsumes('multipart/form-data')
   @ApiBody({
@@ -50,13 +50,13 @@ export class MigrateController {
     }
   }
 
-  @Get('status')
+  @Get('google/status')
   @Authenticated({ sharedLink: true })
   getMigrationStatus(): Promise<MigrationStatus> {
     return this.service.getMigrationStatus();
   }
 
-  @Post('begin')
+  @Post('google/begin')
   @Authenticated({ sharedLink: true })
   async beginMigration(@Auth() auth: AuthDto): Promise<MigrationBegin> {
     try {

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -20,6 +20,7 @@ export enum StorageFolder {
   UPLOAD = 'upload',
   PROFILE = 'profile',
   THUMBNAILS = 'thumbs',
+  MIGRATE = 'migrate',
 }
 
 export const THUMBNAIL_DIR = resolve(join(APP_MEDIA_LOCATION, StorageFolder.THUMBNAILS));

--- a/server/src/dtos/migrate.dto.ts
+++ b/server/src/dtos/migrate.dto.ts
@@ -1,0 +1,5 @@
+export class MigrateDto {}
+
+export class MigrateUploadResponseDto {
+  duplicate!: boolean;
+}

--- a/server/src/dtos/migrate.dto.ts
+++ b/server/src/dtos/migrate.dto.ts
@@ -1,5 +1,11 @@
-export class MigrateDto {}
+import { ApiResponseProperty } from '@nestjs/swagger';
 
-export class MigrateUploadResponseDto {
-  duplicate!: boolean;
+export class MigrationStatus {
+  @ApiResponseProperty({ type: [String], example: ['file1.zip', 'file2.zip'] })
+  res!: string[];
+}
+
+export class MigrationBegin {
+  @ApiResponseProperty({ type: Boolean, example: true })
+  success!: boolean;
 }

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -15,6 +15,7 @@ import { MediaService } from 'src/services/media.service';
 import { MemoryService } from 'src/services/memory.service';
 import { MetadataService } from 'src/services/metadata.service';
 import { MicroservicesService } from 'src/services/microservices.service';
+import { MigrateService } from 'src/services/migrate.service';
 import { NotificationService } from 'src/services/notification.service';
 import { PartnerService } from 'src/services/partner.service';
 import { PersonService } from 'src/services/person.service';
@@ -51,6 +52,7 @@ export const services = [
   MediaService,
   MemoryService,
   MetadataService,
+  MigrateService,
   NotificationService,
   PartnerService,
   PersonService,

--- a/server/src/services/migrate.service.spec.ts
+++ b/server/src/services/migrate.service.spec.ts
@@ -1,0 +1,4 @@
+import { MigrateService } from 'src/services/migrate.service';
+
+// TODO make spec
+describe(MigrateService.name, () => {});

--- a/server/src/services/migrate.service.ts
+++ b/server/src/services/migrate.service.ts
@@ -1,0 +1,79 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import sanitize from 'sanitize-filename';
+import { AccessCore } from 'src/cores/access.core';
+import { StorageCore, StorageFolder } from 'src/cores/storage.core';
+import { AuthDto } from 'src/dtos/auth.dto';
+import { IAccessRepository } from 'src/interfaces/access.interface';
+import { IAssetRepository } from 'src/interfaces/asset.interface';
+import { ICryptoRepository } from 'src/interfaces/crypto.interface';
+import { IJobRepository } from 'src/interfaces/job.interface';
+import { ILoggerRepository } from 'src/interfaces/logger.interface';
+import { IMoveRepository } from 'src/interfaces/move.interface';
+import { IPersonRepository } from 'src/interfaces/person.interface';
+import { IStorageRepository } from 'src/interfaces/storage.interface';
+import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
+
+@Injectable()
+export class MigrateService {
+  private access: AccessCore;
+  private storage: StorageCore;
+
+  constructor(
+    @Inject(IAssetRepository) private assetRepository: IAssetRepository,
+    @Inject(IAccessRepository) accessRepository: IAccessRepository,
+    @Inject(IJobRepository) private jobRepository: IJobRepository,
+    @Inject(IStorageRepository) private storageRepository: IStorageRepository,
+    @Inject(ILoggerRepository) private logger: ILoggerRepository,
+    @Inject(ICryptoRepository) private cryptoRepository: ICryptoRepository,
+    @Inject(IMoveRepository) private moveRepository: IMoveRepository,
+    @Inject(IPersonRepository) private personRepository: IPersonRepository,
+    @Inject(ISystemMetadataRepository) private systemMetadataRepository: ISystemMetadataRepository,
+  ) {
+    this.access = AccessCore.create(accessRepository);
+    this.storage = StorageCore.create(
+      this.assetRepository, // Asset repository not needed for this service
+      this.cryptoRepository,
+      this.moveRepository,
+      this.personRepository,
+      this.storageRepository,
+      this.systemMetadataRepository,
+      this.logger,
+    );
+    this.logger.setContext(MigrateService.name);
+  }
+
+  public async uploadFile(auth: AuthDto, file: Express.Multer.File): Promise<void> {
+    this.access.requireUploadAccess(auth);
+
+    const originalExtension = path.extname(file.originalname).toLowerCase();
+    if (originalExtension !== '.zip') {
+      throw new BadRequestException('Only .zip files are allowed');
+    }
+
+    const sanitizedFilename = sanitize(file.originalname);
+    const uploadFolder = this.getUploadFolder();
+    const uploadPath = path.join(uploadFolder, sanitizedFilename);
+    console.log(uploadPath);
+
+    try {
+      // Ensure the uploads directory exists
+      await fs.mkdir(path.dirname(uploadPath), { recursive: true });
+
+      // Write the file to disk
+      await fs.writeFile(uploadPath, file.buffer);
+
+      this.logger.log(`File ${sanitizedFilename} uploaded successfully.`);
+    } catch (error) {
+      this.logger.error('Failed to upload file', error);
+      throw error;
+    }
+  }
+
+  private getUploadFolder(): string {
+    const folder = StorageCore.getBaseFolder(StorageFolder.MIGRATE);
+    this.storageRepository.mkdirSync(folder);
+    return folder;
+  }
+}

--- a/server/src/services/migrate.service.ts
+++ b/server/src/services/migrate.service.ts
@@ -1,10 +1,14 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ExifTool } from 'exiftool-vendored';
+import { MediaMigrationError, NoPhotosDirError, migrateDirFullGen } from 'google-photos-migrate';
+import { createReadStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import sanitize from 'sanitize-filename';
 import { AccessCore } from 'src/cores/access.core';
 import { StorageCore, StorageFolder } from 'src/cores/storage.core';
 import { AuthDto } from 'src/dtos/auth.dto';
+import { MigrationBegin, MigrationStatus } from 'src/dtos/migrate.dto';
 import { IAccessRepository } from 'src/interfaces/access.interface';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { ICryptoRepository } from 'src/interfaces/crypto.interface';
@@ -14,6 +18,7 @@ import { IMoveRepository } from 'src/interfaces/move.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
 import { IStorageRepository } from 'src/interfaces/storage.interface';
 import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
+import unzipper from 'unzipper';
 
 @Injectable()
 export class MigrateService {
@@ -75,5 +80,97 @@ export class MigrateService {
     const folder = StorageCore.getBaseFolder(StorageFolder.MIGRATE);
     this.storageRepository.mkdirSync(folder);
     return folder;
+  }
+
+  public async getMigrationStatus(): Promise<MigrationStatus> {
+    const folder = this.getUploadFolder();
+    try {
+      const files = await fs.readdir(folder);
+      const zipFiles = files.filter((file) => path.extname(file) === '.zip');
+      const status = new MigrationStatus();
+      status.res = zipFiles;
+      return status;
+    } catch (error) {
+      this.logger.error('Failed to read migration folder', error);
+      throw error;
+    }
+  }
+
+  public async beginMigration(): Promise<MigrationBegin> {
+    const migration = new MigrationBegin();
+    try {
+      // 1: Unzip folder
+      const folder = this.getUploadFolder();
+      await this.unzipFiles(folder, folder);
+
+      // 2: Run google photos migrate on it
+      console.log('Started migration.');
+      const migGen = migrateDirFullGen({
+        inputDir: path.join(folder, 'Takeout'),
+        errorDir: path.join(folder, 'error'),
+        outputDir: path.join(folder, 'output'),
+        log: console.log,
+        warnLog: console.error,
+        verboseLog: console.log,
+        exiftool: new ExifTool(),
+        endExifTool: true,
+      });
+      const counts = { err: 0, suc: 0 };
+      for await (const result of migGen) {
+        if (result instanceof NoPhotosDirError) {
+          throw result;
+        }
+
+        if (result instanceof MediaMigrationError) {
+          console.error(`Error: ${result}`);
+          counts.err++;
+          continue;
+        }
+
+        counts.suc++;
+      }
+
+      console.log(`Done! Processed ${counts.suc + counts.err} files.`);
+      console.log(`Files migrated: ${counts.suc}`);
+      console.log(`Files failed: ${counts.err}`);
+
+      // 3: Import those files
+
+      migration.success = true;
+      return migration;
+    } catch (error) {
+      console.log(error);
+      migration.success = false;
+      return migration;
+    }
+  }
+
+  private async unzipFiles(sourceDir: string, outputDir: string) {
+    try {
+      // Read all files from the source directory
+      const files = await fs.readdir(sourceDir);
+
+      // Filter out only .zip files
+      const zipFiles = files.filter((file) => path.extname(file) === '.zip');
+
+      for (const zipFile of zipFiles) {
+        const zipFilePath = path.join(sourceDir, zipFile);
+
+        // Ensure the output directory exists
+        await fs.mkdir(outputDir, { recursive: true });
+
+        // Unzip the file using unzipper
+        await new Promise((resolve, reject) => {
+          createReadStream(zipFilePath)
+            .pipe(unzipper.Extract({ path: outputDir }))
+            .on('close', resolve)
+            .on('error', reject);
+        });
+      }
+
+      console.log('All zip files have been successfully extracted.');
+    } catch (error) {
+      console.error('An error occurred while extracting zip files:', error);
+    }
   }
 }

--- a/server/src/services/migrate.service.ts
+++ b/server/src/services/migrate.service.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import sanitize from 'sanitize-filename';
 import { AccessCore } from 'src/cores/access.core';
 import { StorageCore, StorageFolder } from 'src/cores/storage.core';
+import { CreateAssetDto } from 'src/dtos/asset-v1.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { MigrationBegin, MigrationStatus } from 'src/dtos/migrate.dto';
 import { IAccessRepository } from 'src/interfaces/access.interface';
@@ -18,7 +19,33 @@ import { IMoveRepository } from 'src/interfaces/move.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
 import { IStorageRepository } from 'src/interfaces/storage.interface';
 import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
+import { AssetServiceV1 } from 'src/services/asset-v1.service';
 import unzipper from 'unzipper';
+
+class UploadFileClient extends File {
+  constructor(
+    private filepath: string,
+    private _size: number,
+  ) {
+    super([], path.basename(filepath));
+  }
+
+  get size() {
+    return this._size;
+  }
+
+  stream() {
+    return createReadStream(this.filepath) as any;
+  }
+}
+
+interface UploadFileServer {
+  uuid: string;
+  checksum: Buffer;
+  originalPath: string;
+  originalName: string;
+  size: number;
+}
 
 @Injectable()
 export class MigrateService {
@@ -49,7 +76,7 @@ export class MigrateService {
     this.logger.setContext(MigrateService.name);
   }
 
-  public async uploadFile(auth: AuthDto, file: Express.Multer.File): Promise<void> {
+  public async uploadZipFile(auth: AuthDto, file: Express.Multer.File): Promise<void> {
     this.access.requireUploadAccess(auth);
 
     const originalExtension = path.extname(file.originalname).toLowerCase();
@@ -96,14 +123,14 @@ export class MigrateService {
     }
   }
 
-  public async beginMigration(): Promise<MigrationBegin> {
+  public async beginMigration(auth: AuthDto, assetServiceV1: AssetServiceV1): Promise<MigrationBegin> {
     const migration = new MigrationBegin();
     try {
       // 1: Unzip folder
       const folder = this.getUploadFolder();
       await this.unzipFiles(folder, folder);
 
-      // 2: Run google photos migrate on it
+      // 2: Run google-photos-migrate on it
       console.log('Started migration.');
       const migGen = migrateDirFullGen({
         inputDir: path.join(folder, 'Takeout'),
@@ -135,6 +162,30 @@ export class MigrateService {
       console.log(`Files failed: ${counts.err}`);
 
       // 3: Import those files
+      const outputFolder = path.join(folder, 'output', 'Photos');
+      const paths = await this.getFilesRecursively(outputFolder);
+
+      for (const filePath of paths) {
+        const fileData = await fs.readFile(filePath); // Read file data synchronously
+        const fileStats = await fs.stat(filePath); // Get file stats
+
+        const cdto: CreateAssetDto = new CreateAssetDto();
+        cdto.deviceAssetId = `${path.basename(filePath)}-${fileStats.size}`.replaceAll(/\s+/g, '');
+        cdto.deviceId = `server`;
+        cdto.fileCreatedAt = fileStats.mtime;
+        cdto.fileModifiedAt = fileStats.mtime;
+        cdto.isFavorite = false;
+        cdto.assetData = new UploadFileClient(filePath, fileStats.size);
+
+        const newUploadFile: UploadFileServer = {
+          checksum: await this.cryptoRepository.hashFile(filePath),
+          originalName: path.basename(filePath),
+          originalPath: filePath,
+          size: fileStats.size,
+          uuid: this.cryptoRepository.hashSha1(fileData).toString(),
+        };
+        await assetServiceV1.uploadFile(auth, cdto, newUploadFile);
+      }
 
       migration.success = true;
       return migration;
@@ -172,5 +223,25 @@ export class MigrateService {
     } catch (error) {
       console.error('An error occurred while extracting zip files:', error);
     }
+  }
+
+  private async getFilesRecursively(dir: string): Promise<string[]> {
+    let files: string[] = [];
+
+    const items = await fs.readdir(dir, { withFileTypes: true });
+
+    for (const item of items) {
+      const fullPath = path.join(dir, item.name);
+
+      if (item.isDirectory()) {
+        // Recursively call the function for the directory
+        const nestedFiles = await this.getFilesRecursively(fullPath);
+        files = [...files, ...nestedFiles];
+      } else if (item.isFile()) {
+        files.push(fullPath);
+      }
+    }
+
+    return files;
   }
 }


### PR DESCRIPTION
https://github.com/immich-app/immich/assets/58121030/a7f1fdfe-9c07-48a2-9b0a-ba4e6b1ef8b3

The goal with this PR is to lay the groundwork for having a seamless and simple way to migrate from GP to Immich via the Web-UI.

So this PR includes 3 new endpoints:
- /migrate/google/upload : endpoint to upload zip files to
- /migrate/google/status : endpoint to check what zip files have been uploaded
- /migrate/google/begin : endpoint to begin the migration process

The idea behind these endpoints is the user can drag and drop individual zip files from the takeout into a new page in the administration panel, and then they can click a button to begin the migration once all zip files are uploaded.

This PR is very much WIP and should not be viewed as the final product. I just want to see what you guys think about this concept and the direction I'm taking it before I fill out all the tests and begin on the Web-UI. Also, while [immich-go](https://github.com/simulot/immich-go) is the community choice for large migrations, I instead used [google-photos-migrate](https://github.com/garzj/google-photos-migrate) as it has a npm package that can easily be used with the server stack (as opposed to go which _could_ be implemented, but would be more complicated). It is likely that `immich-go` is better suited for large imports, but this feature is targeted towards those with smaller libraries which could be successfully uploaded over a web UI. 