### PR TITLE
fix(server): cache-control header missing from / requests

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -43,7 +43,7 @@ export enum AuthType {
   OAUTH = 'oauth',
 }
 
-export const excludePaths = ['/', '/.well-known/immich', '/custom.css', '/favicon.ico'];
+export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico'];
 
 export const FACE_THUMBNAIL_SIZE = 250;
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -43,7 +43,7 @@ export enum AuthType {
   OAUTH = 'oauth',
 }
 
-export const excludePaths = ['/.well-known/immich', '/custom.css', '/favicon.ico'];
+export const excludePaths = ['/', '/.well-known/immich', '/custom.css', '/favicon.ico'];
 
 export const FACE_THUMBNAIL_SIZE = 250;
 

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -38,6 +38,8 @@ async function bootstrap() {
   useSwagger(app);
 
   app.setGlobalPrefix('api', { exclude: excludePaths });
+  app.use(app.get(ApiService).ssr(excludePaths));
+
   if (existsSync(WEB_ROOT)) {
     // copied from https://github.com/sveltejs/kit/blob/679b5989fe62e3964b9a73b712d7b41831aa1f07/packages/adapter-node/src/handler.js#L46
     // provides serving of precompressed assets and caching of immutable assets
@@ -54,7 +56,6 @@ async function bootstrap() {
       }),
     );
   }
-  app.use(app.get(ApiService).ssr(excludePaths));
 
   const server = await (host ? app.listen(port, host) : app.listen(port));
   server.requestTimeout = 30 * 60 * 1000;

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -38,8 +38,6 @@ async function bootstrap() {
   useSwagger(app);
 
   app.setGlobalPrefix('api', { exclude: excludePaths });
-  app.use(app.get(ApiService).ssr(excludePaths));
-
   if (existsSync(WEB_ROOT)) {
     // copied from https://github.com/sveltejs/kit/blob/679b5989fe62e3964b9a73b712d7b41831aa1f07/packages/adapter-node/src/handler.js#L46
     // provides serving of precompressed assets and caching of immutable assets
@@ -48,6 +46,7 @@ async function bootstrap() {
         etag: true,
         gzip: true,
         brotli: true,
+        extensions: [],
         setHeaders: (res, pathname) => {
           if (pathname.startsWith(`/_app/immutable`) && res.statusCode === 200) {
             res.setHeader('cache-control', 'public,max-age=31536000,immutable');
@@ -56,6 +55,7 @@ async function bootstrap() {
       }),
     );
   }
+  app.use(app.get(ApiService).ssr(excludePaths));
 
   const server = await (host ? app.listen(port, host) : app.listen(port));
   server.requestTimeout = 30 * 60 * 1000;


### PR DESCRIPTION
Just ran into the same issue @alextran1502 had a couple of days ago where requests are being made to the old user endpoint. Turns out requests to `/` are missing the cache-control header, because `sirv` runs first and will serve `index.html` that browsers can cache.

Fixed by disabling extension fallback (defaults to `['html', 'htm']`)