### PR TITLE
refactor(server): replace isFavorite column by mapping table

### DIFF
--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -118,7 +118,7 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     fileModifiedAt: entity.fileModifiedAt,
     localDateTime: entity.localDateTime,
     updatedAt: entity.updatedAt,
-    isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
+    isFavorite: entity.userInfo?.isFavorite || false,
     isArchived: entity.isArchived,
     isTrashed: !!entity.deletedAt,
     duration: entity.duration ?? '0:00:00.00000',

--- a/server/src/entities/asset-user.entity.ts
+++ b/server/src/entities/asset-user.entity.ts
@@ -1,0 +1,24 @@
+import { AssetEntity } from 'src/entities/asset.entity';
+import { UserEntity } from 'src/entities/user.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+
+@Entity('asset_user')
+export class AssetUserEntity {
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId', referencedColumnName: 'id' })
+  user?: UserEntity;
+
+  @PrimaryColumn()
+  userId!: string;
+
+  @ManyToOne(() => AssetEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'assetId', referencedColumnName: 'id' })
+  @Index()
+  asset?: AssetEntity;
+
+  @PrimaryColumn()
+  assetId!: string;
+
+  @Column({ type: 'boolean', default: false })
+  isFavorite!: boolean;
+}

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -1,6 +1,7 @@
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
+import { AssetUserEntity } from 'src/entities/asset-user.entity';
 import { ExifEntity } from 'src/entities/exif.entity';
 import { LibraryEntity } from 'src/entities/library.entity';
 import { SharedLinkEntity } from 'src/entities/shared-link.entity';
@@ -104,9 +105,6 @@ export class AssetEntity {
   fileModifiedAt!: Date;
 
   @Column({ type: 'boolean', default: false })
-  isFavorite!: boolean;
-
-  @Column({ type: 'boolean', default: false })
   isArchived!: boolean;
 
   @Column({ type: 'boolean', default: false })
@@ -141,6 +139,9 @@ export class AssetEntity {
 
   @OneToOne(() => ExifEntity, (exifEntity) => exifEntity.asset)
   exifInfo?: ExifEntity;
+
+  @OneToMany(() => AssetUserEntity, (assetUserEntity) => assetUserEntity.asset)
+  userInfo?: AssetUserEntity;
 
   @OneToOne(() => SmartInfoEntity, (smartInfoEntity) => smartInfoEntity.asset)
   smartInfo?: SmartInfoEntity;

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -43,7 +43,7 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
 @Index('IDX_originalPath_libraryId', ['originalPath', 'libraryId'])
 @Index('IDX_asset_id_stackId', ['id', 'stackId'])
 @Index('idx_originalFileName_trigram', { synchronize: false })
-// For all assets, each originalpath must be unique per user and library
+// For all assets, each originalPath must be unique per user and library
 export class AssetEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/server/src/entities/index.ts
+++ b/server/src/entities/index.ts
@@ -4,6 +4,7 @@ import { AlbumEntity } from 'src/entities/album.entity';
 import { APIKeyEntity } from 'src/entities/api-key.entity';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
+import { AssetUserEntity } from 'src/entities/asset-user.entity';
 import { AssetEntity } from 'src/entities/asset.entity';
 import { AuditEntity } from 'src/entities/audit.entity';
 import { ExifEntity } from 'src/entities/exif.entity';
@@ -26,22 +27,25 @@ import { UserMetadataEntity } from 'src/entities/user-metadata.entity';
 import { UserEntity } from 'src/entities/user.entity';
 
 export const entities = [
+  APIKeyEntity,
   ActivityEntity,
   AlbumEntity,
   AlbumUserEntity,
-  APIKeyEntity,
   AssetEntity,
   AssetFaceEntity,
   AssetJobStatusEntity,
+  AssetUserEntity,
   AuditEntity,
   ExifEntity,
   FaceSearchEntity,
   GeodataPlacesEntity,
-  NaturalEarthCountriesEntity,
+  LibraryEntity,
   MemoryEntity,
   MoveEntity,
+  NaturalEarthCountriesEntity,
   PartnerEntity,
   PersonEntity,
+  SessionEntity,
   SharedLinkEntity,
   SmartInfoEntity,
   SmartSearchEntity,
@@ -50,6 +54,4 @@ export const entities = [
   TagEntity,
   UserEntity,
   UserMetadataEntity,
-  SessionEntity,
-  LibraryEntity,
 ];

--- a/server/src/interfaces/asset.interface.ts
+++ b/server/src/interfaces/asset.interface.ts
@@ -151,7 +151,7 @@ export interface IAssetRepository {
     select?: FindOptionsSelect<AssetEntity>,
   ): Promise<AssetEntity[]>;
   getByIdsWithAllRelations(ids: string[]): Promise<AssetEntity[]>;
-  getByDayOfYear(ownerIds: string[], monthDay: MonthDay): Promise<AssetEntity[]>;
+  getByDayOfYear(ownerIds: string[], monthDay: MonthDay, userId: string): Promise<AssetEntity[]>;
   getByChecksum(options: { ownerId: string; checksum: Buffer; libraryId?: string }): Promise<AssetEntity | null>;
   getByChecksums(userId: string, checksums: Buffer[]): Promise<AssetEntity[]>;
   getUploadAssetIdByChecksum(ownerId: string, checksum: Buffer): Promise<string | undefined>;

--- a/server/src/migrations/1723804572991-AddAssetUserTable.ts
+++ b/server/src/migrations/1723804572991-AddAssetUserTable.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAssetUserTable1723804572991 implements MigrationInterface {
+    name = 'AddAssetUserTable1723804572991'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // create table, just with the "isFavorite" property for now
+        await queryRunner.query(`CREATE TABLE "asset_user" ("userId" uuid NOT NULL, "assetId" uuid NOT NULL, "isFavorite" boolean default false not null, CONSTRAINT "PK_b4b14fe8347d81d374bc5b5f8e7" PRIMARY KEY ("userId", "assetId"))`);
+        await queryRunner.query(`ALTER TABLE "asset_user" ADD CONSTRAINT "FK_d9cc706fa73fdbf08b77e73bd79" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "asset_user" ADD CONSTRAINT "FK_b5f17ca35363fb7c1650c7d03f9" FOREIGN KEY ("assetId") REFERENCES "assets"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`CREATE INDEX "IDX_b5f17ca35363fb7c1650c7d03f" ON "asset_user" ("assetId") `);
+
+        // fill with "isFavorite" data
+        await queryRunner.query(`INSERT INTO "asset_user" ("userId", "assetId", "isFavorite") SELECT "ownerId", "id", "isFavorite" FROM "assets" WHERE "isFavorite"`);
+
+        // remove "isFavorite" column
+        await queryRunner.query(`ALTER TABLE "assets" DROP COLUMN "isFavorite"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // add column
+        await queryRunner.query(`ALTER TABLE "assets" ADD COLUMN "isFavorite" boolean default false not null`);
+
+        // fill with data
+        await queryRunner.query(`UPDATE "assets" SET "isFavorite" = true WHERE "assets"."id" IN (SELECT "assetId" FROM "asset_user" WHERE "userId" = "assets"."ownerId" AND "asset_user"."isFavorite")`);
+
+        // drop table
+        await queryRunner.query(`DROP INDEX "public"."IDX_b5f17ca35363fb7c1650c7d03f"`);
+        await queryRunner.query(`ALTER TABLE "asset_user" DROP CONSTRAINT "FK_b5f17ca35363fb7c1650c7d03f9"`);
+        await queryRunner.query(`ALTER TABLE "asset_user" DROP CONSTRAINT "FK_d9cc706fa73fdbf08b77e73bd79"`);
+        await queryRunner.query(`DROP TABLE "asset_user"`);
+    }
+
+}

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -19,7 +19,6 @@ SELECT
   "entity"."fileCreatedAt" AS "entity_fileCreatedAt",
   "entity"."localDateTime" AS "entity_localDateTime",
   "entity"."fileModifiedAt" AS "entity_fileModifiedAt",
-  "entity"."isFavorite" AS "entity_isFavorite",
   "entity"."isArchived" AS "entity_isArchived",
   "entity"."isExternal" AS "entity_isExternal",
   "entity"."isOffline" AS "entity_isOffline",
@@ -59,13 +58,16 @@ SELECT
   "exifInfo"."colorspace" AS "exifInfo_colorspace",
   "exifInfo"."bitsPerSample" AS "exifInfo_bitsPerSample",
   "exifInfo"."rating" AS "exifInfo_rating",
-  "exifInfo"."fps" AS "exifInfo_fps"
+  "exifInfo"."fps" AS "exifInfo_fps",
+  "favoriteInfo"."assetId" IS NOT NULL AS entity_isFavorite
 FROM
   "assets" "entity"
   LEFT JOIN "exif" "exifInfo" ON "exifInfo"."assetId" = "entity"."id"
+  LEFT JOIN "asset_favorites" "favoriteInfo" ON "favoriteInfo"."assetId" = "entity"."id"
+  AND ("favoriteInfo"."userId" = $1)
 WHERE
   (
-    "entity"."ownerId" IN ($1)
+    "entity"."ownerId" IN ($2)
     AND "entity"."isVisible" = true
     AND "entity"."isArchived" = false
     AND "entity"."previewPath" IS NOT NULL
@@ -73,12 +75,12 @@ WHERE
       DAY
       FROM
         "entity"."localDateTime" AT TIME ZONE 'UTC'
-    ) = $2
+    ) = $3
     AND EXTRACT(
       MONTH
       FROM
         "entity"."localDateTime" AT TIME ZONE 'UTC'
-    ) = $3
+    ) = $4
   )
   AND ("entity"."deletedAt" IS NULL)
 ORDER BY

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -77,7 +77,7 @@ export class AssetRepository implements IAssetRepository {
   }
 
   @GenerateSql({ params: [[DummyValue.UUID], { day: 1, month: 1 }] })
-  getByDayOfYear(ownerIds: string[], { day, month }: MonthDay): Promise<AssetEntity[]> {
+  getByDayOfYear(ownerIds: string[], { day, month }: MonthDay, userId: string): Promise<AssetEntity[]> {
     return this.repository
       .createQueryBuilder('entity')
       .where(
@@ -94,6 +94,8 @@ export class AssetRepository implements IAssetRepository {
         },
       )
       .leftJoinAndSelect('entity.exifInfo', 'exifInfo')
+      .leftJoin('entity.favoriteInfo', 'favoriteInfo', 'favoriteInfo.userId = :userId', { userId })
+      .addSelect('favoriteInfo.assetId IS NOT NULL AS entity_isFavorite')
       .orderBy('entity.localDateTime', 'ASC')
       .getMany();
   }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -114,7 +114,9 @@ describe(AssetService.name, () => {
         { yearsAgo: 15, title: '15 years ago', assets: [mapAsset(image4)] },
       ]);
 
-      expect(assetMock.getByDayOfYear.mock.calls).toEqual([[[authStub.admin.user.id], { day: 15, month: 1 }]]);
+      expect(assetMock.getByDayOfYear.mock.calls).toEqual([
+        [[authStub.admin.user.id], { day: 15, month: 1 }, authStub.admin.user.id],
+      ]);
     });
 
     it('should get memories with partners with inTimeline enabled', async () => {
@@ -124,7 +126,7 @@ describe(AssetService.name, () => {
       await sut.getMemoryLane(authStub.admin, { day: 15, month: 1 });
 
       expect(assetMock.getByDayOfYear.mock.calls).toEqual([
-        [[authStub.admin.user.id, userStub.user1.id], { day: 15, month: 1 }],
+        [[authStub.admin.user.id, userStub.user1.id], { day: 15, month: 1 }, authStub.admin.user.id],
       ]);
     });
   });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -71,7 +71,7 @@ export class AssetService {
     });
     const userIds = [auth.user.id, ...partnerIds];
 
-    const assets = await this.assetRepository.getByDayOfYear(userIds, dto);
+    const assets = await this.assetRepository.getByDayOfYear(userIds, dto, auth.user.id);
     const groups: Record<number, AssetEntity[]> = {};
     const currentYear = new Date().getFullYear();
     for (const asset of assets) {


### PR DESCRIPTION
The mapping table can be used to have per-user settings (like favorites) for shared assets.

This only refactors the backend without making use of the new functionality: existing favorites from the assets' owners are moved to the new table. No other favorites (by non-owners) are allowed, yet. Adding this functionality is future work.