### PR TITLE
refactor: dedicated icon for permanently delete

### DIFF
--- a/web/src/lib/components/asset-viewer/delete-button.svelte
+++ b/web/src/lib/components/asset-viewer/delete-button.svelte
@@ -2,7 +2,7 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import { createEventDispatcher } from 'svelte';
   import { t } from 'svelte-i18n';
-  import { mdiDeleteOutline } from '@mdi/js';
+  import { mdiDeleteOutline, mdiDeleteForeverOutline } from '@mdi/js';
   import { type AssetResponseDto } from '@immich/sdk';
 
   export let asset: AssetResponseDto;
@@ -18,7 +18,7 @@
 {#if asset.isTrashed}
   <CircleIconButton
     color="opaque"
-    icon={mdiDeleteOutline}
+    icon={mdiDeleteForeverOutline}
     on:click={() => dispatch('permanentlyDelete')}
     title={$t('permanently_delete')}
   />

--- a/web/src/lib/components/photos-page/actions/delete-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/delete-assets.svelte
@@ -3,7 +3,7 @@
   import MenuOption from '../../shared-components/context-menu/menu-option.svelte';
   import { getAssetControlContext } from '../asset-select-control-bar.svelte';
   import { featureFlags } from '$lib/stores/server-config.store';
-  import { mdiTimerSand, mdiDeleteOutline } from '@mdi/js';
+  import { mdiTimerSand, mdiDeleteOutline, mdiDeleteForeverOutline } from '@mdi/js';
   import { type OnDelete, deleteAssets } from '$lib/utils/actions';
   import DeleteAssetDialog from '../delete-asset-dialog.svelte';
   import { t } from 'svelte-i18n';
@@ -43,7 +43,7 @@
 {:else if loading}
   <CircleIconButton title={$t('loading')} icon={mdiTimerSand} />
 {:else}
-  <CircleIconButton title={label} icon={mdiDeleteOutline} on:click={handleTrash} />
+  <CircleIconButton title={label} icon={mdiDeleteForeverOutline} on:click={handleTrash} />
 {/if}
 
 {#if isShowConfirmation}

--- a/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -20,7 +20,7 @@
   import { featureFlags, serverConfig } from '$lib/stores/server-config.store';
   import { handleError } from '$lib/utils/handle-error';
   import { emptyTrash, restoreTrash } from '@immich/sdk';
-  import { mdiDeleteOutline, mdiHistory } from '@mdi/js';
+  import { mdiDeleteForeverOutline, mdiHistory } from '@mdi/js';
   import type { PageData } from './$types';
   import { handlePromiseError } from '$lib/utils';
   import { dialogController } from '$lib/components/shared-components/dialog/dialog';
@@ -106,7 +106,7 @@
       </LinkButton>
       <LinkButton on:click={() => handleEmptyTrash()} disabled={$isMultiSelectState}>
         <div class="flex place-items-center gap-2 text-sm">
-          <Icon path={mdiDeleteOutline} size="18" />
+          <Icon path={mdiDeleteForeverOutline} size="18" />
           Empty trash
         </div>
       </LinkButton>


### PR DESCRIPTION
Motivation
----------
It's a follow up to #10028. I think it would be better user experience if one can tell by the icon what the delete button is about to do.

I hope I caught all the occurences where one can permanently delete assets.

How to test
-----------
1. Visit e.g. `/trash`
2. If you select some assets, the delete button in the top right corner
   looks different.
   
![image](https://github.com/immich-app/immich/assets/2110676/ec792a8c-524a-499c-a6c6-f8f9e1dc0d45)


![image](https://github.com/immich-app/immich/assets/2110676/a0d63603-a406-4bdc-a28b-a0f03bd7b28c)

