### PR TITLE
fix(mobile): negative coordinate input

### DIFF
--- a/mobile/lib/widgets/common/location_picker.dart
+++ b/mobile/lib/widgets/common/location_picker.dart
@@ -141,7 +141,8 @@ class _ManualPickerInput extends HookWidget {
         errorText: isValid.value ? null : errorText.tr(),
       ),
       onEditingComplete: onEditingComplete,
-      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
+      keyboardType:
+          const TextInputType.numberWithOptions(decimal: true, signed: true),
       inputFormatters: [LengthLimitingTextInputFormatter(8)],
       onTapOutside: (_) => focusNode.unfocus(),
     );

--- a/mobile/lib/widgets/common/location_picker.dart
+++ b/mobile/lib/widgets/common/location_picker.dart
@@ -141,7 +141,7 @@ class _ManualPickerInput extends HookWidget {
         errorText: isValid.value ? null : errorText.tr(),
       ),
       onEditingComplete: onEditingComplete,
-      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      keyboardType: const TextInputType.numberWithOptions(decimal: true, signed: true),
       inputFormatters: [LengthLimitingTextInputFormatter(8)],
       onTapOutside: (_) => focusNode.unfocus(),
     );


### PR DESCRIPTION
Opens the keyboard with a negative sign to allow entering negative coordinates, fixes #11253