### PR TITLE
ci: automatically apply PR labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+cli:
+- changed-files:
+  - any-glob-to-any-file: cli/**
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file: docs/**
+
+🖥️web:
+- changed-files:
+  - any-glob-to-any-file: web/**
+
+📱mobile:
+- changed-files:
+  - any-glob-to-any-file: mobile/**
+
+🗄️server:
+- changed-files:
+  - any-glob-to-any-file: server/**
+
+🧠machine-learning:
+- changed-files:
+  - any-glob-to-any-file: machine-learning/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5

--- a/.github/workflows/pr-require-label.yml
+++ b/.github/workflows/pr-require-label.yml
@@ -3,6 +3,10 @@ name: Enforce PR labels
 on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+  workflow_run:
+    workflows: ["Pull Request Labeler"]
+    types:
+      - completed
 jobs:
   enforce-label:
     name: Enforce label


### PR DESCRIPTION
Motivation
----------
For me as a new contributor it is frustrating to submit a PR and it will always fail. Even worse: I have to wait for another contributor with more power to assign the label for me.

This will improve developer experience, as some of the labels can be assigned automatically based on changed files.

How to test
-----------
1. Merge this PR
2. Submit a couple of PRs with changes in the respective directories
3. Labels should be automatically applied
4. "Enforce PR labels" github workflow will re-run when "Pull Request Labeler" completes


You can check out my fork: https://github.com/roschaefer/immich/pull/4

![image](https://github.com/immich-app/immich/assets/2110676/4fae50eb-9e47-4227-86f1-b6a9199d3448)
