### PR TITLE
fix(mobile): Naming fix for the edited file

### DIFF
--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -97,8 +97,10 @@ class EditImagePage extends ConsumerWidget {
                     gravity: ToastGravity.CENTER,
                   );
 
-                  await PhotoManager.editor
-                      .saveImage(imageData, title: '${asset!.fileName}_edited.jpg');
+                  await PhotoManager.editor.saveImage(
+                    imageData,
+                    title: '${asset!.fileName}_edited.jpg',
+                  );
                   await ref.read(albumProvider.notifier).getDeviceAlbums();
                   Navigator.of(context).popUntil((route) => route.isFirst);
                 } catch (e) {

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -98,7 +98,7 @@ class EditImagePage extends ConsumerWidget {
                   );
 
                   await PhotoManager.editor
-                      .saveImage(imageData, title: "_edited.jpg");
+                      .saveImage(imageData, title: '${asset!.fileName}_edited.jpg');
                   await ref.read(albumProvider.notifier).getDeviceAlbums();
                   Navigator.of(context).popUntil((route) => route.isFirst);
                 } catch (e) {


### PR DESCRIPTION
This commit brings the change in the naming of the edited files on mobile. Its just a simple change that was highly requested today.

Before the edited files are named: `_edited.jpg`
With this commit the edited files are named: `FILE_NAME_edited.jpg`