### PR TITLE
fix(web): hide import json button when using config file

### DIFF
--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -187,12 +187,14 @@
           {$t('export_as_json')}
         </div>
       </LinkButton>
-      <LinkButton on:click={() => inputElement?.click()}>
-        <div class="flex place-items-center gap-2 text-sm">
-          <Icon path={mdiUpload} size="18" />
-          {$t('import_from_json')}
-        </div>
-      </LinkButton>
+      {#if !$featureFlags.configFile}
+        <LinkButton on:click={() => inputElement?.click()}>
+          <div class="flex place-items-center gap-2 text-sm">
+            <Icon path={mdiUpload} size="18" />
+            {$t('import_from_json')}
+          </div>
+        </LinkButton>
+      {/if}
     </div>
 
     <AdminSettings bind:config let:handleReset bind:handleSave let:savedConfig let:defaultConfig>


### PR DESCRIPTION
Using the `Import from JSON` button on the system settings page just returns error 403