### PR TITLE
chore(mobile): split getMyUser and getMyPreference api call

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -566,5 +566,6 @@
   "version_announcement_overlay_title": "New Server Version Available \uD83C\uDF89",
   "viewer_remove_from_stack": "Remove from Stack",
   "viewer_stack_use_as_main_asset": "Use as Main Asset",
-  "viewer_unstack": "Un-Stack"
+  "viewer_unstack": "Un-Stack",
+  "get_my_preferences_error_message": "⚠️ Cannot get user preferences, please make sure the server version is up to date"
 }

--- a/mobile/lib/models/authentication/authentication_state.model.dart
+++ b/mobile/lib/models/authentication/authentication_state.model.dart
@@ -7,6 +7,8 @@ class AuthenticationState {
   final bool isAdmin;
   final bool shouldChangePassword;
   final String profileImagePath;
+  final bool isHavingUserPreferences;
+
   AuthenticationState({
     required this.deviceId,
     required this.userId,
@@ -16,6 +18,7 @@ class AuthenticationState {
     required this.isAdmin,
     required this.shouldChangePassword,
     required this.profileImagePath,
+    required this.isHavingUserPreferences,
   });
 
   AuthenticationState copyWith({
@@ -27,6 +30,7 @@ class AuthenticationState {
     bool? isAdmin,
     bool? shouldChangePassword,
     String? profileImagePath,
+    bool? isHavingUserPreferences,
   }) {
     return AuthenticationState(
       deviceId: deviceId ?? this.deviceId,
@@ -37,12 +41,14 @@ class AuthenticationState {
       isAdmin: isAdmin ?? this.isAdmin,
       shouldChangePassword: shouldChangePassword ?? this.shouldChangePassword,
       profileImagePath: profileImagePath ?? this.profileImagePath,
+      isHavingUserPreferences:
+          isHavingUserPreferences ?? this.isHavingUserPreferences,
     );
   }
 
   @override
   String toString() {
-    return 'AuthenticationState(deviceId: $deviceId, userId: $userId, userEmail: $userEmail, isAuthenticated: $isAuthenticated, name: $name, isAdmin: $isAdmin, shouldChangePassword: $shouldChangePassword, profileImagePath: $profileImagePath)';
+    return 'AuthenticationState(deviceId: $deviceId, userId: $userId, userEmail: $userEmail, isAuthenticated: $isAuthenticated, name: $name, isAdmin: $isAdmin, shouldChangePassword: $shouldChangePassword, profileImagePath: $profileImagePath, isHavingUserPreferences: $isHavingUserPreferences)';
   }
 
   @override
@@ -57,7 +63,8 @@ class AuthenticationState {
         other.name == name &&
         other.isAdmin == isAdmin &&
         other.shouldChangePassword == shouldChangePassword &&
-        other.profileImagePath == profileImagePath;
+        other.profileImagePath == profileImagePath &&
+        other.isHavingUserPreferences == isHavingUserPreferences;
   }
 
   @override
@@ -69,6 +76,7 @@ class AuthenticationState {
         name.hashCode ^
         isAdmin.hashCode ^
         shouldChangePassword.hashCode ^
-        profileImagePath.hashCode;
+        profileImagePath.hashCode ^
+        isHavingUserPreferences.hashCode;
   }
 }

--- a/mobile/lib/pages/photos/photos.page.dart
+++ b/mobile/lib/pages/photos/photos.page.dart
@@ -35,18 +35,13 @@ class PhotosPage extends HookConsumerWidget {
         authenticationProvider.select((state) => state.isHavingUserPreferences),
       );
 
-      if (!hasUserPreferences) {
+      if (!hasUserPreferences && currentUser != null && currentUser.isAdmin) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            backgroundColor: Colors.amber[600],
             content: const Text(
-              "⚠️ Cannot get user preferences, please make sure the server version is up to date.",
-              style: TextStyle(
-                fontSize: 13,
-                color: Colors.black,
-              ),
+              "get_my_preferences_error_message",
             ).tr(),
-            duration: const Duration(seconds: 5),
+            duration: const Duration(seconds: 6),
           ),
         );
       }

--- a/mobile/lib/pages/photos/photos.page.dart
+++ b/mobile/lib/pages/photos/photos.page.dart
@@ -31,11 +31,11 @@ class PhotosPage extends HookConsumerWidget {
     final refreshCount = useState(0);
 
     showUserPreferencesStatus() {
-      final hasUserPreference = ref.read(
+      final hasUserPreferences = ref.read(
         authenticationProvider.select((state) => state.isHavingUserPreferences),
       );
 
-      if (!hasUserPreference) {
+      if (!hasUserPreferences) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             backgroundColor: Colors.amber[600],

--- a/mobile/lib/pages/photos/photos.page.dart
+++ b/mobile/lib/pages/photos/photos.page.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/album/album.provider.dart';
 import 'package:immich_mobile/providers/album/shared_album.provider.dart';
+import 'package:immich_mobile/providers/authentication.provider.dart';
 import 'package:immich_mobile/providers/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/memories/memory_lane.dart';
 import 'package:immich_mobile/providers/asset.provider.dart';
@@ -29,6 +30,28 @@ class PhotosPage extends HookConsumerWidget {
     final tipOneOpacity = useState(0.0);
     final refreshCount = useState(0);
 
+    showUserPreferencesStatus() {
+      final hasUserPreference = ref.read(
+        authenticationProvider.select((state) => state.isHavingUserPreferences),
+      );
+
+      if (!hasUserPreference) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: Colors.amber[600],
+            content: const Text(
+              "⚠️ Cannot get user preferences, please make sure the server version is up to date.",
+              style: TextStyle(
+                fontSize: 13,
+                color: Colors.black,
+              ),
+            ).tr(),
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      }
+    }
+
     useEffect(
       () {
         ref.read(websocketProvider.notifier).connect();
@@ -36,10 +59,12 @@ class PhotosPage extends HookConsumerWidget {
         ref.read(albumProvider.notifier).getAllAlbums();
         ref.read(sharedAlbumProvider.notifier).getAllSharedAlbums();
         ref.read(serverInfoProvider.notifier).getServerInfo();
+        Future.microtask(() => showUserPreferencesStatus());
         return;
       },
       [],
     );
+
     Widget buildLoadingIndicator() {
       Timer(const Duration(seconds: 2), () => tipOneOpacity.value = 1);
 


### PR DESCRIPTION
We are handling a case where `getMyPreference` has additional properties that cause the users to be unable to log in.