### PR TITLE
chore: bump vitest to 1.6.0

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -37,7 +37,7 @@
         "supertest": "^7.0.0",
         "typescript": "^5.3.3",
         "utimes": "^5.2.1",
-        "vitest": "^1.3.0"
+        "vitest": "^1.6.0"
       }
     },
     "../cli": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -47,7 +47,7 @@
     "supertest": "^7.0.0",
     "typescript": "^5.3.3",
     "utimes": "^5.2.1",
-    "vitest": "^1.3.0"
+    "vitest": "^1.6.0"
   },
   "volta": {
     "node": "20.15.1"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -103,7 +103,7 @@
         "typescript": "^5.3.3",
         "unplugin-swc": "^1.4.5",
         "utimes": "^5.2.1",
-        "vitest": "^1.5.0"
+        "vitest": "^1.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/server/package.json
+++ b/server/package.json
@@ -129,7 +129,7 @@
     "typescript": "^5.3.3",
     "unplugin-swc": "^1.4.5",
     "utimes": "^5.2.1",
-    "vitest": "^1.5.0"
+    "vitest": "^1.6.0"
   },
   "volta": {
     "node": "20.15.1"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -65,7 +65,7 @@
         "tslib": "^2.6.2",
         "typescript": "^5.3.3",
         "vite": "^5.1.4",
-        "vitest": "^1.3.1"
+        "vitest": "^1.6.0"
       }
     },
     "../open-api/typescript-sdk": {

--- a/web/package.json
+++ b/web/package.json
@@ -58,7 +58,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
     "vite": "^5.1.4",
-    "vitest": "^1.3.1"
+    "vitest": "^1.6.0"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
The vitest vscode plugin complained about vitest being out of date in web and e2e. I took the liberty to bump to the latest version (1.6.0), including on the server