### PR TITLE
fix(server): do not try to upgrade to an older version

### DIFF
--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -150,6 +150,7 @@ describe(DatabaseService.name, () => {
   for (const version of ['0.2.1', '0.2.0', '0.2.9']) {
     it(`should update the pgvecto.rs extension to ${version}`, async () => {
       databaseMock.getAvailableExtensionVersion.mockResolvedValue(version);
+      databaseMock.getExtensionVersion.mockResolvedValueOnce(void 0);
       databaseMock.getExtensionVersion.mockResolvedValue(version);
 
       await expect(sut.onBootstrapEvent()).resolves.toBeUndefined();
@@ -166,6 +167,7 @@ describe(DatabaseService.name, () => {
     it(`should update the pgvectors extension to ${version}`, async () => {
       process.env.DB_VECTOR_EXTENSION = 'pgvector';
       databaseMock.getAvailableExtensionVersion.mockResolvedValue(version);
+      databaseMock.getExtensionVersion.mockResolvedValueOnce(void 0);
       databaseMock.getExtensionVersion.mockResolvedValue(version);
 
       await expect(sut.onBootstrapEvent()).resolves.toBeUndefined();
@@ -190,10 +192,10 @@ describe(DatabaseService.name, () => {
     });
   }
 
-  for (const version of ['0.4.0', '1.0.0']) {
+  for (const version of ['0.4.0', '0.7.1', '0.7.2', '1.0.0']) {
     it(`should not upgrade pgvector to ${version}`, async () => {
       process.env.DB_VECTOR_EXTENSION = 'pgvector';
-      databaseMock.getExtensionVersion.mockResolvedValue('0.5.0');
+      databaseMock.getExtensionVersion.mockResolvedValue('0.7.2');
       databaseMock.getAvailableExtensionVersion.mockResolvedValue(version);
 
       await expect(sut.onBootstrapEvent()).resolves.toBeUndefined();

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -98,8 +98,10 @@ export class DatabaseService implements OnEvents {
         throw error;
       }
 
+      const initialVersion = await this.databaseRepository.getExtensionVersion(extension);
       const availableVersion = await this.databaseRepository.getAvailableExtensionVersion(extension);
-      if (availableVersion && semver.satisfies(availableVersion, extensionRange)) {
+      const isAvailable = availableVersion && semver.satisfies(availableVersion, extensionRange);
+      if (isAvailable && (!initialVersion || semver.gt(availableVersion, initialVersion))) {
         try {
           this.logger.log(`Updating ${name} extension to ${availableVersion}`);
           const { restartRequired } = await this.databaseRepository.updateVectorExtension(extension, availableVersion);


### PR DESCRIPTION
Only try upgrading if the new version matches the range AND either (1) no previous version is installed (2) new version is newer than current version.

Fixes #10886