### PR TITLE
fix(cli): Update build instructions for CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -4,8 +4,18 @@ Please see the [Immich CLI documentation](https://immich.app/docs/features/comma
 
 # For developers
 
+Before building the CLI, you must build the immich server and the open-api client. To build the server run the following in the server folder:
+
+    $ npm install
+    $ npm run build
+
+Then, to build the open-api client run the following in the open-api folder:
+
+    $ ./bin/generate-open-api.sh
+
 To run the Immich CLI from source, run the following in the cli folder:
 
+    $ npm install
     $ npm run build
     $ ts-node .
 
@@ -17,3 +27,4 @@ You can also build and install the CLI using
 
     $ npm run build
     $ npm install -g .
+****


### PR DESCRIPTION
I was struggling to make the PR #11828 as the build instructions are unclear. I added that the server and open-api have to be built to develop against the open-api. Just saying "Build the OpenAPI" would not be sufficient as it requires the server to be built and that fact is burried under a gazillion lines of log in the generation script.

I hope I got the title right this time...