### PR TITLE
fix(server): oauth linking error message

### DIFF
--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -395,12 +395,12 @@ describe('AuthService', () => {
       userMock.getAdmin.mockResolvedValue(userStub.user1);
       userMock.create.mockResolvedValue(userStub.user1);
 
-      await expect(sut.callback({ url: 'http://immich/auth/login?code=abc123' }, loginDetails)).resolves.toEqual(
-        loginResponseStub.user1oauth,
+      await expect(sut.callback({ url: 'http://immich/auth/login?code=abc123' }, loginDetails)).rejects.toThrow(
+        BadRequestException,
       );
 
       expect(userMock.update).not.toHaveBeenCalled();
-      expect(userMock.create).toHaveBeenCalled();
+      expect(userMock.create).not.toHaveBeenCalled();
     });
 
     it('should allow auto registering by default', async () => {

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -198,8 +198,12 @@ export class AuthService {
     // link existing user
     if (!user) {
       const emailUser = await this.userRepository.getByEmail(profile.email);
-      if (emailUser && !emailUser.oauthId) {
-        user = await this.userRepository.update(emailUser.id, { oauthId: profile.sub });
+      if (emailUser) {
+        if (emailUser.oauthId) {
+          throw new BadRequestException('User already exists, but is linked to another account.');
+        } else {
+          user = await this.userRepository.update(emailUser.id, { oauthId: profile.sub });
+        }
       }
     }
 


### PR DESCRIPTION
On OAuth login, if the email matches an existing user either (1) link the account or (2) throw an error.

Related to https://github.com/immich-app/immich/discussions/10284.