### PR TITLE
refactor(server): add config events for clip

### DIFF
--- a/server/src/interfaces/search.interface.ts
+++ b/server/src/interfaces/search.interface.ts
@@ -170,7 +170,6 @@ export interface AssetDuplicateResult {
 }
 
 export interface ISearchRepository {
-  init(modelName: string): Promise<void>;
   searchMetadata(pagination: SearchPaginationOptions, options: AssetSearchOptions): Paginated<AssetEntity>;
   searchSmart(pagination: SearchPaginationOptions, options: SmartSearchOptions): Paginated<AssetEntity>;
   searchDuplicates(options: AssetDuplicateSearch): Promise<AssetDuplicateResult[]>;
@@ -179,4 +178,6 @@ export interface ISearchRepository {
   searchPlaces(placeName: string): Promise<GeodataPlacesEntity[]>;
   getAssetsByCity(userIds: string[]): Promise<AssetEntity[]>;
   deleteAllSearchEmbeddings(): Promise<void>;
+  getDimensionSize(): Promise<number>;
+  setDimensionSize(dimSize: number): Promise<void>;
 }

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -21,7 +21,6 @@ import {
 } from 'src/interfaces/search.interface';
 import { asVector, searchAssetBuilder } from 'src/utils/database';
 import { Instrumentation } from 'src/utils/instrumentation';
-import { getCLIPModelInfo } from 'src/utils/misc';
 import { Paginated, PaginationMode, PaginationResult, paginatedBuilder } from 'src/utils/pagination';
 import { isValidInteger } from 'src/validation';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -53,17 +52,6 @@ export class SearchRepository implements ISearchRepository {
         .withDeleted()
         .getQuery() +
       ' INNER JOIN cte ON asset.id = cte."assetId" ORDER BY exif.city';
-  }
-
-  async init(modelName: string): Promise<void> {
-    const { dimSize } = getCLIPModelInfo(modelName);
-    const curDimSize = await this.getDimSize();
-    this.logger.verbose(`Current database CLIP dimension size is ${curDimSize}`);
-
-    if (dimSize != curDimSize) {
-      this.logger.log(`Dimension size of model ${modelName} is ${dimSize}, but database expects ${curDimSize}.`);
-      await this.updateDimSize(dimSize);
-    }
   }
 
   @GenerateSql({
@@ -300,32 +288,7 @@ export class SearchRepository implements ISearchRepository {
     );
   }
 
-  private async updateDimSize(dimSize: number): Promise<void> {
-    if (!isValidInteger(dimSize, { min: 1, max: 2 ** 16 })) {
-      throw new Error(`Invalid CLIP dimension size: ${dimSize}`);
-    }
-
-    const curDimSize = await this.getDimSize();
-    if (curDimSize === dimSize) {
-      return;
-    }
-
-    this.logger.log(`Updating database CLIP dimension size to ${dimSize}.`);
-
-    await this.smartSearchRepository.manager.transaction(async (manager) => {
-      await manager.clear(SmartSearchEntity);
-      await manager.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET DATA TYPE vector(${dimSize})`);
-      await manager.query(`REINDEX INDEX clip_index`);
-    });
-
-    this.logger.log(`Successfully updated database CLIP dimension size from ${curDimSize} to ${dimSize}.`);
-  }
-
-  deleteAllSearchEmbeddings(): Promise<void> {
-    return this.smartSearchRepository.clear();
-  }
-
-  private async getDimSize(): Promise<number> {
+  async getDimensionSize(): Promise<number> {
     const res = await this.smartSearchRepository.manager.query(`
       SELECT atttypmod as dimsize
       FROM pg_attribute f
@@ -340,6 +303,22 @@ export class SearchRepository implements ISearchRepository {
       throw new Error(`Could not retrieve CLIP dimension size`);
     }
     return dimSize;
+  }
+
+  setDimensionSize(dimSize: number): Promise<void> {
+    if (!isValidInteger(dimSize, { min: 1, max: 2 ** 16 })) {
+      throw new Error(`Invalid CLIP dimension size: ${dimSize}`);
+    }
+
+    return this.smartSearchRepository.manager.transaction(async (manager) => {
+      await manager.clear(SmartSearchEntity);
+      await manager.query(`ALTER TABLE smart_search ALTER COLUMN embedding SET DATA TYPE vector(${dimSize})`);
+      await manager.query(`REINDEX INDEX clip_index`);
+    });
+  }
+
+  async deleteAllSearchEmbeddings(): Promise<void> {
+    return this.smartSearchRepository.clear();
   }
 
   private getRuntimeConfig(numResults?: number): string {

--- a/server/src/services/smart-info.service.spec.ts
+++ b/server/src/services/smart-info.service.spec.ts
@@ -1,3 +1,4 @@
+import { SystemConfig } from 'src/config';
 import { IAssetRepository, WithoutProperty } from 'src/interfaces/asset.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';
 import { IJobRepository, JobName, JobStatus } from 'src/interfaces/job.interface';
@@ -43,6 +44,215 @@ describe(SmartInfoService.name, () => {
 
   it('should work', () => {
     expect(sut).toBeDefined();
+  });
+
+  describe('onConfigValidateEvent', () => {
+    it('should allow a valid model', () => {
+      expect(() =>
+        sut.onConfigValidateEvent({
+          newConfig: { machineLearning: { clip: { modelName: 'ViT-B-16__openai' } } } as SystemConfig,
+          oldConfig: {} as SystemConfig,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should allow including organization', () => {
+      expect(() =>
+        sut.onConfigValidateEvent({
+          newConfig: { machineLearning: { clip: { modelName: 'immich-app/ViT-B-16__openai' } } } as SystemConfig,
+          oldConfig: {} as SystemConfig,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should fail for an unsupported model', () => {
+      expect(() =>
+        sut.onConfigValidateEvent({
+          newConfig: { machineLearning: { clip: { modelName: 'test-model' } } } as SystemConfig,
+          oldConfig: {} as SystemConfig,
+        }),
+      ).toThrow('Unknown CLIP model: test-model');
+    });
+  });
+
+  describe('onBootstrapEvent', () => {
+    it('should return if not microservices', async () => {
+      await sut.onBootstrapEvent('api');
+
+      expect(systemMock.get).not.toHaveBeenCalled();
+      expect(searchMock.getDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).not.toHaveBeenCalled();
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+
+    it('should return if machine learning is disabled', async () => {
+      systemMock.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
+
+      await sut.onBootstrapEvent('microservices');
+
+      expect(systemMock.get).toHaveBeenCalledTimes(1);
+      expect(searchMock.getDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).not.toHaveBeenCalled();
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+
+    it('should return if model and DB dimension size are equal', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(512);
+
+      await sut.onBootstrapEvent('microservices');
+
+      expect(systemMock.get).toHaveBeenCalledTimes(1);
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).not.toHaveBeenCalled();
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+
+    it('should update DB dimension size if model and DB have different values', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(768);
+      jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: false });
+
+      await sut.onBootstrapEvent('microservices');
+
+      expect(systemMock.get).toHaveBeenCalledTimes(1);
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).toHaveBeenCalledWith(512);
+      expect(jobMock.getQueueStatus).toHaveBeenCalledTimes(1);
+      expect(jobMock.pause).toHaveBeenCalledTimes(1);
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledTimes(1);
+      expect(jobMock.resume).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip pausing and resuming queue if already paused', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(768);
+      jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: true });
+
+      await sut.onBootstrapEvent('microservices');
+
+      expect(systemMock.get).toHaveBeenCalledTimes(1);
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).toHaveBeenCalledWith(512);
+      expect(jobMock.getQueueStatus).toHaveBeenCalledTimes(1);
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledTimes(1);
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onConfigUpdateEvent', () => {
+    it('should return if machine learning is disabled', async () => {
+      systemMock.get.mockResolvedValue(systemConfigStub.machineLearningDisabled);
+
+      await sut.onConfigUpdateEvent({
+        newConfig: systemConfigStub.machineLearningDisabled as SystemConfig,
+        oldConfig: systemConfigStub.machineLearningDisabled as SystemConfig,
+      });
+
+      expect(systemMock.get).not.toHaveBeenCalled();
+      expect(searchMock.getDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).not.toHaveBeenCalled();
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+
+    it('should return if model and DB dimension size are equal', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(512);
+
+      await sut.onConfigUpdateEvent({
+        newConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-16__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+        oldConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-16__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+      });
+
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(searchMock.deleteAllSearchEmbeddings).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).not.toHaveBeenCalled();
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).not.toHaveBeenCalled();
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
+
+    it('should update DB dimension size if model and DB have different values', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(512);
+      jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: false });
+
+      await sut.onConfigUpdateEvent({
+        newConfig: {
+          machineLearning: { clip: { modelName: 'ViT-L-14-quickgelu__dfn2b', enabled: true }, enabled: true },
+        } as SystemConfig,
+        oldConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-16__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+      });
+
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).toHaveBeenCalledWith(768);
+      expect(jobMock.getQueueStatus).toHaveBeenCalledTimes(1);
+      expect(jobMock.pause).toHaveBeenCalledTimes(1);
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledTimes(1);
+      expect(jobMock.resume).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear embeddings if old and new models are different', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(512);
+      jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: false });
+
+      await sut.onConfigUpdateEvent({
+        newConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-32__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+        oldConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-16__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+      });
+
+      expect(searchMock.deleteAllSearchEmbeddings).toHaveBeenCalled();
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).toHaveBeenCalledTimes(1);
+      expect(jobMock.pause).toHaveBeenCalledTimes(1);
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledTimes(1);
+      expect(jobMock.resume).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip pausing and resuming queue if already paused', async () => {
+      searchMock.getDimensionSize.mockResolvedValue(512);
+      jobMock.getQueueStatus.mockResolvedValue({ isActive: false, isPaused: true });
+
+      await sut.onConfigUpdateEvent({
+        newConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-32__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+        oldConfig: {
+          machineLearning: { clip: { modelName: 'ViT-B-16__openai', enabled: true }, enabled: true },
+        } as SystemConfig,
+      });
+
+      expect(searchMock.getDimensionSize).toHaveBeenCalledTimes(1);
+      expect(searchMock.setDimensionSize).not.toHaveBeenCalled();
+      expect(jobMock.getQueueStatus).toHaveBeenCalledTimes(1);
+      expect(jobMock.pause).not.toHaveBeenCalled();
+      expect(jobMock.waitForQueueCompletion).toHaveBeenCalledTimes(1);
+      expect(jobMock.resume).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleQueueEncodeClip', () => {

--- a/server/test/repositories/search.repository.mock.ts
+++ b/server/test/repositories/search.repository.mock.ts
@@ -3,7 +3,6 @@ import { Mocked, vitest } from 'vitest';
 
 export const newSearchRepositoryMock = (): Mocked<ISearchRepository> => {
   return {
-    init: vitest.fn(),
     searchMetadata: vitest.fn(),
     searchSmart: vitest.fn(),
     searchDuplicates: vitest.fn(),
@@ -12,5 +11,7 @@ export const newSearchRepositoryMock = (): Mocked<ISearchRepository> => {
     searchPlaces: vitest.fn(),
     getAssetsByCity: vitest.fn(),
     deleteAllSearchEmbeddings: vitest.fn(),
+    getDimensionSize: vitest.fn(),
+    setDimensionSize: vitest.fn(),
   };
 };


### PR DESCRIPTION
## Description

There is an `onConfigValidateEvent` handler for config changes through the UI, but none for startup. This means changing the model in a config file doesn't work as expected. Additionally, there is no validation on the CLIP model name while it's being saved, so it's possible to have an invalid name there that causes any interaction with the model name to throw an error.

This PR adds `onBootstrapEvent` and `onConfigValidateEvent` handlers to correct these issues. It also moves some logic around updating dimensions from the search repo to the service. As a result, much more of this behavior can be tested. The control flow is now more robust: it can self-correct the next time it runs if the config was updated but the DB dimension size could not be updated, and clears embeddings when switching between models of the same dimension size.

Note that there's still an edge case this doesn't handle. Since the config is not always cached anymore, if it reads from disk with a config where the model has changed after startup, no event will be emitted for this and the discrepancy won't be handled correctly.

## How Has This Been Tested?

With a config file, I loaded the server with the default model. I then brought the server down, changed to a larger model in the config file and confirmed it changed the dimension size at startup. I then removed the config file and started the server again, seeing it changes the dimension size back down to 512 since the DB config uses the default model.

Testing without a config file, I changed the model through the UI back to the larger model and it worked as expected. If I tried to change it to a random string, it displayed an error notification and did not save the config.