### PR TITLE
fix(web, server): correctly determine and display localDateTime

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -227,13 +227,8 @@ export class MetadataService {
     await this.assetRepository.upsertExif(exifData);
 
     const dateTimeOriginal = exifData.dateTimeOriginal;
-    let localDateTime = dateTimeOriginal ?? undefined;
+    const localDateTime = dateTimeOriginal ?? undefined;
 
-    const timeZoneOffset = tzOffset(firstDateTime(tags as Tags)) ?? 0;
-
-    if (dateTimeOriginal && timeZoneOffset) {
-      localDateTime = new Date(dateTimeOriginal.getTime() + timeZoneOffset * 60_000);
-    }
     await this.assetRepository.update({
       id: asset.id,
       duration: asset.duration,

--- a/web/src/lib/utils/timeline-util.spec.ts
+++ b/web/src/lib/utils/timeline-util.spec.ts
@@ -3,13 +3,18 @@ import { formatGroupTitle } from '$lib/utils/timeline-util';
 import { DateTime } from 'luxon';
 
 describe('formatGroupTitle', () => {
+  let originalSystemTimeZone: string | undefined;
+
   beforeAll(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-07-27T12:00:00Z'));
+    originalSystemTimeZone = process.env.TZ;
+    process.env.TZ = 'UTC';
   });
 
   afterAll(() => {
     vi.useRealTimers();
+    process.env.TZ = originalSystemTimeZone;
   });
 
   it('formats today', () => {

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { get } from 'svelte/store';
 
 export const fromLocalDateTime = (localDateTime: string) =>
-  DateTime.fromISO(localDateTime, { zone: 'UTC', locale: get(locale) });
+  DateTime.fromISO(localDateTime, { locale: get(locale) });
 
 export const groupDateFormat: Intl.DateTimeFormatOptions = {
   weekday: 'short',


### PR DESCRIPTION
This is a fix for #10417. Explanation here: https://github.com/immich-app/immich/issues/10417#issuecomment-2295116208

Users will need to re-run metadata analysis for this change to take effect.

I'm unsure if `localDateTime` is even required anymore, but I feel like that's a separate discussion that needs some maintainers that have a deeper understanding of why it was introduced in the first place.