### PR TITLE
fix(app-bar): remove safe area of the app bar in photos page

### DIFF
--- a/mobile/lib/pages/photos/photos.page.dart
+++ b/mobile/lib/pages/photos/photos.page.dart
@@ -119,9 +119,7 @@ class PhotosPage extends HookConsumerWidget {
           child: Container(
             height: kToolbarHeight + MediaQuery.of(context).padding.top,
             color: context.themeData.appBarTheme.backgroundColor,
-            child: const SafeArea(
-              child: ImmichAppBar(),
-            ),
+            child: const ImmichAppBar(),
           ),
         ),
       ],


### PR DESCRIPTION
fixed #10010, #10234

**Before**
<img width="1055" alt="Screenshot 2024-06-15 at 11 54 30" src="https://github.com/immich-app/immich/assets/14053802/a26bb7a5-c4f7-4293-bcd8-e577f4f6871a">

**After**
<img width="1055" alt="Screenshot 2024-06-15 at 11 54 19" src="https://github.com/immich-app/immich/assets/14053802/dd7d69dc-a0e7-487f-b147-68228f710e4c">


**Reason**

The SafeArea used to ensure widget not overlapping with system widgets, but it pushed the appbar to top by 'bottom padding', thus we can't see (or partially see) app bar on android tablets (due to the huge bottom padding).

it used `MediaQuery.of(context).padding.top` to avoid overlap with the top already, so there is no need to use SafeArea.
