### PR TITLE
feat(mobile): render assets on device by default

### DIFF
--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/models/albums/album_add_asset_response.model.dart';
-import 'package:immich_mobile/services/backup.service.dart';
 import 'package:immich_mobile/entities/album.entity.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -24,7 +23,6 @@ final albumServiceProvider = Provider(
     ref.watch(userServiceProvider),
     ref.watch(syncServiceProvider),
     ref.watch(dbProvider),
-    ref.watch(backupServiceProvider),
   ),
 );
 
@@ -33,7 +31,6 @@ class AlbumService {
   final UserService _userService;
   final SyncService _syncService;
   final Isar _db;
-  final BackupService _backupService;
   final Logger _log = Logger('AlbumService');
   Completer<bool> _localCompleter = Completer()..complete(false);
   Completer<bool> _remoteCompleter = Completer()..complete(false);
@@ -43,7 +40,6 @@ class AlbumService {
     this._userService,
     this._syncService,
     this._db,
-    this._backupService,
   );
 
   /// Checks all selected device albums for changes of albums and their assets

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -1,12 +1,8 @@
 import 'dart:async';
-import 'dart:collection';
-import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/models/albums/album_add_asset_response.model.dart';
-import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/services/backup.service.dart';
 import 'package:immich_mobile/entities/album.entity.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
@@ -62,81 +58,20 @@ class AlbumService {
     final Stopwatch sw = Stopwatch()..start();
     bool changes = false;
     try {
-      final List<String> excludedIds =
-          await _backupService.excludedAlbumsQuery().idProperty().findAll();
-      final List<String> selectedIds =
-          await _backupService.selectedAlbumsQuery().idProperty().findAll();
-      if (selectedIds.isEmpty) {
-        final numLocal = await _db.albums.where().localIdIsNotNull().count();
-        if (numLocal > 0) {
-          _syncService.removeAllLocalAlbumsAndAssets();
-        }
-        return false;
-      }
       final List<AssetPathEntity> onDevice =
           await PhotoManager.getAssetPathList(
         hasAll: true,
         filterOption: FilterOptionGroup(containsPathModified: true),
       );
       _log.info("Found ${onDevice.length} device albums");
-      Set<String>? excludedAssets;
-      if (excludedIds.isNotEmpty) {
-        if (Platform.isIOS) {
-          // iOS and Android device album working principle differ significantly
-          // on iOS, an asset can be in multiple albums
-          // on Android, an asset can only be in exactly one album (folder!) at the same time
-          // thus, on Android, excluding an album can be done by ignoring that album
-          // however, on iOS, it it necessary to load the assets from all excluded
-          // albums and check every asset from any selected album against the set
-          // of excluded assets
-          excludedAssets = await _loadExcludedAssetIds(onDevice, excludedIds);
-          _log.info("Found ${excludedAssets.length} assets to exclude");
-        }
-        // remove all excluded albums
-        onDevice.removeWhere((e) => excludedIds.contains(e.id));
-        _log.info(
-          "Ignoring ${excludedIds.length} excluded albums resulting in ${onDevice.length} device albums",
-        );
-      }
-      final hasAll = selectedIds
-          .map((id) => onDevice.firstWhereOrNull((a) => a.id == id))
-          .whereNotNull()
-          .any((a) => a.isAll);
-      if (hasAll) {
-        if (Platform.isAndroid) {
-          // remove the virtual "Recent" album and keep and individual albums
-          // on Android, the virtual "Recent" `lastModified` value is always null
-          onDevice.removeWhere((e) => e.isAll);
-          _log.info("'Recents' is selected, keeping all individual albums");
-        }
-      } else {
-        // keep only the explicitly selected albums
-        onDevice.removeWhere((e) => !selectedIds.contains(e.id));
-        _log.info("'Recents' is not selected, keeping only selected albums");
-      }
-      changes =
-          await _syncService.syncLocalAlbumAssetsToDb(onDevice, excludedAssets);
+
+      changes = await _syncService.syncLocalAlbumAssetsToDb(onDevice);
       _log.info("Syncing completed. Changes: $changes");
     } finally {
       _localCompleter.complete(changes);
     }
     debugPrint("refreshDeviceAlbums took ${sw.elapsedMilliseconds}ms");
     return changes;
-  }
-
-  Future<Set<String>> _loadExcludedAssetIds(
-    List<AssetPathEntity> albums,
-    List<String> excludedAlbumIds,
-  ) async {
-    final Set<String> result = HashSet<String>();
-    for (AssetPathEntity a in albums) {
-      if (excludedAlbumIds.contains(a.id)) {
-        final List<AssetEntity> assets =
-            await a.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
-        result.addAll(assets.map((e) => e.id));
-      }
-    }
-    return result;
   }
 
   /// Checks remote albums (owned if `isShared` is false) for changes,

--- a/mobile/lib/services/hash.service.dart
+++ b/mobile/lib/services/hash.service.dart
@@ -24,13 +24,9 @@ class HashService {
     AssetPathEntity album, {
     int start = 0,
     int end = 0x7fffffffffffffff,
-    Set<String>? excludedAssets,
   }) async {
     final entities = await album.getAssetListRange(start: start, end: end);
-    final filtered = excludedAssets == null
-        ? entities
-        : entities.where((e) => !excludedAssets.contains(e.id)).toList();
-    return _hashAssets(filtered);
+    return _hashAssets(entities);
   }
 
   /// Converts a list of [AssetEntity]s to [Asset]s including only those


### PR DESCRIPTION
This is the first step in reworking the upload mechanism.

This PR removes the relationship between selected albums for backup so that it can be rendered on the timeline. All local assets are rendered on the timeline by default.