### PR TITLE
fix: AssetInterceptor "can't set headers after they are sent"

### DIFF
--- a/server/src/middleware/asset-upload.interceptor.ts
+++ b/server/src/middleware/asset-upload.interceptor.ts
@@ -19,8 +19,6 @@ export class AssetUploadInterceptor implements NestInterceptor {
     const response = await this.service.getUploadAssetIdByChecksum(req.user, checksum);
     if (response) {
       res.status(200);
-      // Returning the response body wrapped in an Observable will cause nestjs
-      // to use it, and skip all downstream request processing.
       return of({ status: AssetMediaStatus.DUPLICATE, id: response.id });
     }
 

--- a/server/src/middleware/asset-upload.interceptor.ts
+++ b/server/src/middleware/asset-upload.interceptor.ts
@@ -1,6 +1,7 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Response } from 'express';
-import { AssetMediaResponseDto } from 'src/dtos/asset-media-response.dto';
+import { of } from 'rxjs';
+import { AssetMediaResponseDto, AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
 import { ImmichHeader } from 'src/dtos/auth.dto';
 import { AuthenticatedRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
@@ -17,7 +18,10 @@ export class AssetUploadInterceptor implements NestInterceptor {
     const checksum = fromMaybeArray(req.headers[ImmichHeader.CHECKSUM]);
     const response = await this.service.getUploadAssetIdByChecksum(req.user, checksum);
     if (response) {
-      res.status(200).send(response);
+      res.status(200);
+      // Returning the response body wrapped in an Observable will cause nestjs
+      // to use it, and skip all downstream request processing.
+      return of({ status: AssetMediaStatus.DUPLICATE, id: response.id });
     }
 
     return next.handle();


### PR DESCRIPTION
This fixes a problem in the interceptor. It was calling send() on the underlying express response, which caused it to send the body. However, it did not prevent the downstream interceptor/controller from running, as was intended. And then later, when the downstream response was trying to be sent to client, protocol errors occurred. 

The symptoms are like this: 

```
immich_web               | Error: write EPIPE
immich_web               |     at afterWriteDispatched (node:internal/stream_base_commons:161:15)
immich_web               |     at writeGeneric (node:internal/stream_base_commons:152:3)
immich_web               |     at Socket._writeGeneric (node:net:953:11)
immich_web               |     at Socket._write (node:net:965:8)
immich_web               |     at doWrite (node:internal/streams/writable:590:12)
immich_web               |     at clearBuffer (node:internal/streams/writable:774:7)
immich_web               |     at Writable.uncork (node:internal/streams/writable:523:7)
immich_web               |     at connectionCorkNT (node:_http_outgoing:981:8)
immich_web               |     at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
immich_web               | 11:00:20 AM [vite] http proxy error: /api/assets/
immich_web               | Error: write EPIPE
immich_web               |     at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:95:16)
immich_web               |     at WriteWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```

in production builds manifest a bit different

```
immich-e2e-server  | [Nest] 7  - 06/04/2024, 10:29:03 PM   ERROR [ImmichServer] [ExceptionsHandler] Cannot set headers after they are sent to the client
immich-e2e-server  | Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
immich-e2e-server  |     at ServerResponse.setHeader (node:_http_outgoing:659:11)
immich-e2e-server  |     at ServerResponse.header (/usr/src/app/node_modules/express/lib/response.js:795:10)
immich-e2e-server  |     at ServerResponse.send (/usr/src/app/node_modules/express/lib/response.js:175:12)
immich-e2e-server  |     at ServerResponse.json (/usr/src/app/node_modules/express/lib/response.js:279:15)
immich-e2e-server  |     at ExpressAdapter.reply (/usr/src/app/node_modules/@nestjs/platform-express/adapters/express-adapter.js:62:62)
immich-e2e-server  |     at RouterResponseController.apply (/usr/src/app/node_modules/@nestjs/core/router/router-response-controller.js:15:36)
immich-e2e-server  |     at /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:176:48
immich-e2e-server  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
immich-e2e-server  |     at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:47:13
immich-e2e-server  |     at async /usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

