### PR TITLE
chore(server): update exiftool and migrate off deprecated method signatures

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,7 +34,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
-        "exiftool-vendored": "~26.2.0",
+        "exiftool-vendored": "~27.0.0",
         "fast-glob": "^3.3.2",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^8.0.0",
@@ -9127,9 +9127,10 @@
       }
     },
     "node_modules/exiftool-vendored": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-26.2.0.tgz",
-      "integrity": "sha512-7P6jQ944or7ic2SJzW+uaWK4TLDXlaCppHrBayl4MpIrVcEeQjiQTez4/oOH0wULIRu4j4H6Xruz4SLrDaafUg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-27.0.0.tgz",
+      "integrity": "sha512-/jHX8Jjadj0YJzpqnuBo1Yy2ln2hnRbBIc+3jcVOLQ6qhHEKsLRlfJ145Ghn7k/EcnfpDzVX3V8AUCTC8juTow==",
+      "license": "MIT",
       "dependencies": {
         "@photostructure/tz-lookup": "^10.0.0",
         "@types/luxon": "^3.4.2",
@@ -22600,9 +22601,9 @@
       }
     },
     "exiftool-vendored": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-26.2.0.tgz",
-      "integrity": "sha512-7P6jQ944or7ic2SJzW+uaWK4TLDXlaCppHrBayl4MpIrVcEeQjiQTez4/oOH0wULIRu4j4H6Xruz4SLrDaafUg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-27.0.0.tgz",
+      "integrity": "sha512-/jHX8Jjadj0YJzpqnuBo1Yy2ln2hnRbBIc+3jcVOLQ6qhHEKsLRlfJ145Ghn7k/EcnfpDzVX3V8AUCTC8juTow==",
       "requires": {
         "@photostructure/tz-lookup": "^10.0.0",
         "@types/luxon": "^3.4.2",

--- a/server/package.json
+++ b/server/package.json
@@ -60,7 +60,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
-    "exiftool-vendored": "~26.2.0",
+    "exiftool-vendored": "~27.0.0",
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^8.0.0",

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -20,15 +20,7 @@ export class MetadataRepository implements IMetadataRepository {
     @Inject(ILoggerRepository) private logger: ILoggerRepository,
   ) {
     this.logger.setContext(MetadataRepository.name);
-  }
-  private exiftool: ExifTool = this.initExiftool();
-
-  async teardown() {
-    await this.exiftool.end();
-  }
-
-  private initExiftool() {
-    return new ExifTool({
+    this.exiftool = new ExifTool({
       defaultVideosToUTC: true,
       backfillTimezones: true,
       inferTimezoneFromDatestamps: true,
@@ -40,6 +32,11 @@ export class MetadataRepository implements IMetadataRepository {
       readArgs: ['-api', 'largefilesupport=1'],
       writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
     });
+  }
+  private exiftool: ExifTool;
+
+  async teardown() {
+    await this.exiftool.end();
   }
 
   readTags(path: string): Promise<ImmichTags | null> {

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -29,26 +29,24 @@ export class MetadataRepository implements IMetadataRepository {
 
   private initExiftool() {
     return new ExifTool({
+      defaultVideosToUTC: true,
+      backfillTimezones: true,
+      inferTimezoneFromDatestamps: true,
+      useMWG: true,
+      numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength'],
+      /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
+      geoTz: (lat, lon) => geotz.find(lat, lon)[0],
       // Enable exiftool LFS to parse metadata for files larger than 2GB.
       readArgs: ['-api', 'largefilesupport=1'],
+      writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
     });
   }
 
   readTags(path: string): Promise<ImmichTags | null> {
-    return this.exiftool
-      .read(path, {
-        defaultVideosToUTC: true,
-        backfillTimezones: true,
-        inferTimezoneFromDatestamps: true,
-        useMWG: true,
-        numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength'],
-        /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
-        geoTz: (lat, lon) => geotz.find(lat, lon)[0],
-      })
-      .catch((error) => {
-        this.logger.warn(`Error reading exif data (${path}): ${error}`, error?.stack);
-        return null;
-      }) as Promise<ImmichTags | null>;
+    return this.exiftool.read(path).catch((error) => {
+      this.logger.warn(`Error reading exif data (${path}): ${error}`, error?.stack);
+      return null;
+    }) as Promise<ImmichTags | null>;
   }
 
   extractBinaryTag(path: string, tagName: string): Promise<Buffer> {
@@ -57,9 +55,7 @@ export class MetadataRepository implements IMetadataRepository {
 
   async writeTags(path: string, tags: Partial<Tags>): Promise<void> {
     try {
-      await this.exiftool.write(path, tags, {
-        writeArgs: ['-overwrite_original'],
-      });
+      await this.exiftool.write(path, tags);
     } catch (error) {
       this.logger.warn(`Error writing exif data (${path}): ${error}`);
     }


### PR DESCRIPTION
As a result of the previous exiftool largefilesupport fix and chatting with the exiftool-vendored maintainer, a new version of exiftool-vendored was released with a clearer API which removes the redundancy of exiftool methods accepting both an `optionalArgs` parameter as well as an options object that also includes `optionalArgs`. Instead, the updated interface is just the necessary args and an options object that accepts readArgs/writeArgs. This PR updates exiftool-vendored and our use of it to remove the deprecated forms while also moving largefilesupport flags into the constructor, since the addition of `readArgs/writeArgs` to the options object now allows it to be persistently set in the constructor for each operation instead of needing to pass args on every call.

* chore(server): update exiftool-vendored to 27.0.0

* chore(server): switch away from deprecated exiftool method signatures
  - options now includes read/writeArgs making the deprecated signatures with args array redundant
  - switch read call from file,args,options to file,options
  - switch write call from file,tags,args to file,tags,options

* chore(server): move largefilesupport flags into exiftool constructor
  - options now includes read/writeArgs making it available to be set globally in constructor
  - switches back to instantiating an instance of exiftool

Note: I also removed the merging of `DefaultReadTaskOptions` into the read call options since it looks like the passed options object is already merged into the default options by exiftool-vendored (validated this with strace by checking that default flags are passed to the processes stdin).

I also added a bit of cleanup that I think should be safe based on my digging around in exiftool:

  * Since there don't seem to be any downsides to enabling largefilesupport always (as discussed in exiftool forums and how the first largefilesupport fix tried to work by passing the flag to the process when launching it), I think it makes sense to just add `largefilesupport` to `writeArgs` too in addition to reads, which also makes it clear to any future maintainers that there's no reason for it to be off
  * The writeTags sets `-overwrite_original`, which as I understand it disables the behavior of keeping an `_original` copy of modified files. Since immich doesn't have any provisions that I know of to handle `_original`  file copies, I added it to the global `writeArgs` flags in the constructor.
    * Digging around the exiftool-vendored code it seems the only write tasks that use writeArgs is write itself and deleteAllTags, so I think setting `-overwrite_original` in `writeArgs` in the constructor is safe and consolidates exiftool config.
  * `readTags` sets some config options in its read call: `defaultVideosToUTC`, `backfillTimezones` `inferTimezoneFromDatestamps`, `useMWG`, an additional `numericTags` (+ FocalLength) as well as better geoTZ are also added. Since most of these are for reads only, it's safe to put them in the constructor config since they only affect the call that already had them set. Only `useMWG` would start to affect write if moved to the constructor, but this is already set for reads and the documentation notes that it's recommended to be on and that it "makes `ExifTool.write` write to "synonymous" MWG tags automatically.", which seems benign especially when any reading already reads using MWG.
  
Here is a comparison of what flags are sent to exiftool for "refresh metadata" and "write" (editing date to trigger writing an xmp file) from the current main branch and with this branch and all the cleanup - the only change is adding struct=1 (this version of exiftool now passes that from defaults to write where before only a couple specific default fields were picked) and adding MWG and largefilesupport:

```diff
@@ -1,29 +1,35 @@
 read(0, "-json
 -api
 largefilesupport=1
 -api
 struct=1
 -use
 MWG
 -*Duration*#
 -GPSAltitude#
 -GPSLatitude#
 -GPSLongitude#
 -GPSPosition#
 -Orientation#
 -FocalLength#
 -all
-/usr/src/app/upload/library/admin/2018/2018-06-14/00J0J_joaONoenBdV_1200x900_cwjpkf.jpg
+/usr/src/app/upload/library/admin/2018/2018-06-29/00J0J_joaONoenBdV_1200x900_cwjpkf.jpg
 -ignoreMinorErrors
 -execute
 ", 65536) = 272
 
 read(0, "-sep
 \37
 -E
--CreationDate=2018-06-16T20:30:00.000-04:00
+-api
+struct=1
+-use
+MWG
+-CreationDate=2018-06-19T20:30:00.000-04:00
+-api
+largefilesupport=1
 -overwrite_original
-/usr/src/app/upload/library/admin/2018/2018-06-15/00J0J_joaONoenBdV_1200x900_cwjpkf.jpg.xmp
+/usr/src/app/upload/library/admin/2018/2018-06-13/00J0J_joaONoenBdV_1200x900_cwjpkf.jpg.xmp
 -ignoreMinorErrors
 -execute
-", 65536) = 194
+", 65536) = 241
```