### PR TITLE
chore(mobile): sync device album asset first

### DIFF
--- a/mobile/lib/providers/asset.provider.dart
+++ b/mobile/lib/providers/asset.provider.dart
@@ -51,8 +51,8 @@ class AssetNotifier extends StateNotifier<bool> {
         log.info("Manual refresh requested, cleared assets and albums from db");
       }
       final bool changedUsers = await _userService.refreshUsers();
-      final bool newRemote = await _assetService.refreshRemoteAssets();
       final bool newLocal = await _albumService.refreshDeviceAlbums();
+      final bool newRemote = await _assetService.refreshRemoteAssets();
       debugPrint(
         "changedUsers: $changedUsers, newRemote: $newRemote, newLocal: $newLocal",
       );


### PR DESCRIPTION
This PR changes the order of fetching assets on the mobile app to quickly show assets on the timeline by showing local assets first, then fetching remote assets and merging them together.
