### PR TITLE
fix(server): video thumbnail generation failing when using qsv

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -363,6 +363,23 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should use scaling divisible by 2 even when using quick sync', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStream2160p);
+      systemMock.get.mockResolvedValue({ ffmpeg: { accel: TranscodeHWAccel.QSV } });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleGeneratePreview({ id: assetStub.video.id });
+
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
+        {
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([expect.stringContaining('scale=-2:1440')]),
+          twoPass: false,
+        },
+      );
+    });
+
     it('should run successfully', async () => {
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
       await sut.handleGeneratePreview({ id: assetStub.image.id });

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -226,9 +226,8 @@ export class BaseConfig implements VideoCodecSWConfig {
     return videoStream.isHDR && this.config.tonemap !== ToneMapping.DISABLED;
   }
 
-  getScaling(videoStream: VideoStreamInfo) {
+  getScaling(videoStream: VideoStreamInfo, mult = 2) {
     const targetResolution = this.getTargetResolution(videoStream);
-    const mult = this.config.accel === TranscodeHWAccel.QSV ? 1 : 2; // QSV doesn't support scaling numbers below -1
     return this.isVideoVertical(videoStream) ? `${targetResolution}:-${mult}` : `-${mult}:${targetResolution}`;
   }
 
@@ -708,6 +707,10 @@ export class QsvSwDecodeConfig extends BaseHWConfig {
 
   useCQP() {
     return this.config.cqMode === CQMode.CQP || this.config.targetVideoCodec === VideoCodec.VP9;
+  }
+
+  getScaling(videoStream: VideoStreamInfo): string {
+    return super.getScaling(videoStream, 1);
   }
 }
 


### PR DESCRIPTION
## Description

The QSV scaling filter disallows setting values below -1, so there's a condition to set the multiplier to -1 when it's enabled. However, the thumbnail config uses the same method but is not currently accelerated, so it must still use -2. This PR moves the QSV special case to its config to avoid side effects.

Fixes #9444