### PR TITLE
fix(mobile): Crop presets break crop rectangle #11462 

### DIFF
--- a/mobile/lib/pages/editing/crop.page.dart
+++ b/mobile/lib/pages/editing/crop.page.dart
@@ -192,6 +192,7 @@ class _AspectRatioButton extends StatelessWidget {
                 : Theme.of(context).iconTheme.color,
           ),
           onPressed: () {
+            cropController.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
             aspectRatio.value = ratio;
             cropController.aspectRatio = ratio;
           },


### PR DESCRIPTION
Fix for the #11462 issue; Added just a small line to my past code! #10989
Edit: Copy of the other pull request with the fixed git history issue

| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/06b5ab0e-0842-4004-a2e1-4540ac702f26">  | <video src="https://github.com/user-attachments/assets/ca431c81-1ee5-4d01-9f65-8890faabe81e">|







