### PR TITLE
fix(web): duplicate thumbnail cover full width

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -21,11 +21,11 @@
     ? 'bg-immich-primary dark:bg-immich-dark-primary border-immich-primary dark:border-immich-dark-primary'
     : 'bg-gray-200 dark:bg-gray-800 border-gray-200 dark:border-gray-800'}"
 >
-  <div class="relative">
+  <div class="relative w-full">
     <button
       type="button"
       on:click={() => onSelectAsset(asset)}
-      class="block relative"
+      class="block relative w-full"
       aria-pressed={isSelected}
       aria-label={$t('keep')}
     >
@@ -34,7 +34,7 @@
         src={getAssetThumbnailUrl(asset.id)}
         alt={getAltText(asset)}
         title={assetData}
-        class="h-60 object-cover rounded-t-xl"
+        class="h-60 object-cover rounded-t-xl w-full"
         draggable="false"
       />
 


### PR DESCRIPTION
Make sure the thumbnail covers the entire width

| Before | After |
| ------ | ----- |
| ![duplicate-card-before](https://github.com/immich-app/immich/assets/59014050/8954ee3b-d179-4aaf-8d07-40254708a084) | ![duplicate-card-after](https://github.com/immich-app/immich/assets/59014050/332b7976-89c5-4af3-a3f0-faa3080d21d7) |
