### PR TITLE
chore(ml): target arm64 cuda

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
           - image: immich-machine-learning
             context: machine-learning
             file: machine-learning/Dockerfile
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             device: cuda
             suffix: -cuda
 


### PR DESCRIPTION
## Description

There are cases where CUDA is used with an arm64 architecture, most notably with Jetson devices.

Fixes #10647