### PR TITLE
feat(web): improve group-tab accessibility

### DIFF
--- a/web/src/lib/components/album-page/albums-controls.svelte
+++ b/web/src/lib/components/album-page/albums-controls.svelte
@@ -129,6 +129,7 @@
 <!-- Filter Albums by Sharing Status (All, Owned, Shared) -->
 <div class="hidden xl:block h-10">
   <GroupTab
+    label={$t('show_albums')}
     filters={Object.values(albumFilterNames)}
     selected={selectedFilterOption}
     onSelect={(selected) => handleChangeAlbumFilter(selected, AlbumFilter.All)}

--- a/web/src/lib/components/elements/group-tab.svelte
+++ b/web/src/lib/components/elements/group-tab.svelte
@@ -1,22 +1,35 @@
 <script lang="ts">
+  import { generateId } from '$lib/utils/generate-id';
+
   export let filters: string[];
   export let selected: string;
+  export let label: string;
   export let onSelect: (selected: string) => void;
+
+  const id = `group-tab-${generateId()}`;
 </script>
 
-<div class="flex bg-gray-200 dark:bg-immich-dark-gray rounded-2xl h-full">
+<fieldset
+  class="dark:bg-immich-dark-gray flex h-full rounded-2xl bg-gray-200 ring-gray-400 has-[:focus-visible]:ring dark:ring-gray-600"
+>
+  <legend class="sr-only">{label}</legend>
   {#each filters as filter, index}
-    <button
-      type="button"
-      class="text-sm px-4 {filter === selected
-        ? 'dark:bg-gray-700 bg-gray-300'
-        : 'dark:hover:bg-gray-800 hover:bg-gray-300'}  {index === 0 ? 'rounded-l-2xl' : ''} {index ===
-      filters.length - 1
-        ? 'rounded-r-2xl'
-        : ''}"
-      on:click={() => onSelect(filter)}
-    >
-      {filter}
-    </button>
+    <div class="group">
+      <input
+        type="radio"
+        name={id}
+        id="{id}-{index}"
+        class="peer sr-only"
+        value={filter}
+        checked={filter === selected}
+        on:change={() => onSelect(filter)}
+      />
+      <label
+        for="{id}-{index}"
+        class="flex h-full cursor-pointer items-center px-4 text-sm hover:bg-gray-300 group-first-of-type:rounded-s-2xl group-last-of-type:rounded-e-2xl peer-checked:bg-gray-300 dark:hover:bg-gray-800 peer-checked:dark:bg-gray-700"
+      >
+        {filter}
+      </label>
+    </div>
   {/each}
-</div>
+</fieldset>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1084,6 +1084,7 @@
   "sharing_sidebar_description": "Display a link to Sharing in the sidebar",
   "shift_to_permanent_delete": "press ⇧ to permanently delete asset",
   "show_album_options": "Show album options",
+  "show_albums": "Show albums",
   "show_all_people": "Show all people",
   "show_and_hide_people": "Show & hide people",
   "show_file_location": "Show file location",

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -24,6 +24,7 @@
   <div class="xl:hidden">
     <div class="w-fit h-14 dark:text-immich-dark-fg py-2">
       <GroupTab
+        label={$t('show_albums')}
         filters={Object.keys(AlbumFilter)}
         selected={$albumViewSettings.filter}
         onSelect={(selected) => ($albumViewSettings.filter = selected)}


### PR DESCRIPTION
- Require a label
- Convert buttons to radio inputs and group these together
- Allow arrow navigation and have only one tab stop
- Add focus styling

| Before | After |
| - | - |
| ![grouptab-before](https://github.com/user-attachments/assets/18e4f0df-9b91-43a1-9cd4-dd07a9f1c625) | ![grouptab-after](https://github.com/user-attachments/assets/050ab11e-770a-424a-ac76-23c6085e8c96) |
