### PR TITLE
fix(server): reindex after changing to a model with a different dimension size

### DIFF
--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -315,6 +315,7 @@ export class SearchRepository implements ISearchRepository {
     await this.smartSearchRepository.manager.transaction(async (manager) => {
       await manager.clear(SmartSearchEntity);
       await manager.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET DATA TYPE vector(${dimSize})`);
+      await manager.query(`REINDEX INDEX clip_index`);
     });
 
     this.logger.log(`Successfully updated database CLIP dimension size from ${curDimSize} to ${dimSize}.`);


### PR DESCRIPTION
## Description

Occasionally, the vector index still expects the old dimension size and rejects the new model's embeddings. A reindex after truncating the table fixes this.
 
Fixes #10493