### PR TITLE
fix(mobile): load original

### DIFF
--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -112,9 +112,7 @@ class GalleryViewerPage extends HookConsumerWidget {
         if (index < totalAssets.value && index >= 0) {
           final asset = loadAsset(index);
           await precacheImage(
-            ImmichImage.imageProvider(
-              asset: asset,
-            ),
+            ImmichImage.imageProvider(asset: asset),
             context,
             onError: onError,
           );
@@ -321,9 +319,8 @@ class GalleryViewerPage extends HookConsumerWidget {
                 final a =
                     index == currentIndex.value ? asset : loadAsset(index);
 
-                final ImageProvider provider = ImmichImage.imageProvider(
-                  asset: a,
-                );
+                final ImageProvider provider =
+                    ImmichImage.imageProvider(asset: a);
 
                 if (a.isImage && !isPlayingVideo.value) {
                   return PhotoViewGalleryPageOptions(

--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -55,8 +55,6 @@ class GalleryViewerPage extends HookConsumerWidget {
     final settings = ref.watch(appSettingsServiceProvider);
     final loadAsset = renderList.loadAsset;
     final totalAssets = useState(renderList.totalAssets);
-    final isLoadPreview = useState(AppSettingsEnum.loadPreview.defaultValue);
-    final isLoadOriginal = useState(AppSettingsEnum.loadOriginal.defaultValue);
     final shouldLoopVideo = useState(AppSettingsEnum.loopVideo.defaultValue);
     final isZoomed = useState(false);
     final isPlayingVideo = useState(false);
@@ -97,10 +95,6 @@ class GalleryViewerPage extends HookConsumerWidget {
 
     useEffect(
       () {
-        isLoadPreview.value =
-            settings.getSetting<bool>(AppSettingsEnum.loadPreview);
-        isLoadOriginal.value =
-            settings.getSetting<bool>(AppSettingsEnum.loadOriginal);
         shouldLoopVideo.value =
             settings.getSetting<bool>(AppSettingsEnum.loopVideo);
         return null;
@@ -118,7 +112,9 @@ class GalleryViewerPage extends HookConsumerWidget {
         if (index < totalAssets.value && index >= 0) {
           final asset = loadAsset(index);
           await precacheImage(
-            ImmichImage.imageProvider(asset: asset),
+            ImmichImage.imageProvider(
+              asset: asset,
+            ),
             context,
             onError: onError,
           );
@@ -324,8 +320,10 @@ class GalleryViewerPage extends HookConsumerWidget {
               builder: (context, index) {
                 final a =
                     index == currentIndex.value ? asset : loadAsset(index);
-                final ImageProvider provider =
-                    ImmichImage.imageProvider(asset: a);
+
+                final ImageProvider provider = ImmichImage.imageProvider(
+                  asset: a,
+                );
 
                 if (a.isImage && !isPlayingVideo.value) {
                   return PhotoViewGalleryPageOptions(

--- a/mobile/lib/providers/image/immich_remote_image_provider.dart
+++ b/mobile/lib/providers/image/immich_remote_image_provider.dart
@@ -101,7 +101,7 @@ class ImmichRemoteImageProvider
     // Load the final remote image
     if (_useOriginal) {
       // Load the original image
-      final url = getImageUrlFromId(key.assetId);
+      final url = getOriginalUrlForRemoteId(key.assetId);
       final codec = await ImageLoader.loadImageFromCache(
         url,
         cache: cache,

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -55,12 +55,8 @@ String getAlbumThumbNailCacheKey(
   );
 }
 
-String getImageUrl(final Asset asset) {
-  return getImageUrlFromId(asset.remoteId!);
-}
-
-String getImageUrlFromId(final String id) {
-  return '${Store.get(StoreKey.serverEndpoint)}/assets/$id/thumbnail?size=preview';
+String getOriginalUrlForRemoteId(final String id) {
+  return '${Store.get(StoreKey.serverEndpoint)}/assets/$id/original';
 }
 
 String getImageCacheKey(final Asset asset) {


### PR DESCRIPTION
fix #10556

When the `Load Original` is enabled

- Remote asset: Download the original asset and display
- Local asset: no change for Android since it has always used the original file. IOS will now use the original file. The caveat for iOS is the double-swiping issue when using this setting when navigating between local + remote assets.