### PR TITLE
refactor: remove dead code from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,6 @@ dev-update:
 dev-scale:
 	docker compose -f ./docker/docker-compose.dev.yml up --build -V  --scale immich-server=3 --remove-orphans
 
-stage:
-	docker compose -f ./docker/docker-compose.staging.yml up --build -V --remove-orphans
-
-pull-stage:
-	docker compose -f ./docker/docker-compose.staging.yml pull
-
 .PHONY: e2e
 e2e:
 	docker compose -f ./e2e/docker-compose.yml up --build -V --remove-orphans


### PR DESCRIPTION
Motivation
----------
I guess these make targets should have been deleted in 57136e48fbed38ef957066d1bd4f1f8462d17fa7.

How to test
-----------
1. Nothing really, this removes dead code