### PR TITLE
docs: Update docs + example.env for DB_PASSWORD

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -12,6 +12,7 @@ DB_DATA_LOCATION=./postgres
 IMMICH_VERSION=release
 
 # Connection secret for postgres. You should change it to a random password
+# Please use only the characters `A-Za-z0-9`, without special characters or spaces
 DB_PASSWORD=postgres
 
 # The values below this line do not need to be changed

--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -56,7 +56,8 @@ Optionally, you can enable hardware acceleration for machine learning and transc
 
 - Populate custom database information if necessary.
 - Populate `UPLOAD_LOCATION` with your preferred location for storing backup assets.
-- Consider changing `DB_PASSWORD` to something randomly generated
+- Consider changing `DB_PASSWORD` to a custom value. Postgres is not publically exposed, so this password is only used for local authentication.
+To avoid issues with Docker parsing this value, it is best to use only the characters `A-Za-z0-9`.
 
 ### Step 3 - Start the containers
 

--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -57,7 +57,7 @@ Optionally, you can enable hardware acceleration for machine learning and transc
 - Populate custom database information if necessary.
 - Populate `UPLOAD_LOCATION` with your preferred location for storing backup assets.
 - Consider changing `DB_PASSWORD` to a custom value. Postgres is not publically exposed, so this password is only used for local authentication.
-To avoid issues with Docker parsing this value, it is best to use only the characters `A-Za-z0-9`.
+  To avoid issues with Docker parsing this value, it is best to use only the characters `A-Za-z0-9`.
 
 ### Step 3 - Start the containers
 


### PR DESCRIPTION
Getting a lot of support tickets for this, especially passwords with spaces or `$`