### PR TITLE
fix: prevent trashing of trashed assets

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
@@ -3,7 +3,6 @@ import { assetFactory } from '@test-data/factories/asset-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/svelte';
-import { init } from 'svelte-i18n';
 import AssetViewerNavBar from './asset-viewer-nav-bar.svelte';
 
 describe('AssetViewerNavBar component', () => {
@@ -14,11 +13,9 @@ describe('AssetViewerNavBar component', () => {
     showDownloadButton: false,
     showMotionPlayButton: false,
     showShareButton: false,
+    onZoomImage: () => {},
+    onCopyImage: () => {},
   };
-
-  beforeAll(async () => {
-    await init({ fallbackLocale: 'en-US' });
-  });
 
   afterEach(() => {
     vi.resetAllMocks();
@@ -32,24 +29,13 @@ describe('AssetViewerNavBar component', () => {
   });
 
   describe('if the current user owns the asset', () => {
-    it('shows trash button', () => {
+    it('shows delete button', () => {
       const ownerId = 'id-of-the-user';
       const user = userAdminFactory.build({ id: ownerId });
       const asset = assetFactory.build({ ownerId, isTrashed: false });
       userStore.set(user);
       const { getByTitle } = render(AssetViewerNavBar, { asset, ...additionalProps });
       expect(getByTitle('delete')).toBeInTheDocument();
-    });
-
-    describe('but if the asset is already trashed', () => {
-      it('hides trash button', () => {
-        const ownerId = 'id-of-the-user';
-        const user = userAdminFactory.build({ id: ownerId });
-        const asset = assetFactory.build({ ownerId, isTrashed: true });
-        userStore.set(user);
-        const { queryByTitle } = render(AssetViewerNavBar, { asset, ...additionalProps });
-        expect(queryByTitle('delete')).toBeNull();
-      });
     });
   });
 });

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
@@ -1,0 +1,55 @@
+import { resetSavedUser, user as userStore } from '$lib/stores/user.store';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import { userAdminFactory } from '@test-data/factories/user-factory';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import { init } from 'svelte-i18n';
+import AssetViewerNavBar from './asset-viewer-nav-bar.svelte';
+
+describe('AssetViewerNavBar component', () => {
+  const additionalProps = {
+    showCopyButton: false,
+    showZoomButton: false,
+    showDetailButton: false,
+    showDownloadButton: false,
+    showMotionPlayButton: false,
+    showShareButton: false,
+  };
+
+  beforeAll(async () => {
+    await init({ fallbackLocale: 'en-US' });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    resetSavedUser();
+  });
+
+  it('shows back button', () => {
+    const asset = assetFactory.build({ isTrashed: false });
+    const { getByTitle } = render(AssetViewerNavBar, { asset, ...additionalProps });
+    expect(getByTitle('go_back')).toBeInTheDocument();
+  });
+
+  describe('if the current user owns the asset', () => {
+    it('shows trash button', () => {
+      const ownerId = 'id-of-the-user';
+      const user = userAdminFactory.build({ id: ownerId });
+      const asset = assetFactory.build({ ownerId, isTrashed: false });
+      userStore.set(user);
+      const { getByTitle } = render(AssetViewerNavBar, { asset, ...additionalProps });
+      expect(getByTitle('delete')).toBeInTheDocument();
+    });
+
+    describe('but if the asset is already trashed', () => {
+      it('hides trash button', () => {
+        const ownerId = 'id-of-the-user';
+        const user = userAdminFactory.build({ id: ownerId });
+        const asset = assetFactory.build({ ownerId, isTrashed: true });
+        userStore.set(user);
+        const { queryByTitle } = render(AssetViewerNavBar, { asset, ...additionalProps });
+        expect(queryByTitle('delete')).toBeNull();
+      });
+    });
+  });
+});

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
+  import DeleteButton from './delete-button.svelte';
   import { user } from '$lib/stores/user.store';
   import { photoZoomState } from '$lib/stores/zoom-image.store';
   import { getAssetJobName } from '$lib/utils';
@@ -16,7 +17,6 @@
     mdiCogRefreshOutline,
     mdiContentCopy,
     mdiDatabaseRefreshOutline,
-    mdiDeleteOutline,
     mdiDotsVertical,
     mdiFolderDownloadOutline,
     mdiHeart,
@@ -64,6 +64,7 @@
     showDetail: void;
     favorite: void;
     delete: void;
+    permanentlyDelete: void;
     toggleArchive: void;
     addToAlbum: void;
     restoreAsset: void;
@@ -181,14 +182,11 @@
     {/if}
 
     {#if isOwner}
-      {#if !asset.isTrashed}
-        <CircleIconButton
-          color="opaque"
-          icon={mdiDeleteOutline}
-          on:click={() => dispatch('delete')}
-          title={$t('delete')}
-        />
-      {/if}
+      <DeleteButton
+        {asset}
+        on:delete={() => dispatch('delete')}
+        on:permanentlyDelete={() => dispatch('permanentlyDelete')}
+      />
       <div
         use:clickOutside={{
           onOutclick: () => (isShowAssetOptions = false),

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -181,12 +181,14 @@
     {/if}
 
     {#if isOwner}
-      <CircleIconButton
-        color="opaque"
-        icon={mdiDeleteOutline}
-        on:click={() => dispatch('delete')}
-        title={$t('delete')}
-      />
+      {#if !asset.isTrashed}
+        <CircleIconButton
+          color="opaque"
+          icon={mdiDeleteOutline}
+          on:click={() => dispatch('delete')}
+          title={$t('delete')}
+        />
+      {/if}
       <div
         use:clickOutside={{
           onOutclick: () => (isShowAssetOptions = false),

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { ShortcutOptions } from '$lib/actions/shortcut';
   import Icon from '$lib/components/elements/icon.svelte';
   import CreateSharedLinkModal from '$lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte';
   import FocusTrap from '$lib/components/shared-components/focus-trap.svelte';
@@ -536,26 +535,21 @@
   $: if (!$user) {
     shouldShowShareModal = false;
   }
+</script>
 
-  const defaultShortcutOptions: ShortcutOptions<unknown>[] = [
+<svelte:window
+  use:shortcuts={[
     { shortcut: { key: 'a', shift: true }, onShortcut: toggleAssetArchive },
     { shortcut: { key: 'ArrowLeft' }, onShortcut: () => navigateAsset('previous') },
     { shortcut: { key: 'ArrowRight' }, onShortcut: () => navigateAsset('next') },
     { shortcut: { key: 'd', shift: true }, onShortcut: () => downloadFile(asset) },
+    { shortcut: { key: 'Delete' }, onShortcut: () => trashOrDelete(asset.isTrashed) },
     { shortcut: { key: 'Delete', shift: true }, onShortcut: () => trashOrDelete(true) },
     { shortcut: { key: 'Escape' }, onShortcut: closeViewer },
     { shortcut: { key: 'f' }, onShortcut: toggleFavorite },
     { shortcut: { key: 'i' }, onShortcut: toggleDetailPanel },
-  ];
-  const deleteShortcutOption: ShortcutOptions<unknown> = {
-    shortcut: { key: 'Delete' },
-    onShortcut: () => trashOrDelete(false),
-  };
-
-  $: shortcutOptions = asset.isTrashed ? defaultShortcutOptions : [...defaultShortcutOptions, deleteShortcutOption];
-</script>
-
-<svelte:window use:shortcuts={shortcutOptions} />
+  ]}
+/>
 
 <svelte:document bind:fullscreenElement />
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { ShortcutOptions } from '$lib/actions/shortcut';
   import Icon from '$lib/components/elements/icon.svelte';
   import CreateSharedLinkModal from '$lib/components/shared-components/create-share-link-modal/create-shared-link-modal.svelte';
   import FocusTrap from '$lib/components/shared-components/focus-trap.svelte';
@@ -535,21 +536,24 @@
   $: if (!$user) {
     shouldShowShareModal = false;
   }
-</script>
 
-<svelte:window
-  use:shortcuts={[
+  let shortcutOptions: ShortcutOptions<unknown>[] = [
     { shortcut: { key: 'a', shift: true }, onShortcut: toggleAssetArchive },
     { shortcut: { key: 'ArrowLeft' }, onShortcut: () => navigateAsset('previous') },
     { shortcut: { key: 'ArrowRight' }, onShortcut: () => navigateAsset('next') },
     { shortcut: { key: 'd', shift: true }, onShortcut: () => downloadFile(asset) },
-    { shortcut: { key: 'Delete' }, onShortcut: () => trashOrDelete(false) },
     { shortcut: { key: 'Delete', shift: true }, onShortcut: () => trashOrDelete(true) },
     { shortcut: { key: 'Escape' }, onShortcut: closeViewer },
     { shortcut: { key: 'f' }, onShortcut: toggleFavorite },
     { shortcut: { key: 'i' }, onShortcut: toggleDetailPanel },
-  ]}
-/>
+  ];
+
+  if (!asset.isTrashed) {
+    shortcutOptions.push({ shortcut: { key: 'Delete' }, onShortcut: () => trashOrDelete(false) });
+  }
+</script>
+
+<svelte:window use:shortcuts={shortcutOptions} />
 
 <svelte:document bind:fullscreenElement />
 

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -537,7 +537,7 @@
     shouldShowShareModal = false;
   }
 
-  let shortcutOptions: ShortcutOptions<unknown>[] = [
+  const defaultShortcutOptions: ShortcutOptions<unknown>[] = [
     { shortcut: { key: 'a', shift: true }, onShortcut: toggleAssetArchive },
     { shortcut: { key: 'ArrowLeft' }, onShortcut: () => navigateAsset('previous') },
     { shortcut: { key: 'ArrowRight' }, onShortcut: () => navigateAsset('next') },
@@ -547,10 +547,12 @@
     { shortcut: { key: 'f' }, onShortcut: toggleFavorite },
     { shortcut: { key: 'i' }, onShortcut: toggleDetailPanel },
   ];
+  const deleteShortcutOption: ShortcutOptions<unknown> = {
+    shortcut: { key: 'Delete' },
+    onShortcut: () => trashOrDelete(false),
+  };
 
-  if (!asset.isTrashed) {
-    shortcutOptions.push({ shortcut: { key: 'Delete' }, onShortcut: () => trashOrDelete(false) });
-  }
+  $: shortcutOptions = asset.isTrashed ? defaultShortcutOptions : [...defaultShortcutOptions, deleteShortcutOption];
 </script>
 
 <svelte:window use:shortcuts={shortcutOptions} />
@@ -583,6 +585,7 @@
           on:showDetail={showDetailInfoHandler}
           on:download={() => downloadFile(asset)}
           on:delete={() => trashOrDelete()}
+          on:permanentlyDelete={() => trashOrDelete(true)}
           on:favorite={toggleFavorite}
           on:addToAlbum={() => openAlbumPicker(false)}
           on:restoreAsset={() => handleRestoreAsset()}

--- a/web/src/lib/components/asset-viewer/delete-button.spec.ts
+++ b/web/src/lib/components/asset-viewer/delete-button.spec.ts
@@ -1,0 +1,34 @@
+import { type AssetResponseDto } from '@immich/sdk';
+
+import { assetFactory } from '@test-data/factories/asset-factory';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/svelte';
+import DeleteButton from './delete-button.svelte';
+
+export let asset: AssetResponseDto;
+
+describe('DeleteButton component', () => {
+  describe('given an asset which is not trashed yet', () => {
+    beforeEach(() => {
+      asset = assetFactory.build({ isTrashed: false });
+    });
+
+    it('displays a button to move the asset to the trash bin', () => {
+      const { getByTitle, queryByTitle } = render(DeleteButton, { asset });
+      expect(getByTitle('delete')).toBeInTheDocument();
+      expect(queryByTitle('deletePermanently')).toBeNull();
+    });
+  });
+
+  describe('but if the asset is already trashed', () => {
+    beforeEach(() => {
+      asset = assetFactory.build({ isTrashed: true });
+    });
+
+    it('displays a button to permanently delete the asset', () => {
+      const { getByTitle, queryByTitle } = render(DeleteButton, { asset });
+      expect(getByTitle('permanently_delete')).toBeInTheDocument();
+      expect(queryByTitle('delete')).toBeNull();
+    });
+  });
+});

--- a/web/src/lib/components/asset-viewer/delete-button.spec.ts
+++ b/web/src/lib/components/asset-viewer/delete-button.spec.ts
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/svelte';
 import DeleteButton from './delete-button.svelte';
 
-export let asset: AssetResponseDto;
+let asset: AssetResponseDto;
 
 describe('DeleteButton component', () => {
   describe('given an asset which is not trashed yet', () => {

--- a/web/src/lib/components/asset-viewer/delete-button.svelte
+++ b/web/src/lib/components/asset-viewer/delete-button.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
+  import { createEventDispatcher } from 'svelte';
+  import { t } from 'svelte-i18n';
+  import { mdiDeleteOutline } from '@mdi/js';
+  import { type AssetResponseDto } from '@immich/sdk';
+
+  export let asset: AssetResponseDto;
+
+  type EventTypes = {
+    delete: void;
+    permanentlyDelete: void;
+  };
+
+  const dispatch = createEventDispatcher<EventTypes>();
+</script>
+
+{#if asset.isTrashed}
+  <CircleIconButton
+    color="opaque"
+    icon={mdiDeleteOutline}
+    on:click={() => dispatch('permanentlyDelete')}
+    title={$t('permanently_delete')}
+  />
+{:else}
+  <CircleIconButton color="opaque" icon={mdiDeleteOutline} on:click={() => dispatch('delete')} title={$t('delete')} />
+{/if}

--- a/web/src/test-data/factories/user-factory.ts
+++ b/web/src/test-data/factories/user-factory.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { UserAvatarColor, type UserResponseDto } from '@immich/sdk';
+import { UserAvatarColor, UserStatus, type UserAdminResponseDto, type UserResponseDto } from '@immich/sdk';
 import { Sync } from 'factory.ts';
 
 export const userFactory = Sync.makeFactory<UserResponseDto>({
@@ -8,4 +8,22 @@ export const userFactory = Sync.makeFactory<UserResponseDto>({
   name: Sync.each(() => faker.person.fullName()),
   profileImagePath: '',
   avatarColor: UserAvatarColor.Primary,
+});
+
+export const userAdminFactory = Sync.makeFactory<UserAdminResponseDto>({
+  id: Sync.each(() => faker.string.uuid()),
+  email: Sync.each(() => faker.internet.email()),
+  name: Sync.each(() => faker.person.fullName()),
+  profileImagePath: '',
+  avatarColor: UserAvatarColor.Primary,
+  isAdmin: true,
+  createdAt: Sync.each(() => faker.date.recent().toISOString()),
+  updatedAt: Sync.each(() => faker.date.recent().toISOString()),
+  deletedAt: null,
+  oauthId: '',
+  quotaUsageInBytes: 0,
+  quotaSizeInBytes: 1000,
+  shouldChangePassword: false,
+  status: UserStatus.Active,
+  storageLabel: null,
 });


### PR DESCRIPTION
Motivation
----------
This will improve user experience ~by hiding a pointless action~ by changing "move to trash" into "delete permanently" if the asset is already in the trash.

~You can not trash a trashed asset again. It won't get any trashier than it already is.~

How to test
-----------
1. Visit route `/trash`
2. Click on an asset
3. Press "Delete" on your keyboard
4. You will see the confirmation dialog to permanently delete the asset
5. Click on the trash button in the top right
6. Same as 4)