### PR TITLE
fix(server): video duration extraction

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -647,13 +647,19 @@ describe(MetadataService.name, () => {
       });
     });
 
-    it('should handle duration', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.image]);
-      metadataMock.readTags.mockResolvedValue({ Duration: 6.21 });
+    it('should extract duration', async () => {
+      assetMock.getByIds.mockResolvedValue([{ ...assetStub.video }]);
+      mediaMock.probe.mockResolvedValue({
+        ...probeStub.videoStreamH264,
+        format: {
+          ...probeStub.videoStreamH264.format,
+          duration: 6.21,
+        },
+      });
 
-      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      await sut.handleMetadataExtraction({ id: assetStub.video.id });
 
-      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.image.id]);
+      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.video.id]);
       expect(assetMock.upsertExif).toHaveBeenCalled();
       expect(assetMock.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -663,10 +669,15 @@ describe(MetadataService.name, () => {
       );
     });
 
-    it('should handle duration in ISO time string', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.image]);
-      metadataMock.readTags.mockResolvedValue({ Duration: '00:00:08.41' });
-
+    it('only extracts duration for videos', async () => {
+      assetMock.getByIds.mockResolvedValue([{ ...assetStub.image }]);
+      mediaMock.probe.mockResolvedValue({
+        ...probeStub.videoStreamH264,
+        format: {
+          ...probeStub.videoStreamH264.format,
+          duration: 6.21,
+        },
+      });
       await sut.handleMetadataExtraction({ id: assetStub.image.id });
 
       expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.image.id]);
@@ -674,39 +685,51 @@ describe(MetadataService.name, () => {
       expect(assetMock.update).toHaveBeenCalledWith(
         expect.objectContaining({
           id: assetStub.image.id,
-          duration: '00:00:08.410',
+          duration: null,
         }),
       );
     });
 
-    it('should handle duration as an object without Scale', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.image]);
-      metadataMock.readTags.mockResolvedValue({ Duration: { Value: 6.2 } });
+    it('omits duration of zero', async () => {
+      assetMock.getByIds.mockResolvedValue([{ ...assetStub.video }]);
+      mediaMock.probe.mockResolvedValue({
+        ...probeStub.videoStreamH264,
+        format: {
+          ...probeStub.videoStreamH264.format,
+          duration: 0,
+        },
+      });
 
-      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      await sut.handleMetadataExtraction({ id: assetStub.video.id });
 
-      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.image.id]);
+      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.video.id]);
       expect(assetMock.upsertExif).toHaveBeenCalled();
       expect(assetMock.update).toHaveBeenCalledWith(
         expect.objectContaining({
           id: assetStub.image.id,
-          duration: '00:00:06.200',
+          duration: null,
         }),
       );
     });
 
-    it('should handle duration with scale', async () => {
-      assetMock.getByIds.mockResolvedValue([assetStub.image]);
-      metadataMock.readTags.mockResolvedValue({ Duration: { Scale: 1.111_111_111_111_11e-5, Value: 558_720 } });
+    it('handles duration of 1 week', async () => {
+      assetMock.getByIds.mockResolvedValue([{ ...assetStub.video }]);
+      mediaMock.probe.mockResolvedValue({
+        ...probeStub.videoStreamH264,
+        format: {
+          ...probeStub.videoStreamH264.format,
+          duration: 604_800,
+        },
+      });
 
-      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      await sut.handleMetadataExtraction({ id: assetStub.video.id });
 
-      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.image.id]);
+      expect(assetMock.getByIds).toHaveBeenCalledWith([assetStub.video.id]);
       expect(assetMock.upsertExif).toHaveBeenCalled();
       expect(assetMock.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: assetStub.image.id,
-          duration: '00:00:06.207',
+          id: assetStub.video.id,
+          duration: '168:00:00.000',
         }),
       );
     });


### PR DESCRIPTION
Extracting the video duration based on EXIF data has proven to be unreliable. Exiftool has [7 different ways](https://exiftool.org/TagNames/Composite.html) for calculating the `Duration` value, and if any of those are missing or invalid the duration will also be wrong. Using `ffprobe` is a more reliable solution to determine the video duration.

Using an [MKV test file](https://github.com/ietf-wg-cellar/matroska-test-files/blob/e6965e5ca666322ed93e2748a10a4f132309e005/test_files/test1.mkv) the duration is now correctly extracted as `00:01:27.336`, whereas it was previously `24:15:36.000`. This should fix #7312 and fix #8244, though I can't verify that myself
