### PR TITLE
fix(ml): limit load retries

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -31,6 +31,7 @@ class InferenceModel(ABC):
         **model_kwargs: Any,
     ) -> None:
         self.loaded = False
+        self.load_attempts = 0
         self.model_name = clean_name(model_name)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else self.cache_dir_default
         self.providers = providers if providers is not None else self.providers_default
@@ -48,9 +49,11 @@ class InferenceModel(ABC):
     def load(self) -> None:
         if self.loaded:
             return
+        self.load_attempts += 1
 
         self.download()
-        log.info(f"Loading {self.model_type.replace('-', ' ')} model '{self.model_name}' to memory")
+        attempt = f"Attempt #{self.load_attempts + 1} to load" if self.load_attempts else "Loading"
+        log.info(f"{attempt} {self.model_type.replace('-', ' ')} model '{self.model_name}' to memory")
         self.session = self._load()
         self.loaded = True
 

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -8,10 +8,10 @@ from typing import Any, Callable
 from unittest import mock
 
 import cv2
-from fastapi import HTTPException
 import numpy as np
 import onnxruntime as ort
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from PIL import Image
 from pytest import MonkeyPatch

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 from unittest import mock
 
 import cv2
+from fastapi import HTTPException
 import numpy as np
 import onnxruntime as ort
 import pytest
@@ -627,6 +628,7 @@ class TestLoad:
     async def test_load(self) -> None:
         mock_model = mock.Mock(spec=InferenceModel)
         mock_model.loaded = False
+        mock_model.load_attempts = 0
 
         res = await load(mock_model)
 
@@ -650,12 +652,27 @@ class TestLoad:
         mock_model.model_task = ModelTask.SEARCH
         mock_model.load.side_effect = [OSError, None]
         mock_model.loaded = False
+        mock_model.load_attempts = 0
 
         res = await load(mock_model)
 
         assert res is mock_model
         mock_model.clear_cache.assert_called_once()
         assert mock_model.load.call_count == 2
+
+    async def test_load_clears_cache_and_raises_if_os_error_and_already_retried(self) -> None:
+        mock_model = mock.Mock(spec=InferenceModel)
+        mock_model.model_name = "test_model_name"
+        mock_model.model_type = ModelType.VISUAL
+        mock_model.model_task = ModelTask.SEARCH
+        mock_model.loaded = False
+        mock_model.load_attempts = 2
+
+        with pytest.raises(HTTPException):
+            await load(mock_model)
+
+        mock_model.clear_cache.assert_not_called()
+        mock_model.load.assert_not_called()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

The ML service tries to load a model, then on failure clears the cache and retries once. However, a new request will mean another two attempts to load. Given that the service can receive many requests for a model, failing to load/download can cause an excessive number of attempts.

This PR limits a single model instance to one retry across its lifetime. After a model is unloaded or the service restarts, it will be able to re-attempt it.

## How Has This Been Tested?

Tested by making a model throw an error on the first attempt, but not the second, and confirming that it still loaded. If I made it throw an error every time, it didn't try to load the model repeatedly.