### PR TITLE
fix(mobile): show correct notification icon for android

### DIFF
--- a/mobile/lib/services/local_notification.service.dart
+++ b/mobile/lib/services/local_notification.service.dart
@@ -29,7 +29,8 @@ class LocalNotificationService {
   static const cancelUploadActionID = 'cancel_upload';
 
   Future<void> setup() async {
-    const androidSetting = AndroidInitializationSettings('notification_icon');
+    const androidSetting =
+        AndroidInitializationSettings('@drawable/notification_icon');
     const iosSetting = DarwinInitializationSettings();
 
     const initSettings =


### PR DESCRIPTION
https://github.com/immich-app/immich/issues/11745

To fix this, I changed the resource for notification icon with "@drawable/notification_icon" in local_notification.service.dart file's setup method.

<img width="320" alt="Screenshot 2024-08-17 at 11 48 15" src="https://github.com/user-attachments/assets/c19a8fc9-731f-40a6-a77f-bd18906e2815">

<img width="316" alt="Screenshot 2024-08-17 at 11 49 38" src="https://github.com/user-attachments/assets/acc1a296-2204-4e9f-b696-59fb21c3186d">
