### PR TITLE
chore: better release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -24,17 +24,3 @@ changelog:
     - title: 🌐 Translations
       labels:
         - translation
-
-    - title: 🔨 Maintenance
-      labels:
-        - maintenance
-        - tech-debt
-        - chore
-
-    - title: 🤖 Dependencies
-      labels:
-        - dependencies
-
-    - title: 💤 Other changes
-      labels:
-        - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,41 +1,40 @@
 changelog:
   categories:
-    - title: ⚠️ Breaking Changes
+    - title: 🚨 Breaking Changes
       labels:
         - breaking-change
 
-    - title: 🗄️ Server
+    - title: 🔒 Security
       labels:
-        - 🗄️server
+        - security
 
-    - title: 📱 Mobile
+    - title: 🚀 Features
       labels:
-        - 📱mobile
+        - feature
+        - enhancement
 
-    - title: 🖥️ Web
+    - title: 🐛 Bug fixes
       labels:
-        - 🖥️web
+        - bugfix
 
-    - title: 🧠 Machine Learning
-      labels:
-        - 🧠machine-learning
-
-    - title: ⚡ CLI
-      labels:
-        - cli
-
-    - title: 📓 Documentation
+    - title: 📚 Documentation
       labels:
         - documentation
 
+    - title: 🌐 Translations
+      labels:
+        - translation
+
     - title: 🔨 Maintenance
       labels:
-        - deployment
-        - dependencies
-        - renovate
         - maintenance
         - tech-debt
+        - chore
 
-    - title: Other changes
+    - title: 🤖 Dependencies
       labels:
-        - "*"
+        - dependencies
+
+    - title: 💤 Other changes
+      labels:
+        - '*'

--- a/renovate.json
+++ b/renovate.json
@@ -81,5 +81,5 @@
   ],
   "ignorePaths": ["mobile/openapi/pubspec.yaml", "mobile/ios", "mobile/android"],
   "ignoreDeps": ["http", "intl"],
-  "labels": ["dependencies", "renovate"]
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Group commits in release notes by type (feature,  bug fixes, etc.) instead of by application (server, mobile, web, etc.)