### PR TITLE
fix(docs): read-only affects XMP writing

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -112,7 +112,8 @@ The `immich-server` container will need access to the gallery. Modify your docke
 ```
 
 :::tip
-The `ro` flag at the end only gives read-only access to the volumes. This will disallow the images from being deleted in the web UI.
+The `ro` flag at the end only gives read-only access to the volumes.
+This will disallow the images from being deleted in the web UI, or adding metadata to the library ([XMP sidecars](/docs/features/xmp-sidecars)).
 :::
 
 :::info

--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -7,7 +7,7 @@ in a directory on the same machine.
 # Mount the directory into the containers.
 
 Edit `docker-compose.yml` to add one or more new mount points in the section `immich-server:` under `volumes:`.
-If you want Immich to be able to delete the images in the external library, remove `:ro` from the end of the mount point.
+If you want Immich to be able to delete the images in the external library or add metadata ([XMP sidecars](/docs/features/xmp-sidecars)), remove `:ro` from the end of the mount point.
 
 ```diff
 immich-server:


### PR DESCRIPTION
Immich cannot add XMP files to a read-only external library. This isn't obvious, which is why this mentions the issue in the documentation.