### PR TITLE
fix(web): confirm button is disabled if two dialogs are shown subsequently

### DIFF
--- a/web/src/lib/components/shared-components/dialog/confirm-dialog.svelte
+++ b/web/src/lib/components/shared-components/dialog/confirm-dialog.svelte
@@ -16,10 +16,7 @@
   export let onCancel: () => void;
   export let onConfirm: () => void;
 
-  let isConfirmButtonDisabled = false;
-
   const handleConfirm = () => {
-    isConfirmButtonDisabled = true;
     onConfirm();
   };
 </script>
@@ -37,7 +34,7 @@
         {cancelText}
       </Button>
     {/if}
-    <Button color={confirmColor} fullwidth on:click={handleConfirm} disabled={disabled || isConfirmButtonDisabled}>
+    <Button color={confirmColor} fullwidth on:click={handleConfirm} {disabled}>
       {confirmText}
     </Button>
   </svelte:fragment>


### PR DESCRIPTION
Fix #10160 