### PR TITLE
fix(server): face search migration sometimes failing

### DIFF
--- a/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
+++ b/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
@@ -9,26 +9,22 @@ export class AddFaceSearchRelation1718486162779 implements MigrationInterface {
       await queryRunner.query(`SET vectors.pgvector_compatibility=on`);
     }
 
+    await queryRunner.query(`ALTER TABLE asset_faces ADD COLUMN IF NOT EXISTS embedding vector(512)`);
+    await queryRunner.query(`ALTER TABLE smart_search ADD COLUMN IF NOT EXISTS embedding vector(512) NOT NULL`);
+
     await queryRunner.query(`
       CREATE TABLE face_search (
       "faceId"  uuid PRIMARY KEY REFERENCES asset_faces(id) ON DELETE CASCADE,
       embedding  vector(512) NOT NULL )`);
 
     await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
-    await queryRunner.query(`ALTER TABLE smart_search ADD COLUMN IF NOT EXISTS embedding vector(512)`);
     await queryRunner.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
 
-    const assetFacesColumns = await queryRunner.query(
-      `SELECT column_name as name
-      FROM information_schema.columns
-      WHERE table_name = 'asset_faces'`);
-    const hasFaceEmbeddings = assetFacesColumns.some((column: { name: string }) => column.name === 'embedding');
-    if (hasFaceEmbeddings) {
-      await queryRunner.query(`
-        INSERT INTO face_search("faceId", embedding)
-        SELECT id, embedding
-        FROM asset_faces faces`);
-    }
+    await queryRunner.query(`
+      INSERT INTO face_search("faceId", embedding)
+      SELECT id, embedding
+      FROM asset_faces faces
+      WHERE faces.embedding IS NOT NULL`);
 
     await queryRunner.query(`ALTER TABLE asset_faces DROP COLUMN IF EXISTS embedding`);
 

--- a/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
+++ b/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
@@ -24,6 +24,9 @@ export class AddFaceSearchRelation1718486162779 implements MigrationInterface {
 
     await queryRunner.query(`ALTER TABLE asset_faces DROP COLUMN "embedding"`);
 
+    await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET DATA TYPE real[]`);
+    await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET DATA TYPE vector(512)`);
+
     await queryRunner.query(`
             CREATE INDEX face_index ON face_search
             USING hnsw (embedding vector_cosine_ops)

--- a/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
+++ b/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
@@ -15,6 +15,7 @@ export class AddFaceSearchRelation1718486162779 implements MigrationInterface {
             embedding  vector(512) NOT NULL )`);
 
     await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
+    await queryRunner.query(`ALTER TABLE smart_search ADD COLUMN IF NOT EXISTS embedding vector(512)`);
     await queryRunner.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
 
     await queryRunner.query(`
@@ -26,6 +27,11 @@ export class AddFaceSearchRelation1718486162779 implements MigrationInterface {
 
     await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET DATA TYPE real[]`);
     await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET DATA TYPE vector(512)`);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS clip_index ON smart_search
+      USING hnsw (embedding vector_cosine_ops)
+      WITH (ef_construction = 300, m = 16)`);
 
     await queryRunner.query(`
             CREATE INDEX face_index ON face_search

--- a/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
+++ b/server/src/migrations/1718486162779-AddFaceSearchRelation.ts
@@ -9,22 +9,26 @@ export class AddFaceSearchRelation1718486162779 implements MigrationInterface {
       await queryRunner.query(`SET vectors.pgvector_compatibility=on`);
     }
 
-    await queryRunner.query(`ALTER TABLE asset_faces ADD COLUMN IF NOT EXISTS embedding vector(512)`);
-    await queryRunner.query(`ALTER TABLE smart_search ADD COLUMN IF NOT EXISTS embedding vector(512) NOT NULL`);
-
     await queryRunner.query(`
       CREATE TABLE face_search (
       "faceId"  uuid PRIMARY KEY REFERENCES asset_faces(id) ON DELETE CASCADE,
       embedding  vector(512) NOT NULL )`);
 
     await queryRunner.query(`ALTER TABLE face_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
+    await queryRunner.query(`ALTER TABLE smart_search ADD COLUMN IF NOT EXISTS embedding vector(512)`);
     await queryRunner.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET STORAGE EXTERNAL`);
 
-    await queryRunner.query(`
-      INSERT INTO face_search("faceId", embedding)
-      SELECT id, embedding
-      FROM asset_faces faces
-      WHERE faces.embedding IS NOT NULL`);
+    const assetFacesColumns = await queryRunner.query(
+      `SELECT column_name as name
+      FROM information_schema.columns
+      WHERE table_name = 'asset_faces'`);
+    const hasFaceEmbeddings = assetFacesColumns.some((column: { name: string }) => column.name === 'embedding');
+    if (hasFaceEmbeddings) {
+      await queryRunner.query(`
+        INSERT INTO face_search("faceId", embedding)
+        SELECT id, embedding
+        FROM asset_faces faces`);
+    }
 
     await queryRunner.query(`ALTER TABLE asset_faces DROP COLUMN IF EXISTS embedding`);
 


### PR DESCRIPTION
## Description

There can be an edge case that causes index creation to fail. Switching the data type to a basic real array and back to the vector type fixes this. Additionally handles not having an `embedding` column as there are a number of people who don't have it.

Tested by using an old DB, dropping the embedding columns of `asset_faces` and `smart_search` and confirming that the server was able to start up. The tables look correct in DataGrip. However, the `face_search` and `smart_search` tables in this case are empty (as expected), but I haven't tested that the migration still copies face embeddings in the typical case. It should, but as this is a sensitive area it should be explicitly tested.