### PR TITLE
fix(docs): adds "immich-machine-learning:/cache" to non-root FAQ

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -307,6 +307,7 @@ You may need to add mount points or docker volumes for the following internal co
 
 - `immich-machine-learning:/.config`
 - `immich-machine-learning:/.cache`
+- `immich-machine-learning:/cache`
 - `redis:/data`
 
 The non-root user/group needs read/write access to the volume mounts, including `UPLOAD_LOCATION`.


### PR DESCRIPTION
Right now, the FAQ for non-root docker only specifies you need bind mounts for:


- immich-machine-learning:/.config
- immich-machine-learning:/.cache
- redis:/data


This PR adds `immich-machine-learning:/cache` since that seems to be required too