### PR TITLE
fix(web): websocket over ipv6

### DIFF
--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -424,12 +424,12 @@ export const utils = {
 
   createPartner: (accessToken: string, id: string) => createPartner({ id }, { headers: asBearerAuth(accessToken) }),
 
-  setAuthCookies: async (context: BrowserContext, accessToken: string) =>
+  setAuthCookies: async (context: BrowserContext, accessToken: string, domain = '127.0.0.1') =>
     await context.addCookies([
       {
         name: 'immich_access_token',
         value: accessToken,
-        domain: '127.0.0.1',
+        domain,
         path: '/',
         expires: 1_742_402_728,
         httpOnly: true,
@@ -439,7 +439,7 @@ export const utils = {
       {
         name: 'immich_auth_type',
         value: 'password',
-        domain: '127.0.0.1',
+        domain,
         path: '/',
         expires: 1_742_402_728,
         httpOnly: true,
@@ -449,7 +449,7 @@ export const utils = {
       {
         name: 'immich_is_authenticated',
         value: 'true',
-        domain: '127.0.0.1',
+        domain,
         path: '/',
         expires: 1_742_402_728,
         httpOnly: false,

--- a/e2e/src/web/specs/websocket.e2e-spec.ts
+++ b/e2e/src/web/specs/websocket.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { LoginResponseDto } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { utils } from 'src/utils';
+
+test.describe('Websocket', () => {
+  let admin: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+  });
+
+  test('connects using ipv4', async ({ page, context }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('http://127.0.0.1:2283/');
+    await expect(page.locator('#sidebar')).toContainText('Server Online');
+  });
+
+  test('connects using ipv6', async ({ page, context }) => {
+    await utils.setAuthCookies(context, admin.accessToken, '[::1]');
+    await page.goto('http://[::1]:2283/');
+    await expect(page.locator('#sidebar')).toContainText('Server Online');
+  });
+});

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -26,7 +26,7 @@ export interface Events {
   on_new_release: (newRelase: ReleaseEvent) => void;
 }
 
-const websocket: Socket<Events> = io('', {
+const websocket: Socket<Events> = io({
   path: '/api/socket.io',
   transports: ['websocket'],
   reconnection: true,


### PR DESCRIPTION
Currently no websocket connection is made when using an ipv6 address like <http://[::1]:2283> and `Server offline` is reported in the sidebar