### PR TITLE
fix(web): external library disk usage unit

### DIFF
--- a/web/src/routes/admin/library-management/+page.svelte
+++ b/web/src/routes/admin/library-management/+page.svelte
@@ -337,7 +337,7 @@
                   <td class=" text-ellipsis px-4 text-sm">
                     {totalCount[index]}
                   </td>
-                  <td class=" text-ellipsis px-4 text-sm">{diskUsage[index]} {diskUsageUnit[index]}</td>
+                  <td class=" text-ellipsis px-4 text-sm"> {diskUsage[index]} {ByteUnit[diskUsageUnit[index]]}</td>
                 {/if}
 
                 <td class=" text-ellipsis px-4 text-sm">


### PR DESCRIPTION
Show unit text instead of enum value, fixes #10927