### PR TITLE
chore: Update feature-request.yaml

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-request.yaml
+++ b/.github/DISCUSSION_TEMPLATE/feature-request.yaml
@@ -1,11 +1,13 @@
-title: "[Feature] <feature-name-goes-here>"
+title: "[Feature] feature-name-goes-here"
 labels: ["feature"]
 
 body:
   - type: markdown
     attributes:
       value: |
-        Please use this form to request new feature for Immich
+        Please use this form to request new feature for Immich.
+        Stick to only a single feature per request. If you list multiple different features at once, 
+        your request will be closed.
 
   - type: checkboxes
     attributes:


### PR DESCRIPTION
People sometimes post lists of multiple features in a request, which is an issue because there is inevitably a duplicate in the list, and also because it makes it unclear when the request is ready to be closed, especially if it mixes features of different priority/desirability.