### PR TITLE
feat(web): show favorite icon in duplicate asset

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
-  import { getAssetThumbnailUrl } from '$lib/utils';
+  import { getAssetThumbnailUrl, isSharedLink } from '$lib/utils';
   import { getAssetResolution, getFileSize } from '$lib/utils/asset-utils';
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { getAllAlbums, type AssetResponseDto } from '@immich/sdk';
-  import { mdiMagnifyPlus } from '@mdi/js';
+  import { mdiHeart, mdiMagnifyPlus } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   export let asset: AssetResponseDto;
@@ -37,6 +37,13 @@
         class="h-60 object-cover rounded-t-xl"
         draggable="false"
       />
+
+      <!-- FAVORITE ICON -->
+      {#if !isSharedLink() && asset.isFavorite}
+        <div class="absolute top-2 left-2">
+          <Icon path={mdiHeart} size="24" class="text-white" />
+        </div>
+      {/if}
 
       <!-- OVERLAY CHIP -->
       <div

--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -40,7 +40,7 @@
 
       <!-- FAVORITE ICON -->
       {#if asset.isFavorite}
-        <div class="absolute top-2 left-2">
+        <div class="absolute bottom-2 left-2">
           <Icon path={mdiHeart} size="24" class="text-white" />
         </div>
       {/if}
@@ -65,7 +65,7 @@
     <button
       type="button"
       on:click={() => onViewAsset(asset)}
-      class="absolute rounded-full bottom-1 left-1 text-gray-200 p-2 hover:text-white bg-black/35 hover:bg-black/50"
+      class="absolute rounded-full top-1 left-1 text-gray-200 p-2 hover:text-white bg-black/35 hover:bg-black/50"
       title={$t('view')}
     >
       <Icon ariaLabel={$t('view')} path={mdiMagnifyPlus} flipped size="18" />

--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
-  import { getAssetThumbnailUrl, isSharedLink } from '$lib/utils';
+  import { getAssetThumbnailUrl } from '$lib/utils';
   import { getAssetResolution, getFileSize } from '$lib/utils/asset-utils';
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { getAllAlbums, type AssetResponseDto } from '@immich/sdk';
@@ -39,7 +39,7 @@
       />
 
       <!-- FAVORITE ICON -->
-      {#if !isSharedLink() && asset.isFavorite}
+      {#if asset.isFavorite}
         <div class="absolute top-2 left-2">
           <Icon path={mdiHeart} size="24" class="text-white" />
         </div>


### PR DESCRIPTION
This show the favorite-heart on the duplicate review page:

![screenshot of the updated duplicate review UI](https://github.com/immich-app/immich/assets/18399125/3a09f971-0e11-4909-9539-3b398395aaf8)

Note that here it is shown in the top left rather than the bottom left, because the view button is already located in the bottom right. I also experimented with moving the heart up above the view button, but that didn't look as nice in my opinion:

![alternative design where the heart is located in the bottom left](https://github.com/immich-app/immich/assets/18399125/b5c9f5d7-b807-402f-9cd0-8e43ad80c59d)

Feel free to object if you think otherwise.

I think this change would be beneficial for the following reason: When reviewing duplicates, I find it useful to know if one of the assets is favorited, because in that case I would then want to ensure afterwards that the asset that I keep is favorited. That way I avoid losing information during the cleanup, i.e. the "isFavorite" information.

What do you think about this suggested change?