### PR TITLE
feat(server): Allow activating non-admin user with server license

### DIFF
--- a/server/src/services/user.service.spec.ts
+++ b/server/src/services/user.service.spec.ts
@@ -274,10 +274,22 @@ describe(UserService.name, () => {
   });
 
   describe('setLicense', () => {
-    it('should save license if valid', async () => {
+    it('should save client license if valid', async () => {
       userMock.upsertMetadata.mockResolvedValue();
 
       const license = { licenseKey: 'IMCL-license-key', activationKey: 'activation-key' };
+      await sut.setLicense(authStub.user1, license);
+
+      expect(userMock.upsertMetadata).toHaveBeenCalledWith(authStub.user1.user.id, {
+        key: UserMetadataKey.LICENSE,
+        value: expect.any(Object),
+      });
+    });
+
+    it('should save server license as client if valid', async () => {
+      userMock.upsertMetadata.mockResolvedValue();
+
+      const license = { licenseKey: 'IMSV-license-key', activationKey: 'activation-key' };
       await sut.setLicense(authStub.user1, license);
 
       expect(userMock.upsertMetadata).toHaveBeenCalledWith(authStub.user1.user.id, {

--- a/web/src/lib/utils/license-utils.ts
+++ b/web/src/lib/utils/license-utils.ts
@@ -3,11 +3,13 @@ import type { ImmichLicense } from '$lib/constants';
 import { serverConfig } from '$lib/stores/server-config.store';
 import { setServerLicense, setUserLicense, type LicenseResponseDto } from '@immich/sdk';
 import { get } from 'svelte/store';
+import { user } from '$lib/stores/user.store';
 
 export const activateLicense = async (licenseKey: string, activationKey: string): Promise<LicenseResponseDto> => {
-  const isServerKey = licenseKey.search('IMSV') !== -1;
+  // Send server key to user activation if user is not admin
+  const isServerActivation = user.isAdmin && licenseKey.search('IMSV') !== -1;
   const licenseKeyDto = { licenseKey, activationKey };
-  return isServerKey ? setServerLicense({ licenseKeyDto }) : setUserLicense({ licenseKeyDto });
+  return isServerActivation ? setServerLicense({ licenseKeyDto }) : setUserLicense({ licenseKeyDto });
 };
 
 export const getActivationKey = async (licenseKey: string): Promise<string> => {

--- a/web/src/lib/utils/license-utils.ts
+++ b/web/src/lib/utils/license-utils.ts
@@ -3,11 +3,12 @@ import type { ImmichLicense } from '$lib/constants';
 import { serverConfig } from '$lib/stores/server-config.store';
 import { setServerLicense, setUserLicense, type LicenseResponseDto } from '@immich/sdk';
 import { get } from 'svelte/store';
-import { user } from '$lib/stores/user.store';
+import { loadUser } from './auth';
 
 export const activateLicense = async (licenseKey: string, activationKey: string): Promise<LicenseResponseDto> => {
   // Send server key to user activation if user is not admin
-  const isServerActivation = user.isAdmin && licenseKey.search('IMSV') !== -1;
+  const user = await loadUser();
+  const isServerActivation = user?.isAdmin && licenseKey.search('IMSV') !== -1;
   const licenseKeyDto = { licenseKey, activationKey };
   return isServerActivation ? setServerLicense({ licenseKeyDto }) : setUserLicense({ licenseKeyDto });
 };


### PR DESCRIPTION
Here's a small suggestion to allow non-admin users to activate their user account with a server license. This would allow a user to move between a self-hosted server to server managed by someone else and not need to buy an individual user license if they already have a server license.

Only a few changes:
* Change user endpoint to accept both server/client licenses
* Change web logic so that the behavior for admins stays the same (server license -> server service, invididual license -> user service), but for non-admins both individual and server licenses go to the user service (currently entering a server license as a non-admin causes web to try to activate the server through the server endpoint, which of course fails due to not being an admin)
* Added test for user endpoint to accept server licenses