### PR TITLE
fix(web): clear locale setting

### DIFF
--- a/web/src/lib/components/user-settings-page/app-settings.svelte
+++ b/web/src/lib/components/user-settings-page/app-settings.svelte
@@ -80,7 +80,9 @@
   };
 
   const handleLocaleChange = (newLocale: string | undefined) => {
-    $locale = newLocale;
+    if (newLocale) {
+      $locale = newLocale;
+    }
   };
 </script>
 


### PR DESCRIPTION
Clearing the locale setting closes the combobox. Fixed by not setting `$locale` to `undefined`