### PR TITLE
feat(deployment): add TZ to example.env

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -5,7 +5,7 @@ UPLOAD_LOCATION=./library
 # The location where your database files are stored
 DB_DATA_LOCATION=./postgres
 
-# To select a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+# To set a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # TZ=Etc/UTC
 
 # The Immich version to use. You can pin this to a specific version like "v1.71.0"

--- a/docker/example.env
+++ b/docker/example.env
@@ -6,7 +6,7 @@ UPLOAD_LOCATION=./library
 DB_DATA_LOCATION=./postgres
 
 # To select a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
-# TZ='Etc/UTC'
+# TZ=Etc/UTC
 
 # The Immich version to use. You can pin this to a specific version like "v1.71.0"
 IMMICH_VERSION=release

--- a/docker/example.env
+++ b/docker/example.env
@@ -4,6 +4,8 @@
 UPLOAD_LOCATION=./library
 # The location where your database files are stored
 DB_DATA_LOCATION=./postgres
+# To select a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+# TZ='Etc/UTC'
 
 # The Immich version to use. You can pin this to a specific version like "v1.71.0"
 IMMICH_VERSION=release

--- a/docker/example.env
+++ b/docker/example.env
@@ -4,6 +4,7 @@
 UPLOAD_LOCATION=./library
 # The location where your database files are stored
 DB_DATA_LOCATION=./postgres
+
 # To select a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # TZ='Etc/UTC'
 


### PR DESCRIPTION
`TZ` is used by exiftool and, apparently, log file timestamps. This needs to be set even if /etc/localtime is passed through. I propose that we add a commented TZ field to example.env to prompt users to select their timezone.