### PR TITLE
docs: Add new community guide to access Immich with a custom domain

### DIFF
--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -38,6 +38,11 @@ const guides: CommunityGuidesProps[] = [
     description: 'Import your Google Photos files into Immich and add your albums',
     url: 'https://github.com/immich-app/immich/discussions/1340',
   },
+  {
+    title: 'Access Immich with custom domain',
+    description: 'Access your local Immich installation over the internet using your own domain',
+    url: 'https://github.com/ppr88/immich-guides/blob/main/open-immich-custom-domain.md',
+  },
 ];
 
 function CommunityGuide({ title, description, url }: CommunityGuidesProps): JSX.Element {


### PR DESCRIPTION
I wrote a beginners friendly guide to expose a local Immich server to the Internet using cloudflare tunnels and a custom domain. The guide is hosted on my personal github and I added a link to it in the community guide section.