### PR TITLE
fix(server): let thumbnail generation fail on error

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -45,7 +45,7 @@ export class MediaRepository implements IMediaRepository {
   }
 
   async generateThumbnail(input: string | Buffer, output: string, options: ThumbnailOptions): Promise<void> {
-    const pipeline = sharp(input, { failOn: 'none', limitInputPixels: false })
+    const pipeline = sharp(input, { failOn: 'error', limitInputPixels: false })
       .pipelineColorspace(options.colorspace === Colorspace.SRGB ? 'srgb' : 'rgb16')
       .rotate();
 


### PR DESCRIPTION
## Description

We currently set image processing to attempt to continue even after it detects corruption or otherwise invalid data. It seems better for stability to fail here.

(Maybe) fixes #10452