### PR TITLE
chore(web): use "immich-form-label" class for combobox label

### DIFF
--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -112,7 +112,7 @@
   };
 </script>
 
-<label class="text-sm text-black dark:text-white" class:sr-only={hideLabel} for={inputId}>{label}</label>
+<label class="immich-form-label" class:sr-only={hideLabel} for={inputId}>{label}</label>
 <div
   class="relative w-full dark:text-gray-300 text-gray-700 text-base"
   use:clickOutside={{ onOutclick: deactivate }}


### PR DESCRIPTION
On the "Edit date and time" dialog I noticed that the font sizes between the two input labels were different:
![before](https://github.com/immich-app/immich/assets/510681/d6713c0b-6545-4122-a009-e0b685864b45)

This PR changes the combobox label to use the existing `immich-form-label` CSS class instead of tailwind's `text-sm`:
![after](https://github.com/immich-app/immich/assets/510681/5d937a45-61a4-45db-8121-d8a1196f11ac)

The spacing is still off, but this may be fixed in a different PR (or in a later edit of this one).

As far as I can tell, the "Edit date and time" dialog is currently the only place where a combobox with visible label is used. In the settings pages, all the comboboxes have their label hidden.

_(Kudos for having such a smooth and simple https://immich.app/docs/developer/setup/ which makes it really low-threshold to contribute! ❤️ )_