### PR TITLE
Update web/bin/immich-web

### DIFF
--- a/web/bin/immich-web
+++ b/web/bin/immich-web
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 
-TYPESCRIPT_SDK=/usr/src/open-api/typescript-sdk
+TYPESCRIPT_SDK=/usr/src/open-api/typescript-sdk;
 
-npm --prefix "$TYPESCRIPT_SDK" install
-npm --prefix "$TYPESCRIPT_SDK" run build
+npm --prefix "$TYPESCRIPT_SDK" install;
+npm --prefix "$TYPESCRIPT_SDK" run build;
 
-node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000
+node ./node_modules/.bin/vite dev --host 0.0.0.0 --port 3000;


### PR DESCRIPTION
Add a semicolon to the commands.

While creating the developer setup, I encountered an error message stating that @immich/sdk was not found. I subsequently discovered that the npm install and npm run build commands were not being executed. By adding a semicolon, I was able to resolve this issue.

```
immich_server            | [10:48:57 AM] Starting compilation in watch mode...
immich_server            |
"mmich_web               | Unknown command: "install
immich_web               |
immich_web               |
immich_web               | Did you mean one of these?
immich_web               |   npm install # Install a package
immich_web               |   npm uninstall # Remove a package
immich_web               | To see a list of supported npm commands, run:
immich_web               |   npm help
"mmich_web               | npm error Missing script: "build
immich_web               | npm error
immich_web               | npm error Did you mean this?
immich_web               | npm error   npm run build # run the "build" package script
immich_web               | npm error
immich_web               | npm error To see a list of scripts, run:
immich_web               | npm error   npm run
immich_web               | npm error A complete log of this run can be found in: /home/node/.npm/_logs/2024-08-06T10_48_58_144Z-debug-0.log
: not found              | /usr/src/app/bin/immich-web: line 7:
immich_web               |
immich_web               | (process:31): VIPS-WARNING **: 10:48:59.027: threads clipped to 1024
immich_web               | Forced re-optimization of dependencies
immich_web               |
immich_web               |   VITE v5.3.5  ready in 4682 ms
immich_web               |
immich_web               |   ➜  Local:   http://localhost:3000/
immich_web               |   ➜  Network: http://172.18.0.6:3000/
```
