### PR TITLE
feat(server): add IP trust list for reverse proxy

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -50,6 +50,7 @@ Regardless of filesystem, it is not recommended to use a network share for your 
 | `IMMICH_API_METRICS_PORT`           | Port for the OTEL metrics                           |            `8081`            | server                   | api                |
 | `IMMICH_MICROSERVICES_METRICS_PORT` | Port for the OTEL metrics                           |            `8082`            | server                   | microservices      |
 | `IMMICH_PROCESS_INVALID_IMAGES`     | When `true`, generate thumbnails for invalid images |                              | server                   | microservices      |
+| `IMMICH_TRUSTED_PROXIES`            | List of comma separated IPs set as trusted proxies  |                              | server                   | api                |
 
 \*1: With the default `WORKDIR` of `/usr/src/app`, this path will resolve to `/usr/src/app/upload`.
 It only need to be set if the Immich deployment method is changing.

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -4,7 +4,7 @@ import { CronExpression } from '@nestjs/schedule';
 import { QueueOptions } from 'bullmq';
 import { Request, Response } from 'express';
 import { RedisOptions } from 'ioredis';
-import Joi from 'joi';
+import Joi, { Root } from 'joi';
 import { CLS_ID, ClsModuleOptions } from 'nestjs-cls';
 import { ImmichHeader } from 'src/dtos/auth.dto';
 import { ConcurrentQueueName, QueueName } from 'src/interfaces/job.interface';
@@ -387,6 +387,20 @@ export const immichAppConfig: ConfigModuleOptions = {
     IMMICH_PORT: Joi.number().optional(),
     IMMICH_API_METRICS_PORT: Joi.number().optional(),
     IMMICH_MICROSERVICES_METRICS_PORT: Joi.number().optional(),
+
+    IMMICH_TRUSTED_PROXIES: Joi.extend((joi: Root) => ({
+      type: 'stringArray',
+      base: joi.array(),
+      coerce: (value) => (value.split ? value.split(',') : value),
+    }))
+      .stringArray()
+      .single()
+      .items(
+        Joi.string().ip({
+          version: ['ipv4', 'ipv6'],
+          cidr: 'optional',
+        }),
+      ),
 
     IMMICH_METRICS: Joi.boolean().optional().default(false),
     IMMICH_HOST_METRICS: Joi.boolean().optional().default(false),

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -14,9 +14,18 @@ import { useSwagger } from 'src/utils/misc';
 
 const host = process.env.HOST;
 
+function parseTrustedProxy(input?: string) {
+  if (!input) {
+    return [];
+  }
+  // Split on ',' char to allow multiple IPs
+  return input.split(',');
+}
+
 async function bootstrap() {
   process.title = 'immich-api';
   const otelPort = Number.parseInt(process.env.IMMICH_API_METRICS_PORT ?? '8081');
+  const trustedProxies = parseTrustedProxy(process.env.IMMICH_TRUSTED_PROXIES ?? '');
 
   otelStart(otelPort);
 
@@ -27,7 +36,7 @@ async function bootstrap() {
   logger.setAppName('Api');
   logger.setContext('Bootstrap');
   app.useLogger(logger);
-  app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
+  app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal', ...trustedProxies]);
   app.set('etag', 'strong');
   app.use(cookieParser());
   app.use(json({ limit: '10mb' }));


### PR DESCRIPTION
Added support for configurable trusted proxy IPs using environment variables. This enhancement allows you to specify trusted proxy IPs directly through environment settings, improving flexibility and security in various deployment environments.

It follow the rules of express `trust proxy` option. See [Behind Proxies](https://expressjs.com/en/guide/behind-proxies.html)

New Environment Variable:

    IMMICH_TRUSTED_PROXIES: A comma-separated list of IP addresses that should be trusted as proxies.

Example Usage in Docker Compose:

```yaml

version: '3.8'

immich-server:
    container_name: immich_server
    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
    volumes:
      - ${UPLOAD_LOCATION}:/usr/src/app/upload
      - /etc/localtime:/etc/localtime:ro
    env_file:
      - .env
   environment:
      - TRUSTED_PROXY_IPS=192.168.0.1,192.168.0.2
    ports:
      - 2283:3001
    depends_on:
      - redis
      - database
    restart: always
```

With this fix, you can now manage trusted proxy IPs without modifying the application code, making it easier to adjust settings in different environments.