### PR TITLE
fix(web): scroll jank on memories page

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -355,7 +355,7 @@
     <!-- GALLERY VIEWER -->
     <section class="bg-immich-dark-gray p-4">
       <div
-        class="sticky mb-10 mt-4 flex place-content-center place-items-center transition-all"
+        class="sticky mb-10 flex place-content-center place-items-center transition-all"
         class:opacity-0={galleryInView}
         class:opacity-100={!galleryInView}
       >

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -210,7 +210,7 @@
 
     {#if galleryInView}
       <div
-        class="sticky top-20 z-30 flex place-content-center place-items-center transition-opacity"
+        class="fixed top-20 z-30 left-1/2 -translate-x-1/2 transition-opacity"
         class:opacity-0={!galleryInView}
         class:opacity-100={galleryInView}
       >
@@ -353,7 +353,7 @@
     </section>
 
     <!-- GALLERY VIEWER -->
-    <section class="bg-immich-dark-gray m-4">
+    <section class="bg-immich-dark-gray p-4">
       <div
         class="sticky mb-10 mt-4 flex place-content-center place-items-center transition-all"
         class:opacity-0={galleryInView}


### PR DESCRIPTION
Fixes #10731 by using fixed positioning to prevent changes in page height. That stops the intersection observer from firing rapidly, which was causing the page to jump up and down. Also changed margin to padding to ensure the button scrolls all the way to the bottom.
