### PR TITLE
feat(mobile): enable wakelock on backup page

### DIFF
--- a/mobile/lib/pages/backup/backup_controller.page.dart
+++ b/mobile/lib/pages/backup/backup_controller.page.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/backup/backup_info_card.dart';
 import 'package:immich_mobile/widgets/backup/current_backup_asset_info_box.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 @RoutePage()
 class BackupControllerPage extends HookConsumerWidget {
@@ -49,7 +50,11 @@ class BackupControllerPage extends HookConsumerWidget {
         ref
             .watch(websocketProvider.notifier)
             .stopListenToEvent('on_upload_success');
-        return null;
+
+        WakelockPlus.enable();
+        return () {
+          WakelockPlus.disable();
+        };
       },
       [],
     );


### PR DESCRIPTION
Adds a wakelock when entering the backup page to allow backup tasks to run without interruption. 

As this will keep the screen on which could be problematic (burn-in etc), I have created a second PR (https://github.com/immich-app/immich/pull/11623) which will darken the screen after a certain period to avoid those issues (similar to what the Synology Photos app does).