### PR TITLE
fix(web): mouse-wheel scrolling on detail panel is disabled

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -106,7 +106,6 @@
 </script>
 
 <svelte:window
-  on:wheel|preventDefault|nonpassive
   use:shortcuts={[
     { shortcut: { key: 'c', ctrl: true }, onShortcut: onCopyShortcut, preventDefault: false },
     { shortcut: { key: 'c', meta: true }, onShortcut: onCopyShortcut, preventDefault: false },


### PR DESCRIPTION
Fix the issue with using the mouse wheel to scroll on the detail panel.   