### PR TITLE
Prevent losing photos

### DIFF
--- a/mobile/assets/i18n/nl-NL.json
+++ b/mobile/assets/i18n/nl-NL.json
@@ -158,7 +158,7 @@
   "control_bottom_app_bar_share": "Delen",
   "control_bottom_app_bar_share_to": "Delen met",
   "control_bottom_app_bar_stack": "Stapel",
-  "control_bottom_app_bar_trash_from_immich": "Verplaatsen naar prullenbak",
+  "control_bottom_app_bar_trash_from_immich": "Naar prullenbak",
   "control_bottom_app_bar_unarchive": "Herstellen",
   "control_bottom_app_bar_unfavorite": "Onfavoriet",
   "control_bottom_app_bar_upload": "Uploaden",


### PR DESCRIPTION
The text "Verplaatsen naar prullenbak" [move to bin] is too long. Only the first 2 words are visible suggesting that you 'move' photos elsewhere. If you do this with a selection in an album, the photos are removed from the album and good luck finding them again... We fix this by replacing the text with "Naar prullenbak" [to bin] which hopefully does fit.