### PR TITLE
fix(server): use luxon for maxdate validator

### DIFF
--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsInt, IsNotEmpty, IsString, Max, Min, ValidateNested } from 'class-validator';
+import { DateTime } from 'luxon';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
@@ -20,7 +21,7 @@ export class PersonCreateDto {
    * Note: the mobile app cannot currently set the birth date to null.
    */
   @ApiProperty({ format: 'date' })
-  @MaxDateString(() => new Date(), { message: 'Birth date cannot be in the future' })
+  @MaxDateString(() => DateTime.now(), { message: 'Birth date cannot be in the future' })
   @IsDateStringFormat('yyyy-MM-dd')
   @Optional({ nullable: true })
   birthDate?: string | null;

--- a/server/src/validation.spec.ts
+++ b/server/src/validation.spec.ts
@@ -1,10 +1,11 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
+import { DateTime } from 'luxon';
 import { IsDateStringFormat, MaxDateString } from 'src/validation';
 
 describe('Validation', () => {
   describe('MaxDateString', () => {
-    const maxDate = new Date(2000, 0, 1);
+    const maxDate = DateTime.fromISO('2000-01-01', { zone: 'utc' });
 
     class MyDto {
       @MaxDateString(maxDate)

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -21,7 +21,6 @@ import {
   ValidationOptions,
   buildMessage,
   isDateString,
-  maxDate,
 } from 'class-validator';
 import { CronJob } from 'cron';
 import { DateTime } from 'luxon';
@@ -203,14 +202,21 @@ export function IsDateStringFormat(format: string, validationOptions?: Validatio
   );
 }
 
-export function MaxDateString(date: Date | (() => Date), validationOptions?: ValidationOptions): PropertyDecorator {
+function maxDate(date: DateTime, maxDate: DateTime | (() => DateTime)) {
+  return date <= (maxDate instanceof DateTime ? maxDate : maxDate());
+}
+
+export function MaxDateString(
+  date: DateTime | (() => DateTime),
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
   return ValidateBy(
     {
       name: 'maxDateString',
       constraints: [date],
       validator: {
         validate: (value, args) => {
-          const date = DateTime.fromISO(value, { zone: 'utc' }).toJSDate();
+          const date = DateTime.fromISO(value, { zone: 'utc' });
           return maxDate(date, args?.constraints[0]);
         },
         defaultMessage: buildMessage(


### PR DESCRIPTION
Use luxon for `MaxDateString` validator and ensure tests are timezone agnostic