### PR TITLE
chore(docs): Encode db dump in UTF-8 for windows

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -45,7 +45,7 @@ docker compose up -d    # Start remainder of Immich apps
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
 
 ```powershell title='Backup'
-docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres > "\path\to\backup\dump.sql"
+docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | Set-Content -Encoding utf8 "\path\to\backup\dump.sql"
 ```
 
 ```powershell title='Restore'

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -45,7 +45,7 @@ docker compose up -d    # Start remainder of Immich apps
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
 
 ```powershell title='Backup'
-docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | Set-Content -Encoding utf8 "\path\to\backup\dump.sql"
+docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | Set-Content -Encoding utf8 "C:\path\to\backup\dump.sql"
 ```
 
 ```powershell title='Restore'


### PR DESCRIPTION
Powershell does not use UTF-8 encoding by default, which makes database dumps incompatible between Windows and Linux. This PR makes Windows save the dump in UTF-8 format.

https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_character_encoding?view=powershell-7.4
> In general, Windows PowerShell uses the Unicode [UTF-16LE](https://wikipedia.org/wiki/UTF-16) encoding by default. However, the default encoding used by cmdlets in Windows PowerShell is not consistent.


Surprisingly, no changes were required to the command to restore the dump. Dumps encoded in UTF-8 using the updated command in this PR restores using the existing command provided in the docs on Windows and Linux.

I found out about this quirk when helping a user on discord migrate their instance from Windows to Linux here: https://discord.com/channels/979116623879368755/1268076684498960444