### PR TITLE
feat: specify remote album for backup

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -266,6 +266,7 @@
   "library_page_sort_most_oldest_photo": "Oldest photo",
   "library_page_sort_most_recent_photo": "Most recent photo",
   "library_page_sort_title": "Album title",
+  "local_album_remote_album_mapping_title": "Backup this album to remote album",
   "location_picker_choose_on_map": "Choose on map",
   "location_picker_latitude": "Latitude",
   "location_picker_latitude_error": "Enter a valid latitude",

--- a/mobile/lib/entities/album.entity.dart
+++ b/mobile/lib/entities/album.entity.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/entities/remote_album_mapping.entity.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/entities/user.entity.dart';
 import 'package:immich_mobile/utils/datetime_comparison.dart';
+import 'package:immich_mobile/utils/hash.dart';
 import 'package:isar/isar.dart';
 import 'package:openapi/api.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -68,6 +70,23 @@ class Album {
     }
 
     return name.join(' ');
+  }
+
+  @ignore
+  String? get remoteAlbumMappingId {
+    final Isar db = Isar.getInstance()!;
+    return db.remoteAlbumMappings
+            .getSync(fastHash(this.localId!))
+            ?.remoteAlbumMappingId ??
+        null;
+  }
+
+  set remoteAlbumMappingId(String? value) {
+    if (this.isRemote) return;
+    final Isar db = Isar.getInstance()!;
+    final mapping = RemoteAlbumMapping(
+        localAlbumMappingId: this.localId!, remoteAlbumMappingId: value);
+    db.writeTxnSync(() => db.remoteAlbumMappings.putSync(mapping));
   }
 
   @override

--- a/mobile/lib/entities/remote_album_mapping.entity.dart
+++ b/mobile/lib/entities/remote_album_mapping.entity.dart
@@ -1,0 +1,15 @@
+import 'package:immich_mobile/utils/hash.dart';
+import 'package:isar/isar.dart';
+
+part 'remote_album_mapping.entity.g.dart';
+
+@Collection()
+class RemoteAlbumMapping {
+  RemoteAlbumMapping(
+      {required this.localAlbumMappingId, required this.remoteAlbumMappingId});
+
+  Id get id => fastHash(localAlbumMappingId);
+  @Index(unique: true)
+  String localAlbumMappingId;
+  String? remoteAlbumMappingId;
+}

--- a/mobile/lib/entities/remote_album_mapping.entity.g.dart
+++ b/mobile/lib/entities/remote_album_mapping.entity.g.dart
@@ -1,0 +1,786 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'remote_album_mapping.entity.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetRemoteAlbumMappingCollection on Isar {
+  IsarCollection<RemoteAlbumMapping> get remoteAlbumMappings =>
+      this.collection();
+}
+
+const RemoteAlbumMappingSchema = CollectionSchema(
+  name: r'RemoteAlbumMapping',
+  id: -1351040990048458851,
+  properties: {
+    r'localAlbumMappingId': PropertySchema(
+      id: 0,
+      name: r'localAlbumMappingId',
+      type: IsarType.string,
+    ),
+    r'remoteAlbumMappingId': PropertySchema(
+      id: 1,
+      name: r'remoteAlbumMappingId',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _remoteAlbumMappingEstimateSize,
+  serialize: _remoteAlbumMappingSerialize,
+  deserialize: _remoteAlbumMappingDeserialize,
+  deserializeProp: _remoteAlbumMappingDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'localAlbumMappingId': IndexSchema(
+      id: -3436349769577783964,
+      name: r'localAlbumMappingId',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'localAlbumMappingId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _remoteAlbumMappingGetId,
+  getLinks: _remoteAlbumMappingGetLinks,
+  attach: _remoteAlbumMappingAttach,
+  version: '3.1.0+1',
+);
+
+int _remoteAlbumMappingEstimateSize(
+  RemoteAlbumMapping object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.localAlbumMappingId.length * 3;
+  {
+    final value = object.remoteAlbumMappingId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _remoteAlbumMappingSerialize(
+  RemoteAlbumMapping object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.localAlbumMappingId);
+  writer.writeString(offsets[1], object.remoteAlbumMappingId);
+}
+
+RemoteAlbumMapping _remoteAlbumMappingDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = RemoteAlbumMapping(
+    localAlbumMappingId: reader.readString(offsets[0]),
+    remoteAlbumMappingId: reader.readStringOrNull(offsets[1]),
+  );
+  return object;
+}
+
+P _remoteAlbumMappingDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readString(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _remoteAlbumMappingGetId(RemoteAlbumMapping object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _remoteAlbumMappingGetLinks(
+    RemoteAlbumMapping object) {
+  return [];
+}
+
+void _remoteAlbumMappingAttach(
+    IsarCollection<dynamic> col, Id id, RemoteAlbumMapping object) {}
+
+extension RemoteAlbumMappingByIndex on IsarCollection<RemoteAlbumMapping> {
+  Future<RemoteAlbumMapping?> getByLocalAlbumMappingId(
+      String localAlbumMappingId) {
+    return getByIndex(r'localAlbumMappingId', [localAlbumMappingId]);
+  }
+
+  RemoteAlbumMapping? getByLocalAlbumMappingIdSync(String localAlbumMappingId) {
+    return getByIndexSync(r'localAlbumMappingId', [localAlbumMappingId]);
+  }
+
+  Future<bool> deleteByLocalAlbumMappingId(String localAlbumMappingId) {
+    return deleteByIndex(r'localAlbumMappingId', [localAlbumMappingId]);
+  }
+
+  bool deleteByLocalAlbumMappingIdSync(String localAlbumMappingId) {
+    return deleteByIndexSync(r'localAlbumMappingId', [localAlbumMappingId]);
+  }
+
+  Future<List<RemoteAlbumMapping?>> getAllByLocalAlbumMappingId(
+      List<String> localAlbumMappingIdValues) {
+    final values = localAlbumMappingIdValues.map((e) => [e]).toList();
+    return getAllByIndex(r'localAlbumMappingId', values);
+  }
+
+  List<RemoteAlbumMapping?> getAllByLocalAlbumMappingIdSync(
+      List<String> localAlbumMappingIdValues) {
+    final values = localAlbumMappingIdValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'localAlbumMappingId', values);
+  }
+
+  Future<int> deleteAllByLocalAlbumMappingId(
+      List<String> localAlbumMappingIdValues) {
+    final values = localAlbumMappingIdValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'localAlbumMappingId', values);
+  }
+
+  int deleteAllByLocalAlbumMappingIdSync(
+      List<String> localAlbumMappingIdValues) {
+    final values = localAlbumMappingIdValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'localAlbumMappingId', values);
+  }
+
+  Future<Id> putByLocalAlbumMappingId(RemoteAlbumMapping object) {
+    return putByIndex(r'localAlbumMappingId', object);
+  }
+
+  Id putByLocalAlbumMappingIdSync(RemoteAlbumMapping object,
+      {bool saveLinks = true}) {
+    return putByIndexSync(r'localAlbumMappingId', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByLocalAlbumMappingId(
+      List<RemoteAlbumMapping> objects) {
+    return putAllByIndex(r'localAlbumMappingId', objects);
+  }
+
+  List<Id> putAllByLocalAlbumMappingIdSync(List<RemoteAlbumMapping> objects,
+      {bool saveLinks = true}) {
+    return putAllByIndexSync(r'localAlbumMappingId', objects,
+        saveLinks: saveLinks);
+  }
+}
+
+extension RemoteAlbumMappingQueryWhereSort
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QWhere> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension RemoteAlbumMappingQueryWhere
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QWhereClause> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      idGreaterThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      idLessThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      localAlbumMappingIdEqualTo(String localAlbumMappingId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'localAlbumMappingId',
+        value: [localAlbumMappingId],
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterWhereClause>
+      localAlbumMappingIdNotEqualTo(String localAlbumMappingId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localAlbumMappingId',
+              lower: [],
+              upper: [localAlbumMappingId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localAlbumMappingId',
+              lower: [localAlbumMappingId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localAlbumMappingId',
+              lower: [localAlbumMappingId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'localAlbumMappingId',
+              lower: [],
+              upper: [localAlbumMappingId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension RemoteAlbumMappingQueryFilter
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QFilterCondition> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'localAlbumMappingId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'localAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'localAlbumMappingId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localAlbumMappingId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      localAlbumMappingIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'localAlbumMappingId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'remoteAlbumMappingId',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'remoteAlbumMappingId',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'remoteAlbumMappingId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'remoteAlbumMappingId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'remoteAlbumMappingId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'remoteAlbumMappingId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterFilterCondition>
+      remoteAlbumMappingIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'remoteAlbumMappingId',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension RemoteAlbumMappingQueryObject
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QFilterCondition> {}
+
+extension RemoteAlbumMappingQueryLinks
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QFilterCondition> {}
+
+extension RemoteAlbumMappingQuerySortBy
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QSortBy> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      sortByLocalAlbumMappingId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localAlbumMappingId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      sortByLocalAlbumMappingIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localAlbumMappingId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      sortByRemoteAlbumMappingId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteAlbumMappingId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      sortByRemoteAlbumMappingIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteAlbumMappingId', Sort.desc);
+    });
+  }
+}
+
+extension RemoteAlbumMappingQuerySortThenBy
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QSortThenBy> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenByLocalAlbumMappingId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localAlbumMappingId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenByLocalAlbumMappingIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localAlbumMappingId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenByRemoteAlbumMappingId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteAlbumMappingId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QAfterSortBy>
+      thenByRemoteAlbumMappingIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteAlbumMappingId', Sort.desc);
+    });
+  }
+}
+
+extension RemoteAlbumMappingQueryWhereDistinct
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QDistinct> {
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QDistinct>
+      distinctByLocalAlbumMappingId({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'localAlbumMappingId',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QDistinct>
+      distinctByRemoteAlbumMappingId({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'remoteAlbumMappingId',
+          caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension RemoteAlbumMappingQueryProperty
+    on QueryBuilder<RemoteAlbumMapping, RemoteAlbumMapping, QQueryProperty> {
+  QueryBuilder<RemoteAlbumMapping, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, String, QQueryOperations>
+      localAlbumMappingIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'localAlbumMappingId');
+    });
+  }
+
+  QueryBuilder<RemoteAlbumMapping, String?, QQueryOperations>
+      remoteAlbumMappingIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'remoteAlbumMappingId');
+    });
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/remote_album_mapping.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:timezone/data/latest.dart';
 import 'package:immich_mobile/constants/locales.dart';
@@ -104,6 +105,7 @@ Future<Isar> loadDb() async {
       ETagSchema,
       if (Platform.isAndroid) AndroidDeviceAssetSchema,
       if (Platform.isIOS) IOSDeviceAssetSchema,
+      RemoteAlbumMappingSchema,
     ],
     directory: dir.path,
     maxSizeMiB: 1024,

--- a/mobile/lib/models/backup/backup_candidate.model.dart
+++ b/mobile/lib/models/backup/backup_candidate.model.dart
@@ -3,19 +3,23 @@
 import 'package:photo_manager/photo_manager.dart';
 
 class BackupCandidate {
-  final String albumName;
+  final String id;
+  final List<String> albumName;
   final AssetEntity asset;
 
   BackupCandidate({
+    required this.id,
     required this.albumName,
     required this.asset,
   });
 
   BackupCandidate copyWith({
-    String? albumName,
+    String? id,
+    List<String>? albumName,
     AssetEntity? asset,
   }) {
     return BackupCandidate(
+      id: id ?? this.id,
       albumName: albumName ?? this.albumName,
       asset: asset ?? this.asset,
     );
@@ -28,9 +32,11 @@ class BackupCandidate {
   bool operator ==(covariant BackupCandidate other) {
     if (identical(this, other)) return true;
 
-    return other.albumName == albumName && other.asset == asset;
+    return other.id == id &&
+        other.albumName == albumName &&
+        other.asset == asset;
   }
 
   @override
-  int get hashCode => albumName.hashCode ^ asset.hashCode;
+  int get hashCode => id.hashCode ^ albumName.hashCode ^ asset.hashCode;
 }

--- a/mobile/lib/models/backup/backup_candidate.model.dart
+++ b/mobile/lib/models/backup/backup_candidate.model.dart
@@ -1,0 +1,36 @@
+// ignore_for_file: public_member_api_docs, sort_constructors_first
+
+import 'package:photo_manager/photo_manager.dart';
+
+class BackupCandidate {
+  final String albumName;
+  final AssetEntity asset;
+
+  BackupCandidate({
+    required this.albumName,
+    required this.asset,
+  });
+
+  BackupCandidate copyWith({
+    String? albumName,
+    AssetEntity? asset,
+  }) {
+    return BackupCandidate(
+      albumName: albumName ?? this.albumName,
+      asset: asset ?? this.asset,
+    );
+  }
+
+  @override
+  String toString() => 'BackupCandidate(albumName: $albumName, asset: $asset)';
+
+  @override
+  bool operator ==(covariant BackupCandidate other) {
+    if (identical(this, other)) return true;
+
+    return other.albumName == albumName && other.asset == asset;
+  }
+
+  @override
+  int get hashCode => albumName.hashCode ^ asset.hashCode;
+}

--- a/mobile/lib/models/backup/backup_candidate.model.dart
+++ b/mobile/lib/models/backup/backup_candidate.model.dart
@@ -4,39 +4,37 @@ import 'package:photo_manager/photo_manager.dart';
 
 class BackupCandidate {
   final String id;
-  final List<String> albumName;
+  final List<String> albumId;
   final AssetEntity asset;
 
   BackupCandidate({
     required this.id,
-    required this.albumName,
+    required this.albumId,
     required this.asset,
   });
 
   BackupCandidate copyWith({
     String? id,
-    List<String>? albumName,
+    List<String>? albumId,
     AssetEntity? asset,
   }) {
     return BackupCandidate(
       id: id ?? this.id,
-      albumName: albumName ?? this.albumName,
+      albumId: albumId ?? this.albumId,
       asset: asset ?? this.asset,
     );
   }
 
   @override
-  String toString() => 'BackupCandidate(albumName: $albumName, asset: $asset)';
+  String toString() => 'BackupCandidate(albumId: $albumId, asset: $asset)';
 
   @override
   bool operator ==(covariant BackupCandidate other) {
     if (identical(this, other)) return true;
 
-    return other.id == id &&
-        other.albumName == albumName &&
-        other.asset == asset;
+    return other.id == id && other.albumId == albumId && other.asset == asset;
   }
 
   @override
-  int get hashCode => id.hashCode ^ albumName.hashCode ^ asset.hashCode;
+  int get hashCode => id.hashCode ^ albumId.hashCode ^ asset.hashCode;
 }

--- a/mobile/lib/models/backup/backup_state.model.dart
+++ b/mobile/lib/models/backup/backup_state.model.dart
@@ -2,7 +2,7 @@
 
 import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
-import 'package:photo_manager/photo_manager.dart';
+import 'package:immich_mobile/models/backup/backup_candidate.model.dart';
 
 import 'package:immich_mobile/models/backup/available_album.model.dart';
 import 'package:immich_mobile/models/backup/current_upload_asset.model.dart';
@@ -41,7 +41,7 @@ class BackUpState {
   final Set<AvailableAlbum> excludedBackupAlbums;
 
   /// Assets that are not overlapping in selected backup albums and excluded backup albums
-  final Set<AssetEntity> allUniqueAssets;
+  final Set<BackupCandidate> allUniqueAssets;
 
   /// All assets from the selected albums that have been backup
   final Set<String> selectedAlbumsBackupAssetsIds;
@@ -94,7 +94,7 @@ class BackUpState {
     List<AvailableAlbum>? availableAlbums,
     Set<AvailableAlbum>? selectedBackupAlbums,
     Set<AvailableAlbum>? excludedBackupAlbums,
-    Set<AssetEntity>? allUniqueAssets,
+    Set<BackupCandidate>? allUniqueAssets,
     Set<String>? selectedAlbumsBackupAssetsIds,
     CurrentUploadAsset? currentUploadAsset,
   }) {

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -290,7 +290,6 @@ class BackupNotifier extends StateNotifier<BackUpState> {
   /// Those assets are unique and are used as the total assets
   ///
   Future<void> _updateBackupAssetCount() async {
-    debugPrint("UPDATE BACKUP ASSET COUNTTT");
     final duplicatedAssetIds = await _backupService.getDuplicatedAssetIds();
     final Set<BackupCandidate> assetsFromSelectedAlbums = {};
     final Set<BackupCandidate> assetsFromExcludedAlbums = {};
@@ -311,7 +310,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       final candidate = assets.map(
         (e) => BackupCandidate(
           id: e.id,
-          albumName: [album.albumEntity.name],
+          albumId: [album.albumEntity.id],
           asset: e,
         ),
       );
@@ -335,7 +334,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
       final candidate = assets.map(
         (e) => BackupCandidate(
           id: e.id,
-          albumName: [album.albumEntity.name],
+          albumId: [album.albumEntity.name],
           asset: e,
         ),
       );
@@ -365,12 +364,12 @@ class BackupNotifier extends StateNotifier<BackUpState> {
 
     /// Merge different album name of the same id
     allUniqueAssets = allUniqueAssets.map((e) {
-      final List<String> albumNames = allUniqueAssets
+      final List<String> albumIds = allUniqueAssets
           .where((a) => a.id == e.id)
-          .map((a) => a.albumName)
+          .map((a) => a.albumId)
           .expand((e) => e)
           .toList();
-      return e.copyWith(albumName: albumNames);
+      return e.copyWith(albumId: albumIds);
     }).toSet();
 
     if (allUniqueAssets.isEmpty) {

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -466,7 +466,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
         return;
       }
 
-      Set<AssetEntity> assetsWillBeBackup = Set.from(state.allUniqueAssets);
+      Set<BackupCandidate> assetsWillBeBackup = Set.from(state.allUniqueAssets);
       // Remove item that has already been backed up
       for (final assetId in state.allAssetsInDatabase) {
         assetsWillBeBackup.removeWhere((e) => e.id == assetId);

--- a/mobile/lib/providers/backup/manual_upload.provider.dart
+++ b/mobile/lib/providers/backup/manual_upload.provider.dart
@@ -6,6 +6,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/models/backup/backup_candidate.model.dart';
 import 'package:immich_mobile/services/background.service.dart';
 import 'package:immich_mobile/models/backup/backup_state.model.dart';
 import 'package:immich_mobile/models/backup/current_upload_asset.model.dart';
@@ -250,7 +251,8 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
         final pmProgressHandler = Platform.isIOS ? PMProgressHandler() : null;
 
         final bool ok = await ref.read(backupServiceProvider).backupAsset(
-              allUploadAssets,
+              allUploadAssets
+                  .map((a) => BackupCandidate(id: a.id, albumId: [], asset: a)),
               state.cancelToken,
               pmProgressHandler,
               _onAssetUploaded,

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/main.dart';
+import 'package:immich_mobile/models/backup/backup_candidate.model.dart';
 import 'package:immich_mobile/services/localization.service.dart';
 import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/models/backup/current_upload_asset.model.dart';
@@ -416,7 +417,7 @@ class BackgroundService {
       return false;
     }
 
-    List<AssetEntity> toUpload = await backupService.buildUploadCandidates(
+    List<BackupCandidate> toUpload = await backupService.buildUploadCandidates(
       selectedAlbums,
       excludedAlbums,
     );

--- a/mobile/lib/widgets/album/album_viewer_appbar.dart
+++ b/mobile/lib/widgets/album/album_viewer_appbar.dart
@@ -155,6 +155,17 @@ class AlbumViewerAppbar extends HookConsumerWidget
     }
 
     void buildBottomSheet() {
+      final optionsActions = [
+        ListTile(
+          leading: const Icon(Icons.settings_rounded),
+          onTap: () => context.navigateTo(AlbumOptionsRoute(album: album)),
+          title: const Text(
+            "translated_text_options",
+            style: TextStyle(fontWeight: FontWeight.w500),
+          ).tr(),
+        ),
+      ];
+
       final ownerActions = [
         ListTile(
           leading: const Icon(Icons.person_add_alt_rounded),
@@ -175,14 +186,6 @@ class AlbumViewerAppbar extends HookConsumerWidget
           },
           title: const Text(
             "control_bottom_app_bar_share",
-            style: TextStyle(fontWeight: FontWeight.w500),
-          ).tr(),
-        ),
-        ListTile(
-          leading: const Icon(Icons.settings_rounded),
-          onTap: () => context.navigateTo(AlbumOptionsRoute(album: album)),
-          title: const Text(
-            "translated_text_options",
             style: TextStyle(fontWeight: FontWeight.w500),
           ).tr(),
         ),
@@ -212,10 +215,13 @@ class AlbumViewerAppbar extends HookConsumerWidget
               child: ListView(
                 shrinkWrap: true,
                 children: [
-                  ...buildBottomSheetActions(),
-                  if (onAddPhotos != null) ...commonActions,
-                  if (onAddPhotos != null && userId == album.ownerId)
+                  if (album.isRemote) ...buildBottomSheetActions(),
+                  if (onAddPhotos != null && album.isRemote) ...commonActions,
+                  if (onAddPhotos != null &&
+                      userId == album.ownerId &&
+                      album.isRemote)
                     ...ownerActions,
+                  ...optionsActions,
                 ],
               ),
             ),
@@ -289,12 +295,11 @@ class AlbumViewerAppbar extends HookConsumerWidget
       actions: [
         if (album.shared && (album.activityEnabled || comments != 0))
           buildActivitiesButton(),
-        if (album.isRemote)
-          IconButton(
-            splashRadius: 25,
-            onPressed: buildBottomSheet,
-            icon: const Icon(Icons.more_horiz_rounded),
-          ),
+        IconButton(
+          splashRadius: 25,
+          onPressed: buildBottomSheet,
+          icon: const Icon(Icons.more_horiz_rounded),
+        ),
       ],
     );
   }

--- a/server/src/dtos/asset-media.dto.ts
+++ b/server/src/dtos/asset-media.dto.ts
@@ -64,6 +64,10 @@ export class AssetMediaCreateDto extends AssetMediaBase {
 
   @ApiProperty({ type: 'string', format: 'binary', required: false })
   [UploadFieldName.SIDECAR_DATA]?: any;
+
+  @Optional()
+  @IsString()
+  toAlbumId?: string;
 }
 
 export class AssetMediaReplaceDto extends AssetMediaBase {}

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -4,6 +4,8 @@ import { AssetMediaStatus, AssetRejectReason, AssetUploadAction } from 'src/dtos
 import { AssetMediaCreateDto, AssetMediaReplaceDto, UploadFieldName } from 'src/dtos/asset-media.dto';
 import { ASSET_CHECKSUM_CONSTRAINT, AssetEntity } from 'src/entities/asset.entity';
 import { AssetType } from 'src/enum';
+import { IAlbumUserRepository } from 'src/interfaces/album-user.interface';
+import { IAlbumRepository } from 'src/interfaces/album.interface';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { IEventRepository } from 'src/interfaces/event.interface';
 import { IJobRepository, JobName } from 'src/interfaces/job.interface';
@@ -16,6 +18,8 @@ import { assetStub } from 'test/fixtures/asset.stub';
 import { authStub } from 'test/fixtures/auth.stub';
 import { fileStub } from 'test/fixtures/file.stub';
 import { IAccessRepositoryMock, newAccessRepositoryMock } from 'test/repositories/access.repository.mock';
+import { newAlbumUserRepositoryMock } from 'test/repositories/album-user.repository.mock';
+import { newAlbumRepositoryMock } from 'test/repositories/album.repository.mock';
 import { newAssetRepositoryMock } from 'test/repositories/asset.repository.mock';
 import { newEventRepositoryMock } from 'test/repositories/event.repository.mock';
 import { newJobRepositoryMock } from 'test/repositories/job.repository.mock';
@@ -196,6 +200,8 @@ describe(AssetMediaService.name, () => {
   let storageMock: Mocked<IStorageRepository>;
   let userMock: Mocked<IUserRepository>;
   let eventMock: Mocked<IEventRepository>;
+  let albumMock: Mocked<IAlbumRepository>;
+  let albumUserMock: Mocked<IAlbumUserRepository>;
 
   beforeEach(() => {
     accessMock = newAccessRepositoryMock();
@@ -205,8 +211,20 @@ describe(AssetMediaService.name, () => {
     storageMock = newStorageRepositoryMock();
     userMock = newUserRepositoryMock();
     eventMock = newEventRepositoryMock();
+    albumMock = newAlbumRepositoryMock();
+    albumUserMock = newAlbumUserRepositoryMock();
 
-    sut = new AssetMediaService(accessMock, assetMock, jobMock, storageMock, userMock, eventMock, loggerMock);
+    sut = new AssetMediaService(
+      accessMock,
+      assetMock,
+      jobMock,
+      storageMock,
+      userMock,
+      eventMock,
+      loggerMock,
+      albumMock,
+      albumUserMock,
+    );
   });
 
   describe('getUploadAssetIdByChecksum', () => {


### PR DESCRIPTION
A rough draft for preserving album info when uploading assets, as requested in #1678.  
Instead of preserving original name, this PR adds an ability to select remote album to which local album will be backed up.

It updates the mobile app with the options for local albums, containing mapping to remote album.

Also, the server is updated to add asset to album when uploading if `toAlbumId` is set in request.

This is still far from complete feature, but I hope that this one will be a good starting point that I will be able to refine and complete.

Opened questions:
- What do I need to modify in `open-api`?
- Is there a better way of adding an Asset to album? I don't want for server to reimplement album add logic in other class or for server to query it's API (but that's possible, probably)
- Untested on iOS, but I will in the future
- Why there's a List of album IDs in BackupCandidate? Can you provide an example, please?
- Is there are some test scenarios that I should consider when developing?

What I've tested:
- Uploading with set mapping adds an image to album
- Uploading with other mapping add an image to other album
- Uploading without mapping uploads the image without adding to album
- Manual upload uploads the image without adding to album