### PR TITLE
chore(mobile): only enable wakelock when backup is running

### DIFF
--- a/mobile/lib/pages/backup/backup_controller.page.dart
+++ b/mobile/lib/pages/backup/backup_controller.page.dart
@@ -51,8 +51,8 @@ class BackupControllerPage extends HookConsumerWidget {
     }
 
     void stopScreenDarkenTimer() {
-      isScreenDarkened.value = false;
       darkenScreenTimer.value?.cancel();
+      isScreenDarkened.value = false;
       SystemChrome.setEnabledSystemUIMode(
         SystemUiMode.manual,
         overlays: [
@@ -74,8 +74,6 @@ class BackupControllerPage extends HookConsumerWidget {
         ref
             .watch(websocketProvider.notifier)
             .stopListenToEvent('on_upload_success');
-
-        WakelockPlus.enable();
 
         return () {
           WakelockPlus.disable();
@@ -102,8 +100,10 @@ class BackupControllerPage extends HookConsumerWidget {
       () {
         if (backupState.backupProgress == BackUpProgressEnum.inProgress) {
           startScreenDarkenTimer();
+          WakelockPlus.enable();
         } else {
           stopScreenDarkenTimer();
+          WakelockPlus.disable();
         }
 
         return null;


### PR DESCRIPTION
Currently, the screen stays on as long as the backup page is open, I think it would make more sense to only enable the Wakelock when the backup is actually running.
That way, one can keep the backup running and the phone can go to sleep again once it is finished.