### PR TITLE
chore(web): remove unnused property

### DIFF
--- a/web/src/lib/components/admin-page/jobs/jobs-panel.svelte
+++ b/web/src/lib/components/admin-page/jobs/jobs-panel.svelte
@@ -42,7 +42,6 @@
   const handleConfirmCommand = async (jobId: JobName, dto: JobCommandDto) => {
     if (dto.force) {
       const isConfirmed = await dialogController.show({
-        id: 'confirm-reprocess-all-faces',
         prompt: $t('admin.confirm_reprocess_all_faces'),
       });
 

--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -303,7 +303,6 @@
     }
 
     const isConfirmed = await dialogController.show({
-      id: 'delete-album',
       prompt: $t('album_delete_confirmation', { values: { album: albumToDelete.albumName } }),
     });
 

--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -66,7 +66,6 @@
 
   const handleMerge = async () => {
     const isConfirm = await dialogController.show({
-      id: 'merge-people',
       prompt: $t('merge_people_prompt'),
     });
 

--- a/web/src/lib/components/forms/edit-user-form.svelte
+++ b/web/src/lib/components/forms/edit-user-form.svelte
@@ -54,7 +54,6 @@
 
   const resetPassword = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'confirm-reset-password',
       prompt: $t('admin.confirm_user_password_reset', { values: { user: user.name } }),
     });
 

--- a/web/src/lib/components/photos-page/actions/remove-from-album.svelte
+++ b/web/src/lib/components/photos-page/actions/remove-from-album.svelte
@@ -19,7 +19,6 @@
 
   const removeFromAlbum = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'remove-from-album',
       prompt: $t('remove_assets_album_confirmation', { values: { count: getAssets().size } }),
     });
 

--- a/web/src/lib/components/photos-page/actions/remove-from-shared-link.svelte
+++ b/web/src/lib/components/photos-page/actions/remove-from-shared-link.svelte
@@ -15,7 +15,6 @@
 
   const handleRemove = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'remove-from-shared-link',
       title: $t('remove_assets_title'),
       prompt: $t('remove_assets_shared_link_confirmation', { values: { count: getAssets().size } }),
       confirmText: $t('remove'),

--- a/web/src/lib/components/shared-components/dialog/dialog.ts
+++ b/web/src/lib/components/shared-components/dialog/dialog.ts
@@ -6,7 +6,6 @@ type DialogActions = {
 };
 
 type DialogOptions = {
-  id?: string;
   title?: string;
   prompt?: string;
   confirmText?: string;
@@ -22,7 +21,7 @@ function createDialogWrapper() {
   const dialog = writable<Dialog | undefined>();
 
   async function show(options: DialogOptions) {
-    return new Promise((resolve) => {
+    return new Promise<boolean>((resolve) => {
       const newDialog: Dialog = {
         ...options,
         onConfirm: () => {

--- a/web/src/lib/components/user-settings-page/device-list.svelte
+++ b/web/src/lib/components/user-settings-page/device-list.svelte
@@ -16,7 +16,6 @@
 
   const handleDelete = async (device: SessionResponseDto) => {
     const isConfirmed = await dialogController.show({
-      id: 'log-out-device',
       prompt: $t('logout_this_device_confirmation'),
     });
 
@@ -35,11 +34,7 @@
   };
 
   const handleDeleteAll = async () => {
-    const isConfirmed = await dialogController.show({
-      id: 'log-out-all-devices',
-      prompt: $t('logout_all_device_confirmation'),
-    });
-
+    const isConfirmed = await dialogController.show({ prompt: $t('logout_all_device_confirmation') });
     if (!isConfirmed) {
       return;
     }

--- a/web/src/lib/components/user-settings-page/partner-settings.svelte
+++ b/web/src/lib/components/user-settings-page/partner-settings.svelte
@@ -78,7 +78,6 @@
 
   const handleRemovePartner = async (partner: PartnerResponseDto) => {
     const isConfirmed = await dialogController.show({
-      id: 'remove-partner',
       title: $t('stop_photo_sharing'),
       prompt: $t('stop_photo_sharing_description', { values: { partner: partner.name } }),
     });

--- a/web/src/lib/components/user-settings-page/user-api-key-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-api-key-list.svelte
@@ -60,11 +60,7 @@
   };
 
   const handleDelete = async (key: ApiKeyResponseDto) => {
-    const isConfirmed = await dialogController.show({
-      id: 'delete-api-key',
-      prompt: $t('delete_api_key_prompt'),
-    });
-
+    const isConfirmed = await dialogController.show({ prompt: $t('delete_api_key_prompt') });
     if (!isConfirmed) {
       return;
     }

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -340,7 +340,6 @@
 
   const handleRemoveAlbum = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'remove-album',
       prompt: $t('album_delete_confirmation', { values: { album: album.albumName } }),
     });
 

--- a/web/src/routes/(user)/sharing/sharedlinks/+page.svelte
+++ b/web/src/routes/(user)/sharing/sharedlinks/+page.svelte
@@ -31,7 +31,6 @@
 
   const handleDeleteLink = async (id: string) => {
     const isConfirmed = await dialogController.show({
-      id: 'delete-shared-link',
       title: $t('delete_shared_link'),
       prompt: $t('confirm_delete_shared_link'),
       confirmText: $t('delete'),

--- a/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -36,7 +36,6 @@
 
   const handleEmptyTrash = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'empty-trash',
       prompt: $t('empty_trash_confirmation'),
     });
 
@@ -62,7 +61,6 @@
 
   const handleRestoreTrash = async () => {
     const isConfirmed = await dialogController.show({
-      id: 'restore-trash',
       prompt: $t('assets_restore_confirmation'),
     });
 

--- a/web/src/routes/admin/library-management/+page.svelte
+++ b/web/src/routes/admin/library-management/+page.svelte
@@ -268,7 +268,6 @@
     }
 
     const isConfirmedLibrary = await dialogController.show({
-      id: 'delete-library',
       prompt: $t('admin.confirm_delete_library', { values: { library: library.name } }),
     });
 
@@ -281,7 +280,6 @@
       deleteAssetCount = totalCount[index];
 
       const isConfirmedLibraryAssetCount = await dialogController.show({
-        id: 'delete-library-assets',
         prompt: $t('admin.confirm_delete_library_assets', { values: { count: deleteAssetCount } }),
       });
 


### PR DESCRIPTION
The dialog store is a proxy for the `DialogWrapper` component, which is a wrapper around the `ConfirmDialog` component, which removed the `id` property in #9932. Since `id` isn't an export it isn't doing anything anymore.