### PR TITLE
chore(mobile): remove exclude album mechanism for backup

### DIFF
--- a/mobile/lib/entities/backup_album.entity.dart
+++ b/mobile/lib/entities/backup_album.entity.dart
@@ -18,5 +18,4 @@ class BackupAlbum {
 enum BackupSelection {
   none,
   select,
-  exclude;
 }

--- a/mobile/lib/entities/backup_album.entity.g.dart
+++ b/mobile/lib/entities/backup_album.entity.g.dart
@@ -107,7 +107,6 @@ P _backupAlbumDeserializeProp<P>(
 const _BackupAlbumselectionEnumValueMap = {
   'none': 0,
   'select': 1,
-  'exclude': 2,
 };
 const _BackupAlbumselectionValueEnumMap = {
   0: BackupSelection.none,

--- a/mobile/lib/entities/backup_album.entity.g.dart
+++ b/mobile/lib/entities/backup_album.entity.g.dart
@@ -112,7 +112,6 @@ const _BackupAlbumselectionEnumValueMap = {
 const _BackupAlbumselectionValueEnumMap = {
   0: BackupSelection.none,
   1: BackupSelection.select,
-  2: BackupSelection.exclude,
 };
 
 Id _backupAlbumGetId(BackupAlbum object) {

--- a/mobile/lib/models/backup/backup_state.model.dart
+++ b/mobile/lib/models/backup/backup_state.model.dart
@@ -38,7 +38,6 @@ class BackUpState {
   /// All available albums on the device
   final List<AvailableAlbum> availableAlbums;
   final Set<AvailableAlbum> selectedBackupAlbums;
-  final Set<AvailableAlbum> excludedBackupAlbums;
 
   /// Assets that are not overlapping in selected backup albums and excluded backup albums
   final Set<AssetEntity> allUniqueAssets;
@@ -68,7 +67,6 @@ class BackUpState {
     required this.backupTriggerDelay,
     required this.availableAlbums,
     required this.selectedBackupAlbums,
-    required this.excludedBackupAlbums,
     required this.allUniqueAssets,
     required this.selectedAlbumsBackupAssetsIds,
     required this.currentUploadAsset,
@@ -93,7 +91,6 @@ class BackUpState {
     int? backupTriggerDelay,
     List<AvailableAlbum>? availableAlbums,
     Set<AvailableAlbum>? selectedBackupAlbums,
-    Set<AvailableAlbum>? excludedBackupAlbums,
     Set<AssetEntity>? allUniqueAssets,
     Set<String>? selectedAlbumsBackupAssetsIds,
     CurrentUploadAsset? currentUploadAsset,
@@ -121,7 +118,6 @@ class BackUpState {
       backupTriggerDelay: backupTriggerDelay ?? this.backupTriggerDelay,
       availableAlbums: availableAlbums ?? this.availableAlbums,
       selectedBackupAlbums: selectedBackupAlbums ?? this.selectedBackupAlbums,
-      excludedBackupAlbums: excludedBackupAlbums ?? this.excludedBackupAlbums,
       allUniqueAssets: allUniqueAssets ?? this.allUniqueAssets,
       selectedAlbumsBackupAssetsIds:
           selectedAlbumsBackupAssetsIds ?? this.selectedAlbumsBackupAssetsIds,
@@ -131,7 +127,7 @@ class BackUpState {
 
   @override
   String toString() {
-    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, excludedBackupAlbums: $excludedBackupAlbums, allUniqueAssets: $allUniqueAssets, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
+    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, allUniqueAssets: $allUniqueAssets, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
   }
 
   @override
@@ -158,7 +154,6 @@ class BackUpState {
         other.backupTriggerDelay == backupTriggerDelay &&
         collectionEquals(other.availableAlbums, availableAlbums) &&
         collectionEquals(other.selectedBackupAlbums, selectedBackupAlbums) &&
-        collectionEquals(other.excludedBackupAlbums, excludedBackupAlbums) &&
         collectionEquals(other.allUniqueAssets, allUniqueAssets) &&
         collectionEquals(
           other.selectedAlbumsBackupAssetsIds,
@@ -187,7 +182,6 @@ class BackUpState {
         backupTriggerDelay.hashCode ^
         availableAlbums.hashCode ^
         selectedBackupAlbums.hashCode ^
-        excludedBackupAlbums.hashCode ^
         allUniqueAssets.hashCode ^
         selectedAlbumsBackupAssetsIds.hashCode ^
         currentUploadAsset.hashCode;

--- a/mobile/lib/models/backup/backup_state.model.dart
+++ b/mobile/lib/models/backup/backup_state.model.dart
@@ -40,7 +40,7 @@ class BackUpState {
   final Set<AvailableAlbum> selectedBackupAlbums;
 
   /// Assets that are not overlapping in selected backup albums and excluded backup albums
-  final Set<AssetEntity> allUniqueAssets;
+  final Set<AssetEntity> backupCandidates;
 
   /// All assets from the selected albums that have been backup
   final Set<String> selectedAlbumsBackupAssetsIds;
@@ -67,7 +67,7 @@ class BackUpState {
     required this.backupTriggerDelay,
     required this.availableAlbums,
     required this.selectedBackupAlbums,
-    required this.allUniqueAssets,
+    required this.backupCandidates,
     required this.selectedAlbumsBackupAssetsIds,
     required this.currentUploadAsset,
   });
@@ -91,7 +91,7 @@ class BackUpState {
     int? backupTriggerDelay,
     List<AvailableAlbum>? availableAlbums,
     Set<AvailableAlbum>? selectedBackupAlbums,
-    Set<AssetEntity>? allUniqueAssets,
+    Set<AssetEntity>? backupCandidates,
     Set<String>? selectedAlbumsBackupAssetsIds,
     CurrentUploadAsset? currentUploadAsset,
   }) {
@@ -118,7 +118,7 @@ class BackUpState {
       backupTriggerDelay: backupTriggerDelay ?? this.backupTriggerDelay,
       availableAlbums: availableAlbums ?? this.availableAlbums,
       selectedBackupAlbums: selectedBackupAlbums ?? this.selectedBackupAlbums,
-      allUniqueAssets: allUniqueAssets ?? this.allUniqueAssets,
+      backupCandidates: backupCandidates ?? this.backupCandidates,
       selectedAlbumsBackupAssetsIds:
           selectedAlbumsBackupAssetsIds ?? this.selectedAlbumsBackupAssetsIds,
       currentUploadAsset: currentUploadAsset ?? this.currentUploadAsset,
@@ -127,7 +127,7 @@ class BackUpState {
 
   @override
   String toString() {
-    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, allUniqueAssets: $allUniqueAssets, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
+    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, backupCandidates: $backupCandidates, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
   }
 
   @override
@@ -154,7 +154,7 @@ class BackUpState {
         other.backupTriggerDelay == backupTriggerDelay &&
         collectionEquals(other.availableAlbums, availableAlbums) &&
         collectionEquals(other.selectedBackupAlbums, selectedBackupAlbums) &&
-        collectionEquals(other.allUniqueAssets, allUniqueAssets) &&
+        collectionEquals(other.backupCandidates, backupCandidates) &&
         collectionEquals(
           other.selectedAlbumsBackupAssetsIds,
           selectedAlbumsBackupAssetsIds,
@@ -182,7 +182,7 @@ class BackUpState {
         backupTriggerDelay.hashCode ^
         availableAlbums.hashCode ^
         selectedBackupAlbums.hashCode ^
-        allUniqueAssets.hashCode ^
+        backupCandidates.hashCode ^
         selectedAlbumsBackupAssetsIds.hashCode ^
         currentUploadAsset.hashCode;
   }

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -3,7 +3,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/immich_colors.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/widgets/backup/album_info_card.dart';
@@ -17,7 +16,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // final availableAlbums = ref.watch(backupProvider).availableAlbums;
     final selectedBackupAlbums = ref.watch(backupProvider).selectedBackupAlbums;
-    final excludedBackupAlbums = ref.watch(backupProvider).excludedBackupAlbums;
     final isDarkTheme = context.isDarkTheme;
     final albums = ref.watch(backupProvider).availableAlbums;
 
@@ -111,83 +109,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
       }).toSet();
     }
 
-    buildExcludedAlbumNameChip() {
-      return excludedBackupAlbums.map((album) {
-        void removeSelection() {
-          ref
-              .watch(backupProvider.notifier)
-              .removeExcludedAlbumForBackup(album);
-        }
-
-        return GestureDetector(
-          onTap: removeSelection,
-          child: Padding(
-            padding: const EdgeInsets.only(right: 8.0),
-            child: Chip(
-              label: Text(
-                album.name,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: isDarkTheme ? Colors.black : immichBackgroundColor,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              backgroundColor: Colors.red[300],
-              deleteIconColor:
-                  isDarkTheme ? Colors.black : immichBackgroundColor,
-              deleteIcon: const Icon(
-                Icons.cancel_rounded,
-                size: 15,
-              ),
-              onDeleted: removeSelection,
-            ),
-          ),
-        );
-      }).toSet();
-    }
-
-    // buildSearchBar() {
-    //   return Padding(
-    //     padding: const EdgeInsets.only(left: 16.0, right: 16, bottom: 8.0),
-    //     child: TextFormField(
-    //       onChanged: (searchValue) {
-    //         // if (searchValue.isEmpty) {
-    //         //   albums = availableAlbums;
-    //         // } else {
-    //         //   albums.value = availableAlbums
-    //         //       .where(
-    //         //         (album) => album.name
-    //         //             .toLowerCase()
-    //         //             .contains(searchValue.toLowerCase()),
-    //         //       )
-    //         //       .toList();
-    //         // }
-    //       },
-    //       decoration: InputDecoration(
-    //         contentPadding: const EdgeInsets.symmetric(
-    //           horizontal: 8.0,
-    //           vertical: 8.0,
-    //         ),
-    //         hintText: "Search",
-    //         hintStyle: TextStyle(
-    //           color: isDarkTheme ? Colors.white : Colors.grey,
-    //           fontSize: 14.0,
-    //         ),
-    //         prefixIcon: const Icon(
-    //           Icons.search,
-    //           color: Colors.grey,
-    //         ),
-    //         border: OutlineInputBorder(
-    //           borderRadius: BorderRadius.circular(10),
-    //           borderSide: BorderSide.none,
-    //         ),
-    //         filled: true,
-    //         fillColor: isDarkTheme ? Colors.white30 : Colors.grey[200],
-    //       ),
-    //     ),
-    //   );
-    // }
-
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -223,7 +144,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                   child: Wrap(
                     children: [
                       ...buildSelectedAlbumNameChip(),
-                      ...buildExcludedAlbumNameChip(),
                     ],
                   ),
                 ),

--- a/mobile/lib/pages/backup/backup_controller.page.dart
+++ b/mobile/lib/pages/backup/backup_controller.page.dart
@@ -29,7 +29,7 @@ class BackupControllerPage extends HookConsumerWidget {
     final didGetBackupInfo = useState(false);
     bool hasExclusiveAccess =
         backupState.backupProgress != BackUpProgressEnum.inBackground;
-    bool shouldBackup = backupState.allUniqueAssets.length -
+    bool shouldBackup = backupState.backupCandidates.length -
                     backupState.selectedAlbumsBackupAssetsIds.length ==
                 0 ||
             !hasExclusiveAccess
@@ -268,7 +268,7 @@ class BackupControllerPage extends HookConsumerWidget {
                     subtitle: "backup_controller_page_total_sub".tr(),
                     info: ref.watch(backupProvider).availableAlbums.isEmpty
                         ? "..."
-                        : "${backupState.allUniqueAssets.length}",
+                        : "${backupState.backupCandidates.length}",
                   ),
                   BackupInfoCard(
                     title: "backup_controller_page_backup".tr(),
@@ -282,7 +282,7 @@ class BackupControllerPage extends HookConsumerWidget {
                     subtitle: "backup_controller_page_remainder_sub".tr(),
                     info: ref.watch(backupProvider).availableAlbums.isEmpty
                         ? "..."
-                        : "${max(0, backupState.allUniqueAssets.length - backupState.selectedAlbumsBackupAssetsIds.length)}",
+                        : "${max(0, backupState.backupCandidates.length - backupState.selectedAlbumsBackupAssetsIds.length)}",
                   ),
                   const Divider(),
                   const CurrentUploadingAssetInfoBox(),

--- a/mobile/lib/pages/backup/backup_controller.page.dart
+++ b/mobile/lib/pages/backup/backup_controller.page.dart
@@ -100,29 +100,6 @@ class BackupControllerPage extends HookConsumerWidget {
       }
     }
 
-    Widget buildExcludedAlbumName() {
-      var text = "backup_controller_page_excluded".tr();
-      var albums = ref.watch(backupProvider).excludedBackupAlbums;
-
-      if (albums.isNotEmpty) {
-        for (var album in albums) {
-          text += "${album.name}, ";
-        }
-
-        return Padding(
-          padding: const EdgeInsets.only(top: 8.0),
-          child: Text(
-            text.trim().substring(0, text.length - 2),
-            style: context.textTheme.labelLarge?.copyWith(
-              color: Colors.red[300],
-            ),
-          ),
-        );
-      } else {
-        return const SizedBox();
-      }
-    }
-
     buildFolderSelectionTile() {
       return Padding(
         padding: const EdgeInsets.only(top: 8.0),
@@ -154,7 +131,6 @@ class BackupControllerPage extends HookConsumerWidget {
                     style: context.textTheme.bodyMedium,
                   ).tr(),
                   buildSelectedAlbumName(),
-                  buildExcludedAlbumName(),
                 ],
               ),
             ),

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -61,7 +61,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
             ),
             availableAlbums: const [],
             selectedBackupAlbums: const {},
-            excludedBackupAlbums: const {},
             allUniqueAssets: const {},
             selectedAlbumsBackupAssetsIds: const {},
             currentUploadAsset: CurrentUploadAsset(
@@ -94,20 +93,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   /// The total unique assets will be used for backing mechanism
   ///
   void addAlbumForBackup(AvailableAlbum album) {
-    if (state.excludedBackupAlbums.contains(album)) {
-      removeExcludedAlbumForBackup(album);
-    }
-
     state = state
         .copyWith(selectedBackupAlbums: {...state.selectedBackupAlbums, album});
-  }
-
-  void addExcludedAlbumForBackup(AvailableAlbum album) {
-    if (state.selectedBackupAlbums.contains(album)) {
-      removeAlbumForBackup(album);
-    }
-    state = state
-        .copyWith(excludedBackupAlbums: {...state.excludedBackupAlbums, album});
   }
 
   void removeAlbumForBackup(AvailableAlbum album) {
@@ -116,14 +103,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     currentSelectedAlbums.removeWhere((a) => a == album);
 
     state = state.copyWith(selectedBackupAlbums: currentSelectedAlbums);
-  }
-
-  void removeExcludedAlbumForBackup(AvailableAlbum album) {
-    Set<AvailableAlbum> currentExcludedAlbums = state.excludedBackupAlbums;
-
-    currentExcludedAlbums.removeWhere((a) => a == album);
-
-    state = state.copyWith(excludedBackupAlbums: currentExcludedAlbums);
   }
 
   Future<void> backupAlbumSelectionDone() {
@@ -240,8 +219,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     }
     state = state.copyWith(availableAlbums: availableAlbums);
 
-    final List<BackupAlbum> excludedBackupAlbums =
-        await _backupService.excludedAlbumsQuery().findAll();
     final List<BackupAlbum> selectedBackupAlbums =
         await _backupService.selectedAlbumsQuery().findAll();
 
@@ -259,22 +236,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       }
     }
 
-    final Set<AvailableAlbum> excludedAlbums = {};
-    for (final BackupAlbum ba in excludedBackupAlbums) {
-      final albumAsset = albumMap[ba.id];
-
-      if (albumAsset != null) {
-        excludedAlbums.add(
-          AvailableAlbum(albumEntity: albumAsset, lastBackup: ba.lastBackup),
-        );
-      } else {
-        log.severe('Excluded album not found');
-      }
-    }
-
     state = state.copyWith(
       selectedBackupAlbums: selectedAlbums,
-      excludedBackupAlbums: excludedAlbums,
     );
 
     log.info(
@@ -290,8 +253,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   ///
   Future<void> _updateBackupAssetCount() async {
     final duplicatedAssetIds = await _backupService.getDuplicatedAssetIds();
-    final Set<AssetEntity> assetsFromSelectedAlbums = {};
-    final Set<AssetEntity> assetsFromExcludedAlbums = {};
+    final Set<AssetEntity> backupCandidates = {};
 
     for (final album in state.selectedBackupAlbums) {
       final assetCount = await album.albumEntity.assetCountAsync;
@@ -304,25 +266,9 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         start: 0,
         end: assetCount,
       );
-      assetsFromSelectedAlbums.addAll(assets);
+      backupCandidates.addAll(assets);
     }
 
-    for (final album in state.excludedBackupAlbums) {
-      final assetCount = await album.albumEntity.assetCountAsync;
-
-      if (assetCount == 0) {
-        continue;
-      }
-
-      final assets = await album.albumEntity.getAssetListRange(
-        start: 0,
-        end: assetCount,
-      );
-      assetsFromExcludedAlbums.addAll(assets);
-    }
-
-    final Set<AssetEntity> allUniqueAssets =
-        assetsFromSelectedAlbums.difference(assetsFromExcludedAlbums);
     final allAssetsInDatabase = await _backupService.getDeviceBackupAsset();
 
     if (allAssetsInDatabase == null) {
@@ -331,17 +277,17 @@ class BackupNotifier extends StateNotifier<BackUpState> {
 
     // Find asset that were backup from selected albums
     final Set<String> selectedAlbumsBackupAssets =
-        Set.from(allUniqueAssets.map((e) => e.id));
+        Set.from(backupCandidates.map((e) => e.id));
 
     selectedAlbumsBackupAssets
         .removeWhere((assetId) => !allAssetsInDatabase.contains(assetId));
 
     // Remove duplicated asset from all unique assets
-    allUniqueAssets.removeWhere(
+    backupCandidates.removeWhere(
       (asset) => duplicatedAssetIds.contains(asset.id),
     );
 
-    if (allUniqueAssets.isEmpty) {
+    if (backupCandidates.isEmpty) {
       log.info("No assets are selected for back up");
       state = state.copyWith(
         backupProgress: BackUpProgressEnum.idle,
@@ -352,7 +298,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     } else {
       state = state.copyWith(
         allAssetsInDatabase: allAssetsInDatabase,
-        allUniqueAssets: allUniqueAssets,
+        allUniqueAssets: backupCandidates,
         selectedAlbumsBackupAssetsIds: selectedAlbumsBackupAssets,
       );
     }
@@ -387,10 +333,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     final selected = state.selectedBackupAlbums.map(
       (e) => BackupAlbum(e.id, e.lastBackup ?? epoch, BackupSelection.select),
     );
-    final excluded = state.excludedBackupAlbums.map(
-      (e) => BackupAlbum(e.id, e.lastBackup ?? epoch, BackupSelection.exclude),
-    );
-    final backupAlbums = selected.followedBy(excluded).toList();
+
+    final backupAlbums = selected.toList();
     backupAlbums.sortBy((e) => e.id);
     return _db.writeTxn(() async {
       final dbAlbums = await _db.backupAlbums.where().sortById().findAll();
@@ -529,9 +473,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         selectedBackupAlbums: state.selectedBackupAlbums
             .map((e) => e.copyWith(lastBackup: latestAssetBackup))
             .toSet(),
-        excludedBackupAlbums: state.excludedBackupAlbums
-            .map((e) => e.copyWith(lastBackup: latestAssetBackup))
-            .toSet(),
         backupProgress: BackUpProgressEnum.done,
         progressInPercentage: 0.0,
         progressInFileSize: "0 B / 0 B",
@@ -630,12 +571,8 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         .filter()
         .selectionEqualTo(BackupSelection.select)
         .findAll();
-    final List<BackupAlbum> excludedBackupAlbums = await _db.backupAlbums
-        .filter()
-        .selectionEqualTo(BackupSelection.exclude)
-        .findAll();
+
     Set<AvailableAlbum> selectedAlbums = state.selectedBackupAlbums;
-    Set<AvailableAlbum> excludedAlbums = state.excludedBackupAlbums;
     if (selectedAlbums.isNotEmpty) {
       selectedAlbums = _updateAlbumsBackupTime(
         selectedAlbums,
@@ -643,17 +580,10 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       );
     }
 
-    if (excludedAlbums.isNotEmpty) {
-      excludedAlbums = _updateAlbumsBackupTime(
-        excludedAlbums,
-        excludedBackupAlbums,
-      );
-    }
     final BackUpProgressEnum previous = state.backupProgress;
     state = state.copyWith(
       backupProgress: BackUpProgressEnum.inBackground,
       selectedBackupAlbums: selectedAlbums,
-      excludedBackupAlbums: excludedAlbums,
     );
     // assumes the background service is currently running
     // if true, waits until it has stopped to start the backup

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -448,7 +448,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   ) {
     if (isDuplicated) {
       state = state.copyWith(
-        allUniqueAssets: state.backupCandidates
+        backupCandidates: state.backupCandidates
             .where((asset) => asset.id != deviceAssetId)
             .toSet(),
       );

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -61,7 +61,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
             ),
             availableAlbums: const [],
             selectedBackupAlbums: const {},
-            allUniqueAssets: const {},
+            backupCandidates: const {},
             selectedAlbumsBackupAssetsIds: const {},
             currentUploadAsset: CurrentUploadAsset(
               id: '...',
@@ -292,13 +292,13 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       state = state.copyWith(
         backupProgress: BackUpProgressEnum.idle,
         allAssetsInDatabase: allAssetsInDatabase,
-        allUniqueAssets: {},
+        backupCandidates: {},
         selectedAlbumsBackupAssetsIds: selectedAlbumsBackupAssets,
       );
     } else {
       state = state.copyWith(
         allAssetsInDatabase: allAssetsInDatabase,
-        allUniqueAssets: backupCandidates,
+        backupCandidates: backupCandidates,
         selectedAlbumsBackupAssetsIds: selectedAlbumsBackupAssets,
       );
     }
@@ -371,13 +371,13 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     if (hasPermission) {
       await PhotoManager.clearFileCache();
 
-      if (state.allUniqueAssets.isEmpty) {
+      if (state.backupCandidates.isEmpty) {
         log.info("No Asset On Device - Abort Backup Process");
         state = state.copyWith(backupProgress: BackUpProgressEnum.idle);
         return;
       }
 
-      Set<AssetEntity> assetsWillBeBackup = Set.from(state.allUniqueAssets);
+      Set<AssetEntity> assetsWillBeBackup = Set.from(state.backupCandidates);
       // Remove item that has already been backed up
       for (final assetId in state.allAssetsInDatabase) {
         assetsWillBeBackup.removeWhere((e) => e.id == assetId);
@@ -448,7 +448,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   ) {
     if (isDuplicated) {
       state = state.copyWith(
-        allUniqueAssets: state.allUniqueAssets
+        allUniqueAssets: state.backupCandidates
             .where((asset) => asset.id != deviceAssetId)
             .toSet(),
       );
@@ -462,11 +462,11 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       );
     }
 
-    if (state.allUniqueAssets.length -
+    if (state.backupCandidates.length -
             state.selectedAlbumsBackupAssetsIds.length ==
         0) {
       final latestAssetBackup =
-          state.allUniqueAssets.map((e) => e.modifiedDateTime).reduce(
+          state.backupCandidates.map((e) => e.modifiedDateTime).reduce(
                 (v, e) => e.isAfter(v) ? e : v,
               );
       state = state.copyWith(

--- a/mobile/lib/providers/backup/backup_verification.provider.dart
+++ b/mobile/lib/providers/backup/backup_verification.provider.dart
@@ -23,7 +23,7 @@ class BackupVerification extends _$BackupVerification {
       state = true;
       final backupState = ref.read(backupProvider);
 
-      if (backupState.allUniqueAssets.length >
+      if (backupState.backupCandidates.length >
           backupState.selectedAlbumsBackupAssetsIds.length) {
         if (context.mounted) {
           ImmichToast.show(

--- a/mobile/lib/providers/backup/backup_verification.provider.g.dart
+++ b/mobile/lib/providers/backup/backup_verification.provider.g.dart
@@ -7,7 +7,7 @@ part of 'backup_verification.provider.dart';
 // **************************************************************************
 
 String _$backupVerificationHash() =>
-    r'b691e0cc27856eef189258d3c102cc73ce4812a4';
+    r'4f64459d68d20de4a61160ec8e9be347ec945fb6';
 
 /// See also [BackupVerification].
 @ProviderFor(BackupVerification)

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -349,7 +349,6 @@ class BackgroundService {
     AppSettingsService settingsService = AppSettingsService();
 
     final selectedAlbums = backupService.selectedAlbumsQuery().findAllSync();
-    final excludedAlbums = backupService.excludedAlbumsQuery().findAllSync();
     if (selectedAlbums.isEmpty) {
       return true;
     }
@@ -361,11 +360,10 @@ class BackgroundService {
         backupService,
         settingsService,
         selectedAlbums,
-        excludedAlbums,
       );
       if (backupOk) {
         await Store.delete(StoreKey.backupFailedSince);
-        final backupAlbums = [...selectedAlbums, ...excludedAlbums];
+        final backupAlbums = [...selectedAlbums];
         backupAlbums.sortBy((e) => e.id);
         db.writeTxnSync(() {
           final dbAlbums = db.backupAlbums.where().sortById().findAllSync();
@@ -404,7 +402,6 @@ class BackgroundService {
     BackupService backupService,
     AppSettingsService settingsService,
     List<BackupAlbum> selectedAlbums,
-    List<BackupAlbum> excludedAlbums,
   ) async {
     _errorGracePeriodExceeded = _isErrorGracePeriodExceeded(settingsService);
     final bool notifyTotalProgress = settingsService
@@ -418,7 +415,6 @@ class BackgroundService {
 
     List<AssetEntity> toUpload = await backupService.buildUploadCandidates(
       selectedAlbums,
-      excludedAlbums,
     );
 
     try {

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -65,14 +65,10 @@ class BackupService {
   QueryBuilder<BackupAlbum, BackupAlbum, QAfterFilterCondition>
       selectedAlbumsQuery() =>
           _db.backupAlbums.filter().selectionEqualTo(BackupSelection.select);
-  QueryBuilder<BackupAlbum, BackupAlbum, QAfterFilterCondition>
-      excludedAlbumsQuery() =>
-          _db.backupAlbums.filter().selectionEqualTo(BackupSelection.exclude);
 
   /// Returns all assets newer than the last successful backup per album
   Future<List<AssetEntity>> buildUploadCandidates(
     List<BackupAlbum> selectedBackupAlbums,
-    List<BackupAlbum> excludedBackupAlbums,
   ) async {
     final filter = FilterOptionGroup(
       containsPathModified: true,
@@ -89,19 +85,13 @@ class BackupService {
     }
     final int allIdx = selectedAlbums.indexWhere((e) => e != null && e.isAll);
     if (allIdx != -1) {
-      final List<AssetPathEntity?> excludedAlbums =
-          await _loadAlbumsWithTimeFilter(excludedBackupAlbums, filter, now);
       final List<AssetEntity> toAdd = await _fetchAssetsAndUpdateLastBackup(
         selectedAlbums.slice(allIdx, allIdx + 1),
         selectedBackupAlbums.slice(allIdx, allIdx + 1),
         now,
       );
-      final List<AssetEntity> toRemove = await _fetchAssetsAndUpdateLastBackup(
-        excludedAlbums,
-        excludedBackupAlbums,
-        now,
-      );
-      return toAdd.toSet().difference(toRemove.toSet()).toList();
+
+      return toAdd.toSet().toList();
     } else {
       return await _fetchAssetsAndUpdateLastBackup(
         selectedAlbums,

--- a/mobile/lib/widgets/backup/album_info_card.dart
+++ b/mobile/lib/widgets/backup/album_info_card.dart
@@ -1,14 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/backup/available_album.model.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
-import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class AlbumInfoCard extends HookConsumerWidget {
   final AvailableAlbum album;
@@ -19,8 +17,6 @@ class AlbumInfoCard extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bool isSelected =
         ref.watch(backupProvider).selectedBackupAlbums.contains(album);
-    final bool isExcluded =
-        ref.watch(backupProvider).excludedBackupAlbums.contains(album);
 
     final isDarkTheme = context.isDarkTheme;
 
@@ -28,8 +24,7 @@ class AlbumInfoCard extends HookConsumerWidget {
       context.primaryColor.withAlpha(100),
       BlendMode.darken,
     );
-    ColorFilter excludedFilter =
-        ColorFilter.mode(Colors.red.withAlpha(75), BlendMode.darken);
+
     ColorFilter unselectedFilter =
         const ColorFilter.mode(Colors.black, BlendMode.color);
 
@@ -48,20 +43,6 @@ class AlbumInfoCard extends HookConsumerWidget {
           ).tr(),
           backgroundColor: context.primaryColor,
         );
-      } else if (isExcluded) {
-        return Chip(
-          visualDensity: VisualDensity.compact,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
-          label: Text(
-            "album_info_card_backup_album_excluded",
-            style: TextStyle(
-              fontSize: 10,
-              color: isDarkTheme ? Colors.black : Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ).tr(),
-          backgroundColor: Colors.red[300],
-        );
       }
 
       return const SizedBox();
@@ -70,8 +51,6 @@ class AlbumInfoCard extends HookConsumerWidget {
     buildImageFilter() {
       if (isSelected) {
         return selectedFilter;
-      } else if (isExcluded) {
-        return excludedFilter;
       } else {
         return unselectedFilter;
       }
@@ -85,28 +64,6 @@ class AlbumInfoCard extends HookConsumerWidget {
           ref.read(backupProvider.notifier).removeAlbumForBackup(album);
         } else {
           ref.read(backupProvider.notifier).addAlbumForBackup(album);
-        }
-      },
-      onDoubleTap: () {
-        ref.read(hapticFeedbackProvider.notifier).selectionClick();
-
-        if (isExcluded) {
-          // Remove from exclude album list
-          ref.read(backupProvider.notifier).removeExcludedAlbumForBackup(album);
-        } else {
-          // Add to exclude album list
-
-          if (album.id == 'isAll' || album.name == 'Recents') {
-            ImmichToast.show(
-              context: context,
-              msg: 'Cannot exclude album contains all assets',
-              toastType: ToastType.error,
-              gravity: ToastGravity.BOTTOM,
-            );
-            return;
-          }
-
-          ref.read(backupProvider.notifier).addExcludedAlbumForBackup(album);
         }
       },
       child: Card(

--- a/mobile/lib/widgets/backup/album_info_list_tile.dart
+++ b/mobile/lib/widgets/backup/album_info_list_tile.dart
@@ -1,14 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/backup/available_album.model.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
-import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class AlbumInfoListTile extends HookConsumerWidget {
   final AvailableAlbum album;
@@ -19,8 +17,6 @@ class AlbumInfoListTile extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bool isSelected =
         ref.watch(backupProvider).selectedBackupAlbums.contains(album);
-    final bool isExcluded =
-        ref.watch(backupProvider).excludedBackupAlbums.contains(album);
     var assetCount = useState(0);
 
     useEffect(
@@ -36,10 +32,6 @@ class AlbumInfoListTile extends HookConsumerWidget {
         return context.isDarkTheme
             ? context.primaryColor.withAlpha(100)
             : context.primaryColor.withAlpha(25);
-      } else if (isExcluded) {
-        return context.isDarkTheme
-            ? Colors.red[300]?.withAlpha(150)
-            : Colors.red[100]?.withAlpha(150);
       } else {
         return Colors.transparent;
       }
@@ -53,13 +45,6 @@ class AlbumInfoListTile extends HookConsumerWidget {
         );
       }
 
-      if (isExcluded) {
-        return const Icon(
-          Icons.remove_circle_rounded,
-          color: Colors.red,
-        );
-      }
-
       return Icon(
         Icons.circle,
         color: context.isDarkTheme ? Colors.grey[400] : Colors.black45,
@@ -67,28 +52,6 @@ class AlbumInfoListTile extends HookConsumerWidget {
     }
 
     return GestureDetector(
-      onDoubleTap: () {
-        ref.watch(hapticFeedbackProvider.notifier).selectionClick();
-
-        if (isExcluded) {
-          // Remove from exclude album list
-          ref.read(backupProvider.notifier).removeExcludedAlbumForBackup(album);
-        } else {
-          // Add to exclude album list
-
-          if (album.id == 'isAll' || album.name == 'Recents') {
-            ImmichToast.show(
-              context: context,
-              msg: 'Cannot exclude album contains all assets',
-              toastType: ToastType.error,
-              gravity: ToastGravity.BOTTOM,
-            );
-            return;
-          }
-
-          ref.read(backupProvider.notifier).addExcludedAlbumForBackup(album);
-        }
-      },
       child: ListTile(
         tileColor: buildTileColor(),
         contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),


### PR DESCRIPTION
This PR is the next step in simplifying and refactoring the backup mechanism.

This PR removes the exclusion album selection for backup to simplify the workflow, laying the groundwork for backup and creating the album directly on the server.