### PR TITLE
fix(web): remove black bezels + better integrate ActivityStatus

### DIFF
--- a/web/src/lib/components/asset-viewer/activity-status.svelte
+++ b/web/src/lib/components/asset-viewer/activity-status.svelte
@@ -3,7 +3,6 @@
   import { mdiCommentOutline, mdiHeart, mdiHeartOutline } from '@mdi/js';
   import { createEventDispatcher } from 'svelte';
   import Icon from '../elements/icon.svelte';
-  import { t } from 'svelte-i18n';
 
   export let isLiked: ActivityResponseDto | null;
   export let numberOfComments: number | undefined;

--- a/web/src/lib/components/asset-viewer/activity-status.svelte
+++ b/web/src/lib/components/asset-viewer/activity-status.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div
-  class="w-full h-14 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"
+  class="w-full h-10 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"
 >
   <button type="button" class={disabled ? 'cursor-not-allowed' : ''} on:click={() => dispatch('favorite')} {disabled}>
     <div class="items-center justify-center">
@@ -29,8 +29,9 @@
       <Icon path={mdiCommentOutline} class="scale-x-[-1]" size={24} />
       {#if numberOfComments}
         <div class="text-xl">{numberOfComments}</div>
-      {:else if !isShowActivity}
-        <div class="text-lg">{$t('say_something')}</div>
+      <!-- the say_something text is removed for being obtrusive but could be put back in -->
+      <!-- if it disappears on narrowing the viewport or once user control auto fadeout is implemented -->
+      <!-- {:else if !isShowActivity} <div class="text-lg">{$t('say_something')}</div> -->
       {/if}
     </div>
   </button>

--- a/web/src/lib/components/asset-viewer/activity-status.svelte
+++ b/web/src/lib/components/asset-viewer/activity-status.svelte
@@ -7,7 +7,6 @@
 
   export let isLiked: ActivityResponseDto | null;
   export let numberOfComments: number | undefined;
-  export let isShowActivity: boolean | undefined;
   export let disabled: boolean;
 
   const dispatch = createEventDispatcher<{
@@ -16,9 +15,7 @@
   }>();
 </script>
 
-<div
-  class="w-full h-10 flex p-4 text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60"
->
+<div class="w-full flex text-white items-center justify-center rounded-full gap-4 bg-immich-dark-bg bg-opacity-60">
   <button type="button" class={disabled ? 'cursor-not-allowed' : ''} on:click={() => dispatch('favorite')} {disabled}>
     <div class="items-center justify-center">
       <Icon path={isLiked ? mdiHeart : mdiHeartOutline} size={24} />
@@ -29,9 +26,6 @@
       <Icon path={mdiCommentOutline} class="scale-x-[-1]" size={24} />
       {#if numberOfComments}
         <div class="text-xl">{numberOfComments}</div>
-      <!-- the say_something text is removed for being obtrusive but could be put back in -->
-      <!-- if it disappears on narrowing the viewport or once user control auto fadeout is implemented -->
-      <!-- {:else if !isShowActivity} <div class="text-lg">{$t('say_something')}</div> -->
       {/if}
     </div>
   </button>

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -682,7 +682,7 @@
             />
           {/if}
           {#if $slideshowState === SlideshowState.None && isShared && ((album && album.isActivityEnabled) || numberOfComments > 0)}
-            <div class="z-[9999] absolute bottom-0 right-0 mb-4 mr-6">
+            <div class="z-[9999] absolute bottom-0 right-0 mb-12 mr-4 justify-self-end">
               <ActivityStatus
                 disabled={!album?.isActivityEnabled}
                 {isLiked}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -682,7 +682,7 @@
             />
           {/if}
           {#if $slideshowState === SlideshowState.None && isShared && ((album && album.isActivityEnabled) || numberOfComments > 0)}
-            <div class="z-[9999] absolute bottom-0 right-0 mb-12 mr-3">
+            <div class="z-[9999] absolute bottom-0 right-0 mb-20 mr-8">
               <ActivityStatus
                 disabled={!album?.isActivityEnabled}
                 {isLiked}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -687,7 +687,6 @@
                 disabled={!album?.isActivityEnabled}
                 {isLiked}
                 {numberOfComments}
-                {isShowActivity}
                 on:favorite={handleFavorite}
                 on:openActivityTab={handleOpenActivity}
               />

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -682,7 +682,7 @@
             />
           {/if}
           {#if $slideshowState === SlideshowState.None && isShared && ((album && album.isActivityEnabled) || numberOfComments > 0)}
-            <div class="z-[9999] absolute bottom-0 right-0 mb-12 mr-4 justify-self-end">
+            <div class="z-[9999] absolute bottom-0 right-0 mb-12 mr-3">
               <ActivityStatus
                 disabled={!album?.isActivityEnabled}
                 {isLiked}

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -51,10 +51,7 @@
   };
 </script>
 
-<div
-  transition:fade={{ duration: 150 }}
-  class="flex h-full select-none place-content-center place-items-center"
->
+<div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   <video
     bind:this={element}
     loop={$loopVideoPreference && loopVideo}

--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -53,8 +53,7 @@
 
 <div
   transition:fade={{ duration: 150 }}
-  class="flex select-none place-content-center place-items-center"
-  style="height: calc(100% - 64px)"
+  class="flex h-full select-none place-content-center place-items-center"
 >
   <video
     bind:this={element}

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -929,6 +929,7 @@
   "saved_api_key": "Saved API Key",
   "saved_profile": "Saved profile",
   "saved_settings": "Saved settings",
+  "say_something": "Say something",
   "scan_all_libraries": "Scan All Libraries",
   "scan_all_library_files": "Re-scan All Library Files",
   "scan_new_library_files": "Scan New Library Files",

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -929,7 +929,6 @@
   "saved_api_key": "Saved API Key",
   "saved_profile": "Saved profile",
   "saved_settings": "Saved settings",
-  "say_something": "Say something",
   "scan_all_libraries": "Scan All Libraries",
   "scan_all_library_files": "Re-scan All Library Files",
   "scan_new_library_files": "Scan New Library Files",

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -635,7 +635,6 @@
               disabled={!album.isActivityEnabled}
               {isLiked}
               numberOfComments={$numberOfComments}
-              {isShowActivity}
               on:favorite={handleFavorite}
               on:openActivityTab={handleOpenAndCloseActivityTab}
             />


### PR DESCRIPTION
My entire description was deleted so I'll keep it brief I guess.

Fixes #10526 

![image](https://github.com/immich-app/immich/assets/28405293/d1816820-8590-4ecd-9be6-d09f2c99279b)

Couldn't test properly cos the headers-already-sent bug broke the video and changed the appearance of the controls but think it's OK.

Tried to right-align the buttons and make ActivityControl as-if a kind of second-row from the bottom, symmetrical to the top row. **TODO**: It should be first-row from bottom on PhotoViewer but idk how to condition in Svelte macros for PhotoViewer vs VideoViewer appearing.

Tried to also make ActivityControl less obtrusive, so removed the "Say Something" text (because it does not fade out nor disappear if the viewport width is decreased). I left the code in a comment and noted these two conditions for maybe bringing it back, tho it's a bit subjective whether it's useful or not.