### PR TITLE
fix(mobile): Fix for incorrectly naming edited files and structure change

### DIFF
--- a/mobile/lib/pages/editing/crop.page.dart
+++ b/mobile/lib/pages/editing/crop.page.dart
@@ -3,6 +3,7 @@ import 'package:crop_image/crop_image.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/hooks/crop_controller_hook.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
 import 'edit.page.dart';
 import 'package:auto_route/auto_route.dart';
 
@@ -14,7 +15,8 @@ import 'package:auto_route/auto_route.dart';
 @RoutePage()
 class CropImagePage extends HookWidget {
   final Image image;
-  const CropImagePage({super.key, required this.image});
+  final Asset asset;
+  const CropImagePage({super.key, required this.image, required this.asset});
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +36,13 @@ class CropImagePage extends HookWidget {
             ),
             onPressed: () async {
               final croppedImage = await cropController.croppedImage();
-              context.pushRoute(EditImageRoute(image: croppedImage));
+              context.pushRoute(
+                EditImageRoute(
+                  asset: asset,
+                  image: croppedImage,
+                  isEdited: true,
+                ),
+              );
             },
           ),
         ],

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:path/path.dart' as p;
 import 'package:immich_mobile/providers/album/album.provider.dart';
 
 /// A stateless widget that provides functionality for editing an image.
@@ -66,7 +67,7 @@ class EditImagePage extends ConsumerWidget {
       final Uint8List imageData = await _imageToUint8List(image);
       await PhotoManager.editor.saveImage(
         imageData,
-        title: "${asset.fileName.split('.').first}_edited.jpg",
+        title: "${p.withoutExtension(asset.fileName)}_edited.jpg",
       );
       await ref.read(albumProvider.notifier).getDeviceAlbums();
       Navigator.of(context).popUntil((route) => route.isFirst);

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -75,34 +75,34 @@ class EditImagePage extends ConsumerWidget {
         ),
         actions: <Widget>[
           TextButton(
-            onPressed: () async {
-              try {
-                final Uint8List imageData = await _imageToUint8List(image);
-                ImmichToast.show(
-                  durationInSecond: 3,
-                  context: context,
-                  msg: 'Image Saved!',
-                  gravity: ToastGravity.CENTER,
-                );
-
-                await PhotoManager.editor.saveImage(
-                  imageData,
-                  title: "${asset.fileName.split('.').first}_edited.jpg",
-                );
-                await ref.read(albumProvider.notifier).getDeviceAlbums();
-                Navigator.of(context).popUntil((route) => route.isFirst);
-              } catch (e) {
-                ImmichToast.show(
-                  durationInSecond: 6,
-                  context: context,
-                  msg: 'Error: ${e.toString()}',
-                  gravity: ToastGravity.BOTTOM,
-                );
-              }
-            },
+            onPressed: isEdited
+                ? () async {
+                    try {
+                      final Uint8List imageData =
+                          await _imageToUint8List(image);
+                      await PhotoManager.editor.saveImage(
+                        imageData,
+                        title:
+                            "${asset.fileName.substring(0, asset.fileName.length - 4)}_edited.jpg",
+                      );
+                      await ref.read(albumProvider.notifier).getDeviceAlbums();
+                      Navigator.of(context).popUntil((route) => route.isFirst);
+                    } catch (e) {
+                      ImmichToast.show(
+                        durationInSecond: 6,
+                        context: context,
+                        msg: 'Error: $e',
+                        gravity: ToastGravity.CENTER,
+                      );
+                    }
+                  }
+                : null,
             child: Text(
               'Save to gallery',
-              style: Theme.of(context).textTheme.displayMedium,
+              style: TextStyle(
+                color:
+                    isEdited ? Theme.of(context).iconTheme.color : Colors.grey,
+              ),
             ),
           ),
         ],

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -24,18 +24,16 @@ import 'package:immich_mobile/providers/album/album.provider.dart';
 @immutable
 @RoutePage()
 class EditImagePage extends ConsumerWidget {
-  final Asset? asset;
-  final Image? image;
+  final Asset asset;
+  final Image image;
+  final bool isEdited;
 
   const EditImagePage({
     super.key,
-    this.image,
-    this.asset,
-  }) : assert(
-          (image != null && asset == null) || (image == null && asset != null),
-          'Must supply one of asset or image',
-        );
-
+    required this.asset,
+    required this.image,
+    required this.isEdited,
+  });
   Future<Uint8List> _imageToUint8List(Image image) async {
     final Completer<Uint8List> completer = Completer();
     image.image.resolve(const ImageConfiguration()).addListener(
@@ -60,17 +58,8 @@ class EditImagePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ImageProvider provider = (asset != null)
-        ? ImmichImage.imageProvider(asset: asset!)
-        : (image != null)
-            ? image!.image
-            : throw Exception('Invalid image source type');
-
-    final Image imageWidget = (asset != null)
-        ? Image(image: ImmichImage.imageProvider(asset: asset!))
-        : (image != null)
-            ? image!
-            : throw Exception('Invalid image source type');
+    final Image imageWidget =
+        Image(image: ImmichImage.imageProvider(asset: asset));
 
     return Scaffold(
       appBar: AppBar(
@@ -85,44 +74,43 @@ class EditImagePage extends ConsumerWidget {
               Navigator.of(context).popUntil((route) => route.isFirst),
         ),
         actions: <Widget>[
-          if (image != null)
-            TextButton(
-              onPressed: () async {
-                try {
-                  final Uint8List imageData = await _imageToUint8List(image!);
-                  ImmichToast.show(
-                    durationInSecond: 3,
-                    context: context,
-                    msg: 'Image Saved!',
-                    gravity: ToastGravity.CENTER,
-                  );
+          TextButton(
+            onPressed: () async {
+              try {
+                final Uint8List imageData = await _imageToUint8List(image);
+                ImmichToast.show(
+                  durationInSecond: 3,
+                  context: context,
+                  msg: 'Image Saved!',
+                  gravity: ToastGravity.CENTER,
+                );
 
-                  await PhotoManager.editor.saveImage(
-                    imageData,
-                    title: '${asset!.fileName}_edited.jpg',
-                  );
-                  await ref.read(albumProvider.notifier).getDeviceAlbums();
-                  Navigator.of(context).popUntil((route) => route.isFirst);
-                } catch (e) {
-                  ImmichToast.show(
-                    durationInSecond: 6,
-                    context: context,
-                    msg: 'Error: ${e.toString()}',
-                    gravity: ToastGravity.BOTTOM,
-                  );
-                }
-              },
-              child: Text(
-                'Save to gallery',
-                style: Theme.of(context).textTheme.displayMedium,
-              ),
+                await PhotoManager.editor.saveImage(
+                  imageData,
+                  title: "${asset.fileName.split('.').first}_edited.jpg",
+                );
+                await ref.read(albumProvider.notifier).getDeviceAlbums();
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              } catch (e) {
+                ImmichToast.show(
+                  durationInSecond: 6,
+                  context: context,
+                  msg: 'Error: ${e.toString()}',
+                  gravity: ToastGravity.BOTTOM,
+                );
+              }
+            },
+            child: Text(
+              'Save to gallery',
+              style: Theme.of(context).textTheme.displayMedium,
             ),
+          ),
         ],
       ),
       body: Column(
         children: <Widget>[
           Expanded(
-            child: Image(image: provider),
+            child: image,
           ),
           Container(
             height: 80,
@@ -148,7 +136,9 @@ class EditImagePage extends ConsumerWidget {
                 color: Theme.of(context).iconTheme.color,
               ),
               onPressed: () {
-                context.pushRoute(CropImageRoute(image: imageWidget));
+                context.pushRoute(
+                  CropImageRoute(asset: asset, image: imageWidget),
+                );
               },
             ),
             Text('Crop', style: Theme.of(context).textTheme.displayMedium),

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -57,7 +57,11 @@ class EditImagePage extends ConsumerWidget {
   }
 
   Future<void> _saveEditedImage(
-      BuildContext context, Asset asset, Image image, WidgetRef ref,) async {
+    BuildContext context,
+    Asset asset,
+    Image image,
+    WidgetRef ref,
+  ) async {
     try {
       final Uint8List imageData = await _imageToUint8List(image);
       await PhotoManager.editor.saveImage(

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -56,6 +56,26 @@ class EditImagePage extends ConsumerWidget {
     return completer.future;
   }
 
+  Future<void> _saveEditedImage(
+      BuildContext context, Asset asset, Image image, WidgetRef ref,) async {
+    try {
+      final Uint8List imageData = await _imageToUint8List(image);
+      await PhotoManager.editor.saveImage(
+        imageData,
+        title: "${asset.fileName.split('.').first}_edited.jpg",
+      );
+      await ref.read(albumProvider.notifier).getDeviceAlbums();
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    } catch (e) {
+      ImmichToast.show(
+        durationInSecond: 6,
+        context: context,
+        msg: 'Error: $e',
+        gravity: ToastGravity.CENTER,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final Image imageWidget =
@@ -76,25 +96,7 @@ class EditImagePage extends ConsumerWidget {
         actions: <Widget>[
           TextButton(
             onPressed: isEdited
-                ? () async {
-                    try {
-                      final Uint8List imageData =
-                          await _imageToUint8List(image);
-                      await PhotoManager.editor.saveImage(
-                        imageData,
-                        title: "${asset.fileName.split('.').first}_edited.jpg",
-                      );
-                      await ref.read(albumProvider.notifier).getDeviceAlbums();
-                      Navigator.of(context).popUntil((route) => route.isFirst);
-                    } catch (e) {
-                      ImmichToast.show(
-                        durationInSecond: 6,
-                        context: context,
-                        msg: 'Error: $e',
-                        gravity: ToastGravity.CENTER,
-                      );
-                    }
-                  }
+                ? () => _saveEditedImage(context, asset, image, ref)
                 : null,
             child: Text(
               'Save to gallery',

--- a/mobile/lib/pages/editing/edit.page.dart
+++ b/mobile/lib/pages/editing/edit.page.dart
@@ -82,8 +82,7 @@ class EditImagePage extends ConsumerWidget {
                           await _imageToUint8List(image);
                       await PhotoManager.editor.saveImage(
                         imageData,
-                        title:
-                            "${asset.fileName.substring(0, asset.fileName.length - 4)}_edited.jpg",
+                        title: "${asset.fileName.split('.').first}_edited.jpg",
                       );
                       await ref.read(albumProvider.notifier).getDeviceAlbums();
                       Navigator.of(context).popUntil((route) => route.isFirst);

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -613,12 +613,14 @@ class CropImageRoute extends PageRouteInfo<CropImageRouteArgs> {
   CropImageRoute({
     Key? key,
     required Image image,
+    required Asset asset,
     List<PageRouteInfo>? children,
   }) : super(
           CropImageRoute.name,
           args: CropImageRouteArgs(
             key: key,
             image: image,
+            asset: asset,
           ),
           initialChildren: children,
         );
@@ -632,6 +634,7 @@ class CropImageRoute extends PageRouteInfo<CropImageRouteArgs> {
       return CropImagePage(
         key: args.key,
         image: args.image,
+        asset: args.asset,
       );
     },
   );
@@ -641,15 +644,18 @@ class CropImageRouteArgs {
   const CropImageRouteArgs({
     this.key,
     required this.image,
+    required this.asset,
   });
 
   final Key? key;
 
   final Image image;
 
+  final Asset asset;
+
   @override
   String toString() {
-    return 'CropImageRouteArgs{key: $key, image: $image}';
+    return 'CropImageRouteArgs{key: $key, image: $image, asset: $asset}';
   }
 }
 
@@ -658,15 +664,17 @@ class CropImageRouteArgs {
 class EditImageRoute extends PageRouteInfo<EditImageRouteArgs> {
   EditImageRoute({
     Key? key,
-    Image? image,
-    Asset? asset,
+    required Asset asset,
+    required Image image,
+    required bool isEdited,
     List<PageRouteInfo>? children,
   }) : super(
           EditImageRoute.name,
           args: EditImageRouteArgs(
             key: key,
-            image: image,
             asset: asset,
+            image: image,
+            isEdited: isEdited,
           ),
           initialChildren: children,
         );
@@ -676,12 +684,12 @@ class EditImageRoute extends PageRouteInfo<EditImageRouteArgs> {
   static PageInfo page = PageInfo(
     name,
     builder: (data) {
-      final args = data.argsAs<EditImageRouteArgs>(
-          orElse: () => const EditImageRouteArgs());
+      final args = data.argsAs<EditImageRouteArgs>();
       return EditImagePage(
         key: args.key,
-        image: args.image,
         asset: args.asset,
+        image: args.image,
+        isEdited: args.isEdited,
       );
     },
   );
@@ -690,19 +698,22 @@ class EditImageRoute extends PageRouteInfo<EditImageRouteArgs> {
 class EditImageRouteArgs {
   const EditImageRouteArgs({
     this.key,
-    this.image,
-    this.asset,
+    required this.asset,
+    required this.image,
+    required this.isEdited,
   });
 
   final Key? key;
 
-  final Image? image;
+  final Asset asset;
 
-  final Asset? asset;
+  final Image image;
+
+  final bool isEdited;
 
   @override
   String toString() {
-    return 'EditImageRouteArgs{key: $key, image: $image, asset: $asset}';
+    return 'EditImageRouteArgs{key: $key, asset: $asset, image: $image, isEdited: $isEdited}';
   }
 }
 

--- a/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart'
 import 'package:immich_mobile/widgets/asset_viewer/video_controls.dart';
 import 'package:immich_mobile/widgets/asset_grid/delete_dialog.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/widgets/common/immich_image.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/providers/asset.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
@@ -236,6 +237,7 @@ class BottomGalleryBar extends ConsumerWidget {
     }
 
     void handleEdit() async {
+      final image = Image(image: ImmichImage.imageProvider(asset: asset));
       if (asset.isOffline) {
         ImmichToast.show(
           durationInSecond: 1,
@@ -247,8 +249,11 @@ class BottomGalleryBar extends ConsumerWidget {
       }
       Navigator.of(context).push(
         MaterialPageRoute(
-          builder: (context) =>
-              EditImagePage(asset: asset), // Send the Asset object
+          builder: (context) => EditImagePage(
+            asset: asset,
+            image: image,
+            isEdited: false,
+          ),
         ),
       );
     }


### PR DESCRIPTION
This commit brings a few core changes to the overall edit page.

- Improving the efficiency and a few breaking changes to the structure for the edit page with a new parameter. 
- Issue fix for incorrectly naming edited files: Before: `null_edited`  Now: `FILENAME_edited`

