### PR TITLE
fix(web): match storage_template_migration_job with storage_template_migration

### DIFF
--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -215,7 +215,7 @@
     "storage_template_migration": "Storage template migration",
     "storage_template_migration_description": "Apply the current <link>{template}</link> to previously uploaded assets",
     "storage_template_migration_info": "Template changes will only apply to new assets. To retroactively apply the template to previously uploaded assets, run the <link>{job}</link>.",
-    "storage_template_migration_job": "Storage Migration Job",
+    "storage_template_migration_job": "Storage Template Migration Job",
     "storage_template_more_details": "For more details about this feature, refer to the <template-link>Storage Template</template-link> and its <implications-link>implications</implications-link>",
     "storage_template_onboarding_description": "When enabled, this feature will auto-organize files based on a user-defined template. Due to stability issues the feature has been turned off by default. For more information, please see the <link>documentation</link>.",
     "storage_template_path_length": "Approximate path length limit: <b>{length, number}</b>/{limit, number}",


### PR DESCRIPTION
This Pull Request simply makes two labels uniform.

The name of the job is set to "Storage template migration", while the settings description has "Storage Migration Job". See the two screenshots below: 
![image](https://github.com/immich-app/immich/assets/580549/ce9094d1-16ae-4c82-b004-fab8fdd6675e)

![image](https://github.com/immich-app/immich/assets/580549/03c4fd45-4982-4119-ab69-f0b7b31431de)

