### PR TITLE
feat(mobile): patch GetMyPreferences

### DIFF
--- a/mobile/lib/extensions/api_extensions.dart
+++ b/mobile/lib/extensions/api_extensions.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart';
+import 'package:openapi/api.dart';
+
+extension UsersApiExtension on UsersApi {
+  /// Override getMyUserPreference to avoid breaking the client
+  /// when there are new properties get added to the response
+  Future<UserPreferencesResponseDto?> getMyPreferencesExtended() async {
+    final response = await getMyPreferencesWithHttpInfo();
+
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(
+        response.statusCode,
+        await _decodeBodyBytes(response),
+      );
+    }
+
+    if (response.body.isNotEmpty &&
+        response.statusCode != HttpStatus.noContent) {
+      String decodedBytes = await _decodeBodyBytes(response);
+      dynamic jsonString =
+          await compute((String j) => json.decode(j), decodedBytes);
+
+      ///
+      /// START PATCHING `UserPreferencesResponseDto` HERE
+      ///
+
+      // patching `rating` with the default value
+      if (jsonString['rating'] == null) {
+        jsonString['rating'] = jsonEncode(RatingResponse(enabled: false));
+      }
+
+      return UserPreferencesResponseDto.fromJson(json.encode(jsonString));
+    }
+
+    return null;
+  }
+
+  Future<String> _decodeBodyBytes(Response response) async {
+    final contentType = response.headers['content-type'];
+    return contentType != null &&
+            contentType.toLowerCase().startsWith('application/json')
+        ? response.bodyBytes.isEmpty
+            ? ''
+            : utf8.decode(response.bodyBytes)
+        : response.body;
+  }
+}

--- a/mobile/lib/providers/authentication.provider.dart
+++ b/mobile/lib/providers/authentication.provider.dart
@@ -4,6 +4,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_udid/flutter_udid.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/api_extensions.dart';
 import 'package:immich_mobile/providers/album/album.provider.dart';
 import 'package:immich_mobile/providers/album/shared_album.provider.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -171,15 +172,16 @@ class AuthenticationNotifier extends StateNotifier<AuthenticationState> {
     try {
       final responses = await Future.wait([
         _apiService.usersApi.getMyUser(),
-        _apiService.usersApi.getMyPreferences(),
+        _apiService.usersApi.getMyPreferencesExtended(),
       ]);
-      userResponse = responses[0] as UserAdminResponseDto;
-      userPreferences = responses[1] as UserPreferencesResponseDto;
+      userResponse = responses[0] as UserAdminResponseDto?;
+      userPreferences = responses[1] as UserPreferencesResponseDto?;
     } on ApiException catch (error, stackTrace) {
       if (error.code == 401) {
         _log.severe("Unauthorized access, token likely expired. Logging out.");
         return false;
       }
+
       _log.severe(
         "Error getting user information from the server [API EXCEPTION]",
         stackTrace,


### PR DESCRIPTION
Add an extension to the UsersApi to patch the `getMyPreferences` endpoint to avoid locking the users out from logging in when the version between the server and the client mismatched