### PR TITLE
refactor(server): bulk interface

### DIFF
--- a/server/src/interfaces/album.interface.ts
+++ b/server/src/interfaces/album.interface.ts
@@ -28,10 +28,8 @@ export interface IAlbumRepository extends IBulkAsset {
   getById(id: string, options: AlbumInfoOptions): Promise<AlbumEntity | null>;
   getByIds(ids: string[]): Promise<AlbumEntity[]>;
   getByAssetId(ownerId: string, assetId: string): Promise<AlbumEntity[]>;
-  getAssetIds(albumId: string, assetIds?: string[]): Promise<Set<string>>;
   hasAsset(asset: AlbumAsset): Promise<boolean>;
   removeAsset(assetId: string): Promise<void>;
-  removeAssetIds(albumId: string, assetIds: string[]): Promise<void>;
   getMetadataForIds(ids: string[]): Promise<AlbumAssetCount[]>;
   getInvalidThumbnail(): Promise<string[]>;
   getOwned(ownerId: string): Promise<AlbumEntity[]>;

--- a/server/src/interfaces/memory.interface.ts
+++ b/server/src/interfaces/memory.interface.ts
@@ -1,14 +1,12 @@
 import { MemoryEntity } from 'src/entities/memory.entity';
+import { IBulkAsset } from 'src/utils/asset.util';
 
 export const IMemoryRepository = 'IMemoryRepository';
 
-export interface IMemoryRepository {
+export interface IMemoryRepository extends IBulkAsset {
   search(ownerId: string): Promise<MemoryEntity[]>;
   get(id: string): Promise<MemoryEntity | null>;
   create(memory: Partial<MemoryEntity>): Promise<MemoryEntity>;
   update(memory: Partial<MemoryEntity>): Promise<MemoryEntity>;
   delete(id: string): Promise<void>;
-  getAssetIds(id: string, assetIds: string[]): Promise<Set<string>>;
-  addAssetIds(id: string, assetIds: string[]): Promise<void>;
-  removeAssetIds(id: string, assetIds: string[]): Promise<void>;
 }

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -585,14 +585,6 @@ WHERE
   "albums_assets"."albumsId" = $1
   AND "albums_assets"."assetsId" IN ($2)
 
--- AlbumRepository.getAssetIds (no assets)
-SELECT
-  "albums_assets"."assetsId" AS "assetId"
-FROM
-  "albums_assets_assets" "albums_assets"
-WHERE
-  "albums_assets"."albumsId" = $1
-
 -- AlbumRepository.hasAsset
 SELECT
   1 AS "row_exists"

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import _ from 'lodash';
-import { Chunked, ChunkedArray, DATABASE_PARAMETER_CHUNK_SIZE, DummyValue, GenerateSql } from 'src/decorators';
+import { Chunked, ChunkedArray, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AssetEntity } from 'src/entities/asset.entity';
 import { AlbumAsset, AlbumAssetCount, AlbumInfoOptions, IAlbumRepository } from 'src/interfaces/album.interface';
 import { Instrumentation } from 'src/utils/instrumentation';
-import { setUnion } from 'src/utils/set';
 import { DataSource, FindOptionsOrder, FindOptionsRelations, In, IsNull, Not, Repository } from 'typeorm';
 
 const withoutDeletedUsers = <T extends AlbumEntity | null>(album: T) => {
@@ -215,6 +213,10 @@ export class AlbumRepository implements IAlbumRepository {
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
   @Chunked({ paramIndex: 1 })
   async removeAssetIds(albumId: string, assetIds: string[]): Promise<void> {
+    if (assetIds.length === 0) {
+      return;
+    }
+
     await this.dataSource
       .createQueryBuilder()
       .delete()
@@ -233,27 +235,22 @@ export class AlbumRepository implements IAlbumRepository {
    * @param assetIds Optional list of asset IDs to filter on.
    * @returns Set of Asset IDs for the given album ID.
    */
-  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] }, { name: 'no assets', params: [DummyValue.UUID] })
-  async getAssetIds(albumId: string, assetIds?: string[]): Promise<Set<string>> {
-    const query = this.dataSource
+  @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
+  @ChunkedSet({ paramIndex: 1 })
+  async getAssetIds(albumId: string, assetIds: string[]): Promise<Set<string>> {
+    if (assetIds.length === 0) {
+      return new Set();
+    }
+
+    const results = await this.dataSource
       .createQueryBuilder()
       .select('albums_assets.assetsId', 'assetId')
       .from('albums_assets_assets', 'albums_assets')
-      .where('"albums_assets"."albumsId" = :albumId', { albumId });
+      .where('"albums_assets"."albumsId" = :albumId', { albumId })
+      .andWhere('"albums_assets"."assetsId" IN (:...assetIds)', { assetIds })
+      .getRawMany<{ assetId: string }>();
 
-    if (!assetIds?.length) {
-      const result = await query.getRawMany();
-      return new Set(result.map((row) => row['assetId']));
-    }
-
-    return Promise.all(
-      _.chunk(assetIds, DATABASE_PARAMETER_CHUNK_SIZE).map((idChunk) =>
-        query
-          .andWhere('"albums_assets"."assetsId" IN (:...assetIds)', { assetIds: idChunk })
-          .getRawMany()
-          .then((result) => new Set(result.map((row) => row['assetId']))),
-      ),
-    ).then((results) => setUnion(...results));
+    return new Set(results.map(({ assetId }) => assetId));
   }
 
   @GenerateSql({ params: [{ albumId: DummyValue.UUID, assetId: DummyValue.UUID }] })

--- a/server/src/repositories/memory.repository.ts
+++ b/server/src/repositories/memory.repository.ts
@@ -61,9 +61,9 @@ export class MemoryRepository implements IMemoryRepository {
       .from('memories_assets_assets', 'memories_assets')
       .where('"memories_assets"."memoriesId" = :memoryId', { memoryId: id })
       .andWhere('memories_assets.assetsId IN (:...assetIds)', { assetIds })
-      .getRawMany();
+      .getRawMany<{ assetId: string }>();
 
-    return new Set(results.map((row) => row['assetId']));
+    return new Set(results.map(({ assetId }) => assetId));
   }
 
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })


### PR DESCRIPTION
- Fix incorrect types
- Move all `addAssetIds`, `removeAssetIds`, and `getAssetIds` interface definintions/usages to the `IBulkAsset` interface itself.