### PR TITLE
fix(web): prevent change-location suggestion race-condition

### DIFF
--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -69,15 +69,18 @@
   };
 
   const handleSearchPlaces = () => {
-    if (searchWord === '') {
-      return;
-    }
-
     if (latestSearchTimeout) {
       clearTimeout(latestSearchTimeout);
     }
     showLoadingSpinner = true;
+
     const searchTimeout = window.setTimeout(() => {
+      if (searchWord === '') {
+        places = [];
+        showLoadingSpinner = false;
+        return;
+      }
+
       searchPlaces({ name: searchWord })
         .then((searchResult) => {
           // skip result when a newer search is happening


### PR DESCRIPTION
When debouncer activated on fast deletion, the handleSearchPlaces() function would fire a request with empty query. UI would then show "Immich Server Error".