### PR TITLE
fix(mobile): iOS crashing when download iCloud content

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1186,18 +1186,18 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: "68d6099d07ce5033170f8368af8128a4555cf1d590a97242f83669552de989b1"
+      sha256: "1e8bbe46a6858870e34c976aafd85378bed221ce31c1201961eba9ad3d94df9f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.3"
   photo_manager_image_provider:
     dependency: "direct main"
     description:
       name: photo_manager_image_provider
-      sha256: c187f60c3fdbe5630735d9a0bccbb071397ec03dcb1ba6085c29c8adece798a0
+      sha256: "38ef1023dc11de3a8669f16e7c981673b3c5cfee715d17120f4b87daa2cdd0af"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   platform:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   path_provider_ios:
   # TODO: upgrade to stable after 3.0.1 is released. 3.0.0 is broken
   # https://github.com/fluttercandies/flutter_photo_manager/pull/990#issuecomment-2058066427
-  photo_manager: ^3.2.0
-  photo_manager_image_provider: ^2.1.0
+  photo_manager: ^3.2.3
+  photo_manager_image_provider: ^2.1.1
   flutter_hooks: ^0.20.4
   hooks_riverpod: ^2.4.9
   riverpod_annotation: ^2.3.3


### PR DESCRIPTION
New version of `photo_manager` handles this issue https://github.com/fluttercandies/flutter_photo_manager/releases/tag/3.2.3

Fix #11580
Fix #9884
Fix #8141
Fix #3842