### PR TITLE
feat(web): display original heif images for safari

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -267,6 +267,11 @@ const supportedImageMimeTypes = new Set([
   'image/webp',
 ]);
 
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+if (isSafari) {
+  supportedImageMimeTypes.add('image/heic').add('image/heif');
+}
+
 /**
  * Returns true if the asset is an image supported by web browsers, false otherwise
  */

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -267,7 +267,7 @@ const supportedImageMimeTypes = new Set([
   'image/webp',
 ]);
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // https://stackoverflow.com/a/23522755
 if (isSafari) {
   supportedImageMimeTypes.add('image/heic').add('image/heif');
 }


### PR DESCRIPTION
## Description

Safari supports this format, so it's fine to display HEIF images on this client.

Fixes #8972