### PR TITLE
feat(server): conditionally run facial recognition nightly

### DIFF
--- a/server/src/entities/system-metadata.entity.ts
+++ b/server/src/entities/system-metadata.entity.ts
@@ -12,6 +12,7 @@ export class SystemMetadataEntity<T extends keyof SystemMetadata = SystemMetadat
 
 export enum SystemMetadataKey {
   REVERSE_GEOCODING_STATE = 'reverse-geocoding-state',
+  FACIAL_RECOGNITION_STATE = 'facial-recognition-state',
   ADMIN_ONBOARDING = 'admin-onboarding',
   SYSTEM_CONFIG = 'system-config',
   VERSION_CHECK_STATE = 'version-check-state',
@@ -22,6 +23,7 @@ export type VersionCheckMetadata = { checkedAt: string; releaseVersion: string }
 
 export interface SystemMetadata extends Record<SystemMetadataKey, Record<string, any>> {
   [SystemMetadataKey.REVERSE_GEOCODING_STATE]: { lastUpdate?: string; lastImportFileName?: string };
+  [SystemMetadataKey.FACIAL_RECOGNITION_STATE]: { lastRun?: Date };
   [SystemMetadataKey.ADMIN_ONBOARDING]: { isOnboarded: boolean };
   [SystemMetadataKey.SYSTEM_CONFIG]: DeepPartial<SystemConfig>;
   [SystemMetadataKey.VERSION_CHECK_STATE]: VersionCheckMetadata;

--- a/server/src/entities/system-metadata.entity.ts
+++ b/server/src/entities/system-metadata.entity.ts
@@ -23,7 +23,7 @@ export type VersionCheckMetadata = { checkedAt: string; releaseVersion: string }
 
 export interface SystemMetadata extends Record<SystemMetadataKey, Record<string, any>> {
   [SystemMetadataKey.REVERSE_GEOCODING_STATE]: { lastUpdate?: string; lastImportFileName?: string };
-  [SystemMetadataKey.FACIAL_RECOGNITION_STATE]: { lastRun?: Date };
+  [SystemMetadataKey.FACIAL_RECOGNITION_STATE]: { lastRun?: string };
   [SystemMetadataKey.ADMIN_ONBOARDING]: { isOnboarded: boolean };
   [SystemMetadataKey.SYSTEM_CONFIG]: DeepPartial<SystemConfig>;
   [SystemMetadataKey.VERSION_CHECK_STATE]: VersionCheckMetadata;

--- a/server/src/interfaces/job.interface.ts
+++ b/server/src/interfaces/job.interface.ts
@@ -153,6 +153,10 @@ export interface IDeferrableJob extends IEntityJob {
   deferred?: boolean;
 }
 
+export interface INightlyJob extends IBaseJob {
+  nightly?: boolean;
+}
+
 export interface IEmailJob {
   to: string;
   subject: string;
@@ -229,7 +233,7 @@ export type JobItem =
   // Facial Recognition
   | { name: JobName.QUEUE_FACE_DETECTION; data: IBaseJob }
   | { name: JobName.FACE_DETECTION; data: IEntityJob }
-  | { name: JobName.QUEUE_FACIAL_RECOGNITION; data: IBaseJob }
+  | { name: JobName.QUEUE_FACIAL_RECOGNITION; data: INightlyJob }
   | { name: JobName.FACIAL_RECOGNITION; data: IDeferrableJob }
   | { name: JobName.GENERATE_PERSON_THUMBNAIL; data: IEntityJob }
 

--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -64,4 +64,5 @@ export interface IPersonRepository {
   getNumberOfPeople(userId: string): Promise<PeopleStatistics>;
   reassignFaces(data: UpdateFacesData): Promise<number>;
   update(entity: Partial<PersonEntity>): Promise<PersonEntity>;
+  getLatestFaceDate(): Promise<Date | undefined>;
 }

--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -64,5 +64,5 @@ export interface IPersonRepository {
   getNumberOfPeople(userId: string): Promise<PeopleStatistics>;
   reassignFaces(data: UpdateFacesData): Promise<number>;
   update(entity: Partial<PersonEntity>): Promise<PersonEntity>;
-  getLatestFaceDate(): Promise<Date | undefined>;
+  getLatestFaceDate(): Promise<string | undefined>;
 }

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -434,3 +434,9 @@ WHERE
   (("AssetFaceEntity"."personId" = $1))
 LIMIT
   1
+
+-- PersonRepository.getLatestFaceDate
+SELECT
+  MAX("jobStatus"."facesRecognizedAt") AS "latestDate"
+FROM
+  "asset_job_status" "jobStatus"

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -437,6 +437,6 @@ LIMIT
 
 -- PersonRepository.getLatestFaceDate
 SELECT
-  MAX("jobStatus"."facesRecognizedAt") AS "latestDate"
+  MAX("jobStatus"."facesRecognizedAt")::text AS "latestDate"
 FROM
   "asset_job_status" "jobStatus"

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import _ from 'lodash';
 import { ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
+import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
 import { AssetEntity } from 'src/entities/asset.entity';
 import { PersonEntity } from 'src/entities/person.entity';
 import {
@@ -25,6 +26,7 @@ export class PersonRepository implements IPersonRepository {
     @InjectRepository(AssetEntity) private assetRepository: Repository<AssetEntity>,
     @InjectRepository(PersonEntity) private personRepository: Repository<PersonEntity>,
     @InjectRepository(AssetFaceEntity) private assetFaceRepository: Repository<AssetFaceEntity>,
+    @InjectRepository(AssetJobStatusEntity) private jobStatusRepository: Repository<AssetJobStatusEntity>,
   ) {}
 
   @GenerateSql({ params: [{ oldPersonId: DummyValue.UUID, newPersonId: DummyValue.UUID }] })
@@ -266,5 +268,14 @@ export class PersonRepository implements IPersonRepository {
   @GenerateSql({ params: [DummyValue.UUID] })
   async getRandomFace(personId: string): Promise<AssetFaceEntity | null> {
     return this.assetFaceRepository.findOneBy({ personId });
+  }
+
+  @GenerateSql()
+  async getLatestFaceDate(): Promise<Date | undefined> {
+    const result: { latestDate?: Date } | undefined = await this.jobStatusRepository
+      .createQueryBuilder('jobStatus')
+      .select('MAX(jobStatus.facesRecognizedAt)', 'latestDate')
+      .getRawOne();
+    return result?.latestDate;
   }
 }

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -271,10 +271,10 @@ export class PersonRepository implements IPersonRepository {
   }
 
   @GenerateSql()
-  async getLatestFaceDate(): Promise<Date | undefined> {
-    const result: { latestDate?: Date } | undefined = await this.jobStatusRepository
+  async getLatestFaceDate(): Promise<string | undefined> {
+    const result: { latestDate?: string } | undefined = await this.jobStatusRepository
       .createQueryBuilder('jobStatus')
-      .select('MAX(jobStatus.facesRecognizedAt)', 'latestDate')
+      .select('MAX(jobStatus.facesRecognizedAt)::text', 'latestDate')
       .getRawOne();
     return result?.latestDate;
   }

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -71,7 +71,7 @@ describe(JobService.name, () => {
         { name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } },
         { name: JobName.CLEAN_OLD_AUDIT_LOGS },
         { name: JobName.USER_SYNC_USAGE },
-        { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false } },
+        { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false, nightly: true } },
         { name: JobName.CLEAN_OLD_SESSION_TOKENS },
       ]);
     });

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -210,7 +210,7 @@ export class JobService {
       { name: JobName.QUEUE_GENERATE_THUMBNAILS, data: { force: false } },
       { name: JobName.CLEAN_OLD_AUDIT_LOGS },
       { name: JobName.USER_SYNC_USAGE },
-      { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false } },
+      { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false, nightly: true } },
       { name: JobName.CLEAN_OLD_SESSION_TOKENS },
     ]);
   }

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -568,7 +568,7 @@ describe(PersonService.name, () => {
         },
       ]);
       expect(systemMock.set).toHaveBeenCalledWith(SystemMetadataKey.FACIAL_RECOGNITION_STATE, {
-        lastRun: expect.any(Date),
+        lastRun: expect.any(String),
       });
     });
 
@@ -593,7 +593,7 @@ describe(PersonService.name, () => {
         },
       ]);
       expect(systemMock.set).toHaveBeenCalledWith(SystemMetadataKey.FACIAL_RECOGNITION_STATE, {
-        lastRun: expect.any(Date),
+        lastRun: expect.any(String),
       });
     });
 
@@ -624,7 +624,7 @@ describe(PersonService.name, () => {
         },
       ]);
       expect(systemMock.set).toHaveBeenCalledWith(SystemMetadataKey.FACIAL_RECOGNITION_STATE, {
-        lastRun: expect.any(Date),
+        lastRun: expect.any(String),
       });
     });
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -598,7 +598,7 @@ describe(PersonService.name, () => {
     });
 
     it('should run nightly if new face has been added since last run', async () => {
-      personMock.getLatestFaceDate.mockResolvedValue(new Date());
+      personMock.getLatestFaceDate.mockResolvedValue(new Date().toISOString());
       personMock.getAllFaces.mockResolvedValue({
         items: [faceStub.face1],
         hasNextPage: false,
@@ -631,8 +631,8 @@ describe(PersonService.name, () => {
     it('should skip nightly if no new face has been added since last run', async () => {
       const lastRun = new Date();
 
-      systemMock.get.mockResolvedValue({ lastRun });
-      personMock.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1));
+      systemMock.get.mockResolvedValue({ lastRun: lastRun.toISOString() });
+      personMock.getLatestFaceDate.mockResolvedValue(new Date(lastRun.getTime() - 1).toISOString());
       personMock.getAllFaces.mockResolvedValue({
         items: [faceStub.face1],
         hasNextPage: false,

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -26,6 +26,7 @@ import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetEntity, AssetType } from 'src/entities/asset.entity';
 import { PersonPathType } from 'src/entities/move.entity';
 import { PersonEntity } from 'src/entities/person.entity';
+import { SystemMetadataKey } from 'src/entities/system-metadata.entity';
 import { IAccessRepository } from 'src/interfaces/access.interface';
 import { IAssetRepository, WithoutProperty } from 'src/interfaces/asset.interface';
 import { ICryptoRepository } from 'src/interfaces/crypto.interface';
@@ -34,6 +35,7 @@ import {
   IDeferrableJob,
   IEntityJob,
   IJobRepository,
+  INightlyJob,
   JOBS_ASSET_PAGINATION_SIZE,
   JobItem,
   JobName,
@@ -67,7 +69,7 @@ export class PersonService {
     @Inject(IMoveRepository) moveRepository: IMoveRepository,
     @Inject(IMediaRepository) private mediaRepository: IMediaRepository,
     @Inject(IPersonRepository) private repository: IPersonRepository,
-    @Inject(ISystemMetadataRepository) systemMetadataRepository: ISystemMetadataRepository,
+    @Inject(ISystemMetadataRepository) private systemMetadataRepository: ISystemMetadataRepository,
     @Inject(IStorageRepository) private storageRepository: IStorageRepository,
     @Inject(IJobRepository) private jobRepository: IJobRepository,
     @Inject(ISearchRepository) private smartInfoRepository: ISearchRepository,
@@ -376,13 +378,26 @@ export class PersonService {
     return JobStatus.SUCCESS;
   }
 
-  async handleQueueRecognizeFaces({ force }: IBaseJob): Promise<JobStatus> {
+  async handleQueueRecognizeFaces({ force, nightly }: INightlyJob): Promise<JobStatus> {
     const { machineLearning } = await this.configCore.getConfig({ withCache: false });
     if (!isFacialRecognitionEnabled(machineLearning)) {
       return JobStatus.SKIPPED;
     }
 
     await this.jobRepository.waitForQueueCompletion(QueueName.THUMBNAIL_GENERATION, QueueName.FACE_DETECTION);
+
+    if (nightly) {
+      const [state, latestFaceDate] = await Promise.all([
+        this.systemMetadataRepository.get(SystemMetadataKey.FACIAL_RECOGNITION_STATE),
+        this.repository.getLatestFaceDate(),
+      ]);
+
+      if (state && state.lastRun && latestFaceDate && state.lastRun > latestFaceDate) {
+        this.logger.debug('Skipping facial recognition nightly since no face has been added since the last run');
+        return JobStatus.SKIPPED;
+      }
+    }
+
     const { waiting } = await this.jobRepository.getJobCounts(QueueName.FACIAL_RECOGNITION);
 
     if (force) {
@@ -394,6 +409,7 @@ export class PersonService {
       return JobStatus.SKIPPED;
     }
 
+    const lastRun = new Date();
     const facePagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
       this.repository.getAllFaces(pagination, { where: force ? undefined : { personId: IsNull() } }),
     );
@@ -403,6 +419,8 @@ export class PersonService {
         page.map((face) => ({ name: JobName.FACIAL_RECOGNITION, data: { id: face.id, deferred: false } })),
       );
     }
+
+    await this.systemMetadataRepository.set(SystemMetadataKey.FACIAL_RECOGNITION_STATE, { lastRun });
 
     return JobStatus.SUCCESS;
   }

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -409,7 +409,7 @@ export class PersonService {
       return JobStatus.SKIPPED;
     }
 
-    const lastRun = new Date();
+    const lastRun = new Date().toISOString();
     const facePagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
       this.repository.getAllFaces(pagination, { where: force ? undefined : { personId: IsNull() } }),
     );

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -392,7 +392,7 @@ export class PersonService {
         this.repository.getLatestFaceDate(),
       ]);
 
-      if (state && state.lastRun && latestFaceDate && state.lastRun > latestFaceDate) {
+      if (state?.lastRun && latestFaceDate && state.lastRun > latestFaceDate) {
         this.logger.debug('Skipping facial recognition nightly since no face has been added since the last run');
         return JobStatus.SKIPPED;
       }

--- a/server/test/repositories/person.repository.mock.ts
+++ b/server/test/repositories/person.repository.mock.ts
@@ -29,5 +29,6 @@ export const newPersonRepositoryMock = (): Mocked<IPersonRepository> => {
     getFaceById: vitest.fn(),
     getFaceByIdWithAssets: vitest.fn(),
     getNumberOfPeople: vitest.fn(),
+    getLatestFaceDate: vitest.fn(),
   };
 };


### PR DESCRIPTION
## Description

The facial recognition nightly currently runs every night, but there's no need when no new face has been detected since the last run.

This PR stores the last run date in the system metadata table and compares it with the newest `facesRecognizedAt` value in the job status table. It only does this in the nightly; manual runs still behave like before.

The query for getting the latest face detection date is a full table scan, but it isn't worth indexing the column just for one non-interactive query a day. It at least avoids sorting.

Resolves #11078