### PR TITLE
fix(web): use fixed position for download and upload panel

### DIFF
--- a/web/src/lib/components/asset-viewer/download-panel.svelte
+++ b/web/src/lib/components/asset-viewer/download-panel.svelte
@@ -16,7 +16,7 @@
 {#if $isDownloading}
   <div
     transition:fly={{ x: -100, duration: 350 }}
-    class="absolute bottom-10 left-2 z-[10000] max-h-[270px] w-[315px] rounded-2xl border bg-immich-bg p-4 text-sm shadow-sm"
+    class="fixed bottom-10 left-2 z-[10000] max-h-[270px] w-[315px] rounded-2xl border bg-immich-bg p-4 text-sm shadow-sm"
   >
     <p class="mb-2 text-xs text-gray-500">{$t('downloading').toUpperCase()}</p>
     <div class="my-2 mb-2 flex max-h-[200px] flex-col overflow-y-auto text-sm">

--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -54,7 +54,7 @@
       }
       uploadAssetsStore.resetStore();
     }}
-    class="absolute bottom-6 right-6 z-[10000]"
+    class="fixed bottom-6 right-6 z-[10000]"
   >
     {#if showDetail}
       <div


### PR DESCRIPTION
When scrolling on the search page, the download and upload panel should stay in a fixed position, but they currently scroll along with the page. Fixes #11267