### PR TITLE
fix: clear multiselect when asset-grid is empty

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -48,6 +48,11 @@
   $: timelineY = element?.scrollTop || 0;
   $: isEmpty = $assetStore.initialized && $assetStore.buckets.length === 0;
   $: idsSelectedAssets = [...$selectedAssets].map(({ id }) => id);
+  $: {
+    if (isEmpty) {
+      assetInteractionStore.clearMultiselect();
+    }
+  }
 
   $: {
     void assetStore.updateViewport(viewport);


### PR DESCRIPTION
Noticed a bug with #9862:
If you select one or multiple assets and restore them all, the multi-selection bar is still present