### PR TITLE
fix(web): language setting

### DIFF
--- a/web/src/lib/components/user-settings-page/app-settings.svelte
+++ b/web/src/lib/components/user-settings-page/app-settings.svelte
@@ -2,7 +2,7 @@
   import type { ComboBoxOption } from '$lib/components/shared-components/combobox.svelte';
   import SettingCombobox from '$lib/components/shared-components/settings/setting-combobox.svelte';
   import SettingSwitch from '$lib/components/shared-components/settings/setting-switch.svelte';
-  import { fallbackLang, fallbackLocale, langs, locales } from '$lib/constants';
+  import { defaultLang, fallbackLocale, langs, locales } from '$lib/constants';
   import {
     alwaysLoadOriginalFile,
     colorTheme,
@@ -16,8 +16,7 @@
   import { findLocale } from '$lib/utils';
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
-  import { t, locale as i18nLocale, init } from 'svelte-i18n';
-  import { get } from 'svelte/store';
+  import { t, init } from 'svelte-i18n';
 
   let time = new Date();
 
@@ -65,18 +64,20 @@
     $locale = $locale ? undefined : fallbackLocale.code;
   };
 
+  const langOptions = langs.map((lang) => ({ label: lang.name, value: lang.code }));
+  const defaultLangOption = { label: defaultLang.name, value: defaultLang.code };
+
   const handleLanguageChange = async (newLang: string | undefined) => {
-    newLang = newLang || fallbackLang;
-    $lang = newLang;
+    if (newLang) {
+      $lang = newLang;
 
-    const previousLang = get(i18nLocale);
+      if (newLang === 'dev') {
+        // Reload required, because fallbackLocale cannot be cleared.
+        window.location.reload();
+      }
 
-    if (newLang === 'dev') {
-      await init({ fallbackLocale: 'dev', initialLocale: 'dev' });
-    } else if (previousLang == 'dev' && newLang !== 'dev') {
-      await init({ fallbackLocale: 'en-US', initialLocale: newLang });
+      await init({ fallbackLocale: defaultLang.code, initialLocale: newLang });
     }
-    $i18nLocale = newLang;
   };
 
   const handleLocaleChange = (newLocale: string | undefined) => {
@@ -101,8 +102,8 @@
       <div class="ml-4">
         <SettingCombobox
           comboboxPlaceholder={$t('language')}
-          {selectedOption}
-          options={langs.map((lang) => ({ label: lang.name, value: lang.code }))}
+          selectedOption={langOptions.find(({ value }) => value === $lang) || defaultLangOption}
+          options={langOptions}
           title={$t('language')}
           subtitle={$t('language_setting_description')}
           onSelect={(combobox) => handleLanguageChange(combobox?.value)}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -244,7 +244,7 @@ export const locales = [
   { code: 'zu-ZA', name: 'Zulu (South Africa)' },
 ];
 
-export const fallbackLang = 'en-US';
+export const defaultLang = { name: 'English', code: 'en', loader: () => import('$lib/i18n/en.json') };
 
 export const langs = [
   { name: 'Arabic', code: 'ar', loader: () => import('$lib/i18n/ar.json') },
@@ -252,7 +252,7 @@ export const langs = [
   { name: 'Czech', code: 'cs', loader: () => import('$lib/i18n/cs.json') },
   { name: 'Danish', code: 'da', loader: () => import('$lib/i18n/da.json') },
   { name: 'German', code: 'de', loader: () => import('$lib/i18n/de.json') },
-  { name: 'English', code: 'en', loader: () => import('$lib/i18n/en.json') },
+  defaultLang,
   { name: 'Spanish', code: 'es', loader: () => import('$lib/i18n/es.json') },
   { name: 'Finnish', code: 'fi', loader: () => import('$lib/i18n/fi.json') },
   { name: 'French', code: 'fr', loader: () => import('$lib/i18n/fr.json') },

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -1,5 +1,5 @@
 import { browser } from '$app/environment';
-import { Theme } from '$lib/constants';
+import { Theme, defaultLang } from '$lib/constants';
 import { persisted } from 'svelte-local-storage-store';
 import { get } from 'svelte/store';
 
@@ -42,7 +42,7 @@ export const locale = persisted<string | undefined>('locale', undefined, {
   },
 });
 
-export const lang = persisted<string | undefined>('lang', undefined, {
+export const lang = persisted('lang', defaultLang.code, {
   serializer: {
     parse: (text) => text,
     stringify: (object) => object ?? '',

--- a/web/src/routes/+layout.ts
+++ b/web/src/routes/+layout.ts
@@ -1,4 +1,4 @@
-import { fallbackLang, langs } from '$lib/constants';
+import { defaultLang, langs } from '$lib/constants';
 import { lang } from '$lib/stores/preferences.store';
 import { defaults } from '@immich/sdk';
 import { init, register } from 'svelte-i18n';
@@ -20,7 +20,7 @@ export const load = (async ({ fetch }) => {
 
   const preferenceLang = get(lang);
 
-  await init({ fallbackLocale: fallbackLang, initialLocale: preferenceLang || fallbackLang });
+  await init({ fallbackLocale: preferenceLang === 'dev' ? 'dev' : defaultLang.code, initialLocale: preferenceLang });
 
   return {
     meta: {


### PR DESCRIPTION
- Language value is no longer set to locale
- Clearing the language now waits for new input instead of setting the fallback language
- Changing to `Development` language consistently works (does require a hard reload though)
