### PR TITLE
chore(web): resolve timeline flashing temporarily

### DIFF
--- a/web/src/lib/stores/assets.store.ts
+++ b/web/src/lib/stores/assets.store.ts
@@ -253,8 +253,9 @@ export class AssetStore {
 
   connect() {
     this.unsubscribers.push(
-      websocketEvents.on('on_upload_success', (asset) => {
-        this.addPendingChanges({ type: 'add', values: [asset] });
+      websocketEvents.on('on_upload_success', (_) => {
+        // TODO!: Temporarily disable to avoid flashing effect of the timeline
+        // this.addPendingChanges({ type: 'add', values: [asset] });
       }),
       websocketEvents.on('on_asset_trash', (ids) => {
         this.addPendingChanges({ type: 'trash', values: ids });


### PR DESCRIPTION
Temporarily resolve timeline flashing by disable websocket event of `on_upload_success`
