### PR TITLE
memory - clear timeout after setTimeout complete

### DIFF
--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -308,8 +308,11 @@ export const findLocale = (code: string | undefined) => {
 };
 
 export const asyncTimeout = (ms: number) => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      clearTimeout(timeout);
+      resolve();
+    }, ms);
   });
 };
 


### PR DESCRIPTION
I notice the the asyncTimeout creates timeout value using setTimeout. The timeout values are not properly cleared. Not sure if the garbage collector does this job for us but I think we better should clear timeout after done.