### PR TITLE
fix(web): six digit year input

### DIFF
--- a/web/src/lib/components/elements/date-input.svelte
+++ b/web/src/lib/components/elements/date-input.svelte
@@ -5,7 +5,11 @@
     type: 'date' | 'datetime-local';
   }
 
+  export let type: $$Props['type'];
   export let value: $$Props['value'] = undefined;
+  export let max: $$Props['max'] = undefined;
+
+  $: fallbackMax = type === 'date' ? '9999-12-31' : '9999-12-31T23:59';
 
   // Updating `value` directly causes the date input to reset itself or
   // interfere with user changes.
@@ -14,7 +18,9 @@
 
 <input
   {...$$restProps}
+  {type}
   {value}
+  max={max || fallbackMax}
   on:input={(e) => (updatedValue = e.currentTarget.value)}
   on:blur={() => (value = updatedValue)}
   on:keydown={(e) => {


### PR DESCRIPTION
Some browsers such as Chrome allow 6 digit year inputs. Fixes #8531 by setting a default `max` value. However, iOS Safari doesn't support the `max` attribute for date inputs, so I'm not sure if the issue is also fixed there.