### PR TITLE
feat(web): add keyboard shortcuts to duplicates utility

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
@@ -5,6 +5,7 @@
   import DuplicateAsset from '$lib/components/utilities-page/duplicates/duplicate-asset.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { suggestDuplicateByFileSize } from '$lib/utils';
+  import { shortcuts } from '$lib/actions/shortcut';
   import { type AssetResponseDto } from '@immich/sdk';
   import { mdiCheck, mdiTrashCanOutline } from '@mdi/js';
   import { onDestroy, onMount } from 'svelte';
@@ -60,6 +61,14 @@
     onResolve(duplicateAssetIds, trashIds);
   };
 </script>
+
+<svelte:window
+  use:shortcuts={[
+    { shortcut: { key: 'k', shift: true }, onShortcut: onSelectAll },
+    { shortcut: { key: 't', shift: true }, onShortcut: onSelectNone },
+    { shortcut: { key: 'c', shift: true }, onShortcut: handleResolve },
+  ]}
+/>
 
 <div class="pt-4 rounded-3xl border dark:border-2 border-gray-300 dark:border-gray-700 max-w-[54rem] mx-auto mb-16">
   <div class="flex flex-wrap gap-1 place-items-center place-content-center px-4 pt-4">


### PR DESCRIPTION
## Feature Description

- When we have a lot of duplicates in our library, it might be easier to have keyboard shortcuts for the basic operations in the duplicates page

## Details

- Add the following keyboard shortcuts
  - `Shift + k` : `select_keep_all`
  - `Shift + t` : `select_trash_all`
  - `Shift + c` : `confirm current selection`

PS: This is my first PR on Immich, let me know if I missed something. I did run the PR Checklist for the web.
