### PR TITLE
feat(mobile): Adding setting in mobile app to TLS client certificate

### DIFF
--- a/mobile/lib/entities/store.entity.dart
+++ b/mobile/lib/entities/store.entity.dart
@@ -1,3 +1,7 @@
+
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:collection/collection.dart';
 import 'package:immich_mobile/entities/user.entity.dart';
 import 'package:isar/isar.dart';
@@ -140,6 +144,36 @@ class StoreValue {
   }
 }
 
+class SSLClientCertStoreVal {
+  final Uint8List data;
+  final String? password;
+
+  SSLClientCertStoreVal(this.data, this.password);
+
+  void save() {
+    final b64Str = base64Encode(data);
+    Store.put(StoreKey.sslClientCertData, b64Str);
+    if (password != null) {
+      Store.put(StoreKey.sslClientPasswd, password!);
+    }
+  }
+
+  static SSLClientCertStoreVal? load() {
+    final b64Str = Store.tryGet<String>(StoreKey.sslClientCertData);
+    if (b64Str == null) {
+      return null;
+    }
+    final Uint8List certData = base64Decode(b64Str);
+    final passwd = Store.tryGet<String>(StoreKey.sslClientPasswd);
+    return SSLClientCertStoreVal(certData, passwd);
+  }
+
+  static void delete() {
+    Store.delete(StoreKey.sslClientCertData);
+    Store.delete(StoreKey.sslClientPasswd);
+  }
+}
+
 class StoreKeyNotFoundException implements Exception {
   final StoreKey key;
   StoreKeyNotFoundException(this.key);
@@ -164,6 +198,8 @@ enum StoreKey<T> {
   serverEndpoint<String>(12, type: String),
   autoBackup<bool>(13, type: bool),
   backgroundBackup<bool>(14, type: bool),
+  sslClientCertData<String>(15, type: String),
+  sslClientPasswd<String>(16, type: String),
   // user settings from [AppSettingsEnum] below:
   loadPreview<bool>(100, type: bool),
   loadOriginal<bool>(101, type: bool),

--- a/mobile/lib/widgets/settings/advanced_settings.dart
+++ b/mobile/lib/widgets/settings/advanced_settings.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/immich_logger.service.dart';
 import 'package:immich_mobile/utils/http_ssl_cert_override.dart';
+import 'package:immich_mobile/widgets/settings/ssl_client_cert_settings.dart';
 import 'package:logging/logging.dart';
 
 class AdvancedSettings extends HookConsumerWidget {
@@ -64,6 +65,7 @@ class AdvancedSettings extends HookConsumerWidget {
         onChanged: (_) => HttpOverrides.global = HttpSSLCertOverride(),
       ),
       const CustomeProxyHeaderSettings(),
+      const SslClientCertSettings(),
     ];
 
     return SettingsSubPageScaffold(settings: advancedSettings);

--- a/mobile/lib/widgets/settings/ssl_client_cert_settings.dart
+++ b/mobile/lib/widgets/settings/ssl_client_cert_settings.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/utils/http_ssl_cert_override.dart';
+
+class SslClientCertSettings extends HookConsumerWidget {
+  const SslClientCertSettings({super.key});
+
+  void storeCert(BuildContext context, Uint8List data, String? passwd) {
+    if (passwd!.isEmpty) {
+      passwd = null;
+    }
+    final cert = SSLClientCertStoreVal(data, passwd);
+    cert.save();
+    HttpOverrides.global = HttpSSLCertOverride();
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        content: const Text("Imported Successfully"),
+        actions: [
+          TextButton(
+            onPressed: () => ctx.pop(),
+            child: const Text("OK"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void setPassword(BuildContext context, Uint8List data) {
+    final passwd = TextEditingController();
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        content: TextField(
+          controller: passwd,
+          obscureText: true,
+          obscuringCharacter: "*",
+          decoration: const InputDecoration(
+            hintText: "Enter password",
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => {ctx.pop(), storeCert(context, data, passwd.text)},
+            child: const Text("OK"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool certExist() {
+    return SSLClientCertStoreVal.load() != null;
+  }
+
+  Future<void> importCert(BuildContext ctx) async {
+    FilePickerResult? res = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: [
+        'p12',
+        'pfx',
+      ],
+    );
+    if (res != null) {
+      File file = File(res.files.single.path!);
+      final bytes = await file.readAsBytes();
+      setPassword(ctx, bytes);
+    }
+  }
+
+  void removeCert(BuildContext context) {
+    if (!certExist()) {
+      showDialog(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          content: const Text("No client certificate exist!"),
+          actions: [
+            TextButton(
+              onPressed: () => ctx.pop(),
+              child: const Text("OK"),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+    SSLClientCertStoreVal.delete();
+    HttpOverrides.global = HttpSSLCertOverride();
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        content: const Text("Client certificate is removed!"),
+        actions: [
+          TextButton(
+            onPressed: () => ctx.pop(),
+            child: const Text("OK"),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    bool isLoggedIn = ref.read(currentUserProvider) != null;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+      horizontalTitleGap: 20,
+      isThreeLine: true,
+      title: Text(
+        "TLS Client Certificate",
+        style: context.textTheme.bodyLarge?.copyWith(
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            "Supports PKCS12 (.p12, .pfx) format only. "
+            "Cert Import/Remove is available only before login",
+            style: context.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 6),
+          Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: isLoggedIn ? null : () => importCert(context),
+                child: const Text("Import"),
+              ),
+              const SizedBox(
+                width: 15,
+              ),
+              ElevatedButton(
+                onPressed: isLoggedIn ? null : () => removeCert(context),
+                child: const Text("Remove"),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   # easy to remove packages:
   image_picker: ^1.0.7 # only used to select user profile image from system gallery -> we can simply select an image from within immich?
   logging: ^1.2.0
+  file_picker: ^8.0.0+1
 
 # This is uncommented in F-Droid build script
 # Taken from https://github.com/Myzel394/locus/blob/445013d22ec1d759027d4303bd65b30c5c8588c8/pubspec.yaml#L105


### PR DESCRIPTION
This is to add an advanced setting in Immich mobile app to import TLS client certificate and private key.

Some users deploy Immich server behind a reverse web proxy server like nginx. Through setting up reverse proxy server, immich client could be asked a TLS/SSL client certificate for authentication. This can add an additional secure layer to protect Immich server behind a reverse proxy. 