### PR TITLE
fix(server): min face detection score not being passed correctly

### DIFF
--- a/server/src/interfaces/machine-learning.interface.ts
+++ b/server/src/interfaces/machine-learning.interface.ts
@@ -35,7 +35,7 @@ export type ClipTextualResponse = { [ModelTask.SEARCH]: number[] };
 
 export type FacialRecognitionRequest = {
   [ModelTask.FACIAL_RECOGNITION]: {
-    [ModelType.DETECTION]: FaceDetectionOptions;
+    [ModelType.DETECTION]: ModelOptions & { options: { minScore: number } };
     [ModelType.RECOGNITION]: ModelOptions;
   };
 };

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -37,7 +37,7 @@ export class MachineLearningRepository implements IMachineLearningRepository {
   async detectFaces(url: string, imagePath: string, { modelName, minScore }: FaceDetectionOptions) {
     const request = {
       [ModelTask.FACIAL_RECOGNITION]: {
-        [ModelType.DETECTION]: { modelName, minScore },
+        [ModelType.DETECTION]: { modelName, options: { minScore } },
         [ModelType.RECOGNITION]: { modelName },
       },
     };


### PR DESCRIPTION
## Description

When building the request for face detection, the min score is supposed to be in an `options` object. However, it is currently being passed as a top-level field, and is ignored as a result. 

## How Has This Been Tested?

Tested by running face detection with different detection thresholds and confirming that the results change accordingly.