### PR TITLE
docs: cleanup external libraries

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -112,7 +112,7 @@ The `immich-server` container will need access to the gallery. Modify your docke
 ```
 
 :::tip
-The `ro` flag at the end only gives read-only access to the volumes. This will disallow the images from being delete in the web UI.
+The `ro` flag at the end only gives read-only access to the volumes. This will disallow the images from being deleted in the web UI.
 :::
 
 :::info

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -104,8 +104,8 @@ The `immich-server` container will need access to the gallery. Modify your docke
   immich-server:
     volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
-+     - /mnt/nas/christmas-trip:/mnt/media/christmas-trip:ro
-+     - /home/user/old-pics:/mnt/media/old-pics:ro
++     - /mnt/nas/christmas-trip:/mnt/nas/christmas-trip:ro
++     - /home/user/old-pics:/home/user/old-pics:ro
 +     - /mnt/media/videos:/mnt/media/videos:ro
 +     - /mnt/media/videos2:/mnt/media/videos2 # the files in this folder can be deleted, as it does not end with :ro
 +     - "C:/Users/user_name/Desktop/my media:/mnt/media/my-media:ro" # import path in Windows system.

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -107,15 +107,16 @@ The `immich-server` container will need access to the gallery. Modify your docke
 +     - /mnt/nas/christmas-trip:/mnt/media/christmas-trip:ro
 +     - /home/user/old-pics:/mnt/media/old-pics:ro
 +     - /mnt/media/videos:/mnt/media/videos:ro
++     - /mnt/media/videos2:/mnt/media/videos2 # the files in this folder can be deleted, as it does not end with :ro
 +     - "C:/Users/user_name/Desktop/my media:/mnt/media/my-media:ro" # import path in Windows system.
 ```
 
 :::tip
-The `ro` flag at the end only gives read-only access to the volumes. While Immich does not modify files, it's a good practice to mount read-only.
+The `ro` flag at the end only gives read-only access to the volumes. This will disallow the images from being delete in the web UI.
 :::
 
 :::info
-_Remember to bring the container `docker compose down/up` to register the changes. Make sure you can see the mounted path in the container._
+_Remember to run `docker compose up -d` to register the changes. Make sure you can see the mounted path in the container._
 :::
 
 ### Create External Libraries

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -16,12 +16,7 @@ immich-server:
 +       - /mnt/photos2:/usr/src/app/external2:ro # you can delete this line if you only have one mount point, or you can add more lines if you have more than two
 ```
 
-Restart Immich.
-
-```
-docker compose down
-docker compose up -d
-```
+Restart Immich by running `docker compose up -d`.
 
 # Create the library
 

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -6,29 +6,15 @@ in a directory on the same machine.
 
 # Mount the directory into the containers.
 
-Edit `docker-compose.yml` to add two new mount points in the section `immich-server:` under `volumes:`
+Edit `docker-compose.yml` to add one or more new mount points in the section `immich-server:` under `volumes:`.
+If you want Immich to be able to delete the images in the external library, remove `:ro` from the end of the mount point.
 
 ```diff
 immich-server:
     volumes:
-+       - ${EXTERNAL_PATH}:/usr/src/app/external
++       - /home/user/photos1:/usr/src/app/external:ro
++       - /mnt/photos2:/usr/src/app/external2:ro # you can delete this line if you only have one mount point, or you can add more lines if you have more than two
 ```
-
-Edit `.env` to define `EXTERNAL_PATH`, substituting in the correct path for your computer:
-
-```
-EXTERNAL_PATH=<your-path-here>
-```
-
-On my computer, for example, I use this path:
-
-```
-EXTERNAL_PATH=/home/tenino/photos
-```
-
-:::info EXTERNAL_PATH design
-The design choice to put the EXTERNAL_PATH into .env rather than put two copies of the absolute path in the yml file is in order to make everything easier. If you have two copies of the same path that have to be kept in sync, then someday later when you move the data, update only one of the paths, without everything breaking mysteriously.
-:::
 
 Restart Immich.
 

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -12,6 +12,7 @@ If you want Immich to be able to delete the images in the external library, remo
 ```diff
 immich-server:
     volumes:
+        - ${UPLOAD_LOCATION}:/usr/src/app/upload
 +       - /home/user/photos1:/home/user/photos1:ro
 +       - /mnt/photos2:/mnt/photos2:ro # you can delete this line if you only have one mount point, or you can add more lines if you have more than two
 ```

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -12,8 +12,8 @@ If you want Immich to be able to delete the images in the external library, remo
 ```diff
 immich-server:
     volumes:
-+       - /home/user/photos1:/usr/src/app/external:ro
-+       - /mnt/photos2:/usr/src/app/external2:ro # you can delete this line if you only have one mount point, or you can add more lines if you have more than two
++       - /home/user/photos1:/home/user/photos1:ro
++       - /mnt/photos2:/mnt/photos2:ro # you can delete this line if you only have one mount point, or you can add more lines if you have more than two
 ```
 
 Restart Immich by running `docker compose up -d`.


### PR DESCRIPTION
Getting a lot of help tickets with multiple EXTERNAL_PATH, which isn't needed anymore with the monolith server container. 