### PR TITLE
fix(web): correctly populate the camera model search dropdown

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-camera-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-camera-section.svelte
@@ -41,7 +41,7 @@
       includeNull: true,
     });
 
-    const models = results.map((result) => result ?? '');
+    models = results.map((result) => result ?? '');
 
     if (filters.model && !models.includes(filters.model)) {
       filters.model = undefined;


### PR DESCRIPTION
#10866 introduced a regression that prevented the camera models dropdown from being populated. This has been fixed.

![image](https://github.com/user-attachments/assets/0104cba2-e20c-4721-a3a4-0e48f0322141)
