### PR TITLE
chore(ml): set higher worker timeout for openvino

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -155,18 +155,18 @@ Redis (Sentinel) URL example JSON before encoding:
 
 ## Machine Learning
 
-| Variable                                         | Description                                                          |       Default       | Containers       |
-| :----------------------------------------------- | :------------------------------------------------------------------- | :-----------------: | :--------------- |
-| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if \<= 0)   |        `300`        | machine learning |
-| `MACHINE_LEARNING_MODEL_TTL_POLL_S`              | Interval (s) between checks for the model TTL (disabled if \<= 0)    |        `10`         | machine learning |
-| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                                |      `/cache`       | machine learning |
-| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if \<= 0)          | number of CPU cores | machine learning |
-| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                                  |         `1`         | machine learning |
-| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                           |         `2`         | machine learning |
-| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                                  |         `1`         | machine learning |
-| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed       |        `120`        | machine learning |
-| `MACHINE_LEARNING_PRELOAD__CLIP`                 | Name of a CLIP model to be preloaded and kept in cache               |                     | machine learning |
-| `MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION`   | Name of a facial recognition model to be preloaded and kept in cache |                     | machine learning |
+| Variable                                         | Description                                                          |                Default                | Containers       |
+| :----------------------------------------------- | :------------------------------------------------------------------- | :-----------------------------------: | :--------------- |
+| `MACHINE_LEARNING_MODEL_TTL`                     | Inactivity time (s) before a model is unloaded (disabled if \<= 0)   |                 `300`                 | machine learning |
+| `MACHINE_LEARNING_MODEL_TTL_POLL_S`              | Interval (s) between checks for the model TTL (disabled if \<= 0)    |                 `10`                  | machine learning |
+| `MACHINE_LEARNING_CACHE_FOLDER`                  | Directory where models are downloaded                                |               `/cache`                | machine learning |
+| `MACHINE_LEARNING_REQUEST_THREADS`<sup>\*1</sup> | Thread count of the request thread pool (disabled if \<= 0)          |          number of CPU cores          | machine learning |
+| `MACHINE_LEARNING_MODEL_INTER_OP_THREADS`        | Number of parallel model operations                                  |                  `1`                  | machine learning |
+| `MACHINE_LEARNING_MODEL_INTRA_OP_THREADS`        | Number of threads for each model operation                           |                  `2`                  | machine learning |
+| `MACHINE_LEARNING_WORKERS`<sup>\*2</sup>         | Number of worker processes to spawn                                  |                  `1`                  | machine learning |
+| `MACHINE_LEARNING_WORKER_TIMEOUT`                | Maximum time (s) of unresponsiveness before a worker is killed       | `120` (`300` if using OpenVINO image) | machine learning |
+| `MACHINE_LEARNING_PRELOAD__CLIP`                 | Name of a CLIP model to be preloaded and kept in cache               |                                       | machine learning |
+| `MACHINE_LEARNING_PRELOAD__FACIAL_RECOGNITION`   | Name of a facial recognition model to be preloaded and kept in cache |                                       | machine learning |
 
 \*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
+ARG DEVICE
 ENV TRANSFORMERS_CACHE=/cache \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/machine-learning/start.sh
+++ b/machine-learning/start.sh
@@ -5,12 +5,13 @@ lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 if ! [ "$DEVICE" = "openvino" ]; then
 	export LD_PRELOAD="$lib_path"
 	export LD_BIND_NOW=1
+	: "${MACHINE_LEARNING_WORKER_TIMEOUT:=120}"
+else
+	: "${MACHINE_LEARNING_WORKER_TIMEOUT:=300}"
 fi
 
 : "${IMMICH_HOST:=[::]}"
 : "${IMMICH_PORT:=3003}"
-: "${MACHINE_LEARNING_WORKERS:=1}"
-: "${MACHINE_LEARNING_WORKER_TIMEOUT:=120}"
 
 gunicorn app.main:app \
 	-k app.config.CustomUvicornWorker \


### PR DESCRIPTION
## Description

The first time a model is loaded into OpenVINO, it must be compiled into OpenVINO format. This process is intensive and can take over 120s. Since it also takes up the GIL and hence doesn't allow the server to respond to requests, it can exceed gunicorn's worker timeout and cause crashes. 

Increasing the default timeout for OpenVINO will prevent the service from crashing here.