### PR TITLE
fix(web): Fix grammar in license message in en.json

### DIFF
--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -767,7 +767,7 @@
   "license_trial_info_1": "You are running an Unlicensed version of Immich",
   "license_trial_info_2": "You have been using Immich for approximately",
   "license_trial_info_3": "{accountAge, plural, one {# day} other {# days}}",
-  "license_trial_info_4": "Please considering purchasing a license to support the continued development of the service",
+  "license_trial_info_4": "Please consider purchasing a license to support the continued development of the service",
   "light": "Light",
   "like_deleted": "Like deleted",
   "link_options": "Link options",


### PR DESCRIPTION
When hovering over the license page in the app, there is a grammatical error in the message that pops up.

Original: "Please considering purchasing a license to support the continued development of the service"

Updated: "Please consider purchasing a license to support the continued development of the service"