### PR TITLE
fix(web): download archive for public user

### DIFF
--- a/e2e/src/web/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/web/specs/shared-link.e2e-spec.ts
@@ -51,6 +51,13 @@ test.describe('Shared Links', () => {
     await page.getByText('DOWNLOADING', { exact: true }).waitFor();
   });
 
+  test('download all from shared link', async ({ page }) => {
+    await page.goto(`/share/${sharedLink.key}`);
+    await page.getByRole('heading', { name: 'Test Album' }).waitFor();
+    await page.getByRole('button', { name: 'Download' }).click();
+    await page.getByText('DOWNLOADING', { exact: true }).waitFor();
+  });
+
   test('enter password for a shared link', async ({ page }) => {
     await page.goto(`/share/${sharedLinkPassword.key}`);
     await page.getByPlaceholder('Password').fill('test-password');

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -21,6 +21,7 @@ import {
   type AssetResponseDto,
   type AssetTypeEnum,
   type DownloadInfoDto,
+  type UserPreferencesResponseDto,
   type UserResponseDto,
 } from '@immich/sdk';
 import { DateTime } from 'luxon';
@@ -100,8 +101,8 @@ export const downloadBlob = (data: Blob, filename: string) => {
 };
 
 export const downloadArchive = async (fileName: string, options: Omit<DownloadInfoDto, 'archiveSize'>) => {
-  const $preferences = get(preferences);
-  const dto = { ...options, archiveSize: $preferences.download.archiveSize };
+  const $preferences = get<UserPreferencesResponseDto | undefined>(preferences);
+  const dto = { ...options, archiveSize: $preferences?.download.archiveSize };
 
   const [error, downloadInfo] = await withError(() => getDownloadInfo({ downloadInfoDto: dto, key: getKey() }));
   if (error) {


### PR DESCRIPTION
Preferences aren't loaded for public users and they will be `undefined` causing an error. Fixes #10874