### PR TITLE
fix(server): closed connections

### DIFF
--- a/server/src/middleware/error.interceptor.ts
+++ b/server/src/middleware/error.interceptor.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { Observable, catchError, throwError } from 'rxjs';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
-import { isConnectionAborted, routeToErrorMessage } from 'src/utils/misc';
+import { routeToErrorMessage } from 'src/utils/misc';
 
 @Injectable()
 export class ErrorInterceptor implements NestInterceptor {
@@ -21,15 +21,13 @@ export class ErrorInterceptor implements NestInterceptor {
     return next.handle().pipe(
       catchError((error) =>
         throwError(() => {
-          if (error instanceof HttpException === false) {
-            const errorMessage = routeToErrorMessage(context.getHandler().name);
-            if (!isConnectionAborted(error)) {
-              this.logger.error(errorMessage, error, error?.errors, error?.stack);
-            }
-            return new InternalServerErrorException(errorMessage);
-          } else {
+          if (error instanceof HttpException) {
             return error;
           }
+
+          const errorMessage = routeToErrorMessage(context.getHandler().name);
+          this.logger.error(errorMessage, error, error?.errors, error?.stack);
+          return new InternalServerErrorException(errorMessage);
         }),
       ),
     );

--- a/server/src/middleware/http-exception.filter.ts
+++ b/server/src/middleware/http-exception.filter.ts
@@ -29,9 +29,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
       };
     }
 
-    response.status(status).json({
-      ...responseBody,
-      correlationId: this.cls.getId(),
-    });
+    if (!response.headersSent) {
+      response.status(status).json({
+        ...responseBody,
+        correlationId: this.cls.getId(),
+      });
+    }
   }
 }

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -65,7 +65,7 @@ export const sendFile = async (
 
     await access(file.path, constants.R_OK);
 
-    return _sendFile(file.path, options);
+    return await _sendFile(file.path, options);
   } catch (error: Error | any) {
     // ignore client-closed connection
     if (isConnectionAborted(error)) {


### PR DESCRIPTION
- `await _sendFile` so the catch blocks works correctly
- don't write to `res` if headers have been sent