### PR TITLE
fix(cli): handle patterns correctly on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,38 @@ jobs:
         run: npm run test:cov
         if: ${{ !cancelled() }}
 
+  cli-unit-tests-win:
+    name: CLI (Windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ./cli
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup typescript-sdk
+        run: npm ci && npm run build
+        working-directory: ./open-api/typescript-sdk
+
+      - name: Install deps
+        run: npm ci
+
+      # Skip linter & formatter in Windows test.
+      - name: Run tsc
+        run: npm run check
+        if: ${{ !cancelled() }}
+
+      - name: Run unit tests & coverage
+        run: npm run test:cov
+        if: ${{ !cancelled() }}
+
   web-unit-tests:
     name: Web
     runs-on: ubuntu-latest

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  resolve: { alias: { src: '/src' } },
   build: {
     rollupOptions: {
       input: 'src/index.ts',


### PR DESCRIPTION
[`fast-glob` requires slash (instead of backslash) for matching path. ](https://www.npmjs.com/package/fast-glob#how-to-write-patterns-on-windows)

So before this change, `--recursive` didn't work on WIndows.

Before: 
![image](https://github.com/immich-app/immich/assets/16451516/9e204076-b57a-4f8b-b53a-ec83a327f09f)

After:
![image](https://github.com/immich-app/immich/assets/16451516/254b9fcf-4549-4642-ab65-a859724caea9)

## Some changes

- On Windows, use `convertPathToPattern` from `fast-glob`.
- Add test CI for CLI on the Windows platform.
- To unify the test cases (a file may have multiple valid path formats), compare file contents instead of the paths.