### PR TITLE
feat(server): significantly improve Australian reverse geocoding accuracy

### DIFF
--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -297,7 +297,16 @@ export class MapRepository implements IMapRepository {
           admin2Name: admin2Map.get(`${lineSplit[8]}.${lineSplit[10]}.${lineSplit[11]}`),
         }),
       resourcePaths.geodata.cities500,
-      { entityFilter: (lineSplit) => lineSplit[7] != 'PPLX' },
+      {
+        entityFilter: (lineSplit) => {
+          if (lineSplit[7] === 'PPLX') {
+            // Exclude populated subsections of cities that are not in Australia.
+            // Australia has a lot of PPLX areas, so we include them.
+            return lineSplit[8] === 'AU';
+          }
+          return true;
+        },
+      },
     );
   }
 


### PR DESCRIPTION
## Description
Many Australian suburbs are recorded as PPLXs instead of PPLs in the `cities500` geonames dataset.

The current implementation of Immich specifically excludes [PPLXs](https://github.com/immich-app/immich/blob/ade29012592cbc50e9b2ad931ff3c4d869421267/server/src/repositories/map.repository.ts#L300). This leads to the majority of photos taken in Australia having a reverse geocoded suburb that is completely off.

**This PR allows PPLXs only from Australia to be ingested into the reverse geocoding table.**

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Built the server and ran it on my own instance. Uploaded a photo taken in Australia and observed that the reverse geocoded suburb was much more accurate.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable