### PR TITLE
fix(web): Fix typo in license-activation error popup

### DIFF
--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -752,7 +752,7 @@
   "license_button_buy": "Buy",
   "license_button_buy_license": "Buy License",
   "license_button_select": "Select",
-  "license_failed_activation": "Failed to activate license. Please check your email for the the correct license key!",
+  "license_failed_activation": "Failed to activate license. Please check your email for the correct license key!",
   "license_individual_description_1": "1 license per user on any server",
   "license_individual_title": "Individual License",
   "license_info_licensed": "Licensed",


### PR DESCRIPTION
The error popup that appears after entering an invalid license key contains a small typo.

#### Previous: 
"Failed to activate license. Please check your email for the the correct license key!"

#### New: 
"Failed to activate license. Please check your email for the correct license key!"