### PR TITLE
chore(web): remove font-size of 17px

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -29,7 +29,8 @@
   src: url('$lib/assets/fonts/overpass/Overpass.ttf') format('truetype-variations');
   font-weight: 1 999;
   font-style: normal;
-  ascent-override: 100%;
+  ascent-override: 106.25%;
+  size-adjust: 106.25%;
 }
 
 @font-face {
@@ -37,7 +38,8 @@
   src: url('$lib/assets/fonts/overpass/OverpassMono.ttf') format('truetype-variations');
   font-weight: 1 999;
   font-style: monospace;
-  ascent-override: 100%;
+  ascent-override: 106.25%;
+  size-adjust: 106.25%;
 }
 
 :root {
@@ -57,7 +59,6 @@
 html {
   height: 100%;
   width: 100%;
-  font-size: 17px;
 }
 
 html::-webkit-scrollbar {


### PR DESCRIPTION
This change is somewhat subjective, but I believe removing the `17px` font-size is better. It allows users to use their default font size (typically 16px) and makes the UI slightly smaller, which looks better in my opinion. The font-face size has been increased to compensate for 17px --> 16px.