### PR TITLE
fix: immich port with external domain

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -24,6 +24,8 @@ export const envName = (process.env.IMMICH_ENV || 'production').toUpperCase();
 export const isDev = () => process.env.IMMICH_ENV === 'development';
 export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload';
 export const WEB_ROOT = process.env.IMMICH_WEB_ROOT || '/usr/src/app/www';
+const HOST_SERVER_PORT = process.env.IMMICH_PORT || '2283';
+export const FALLBACK_EXTERNAL_DOMAIN = 'http://localhost:' + HOST_SERVER_PORT;
 
 const GEODATA_ROOT_PATH = process.env.IMMICH_REVERSE_GEOCODING_ROOT || '/usr/src/resources';
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -25,7 +25,7 @@ export const isDev = () => process.env.IMMICH_ENV === 'development';
 export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload';
 export const WEB_ROOT = process.env.IMMICH_WEB_ROOT || '/usr/src/app/www';
 const HOST_SERVER_PORT = process.env.IMMICH_PORT || '2283';
-export const FALLBACK_EXTERNAL_DOMAIN = 'http://localhost:' + HOST_SERVER_PORT;
+export const DEFAULT_EXTERNAL_DOMAIN = 'http://localhost:' + HOST_SERVER_PORT;
 
 const GEODATA_ROOT_PATH = process.env.IMMICH_REVERSE_GEOCODING_ROOT || '/usr/src/resources';
 

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { FALLBACK_EXTERNAL_DOMAIN } from 'src/constants';
 import { SystemConfigCore } from 'src/cores/system-config.core';
 import { OnServerEvent } from 'src/decorators';
 import { AlbumEntity } from 'src/entities/album.entity';
@@ -63,7 +64,7 @@ export class NotificationService {
     const { html, text } = this.notificationRepository.renderEmail({
       template: EmailTemplate.WELCOME,
       data: {
-        baseUrl: server.externalDomain || 'http://localhost:2283',
+        baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
         displayName: user.name,
         username: user.email,
         password: tempPassword,
@@ -100,7 +101,7 @@ export class NotificationService {
     const { html, text } = this.notificationRepository.renderEmail({
       template: EmailTemplate.ALBUM_INVITE,
       data: {
-        baseUrl: server.externalDomain || 'http://localhost:2283',
+        baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
         albumId: album.id,
         albumName: album.albumName,
         senderName: album.owner.name,
@@ -144,7 +145,7 @@ export class NotificationService {
       const { html, text } = this.notificationRepository.renderEmail({
         template: EmailTemplate.ALBUM_UPDATE,
         data: {
-          baseUrl: server.externalDomain || 'http://localhost:2283',
+          baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
           albumId: album.id,
           albumName: album.albumName,
           recipientName: recipient.name,

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { FALLBACK_EXTERNAL_DOMAIN } from 'src/constants';
+import { DEFAULT_EXTERNAL_DOMAIN } from 'src/constants';
 import { SystemConfigCore } from 'src/cores/system-config.core';
 import { OnServerEvent } from 'src/decorators';
 import { AlbumEntity } from 'src/entities/album.entity';
@@ -64,7 +64,7 @@ export class NotificationService {
     const { html, text } = this.notificationRepository.renderEmail({
       template: EmailTemplate.WELCOME,
       data: {
-        baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
+        baseUrl: server.externalDomain || DEFAULT_EXTERNAL_DOMAIN,
         displayName: user.name,
         username: user.email,
         password: tempPassword,
@@ -101,7 +101,7 @@ export class NotificationService {
     const { html, text } = this.notificationRepository.renderEmail({
       template: EmailTemplate.ALBUM_INVITE,
       data: {
-        baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
+        baseUrl: server.externalDomain || DEFAULT_EXTERNAL_DOMAIN,
         albumId: album.id,
         albumName: album.albumName,
         senderName: album.owner.name,
@@ -145,7 +145,7 @@ export class NotificationService {
       const { html, text } = this.notificationRepository.renderEmail({
         template: EmailTemplate.ALBUM_UPDATE,
         data: {
-          baseUrl: server.externalDomain || FALLBACK_EXTERNAL_DOMAIN,
+          baseUrl: server.externalDomain || DEFAULT_EXTERNAL_DOMAIN,
           albumId: album.id,
           albumName: album.albumName,
           recipientName: recipient.name,


### PR DESCRIPTION
Currently, the fallback for the external domain uses the `:2283` port which is the wrong port if you have `IMMICH_PORT` set.