### PR TITLE
fix(server): exiftool largefilesupport only set for the first call

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DefaultExiftoolArgs, DefaultReadTaskOptions, ExifTool, Tags } from 'exiftool-vendored';
+import { DefaultReadTaskOptions, Tags, exiftool } from 'exiftool-vendored';
 import geotz from 'geo-tz';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { ExifEntity } from 'src/entities/exif.entity';
@@ -21,20 +21,13 @@ export class MetadataRepository implements IMetadataRepository {
   ) {
     this.logger.setContext(MetadataRepository.name);
   }
-  private exiftool: ExifTool = this.initExiftool();
 
   async teardown() {
-    await this.exiftool.end();
-  }
-
-  private initExiftool() {
-    // Enable exiftool LFS to parse metadata for files larger than 2GB.
-    const exiftoolArgs = ['-api', 'largefilesupport=1', ...DefaultExiftoolArgs];
-    return new ExifTool({ exiftoolArgs });
+    await exiftool.end();
   }
 
   readTags(path: string): Promise<ImmichTags | null> {
-    return this.exiftool
+    return exiftool
       .read(path, undefined, {
         ...DefaultReadTaskOptions,
 
@@ -53,12 +46,12 @@ export class MetadataRepository implements IMetadataRepository {
   }
 
   extractBinaryTag(path: string, tagName: string): Promise<Buffer> {
-    return this.exiftool.extractBinaryTagToBuffer(tagName, path);
+    return exiftool.extractBinaryTagToBuffer(tagName, path);
   }
 
   async writeTags(path: string, tags: Partial<Tags>): Promise<void> {
     try {
-      await this.exiftool.write(path, tags, ['-overwrite_original']);
+      await exiftool.write(path, tags, ['-overwrite_original']);
     } catch (error) {
       this.logger.warn(`Error writing exif data (${path}): ${error}`);
     }

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -31,6 +31,8 @@ export class MetadataRepository implements IMetadataRepository {
       .read(path, undefined, {
         ...DefaultReadTaskOptions,
 
+        // Enable exiftool LFS to parse metadata for files larger than 2GB.
+        optionalArgs: ['-api', 'largefilesupport=1'],
         defaultVideosToUTC: true,
         backfillTimezones: true,
         inferTimezoneFromDatestamps: true,


### PR DESCRIPTION
The previous largefilesupport fix doesn't work as it should since exiftool is used as a long-running process in `stay_open` mode. In this mode, flags passed when spawning the process only take effect until the first `-execute`, after which the flags are reset. So the previous fix for largefilesupport only works for the first operation.

This branch reverts that fix and instead passes the largefilesupport flags to the <strike>write</strike> read command each time, which results in the flag being set for each operation and ensures that large files work for all metadata read operations.

I also noticed exiftool being used for `extractBinaryTagToBuffer` and `writeTags`. The former doesn't appear to have any way to add largefilesupport flags and the latter appears to be only for sidecar metadata files so it probably isn't needed, but could probably be added there too.

Fixes #4349