### PR TITLE
chore(server): support pgvecto.rs 0.3.0

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { SemVer } from 'semver';
 
 export const POSTGRES_VERSION_RANGE = '>=14.0.0';
-export const VECTORS_VERSION_RANGE = '0.2.x';
+export const VECTORS_VERSION_RANGE = '>=0.2 <0.4';
 export const VECTOR_VERSION_RANGE = '>=0.5 <1';
 
 export const NEXT_RELEASE = 'NEXT_RELEASE';


### PR DESCRIPTION
## Description

There were no visible issues when upgrading or creating a new instance with 0.3.0 during my testing. Smart search jobs, search, face detection, facial recognition, and changing search models all worked.

Upgrading just required a restart of the database. For non-superuser instances upgrading from 0.2.x to 0.3.0, I believe these two commands are all that's needed, followed by restarting the database:

```sql
ALTER EXTENSION vectors UPDATE;
SELECT pgvectors_upgrade();
```

I'm fine with bumping the default to 0.3.0, but can also wait a bit in case any issues pop up.