### PR TITLE
refactor(ml): model sessions

### DIFF
--- a/machine-learning/app/conftest.py
+++ b/machine-learning/app/conftest.py
@@ -8,8 +8,9 @@ from fastapi.testclient import TestClient
 from numpy.typing import NDArray
 from PIL import Image
 
-from .main import app
 from app.config import log
+
+from .main import app
 
 
 @pytest.fixture
@@ -150,7 +151,7 @@ def path() -> Iterator[mock.Mock]:
     path.is_file.return_value = True
     path.with_suffix.return_value = path
     path.return_value = path
-        
+
     with mock.patch("app.models.base.Path", return_value=path) as mocked:
         yield mocked
 

--- a/machine-learning/app/conftest.py
+++ b/machine-learning/app/conftest.py
@@ -130,6 +130,12 @@ def ort_session() -> Iterator[mock.Mock]:
 
 
 @pytest.fixture(scope="function")
+def ann_session() -> Iterator[mock.Mock]:
+    with mock.patch("app.sessions.ann.Ann") as mocked:
+        yield mocked
+
+
+@pytest.fixture(scope="function")
 def rmtree() -> Iterator[mock.Mock]:
     with mock.patch("app.models.base.rmtree", autospec=True) as mocked:
         mocked.avoids_symlink_attacks = True
@@ -137,13 +143,15 @@ def rmtree() -> Iterator[mock.Mock]:
 
 
 @pytest.fixture(scope="function")
-def cache_dir() -> Iterator[mock.Mock]:
-    mock_cache_dir = mock.MagicMock()
-    mock_cache_dir.exists.return_value = True
-    mock_cache_dir.is_dir.return_value = True
-    mock_cache_dir.is_file.return_value = True
+def path() -> Iterator[mock.Mock]:
+    path = mock.MagicMock()
+    path.exists.return_value = True
+    path.is_dir.return_value = True
+    path.is_file.return_value = True
+    path.with_suffix.return_value = path
+    path.return_value = path
         
-    with mock.patch("app.models.base.Path", return_value=mock_cache_dir) as mocked:
+    with mock.patch("app.models.base.Path", return_value=path) as mocked:
         yield mocked
 
 

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -32,7 +32,8 @@ class InferenceModel(ABC):
         self.model_name = clean_name(model_name)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else self._cache_dir_default
         self.model_format = preferred_format if preferred_format is not None else self._model_format_default
-        self.session = session
+        if session is not None:
+            self.session = session
 
     def download(self) -> None:
         if not self.cached:

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -5,15 +5,14 @@ from pathlib import Path
 from shutil import rmtree
 from typing import Any, ClassVar
 
-import onnxruntime as ort
 from huggingface_hub import snapshot_download
 
 import ann.ann
-from app.models.constants import SUPPORTED_PROVIDERS
+from app.sessions.ort import OrtSession
 
 from ..config import clean_name, log, settings
 from ..schemas import ModelFormat, ModelIdentity, ModelSession, ModelTask, ModelType
-from .ann import AnnSession
+from ..sessions.ann import AnnSession
 
 
 class InferenceModel(ABC):
@@ -24,20 +23,16 @@ class InferenceModel(ABC):
         self,
         model_name: str,
         cache_dir: Path | str | None = None,
-        providers: list[str] | None = None,
-        provider_options: list[dict[str, Any]] | None = None,
-        sess_options: ort.SessionOptions | None = None,
         preferred_format: ModelFormat | None = None,
+        session: ModelSession | None = None,
         **model_kwargs: Any,
     ) -> None:
-        self.loaded = False
+        self.loaded = session is not None
         self.load_attempts = 0
         self.model_name = clean_name(model_name)
         self.cache_dir = Path(cache_dir) if cache_dir is not None else self.cache_dir_default
-        self.providers = providers if providers is not None else self.providers_default
-        self.provider_options = provider_options if provider_options is not None else self.provider_options_default
-        self.sess_options = sess_options if sess_options is not None else self.sess_options_default
-        self.preferred_format = preferred_format if preferred_format is not None else self.preferred_format_default
+        self.model_format = preferred_format if preferred_format is not None else self._model_format_default
+        self.session = session
 
     def download(self) -> None:
         if not self.cached:
@@ -70,7 +65,7 @@ class InferenceModel(ABC):
         pass
 
     def _download(self) -> None:
-        ignore_patterns = [] if self.preferred_format == ModelFormat.ARMNN else ["*.armnn"]
+        ignore_patterns = [] if self.model_format == ModelFormat.ARMNN else ["*.armnn"]
         snapshot_download(
             f"immich-app/{clean_name(self.model_name)}",
             cache_dir=self.cache_dir,
@@ -105,26 +100,11 @@ class InferenceModel(ABC):
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def _make_session(self, model_path: Path) -> ModelSession:
-        if not model_path.is_file():
-            onnx_path = model_path.with_suffix(".onnx")
-            if not onnx_path.is_file():
-                raise ValueError(f"Model path '{model_path}' does not exist")
-
-            log.warning(
-                f"Could not find model path '{model_path}'. " f"Falling back to ONNX model path '{onnx_path}' instead.",
-            )
-            model_path = onnx_path
-
         match model_path.suffix:
             case ".armnn":
-                session = AnnSession(model_path)
+                session: ModelSession = AnnSession(model_path)
             case ".onnx":
-                session = ort.InferenceSession(
-                    model_path.as_posix(),
-                    sess_options=self.sess_options,
-                    providers=self.providers,
-                    provider_options=self.provider_options,
-                )
+                session = OrtSession(model_path)
             case _:
                 raise ValueError(f"Unsupported model file type: {model_path.suffix}")
         return session
@@ -135,7 +115,7 @@ class InferenceModel(ABC):
 
     @property
     def model_path(self) -> Path:
-        return self.model_dir / f"model.{self.preferred_format}"
+        return self.model_dir / f"model.{self.model_format}"
 
     @property
     def model_task(self) -> ModelTask:
@@ -162,95 +142,18 @@ class InferenceModel(ABC):
         return self.model_path.is_file()
 
     @property
-    def providers(self) -> list[str]:
-        return self._providers
-
-    @providers.setter
-    def providers(self, providers: list[str]) -> None:
-        log.info(
-            (f"Setting '{self.model_name}' execution providers to {providers}, " "in descending order of preference"),
-        )
-        self._providers = providers
-
-    @property
-    def providers_default(self) -> list[str]:
-        available_providers = set(ort.get_available_providers())
-        log.debug(f"Available ORT providers: {available_providers}")
-        if (openvino := "OpenVINOExecutionProvider") in available_providers:
-            device_ids: list[str] = ort.capi._pybind_state.get_available_openvino_device_ids()
-            log.debug(f"Available OpenVINO devices: {device_ids}")
-
-            gpu_devices = [device_id for device_id in device_ids if device_id.startswith("GPU")]
-            if not gpu_devices:
-                log.warning("No GPU device found in OpenVINO. Falling back to CPU.")
-                available_providers.remove(openvino)
-        return [provider for provider in SUPPORTED_PROVIDERS if provider in available_providers]
-
-    @property
-    def provider_options(self) -> list[dict[str, Any]]:
-        return self._provider_options
-
-    @provider_options.setter
-    def provider_options(self, provider_options: list[dict[str, Any]]) -> None:
-        log.debug(f"Setting execution provider options to {provider_options}")
-        self._provider_options = provider_options
-
-    @property
-    def provider_options_default(self) -> list[dict[str, Any]]:
-        options = []
-        for provider in self.providers:
-            match provider:
-                case "CPUExecutionProvider" | "CUDAExecutionProvider":
-                    option = {"arena_extend_strategy": "kSameAsRequested"}
-                case "OpenVINOExecutionProvider":
-                    option = {"device_type": "GPU_FP32", "cache_dir": (self.cache_dir / "openvino").as_posix()}
-                case _:
-                    option = {}
-            options.append(option)
-        return options
-
-    @property
-    def sess_options(self) -> ort.SessionOptions:
-        return self._sess_options
-
-    @sess_options.setter
-    def sess_options(self, sess_options: ort.SessionOptions) -> None:
-        log.debug(f"Setting execution_mode to {sess_options.execution_mode.name}")
-        log.debug(f"Setting inter_op_num_threads to {sess_options.inter_op_num_threads}")
-        log.debug(f"Setting intra_op_num_threads to {sess_options.intra_op_num_threads}")
-        self._sess_options = sess_options
-
-    @property
-    def sess_options_default(self) -> ort.SessionOptions:
-        sess_options = ort.SessionOptions()
-        sess_options.enable_cpu_mem_arena = False
-
-        # avoid thread contention between models
-        if settings.model_inter_op_threads > 0:
-            sess_options.inter_op_num_threads = settings.model_inter_op_threads
-        # these defaults work well for CPU, but bottleneck GPU
-        elif settings.model_inter_op_threads == 0 and self.providers == ["CPUExecutionProvider"]:
-            sess_options.inter_op_num_threads = 1
-
-        if settings.model_intra_op_threads > 0:
-            sess_options.intra_op_num_threads = settings.model_intra_op_threads
-        elif settings.model_intra_op_threads == 0 and self.providers == ["CPUExecutionProvider"]:
-            sess_options.intra_op_num_threads = 2
-
-        if sess_options.inter_op_num_threads > 1:
-            sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
-
-        return sess_options
-
-    @property
-    def preferred_format(self) -> ModelFormat:
+    def model_format(self) -> ModelFormat:
         return self._preferred_format
 
-    @preferred_format.setter
-    def preferred_format(self, preferred_format: ModelFormat) -> None:
+    @model_format.setter
+    def model_format(self, preferred_format: ModelFormat) -> None:
         log.debug(f"Setting preferred format to {preferred_format}")
         self._preferred_format = preferred_format
 
     @property
-    def preferred_format_default(self) -> ModelFormat:
-        return ModelFormat.ARMNN if ann.ann.is_available and settings.ann else ModelFormat.ONNX
+    def _model_format_default(self) -> ModelFormat:
+        prefer_ann = ann.ann.is_available and settings.ann
+        ann_exists = (self.model_dir / "model.armnn").is_file()
+        if prefer_ann and not ann_exists:
+            log.warning(f"ARM NN is available, but '{self.model_name}' does not support ARM NN. Falling back to ONNX.")
+        return ModelFormat.ARMNN if prefer_ann and ann_exists else ModelFormat.ONNX

--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -30,7 +30,7 @@ class InferenceModel(ABC):
         self.loaded = session is not None
         self.load_attempts = 0
         self.model_name = clean_name(model_name)
-        self.cache_dir = Path(cache_dir) if cache_dir is not None else self.cache_dir_default
+        self.cache_dir = Path(cache_dir) if cache_dir is not None else self._cache_dir_default
         self.model_format = preferred_format if preferred_format is not None else self._model_format_default
         self.session = session
 
@@ -134,7 +134,7 @@ class InferenceModel(ABC):
         self._cache_dir = cache_dir
 
     @property
-    def cache_dir_default(self) -> Path:
+    def _cache_dir_default(self) -> Path:
         return settings.cache_folder / self.model_task.value / self.model_name
 
     @property

--- a/machine-learning/app/models/facial_recognition/recognition.py
+++ b/machine-learning/app/models/facial_recognition/recognition.py
@@ -3,7 +3,6 @@ from typing import Any
 
 import numpy as np
 import onnx
-import onnxruntime as ort
 from insightface.model_zoo import ArcFaceONNX
 from insightface.utils.face_align import norm_crop
 from numpy.typing import NDArray
@@ -13,7 +12,8 @@ from PIL import Image
 from app.config import clean_name, log
 from app.models.base import InferenceModel
 from app.models.transforms import decode_cv2
-from app.schemas import FaceDetectionOutput, FacialRecognitionOutput, ModelSession, ModelTask, ModelType
+from app.schemas import FaceDetectionOutput, FacialRecognitionOutput, ModelFormat, ModelSession, ModelTask, ModelType
+from app.sessions import has_batch_axis
 
 
 class FaceRecognizer(InferenceModel):
@@ -28,13 +28,15 @@ class FaceRecognizer(InferenceModel):
         **model_kwargs: Any,
     ) -> None:
         self.min_score = model_kwargs.pop("minScore", min_score)
+        self.batch = False
         super().__init__(clean_name(model_name), cache_dir, **model_kwargs)
 
     def _load(self) -> ModelSession:
         session = self._make_session(self.model_path)
-        if not self._has_batch_dim(session):
-            self._add_batch_dim(self.model_path)
+        if self.model_format == ModelFormat.ONNX and not has_batch_axis(session):
+            self._add_batch_axis(self.model_path)
             session = self._make_session(self.model_path)
+            self.batch = True
         self.model = ArcFaceONNX(
             self.model_path.with_suffix(".onnx").as_posix(),
             session=session,
@@ -47,8 +49,19 @@ class FaceRecognizer(InferenceModel):
         if faces["boxes"].shape[0] == 0:
             return []
         inputs = decode_cv2(inputs)
-        embeddings: NDArray[np.float32] = self.model.get_feat(self._crop(inputs, faces))
+        cropped_faces = self._crop(inputs, faces)
+        embeddings = self._predict_batch(cropped_faces) if self.batch else self._predict_single(cropped_faces)
         return self.postprocess(faces, embeddings)
+
+    def _predict_batch(self, cropped_faces: list[NDArray[np.uint8]]) -> NDArray[np.float32]:
+        embeddings: NDArray[np.float32] = self.model.get_feat(cropped_faces)
+        return embeddings
+
+    def _predict_single(self, cropped_faces: list[NDArray[np.uint8]]) -> NDArray[np.float32]:
+        embeddings: list[NDArray[np.float32]] = []
+        for face in cropped_faces:
+            embeddings.append(self.model.get_feat(face))
+        return np.concatenate(embeddings, axis=0)
 
     def postprocess(self, faces: FaceDetectionOutput, embeddings: NDArray[np.float32]) -> FacialRecognitionOutput:
         return [
@@ -63,11 +76,8 @@ class FaceRecognizer(InferenceModel):
     def _crop(self, image: NDArray[np.uint8], faces: FaceDetectionOutput) -> list[NDArray[np.uint8]]:
         return [norm_crop(image, landmark) for landmark in faces["landmarks"]]
 
-    def _has_batch_dim(self, session: ort.InferenceSession) -> bool:
-        return not isinstance(session, ort.InferenceSession) or session.get_inputs()[0].shape[0] == "batch"
-
-    def _add_batch_dim(self, model_path: Path) -> None:
-        log.debug(f"Adding batch dimension to model {model_path}")
+    def _add_batch_axis(self, model_path: Path) -> None:
+        log.debug(f"Adding batch axis to model {model_path}")
         proto = onnx.load(model_path)
         static_input_dims = [shape.dim_value for shape in proto.graph.input[0].type.tensor_type.shape.dim[1:]]
         static_output_dims = [shape.dim_value for shape in proto.graph.output[0].type.tensor_type.shape.dim[1:]]

--- a/machine-learning/app/models/facial_recognition/recognition.py
+++ b/machine-learning/app/models/facial_recognition/recognition.py
@@ -27,16 +27,15 @@ class FaceRecognizer(InferenceModel):
         cache_dir: Path | str | None = None,
         **model_kwargs: Any,
     ) -> None:
-        self.min_score = model_kwargs.pop("minScore", min_score)
-        self.batch = False
         super().__init__(clean_name(model_name), cache_dir, **model_kwargs)
+        self.min_score = model_kwargs.pop("minScore", min_score)
+        self.batch = self.model_format == ModelFormat.ONNX
 
     def _load(self) -> ModelSession:
         session = self._make_session(self.model_path)
         if self.model_format == ModelFormat.ONNX and not has_batch_axis(session):
             self._add_batch_axis(self.model_path)
             session = self._make_session(self.model_path)
-            self.batch = True
         self.model = ArcFaceONNX(
             self.model_path.with_suffix(".onnx").as_posix(),
             session=session,

--- a/machine-learning/app/schemas.py
+++ b/machine-learning/app/schemas.py
@@ -54,6 +54,14 @@ class ModelSource(StrEnum):
 ModelIdentity = tuple[ModelType, ModelTask]
 
 
+class SessionNode(Protocol):
+    @property
+    def name(self) -> str | None: ...
+
+    @property
+    def shape(self) -> tuple[int, ...]: ...
+
+
 class ModelSession(Protocol):
     def run(
         self,
@@ -61,6 +69,10 @@ class ModelSession(Protocol):
         input_feed: dict[str, npt.NDArray[np.float32]] | dict[str, npt.NDArray[np.int32]],
         run_options: Any = None,
     ) -> list[npt.NDArray[np.float32]]: ...
+
+    def get_inputs(self) -> list[SessionNode]: ...
+
+    def get_outputs(self) -> list[SessionNode]: ...
 
 
 class HasProfiling(Protocol):

--- a/machine-learning/app/sessions/__init__.py
+++ b/machine-learning/app/sessions/__init__.py
@@ -1,0 +1,5 @@
+from app.schemas import ModelSession
+
+
+def has_batch_axis(session: ModelSession) -> bool:
+    return not isinstance(session.get_inputs()[0].shape[0], int) or session.get_inputs()[0].shape[0] < 0

--- a/machine-learning/app/sessions/ann.py
+++ b/machine-learning/app/sessions/ann.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ann.ann import Ann
+from app.schemas import SessionNode
 
 from ..config import log, settings
 
@@ -45,11 +46,11 @@ class AnnSession:
         log.info("Unloaded ANN model %d", self.model)
         self.ann.destroy()
 
-    def get_inputs(self) -> list[AnnNode]:
+    def get_inputs(self) -> list[SessionNode]:
         shapes = self.ann.input_shapes[self.model]
         return [AnnNode(None, s) for s in shapes]
 
-    def get_outputs(self) -> list[AnnNode]:
+    def get_outputs(self) -> list[SessionNode]:
         shapes = self.ann.output_shapes[self.model]
         return [AnnNode(None, s) for s in shapes]
 

--- a/machine-learning/app/sessions/ann.py
+++ b/machine-learning/app/sessions/ann.py
@@ -17,27 +17,15 @@ class AnnSession:
     Wrapper for ANN to be drop-in replacement for ONNX session.
     """
 
-    def __init__(self, model_path: Path):
-        tuning_file = Path(settings.cache_folder) / "gpu-tuning.ann"
-        with tuning_file.open(mode="a"):
-            # make sure tuning file exists (without clearing contents)
-            # once filled, the tuning file reduces the cost/time of the first
-            # inference after model load by 10s of seconds
-            pass
-        self.ann = Ann(tuning_level=3, tuning_file=tuning_file.as_posix())
-        log.info("Loading ANN model %s ...", model_path)
-        cache_file = model_path.with_suffix(".anncache")
-        save = False
-        if not cache_file.is_file():
-            save = True
-            with cache_file.open(mode="a"):
-                # create empty model cache file
-                pass
+    def __init__(self, model_path: Path, cache_dir: Path = settings.cache_folder) -> None:
+        self.model_path = model_path
+        self.cache_dir = cache_dir
+        self.ann = Ann(tuning_level=3, tuning_file=(cache_dir / "gpu-tuning.ann").as_posix())
 
+        log.info("Loading ANN model %s ...", model_path)
         self.model = self.ann.load(
             model_path.as_posix(),
-            save_cached_network=save,
-            cached_network_path=cache_file.as_posix(),
+            cached_network_path=model_path.with_suffix(".anncache").as_posix(),
         )
         log.info("Loaded ANN model with ID %d", self.model)
 

--- a/machine-learning/app/sessions/ort.py
+++ b/machine-learning/app/sessions/ort.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import onnxruntime as ort
+from numpy.typing import NDArray
+
+from app.models.constants import SUPPORTED_PROVIDERS
+from app.schemas import SessionNode
+
+from ..config import log, settings
+
+
+class OrtSession:
+    def __init__(
+        self,
+        model_path: Path,
+        providers: list[str] | None = None,
+        provider_options: list[dict[str, Any]] | None = None,
+        sess_options: ort.SessionOptions | None = None,
+    ):
+        self.model_path = model_path
+        self.providers = providers if providers is not None else self._providers_default
+        self.provider_options = provider_options if provider_options is not None else self._provider_options_default
+        self.sess_options = sess_options if sess_options is not None else self._sess_options_default
+        self.session = ort.InferenceSession(
+            model_path.as_posix(),
+            providers=self.providers,
+            provider_options=self.provider_options,
+            sess_options=self.sess_options,
+        )
+
+    def get_inputs(self) -> list[SessionNode]:
+        inputs: list[SessionNode] = self.session.get_inputs()
+        return inputs
+
+    def get_outputs(self) -> list[SessionNode]:
+        outputs: list[SessionNode] = self.session.get_outputs()
+        return outputs
+
+    def run(
+        self,
+        output_names: list[str] | None,
+        input_feed: dict[str, NDArray[np.float32]] | dict[str, NDArray[np.int32]],
+        run_options: Any = None,
+    ) -> list[NDArray[np.float32]]:
+        outputs: list[NDArray[np.float32]] = self.session.run(output_names, input_feed, run_options)
+        return outputs
+
+    @property
+    def providers(self) -> list[str]:
+        return self._providers
+
+    @providers.setter
+    def providers(self, providers: list[str]) -> None:
+        log.info(f"Setting execution providers to {providers}, in descending order of preference")
+        self._providers = providers
+
+    @property
+    def _providers_default(self) -> list[str]:
+        available_providers = set(ort.get_available_providers())
+        log.debug(f"Available ORT providers: {available_providers}")
+        if (openvino := "OpenVINOExecutionProvider") in available_providers:
+            device_ids: list[str] = ort.capi._pybind_state.get_available_openvino_device_ids()
+            log.debug(f"Available OpenVINO devices: {device_ids}")
+
+            gpu_devices = [device_id for device_id in device_ids if device_id.startswith("GPU")]
+            if not gpu_devices:
+                log.warning("No GPU device found in OpenVINO. Falling back to CPU.")
+                available_providers.remove(openvino)
+        return [provider for provider in SUPPORTED_PROVIDERS if provider in available_providers]
+
+    @property
+    def provider_options(self) -> list[dict[str, Any]]:
+        return self._provider_options
+
+    @provider_options.setter
+    def provider_options(self, provider_options: list[dict[str, Any]]) -> None:
+        log.debug(f"Setting execution provider options to {provider_options}")
+        self._provider_options = provider_options
+
+    @property
+    def _provider_options_default(self) -> list[dict[str, Any]]:
+        options = []
+        for provider in self.providers:
+            match provider:
+                case "CPUExecutionProvider" | "CUDAExecutionProvider":
+                    option = {"arena_extend_strategy": "kSameAsRequested"}
+                case "OpenVINOExecutionProvider":
+                    option = {"device_type": "GPU_FP32", "cache_dir": (self.model_path.parent / "openvino").as_posix()}
+                case _:
+                    option = {}
+            options.append(option)
+        return options
+
+    @property
+    def sess_options(self) -> ort.SessionOptions:
+        return self._sess_options
+
+    @sess_options.setter
+    def sess_options(self, sess_options: ort.SessionOptions) -> None:
+        log.debug(f"Setting execution_mode to {sess_options.execution_mode.name}")
+        log.debug(f"Setting inter_op_num_threads to {sess_options.inter_op_num_threads}")
+        log.debug(f"Setting intra_op_num_threads to {sess_options.intra_op_num_threads}")
+        self._sess_options = sess_options
+
+    @property
+    def _sess_options_default(self) -> ort.SessionOptions:
+        sess_options = ort.SessionOptions()
+        sess_options.enable_cpu_mem_arena = False
+
+        # avoid thread contention between models
+        if settings.model_inter_op_threads > 0:
+            sess_options.inter_op_num_threads = settings.model_inter_op_threads
+        # these defaults work well for CPU, but bottleneck GPU
+        elif settings.model_inter_op_threads == 0 and self.providers == ["CPUExecutionProvider"]:
+            sess_options.inter_op_num_threads = 1
+
+        if settings.model_intra_op_threads > 0:
+            sess_options.intra_op_num_threads = settings.model_intra_op_threads
+        elif settings.model_intra_op_threads == 0 and self.providers == ["CPUExecutionProvider"]:
+            sess_options.intra_op_num_threads = 2
+
+        if sess_options.inter_op_num_threads > 1:
+            sess_options.execution_mode = ort.ExecutionMode.ORT_PARALLEL
+
+        return sess_options

--- a/machine-learning/app/sessions/ort.py
+++ b/machine-learning/app/sessions/ort.py
@@ -16,17 +16,17 @@ from ..config import log, settings
 class OrtSession:
     def __init__(
         self,
-        model_path: Path,
+        model_path: Path | str,
         providers: list[str] | None = None,
         provider_options: list[dict[str, Any]] | None = None,
         sess_options: ort.SessionOptions | None = None,
     ):
-        self.model_path = model_path
+        self.model_path = Path(model_path)
         self.providers = providers if providers is not None else self._providers_default
         self.provider_options = provider_options if provider_options is not None else self._provider_options_default
         self.sess_options = sess_options if sess_options is not None else self._sess_options_default
         self.session = ort.InferenceSession(
-            model_path.as_posix(),
+            self.model_path.as_posix(),
             providers=self.providers,
             provider_options=self.provider_options,
             sess_options=self.sess_options,

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -162,7 +162,7 @@ class TestBase:
 
         encoder = OpenClipTextualEncoder("ViT-B-32__openai")
 
-        assert encoder.preferred_format == ModelFormat.ONNX
+        assert encoder.model_format == ModelFormat.ONNX
 
     def test_sets_default_preferred_format_to_armnn_if_available(self, mocker: MockerFixture) -> None:
         mocker.patch.object(settings, "ann", True)
@@ -170,7 +170,7 @@ class TestBase:
 
         encoder = OpenClipTextualEncoder("ViT-B-32__openai")
 
-        assert encoder.preferred_format == ModelFormat.ARMNN
+        assert encoder.model_format == ModelFormat.ARMNN
 
     def test_sets_preferred_format_kwarg(self, mocker: MockerFixture) -> None:
         mocker.patch.object(settings, "ann", False)
@@ -178,7 +178,7 @@ class TestBase:
 
         encoder = OpenClipTextualEncoder("ViT-B-32__openai", preferred_format=ModelFormat.ARMNN)
 
-        assert encoder.preferred_format == ModelFormat.ARMNN
+        assert encoder.model_format == ModelFormat.ARMNN
 
     def test_casts_cache_dir_string_to_path(self) -> None:
         cache_dir = "/test_cache"

--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -97,4 +97,4 @@ line-length = 120
 target-version = ['py311']
 
 [tool.pytest.ini_options]
-markers = ["providers"]
+markers = ["providers", "ov_device_ids"]


### PR DESCRIPTION
### Description

The ML service has some coupling with ONNX Runtime: much of the logic in the base inference class is only relevant to this backend, while handling for other backends is treated as a special case. This PR abstracts ONNX Runtime into a `ModelSession` wrapper similar to how ARM NN is handled.

The catalyst for this change is that facial recognition recently broke for ARM NN due to a change that only applied to ONNX Runtime. As part of this, it also adds relevant tests for facial recognition, as well as `AnnSession` in general as its test coverage was quite low.

### How Has This Been Tested?

Tested that the endpoint still works for each model task using ONNX Runtime. I'm unable to test ARM NN.