### PR TITLE
fix(server): consider all I-frames for video thumbnails

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -344,7 +344,7 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
         {
-          inputOptions: ['-skip_frame nokey', '-sws_flags accurate_rnd+full_chroma_int'],
+          inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
             '-frames:v 1',
@@ -371,7 +371,7 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
         {
-          inputOptions: ['-skip_frame nokey', '-sws_flags accurate_rnd+full_chroma_int'],
+          inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
             '-frames:v 1',
@@ -400,7 +400,7 @@ describe(MediaService.name, () => {
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
         {
-          inputOptions: ['-skip_frame nokey', '-sws_flags accurate_rnd+full_chroma_int'],
+          inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
             '-frames:v 1',

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -384,7 +384,7 @@ export class ThumbnailConfig extends BaseConfig {
   }
 
   getBaseInputOptions(): string[] {
-    return ['-skip_frame nokey', '-sws_flags accurate_rnd+full_chroma_int'];
+    return ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'];
   }
 
   getBaseOutputOptions() {


### PR DESCRIPTION
### Description

The behavior of `-skip_frame nokey` apparently depends on the decoder. The HEVC and VP9 videos I tested on still process I-frames that aren't keyframes, but H.264 really only processes keyframes. `-skip_frame nointra` is consistent across decoders from what I can see.

### How Has This Been Tested?

Confirmed that the sample videos sent to me from #8683 have non-black thumbnails with this change. The thumbnails for HEVC and VP9 videos are the same as before from what I can tell.