### PR TITLE
fix(server): exif description whitespace handling

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -710,6 +710,26 @@ describe(MetadataService.name, () => {
         }),
       );
     });
+
+    it('trims whitespace from description', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({ Description: '\t \v \f \n \r' });
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: '',
+        }),
+      );
+
+      metadataMock.readTags.mockResolvedValue({ ImageDescription: ' my\n description' });
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'my\n description',
+        }),
+      );
+    });
   });
 
   describe('handleQueueSidecar', () => {
@@ -889,6 +909,7 @@ describe(MetadataService.name, () => {
         }),
       ).resolves.toBe(JobStatus.SUCCESS);
       expect(metadataMock.writeTags).toHaveBeenCalledWith(assetStub.sidecar.sidecarPath, {
+        Description: description,
         ImageDescription: description,
         CreationDate: date,
         GPSLatitude: gps,

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -513,7 +513,7 @@ export class MetadataService implements OnEvents {
       bitsPerSample: this.getBitsPerSample(tags),
       colorspace: tags.ColorSpace ?? null,
       dateTimeOriginal: this.getDateTimeOriginal(tags) ?? asset.fileCreatedAt,
-      description: (tags.ImageDescription || tags.Description)?.trim() ?? '',
+      description: (tags.ImageDescription || tags.Description || '').trim(),
       exifImageHeight: validate(tags.ImageHeight),
       exifImageWidth: validate(tags.ImageWidth),
       exposureTime: tags.ExposureTime ?? null,

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -314,6 +314,7 @@ export class MetadataService implements OnEvents {
     const sidecarPath = asset.sidecarPath || `${asset.originalPath}.xmp`;
     const exif = _.omitBy<Tags>(
       {
+        Description: description,
         ImageDescription: description,
         CreationDate: dateTimeOriginal,
         GPSLatitude: latitude,
@@ -512,7 +513,7 @@ export class MetadataService implements OnEvents {
       bitsPerSample: this.getBitsPerSample(tags),
       colorspace: tags.ColorSpace ?? null,
       dateTimeOriginal: this.getDateTimeOriginal(tags) ?? asset.fileCreatedAt,
-      description: (tags.ImageDescription || tags.Description) ?? '',
+      description: (tags.ImageDescription || tags.Description)?.trim() ?? '',
       exifImageHeight: validate(tags.ImageHeight),
       exifImageWidth: validate(tags.ImageWidth),
       exposureTime: tags.ExposureTime ?? null,


### PR DESCRIPTION
Fixes #11238 which consists of two issues:
1. Not possible to clear description of an asset with the `Description` exif tag
2. Whitespace in exif description tags is included in the asset description
