### PR TITLE
docs: add info about translations and weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,21 @@
 <br/>
 <p align="center">
 
-  <a href="readme_i18n/README_ca_ES.md">Català</a>
-  <a href="readme_i18n/README_es_ES.md">Español</a>
-  <a href="readme_i18n/README_fr_FR.md">Français</a>
-  <a href="readme_i18n/README_it_IT.md">Italiano</a>
-  <a href="readme_i18n/README_ja_JP.md">日本語</a>
-  <a href="readme_i18n/README_ko_KR.md">한국어</a>
-  <a href="readme_i18n/README_de_DE.md">Deutsch</a>
-  <a href="readme_i18n/README_nl_NL.md">Nederlands</a>
-  <a href="readme_i18n/README_tr_TR.md">Türkçe</a>
-  <a href="readme_i18n/README_zh_CN.md">中文</a>
-  <a href="readme_i18n/README_ru_RU.md">Русский</a>
-  <a href="readme_i18n/README_pt_BR.md">Português Brasileiro</a>
-  <a href="readme_i18n/README_sv_SE.md">Svenska</a>
-  <a href="readme_i18n/README_ar_JO.md">العربية</a>
+<a href="readme_i18n/README_ca_ES.md">Català</a>
+<a href="readme_i18n/README_es_ES.md">Español</a>
+<a href="readme_i18n/README_fr_FR.md">Français</a>
+<a href="readme_i18n/README_it_IT.md">Italiano</a>
+<a href="readme_i18n/README_ja_JP.md">日本語</a>
+<a href="readme_i18n/README_ko_KR.md">한국어</a>
+<a href="readme_i18n/README_de_DE.md">Deutsch</a>
+<a href="readme_i18n/README_nl_NL.md">Nederlands</a>
+<a href="readme_i18n/README_tr_TR.md">Türkçe</a>
+<a href="readme_i18n/README_zh_CN.md">中文</a>
+<a href="readme_i18n/README_ru_RU.md">Русский</a>
+<a href="readme_i18n/README_pt_BR.md">Português Brasileiro</a>
+<a href="readme_i18n/README_sv_SE.md">Svenska</a>
+<a href="readme_i18n/README_ar_JO.md">العربية</a>
+
 </p>
 
 ## Disclaimer
@@ -42,45 +43,36 @@
 - ⚠️ **Do not use the app as the only way to store your photos and videos.**
 - ⚠️ Always follow [3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) backup plan for your precious photos and videos!
 
-## Content
+> [!NOTE]
+> You can find the main documentation, including installation guides, at https://immich.app/.
 
-- [Official Documentation](https://immich.app/docs)
-- [Roadmap](https://github.com/orgs/immich-app/projects/1)
+## Links
+
+- [Documentation](https://immich.app/docs)
+- [About](https://immich.app/docs/overview/introduction)
+- [Installation](https://immich.app/docs/install/requirements)
+- [Roadmap](https://immich.app/roadmap)
 - [Demo](#demo)
 - [Features](#features)
-- [Introduction](https://immich.app/docs/overview/introduction)
-- [Installation](https://immich.app/docs/install/requirements)
-- [Contribution Guidelines](https://immich.app/docs/overview/support-the-project)
-
-## Documentation
-
-You can find the main documentation, including installation guides, at https://immich.app/.
+- [Translations](https://immich.app/docs/developer/tranlations)
+- [Contributing](https://immich.app/docs/overview/support-the-project)
 
 ## Demo
 
-You can access the web demo at https://demo.immich.app
+Access the demo [here](https://demo.immich.app). The demo is running on a Free-tier Oracle VM in Amsterdam with a 2.4Ghz quad-core ARM64 CPU and 24GB RAM.
 
 For the mobile app, you can use `https://demo.immich.app/api` for the `Server Endpoint URL`
 
-```bash title="Demo Credential"
-The credential
-email: demo@immich.app
-password: demo
-```
+### Login credentials
 
-```
-Spec: Free-tier Oracle VM - Amsterdam - 2.4Ghz quad-core ARM64 CPU, 24GB RAM
-```
-
-## Activities
-
-![Activities](https://repobeats.axiom.co/api/embed/9e86d9dc3ddd137161f2f6d2e758d7863b1789cb.svg "Repobeats analytics image")
+| Email           | Password |
+| --------------- | -------- |
+| demo@immich.app | demo     |
 
 ## Features
 
-
 | Features                                     | Mobile | Web |
-| :--------------------------------------------- | -------- | ----- |
+| :------------------------------------------- | ------ | --- |
 | Upload and view videos and photos            | Yes    | Yes |
 | Auto backup when the app is opened           | Yes    | N/A |
 | Prevent duplication of assets                | Yes    | Yes |
@@ -110,13 +102,19 @@ Spec: Free-tier Oracle VM - Amsterdam - 2.4Ghz quad-core ARM64 CPU, 24GB RAM
 | Read-only gallery                            | Yes    | Yes |
 | Stacked Photos                               | Yes    | Yes |
 
-## Contributors
+## Translations
 
-<a href="https://github.com/alextran1502/immich/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=immich-app/immich" width="100%"/>
+Read more about translations [here](https://immich.app/docs/developer/translations).
+
+<a href="https://hosted.weblate.org/engage/immich/">
+<img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />
 </a>
 
-## Star History
+## Repository activity
+
+![Activities](https://repobeats.axiom.co/api/embed/9e86d9dc3ddd137161f2f6d2e758d7863b1789cb.svg "Repobeats analytics image")
+
+## Star history
 
 <a href="https://star-history.com/#immich-app/immich&Date">
  <picture>
@@ -124,4 +122,10 @@ Spec: Free-tier Oracle VM - Amsterdam - 2.4Ghz quad-core ARM64 CPU, 24GB RAM
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" />
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=immich-app/immich&type=Date" width="100%" />
  </picture>
+</a>
+
+## Contributors
+
+<a href="https://github.com/alextran1502/immich/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=immich-app/immich" width="100%"/>
 </a>

--- a/docs/docs/developer/translations.md
+++ b/docs/docs/developer/translations.md
@@ -1,0 +1,21 @@
+# Translations
+
+:::tip
+You can request a new language [here](https://hosted.weblate.org/new-lang/immich/immich/).
+:::
+
+## Weblate
+
+[Weblate](https://weblate.org/) is a "libre software web-based continuous localization system". Immich localization efforts are managed on their [hosted platform](https://hosted.weblate.org/projects/immich/immich/).
+
+## International message format
+
+Plurals, numbers, dates and other locale specific message formats can be handled by using the [ICU message format](https://unicode-org.github.io/icu/userguide/format_parse/messages/). Internally, this is handled by the [intl-messageformat](https://www.npmjs.com/package/intl-messageformat) library. Their [documentation](https://formatjs.io/docs/intl-messageformat/) includes common, editable examples via a "live editor" feature, which can be useful to test and debug message formats.
+
+## Progress
+
+Immich currently supports the following languages:
+
+<a href="https://hosted.weblate.org/engage/immich/">
+<img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />
+</a>

--- a/docs/docs/overview/support-the-project.md
+++ b/docs/docs/overview/support-the-project.md
@@ -4,11 +4,17 @@ sidebar_position: 5
 
 # Support The Project
 
-## Contributing
+## Report issues
 
-1. Testing - Using Immich and reporting bugs is a great way to help support the project. Found a bug? [Open an issue on GitHub][github-issue].
-1. Translations - The Immich mobile app has been translated into [17 languages][github-langs] so far! To contribute with translations, email me at alex.tran1502@gmail.com or send me a message on discord.
-1. Development - If you are a programmer or developer, take a look at Immich's [technology stack](/docs/developer/architecture.mdx) and consider fixing bugs or building new features. The team and I are always looking for new contributors. For information about how to contribute as a developer, see the [Developer](/docs/developer/architecture.mdx) section.
+By far the easiest way to help make Immich better it to use it and report issues and bugs. Found a bug? [Open an issue on GitHub][github-issue].
+
+## Translations
+
+Support the project by localizing on [Weblate](https://hosted.weblate.org/projects/immich/immich/). For more information, see the [Translations](/docs/developer/translations) section.
+
+## Development
+
+If you are a programmer or developer, take a look at Immich's [technology stack](/docs/developer/architecture.mdx) and consider fixing bugs or building new features. The team and I are always looking for new contributors. For information about how to contribute as a developer, see the [Developer](/docs/developer/architecture.mdx) section.
 
 [github-issue]: https://github.com/immich-app/immich/issues/new/choose
 [github-langs]: https://github.com/immich-app/immich/tree/main/mobile/assets/i18n

--- a/docs/src/pages/roadmap.tsx
+++ b/docs/src/pages/roadmap.tsx
@@ -14,6 +14,7 @@ import {
   mdiCheckboxMarked,
   mdiCloudUploadOutline,
   mdiCollage,
+  mdiContentDuplicate,
   mdiDevices,
   mdiEmailOutline,
   mdiExpansionCard,
@@ -28,6 +29,7 @@ import {
   mdiForum,
   mdiHandshakeOutline,
   mdiHeart,
+  mdiHistory,
   mdiImage,
   mdiImageAlbum,
   mdiImageEdit,
@@ -63,14 +65,13 @@ import {
   mdiVectorCombine,
   mdiVideo,
   mdiWeb,
-  mdiContentDuplicate,
 } from '@mdi/js';
 import Layout from '@theme/Layout';
 import React from 'react';
 import { Item, Timeline } from '../components/timeline';
 
 const releases = {
-  'v1.106.0': new Date(2024, 5, 11),
+  'v1.106.1': new Date(2024, 5, 11),
   'v1.104.0': new Date(2024, 4, 13),
   'v1.103.0': new Date(2024, 3, 29),
   'v1.102.0': new Date(2024, 3, 15),
@@ -201,14 +202,6 @@ const roadmap: Item[] = [
   },
   {
     done: false,
-    icon: mdiWeb,
-    iconColor: 'royalblue',
-    title: 'Web translations',
-    description: 'Translate the web application to multiple languages',
-    getDateLabel: () => 'Planned for 2024',
-  },
-  {
-    done: false,
     icon: mdiCameraBurst,
     iconColor: 'rebeccapurple',
     title: 'Auto stacking',
@@ -219,17 +212,30 @@ const roadmap: Item[] = [
 
 const milestones: Item[] = [
   withRelease({
+    icon: mdiHistory,
+    title: 'Versioned documentation',
+    description: 'View documentation as it was at the time of past releases',
+    release: 'v1.106.1',
+  }),
+  withRelease({
+    icon: mdiWeb,
+    iconColor: 'royalblue',
+    title: 'Web translations',
+    description: 'Translate the web application to multiple languages',
+    release: 'v1.106.1',
+  }),
+  withRelease({
     icon: mdiContentDuplicate,
     title: 'Similar image detection',
     description: 'Detect duplicate assets that aren’t exactly identical',
-    release: 'v1.106.0',
+    release: 'v1.106.1',
   }),
   withRelease({
     icon: mdiVectorCombine,
     title: 'Container consolidation',
     description:
       'The microservices container can be run as a worker within the server image, allowing us to remove it from the default stack.',
-    release: 'v1.106.0',
+    release: 'v1.106.1',
   }),
   withRelease({
     icon: mdiPencil,


### PR DESCRIPTION
- Clean up readme
- Add translation progress svg to readme 
- Move translations from roadmap to milestone
- Refer milestones to 106.1 since it actually has a release, not just a tag.
- Add milestone for versioned documentation
- Add developer (contributing) page for translations