### PR TITLE
fix: "acess" should be "access"

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -24,7 +24,7 @@ This environment includes the services below. Additional details are available i
 - Web app - [`/web`](https://github.com/immich-app/immich/tree/main/web)
 - Machine learning - [`/machine-learning`](https://github.com/immich-app/immich/tree/main/machine-learning)
 - Redis
-- PostgreSQL development database with exposed port `5432` so you can use any database client to acess it
+- PostgreSQL development database with exposed port `5432` so you can use any database client to access it
 
 All the services are packaged to run as with single Docker Compose command.
 


### PR DESCRIPTION
Hello, I was reading the docs and came across a typo on this page https://immich.app/docs/developer/setup

The word "acess" should be "access". 

This is my first contribution here, so please let me know if you need me to make any changes. 