### PR TITLE
chore(mobile): update photo_manager dep

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -167,7 +167,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
-  photo_manager: 4f6810b7dfc4feb03b461ac1a70dacf91fba7604
+  photo_manager: ff695c7a1dd5bc379974953a2b5c0a293f7c4c8a
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1162,10 +1162,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: "8cf79918f6de9843b394a1670fe1aec54ebcac852b4b4c9ef88211894547dc61"
+      sha256: "68d6099d07ce5033170f8368af8128a4555cf1d590a97242f83669552de989b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev.5"
+    version: "3.2.0"
   photo_manager_image_provider:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   path_provider_ios:
   # TODO: upgrade to stable after 3.0.1 is released. 3.0.0 is broken
   # https://github.com/fluttercandies/flutter_photo_manager/pull/990#issuecomment-2058066427
-  photo_manager: ^3.0.0-dev.5
+  photo_manager: ^3.2.0
   photo_manager_image_provider: ^2.1.0
   flutter_hooks: ^0.20.4
   hooks_riverpod: ^2.4.9


### PR DESCRIPTION
Update `photo_manager` package.

- LivePhotos are uploaded with correct name
- Albums are retrieved successfully on iOS (iPhone 15), Android (Samsung S23, Pixel 8a)
- Media are displayed correctly on iOS (iPhone 15), Android (Samsung S23, Pixel 8a)
- Potentially fix a crashing issue with retrieving and uploading iCloud media on iOS

![image](https://github.com/immich-app/immich/assets/27055614/e81805f6-e4fd-4806-bcc5-2ced9bde86ae)
