### PR TITLE
chore: seperate sub-process for api worker

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,4 +1,5 @@
 import { CommandFactory } from 'nest-commander';
+import { fork } from 'node:child_process';
 import { Worker } from 'node:worker_threads';
 import { ImmichAdminModule } from 'src/app.module';
 import { LogLevel } from 'src/config';
@@ -16,7 +17,7 @@ async function bootstrapImmichAdmin() {
 
 function bootstrapWorker(name: string) {
   console.log(`Starting ${name} worker`);
-  const worker = new Worker(`./dist/workers/${name}.js`);
+  const worker = name === 'api' ? fork(`./dist/workers/${name}.js`) : new Worker(`./dist/workers/${name}.js`);
   worker.on('exit', (exitCode) => {
     if (exitCode !== 0) {
       console.error(`${name} worker exited with code ${exitCode}`);

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -3,7 +3,6 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { json } from 'body-parser';
 import cookieParser from 'cookie-parser';
 import { existsSync } from 'node:fs';
-import { isMainThread } from 'node:worker_threads';
 import sirv from 'sirv';
 import { ApiModule } from 'src/app.module';
 import { envName, excludePaths, isDev, serverVersion, WEB_ROOT } from 'src/constants';
@@ -16,6 +15,7 @@ import { useSwagger } from 'src/utils/misc';
 const host = process.env.HOST;
 
 async function bootstrap() {
+  process.title = 'immich-api';
   otelSDK.start();
 
   const port = Number(process.env.IMMICH_PORT) || 3001;
@@ -60,9 +60,7 @@ async function bootstrap() {
   logger.log(`Immich Server is listening on ${await app.getUrl()} [v${serverVersion}] [${envName}] `);
 }
 
-if (!isMainThread) {
-  bootstrap().catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
-}
+bootstrap().catch((error) => {
+  console.error(error);
+  throw error;
+});


### PR DESCRIPTION
Spin up a separate node process for forks, gives the API its own separate uncontested resources