### PR TITLE
fix(server): `/places` entries sometimes not ordered alphabetically

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -405,3 +405,5 @@ FROM
   "assets" "asset"
   INNER JOIN "exif" "exif" ON "exif"."assetId" = "asset"."id"
   INNER JOIN cte ON asset.id = cte."assetId"
+ORDER BY
+  exif.city

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -52,7 +52,7 @@ export class SearchRepository implements ISearchRepository {
         .innerJoinAndSelect('asset.exifInfo', 'exif')
         .withDeleted()
         .getQuery() +
-      ' INNER JOIN cte ON asset.id = cte."assetId"';
+      ' INNER JOIN cte ON asset.id = cte."assetId" ORDER BY exif.city';
   }
 
   async init(modelName: string): Promise<void> {


### PR DESCRIPTION
## Description

Whether this query returns a sorted result depends on the query plan. This PR makes it consistently sort them before returning.

## How Has This Been Tested?

Tested on an instance where the results were not sorted and confirmed that the revised query sorts them as expected.