### PR TITLE
fix(web): cannot view image when metadata sharing is turned off for public sharing

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -263,6 +263,11 @@ const supportedImageExtensions = new Set(['apng', 'avif', 'gif', 'jpg', 'jpeg', 
  * Returns true if the asset is an image supported by web browsers, false otherwise
  */
 export function isWebCompatibleImage(asset: AssetResponseDto): boolean {
+  // originalPath is undefined when public shared link has metadata option turned off
+  if (asset.originalPath === undefined) {
+    return false;
+  }
+
   const imgExtension = getFilenameExtension(asset.originalPath);
 
   return supportedImageExtensions.has(imgExtension);

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -264,7 +264,7 @@ const supportedImageExtensions = new Set(['apng', 'avif', 'gif', 'jpg', 'jpeg', 
  */
 export function isWebCompatibleImage(asset: AssetResponseDto): boolean {
   // originalPath is undefined when public shared link has metadata option turned off
-  if (asset.originalPath === undefined) {
+  if (!asset.originalPath) {
     return false;
   }
 


### PR DESCRIPTION
Not the cleanest fix, open for suggestion

fix #10130
