### PR TITLE
feat: people infinite scroll

### DIFF
--- a/e2e/src/api/specs/person.e2e-spec.ts
+++ b/e2e/src/api/specs/person.e2e-spec.ts
@@ -65,6 +65,7 @@ describe('/people', () => {
 
       expect(status).toBe(200);
       expect(body).toEqual({
+        hasNextPage: false,
         total: 3,
         hidden: 1,
         people: [
@@ -80,12 +81,28 @@ describe('/people', () => {
 
       expect(status).toBe(200);
       expect(body).toEqual({
+        hasNextPage: false,
         total: 3,
         hidden: 1,
         people: [
           expect.objectContaining({ name: 'multiple_assets_person' }),
           expect.objectContaining({ name: 'visible_person' }),
         ],
+      });
+    });
+
+    it('should support pagination', async () => {
+      const { status, body } = await request(app)
+        .get('/people')
+        .set('Authorization', `Bearer ${admin.accessToken}`)
+        .query({ withHidden: true, page: 2, size: 1 });
+
+      expect(status).toBe(200);
+      expect(body).toEqual({
+        hasNextPage: true,
+        total: 3,
+        hidden: 1,
+        people: [expect.objectContaining({ name: 'visible_person' })],
       });
     });
   });

--- a/mobile/openapi/lib/api/people_api.dart
+++ b/mobile/openapi/lib/api/people_api.dart
@@ -66,8 +66,14 @@ class PeopleApi {
   /// Performs an HTTP 'GET /people' operation and returns the [Response].
   /// Parameters:
   ///
+  /// * [num] page:
+  ///   Page number for pagination
+  ///
+  /// * [num] size:
+  ///   Number of items per page
+  ///
   /// * [bool] withHidden:
-  Future<Response> getAllPeopleWithHttpInfo({ bool? withHidden, }) async {
+  Future<Response> getAllPeopleWithHttpInfo({ num? page, num? size, bool? withHidden, }) async {
     // ignore: prefer_const_declarations
     final path = r'/people';
 
@@ -78,6 +84,12 @@ class PeopleApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
+    if (page != null) {
+      queryParams.addAll(_queryParams('', 'page', page));
+    }
+    if (size != null) {
+      queryParams.addAll(_queryParams('', 'size', size));
+    }
     if (withHidden != null) {
       queryParams.addAll(_queryParams('', 'withHidden', withHidden));
     }
@@ -98,9 +110,15 @@ class PeopleApi {
 
   /// Parameters:
   ///
+  /// * [num] page:
+  ///   Page number for pagination
+  ///
+  /// * [num] size:
+  ///   Number of items per page
+  ///
   /// * [bool] withHidden:
-  Future<PeopleResponseDto?> getAllPeople({ bool? withHidden, }) async {
-    final response = await getAllPeopleWithHttpInfo( withHidden: withHidden, );
+  Future<PeopleResponseDto?> getAllPeople({ num? page, num? size, bool? withHidden, }) async {
+    final response = await getAllPeopleWithHttpInfo( page: page, size: size, withHidden: withHidden, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/mobile/openapi/lib/model/people_response_dto.dart
+++ b/mobile/openapi/lib/model/people_response_dto.dart
@@ -13,10 +13,20 @@ part of openapi.api;
 class PeopleResponseDto {
   /// Returns a new [PeopleResponseDto] instance.
   PeopleResponseDto({
+    this.hasNextPage,
     required this.hidden,
     this.people = const [],
     required this.total,
   });
+
+  /// This property was added in v1.110.0
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? hasNextPage;
 
   int hidden;
 
@@ -26,6 +36,7 @@ class PeopleResponseDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is PeopleResponseDto &&
+    other.hasNextPage == hasNextPage &&
     other.hidden == hidden &&
     _deepEquality.equals(other.people, people) &&
     other.total == total;
@@ -33,15 +44,21 @@ class PeopleResponseDto {
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (hasNextPage == null ? 0 : hasNextPage!.hashCode) +
     (hidden.hashCode) +
     (people.hashCode) +
     (total.hashCode);
 
   @override
-  String toString() => 'PeopleResponseDto[hidden=$hidden, people=$people, total=$total]';
+  String toString() => 'PeopleResponseDto[hasNextPage=$hasNextPage, hidden=$hidden, people=$people, total=$total]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+    if (this.hasNextPage != null) {
+      json[r'hasNextPage'] = this.hasNextPage;
+    } else {
+    //  json[r'hasNextPage'] = null;
+    }
       json[r'hidden'] = this.hidden;
       json[r'people'] = this.people;
       json[r'total'] = this.total;
@@ -56,6 +73,7 @@ class PeopleResponseDto {
       final json = value.cast<String, dynamic>();
 
       return PeopleResponseDto(
+        hasNextPage: mapValueOfType<bool>(json, r'hasNextPage'),
         hidden: mapValueOfType<int>(json, r'hidden')!,
         people: PersonResponseDto.listFromJson(json[r'people']),
         total: mapValueOfType<int>(json, r'total')!,

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3825,6 +3825,29 @@
         "operationId": "getAllPeople",
         "parameters": [
           {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "Page number for pagination",
+            "schema": {
+              "minimum": 1,
+              "default": 1,
+              "type": "number"
+            }
+          },
+          {
+            "name": "size",
+            "required": false,
+            "in": "query",
+            "description": "Number of items per page",
+            "schema": {
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 500,
+              "type": "number"
+            }
+          },
+          {
             "name": "withHidden",
             "required": false,
             "in": "query",
@@ -9531,6 +9554,10 @@
       },
       "PeopleResponseDto": {
         "properties": {
+          "hasNextPage": {
+            "description": "This property was added in v1.110.0",
+            "type": "boolean"
+          },
           "hidden": {
             "type": "integer"
           },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -607,6 +607,8 @@ export type UpdatePartnerDto = {
     inTimeline: boolean;
 };
 export type PeopleResponseDto = {
+    /** This property was added in v1.110.0 */
+    hasNextPage?: boolean;
     hidden: number;
     people: PersonResponseDto[];
     total: number;
@@ -2173,13 +2175,17 @@ export function updatePartner({ id, updatePartnerDto }: {
         body: updatePartnerDto
     })));
 }
-export function getAllPeople({ withHidden }: {
+export function getAllPeople({ page, size, withHidden }: {
+    page?: number;
+    size?: number;
     withHidden?: boolean;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: PeopleResponseDto;
     }>(`/people${QS.query(QS.explode({
+        page,
+        size,
         withHidden
     }))}`, {
         ...opts

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsInt, IsNotEmpty, IsString, Max, MaxDate, Min, ValidateNested } from 'class-validator';
 import { PropertyLifecycle } from 'src/decorators';
@@ -64,13 +64,15 @@ export class PersonSearchDto {
   @ValidateBoolean({ optional: true })
   withHidden?: boolean;
 
-  @ApiProperty({ description: 'Page number for pagination', default: 1, required: false })
+  /** Page number for pagination */
+  @ApiPropertyOptional()
   @IsInt()
   @Min(1)
   @Type(() => Number)
   page: number = 1;
 
-  @ApiProperty({ description: 'Number of items per page', default: 500, required: false })
+  /** Number of items per page */
+  @ApiPropertyOptional()
   @IsInt()
   @Min(1)
   @Max(1000)

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsString, MaxDate, ValidateNested } from 'class-validator';
+import { IsArray, IsInt, IsNotEmpty, IsString, Max, MaxDate, Min, ValidateNested } from 'class-validator';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
@@ -63,6 +63,19 @@ export class MergePersonDto {
 export class PersonSearchDto {
   @ValidateBoolean({ optional: true })
   withHidden?: boolean;
+
+  @ApiProperty({ description: 'Page number for pagination', default: 1, required: false })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page: number = 1;
+
+  @ApiProperty({ description: 'Number of items per page', default: 500, required: false })
+  @IsInt()
+  @Min(1)
+  @Max(1000)
+  @Type(() => Number)
+  size: number = 500;
 }
 
 export class PersonResponseDto {
@@ -132,6 +145,10 @@ export class PeopleResponseDto {
   @ApiProperty({ type: 'integer' })
   hidden!: number;
   people!: PersonResponseDto[];
+
+  // TODO: make required after a few versions
+  @PropertyLifecycle({ addedAt: 'v1.110.0' })
+  hasNextPage?: boolean;
 }
 
 export function mapPerson(person: PersonEntity): PersonResponseDto {

--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -37,7 +37,7 @@ export interface PeopleStatistics {
 
 export interface IPersonRepository {
   getAll(pagination: PaginationOptions, options?: FindManyOptions<PersonEntity>): Paginated<PersonEntity>;
-  getAllForUser(userId: string, options: PersonSearchOptions): Promise<PersonEntity[]>;
+  getAllForUser(pagination: PaginationOptions, userId: string, options: PersonSearchOptions): Paginated<PersonEntity>;
   getAllWithoutFaces(): Promise<PersonEntity[]>;
   getById(personId: string): Promise<PersonEntity | null>;
   getByName(userId: string, personName: string, options: PersonNameSearchOptions): Promise<PersonEntity[]>;

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -37,9 +37,12 @@ ORDER BY
   "person"."isHidden" ASC,
   NULLIF("person"."name", '') IS NULL ASC,
   COUNT("face"."assetId") DESC,
-  NULLIF("person"."name", '') ASC NULLS LAST
+  NULLIF("person"."name", '') ASC NULLS LAST,
+  "person"."createdAt" ASC
 LIMIT
-  500
+  11
+OFFSET
+  10
 
 -- PersonRepository.getAllWithoutFaces
 SELECT

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -115,9 +115,13 @@ describe(PersonService.name, () => {
 
   describe('getAll', () => {
     it('should get all hidden and visible people with thumbnails', async () => {
-      personMock.getAllForUser.mockResolvedValue([personStub.withName, personStub.hidden]);
+      personMock.getAllForUser.mockResolvedValue({
+        items: [personStub.withName, personStub.hidden],
+        hasNextPage: false,
+      });
       personMock.getNumberOfPeople.mockResolvedValue({ total: 2, hidden: 1 });
-      await expect(sut.getAll(authStub.admin, { withHidden: true })).resolves.toEqual({
+      await expect(sut.getAll(authStub.admin, { withHidden: true, page: 1, size: 10 })).resolves.toEqual({
+        hasNextPage: false,
         total: 2,
         hidden: 1,
         people: [
@@ -132,7 +136,7 @@ describe(PersonService.name, () => {
           },
         ],
       });
-      expect(personMock.getAllForUser).toHaveBeenCalledWith(authStub.admin.user.id, {
+      expect(personMock.getAllForUser).toHaveBeenCalledWith({ skip: 0, take: 10 }, authStub.admin.user.id, {
         minimumFaceCount: 3,
         withHidden: true,
       });

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -91,15 +91,22 @@ export class PersonService {
   }
 
   async getAll(auth: AuthDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
+    const { withHidden = false, page, size } = dto;
+    const pagination = {
+      take: size,
+      skip: (page - 1) * size,
+    };
+
     const { machineLearning } = await this.configCore.getConfig({ withCache: false });
-    const people = await this.repository.getAllForUser(auth.user.id, {
+    const { items, hasNextPage } = await this.repository.getAllForUser(pagination, auth.user.id, {
       minimumFaceCount: machineLearning.facialRecognition.minFaces,
-      withHidden: dto.withHidden || false,
+      withHidden,
     });
     const { total, hidden } = await this.repository.getNumberOfPeople(auth.user.id);
 
     return {
-      people: people.map((person) => mapPerson(person)),
+      people: items.map((person) => mapPerson(person)),
+      hasNextPage,
       total,
       hidden,
     };

--- a/web/src/lib/__mocks__/intersection-observer.mock.ts
+++ b/web/src/lib/__mocks__/intersection-observer.mock.ts
@@ -1,0 +1,9 @@
+import { vi } from 'vitest';
+
+export const getIntersectionObserverMock = () =>
+  vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    takeRecords: vi.fn(),
+    unobserve: vi.fn(),
+  }));

--- a/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
+++ b/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
@@ -1,3 +1,4 @@
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import ManagePeopleVisibility from '$lib/components/faces-page/manage-people-visibility.svelte';
 import type { PersonResponseDto } from '@immich/sdk';
@@ -18,6 +19,7 @@ describe('ManagePeopleVisibility Component', () => {
   });
 
   beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
     personVisible = personFactory.build({ isHidden: false });
     personHidden = personFactory.build({ isHidden: true });
     personWithoutName = personFactory.build({ isHidden: false, name: undefined });
@@ -33,6 +35,7 @@ describe('ManagePeopleVisibility Component', () => {
       props: {
         people: [personVisible, personHidden, personWithoutName],
         onClose: vi.fn(),
+        loadNextPage: vi.fn(),
       },
     });
 
@@ -46,6 +49,7 @@ describe('ManagePeopleVisibility Component', () => {
       props: {
         people: [personVisible, personHidden, personWithoutName],
         onClose: vi.fn(),
+        loadNextPage: vi.fn(),
       },
     });
 
@@ -64,6 +68,7 @@ describe('ManagePeopleVisibility Component', () => {
       props: {
         people: [personVisible, personHidden, personWithoutName],
         onClose: vi.fn(),
+        loadNextPage: vi.fn(),
       },
     });
 
@@ -87,6 +92,7 @@ describe('ManagePeopleVisibility Component', () => {
       props: {
         people: [personVisible, personHidden, personWithoutName],
         onClose: vi.fn(),
+        loadNextPage: vi.fn(),
       },
     });
 

--- a/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
+++ b/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
@@ -34,6 +34,7 @@ describe('ManagePeopleVisibility Component', () => {
     const { getByText } = render(ManagePeopleVisibility, {
       props: {
         people: [personVisible, personHidden, personWithoutName],
+        totalPeopleCount: 3,
         onClose: vi.fn(),
         loadNextPage: vi.fn(),
       },
@@ -48,6 +49,7 @@ describe('ManagePeopleVisibility Component', () => {
     const { getByText, getByTitle } = render(ManagePeopleVisibility, {
       props: {
         people: [personVisible, personHidden, personWithoutName],
+        totalPeopleCount: 3,
         onClose: vi.fn(),
         loadNextPage: vi.fn(),
       },
@@ -67,6 +69,7 @@ describe('ManagePeopleVisibility Component', () => {
     const { getByText, getByTitle } = render(ManagePeopleVisibility, {
       props: {
         people: [personVisible, personHidden, personWithoutName],
+        totalPeopleCount: 3,
         onClose: vi.fn(),
         loadNextPage: vi.fn(),
       },
@@ -91,6 +94,7 @@ describe('ManagePeopleVisibility Component', () => {
     const { getByText, getByTitle } = render(ManagePeopleVisibility, {
       props: {
         people: [personVisible, personHidden, personWithoutName],
+        totalPeopleCount: 3,
         onClose: vi.fn(),
         loadNextPage: vi.fn(),
       },

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -25,6 +25,7 @@
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
 
   export let people: PersonResponseDto[];
+  export let totalPeopleCount: number;
   export let titleId: string | undefined = undefined;
   export let onClose: () => void;
   export let loadNextPage: () => void;
@@ -123,7 +124,7 @@
     <CircleIconButton title={$t('close')} icon={mdiClose} on:click={onClose} />
     <div class="flex gap-2 items-center">
       <p id={titleId} class="ml-2">{$t('show_and_hide_people')}</p>
-      <p class="text-sm text-gray-400 dark:text-gray-600">({people.length.toLocaleString($locale)})</p>
+      <p class="text-sm text-gray-400 dark:text-gray-600">({totalPeopleCount.toLocaleString($locale)})</p>
     </div>
   </div>
   <div class="flex items-center justify-end">

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -10,6 +10,7 @@
   import { shortcut } from '$lib/actions/shortcut';
   import ImageThumbnail from '$lib/components/assets/thumbnail/image-thumbnail.svelte';
   import Button from '$lib/components/elements/buttons/button.svelte';
+  import PeopleInfiniteScroll from '$lib/components/faces-page/people-infinite-scroll.svelte';
   import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
   import {
     notificationController,
@@ -24,8 +25,9 @@
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
 
   export let people: PersonResponseDto[];
-  export let onClose: () => void;
   export let titleId: string | undefined = undefined;
+  export let onClose: () => void;
+  export let loadNextPage: () => void;
 
   let toggleVisibility = ToggleVisibility.SHOW_ALL;
   let showLoadingSpinner = false;
@@ -138,31 +140,29 @@
 </div>
 
 <div class="flex flex-wrap gap-1 bg-immich-bg p-2 pb-8 dark:bg-immich-dark-bg md:px-8 mt-16">
-  <div class="w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-9 gap-1">
-    {#each people as person, index (person.id)}
-      {@const hidden = personIsHidden[person.id]}
-      <button
-        type="button"
-        class="group relative"
-        on:click={() => (personIsHidden[person.id] = !hidden)}
-        aria-pressed={hidden}
-        aria-label={person.name ? $t('hide_named_person', { values: { name: person.name } }) : $t('hide_person')}
-      >
-        <ImageThumbnail
-          preload={index < 20}
-          {hidden}
-          shadow
-          url={getPeopleThumbnailUrl(person)}
-          altText={person.name}
-          widthStyle="100%"
-          hiddenIconClass="text-white group-hover:text-black transition-colors"
-        />
-        {#if person.name}
-          <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
-            {person.name}
-          </span>
-        {/if}
-      </button>
-    {/each}
-  </div>
+  <PeopleInfiniteScroll {people} hasNextPage={true} {loadNextPage} let:person let:index>
+    {@const hidden = personIsHidden[person.id]}
+    <button
+      type="button"
+      class="group relative"
+      on:click={() => (personIsHidden[person.id] = !hidden)}
+      aria-pressed={hidden}
+      aria-label={person.name ? $t('hide_named_person', { values: { name: person.name } }) : $t('hide_person')}
+    >
+      <ImageThumbnail
+        preload={index < 20}
+        {hidden}
+        shadow
+        url={getPeopleThumbnailUrl(person)}
+        altText={person.name}
+        widthStyle="100%"
+        hiddenIconClass="text-white group-hover:text-black transition-colors"
+      />
+      {#if person.name}
+        <span class="absolute bottom-2 left-0 w-full select-text px-1 text-center font-medium text-white">
+          {person.name}
+        </span>
+      {/if}
+    </button>
+  </PeopleInfiniteScroll>
 </div>

--- a/web/src/lib/components/faces-page/people-infinite-scroll.svelte
+++ b/web/src/lib/components/faces-page/people-infinite-scroll.svelte
@@ -7,7 +7,7 @@
 
   let lastPersonContainer: HTMLElement | undefined;
 
-  const resizeObserver = new IntersectionObserver((entries) => {
+  const intersectionObserver = new IntersectionObserver((entries) => {
     const entry = entries.find((entry) => entry.target === lastPersonContainer);
     if (entry?.isIntersecting) {
       loadNextPage();
@@ -15,8 +15,8 @@
   });
 
   $: if (lastPersonContainer) {
-    resizeObserver.disconnect();
-    resizeObserver.observe(lastPersonContainer);
+    intersectionObserver.disconnect();
+    intersectionObserver.observe(lastPersonContainer);
   }
 </script>
 

--- a/web/src/lib/components/faces-page/people-infinite-scroll.svelte
+++ b/web/src/lib/components/faces-page/people-infinite-scroll.svelte
@@ -20,7 +20,7 @@
   }
 </script>
 
-<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-9 gap-1">
+<div class="w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-9 gap-1">
   {#each people as person, index (person.id)}
     {#if hasNextPage && index === people.length - 1}
       <div bind:this={lastPersonContainer}>

--- a/web/src/lib/components/faces-page/people-infinite-scroll.svelte
+++ b/web/src/lib/components/faces-page/people-infinite-scroll.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { PersonResponseDto } from '@immich/sdk';
+
+  export let people: PersonResponseDto[];
+  export let hasNextPage: boolean | undefined = undefined;
+  export let loadNextPage: () => void;
+
+  let lastPersonContainer: HTMLElement | undefined;
+
+  const resizeObserver = new IntersectionObserver((entries) => {
+    const entry = entries.find((entry) => entry.target === lastPersonContainer);
+    if (entry?.isIntersecting) {
+      loadNextPage();
+    }
+  });
+
+  $: if (lastPersonContainer) {
+    resizeObserver.disconnect();
+    resizeObserver.observe(lastPersonContainer);
+  }
+</script>
+
+<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-9 gap-1">
+  {#each people as person, index (person.id)}
+    {#if hasNextPage && index === people.length - 1}
+      <div bind:this={lastPersonContainer}>
+        <slot {person} {index} />
+      </div>
+    {:else}
+      <slot {person} {index} />
+    {/if}
+  {/each}
+</div>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -567,6 +567,7 @@
     "failed_to_get_people": "Failed to get people",
     "failed_to_load_asset": "Failed to load asset",
     "failed_to_load_assets": "Failed to load assets",
+    "failed_to_load_people": "Failed to load people",
     "failed_to_stack_assets": "Failed to stack assets",
     "failed_to_unstack_assets": "Failed to un-stack assets",
     "import_path_already_exists": "This import path already exists.",

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -42,7 +42,7 @@
 
   $: people = data.people.people;
   $: visiblePeople = people.filter((people) => !people.isHidden);
-  $: countVisiblePeople = searchName ? searchedPeopleLocal.length : visiblePeople.length;
+  $: countVisiblePeople = searchName ? searchedPeopleLocal.length : data.people.total - data.people.hidden;
   $: showPeople = searchName ? searchedPeopleLocal : visiblePeople;
 
   let selectHidden = false;
@@ -414,6 +414,7 @@
   >
     <ManagePeopleVisibility
       bind:people
+      totalPeopleCount={data.people.total}
       titleId="manage-visibility-title"
       onClose={() => (selectHidden = false)}
       {loadNextPage}

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -41,7 +41,6 @@
   export let data: PageData;
 
   $: people = data.people.people;
-  $: nextPage = data.people.hasNextPage ? 2 : null;
   $: visiblePeople = people.filter((people) => !people.isHidden);
   $: countVisiblePeople = searchName ? searchedPeopleLocal.length : visiblePeople.length;
   $: showPeople = searchName ? searchedPeopleLocal : visiblePeople;
@@ -52,6 +51,7 @@
   let showSetBirthDateModal = false;
   let showMergeModal = false;
   let personName = '';
+  let nextPage = data.people.hasNextPage ? 2 : null;
   let personMerge1: PersonResponseDto;
   let personMerge2: PersonResponseDto;
   let potentialMergePeople: PersonResponseDto[] = [];
@@ -339,11 +339,14 @@
   </svelte:fragment>
 
   {#if countVisiblePeople > 0 && (!searchName || searchedPeopleLocal.length > 0)}
-    <PeopleInfiniteScroll people={showPeople} hasNextPage={!!nextPage && !searchName} {loadNextPage}>
+    <PeopleInfiniteScroll
+      people={showPeople}
+      hasNextPage={!!nextPage && !searchName}
+      {loadNextPage}
+      let:person
+      let:index
+    >
       <PeopleCard
-        slot="default"
-        let:person
-        let:index
         {person}
         preload={index < 20}
         on:change-name={() => handleChangeName(person)}
@@ -409,6 +412,11 @@
     aria-labelledby="manage-visibility-title"
     use:focusTrap
   >
-    <ManagePeopleVisibility bind:people titleId="manage-visibility-title" onClose={() => (selectHidden = false)} />
+    <ManagePeopleVisibility
+      bind:people
+      titleId="manage-visibility-title"
+      onClose={() => (selectHidden = false)}
+      {loadNextPage}
+    />
   </section>
 {/if}


### PR DESCRIPTION
Adds pagination for people to the server and infinite scroll to the people page on web for viewing more then 500 people.

- Order by `person.createdAt` to have results in the same order every time
- `hasNextPage` is optional to keep backwards compatibility with the mobile app
- Web will see some performance issues when loading a lot of people. I plan to address this in a future PR using virtual scroll.