### PR TITLE
refactor(server): startup checks for vector extension

### DIFF
--- a/server/src/interfaces/database.interface.ts
+++ b/server/src/interfaces/database.interface.ts
@@ -40,8 +40,10 @@ export interface VectorUpdateResult {
 export const IDatabaseRepository = 'IDatabaseRepository';
 
 export interface IDatabaseRepository {
-  getExtensionVersion(extensionName: string): Promise<ExtensionVersion>;
+  getExtensionVersion(extension: DatabaseExtension): Promise<ExtensionVersion>;
+  getExtensionVersionRange(extension: VectorExtension): string;
   getPostgresVersion(): Promise<string>;
+  getPostgresVersionRange(): string;
   createExtension(extension: DatabaseExtension): Promise<void>;
   updateExtension(extension: DatabaseExtension, version?: string): Promise<void>;
   updateVectorExtension(extension: VectorExtension, version?: string): Promise<VectorUpdateResult>;

--- a/server/src/interfaces/database.interface.ts
+++ b/server/src/interfaces/database.interface.ts
@@ -28,6 +28,11 @@ export const EXTENSION_NAMES: Record<DatabaseExtension, string> = {
   vectors: 'pgvecto.rs',
 } as const;
 
+export interface ExtensionVersion {
+  availableVersion: string | null;
+  installedVersion: string | null;
+}
+
 export interface VectorUpdateResult {
   restartRequired: boolean;
 }
@@ -35,8 +40,7 @@ export interface VectorUpdateResult {
 export const IDatabaseRepository = 'IDatabaseRepository';
 
 export interface IDatabaseRepository {
-  getExtensionVersion(extensionName: string): Promise<string | undefined>;
-  getAvailableExtensionVersion(extension: DatabaseExtension): Promise<string | undefined>;
+  getExtensionVersion(extensionName: string): Promise<ExtensionVersion>;
   getPostgresVersion(): Promise<string>;
   createExtension(extension: DatabaseExtension): Promise<void>;
   updateExtension(extension: DatabaseExtension, version?: string): Promise<void>;

--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -7,6 +7,7 @@ import {
   DatabaseExtension,
   DatabaseLock,
   EXTENSION_NAMES,
+  ExtensionVersion,
   IDatabaseRepository,
   VectorExtension,
   VectorIndex,
@@ -29,20 +30,14 @@ export class DatabaseRepository implements IDatabaseRepository {
     this.logger.setContext(DatabaseRepository.name);
   }
 
-  async getExtensionVersion(extension: DatabaseExtension): Promise<string | undefined> {
-    const res = await this.dataSource.query(`SELECT extversion FROM pg_extension WHERE extname = $1`, [extension]);
-    return res[0]?.['extversion'];
-  }
-
-  async getAvailableExtensionVersion(extension: DatabaseExtension): Promise<string | undefined> {
-    const res = await this.dataSource.query(
-      `
-    SELECT version FROM pg_available_extension_versions
-    WHERE name = $1 AND installed = false
-    ORDER BY version DESC`,
+  async getExtensionVersion(extension: DatabaseExtension): Promise<ExtensionVersion> {
+    const [res]: ExtensionVersion[] = await this.dataSource.query(
+      `SELECT default_version as "availableVersion", installed_version as "installedVersion"
+      FROM pg_available_extensions
+      WHERE name = $1`,
       [extension],
     );
-    return res[0]?.['version'];
+    return res ?? { availableVersion: null, installedVersion: null };
   }
 
   async getPostgresVersion(): Promise<string> {
@@ -59,28 +54,34 @@ export class DatabaseRepository implements IDatabaseRepository {
   }
 
   async updateVectorExtension(extension: VectorExtension, targetVersion?: string): Promise<VectorUpdateResult> {
-    const currentVersion = await this.getExtensionVersion(extension);
-    if (!currentVersion) {
+    const { availableVersion, installedVersion } = await this.getExtensionVersion(extension);
+    if (!installedVersion) {
       throw new Error(`${EXTENSION_NAMES[extension]} extension is not installed`);
     }
+
+    if (!availableVersion) {
+      throw new Error(`No available version for ${EXTENSION_NAMES[extension]} extension`);
+    }
+    targetVersion ??= availableVersion;
 
     const isVectors = extension === DatabaseExtension.VECTORS;
     let restartRequired = false;
     await this.dataSource.manager.transaction(async (manager) => {
       await this.setSearchPath(manager);
 
-      const isSchemaUpgrade = targetVersion && semver.satisfies(targetVersion, '0.1.1 || 0.1.11');
+      if (isVectors && installedVersion === '0.1.1') {
+        await this.setExtVersion(manager, DatabaseExtension.VECTORS, '0.1.11');
+      }
+
+      const isSchemaUpgrade = semver.satisfies(installedVersion, '0.1.1 || 0.1.11');
       if (isSchemaUpgrade && isVectors) {
-        await this.updateVectorsSchema(manager, currentVersion);
+        await this.updateVectorsSchema(manager);
       }
 
-      await manager.query(`ALTER EXTENSION ${extension} UPDATE${targetVersion ? ` TO '${targetVersion}'` : ''}`);
+      await manager.query(`ALTER EXTENSION ${extension} UPDATE TO '${targetVersion}'`);
 
-      if (!isSchemaUpgrade) {
-        return;
-      }
-
-      if (isVectors) {
+      const diff = semver.diff(installedVersion, targetVersion);
+      if (isVectors && diff && ['minor', 'major'].includes(diff)) {
         await manager.query('SELECT pgvectors_upgrade()');
         restartRequired = true;
       } else {
@@ -96,24 +97,24 @@ export class DatabaseRepository implements IDatabaseRepository {
     try {
       await this.dataSource.query(`REINDEX INDEX ${index}`);
     } catch (error) {
-      if (getVectorExtension() === DatabaseExtension.VECTORS) {
-        this.logger.warn(`Could not reindex index ${index}. Attempting to auto-fix.`);
-        const table = index === VectorIndex.CLIP ? 'smart_search' : 'face_search';
-        const dimSize = await this.getDimSize(table);
-        await this.dataSource.manager.transaction(async (manager) => {
-          await this.setSearchPath(manager);
-          await manager.query(`DROP INDEX IF EXISTS ${index}`);
-          await manager.query(`ALTER TABLE ${table} ALTER COLUMN embedding SET DATA TYPE real[]`);
-          await manager.query(`ALTER TABLE ${table} ALTER COLUMN embedding SET DATA TYPE vector(${dimSize})`);
-          await manager.query(`SET vectors.pgvector_compatibility=on`);
-          await manager.query(`
-            CREATE INDEX IF NOT EXISTS ${index} ON ${table}
-            USING hnsw (embedding vector_cosine_ops)
-            WITH (ef_construction = 300, m = 16)`);
-        });
-      } else {
+      if (getVectorExtension() !== DatabaseExtension.VECTORS) {
         throw error;
       }
+      this.logger.warn(`Could not reindex index ${index}. Attempting to auto-fix.`);
+
+      const table = await this.getIndexTable(index);
+      const dimSize = await this.getDimSize(table);
+      await this.dataSource.manager.transaction(async (manager) => {
+        await this.setSearchPath(manager);
+        await manager.query(`DROP INDEX IF EXISTS ${index}`);
+        await manager.query(`ALTER TABLE ${table} ALTER COLUMN embedding SET DATA TYPE real[]`);
+        await manager.query(`ALTER TABLE ${table} ALTER COLUMN embedding SET DATA TYPE vector(${dimSize})`);
+        await manager.query(`SET vectors.pgvector_compatibility=on`);
+        await manager.query(`
+          CREATE INDEX IF NOT EXISTS ${index} ON ${table}
+          USING hnsw (embedding vector_cosine_ops)
+          WITH (ef_construction = 300, m = 16)`);
+      });
     }
   }
 
@@ -123,13 +124,8 @@ export class DatabaseRepository implements IDatabaseRepository {
     }
 
     try {
-      const res = await this.dataSource.query(
-        `
-          SELECT idx_status
-          FROM pg_vector_index_stat
-          WHERE indexname = $1`,
-        [name],
-      );
+      const query = `SELECT idx_status FROM pg_vector_index_stat WHERE indexname = $1`;
+      const res = await this.dataSource.query(query, [name]);
       return res[0]?.['idx_status'] === 'UPGRADE';
     } catch (error) {
       const message: string = (error as any).message;
@@ -146,19 +142,27 @@ export class DatabaseRepository implements IDatabaseRepository {
     await manager.query(`SET search_path TO "$user", public, vectors`);
   }
 
-  private async updateVectorsSchema(manager: EntityManager, currentVersion: string): Promise<void> {
-    await manager.query('CREATE SCHEMA IF NOT EXISTS vectors');
-    await manager.query(`UPDATE pg_catalog.pg_extension SET extversion = $1 WHERE extname = $2`, [
-      currentVersion,
-      DatabaseExtension.VECTORS,
-    ]);
-    await manager.query('UPDATE pg_catalog.pg_extension SET extrelocatable = true WHERE extname = $1', [
-      DatabaseExtension.VECTORS,
-    ]);
+  private async setExtVersion(manager: EntityManager, extName: DatabaseExtension, version: string): Promise<void> {
+    const query = `UPDATE pg_catalog.pg_extension SET extversion = $1 WHERE extname = $2`;
+    await manager.query(query, [version, extName]);
+  }
+
+  private async getIndexTable(index: VectorIndex): Promise<string> {
+    const tableQuery = `SELECT relname FROM pg_stat_all_indexes WHERE indexrelname = $1`;
+    const [res]: { relname: string | null }[] = await this.dataSource.manager.query(tableQuery, [index]);
+    const table = res?.relname;
+    if (!table) {
+      throw new Error(`Could not find table for index ${index}`);
+    }
+    return table;
+  }
+
+  private async updateVectorsSchema(manager: EntityManager): Promise<void> {
+    const extension = DatabaseExtension.VECTORS;
+    await manager.query(`CREATE SCHEMA IF NOT EXISTS ${extension}`);
+    await manager.query('UPDATE pg_catalog.pg_extension SET extrelocatable = true WHERE extname = $1', [extension]);
     await manager.query('ALTER EXTENSION vectors SET SCHEMA vectors');
-    await manager.query('UPDATE pg_catalog.pg_extension SET extrelocatable = false WHERE extname = $1', [
-      DatabaseExtension.VECTORS,
-    ]);
+    await manager.query('UPDATE pg_catalog.pg_extension SET extrelocatable = false WHERE extname = $1', [extension]);
   }
 
   private async getDimSize(table: string, column = 'embedding'): Promise<number> {

--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import AsyncLock from 'async-lock';
 import semver from 'semver';
+import { POSTGRES_VERSION_RANGE, VECTOR_VERSION_RANGE, VECTORS_VERSION_RANGE } from 'src/constants';
 import { getVectorExtension } from 'src/database.config';
 import {
   DatabaseExtension,
@@ -40,9 +41,17 @@ export class DatabaseRepository implements IDatabaseRepository {
     return res ?? { availableVersion: null, installedVersion: null };
   }
 
+  getExtensionVersionRange(extension: VectorExtension): string {
+    return extension === DatabaseExtension.VECTORS ? VECTORS_VERSION_RANGE : VECTOR_VERSION_RANGE;
+  }
+
   async getPostgresVersion(): Promise<string> {
     const [{ server_version: version }] = await this.dataSource.query(`SHOW server_version`);
     return version;
+  }
+
+  getPostgresVersionRange(): string {
+    return POSTGRES_VERSION_RANGE;
   }
 
   async createExtension(extension: DatabaseExtension): Promise<void> {

--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -38,6 +38,10 @@ describe(DatabaseService.name, () => {
     delete process.env.DB_VECTOR_EXTENSION;
   });
 
+  it('should work', () => {
+    expect(sut).toBeDefined();
+  });
+
   it('should throw an error if PostgreSQL version is below minimum supported version', async () => {
     databaseMock.getPostgresVersion.mockResolvedValueOnce('13.10.0');
 
@@ -52,10 +56,6 @@ describe(DatabaseService.name, () => {
   ])('should work with $extensionName', ({ extension, extensionName }) => {
     beforeEach(() => {
       process.env.DB_VECTOR_EXTENSION = extensionName;
-    });
-
-    it('should work', () => {
-      expect(sut).toBeDefined();
     });
 
     it(`should start up successfully with ${extension}`, async () => {

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -8,6 +8,7 @@ import {
   DatabaseLock,
   EXTENSION_NAMES,
   IDatabaseRepository,
+  VectorExtension,
   VectorIndex,
 } from 'src/interfaces/database.interface';
 import { OnEvents } from 'src/interfaces/event.interface';
@@ -25,43 +26,39 @@ const EXTENSION_RANGES = {
 };
 
 const messages = {
-  notInstalled: (name: string) => `Unexpected: The ${name} extension is not installed.`,
+  notInstalled: (name: string) =>
+    `The ${name} extension is not available in this Postgres instance.
+    If using a container image, ensure the image has the extension installed.`,
   nightlyVersion: ({ name, extension, version }: NightlyVersionArgs) => `
-        The ${name} extension version is ${version}, which means it is a nightly release.
+    The ${name} extension version is ${version}, which means it is a nightly release.
 
-        Please run 'DROP EXTENSION IF EXISTS ${extension}' and switch to a release version.
-        See https://immich.app/docs/guides/database-queries for how to query the database.`,
-  outOfRange: ({ name, extension, version, range }: OutOfRangeArgs) => `
-        The ${name} extension version is ${version}, but Immich only supports ${range}.
+    Please run 'DROP EXTENSION IF EXISTS ${extension}' and switch to a release version.
+    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+  outOfRange: ({ name, version, range }: OutOfRangeArgs) =>
+    `The ${name} extension version is ${version}, but Immich only supports ${range}.
+    Please change ${name} to a compatible version in the Postgres instance.`,
+  createFailed: ({ name, extension, otherName }: CreateFailedArgs) =>
+    `Failed to activate ${name} extension.
+    Please ensure the Postgres instance has ${name} installed.
 
-        If the Postgres instance already has a compatible version installed, Immich may not have the necessary permissions to activate it.
-        In this case, please run 'ALTER EXTENSION UPDATE ${extension}' manually as a superuser.
-        See https://immich.app/docs/guides/database-queries for how to query the database.
+    If the Postgres instance already has ${name} installed, Immich may not have the necessary permissions to activate it.
+    In this case, please run 'CREATE EXTENSION IF NOT EXISTS ${extension}' manually as a superuser.
+    See https://immich.app/docs/guides/database-queries for how to query the database.
 
-        Otherwise, please update the version of ${name} in the Postgres instance to a compatible version.`,
-  createFailed: ({ name, extension, otherName }: CreateFailedArgs) => `
-        Failed to activate ${name} extension.
-        Please ensure the Postgres instance has ${name} installed.
+    Alternatively, if your Postgres instance has ${otherName}, you may use this instead by setting the environment variable 'DB_VECTOR_EXTENSION=${otherName}'.
+    Note that switching between the two extensions after a successful startup is not supported.
+    The exception is if your version of Immich prior to upgrading was 1.90.2 or earlier.
+    In this case, you may set either extension now, but you will not be able to switch to the other extension following a successful startup.`,
+  updateFailed: ({ name, extension, availableVersion }: UpdateFailedArgs) =>
+    `The ${name} extension can be updated to ${availableVersion}.
+    Immich attempted to update the extension, but failed to do so.
+    This may be because Immich does not have the necessary permissions to update the extension.
 
-        If the Postgres instance already has ${name} installed, Immich may not have the necessary permissions to activate it.
-        In this case, please run 'CREATE EXTENSION IF NOT EXISTS ${extension}' manually as a superuser.
-        See https://immich.app/docs/guides/database-queries for how to query the database.
-
-        Alternatively, if your Postgres instance has ${otherName}, you may use this instead by setting the environment variable 'DB_VECTOR_EXTENSION=${otherName}'.
-        Note that switching between the two extensions after a successful startup is not supported.
-        The exception is if your version of Immich prior to upgrading was 1.90.2 or earlier.
-        In this case, you may set either extension now, but you will not be able to switch to the other extension following a successful startup.
-      `,
-  updateFailed: ({ name, extension, availableVersion }: UpdateFailedArgs) => `
-        The ${name} extension can be updated to ${availableVersion}.
-        Immich attempted to update the extension, but failed to do so.
-        This may be because Immich does not have the necessary permissions to update the extension.
-
-        Please run 'ALTER EXTENSION ${extension} UPDATE' manually as a superuser.
-        See https://immich.app/docs/guides/database-queries for how to query the database.`,
-  restartRequired: ({ name, availableVersion }: RestartRequiredArgs) => `
-        The ${name} extension has been updated to ${availableVersion}.
-        Please restart the Postgres instance to complete the update.`,
+    Please run 'ALTER EXTENSION ${extension} UPDATE' manually as a superuser.
+    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+  restartRequired: ({ name, availableVersion }: RestartRequiredArgs) =>
+    `The ${name} extension has been updated to ${availableVersion}.
+    Please restart the Postgres instance to complete the update.`,
 };
 
 @Injectable()
@@ -85,66 +82,79 @@ export class DatabaseService implements OnEvents {
 
     await this.databaseRepository.withLock(DatabaseLock.Migrations, async () => {
       const extension = getVectorExtension();
-      const otherExtension =
-        extension === DatabaseExtension.VECTORS ? DatabaseExtension.VECTOR : DatabaseExtension.VECTORS;
-      const otherName = EXTENSION_NAMES[otherExtension];
       const name = EXTENSION_NAMES[extension];
       const extensionRange = EXTENSION_RANGES[extension];
 
-      try {
-        await this.databaseRepository.createExtension(extension);
-      } catch (error) {
-        this.logger.fatal(messages.createFailed({ name, extension, otherName }));
-        throw error;
-      }
-
-      const initialVersion = await this.databaseRepository.getExtensionVersion(extension);
-      const availableVersion = await this.databaseRepository.getAvailableExtensionVersion(extension);
-      const isAvailable = availableVersion && semver.satisfies(availableVersion, extensionRange);
-      if (isAvailable && (!initialVersion || semver.gt(availableVersion, initialVersion))) {
-        try {
-          this.logger.log(`Updating ${name} extension to ${availableVersion}`);
-          const { restartRequired } = await this.databaseRepository.updateVectorExtension(extension, availableVersion);
-          if (restartRequired) {
-            this.logger.warn(messages.restartRequired({ name, availableVersion }));
-          }
-        } catch (error) {
-          this.logger.warn(messages.updateFailed({ name, extension, availableVersion }));
-          this.logger.error(error);
-        }
-      }
-
-      const version = await this.databaseRepository.getExtensionVersion(extension);
-      if (!version) {
+      const { availableVersion, installedVersion } = await this.databaseRepository.getExtensionVersion(extension);
+      if (!availableVersion) {
         throw new Error(messages.notInstalled(name));
       }
 
-      if (semver.eq(version, '0.0.0')) {
-        throw new Error(messages.nightlyVersion({ name, extension, version }));
+      if ([availableVersion, installedVersion].some((version) => version && semver.eq(version, '0.0.0'))) {
+        throw new Error(messages.nightlyVersion({ name, extension, version: '0.0.0' }));
       }
 
-      if (!semver.satisfies(version, extensionRange)) {
-        throw new Error(messages.outOfRange({ name, extension, version, range: extensionRange }));
+      if (!semver.satisfies(availableVersion, extensionRange)) {
+        throw new Error(messages.outOfRange({ name, extension, version: availableVersion, range: extensionRange }));
       }
 
-      try {
-        if (await this.databaseRepository.shouldReindex(VectorIndex.CLIP)) {
-          await this.databaseRepository.reindex(VectorIndex.CLIP);
-        }
-
-        if (await this.databaseRepository.shouldReindex(VectorIndex.FACE)) {
-          await this.databaseRepository.reindex(VectorIndex.FACE);
-        }
-      } catch (error) {
-        this.logger.warn(
-          'Could not run vector reindexing checks. If the extension was updated, please restart the Postgres instance.',
-        );
-        throw error;
+      if (!installedVersion) {
+        await this.createExtension(extension);
       }
+
+      if (installedVersion && semver.gt(availableVersion, installedVersion)) {
+        await this.updateExtension(extension, availableVersion);
+      } else if (installedVersion && !semver.satisfies(installedVersion, extensionRange)) {
+        throw new Error(messages.outOfRange({ name, extension, version: installedVersion, range: extensionRange }));
+      }
+
+      await this.checkReindexing();
 
       if (process.env.DB_SKIP_MIGRATIONS !== 'true') {
         await this.databaseRepository.runMigrations();
       }
     });
+  }
+
+  private async createExtension(extension: DatabaseExtension) {
+    try {
+      await this.databaseRepository.createExtension(extension);
+    } catch (error) {
+      const otherExtension =
+        extension === DatabaseExtension.VECTORS ? DatabaseExtension.VECTOR : DatabaseExtension.VECTORS;
+      const name = EXTENSION_NAMES[extension];
+      this.logger.fatal(messages.createFailed({ name, extension, otherName: EXTENSION_NAMES[otherExtension] }));
+      throw error;
+    }
+  }
+
+  private async updateExtension(extension: VectorExtension, availableVersion: string) {
+    this.logger.log(`Updating ${EXTENSION_NAMES[extension]} extension to ${availableVersion}`);
+    try {
+      const { restartRequired } = await this.databaseRepository.updateVectorExtension(extension, availableVersion);
+      if (restartRequired) {
+        this.logger.warn(messages.restartRequired({ name: EXTENSION_NAMES[extension], availableVersion }));
+      }
+    } catch (error) {
+      this.logger.warn(messages.updateFailed({ name: EXTENSION_NAMES[extension], extension, availableVersion }));
+      throw error;
+    }
+  }
+
+  private async checkReindexing() {
+    try {
+      if (await this.databaseRepository.shouldReindex(VectorIndex.CLIP)) {
+        await this.databaseRepository.reindex(VectorIndex.CLIP);
+      }
+
+      if (await this.databaseRepository.shouldReindex(VectorIndex.FACE)) {
+        await this.databaseRepository.reindex(VectorIndex.FACE);
+      }
+    } catch (error) {
+      this.logger.warn(
+        'Could not run vector reindexing checks. If the extension was updated, please restart the Postgres instance.',
+      );
+      throw error;
+    }
   }
 }

--- a/server/test/repositories/database.repository.mock.ts
+++ b/server/test/repositories/database.repository.mock.ts
@@ -4,7 +4,6 @@ import { Mocked, vitest } from 'vitest';
 export const newDatabaseRepositoryMock = (): Mocked<IDatabaseRepository> => {
   return {
     getExtensionVersion: vitest.fn(),
-    getAvailableExtensionVersion: vitest.fn(),
     getPostgresVersion: vitest.fn().mockResolvedValue('14.10 (Debian 14.10-1.pgdg120+1)'),
     createExtension: vitest.fn().mockResolvedValue(void 0),
     updateExtension: vitest.fn(),

--- a/server/test/repositories/database.repository.mock.ts
+++ b/server/test/repositories/database.repository.mock.ts
@@ -4,7 +4,9 @@ import { Mocked, vitest } from 'vitest';
 export const newDatabaseRepositoryMock = (): Mocked<IDatabaseRepository> => {
   return {
     getExtensionVersion: vitest.fn(),
+    getExtensionVersionRange: vitest.fn(),
     getPostgresVersion: vitest.fn().mockResolvedValue('14.10 (Debian 14.10-1.pgdg120+1)'),
+    getPostgresVersionRange: vitest.fn().mockReturnValue('>=14.0.0'),
     createExtension: vitest.fn().mockResolvedValue(void 0),
     updateExtension: vitest.fn(),
     updateVectorExtension: vitest.fn(),


### PR DESCRIPTION
- Fixes the 0.1.1 `extversion` not being corrected to 0.1.11 in the DB, preventing an upgrade from versions 1.91.0-1.94.2 to 1.106.0 or later
- Fixes the reindexing check assuming the existence of the `face_search` table, preventing an upgrade from versions 1.91.0-1.94.2 to 1.107.0 or later
- Throws an error if the available version is outside of the allowed version range since this means the wrong version is installed. Creating or updating to this just makes downgrading more difficult
- Does not recommend running `ALTER EXTENSION UPDATE` unless the update query itself failed
- Throws immediately if the extension isn't created and isn't available
- Checks if extension is nightly *before* creating it
- Runs `pgvectors_upgrade()` on minor or major updates even if there's no schema change
- Throws an error if the Postgres image was downgraded to have a lower version of an extension than what's activated in the DB
  - This will just throw an uglier and less helpful error later
  - Could benefit from official downgrading instructions, but it's enough steps to warrant its own documentation PR
- Gets both current and available versions in one query
- Refactors tests to be less coupled to current version constraints and avoid manually duplicating the test suite for each extension
- Adds a few helper methods in the database service for readability

### How Has This Been Tested?
- Tested upgrading directly from 1.90.2 to main
  - Confirmed a successful startup with a correct DB layout containing the expected vector data
  - Search and face detection both worked
- Tested on an existing instance with no issues during startup
- Tested upgrading from 0.2.0 to 0.2.1, confirming it did update and started up successfully
- Tested that switching to the pgvecto.rs 0.3.0 image raised the correct error

Also tested that 0.3.0 works following these changes, but updating can be a separate PR.