### PR TITLE
fix(web): asset viewer dynamic size

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -380,7 +380,7 @@
 
 <section
   id="immich-asset-viewer"
-  class="fixed left-0 top-0 z-[1001] grid h-screen w-screen grid-cols-4 grid-rows-[64px_1fr] overflow-hidden bg-black"
+  class="fixed left-0 top-0 z-[1001] grid size-full grid-cols-4 grid-rows-[64px_1fr] overflow-hidden bg-black"
   use:focusTrap
 >
   <!-- Top navigation bar -->


### PR DESCRIPTION
Make sure the asset viewer doesn't go underneath dynamic UI elements

| Before | After |
| - | - |
| ![asset-viewer-before](https://github.com/user-attachments/assets/02e863af-a53d-4cfe-b2a7-88b4181d62da) | ![asset-viewer-after](https://github.com/user-attachments/assets/7cbadc94-70d6-4d41-aa3f-8fb9e984da01) |
