### PR TITLE
fix(server): reset-admin-password command

### DIFF
--- a/e2e/src/immich-admin/specs/immich-admin.e2e-spec.ts
+++ b/e2e/src/immich-admin/specs/immich-admin.e2e-spec.ts
@@ -9,11 +9,30 @@ describe(`immich-admin`, () => {
 
   describe('list-users', () => {
     it('should list the admin user', async () => {
-      const { stdout, stderr, exitCode } = await immichAdmin(['list-users']);
+      const { stdout, stderr, exitCode } = await immichAdmin(['list-users']).promise;
       expect(exitCode).toBe(0);
       expect(stderr).toBe('');
       expect(stdout).toContain("email: 'admin@immich.cloud'");
       expect(stdout).toContain("name: 'Immich Admin'");
+    });
+  });
+
+  describe('reset-admin-password', () => {
+    it('should reset admin password', async () => {
+      const { child, promise } = immichAdmin(['reset-admin-password']);
+
+      let data = '';
+      child.stdout.on('data', (chunk) => {
+        data += chunk;
+        if (data.includes('Please choose a new password (optional)')) {
+          child.stdin.end('\n');
+        }
+      });
+
+      const { stderr, stdout, exitCode } = await promise;
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).toContain('The admin password has been updated to:');
     });
   });
 });

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -64,7 +64,7 @@ export const tempDir = tmpdir();
 export const asBearerAuth = (accessToken: string) => ({ Authorization: `Bearer ${accessToken}` });
 export const asKeyAuth = (key: string) => ({ 'x-api-key': key });
 export const immichCli = (args: string[]) =>
-  executeCommand('node', ['node_modules/.bin/immich', '-d', `/${tempDir}/immich/`, ...args]);
+  executeCommand('node', ['node_modules/.bin/immich', '-d', `/${tempDir}/immich/`, ...args]).promise;
 export const immichAdmin = (args: string[]) =>
   executeCommand('docker', ['exec', '-i', 'immich-e2e-server', '/bin/bash', '-c', `immich-admin ${args.join(' ')}`]);
 

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -70,7 +70,7 @@ export const immichAdmin = (args: string[]) =>
 
 const executeCommand = (command: string, args: string[]) => {
   let _resolve: (value: CommandResponse) => void;
-  const deferred = new Promise<CommandResponse>((resolve) => (_resolve = resolve));
+  const promise = new Promise<CommandResponse>((resolve) => (_resolve = resolve));
   const child = spawn(command, args, { stdio: 'pipe' });
 
   let stdout = '';
@@ -86,7 +86,7 @@ const executeCommand = (command: string, args: string[]) => {
     });
   });
 
-  return deferred;
+  return { promise, child };
 };
 
 let client: pg.Client | null = null;

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -140,7 +140,7 @@ export class UserAdminResponseDto extends UserResponseDto {
 }
 
 export function mapUserAdmin(entity: UserEntity): UserAdminResponseDto {
-  const license = entity.metadata.find(
+  const license = entity.metadata?.find(
     (item): item is UserMetadataEntity<UserMetadataKey.LICENSE> => item.key === UserMetadataKey.LICENSE,
   )?.value;
   return {


### PR DESCRIPTION
The `reset-admin-password` command calls `mapUserAdmin`, but the user doesn't include metadata and will cause an error. Fixes #10865