### PR TITLE
fix(server): increase pixel limit for thumbnail generation

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -45,7 +45,7 @@ export class MediaRepository implements IMediaRepository {
   }
 
   async generateThumbnail(input: string | Buffer, output: string, options: ThumbnailOptions): Promise<void> {
-    const pipeline = sharp(input, { failOn: 'none' })
+    const pipeline = sharp(input, { failOn: 'none', limitInputPixels: false })
       .pipelineColorspace(options.colorspace === Colorspace.SRGB ? 'srgb' : 'rgb16')
       .rotate();
 


### PR DESCRIPTION
## Description

There are images exceeding the default limit that we should be able to process. This PR disables the pixel limit as we don't generally allow arbitrary uploads to Immich unless the user opts into this for a shared album.

Fixes #4017