### PR TITLE
chore: add `healthcheck` field to server and ml

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -46,6 +46,8 @@ services:
     depends_on:
       - redis
       - database
+    healthcheck:
+      disable: false
 
   immich-web:
     container_name: immich_web
@@ -91,6 +93,8 @@ services:
     depends_on:
       - database
     restart: unless-stopped
+    healthcheck:
+      disable: false
 
   redis:
     container_name: immich_redis

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -21,6 +21,8 @@ services:
       - redis
       - database
     restart: always
+    healthcheck:
+      disable: false
 
   immich-machine-learning:
     container_name: immich_machine_learning
@@ -40,6 +42,8 @@ services:
     env_file:
       - .env
     restart: always
+    healthcheck:
+      disable: false
 
   redis:
     container_name: immich_redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - redis
       - database
     restart: always
+    healthcheck:
+      disable: false
 
   immich-machine-learning:
     container_name: immich_machine_learning
@@ -41,6 +43,8 @@ services:
     env_file:
       - .env
     restart: always
+    healthcheck:
+      disable: false
 
   redis:
     container_name: immich_redis


### PR DESCRIPTION
## Description

There have been some cases where the implicitly enabled health checks lead to confusing behavior for the admin to figure out. There's no indication these health checks are being run, so they just see an unusual CPU usage or disks not spinning down.

This PR adds a `healthcheck` field to the server and machine learning services, serving multiple purposes:
1. Letting the admin know these health checks exist
2. Showing that they're enabled by default
3. Showing them how to disable it
4. Giving them a direction on how they can further customize them through Docker Compose