### PR TITLE
fix(web): prevent new uploads from temporarily showing in trash

### DIFF
--- a/web/src/lib/stores/asset.store.spec.ts
+++ b/web/src/lib/stores/asset.store.spec.ts
@@ -202,6 +202,15 @@ describe('AssetStore', () => {
       expect(updateAssetsSpy).toBeCalledWith([asset]);
       expect(assetStore.assets.length).toEqual(1);
     });
+
+    it('ignores trashed assets when isTrashed is true', () => {
+      const asset = assetFactory.build({ isTrashed: false });
+      const trashedAsset = assetFactory.build({ isTrashed: true });
+
+      const assetStore = new AssetStore({ isTrashed: true });
+      assetStore.addAssets([asset, trashedAsset]);
+      expect(assetStore.assets).toEqual([trashedAsset]);
+    });
   });
 
   describe('updateAssets', () => {

--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -326,7 +326,8 @@ export class AssetStore {
         this.options.personId ||
         this.options.albumId ||
         isMismatched(this.options.isArchived, asset.isArchived) ||
-        isMismatched(this.options.isFavorite, asset.isFavorite)
+        isMismatched(this.options.isFavorite, asset.isFavorite) ||
+        isMismatched(this.options.isTrashed, asset.isTrashed)
       ) {
         // If asset is already in the bucket we don't need to recalculate
         // asset store containers


### PR DESCRIPTION
Uploaded assets get added to the asset store through websocket events, but it doesn't check if the `isTrashed` value matches. This causes uploads to temporarily appear on the trash page until the page is refreshed.

Fixes #8979
