### PR TITLE
fix: do not code format repro steps in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -83,7 +83,6 @@ body:
         2.
         3.
         ...
-      render: bash
     validations:
       required: true
 


### PR DESCRIPTION
When describing the reproduction steps, the template currently uses bash highlighting/colors. This is confusing and unnecessary.