### PR TITLE
fix(server): correct person birth date across timezones

### DIFF
--- a/e2e/src/api/specs/person.e2e-spec.ts
+++ b/e2e/src/api/specs/person.e2e-spec.ts
@@ -6,10 +6,19 @@ import request from 'supertest';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 const invalidBirthday = [
-  { birthDate: 'false', response: 'birthDate must be a date string' },
-  { birthDate: '123567', response: 'birthDate must be a date string' },
-  { birthDate: 123_567, response: 'birthDate must be a date string' },
-  { birthDate: new Date(9999, 0, 0).toISOString(), response: ['Birth date cannot be in the future'] },
+  {
+    birthDate: 'false',
+    response: ['birthDate must be a string in the format yyyy-MM-dd', 'Birth date cannot be in the future'],
+  },
+  {
+    birthDate: '123567',
+    response: ['birthDate must be a string in the format yyyy-MM-dd', 'Birth date cannot be in the future'],
+  },
+  {
+    birthDate: 123_567,
+    response: ['birthDate must be a string in the format yyyy-MM-dd', 'Birth date cannot be in the future'],
+  },
+  { birthDate: '9999-01-01', response: ['Birth date cannot be in the future'] },
 ];
 
 describe('/people', () => {
@@ -185,13 +194,13 @@ describe('/people', () => {
         .set('Authorization', `Bearer ${admin.accessToken}`)
         .send({
           name: 'New Person',
-          birthDate: '1990-01-01T05:00:00.000Z',
+          birthDate: '1990-01-01',
         });
       expect(status).toBe(201);
       expect(body).toMatchObject({
         id: expect.any(String),
         name: 'New Person',
-        birthDate: '1990-01-01T05:00:00.000Z',
+        birthDate: '1990-01-01',
       });
     });
   });
@@ -233,7 +242,7 @@ describe('/people', () => {
       const { status, body } = await request(app)
         .put(`/people/${visiblePerson.id}`)
         .set('Authorization', `Bearer ${admin.accessToken}`)
-        .send({ birthDate: '1990-01-01T05:00:00.000Z' });
+        .send({ birthDate: '1990-01-01' });
       expect(status).toBe(200);
       expect(body).toMatchObject({ birthDate: '1990-01-01' });
     });

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsInt, IsNotEmpty, IsString, Max, MaxDate, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateNested } from 'class-validator';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { PersonEntity } from 'src/entities/person.entity';
-import { Optional, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
+import { IsDateStringFormat, MaxDateString, Optional, ValidateBoolean, ValidateUUID } from 'src/validation';
 
 export class PersonCreateDto {
   /**
@@ -19,9 +19,11 @@ export class PersonCreateDto {
    * Person date of birth.
    * Note: the mobile app cannot currently set the birth date to null.
    */
-  @MaxDate(() => new Date(), { message: 'Birth date cannot be in the future' })
-  @ValidateDate({ optional: true, nullable: true, format: 'date' })
-  birthDate?: Date | null;
+  @ApiProperty({ format: 'date' })
+  @MaxDateString(() => new Date(), { message: 'Birth date cannot be in the future' })
+  @IsDateStringFormat('yyyy-MM-dd')
+  @IsOptional()
+  birthDate?: string | null;
 
   /**
    * Person visibility
@@ -84,7 +86,7 @@ export class PersonResponseDto {
   id!: string;
   name!: string;
   @ApiProperty({ format: 'date' })
-  birthDate!: Date | null;
+  birthDate!: string | null;
   thumbnailPath!: string;
   isHidden!: boolean;
   @PropertyLifecycle({ addedAt: 'v1.107.0' })

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsInt, IsNotEmpty, IsString, Max, Min, ValidateNested } from 'class-validator';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
@@ -22,7 +22,7 @@ export class PersonCreateDto {
   @ApiProperty({ format: 'date' })
   @MaxDateString(() => new Date(), { message: 'Birth date cannot be in the future' })
   @IsDateStringFormat('yyyy-MM-dd')
-  @IsOptional()
+  @Optional({ nullable: true })
   birthDate?: string | null;
 
   /**

--- a/server/src/entities/person.entity.ts
+++ b/server/src/entities/person.entity.ts
@@ -33,7 +33,7 @@ export class PersonEntity {
   name!: string;
 
   @Column({ type: 'date', nullable: true })
-  birthDate!: Date | null;
+  birthDate!: string | null;
 
   @Column({ default: '' })
   thumbnailPath!: string;

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -256,15 +256,15 @@ describe(PersonService.name, () => {
       personMock.getAssets.mockResolvedValue([assetStub.image]);
       accessMock.person.checkOwnerAccess.mockResolvedValue(new Set(['person-1']));
 
-      await expect(sut.update(authStub.admin, 'person-1', { birthDate: new Date('1976-06-30') })).resolves.toEqual({
+      await expect(sut.update(authStub.admin, 'person-1', { birthDate: '1976-06-30' })).resolves.toEqual({
         id: 'person-1',
         name: 'Person 1',
-        birthDate: new Date('1976-06-30'),
+        birthDate: '1976-06-30',
         thumbnailPath: '/path/to/thumbnail.jpg',
         isHidden: false,
         updatedAt: expect.any(Date),
       });
-      expect(personMock.update).toHaveBeenCalledWith({ id: 'person-1', birthDate: new Date('1976-06-30') });
+      expect(personMock.update).toHaveBeenCalledWith({ id: 'person-1', birthDate: '1976-06-30' });
       expect(jobMock.queue).not.toHaveBeenCalled();
       expect(jobMock.queueAll).not.toHaveBeenCalled();
       expect(accessMock.person.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['person-1']));

--- a/server/src/validation.spec.ts
+++ b/server/src/validation.spec.ts
@@ -16,9 +16,9 @@ describe('Validation', () => {
       await expect(validate(dto)).resolves.toHaveLength(0);
     });
 
-    it('fails when date is equal to maxDate', async () => {
+    it('passes when date is equal to maxDate', async () => {
       const dto = plainToInstance(MyDto, { date: '2000-01-01' });
-      await expect(validate(dto)).resolves.toHaveLength(1);
+      await expect(validate(dto)).resolves.toHaveLength(0);
     });
 
     it('fails when date is after maxDate', async () => {

--- a/server/src/validation.spec.ts
+++ b/server/src/validation.spec.ts
@@ -1,0 +1,56 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IsDateStringFormat, MaxDateString } from 'src/validation';
+
+describe('Validation', () => {
+  describe('MaxDateString', () => {
+    const maxDate = new Date(2000, 0, 1);
+
+    class MyDto {
+      @MaxDateString(maxDate)
+      date!: string;
+    }
+
+    it('passes when date is before maxDate', async () => {
+      const dto = plainToInstance(MyDto, { date: '1999-12-31' });
+      await expect(validate(dto)).resolves.toHaveLength(0);
+    });
+
+    it('fails when date is equal to maxDate', async () => {
+      const dto = plainToInstance(MyDto, { date: '2000-01-01' });
+      await expect(validate(dto)).resolves.toHaveLength(1);
+    });
+
+    it('fails when date is after maxDate', async () => {
+      const dto = plainToInstance(MyDto, { date: '2010-01-01' });
+      await expect(validate(dto)).resolves.toHaveLength(1);
+    });
+  });
+
+  describe('IsDateStringFormat', () => {
+    class MyDto {
+      @IsDateStringFormat('yyyy-MM-dd')
+      date!: string;
+    }
+
+    it('passes when date is valid', async () => {
+      const dto = plainToInstance(MyDto, { date: '1999-12-31' });
+      await expect(validate(dto)).resolves.toHaveLength(0);
+    });
+
+    it('fails when date has invalid format', async () => {
+      const dto = plainToInstance(MyDto, { date: '2000-01-01T00:00:00Z' });
+      await expect(validate(dto)).resolves.toHaveLength(1);
+    });
+
+    it('fails when empty string', async () => {
+      const dto = plainToInstance(MyDto, { date: '' });
+      await expect(validate(dto)).resolves.toHaveLength(1);
+    });
+
+    it('fails when undefined', async () => {
+      const dto = plainToInstance(MyDto, {});
+      await expect(validate(dto)).resolves.toHaveLength(1);
+    });
+  });
+});

--- a/server/test/fixtures/person.stub.ts
+++ b/server/test/fixtures/person.stub.ts
@@ -65,7 +65,7 @@ export const personStub = {
     ownerId: userStub.admin.id,
     owner: userStub.admin,
     name: 'Person 1',
-    birthDate: new Date('1976-06-30'),
+    birthDate: '1976-06-30',
     thumbnailPath: '/path/to/thumbnail.jpg',
     faces: [],
     faceAssetId: null,


### PR DESCRIPTION
The person's birth date is being set to the previous day when the server has a timezone with a negative UTC offset. Fixes #11354 by keeping `birthDate` as a string instead of converting it to a `Date`.

Testing this is difficult, because there doesn't seem to be a way to set the timezone during tests.
