### PR TITLE
refactor: default immich-server URL -> localhost

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -43,6 +43,8 @@ services:
     build:
       context: ../web
     command: ['/usr/src/app/bin/immich-web']
+    environment:
+      IMMICH_SERVER_URL: "http://immich-server:3001/"
     env_file:
       - .env
     ports:

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -5,7 +5,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig } from 'vite';
 
 const upstream = {
-  target: process.env.IMMICH_SERVER_URL || 'http://immich-server:3001/',
+  target: process.env.IMMICH_SERVER_URL || 'http://localhost:3001/',
   secure: true,
   changeOrigin: true,
   logLevel: 'info',


### PR DESCRIPTION
Background
----------
I'm facing issues with the development workflow [from the docs](https://immich.app/docs/developer/setup). I'm supposed to `make dev` from the root directory. Now I run into missing dependencies error:
```
Cannot find module 'svelte-i18n' imported from '/usr/src/app/src/routes/+layout.ts'
```

* `cd web` and `npm install` does not resolve the issue.
* `make dev-update` hangs on my machine.
* `cd docker/` and `docker compose -f docker-compose.dev.yml exec -it immich-web npm install` no success

I'm giving up on this here and go for an:

Easier workflow
-----------
1. `cd docker` and `docker compose -f docker-compose.dev.yml up immich-server database redis` (dockerize only the services that are needed)
2. `set -x IMMICH_SERVER_URL http://localhost:3001`
3. `cd web` and `npm run dev`
4. Development server running on http://localhost:3000/

Motivation
----------
This will reduce one step, i.e. setting the environment variable from step 2 above.

I think the default URL was expecting a docker environment. But in this scenario we can configure it in `docker-compose.yml`, right? So why not have best of both worlds?

As far as I can tell, the `immich-web` service is only used in development. So, I hope this change has no unintended side-effects.