### PR TITLE
chore(mobile): Revert "remove exclude album mechanism for backup (#10552)"

### DIFF
--- a/mobile/lib/entities/backup_album.entity.dart
+++ b/mobile/lib/entities/backup_album.entity.dart
@@ -18,4 +18,5 @@ class BackupAlbum {
 enum BackupSelection {
   none,
   select,
+  exclude;
 }

--- a/mobile/lib/entities/backup_album.entity.g.dart
+++ b/mobile/lib/entities/backup_album.entity.g.dart
@@ -107,10 +107,12 @@ P _backupAlbumDeserializeProp<P>(
 const _BackupAlbumselectionEnumValueMap = {
   'none': 0,
   'select': 1,
+  'exclude': 2,
 };
 const _BackupAlbumselectionValueEnumMap = {
   0: BackupSelection.none,
   1: BackupSelection.select,
+  2: BackupSelection.exclude,
 };
 
 Id _backupAlbumGetId(BackupAlbum object) {

--- a/mobile/lib/models/backup/backup_state.model.dart
+++ b/mobile/lib/models/backup/backup_state.model.dart
@@ -38,9 +38,10 @@ class BackUpState {
   /// All available albums on the device
   final List<AvailableAlbum> availableAlbums;
   final Set<AvailableAlbum> selectedBackupAlbums;
+  final Set<AvailableAlbum> excludedBackupAlbums;
 
   /// Assets that are not overlapping in selected backup albums and excluded backup albums
-  final Set<AssetEntity> backupCandidates;
+  final Set<AssetEntity> allUniqueAssets;
 
   /// All assets from the selected albums that have been backup
   final Set<String> selectedAlbumsBackupAssetsIds;
@@ -67,7 +68,8 @@ class BackUpState {
     required this.backupTriggerDelay,
     required this.availableAlbums,
     required this.selectedBackupAlbums,
-    required this.backupCandidates,
+    required this.excludedBackupAlbums,
+    required this.allUniqueAssets,
     required this.selectedAlbumsBackupAssetsIds,
     required this.currentUploadAsset,
   });
@@ -91,7 +93,8 @@ class BackUpState {
     int? backupTriggerDelay,
     List<AvailableAlbum>? availableAlbums,
     Set<AvailableAlbum>? selectedBackupAlbums,
-    Set<AssetEntity>? backupCandidates,
+    Set<AvailableAlbum>? excludedBackupAlbums,
+    Set<AssetEntity>? allUniqueAssets,
     Set<String>? selectedAlbumsBackupAssetsIds,
     CurrentUploadAsset? currentUploadAsset,
   }) {
@@ -118,7 +121,8 @@ class BackUpState {
       backupTriggerDelay: backupTriggerDelay ?? this.backupTriggerDelay,
       availableAlbums: availableAlbums ?? this.availableAlbums,
       selectedBackupAlbums: selectedBackupAlbums ?? this.selectedBackupAlbums,
-      backupCandidates: backupCandidates ?? this.backupCandidates,
+      excludedBackupAlbums: excludedBackupAlbums ?? this.excludedBackupAlbums,
+      allUniqueAssets: allUniqueAssets ?? this.allUniqueAssets,
       selectedAlbumsBackupAssetsIds:
           selectedAlbumsBackupAssetsIds ?? this.selectedAlbumsBackupAssetsIds,
       currentUploadAsset: currentUploadAsset ?? this.currentUploadAsset,
@@ -127,7 +131,7 @@ class BackUpState {
 
   @override
   String toString() {
-    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, backupCandidates: $backupCandidates, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
+    return 'BackUpState(backupProgress: $backupProgress, allAssetsInDatabase: $allAssetsInDatabase, progressInPercentage: $progressInPercentage, progressInFileSize: $progressInFileSize, progressInFileSpeed: $progressInFileSpeed, progressInFileSpeeds: $progressInFileSpeeds, progressInFileSpeedUpdateTime: $progressInFileSpeedUpdateTime, progressInFileSpeedUpdateSentBytes: $progressInFileSpeedUpdateSentBytes, iCloudDownloadProgress: $iCloudDownloadProgress, cancelToken: $cancelToken, serverInfo: $serverInfo, autoBackup: $autoBackup, backgroundBackup: $backgroundBackup, backupRequireWifi: $backupRequireWifi, backupRequireCharging: $backupRequireCharging, backupTriggerDelay: $backupTriggerDelay, availableAlbums: $availableAlbums, selectedBackupAlbums: $selectedBackupAlbums, excludedBackupAlbums: $excludedBackupAlbums, allUniqueAssets: $allUniqueAssets, selectedAlbumsBackupAssetsIds: $selectedAlbumsBackupAssetsIds, currentUploadAsset: $currentUploadAsset)';
   }
 
   @override
@@ -154,7 +158,8 @@ class BackUpState {
         other.backupTriggerDelay == backupTriggerDelay &&
         collectionEquals(other.availableAlbums, availableAlbums) &&
         collectionEquals(other.selectedBackupAlbums, selectedBackupAlbums) &&
-        collectionEquals(other.backupCandidates, backupCandidates) &&
+        collectionEquals(other.excludedBackupAlbums, excludedBackupAlbums) &&
+        collectionEquals(other.allUniqueAssets, allUniqueAssets) &&
         collectionEquals(
           other.selectedAlbumsBackupAssetsIds,
           selectedAlbumsBackupAssetsIds,
@@ -182,7 +187,8 @@ class BackUpState {
         backupTriggerDelay.hashCode ^
         availableAlbums.hashCode ^
         selectedBackupAlbums.hashCode ^
-        backupCandidates.hashCode ^
+        excludedBackupAlbums.hashCode ^
+        allUniqueAssets.hashCode ^
         selectedAlbumsBackupAssetsIds.hashCode ^
         currentUploadAsset.hashCode;
   }

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -3,6 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/immich_colors.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/widgets/backup/album_info_card.dart';
@@ -16,6 +17,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // final availableAlbums = ref.watch(backupProvider).availableAlbums;
     final selectedBackupAlbums = ref.watch(backupProvider).selectedBackupAlbums;
+    final excludedBackupAlbums = ref.watch(backupProvider).excludedBackupAlbums;
     final isDarkTheme = context.isDarkTheme;
     final albums = ref.watch(backupProvider).availableAlbums;
 
@@ -109,6 +111,83 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
       }).toSet();
     }
 
+    buildExcludedAlbumNameChip() {
+      return excludedBackupAlbums.map((album) {
+        void removeSelection() {
+          ref
+              .watch(backupProvider.notifier)
+              .removeExcludedAlbumForBackup(album);
+        }
+
+        return GestureDetector(
+          onTap: removeSelection,
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8.0),
+            child: Chip(
+              label: Text(
+                album.name,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isDarkTheme ? Colors.black : immichBackgroundColor,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              backgroundColor: Colors.red[300],
+              deleteIconColor:
+                  isDarkTheme ? Colors.black : immichBackgroundColor,
+              deleteIcon: const Icon(
+                Icons.cancel_rounded,
+                size: 15,
+              ),
+              onDeleted: removeSelection,
+            ),
+          ),
+        );
+      }).toSet();
+    }
+
+    // buildSearchBar() {
+    //   return Padding(
+    //     padding: const EdgeInsets.only(left: 16.0, right: 16, bottom: 8.0),
+    //     child: TextFormField(
+    //       onChanged: (searchValue) {
+    //         // if (searchValue.isEmpty) {
+    //         //   albums = availableAlbums;
+    //         // } else {
+    //         //   albums.value = availableAlbums
+    //         //       .where(
+    //         //         (album) => album.name
+    //         //             .toLowerCase()
+    //         //             .contains(searchValue.toLowerCase()),
+    //         //       )
+    //         //       .toList();
+    //         // }
+    //       },
+    //       decoration: InputDecoration(
+    //         contentPadding: const EdgeInsets.symmetric(
+    //           horizontal: 8.0,
+    //           vertical: 8.0,
+    //         ),
+    //         hintText: "Search",
+    //         hintStyle: TextStyle(
+    //           color: isDarkTheme ? Colors.white : Colors.grey,
+    //           fontSize: 14.0,
+    //         ),
+    //         prefixIcon: const Icon(
+    //           Icons.search,
+    //           color: Colors.grey,
+    //         ),
+    //         border: OutlineInputBorder(
+    //           borderRadius: BorderRadius.circular(10),
+    //           borderSide: BorderSide.none,
+    //         ),
+    //         filled: true,
+    //         fillColor: isDarkTheme ? Colors.white30 : Colors.grey[200],
+    //       ),
+    //     ),
+    //   );
+    // }
+
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -144,6 +223,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                   child: Wrap(
                     children: [
                       ...buildSelectedAlbumNameChip(),
+                      ...buildExcludedAlbumNameChip(),
                     ],
                   ),
                 ),

--- a/mobile/lib/pages/backup/backup_controller.page.dart
+++ b/mobile/lib/pages/backup/backup_controller.page.dart
@@ -29,7 +29,7 @@ class BackupControllerPage extends HookConsumerWidget {
     final didGetBackupInfo = useState(false);
     bool hasExclusiveAccess =
         backupState.backupProgress != BackUpProgressEnum.inBackground;
-    bool shouldBackup = backupState.backupCandidates.length -
+    bool shouldBackup = backupState.allUniqueAssets.length -
                     backupState.selectedAlbumsBackupAssetsIds.length ==
                 0 ||
             !hasExclusiveAccess
@@ -100,6 +100,29 @@ class BackupControllerPage extends HookConsumerWidget {
       }
     }
 
+    Widget buildExcludedAlbumName() {
+      var text = "backup_controller_page_excluded".tr();
+      var albums = ref.watch(backupProvider).excludedBackupAlbums;
+
+      if (albums.isNotEmpty) {
+        for (var album in albums) {
+          text += "${album.name}, ";
+        }
+
+        return Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Text(
+            text.trim().substring(0, text.length - 2),
+            style: context.textTheme.labelLarge?.copyWith(
+              color: Colors.red[300],
+            ),
+          ),
+        );
+      } else {
+        return const SizedBox();
+      }
+    }
+
     buildFolderSelectionTile() {
       return Padding(
         padding: const EdgeInsets.only(top: 8.0),
@@ -131,6 +154,7 @@ class BackupControllerPage extends HookConsumerWidget {
                     style: context.textTheme.bodyMedium,
                   ).tr(),
                   buildSelectedAlbumName(),
+                  buildExcludedAlbumName(),
                 ],
               ),
             ),
@@ -268,7 +292,7 @@ class BackupControllerPage extends HookConsumerWidget {
                     subtitle: "backup_controller_page_total_sub".tr(),
                     info: ref.watch(backupProvider).availableAlbums.isEmpty
                         ? "..."
-                        : "${backupState.backupCandidates.length}",
+                        : "${backupState.allUniqueAssets.length}",
                   ),
                   BackupInfoCard(
                     title: "backup_controller_page_backup".tr(),
@@ -282,7 +306,7 @@ class BackupControllerPage extends HookConsumerWidget {
                     subtitle: "backup_controller_page_remainder_sub".tr(),
                     info: ref.watch(backupProvider).availableAlbums.isEmpty
                         ? "..."
-                        : "${max(0, backupState.backupCandidates.length - backupState.selectedAlbumsBackupAssetsIds.length)}",
+                        : "${max(0, backupState.allUniqueAssets.length - backupState.selectedAlbumsBackupAssetsIds.length)}",
                   ),
                   const Divider(),
                   const CurrentUploadingAssetInfoBox(),

--- a/mobile/lib/providers/backup/backup_verification.provider.dart
+++ b/mobile/lib/providers/backup/backup_verification.provider.dart
@@ -23,7 +23,7 @@ class BackupVerification extends _$BackupVerification {
       state = true;
       final backupState = ref.read(backupProvider);
 
-      if (backupState.backupCandidates.length >
+      if (backupState.allUniqueAssets.length >
           backupState.selectedAlbumsBackupAssetsIds.length) {
         if (context.mounted) {
           ImmichToast.show(

--- a/mobile/lib/providers/backup/backup_verification.provider.g.dart
+++ b/mobile/lib/providers/backup/backup_verification.provider.g.dart
@@ -7,7 +7,7 @@ part of 'backup_verification.provider.dart';
 // **************************************************************************
 
 String _$backupVerificationHash() =>
-    r'4f64459d68d20de4a61160ec8e9be347ec945fb6';
+    r'b691e0cc27856eef189258d3c102cc73ce4812a4';
 
 /// See also [BackupVerification].
 @ProviderFor(BackupVerification)

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -349,6 +349,7 @@ class BackgroundService {
     AppSettingsService settingsService = AppSettingsService();
 
     final selectedAlbums = backupService.selectedAlbumsQuery().findAllSync();
+    final excludedAlbums = backupService.excludedAlbumsQuery().findAllSync();
     if (selectedAlbums.isEmpty) {
       return true;
     }
@@ -360,10 +361,11 @@ class BackgroundService {
         backupService,
         settingsService,
         selectedAlbums,
+        excludedAlbums,
       );
       if (backupOk) {
         await Store.delete(StoreKey.backupFailedSince);
-        final backupAlbums = [...selectedAlbums];
+        final backupAlbums = [...selectedAlbums, ...excludedAlbums];
         backupAlbums.sortBy((e) => e.id);
         db.writeTxnSync(() {
           final dbAlbums = db.backupAlbums.where().sortById().findAllSync();
@@ -402,6 +404,7 @@ class BackgroundService {
     BackupService backupService,
     AppSettingsService settingsService,
     List<BackupAlbum> selectedAlbums,
+    List<BackupAlbum> excludedAlbums,
   ) async {
     _errorGracePeriodExceeded = _isErrorGracePeriodExceeded(settingsService);
     final bool notifyTotalProgress = settingsService
@@ -415,6 +418,7 @@ class BackgroundService {
 
     List<AssetEntity> toUpload = await backupService.buildUploadCandidates(
       selectedAlbums,
+      excludedAlbums,
     );
 
     try {

--- a/mobile/lib/widgets/backup/album_info_list_tile.dart
+++ b/mobile/lib/widgets/backup/album_info_list_tile.dart
@@ -1,12 +1,14 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/backup/available_album.model.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class AlbumInfoListTile extends HookConsumerWidget {
   final AvailableAlbum album;
@@ -17,6 +19,8 @@ class AlbumInfoListTile extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bool isSelected =
         ref.watch(backupProvider).selectedBackupAlbums.contains(album);
+    final bool isExcluded =
+        ref.watch(backupProvider).excludedBackupAlbums.contains(album);
     var assetCount = useState(0);
 
     useEffect(
@@ -32,6 +36,10 @@ class AlbumInfoListTile extends HookConsumerWidget {
         return context.isDarkTheme
             ? context.primaryColor.withAlpha(100)
             : context.primaryColor.withAlpha(25);
+      } else if (isExcluded) {
+        return context.isDarkTheme
+            ? Colors.red[300]?.withAlpha(150)
+            : Colors.red[100]?.withAlpha(150);
       } else {
         return Colors.transparent;
       }
@@ -45,6 +53,13 @@ class AlbumInfoListTile extends HookConsumerWidget {
         );
       }
 
+      if (isExcluded) {
+        return const Icon(
+          Icons.remove_circle_rounded,
+          color: Colors.red,
+        );
+      }
+
       return Icon(
         Icons.circle,
         color: context.isDarkTheme ? Colors.grey[400] : Colors.black45,
@@ -52,6 +67,28 @@ class AlbumInfoListTile extends HookConsumerWidget {
     }
 
     return GestureDetector(
+      onDoubleTap: () {
+        ref.watch(hapticFeedbackProvider.notifier).selectionClick();
+
+        if (isExcluded) {
+          // Remove from exclude album list
+          ref.read(backupProvider.notifier).removeExcludedAlbumForBackup(album);
+        } else {
+          // Add to exclude album list
+
+          if (album.id == 'isAll' || album.name == 'Recents') {
+            ImmichToast.show(
+              context: context,
+              msg: 'Cannot exclude album contains all assets',
+              toastType: ToastType.error,
+              gravity: ToastGravity.BOTTOM,
+            );
+            return;
+          }
+
+          ref.read(backupProvider.notifier).addExcludedAlbumForBackup(album);
+        }
+      },
       child: ListTile(
         tileColor: buildTileColor(),
         contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),


### PR DESCRIPTION
This reverts commit 5f47cf604ad6719f70a0e98d34de85510d4758f3.

After many sleepless nights thinking about this mechanism, it is a loss to remove the exclusion mechanism, especially for iOS users with no "Camera" album notion. You cannot do it anymore if you want to upload everything but the WhatsApp album.
