### PR TITLE
feat(format): nrw format

### DIFF
--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -30,6 +30,7 @@ describe('mimeTypes', () => {
     { mimetype: 'image/kdc', extension: '.kdc' },
     { mimetype: 'image/mrw', extension: '.mrw' },
     { mimetype: 'image/nef', extension: '.nef' },
+    { mimetype: 'image/nrw', extension: '.nrw' },
     { mimetype: 'image/orf', extension: '.orf' },
     { mimetype: 'image/ori', extension: '.ori' },
     { mimetype: 'image/pef', extension: '.pef' },

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -19,6 +19,7 @@ const raw: Record<string, string[]> = {
   '.kdc': ['image/kdc', 'image/x-kodak-kdc'],
   '.mrw': ['image/mrw', 'image/x-minolta-mrw'],
   '.nef': ['image/nef', 'image/x-nikon-nef'],
+  '.nrw': ['image/nrw', 'image/x-nikon-nrw'],
   '.orf': ['image/orf', 'image/x-olympus-orf'],
   '.ori': ['image/ori', 'image/x-olympus-ori'],
   '.pef': ['image/pef', 'image/x-pentax-pef'],


### PR DESCRIPTION
I have a bunch of pictures taken with a Nikon Coolpix which saves RAW images in NRW format. This is supported by libraw and exiftool, but not currently exposed as supported by Immich. This diff seems to do the job for me (screenshot below of it rendering).

<img width="961" alt="image" src="https://github.com/user-attachments/assets/cdb888c0-b251-4f62-be55-986c144c42b4">

As supplemental information, the relevant output from exiftool one one such file is:

```
ExifTool Version Number         : 12.76
File Name                       : DSCN7692.NRW
Directory                       : .
File Size                       : 26 MB
File Modification Date/Time     : 2022:04:06 22:54:30+00:00
File Access Date/Time           : 2024:05:04 14:56:58+00:00
File Inode Change Date/Time     : 2024:05:04 14:56:58+00:00
File Permissions                : -rwxrwx---
File Type                       : NRW
File Type Extension             : nrw
MIME Type                       : image/x-nikon-nrw
Exif Byte Order                 : Little-endian (Intel, II)
Make                            : NIKON CORPORATION
Camera Model Name               : COOLPIX P1000
Orientation                     : Horizontal (normal)
Software                        : COOLPIX P1000  V1.1
Modify Date                     : 2022:04:06 17:54:31
Jpg From Raw Start              : 24482048
Jpg From Raw Length             : 1828235
Y Cb Cr Positioning             : Centered
Image Width                     : 4624
Image Height                    : 3470
Bits Per Sample                 : 12
Compression                     : Uncompressed
```

And raw-identify works:

```
$ raw-identify DSCN7692.NRW
DSCN7692.NRW is a Nikon COOLPIX P1000 image.
```
