### PR TITLE
feat: split ips; internal local ip when on LAN, external ip otherwise

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,6 +7,7 @@ COPY --chown=node:node package*.json ./
 RUN npm ci
 COPY --chown=node:node . .
 ENV CHOKIDAR_USEPOLLING=true
+ENV PUBLIC_SERVER_URLS=
 EXPOSE 24678
 EXPOSE 3000
 ENTRYPOINT ["/sbin/tini", "--", "/bin/sh"]

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -14,6 +14,55 @@
     <link rel="icon" type="image/png" sizes="144x144" href="/favicon-144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180.png" />
     %sveltekit.head%
+    <style>
+      /* prevent FOUC */
+      html {
+        height: 100%;
+        width: 100%;
+      }
+      body,
+      html {
+        margin: 0;
+        padding: 0;
+      }
+      @keyframes delayedVisibility {
+        to {
+          visibility: visible;
+        }
+      }
+      #stencil {
+        display: flex;
+        width: 100%;
+        height: 100vh;
+        color: rgb(156 163 175);
+        fill: rgb(66, 80, 175);
+        place-items: center;
+        justify-content: center;
+        overflow: hidden;
+        visibility: hidden;
+        animation: 0s linear 0.3s forwards delayedVisibility;
+      }
+      .dark #stencil {
+        color: rgb(75 85 99);
+      }
+      @keyframes loadspin {
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+      #stencil svg {
+        fill: rgb(66, 80, 175);
+        height: 100px;
+        width: 100px;
+        animation: loadspin 1s linear infinite;
+      }
+      .bg-immich-bg {
+        background-color: white;
+      }
+      .dark .dark\:bg-immich-dark-bg {
+        background-color: black;
+      }
+    </style>
     <script>
       /**
        * Prevent FOUC on page load.
@@ -53,6 +102,18 @@
   </head>
 
   <body class="bg-immich-bg dark:bg-immich-dark-bg">
+    <div id="stencil">
+      <svg role="status" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+          fill="currentColor"
+        />
+        <path
+          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+          fill="currentFill"
+        />
+      </svg>
+    </div>
     <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/web/src/lib/utils/server.ts
+++ b/web/src/lib/utils/server.ts
@@ -1,0 +1,38 @@
+import { env } from '$env/dynamic/public';
+import { defaults } from '@immich/sdk';
+
+const wait = (ms: number) => new Promise((_, reject) => setTimeout(reject, ms));
+
+const tryServers = async (fetchFn: typeof fetch) => {
+  const server_urls_env = env.PUBLIC_SERVER_URLS;
+  if (server_urls_env) {
+    const servers = server_urls_env.split(',');
+    // servers are in priority order, try in parallel, use first success
+    const fetchers = servers.map((url) => ({ url, fetcher: fetchFn(`${url}/server-info/config`) }));
+    for (const { url, fetcher } of fetchers) {
+      try {
+        const response = (await Promise.race([fetcher, wait(1000)])) as Response;
+        if (response?.ok) {
+          defaults.basePath = url;
+          return true;
+        }
+      } catch {
+        // ignore, handled upstream
+      }
+    }
+  }
+
+  return false;
+};
+
+export async function initSDK(fetcher: typeof fetch) {
+  // set event.fetch on the fetch-client used by @immich/sdk
+  // https://kit.svelte.dev/docs/load#making-fetch-requests
+  // https://github.com/oazapfts/oazapfts/blob/main/README.md#fetch-options
+  defaults.fetch = fetcher;
+  try {
+    await Promise.race([tryServers(fetcher), wait(5000)]);
+  } catch {
+    throw 'Could not connect to any server';
+  }
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -51,6 +51,8 @@
   };
 
   onMount(() => {
+    const element = document.querySelector('#stencil');
+    element?.remove();
     // if the browser theme changes, changes the Immich theme too
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', handleChangeTheme);
   });
@@ -106,25 +108,29 @@
   {/if}
 </svelte:head>
 
-<noscript
-  class="absolute z-[1000] flex h-screen w-screen place-content-center place-items-center bg-immich-bg dark:bg-immich-dark-bg dark:text-immich-dark-fg"
->
-  <FullscreenContainer title={$t('welcome_to_immich')}>
-    To use Immich, you must enable JavaScript or use a JavaScript compatible browser.
-  </FullscreenContainer>
-</noscript>
+{#if $page.data.hasError}
+  <FullscreenContainer title="Error connecting to Immich Server"></FullscreenContainer>
+{:else}
+  <noscript
+    class="absolute z-[1000] flex h-screen w-screen place-content-center place-items-center bg-immich-bg dark:bg-immich-dark-bg dark:text-immich-dark-fg"
+  >
+    <FullscreenContainer title={$t('welcome_to_immich')}>
+      To use Immich, you must enable JavaScript or use a JavaScript compatible browser.
+    </FullscreenContainer>
+  </noscript>
 
-<slot />
+  <slot />
 
-{#if showNavigationLoadingBar}
-  <NavigationLoadingBar />
-{/if}
+  {#if showNavigationLoadingBar}
+    <NavigationLoadingBar />
+  {/if}
 
-<DownloadPanel />
-<UploadPanel />
-<NotificationList />
-<DialogWrapper />
+  <DownloadPanel />
+  <UploadPanel />
+  <NotificationList />
+  <DialogWrapper />
 
-{#if $user?.isAdmin}
-  <VersionAnnouncementBox />
+  {#if $user?.isAdmin}
+    <VersionAnnouncementBox />
+  {/if}
 {/if}


### PR DESCRIPTION
New feature for selfhosters: 

The environment variable: 
`PUBLIC_SERVER_URLS`

If you run Immich on your local network, you want to access it using the fast local network when you are at home, on a LAN, but still access it when you are away from home, using the public address. 

Lets say your public address is `10.10.10.1` (at `immich.example.com`) and your internal address is `192.168.1.1`.

If you specify `PUBLIC_SERVER_URLS=http://192.168.1.1:2283/api,http://immich.example.com` then when the immich frontend code loads, it will try to access the API server first at 192.168.1.1, then at immich.example.com. 

If you on a LAN, the first ip will resolve and you'll access it on a fast internal network. 

Once you leave your home network, the first request will fail, and will fallback to the external domain, which will access the server over your public (slower) internet uplink. 


This PR also adds a loading/stencil during the time its searching for the right server. The spinner only appears after .3 seconds, so it doesn't flicker on very short loads. 
