### PR TITLE
feat(server): add av1 support for vaapi

### DIFF
--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -842,7 +842,7 @@ export class VAAPIConfig extends BaseHWConfig {
   }
 
   getSupportedCodecs() {
-    return [VideoCodec.H264, VideoCodec.HEVC, VideoCodec.VP9];
+    return [VideoCodec.H264, VideoCodec.HEVC, VideoCodec.VP9, VideoCodec.AV1];
   }
 
   useCQP() {


### PR DESCRIPTION
## Description

VAAPI normally gets AV1 encoding in FFmpeg 6.1, but it seems the Jellyfin build we're using has it anyway.

Fixes #10056