### PR TITLE
fix(mobile): Motion Photos stopping music

### DIFF
--- a/mobile/lib/providers/asset_viewer/video_player_controller_provider.dart
+++ b/mobile/lib/providers/asset_viewer/video_player_controller_provider.dart
@@ -31,6 +31,9 @@ Future<VideoPlayerController> videoPlayerController(
     controller = VideoPlayerController.networkUrl(
       url,
       httpHeaders: {"x-immich-user-token": accessToken},
+      videoPlayerOptions: asset.livePhotoVideoId != null
+          ? VideoPlayerOptions(mixWithOthers: true)
+          : VideoPlayerOptions(mixWithOthers: false),
     );
   }
 

--- a/mobile/lib/providers/asset_viewer/video_player_controller_provider.g.dart
+++ b/mobile/lib/providers/asset_viewer/video_player_controller_provider.g.dart
@@ -7,7 +7,7 @@ part of 'video_player_controller_provider.dart';
 // **************************************************************************
 
 String _$videoPlayerControllerHash() =>
-    r'40b31f7b1a73fab84c311b0f06bedf5322143cd9';
+    r'642469a44287188a7c301f5cad3df3e23c84d85c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/mobile/lib/providers/map/map_state.provider.g.dart
+++ b/mobile/lib/providers/map/map_state.provider.g.dart
@@ -6,7 +6,7 @@ part of 'map_state.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$mapStateNotifierHash() => r'87a8623f726d438d115d5a15609c71372726ee2f';
+String _$mapStateNotifierHash() => r'31fafe17aa85c48379a22ed3db3cc94af59ce5b8';
 
 /// See also [MapStateNotifier].
 @ProviderFor(MapStateNotifier)


### PR DESCRIPTION
Hello! this pr is intended to fix #9467 

Sets the  `mixWithOthers` option of the videoPlayer when playing a Motion Photo

Tested on android and works as expected, 'normal' videos continue pausing music when played as i think that is the expected behavior.

