### PR TITLE
fix(web): show camera make in search options after searching

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-camera-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-camera-section.svelte
@@ -27,11 +27,12 @@
       model,
       includeNull: true,
     });
+
+    makes = results.map((result) => result ?? '');
+
     if (filters.make && !makes.includes(filters.make)) {
       filters.make = undefined;
     }
-
-    makes = results.map((result) => result ?? '');
   }
 
   async function updateModels(make?: string) {


### PR DESCRIPTION
To reproduce:
1. Search for camera make
2. Open search options
3. Camera make is empty, should be populated