### PR TITLE
chore(docs): remove microservices from hwa docs

### DIFF
--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -60,17 +60,17 @@ For RKMPP to work:
 #### Basic Setup
 
 1. If you do not already have it, download the latest [`hwaccel.transcoding.yml`][hw-file] file and ensure it's in the same folder as the `docker-compose.yml`.
-2. In the `docker-compose.yml` under `immich-microservices`, uncomment the `extends` section and change `cpu` to the appropriate backend.
+2. In the `docker-compose.yml` under `immich-server`, uncomment the `extends` section and change `cpu` to the appropriate backend.
 
 - For VAAPI on WSL2, be sure to use `vaapi-wsl` rather than `vaapi`
 
-3. Redeploy the `immich-microservices` container with these updated settings.
+3. Redeploy the `immich-server` container with these updated settings.
 4. In the Admin page under `Video transcoding settings`, change the hardware acceleration setting to the appropriate option and save.
 5. (Optional) If using a compatible backend, you may enable hardware decoding for optimal performance.
 
 #### Single Compose File
 
-Some platforms, including Unraid and Portainer, do not support multiple Compose files as of writing. As an alternative, you can "inline" the relevant contents of the [`hwaccel.transcoding.yml`][hw-file] file into the `immich-microservices` service directly.
+Some platforms, including Unraid and Portainer, do not support multiple Compose files as of writing. As an alternative, you can "inline" the relevant contents of the [`hwaccel.transcoding.yml`][hw-file] file into the `immich-server` service directly.
 
 For example, the `qsv` section in this file is:
 
@@ -79,21 +79,22 @@ devices:
   - /dev/dri:/dev/dri
 ```
 
-You can add this to the `immich-microservices` service instead of extending from `hwaccel.transcoding.yml`:
+You can add this to the `immich-server` service instead of extending from `hwaccel.transcoding.yml`:
 
 ```yaml
-immich-microservices:
-  container_name: immich_microservices
+immich-server:
+  container_name: immich_server
   image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
   # Note the lack of an `extends` section
   devices:
     - /dev/dri:/dev/dri
-  command: ['start.sh', 'microservices']
   volumes:
     - ${UPLOAD_LOCATION}:/usr/src/app/upload
     - /etc/localtime:/etc/localtime:ro
   env_file:
     - .env
+  ports:
+    - 2283:3001
   depends_on:
     - redis
     - database


### PR DESCRIPTION
## Description

The hardware acceleration docs still reference `immich-microservices`. This PR updates them to reference `immich-server` instead.