### PR TITLE
fix(server): library refresh not checking trashed assets

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -320,17 +320,11 @@ FROM
     FROM
       "assets" "AssetEntity"
       LEFT JOIN "libraries" "AssetEntity__AssetEntity_library" ON "AssetEntity__AssetEntity_library"."id" = "AssetEntity"."libraryId"
-      AND (
-        "AssetEntity__AssetEntity_library"."deletedAt" IS NULL
-      )
     WHERE
       (
-        (
-          ((("AssetEntity__AssetEntity_library"."id" = $1)))
-          AND ("AssetEntity"."originalPath" = $2)
-        )
+        ((("AssetEntity__AssetEntity_library"."id" = $1)))
+        AND ("AssetEntity"."originalPath" = $2)
       )
-      AND ("AssetEntity"."deletedAt" IS NULL)
   ) "distinctAlias"
 ORDER BY
   "AssetEntity_id" ASC

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -188,7 +188,8 @@ export class AssetRepository implements IAssetRepository {
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.STRING] })
   getByLibraryIdAndOriginalPath(libraryId: string, originalPath: string): Promise<AssetEntity | null> {
     return this.repository.findOne({
-      where: { library: { id: libraryId }, originalPath: originalPath },
+      where: { library: { id: libraryId }, originalPath },
+      withDeleted: true,
     });
   }
 


### PR DESCRIPTION
## Description

The query used to check if an asset exists excludes trashed assets, so it will consider such an asset as new and fail to import it due to the uniqueness constraint in the DB. This PR changes the query so the handler knows the asset already exists.