### PR TITLE
WIP: asset/album sync within an isolate

### DIFF
--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    ext.kotlin_version = '1.9.24' 
+    ext.kotlin_version = '2.0.0'
 
     repositories {
         google()

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/services/asset.service.dart';
 import 'package:timezone/data/latest.dart';
 import 'package:immich_mobile/constants/locales.dart';
 import 'package:immich_mobile/services/background.service.dart';
@@ -80,6 +81,8 @@ Future<void> initApp() async {
   };
 
   PlatformDispatcher.instance.onError = (error, stack) {
+    print(error);
+    print(stack);
     log.severe('PlatformDispatcher - Catch all', error, stack);
     return true;
   };
@@ -166,6 +169,8 @@ class ImmichAppState extends ConsumerState<ImmichApp>
     }
     SystemChrome.setSystemUIOverlayStyle(overlayStyle);
     await ref.read(localNotificationService).setup();
+
+    dbIso.create();
   }
 
   @override

--- a/mobile/lib/pages/common/headers_settings.page.dart
+++ b/mobile/lib/pages/common/headers_settings.page.dart
@@ -10,6 +10,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 class SettingsHeader {
   String key = "";
   String value = "";
+
+  SettingsHeader({this.key = '', this.value = ''});
 }
 
 @RoutePage()
@@ -28,20 +30,13 @@ class HeaderSettingsPage extends HookConsumerWidget {
       if (headersStr.isNotEmpty) {
         var customHeaders = jsonDecode(headersStr) as Map;
         customHeaders.forEach((k, v) {
-          final header = SettingsHeader();
-          header.key = k;
-          header.value = v;
-          headers.value.add(header);
+          headers.value.add(SettingsHeader(key: k, value: v));
         });
       }
 
       // add first one to help the user
       if (headers.value.isEmpty) {
-        final header = SettingsHeader();
-        header.key = '';
-        header.value = '';
-
-        headers.value.add(header);
+        headers.value.add(SettingsHeader());
       }
     }
     setInitialHeaders.value = true;

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/entities/user.entity.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/db.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/asset.service.dart';
 import 'package:immich_mobile/services/sync.service.dart';
 import 'package:immich_mobile/services/user.service.dart';
 import 'package:isar/isar.dart';
@@ -81,24 +82,35 @@ class AlbumService {
     final Stopwatch sw = Stopwatch()..start();
     bool changes = false;
     try {
-      await _userService.refreshUsers();
-      final List<AlbumResponseDto>? serverAlbums = await _apiService.albumsApi
-          .getAllAlbums(shared: isShared ? true : null);
-      if (serverAlbums == null) {
-        return false;
-      }
-      changes = await _syncService.syncRemoteAlbumsToDb(
-        serverAlbums,
-        isShared: isShared,
-        loadDetails: (dto) async => dto.assetCount == dto.assets.length
-            ? dto
-            : (await _apiService.albumsApi.getAlbumInfo(dto.id)) ?? dto,
-      );
+      changes = await dbIso.dispatch("refreshRemoteAlbums", isShared);
     } finally {
       _remoteCompleter.complete(changes);
     }
     debugPrint("refreshRemoteAlbums took ${sw.elapsedMilliseconds}ms");
     return changes;
+  }
+
+  /// Checks remote albums (owned if `isShared` is false) for changes,
+  /// updates the local database and returns `true` if there were any changes
+  Future<bool> refreshRemoteAlbumsBackground({required bool isShared}) async {
+    _log.info('refreshRemoteAlbumsBackground started');
+
+    await _userService.refreshUsers();
+    _log.info('refreshRemoteAlbumsBackground refreshUsers done');
+
+    final List<AlbumResponseDto>? serverAlbums = await _apiService.albumsApi
+        .getAllAlbums(shared: isShared ? true : null);
+    _log.info('refreshRemoteAlbumsBackground getAllAlbums done');
+    if (serverAlbums == null) {
+      return false;
+    }
+    return await _syncService.syncRemoteAlbumsToDb(
+      serverAlbums,
+      isShared: isShared,
+      loadDetails: (dto) async => dto.assetCount == dto.assets.length
+          ? dto
+          : (await _apiService.albumsApi.getAlbumInfo(dto.id)) ?? dto,
+    );
   }
 
   Future<Album?> createAlbum(

--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/services/asset.service.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
@@ -69,6 +70,9 @@ class ApiService implements Authentication {
 
     // Save in hivebox for next startup
     Store.put(StoreKey.serverEndpoint, endpoint);
+
+    await dbIso.dispatch("connectServices", ConnectServicesPayload(endpoint, _accessToken ?? ''));
+
     return endpoint;
   }
 

--- a/mobile/lib/services/sync.service.dart
+++ b/mobile/lib/services/sync.service.dart
@@ -62,8 +62,12 @@ class SyncService {
     List<AlbumResponseDto> remote, {
     required bool isShared,
     required FutureOr<AlbumResponseDto> Function(AlbumResponseDto) loadDetails,
-  }) =>
-      _lock.run(() => _syncRemoteAlbumsToDb(remote, isShared, loadDetails));
+  }) async {
+    _log.info('syncRemoteAlbumsToDb waiting for lock');
+    var r = await _lock.run(() => _syncRemoteAlbumsToDb(remote, isShared, loadDetails));
+    _log.info('syncRemoteAlbumsToDb finished');
+    return r;
+  }
 
   /// Syncs all device albums and their assets to the database
   /// Returns `true` if there were any changes
@@ -286,7 +290,10 @@ class SyncService {
     bool isShared,
     FutureOr<AlbumResponseDto> Function(AlbumResponseDto) loadDetails,
   ) async {
+    _log.info('_syncRemoteAlbumsToDb started');
+
     remote.sortBy((e) => e.id);
+    _log.info('_syncRemoteAlbumsToDb sorted remote');
 
     final baseQuery = _db.albums.where().remoteIdIsNotNull().filter();
     final QueryBuilder<Album, Album, QAfterFilterCondition> query;
@@ -296,12 +303,16 @@ class SyncService {
       final User me = Store.get(StoreKey.currentUser);
       query = baseQuery.owner((q) => q.isarIdEqualTo(me.isarId));
     }
+
+    _log.info('_syncRemoteAlbumsToDb starting findAll');
     final List<Album> dbAlbums = await query.sortByRemoteId().findAll();
+    _log.info('_syncRemoteAlbumsToDb done findAll');
     assert(dbAlbums.isSortedBy((e) => e.remoteId!), "dbAlbums not sorted!");
 
     final List<Asset> toDelete = [];
     final List<Asset> existing = [];
 
+    _log.info('_syncRemoteAlbumsToDb computing changes');
     final bool changes = await diffSortedLists(
       remote,
       dbAlbums,
@@ -315,6 +326,7 @@ class SyncService {
 
     if (isShared && toDelete.isNotEmpty) {
       final List<int> idsToRemove = sharedAssetsToRemove(toDelete, existing);
+      _log.info('_syncRemoteAlbumsToDb removing assets');
       if (idsToRemove.isNotEmpty) {
         await _db.writeTxn(() async {
           await _db.assets.deleteAll(idsToRemove);


### PR DESCRIPTION
Hi,

I've had a problem with my phone locking up, and suspected it's the number of assets being synced - #10030.
Looking at the code, it seems to be done on the UI thread. Isar has a recipe for [multi isolate usage](https://isar.dev/recipes/multi_isolate.html#example)

I played around a bit with isolates (first time using it) and uploaded a profile build to my phone.

There's a lot less visual jank whilst the assets/albums are syncing. Importantly, the app doesn't _permanently_ freeze anymore.

Have to say it's not without problems, the search page does some kind of syncing and it doesn't display properly at the moment, but i'm sure that's fixable.

Working in isolates is a bit challenging as the app has shared states. To that extent, I wasn't sure if the hashingService does something sequentially, which might pose a roadblock to this PR.

The demo server doesn't reproduce this problem, otherwise I would have made a demo video comparing before/after. I wonder if you could run the code and use the dart tools to measure FPS on a larger(than the demo) server so that you can see the impact.

It's currently a bit all over the place, just to test/validate the problem...