### PR TITLE
fix(doc): Fix broken link in Cursed Knowledge doc

### DIFF
--- a/docs/src/pages/cursed-knowledge.tsx
+++ b/docs/src/pages/cursed-knowledge.tsx
@@ -49,7 +49,7 @@ const items: Item[] = [
     iconColor: 'greenyellow',
     title: 'JavaScript Date objects are cursed',
     description: 'JavaScript date objects are 1 indexed for years and days, but 0 indexed for months.',
-    link: { url: 'https://github.com/immich-app/immich/pulls/6787', text: '#6787' },
+    link: { url: 'https://github.com/immich-app/immich/pull/6787', text: '#6787' },
     date: new Date(2024, 0, 31),
   },
 ];


### PR DESCRIPTION
I think this link in [Cursed Knowledge](https://immich.app/cursed-knowledge/) is supposed to point at #6787, rather than a blank search page.