### PR TITLE
fix(web): set album description textarea height correctly

### DIFF
--- a/web/src/lib/components/album-page/album-description.spec.ts
+++ b/web/src/lib/components/album-page/album-description.spec.ts
@@ -1,0 +1,18 @@
+import AlbumDescription from '$lib/components/album-page/album-description.svelte';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/svelte';
+import { describe } from 'vitest';
+
+describe('AlbumDescription component', () => {
+  it('shows an AutogrowTextarea component when isOwned is true', () => {
+    render(AlbumDescription, { isOwned: true, id: '', description: '' });
+    const autogrowTextarea = screen.getByTestId('autogrow-textarea');
+    expect(autogrowTextarea).toBeInTheDocument();
+  });
+
+  it('does not show an AutogrowTextarea component when isOwned is false', () => {
+    render(AlbumDescription, { isOwned: false, id: '', description: '' });
+    const autogrowTextarea = screen.queryByTestId('autogrow-textarea');
+    expect(autogrowTextarea).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/album-page/album-description.svelte
+++ b/web/src/lib/components/album-page/album-description.svelte
@@ -28,6 +28,7 @@
     elementClass="w-full mt-2 resize-none text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
     onContentUpdate={handleUpdateDescription}
     placeholder="Add a description"
+    data-testid="autogrow-textarea"
   />
 {:else if description}
   <p class="break-words whitespace-pre-line w-full text-black dark:text-white text-base">

--- a/web/src/lib/components/album-page/album-description.svelte
+++ b/web/src/lib/components/album-page/album-description.svelte
@@ -7,7 +7,7 @@
   export let description: string;
   export let isOwned: boolean;
 
-  const handleUpdateDescription = async (newDescription) => {
+  const handleUpdateDescription = async (newDescription: string) => {
     try {
       await updateAlbumInfo({
         id,

--- a/web/src/lib/components/album-page/album-description.svelte
+++ b/web/src/lib/components/album-page/album-description.svelte
@@ -28,7 +28,6 @@
     class="w-full mt-2 text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
     onContentUpdate={handleUpdateDescription}
     placeholder="Add a description"
-    data-testid="autogrow-textarea"
   />
 {:else if description}
   <p class="break-words whitespace-pre-line w-full text-black dark:text-white text-base">

--- a/web/src/lib/components/album-page/album-description.svelte
+++ b/web/src/lib/components/album-page/album-description.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
-  import { autoGrowHeight } from '$lib/actions/autogrow';
   import { updateAlbumInfo } from '@immich/sdk';
   import { handleError } from '$lib/utils/handle-error';
-  import { shortcut } from '$lib/actions/shortcut';
+  import AutogrowTextarea from '$lib/components/shared-components/autogrow-textarea.svelte';
 
   export let id: string;
   export let description: string;
   export let isOwned: boolean;
 
-  $: newDescription = description;
-
-  const handleUpdateDescription = async () => {
-    if (newDescription === description) {
-      return;
-    }
-
+  const handleUpdateDescription = async (newDescription) => {
     try {
       await updateAlbumInfo({
         id,
@@ -24,24 +17,17 @@
       });
     } catch (error) {
       handleError(error, 'Error updating album description');
-      return;
     }
     description = newDescription;
   };
 </script>
 
 {#if isOwned}
-  <textarea
-    class="w-full mt-2 resize-none text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
-    bind:value={newDescription}
-    on:input={(e) => autoGrowHeight(e.currentTarget)}
-    on:focusout={handleUpdateDescription}
-    use:autoGrowHeight
+  <AutogrowTextarea
+    content={description}
+    elementClass="w-full mt-2 resize-none text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
+    onContentUpdate={handleUpdateDescription}
     placeholder="Add a description"
-    use:shortcut={{
-      shortcut: { key: 'Enter', ctrl: true },
-      onShortcut: (e) => e.currentTarget.blur(),
-    }}
   />
 {:else if description}
   <p class="break-words whitespace-pre-line w-full text-black dark:text-white text-base">

--- a/web/src/lib/components/album-page/album-description.svelte
+++ b/web/src/lib/components/album-page/album-description.svelte
@@ -25,7 +25,7 @@
 {#if isOwned}
   <AutogrowTextarea
     content={description}
-    elementClass="w-full mt-2 resize-none text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
+    class="w-full mt-2 text-black dark:text-white border-b-2 border-transparent border-gray-500 bg-transparent text-base outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:focus:border-immich-dark-primary hover:border-gray-400"
     onContentUpdate={handleUpdateDescription}
     placeholder="Add a description"
     data-testid="autogrow-textarea"

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -30,7 +30,7 @@
   <section class="px-4 mt-10">
     <AutogrowTextarea
       content={description}
-      elementClass="max-h-[500px] w-full resize-none border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary immich-scrollbar"
+      class="max-h-[500px] w-full border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary immich-scrollbar"
       onContentUpdate={handleFocusOut}
       placeholder="Add a description"
     />

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -12,7 +12,7 @@
 
   $: description = asset.exifInfo?.description || '';
 
-  const handleFocusOut = async (newDescription) => {
+  const handleFocusOut = async (newDescription: string) => {
     try {
       await updateAsset({ id: asset.id, updateAssetDto: { description: newDescription } });
       notificationController.show({

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -1,32 +1,18 @@
 <script lang="ts">
-  import { autoGrowHeight } from '$lib/actions/autogrow';
-  import { clickOutside } from '$lib/actions/click-outside';
-  import { shortcut } from '$lib/actions/shortcut';
   import {
     NotificationType,
     notificationController,
   } from '$lib/components/shared-components/notification/notification';
   import { handleError } from '$lib/utils/handle-error';
   import { updateAsset, type AssetResponseDto } from '@immich/sdk';
-  import { tick } from 'svelte';
+  import AutogrowTextarea from '$lib/components/shared-components/autogrow-textarea.svelte';
 
   export let asset: AssetResponseDto;
   export let isOwner: boolean;
 
-  let textarea: HTMLTextAreaElement;
   $: description = asset.exifInfo?.description || '';
-  $: newDescription = description;
 
-  $: if (textarea) {
-    newDescription;
-    void tick().then(() => autoGrowHeight(textarea));
-  }
-
-  const handleFocusOut = async () => {
-    if (description === newDescription) {
-      return;
-    }
-
+  const handleFocusOut = async (newDescription) => {
     try {
       await updateAsset({ id: asset.id, updateAssetDto: { description: newDescription } });
       notificationController.show({
@@ -36,23 +22,18 @@
     } catch (error) {
       handleError(error, 'Cannot update the description');
     }
+    description = newDescription;
   };
 </script>
 
 {#if isOwner}
   <section class="px-4 mt-10">
-    <textarea
-      bind:this={textarea}
-      class="max-h-[500px] w-full resize-none border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary immich-scrollbar"
+    <AutogrowTextarea
+      content={description}
+      elementClass="max-h-[500px] w-full resize-none border-b border-gray-500 bg-transparent text-base text-black outline-none transition-all focus:border-b-2 focus:border-immich-primary disabled:border-none dark:text-white dark:focus:border-immich-dark-primary immich-scrollbar"
+      onContentUpdate={handleFocusOut}
       placeholder="Add a description"
-      on:focusout={handleFocusOut}
-      on:input={(e) => (newDescription = e.currentTarget.value)}
-      use:clickOutside={{ onOutclick: void handleFocusOut }}
-      use:shortcut={{
-        shortcut: { key: 'Enter', ctrl: true },
-        onShortcut: (e) => e.currentTarget.blur(),
-      }}>{description}</textarea
-    >
+    />
   </section>
 {:else if description}
   <section class="px-4 mt-6">

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -47,13 +47,12 @@
       placeholder="Add a description"
       on:focusout={handleFocusOut}
       on:input={(e) => (newDescription = e.currentTarget.value)}
-      value={description}
       use:clickOutside={{ onOutclick: void handleFocusOut }}
       use:shortcut={{
         shortcut: { key: 'Enter', ctrl: true },
         onShortcut: (e) => e.currentTarget.blur(),
-      }}
-    />
+      }}>{description}</textarea
+    >
   </section>
 {:else if description}
   <section class="px-4 mt-6">

--- a/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
+++ b/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
@@ -1,10 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event'
 import AutogrowTextarea from '$lib/components/shared-components/autogrow-textarea.svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 
 describe('AutogrowTextarea component', () => {
-  const getTextarea = () =>
-    screen.getByRole('textbox') as HTMLTextAreaElement;
+  const getTextarea = () => screen.getByRole('textbox') as HTMLTextAreaElement;
 
   it('should render correctly', () => {
     render(AutogrowTextarea);
@@ -25,7 +24,7 @@ describe('AutogrowTextarea component', () => {
   });
 
   it('should execute the passed callback on blur', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     const update = vi.fn();
     render(AutogrowTextarea, { onContentUpdate: update });
     const textarea = getTextarea();
@@ -37,7 +36,7 @@ describe('AutogrowTextarea component', () => {
   });
 
   it('should execute the passed when pressing ctrl+enter in the textarea', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     const update = vi.fn();
     render(AutogrowTextarea, { onContentUpdate: update });
     const textarea = getTextarea();

--- a/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
+++ b/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event'
+import AutogrowTextarea from '$lib/components/shared-components/autogrow-textarea.svelte';
+
+describe('AutogrowTextarea component', () => {
+  const getTextarea = () =>
+    screen.getByRole('textbox') as HTMLTextAreaElement;
+
+  it('should render correctly', () => {
+    render(AutogrowTextarea);
+    const textarea = getTextarea();
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it('should show the content passed to the component', () => {
+    render(AutogrowTextarea, { content: 'stuff' });
+    const textarea = getTextarea();
+    expect(textarea.value).toBe('stuff');
+  });
+
+  it('should show the placeholder passed to the component', () => {
+    render(AutogrowTextarea, { placeholder: 'asdf' });
+    const textarea = getTextarea();
+    expect(textarea.placeholder).toBe('asdf');
+  });
+
+  it('should execute the passed callback on blur', async () => {
+    const user = userEvent.setup()
+    const update = vi.fn();
+    render(AutogrowTextarea, { onContentUpdate: update });
+    const textarea = getTextarea();
+    await user.click(textarea);
+    const string = 'content';
+    await user.keyboard(string);
+    textarea.blur();
+    await waitFor(() => expect(update).toHaveBeenCalledWith(string));
+  });
+
+  it('should execute the passed when pressing ctrl+enter in the textarea', async () => {
+    const user = userEvent.setup()
+    const update = vi.fn();
+    render(AutogrowTextarea, { onContentUpdate: update });
+    const textarea = getTextarea();
+    await user.click(textarea);
+    const string = 'content';
+    await user.keyboard(string);
+    await user.keyboard('{Control>}{Enter}{/Control}');
+    await waitFor(() => expect(update).toHaveBeenCalledWith(string));
+  });
+});

--- a/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
+++ b/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 
 describe('AutogrowTextarea component', () => {
-  const getTextarea = () => screen.getByRole('textbox') as HTMLTextAreaElement;
+  const getTextarea = () => screen.getByTestId('autogrow-textarea') as HTMLTextAreaElement;
 
   it('should render correctly', () => {
     render(AutogrowTextarea);

--- a/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
+++ b/web/src/lib/components/shared-components/autogrow-textarea.spec.ts
@@ -26,16 +26,15 @@ describe('AutogrowTextarea component', () => {
   it('should execute the passed callback on blur', async () => {
     const user = userEvent.setup();
     const update = vi.fn();
-    render(AutogrowTextarea, { onContentUpdate: update });
+    render(AutogrowTextarea, { content: 'existing', onContentUpdate: update });
     const textarea = getTextarea();
     await user.click(textarea);
-    const string = 'content';
-    await user.keyboard(string);
+    await user.keyboard('extra');
     textarea.blur();
-    await waitFor(() => expect(update).toHaveBeenCalledWith(string));
+    await waitFor(() => expect(update).toHaveBeenCalledWith('existingextra'));
   });
 
-  it('should execute the passed when pressing ctrl+enter in the textarea', async () => {
+  it('should execute the passed callback when pressing ctrl+enter in the textarea', async () => {
     const user = userEvent.setup();
     const update = vi.fn();
     render(AutogrowTextarea, { onContentUpdate: update });
@@ -45,5 +44,17 @@ describe('AutogrowTextarea component', () => {
     await user.keyboard(string);
     await user.keyboard('{Control>}{Enter}{/Control}');
     await waitFor(() => expect(update).toHaveBeenCalledWith(string));
+  });
+
+  it('should not execute the passed callback if the text has not changed', async () => {
+    const user = userEvent.setup();
+    const update = vi.fn();
+    render(AutogrowTextarea, { content: 'initial', onContentUpdate: update });
+    const textarea = getTextarea();
+    await user.click(textarea);
+    await user.clear(textarea);
+    await user.keyboard('initial');
+    await user.keyboard('{Control>}{Enter}{/Control}');
+    await waitFor(() => expect(update).not.toHaveBeenCalled());
   });
 });

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -4,10 +4,10 @@
   import { shortcut } from '$lib/actions/shortcut';
   import { tick } from 'svelte';
 
-  export let content: string;
-  export let elementClass: string;
-  export let onContentUpdate: (newContent: string) => void;
-  export let placeholder: string;
+  export let content: string = '';
+  export let elementClass: string = '';
+  export let onContentUpdate: (newContent: string) => void = () => null;
+  export let placeholder: string = '';
 
   let textarea: HTMLTextAreaElement;
   $: newContent = content;

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -35,5 +35,6 @@
   use:shortcut={{
     shortcut: { key: 'Enter', ctrl: true },
     onShortcut: (e) => e.currentTarget.blur(),
-  }}>{content}</textarea
+  }}
+  {...$$restProps}>{content}</textarea
 >

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -35,5 +35,5 @@
     shortcut: { key: 'Enter', ctrl: true },
     onShortcut: (e) => e.currentTarget.blur(),
   }}
-  {...$$restProps}>{content}</textarea
+  data-testid="autogrow-textarea">{content}</textarea
 >

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { autoGrowHeight } from '$lib/actions/autogrow';
+  import { clickOutside } from '$lib/actions/click-outside';
+  import { shortcut } from '$lib/actions/shortcut';
+  import { tick } from 'svelte';
+
+  export let content: string;
+  export let elementClass: string;
+  export let onContentUpdate: (newContent) => void;
+  export let placeholder: string;
+
+  let textarea: HTMLTextAreaElement;
+  $: newContent = content;
+
+  $: if (textarea) {
+    newContent;
+    void tick().then(() => autoGrowHeight(textarea));
+  }
+
+  const updateContent = () => {
+    if (content === newContent) {
+      return;
+    }
+    onContentUpdate(newContent);
+  };
+</script>
+
+<textarea
+  bind:this={textarea}
+  class={elementClass}
+  on:focusout={updateContent}
+  on:input={(e) => (newContent = e.currentTarget.value)}
+  use:clickOutside={{ onOutclick: updateContent }}
+  {placeholder}
+  use:shortcut={{
+    shortcut: { key: 'Enter', ctrl: true },
+    onShortcut: (e) => e.currentTarget.blur(),
+  }}>{content}</textarea
+>

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { autoGrowHeight } from '$lib/actions/autogrow';
-  import { clickOutside } from '$lib/actions/click-outside';
   import { shortcut } from '$lib/actions/shortcut';
   import { tick } from 'svelte';
 
   export let content: string = '';
-  export let elementClass: string = '';
+  let className: string = '';
+  export { className as class };
   export let onContentUpdate: (newContent: string) => void = () => null;
   export let placeholder: string = '';
 
@@ -27,10 +27,9 @@
 
 <textarea
   bind:this={textarea}
-  class={elementClass}
+  class="resize-none {className}"
   on:focusout={updateContent}
   on:input={(e) => (newContent = e.currentTarget.value)}
-  use:clickOutside={{ onOutclick: updateContent }}
   {placeholder}
   use:shortcut={{
     shortcut: { key: 'Enter', ctrl: true },

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -6,7 +6,7 @@
 
   export let content: string;
   export let elementClass: string;
-  export let onContentUpdate: (newContent) => void;
+  export let onContentUpdate: (newContent: string) => void;
   export let placeholder: string;
 
   let textarea: HTMLTextAreaElement;


### PR DESCRIPTION
Fixes #9879.

Changes:
* Applied the same approach #9765 implemented to the album description textarea
* Deduplicated the detail panel description and the album description sections into a single component
* Set the textarea value correctly since `value` is not a valid textarea property