### PR TITLE
Update backup-and-restore.md - added "-d immich" to psql restore command

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -37,7 +37,7 @@ docker start immich_postgres    # Start Postgres server
 sleep 10    # Wait for Postgres server to start up
 gunzip < "/path/to/backup/dump.sql.gz" \
 | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
-| docker exec -i immich_postgres psql --username=postgres    # Restore Backup
+| docker exec -i immich_postgres psql --username=postgres -d immich   # Restore Backup
 docker compose up -d    # Start remainder of Immich apps
 ```
 


### PR DESCRIPTION
The current command to unzip the backup and restore it to the database using the psql command malfunctions, because the database name "immich" needs to be included.

I've made several backups/restores now and none work if the "-d immich" is absent - all work just fine when it is present.

So, we need to update the instructions now.

I backed-up/restored using v1.104.0 - it's possible something works different in v1.105.x.  But regardless of that, many people restoring will be using versions earlier than 1.105.