### PR TITLE
feat(web): use websocket to update the feature photo

### DIFF
--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -8,6 +8,8 @@
   import { getMetadataSearchQuery } from '$lib/utils/metadata-search';
   import { t } from 'svelte-i18n';
   import EmptyPlaceholder from '$lib/components/shared-components/empty-placeholder.svelte';
+  import { onMount } from 'svelte';
+  import { websocketEvents } from '$lib/stores/websocket';
 
   export let data: PageData;
 
@@ -36,6 +38,18 @@
       MAX_PLACE_ITEMS = screenSize < 768 ? Math.floor(innerWidth / 150) : Math.floor(innerWidth / 172);
     }
   }
+
+  onMount(() => {
+    return websocketEvents.on('on_person_thumbnail', (personId: string) => {
+      people.map((person) => {
+        if (person.id === personId) {
+          person.updatedAt = Date.now().toString();
+        }
+      });
+      // trigger reactivity
+      people = people;
+    });
+  });
 </script>
 
 <svelte:window bind:innerWidth={screenSize} />


### PR DESCRIPTION
following #9443

With this PR, if the server sends a thumbnail generation event of a person, the client updates the thumbnail of that person. This PR changes the value of `updatedAt` to force the browser to fetch the new thumbnail. IMO, it's not a bad thing to change this value even if it's not the same as the one stored on the server: `updatedAt` is only used to force the browser to request a new thumbnail.

## How was this PR tested ?

- Stop the machine-learning process
- Change a feature photo
- Go back to /people
- Re-start the machine-learning process
- See the thumbnail changing without reloading