### PR TITLE
chore(web): ensure goto is awaited for login page

### DIFF
--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -17,9 +17,9 @@
     </p>
 
     <LoginForm
-      onSuccess={() => goto(AppRoute.PHOTOS, { invalidateAll: true })}
-      onFirstLogin={() => goto(AppRoute.AUTH_CHANGE_PASSWORD)}
-      onOnboarding={() => goto(AppRoute.AUTH_ONBOARDING)}
+      onSuccess={async () => await goto(AppRoute.PHOTOS, { invalidateAll: true })}
+      onFirstLogin={async () => await goto(AppRoute.AUTH_CHANGE_PASSWORD)}
+      onOnboarding={async () => await goto(AppRoute.AUTH_ONBOARDING)}
     />
   </FullscreenContainer>
 {/if}

--- a/web/src/routes/auth/onboarding/+page.svelte
+++ b/web/src/routes/auth/onboarding/+page.svelte
@@ -6,6 +6,7 @@
   import OnboadingStorageTemplate from '$lib/components/onboarding-page/onboarding-storage-template.svelte';
   import OnboardingTheme from '$lib/components/onboarding-page/onboarding-theme.svelte';
   import { AppRoute, QueryParameter } from '$lib/constants';
+  import { retrieveServerConfig } from '$lib/stores/server-config.store';
   import { updateAdminOnboarding } from '@immich/sdk';
 
   let index = 0;
@@ -35,6 +36,7 @@
   const handleDoneClicked = async () => {
     if (index >= onboardingSteps.length - 1) {
       await updateAdminOnboarding({ adminOnboardingUpdateDto: { isOnboarded: true } });
+      await retrieveServerConfig();
       await goto(AppRoute.PHOTOS);
     } else {
       index++;


### PR DESCRIPTION
I discovered that sometimes, the new admin user cannot navigate to the onboarding page after signing up. I am adding await to ensure that the goto functions properly.

Additionally, ensure that the server config is updated after onboarding is finished
