### PR TITLE
fix(web): byte units enum

### DIFF
--- a/web/src/lib/components/admin-page/server-stats/stats-card.svelte
+++ b/web/src/lib/components/admin-page/server-stats/stats-card.svelte
@@ -27,7 +27,7 @@
       class="text-immich-primary dark:text-immich-dark-primary">{value}</span
     >
     {#if unit}
-      <span class="absolute -top-5 right-2 text-base font-light text-gray-400">{ByteUnit[unit]}</span>
+      <span class="absolute -top-5 right-2 text-base font-light text-gray-400">{unit}</span>
     {/if}
   </div>
 </div>

--- a/web/src/lib/utils/byte-units.ts
+++ b/web/src/lib/utils/byte-units.ts
@@ -1,12 +1,14 @@
-export enum ByteUnit {
-  'B' = 0,
-  'KiB' = 1,
-  'MiB' = 2,
-  'GiB' = 3,
-  'TiB' = 4,
-  'PiB' = 5,
-  'EiB' = 6,
+export const enum ByteUnit {
+  'B' = 'B',
+  'KiB' = 'KiB',
+  'MiB' = 'MiB',
+  'GiB' = 'GiB',
+  'TiB' = 'TiB',
+  'PiB' = 'PiB',
+  'EiB' = 'EiB',
 }
+
+const byteUnits = [ByteUnit.B, ByteUnit.KiB, ByteUnit.MiB, ByteUnit.GiB, ByteUnit.TiB, ByteUnit.PiB, ByteUnit.EiB];
 
 /**
  * Convert bytes to best human readable unit and number of that unit.
@@ -21,7 +23,7 @@ export enum ByteUnit {
 export function getBytesWithUnit(bytes: number, maxPrecision = 1): [number, ByteUnit] {
   const magnitude = Math.floor(Math.log(bytes === 0 ? 1 : bytes) / Math.log(1024));
 
-  return [Number.parseFloat((bytes / 1024 ** magnitude).toFixed(maxPrecision)), magnitude];
+  return [Number.parseFloat((bytes / 1024 ** magnitude).toFixed(maxPrecision)), byteUnits[magnitude]];
 }
 
 /**
@@ -37,7 +39,7 @@ export function getBytesWithUnit(bytes: number, maxPrecision = 1): [number, Byte
  */
 export function getByteUnitString(bytes: number, locale?: string, maxPrecision = 1): string {
   const [size, unit] = getBytesWithUnit(bytes, maxPrecision);
-  return `${size.toLocaleString(locale)} ${ByteUnit[unit]}`;
+  return `${size.toLocaleString(locale)} ${unit}`;
 }
 
 /**
@@ -50,7 +52,7 @@ export function getByteUnitString(bytes: number, locale?: string, maxPrecision =
  * @returns bytes (number)
  */
 export function convertToBytes(size: number, unit: ByteUnit): number {
-  return size * 1024 ** unit;
+  return size * 1024 ** byteUnits.indexOf(unit);
 }
 
 /**
@@ -63,5 +65,5 @@ export function convertToBytes(size: number, unit: ByteUnit): number {
  * @returns bytes (number)
  */
 export function convertFromBytes(bytes: number, unit: ByteUnit): number {
-  return bytes / 1024 ** unit;
+  return bytes / 1024 ** byteUnits.indexOf(unit);
 }

--- a/web/src/routes/admin/library-management/+page.svelte
+++ b/web/src/routes/admin/library-management/+page.svelte
@@ -337,7 +337,7 @@
                   <td class=" text-ellipsis px-4 text-sm">
                     {totalCount[index]}
                   </td>
-                  <td class=" text-ellipsis px-4 text-sm"> {diskUsage[index]} {ByteUnit[diskUsageUnit[index]]}</td>
+                  <td class=" text-ellipsis px-4 text-sm">{diskUsage[index]} {diskUsageUnit[index]}</td>
                 {/if}
 
                 <td class=" text-ellipsis px-4 text-sm">


### PR DESCRIPTION
Returning the byte unit as a numeric enum in `getBytesWithUnit` is error-prone:
1. Manual mapping to a string can be forgotten
2. `ByteUnit.B` is zero and thus falsy, causing issues with `if (unit)` checks

Switching to a string enum solves these problems. This also fixes an issue I saw on discord for small viewports (the 3 should be GiB):

![image](https://github.com/user-attachments/assets/d2b53dad-21ec-4791-8718-e728fa9a589c)
