### PR TITLE
fix(server): orientation handling for person thumbnails

### DIFF
--- a/server/src/interfaces/media.interface.ts
+++ b/server/src/interfaces/media.interface.ts
@@ -47,6 +47,10 @@ export interface ImageDimensions {
   height: number;
 }
 
+export interface InputDimensions extends ImageDimensions {
+  inputPath: string;
+}
+
 export interface VideoInfo {
   format: VideoFormat;
   videoStreams: VideoStreamInfo[];

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -917,9 +917,9 @@ describe(PersonService.name, () => {
           colorspace: Colorspace.P3,
           crop: {
             left: 0,
-            top: 428,
-            width: 1102,
-            height: 1102,
+            top: 85,
+            width: 510,
+            height: 510,
           },
         },
       );

--- a/server/test/fixtures/face.stub.ts
+++ b/server/test/fixtures/face.stub.ts
@@ -72,8 +72,8 @@ export const faceStub = {
     boundingBoxY1: 5,
     boundingBoxX2: 505,
     boundingBoxY2: 505,
-    imageHeight: 1000,
-    imageWidth: 1000,
+    imageHeight: 2880,
+    imageWidth: 2160,
   }),
   middle: Object.freeze<NonNullableProperty<AssetFaceEntity>>({
     id: 'assetFaceId6',


### PR DESCRIPTION
## Description

We don't need to check the orientation tag - we just need to be consistent with the preview image.

Fixes #8317

## How Has This Been Tested?

Confirmed that the person thumbnails in the sample image in #8317 can be generated successfully with this change. It fails on main. Also ran facial recognition on all assets and didn't see any errors.