### PR TITLE
fix(mobile): changed "x jaren" to "x jaar" in dutch app translations

### DIFF
--- a/mobile/assets/i18n/nl-NL.json
+++ b/mobile/assets/i18n/nl-NL.json
@@ -305,7 +305,7 @@
   "memories_start_over": "Opnieuw beginnen",
   "memories_swipe_to_close": "Swipe omhoog om te sluiten",
   "memories_year_ago": "Een jaar geleden",
-  "memories_years_ago": "{} jaren geleden",
+  "memories_years_ago": "{} jaar geleden",
   "monthly_title_text_date_format": "MMMM y",
   "motion_photos_page_title": "Bewegende foto's",
   "multiselect_grid_edit_date_time_err_read_only": "Kan datum van alleen-lezen asset(s) niet wijzigen, overslaan",


### PR DESCRIPTION
See this link for more information: https://thedutchonlineacademy.com/en/grammar/jaar-or-jaren

This is already set to "x jaar" on the web version so nothing is changed there