### PR TITLE
ci: Provide geonames database as GitHub release asset

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: write
   packages: write
 
 jobs:
@@ -119,6 +120,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          load: ${{ github.event_name == 'release' }}
           platforms: ${{ matrix.platforms }}
           # Skip pushing when PR from a fork
           push: ${{ !github.event.pull_request.head.repo.fork }}
@@ -132,3 +134,16 @@ jobs:
             BUILD_IMAGE=${{ github.event_name == 'release' && github.ref_name || steps.metadata.outputs.tags }}
             BUILD_SOURCE_REF=${{ github.ref_name }}
             BUILD_SOURCE_COMMIT=${{ github.sha }}
+
+      - name: Extract geodata
+        if: ${{ github.event_name == 'release' && matrix.image == 'immich-server' }}
+        run: |
+          id="$(docker create ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.ref_name }})"
+          docker cp "$id":/usr/bin/resources geodata
+          zip -r geodata.zip geodata
+
+      - name: Upload geodata as release asset
+        if: ${{ github.event_name == 'release' && matrix.image == 'immich-server' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          files: geodata.zip


### PR DESCRIPTION
As discussed on Discord, this adds an archive containing the geonames database at the time of release as release asset.
This is useful for reproducible builds such as on NixOS.