### PR TITLE
feat(server): sort images in duplicate groups by date

### DIFF
--- a/server/src/dtos/duplicate.dto.ts
+++ b/server/src/dtos/duplicate.dto.ts
@@ -20,7 +20,7 @@ export function mapDuplicateResponse(assets: AssetResponseDto[]): DuplicateRespo
   const grouped = groupBy(assets, (a) => a.duplicateId);
 
   for (const [duplicateId, unsortedAssets] of Object.entries(grouped)) {
-    const assets = sortBy(unsortedAssets, (a) => a.localDateTime);
+    const assets = sortBy(unsortedAssets, (asset) => asset.localDateTime);
     result.push({ duplicateId, assets });
   }
 

--- a/server/src/dtos/duplicate.dto.ts
+++ b/server/src/dtos/duplicate.dto.ts
@@ -1,5 +1,5 @@
 import { IsNotEmpty } from 'class-validator';
-import { groupBy } from 'lodash';
+import { groupBy, sortBy } from 'lodash';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { ValidateUUID } from 'src/validation';
 
@@ -19,7 +19,8 @@ export function mapDuplicateResponse(assets: AssetResponseDto[]): DuplicateRespo
 
   const grouped = groupBy(assets, (a) => a.duplicateId);
 
-  for (const [duplicateId, assets] of Object.entries(grouped)) {
+  for (const [duplicateId, unsortedAssets] of Object.entries(grouped)) {
+    const assets = sortBy(unsortedAssets, (a) => a.localDateTime);
     result.push({ duplicateId, assets });
   }
 


### PR DESCRIPTION
Why **sort images** in duplicate groups: consistent order. I'm not 100% sure I imagined it but sometimes reloading the duplicate page (or going back from the full-screen view) changes the order of images, which is not good for my brain to follow.

Why sort images in duplicate groups **by date**: having (relative) date information makes it easier to find which images to keep. False positives are easier to spot when ordered chronologically. I often takes a picture of something again when I think the previous one was bad. Some pictures are of the same thing, but I don't want to consider them as such if they've been taken at the same date.

Why **not sort duplicate groups**: This might be a personal preference but it's more fun to not know what is coming next. You would probably get tired of a specific trip after a while. Also makes it easier to figure out a good policy for duplicates you want to keep.

Why **sort duplicate groups** (not what I implemented): If you go duplicates-hunting right after adding a lot of pictures, reloading the page might put you on another duplicate group. (This could be true whatever the sorting algorithm is, if the upload order matches that).

Why not doing it **client side**: Because it's harder and I could implement this myself for going through my \*checks notes\* 1,041 duplicate groups. Yeah I have the duplicate detection value cranked to the minimum, I should call this feature "similar pictures detection" at this point :D .

Other reason why you might **not want to accept** this contribution: I never wrote TypeScript in my life (is that even the programming language this stuff is written in?), I just stole code from other parts of the codebase until the nix package built and it worked on my server (I don't test on animals but I do test in production).