### PR TITLE
feat(server): Storage template support album condition

### DIFF
--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -308,7 +308,7 @@ export class StorageTemplateService {
       filetypefull: asset.type == AssetType.IMAGE ? 'IMAGE' : 'VIDEO',
       assetId: asset.id,
       //just throw into the root if it doesn't belong to an album
-      album: (albumName && sanitize(albumName.replaceAll(/\.+/g, ''))) || '.',
+      album: (albumName && sanitize(albumName.replaceAll(/\.+/g, ''))) || '',
     };
 
     const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -329,6 +329,6 @@ export class StorageTemplateService {
       substitutions[token] = dt.toFormat(token);
     }
 
-    return template(substitutions);
+    return template(substitutions).replaceAll(/\/{2,}/gm, '/');
   }
 }


### PR DESCRIPTION
As proposed in https://github.com/immich-app/immich/discussions/11999 it would be nice if we could support this very small change with big benefits. Let me know if there is anything missing.
This allows to do the following in the Storage template:
```
{{y}}/{{#if album}}{{album}}{{else}}{{MM}}{{/if}}/{{filename}}
```
See [Handlebars](https://handlebarsjs.com/guide/builtin-helpers.html#if) for more details.
Which results in a directory structure where images without an album go in a month folder:
```
...
└── 2024
    ├── 08
    │   ├──image_name.jpg
    └── Album name
        ├── 20240728_002331.jpg
        ├── 20240801_175952.jpg
 ...
```