### PR TITLE
fix(server): ensure new exclusion patterns work

### DIFF
--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -383,7 +383,7 @@ describe('/libraries', () => {
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
       const { assets: newAssets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
-      expect(newAssets.count).toBe(2);
+      expect(newAssets.count).toBe(3);
 
       expect(newAssets.items).toEqual(
         expect.arrayContaining([
@@ -447,8 +447,14 @@ describe('/libraries', () => {
 
       const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
 
+      expect(assets.count).toBe(2);
+
       expect(assets.items).toEqual(
         expect.arrayContaining([
+          expect.objectContaining({
+            isOffline: false,
+            originalFileName: 'assetA.png',
+          }),
           expect.objectContaining({
             isOffline: true,
             originalFileName: 'assetB.png',
@@ -500,6 +506,8 @@ describe('/libraries', () => {
       await utils.waitForWebsocketEvent({ event: 'assetDelete', total: 1 });
 
       expect(existsSync(`${testAssetDir}/temp/offline1/assetA.png`)).toBe(true);
+
+      utils.removeImageFile(`${testAssetDir}/temp/offline1/assetA.png`);
     });
 
     it('should scan new files', async () => {

--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -7,7 +7,6 @@ import {
   scanLibrary,
 } from '@immich/sdk';
 import { cpSync, existsSync } from 'node:fs';
-import { afterEach } from 'node:test';
 import { Socket } from 'socket.io-client';
 import { userDto, uuidDto } from 'src/fixtures';
 import { errorDto } from 'src/responses';

--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   scanLibrary,
 } from '@immich/sdk';
 import { cpSync, existsSync } from 'node:fs';
+import { afterEach } from 'node:test';
 import { Socket } from 'socket.io-client';
 import { userDto, uuidDto } from 'src/fixtures';
 import { errorDto } from 'src/responses';
@@ -440,7 +441,7 @@ describe('/libraries', () => {
       await request(app)
         .put(`/libraries/${library.id}`)
         .set('Authorization', `Bearer ${admin.accessToken}`)
-        .send({ exclusionPattern: ['**/directoryB/**'] });
+        .send({ exclusionPatterns: ['**/directoryB/**'] });
 
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');

--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -429,8 +429,6 @@ describe('/libraries', () => {
     });
 
     it('should offline a file covered by exclusion pattern', async () => {
-      utils.createImageFile(`${testAssetDir}/temp/dir/assetA.png`);
-      utils.createImageFile(`${testAssetDir}/temp/dir/assetB.png`);
       utils.createImageFile(`${testAssetDir}/temp/ignore/assetC.png`);
       const library = await utils.createLibrary(admin.accessToken, {
         ownerId: admin.userId,
@@ -467,7 +465,7 @@ describe('/libraries', () => {
         ]),
       );
 
-      utils.removeImageFile(`${testAssetDir}/temp/directoryB/assetC.png`);
+      utils.removeImageFile(`${testAssetDir}/temp/ignore/assetC.png`);
     });
 
     it('should not try to delete offline files', async () => {

--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -428,7 +428,7 @@ describe('/libraries', () => {
       utils.removeImageFile(`${testAssetDir}/temp/directoryB/assetC.png`);
     });
 
-    it('should offline a file covered by exclusion pattern', async () => {
+    it('should offline a file covered by an exclusion pattern', async () => {
       utils.createImageFile(`${testAssetDir}/temp/ignore/assetC.png`);
       const library = await utils.createLibrary(admin.accessToken, {
         ownerId: admin.userId,
@@ -450,14 +450,6 @@ describe('/libraries', () => {
 
       expect(assets.items).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({
-            isOffline: false,
-            originalFileName: 'assetA.png',
-          }),
-          expect.objectContaining({
-            isOffline: false,
-            originalFileName: 'assetB.png',
-          }),
           expect.objectContaining({
             isOffline: true,
             originalFileName: 'assetC.png',

--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -454,7 +454,7 @@ describe('/libraries', () => {
         expect.arrayContaining([
           expect.objectContaining({
             isOffline: false,
-            originalFileName: 'asseta.png',
+            originalFileName: 'assetA.png',
           }),
           expect.objectContaining({
             isOffline: false,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -51,7 +51,7 @@
         "nodemailer": "^6.9.13",
         "openid-client": "^5.4.3",
         "pg": "^8.11.3",
-        "picomatch": "^4.0.0",
+        "picomatch": "^4.0.2",
         "react": "^18.3.1",
         "react-email": "^3.0.0",
         "reflect-metadata": "^0.2.0",
@@ -11403,6 +11403,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -77,7 +77,7 @@
     "nodemailer": "^6.9.13",
     "openid-client": "^5.4.3",
     "pg": "^8.11.3",
-    "picomatch": "^4.0.0",
+    "picomatch": "^4.0.2",
     "react": "^18.3.1",
     "react-email": "^3.0.0",
     "reflect-metadata": "^0.2.0",

--- a/server/src/interfaces/job.interface.ts
+++ b/server/src/interfaces/job.interface.ts
@@ -133,6 +133,7 @@ export interface ILibraryFileJob extends IEntityJob {
 
 export interface ILibraryOfflineJob extends IEntityJob {
   importPaths: string[];
+  exclusionPatterns: string[];
 }
 
 export interface ILibraryRefreshJob extends IEntityJob {

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -325,11 +325,25 @@ describe(LibraryService.name, () => {
       expect(assetMock.update).not.toHaveBeenCalled();
     });
 
-    it('should offline assets no longer on disk or matching exclusion pattern', async () => {
+    it('should offline assets no longer on disk', async () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/'],
         exclusionPatterns: [],
+      };
+
+      assetMock.getById.mockResolvedValue(assetStub.external);
+
+      await expect(sut.handleOfflineCheck(mockAssetJob)).resolves.toBe(JobStatus.SUCCESS);
+
+      expect(assetMock.update).toHaveBeenCalledWith({ id: assetStub.external.id, isOffline: true });
+    });
+
+    it('should offline assets matching an exclusion pattern', async () => {
+      const mockAssetJob: ILibraryOfflineJob = {
+        id: assetStub.external.id,
+        importPaths: ['/'],
+        exclusionPatterns: ['**/user1/**'],
       };
 
       assetMock.getById.mockResolvedValue(assetStub.external);

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -301,6 +301,7 @@ describe(LibraryService.name, () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/'],
+        exclusionPatterns: [],
       };
 
       assetMock.getById.mockResolvedValue(null);
@@ -314,6 +315,7 @@ describe(LibraryService.name, () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/'],
+        exclusionPatterns: [],
       };
 
       assetMock.getById.mockResolvedValue(assetStub.offline);
@@ -327,6 +329,7 @@ describe(LibraryService.name, () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/'],
+        exclusionPatterns: [],
       };
 
       assetMock.getById.mockResolvedValue(assetStub.external);
@@ -340,6 +343,7 @@ describe(LibraryService.name, () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/data/user2'],
+        exclusionPatterns: [],
       };
 
       assetMock.getById.mockResolvedValue(assetStub.external);
@@ -354,6 +358,7 @@ describe(LibraryService.name, () => {
       const mockAssetJob: ILibraryOfflineJob = {
         id: assetStub.external.id,
         importPaths: ['/'],
+        exclusionPatterns: [],
       };
 
       assetMock.getById.mockResolvedValue(assetStub.external);

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -556,6 +556,13 @@ export class LibraryService {
       return JobStatus.SUCCESS;
     }
 
+    const isExcluded = job.exclusionPatterns.some((pattern) => picomatch.isMatch(asset.originalPath, pattern));
+    if (isExcluded) {
+      this.logger.debug(`Asset is covered by an exclusion pattern, marking offline: ${asset.originalPath}`);
+      await this.assetRepository.update({ id: asset.id, isOffline: true });
+      return JobStatus.SUCCESS;
+    }
+
     const fileExists = await this.storageRepository.checkFileExists(asset.originalPath, R_OK);
     if (!fileExists) {
       this.logger.debug(

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -565,9 +565,7 @@ export class LibraryService {
 
     const fileExists = await this.storageRepository.checkFileExists(asset.originalPath, R_OK);
     if (!fileExists) {
-      this.logger.debug(
-        `Asset is no longer found on disk or is covered by exclusion pattern, marking offline: ${asset.originalPath}`,
-      );
+      this.logger.debug(`Asset is no longer found on disk, marking offline: ${asset.originalPath}`);
       await this.assetRepository.update({ id: asset.id, isOffline: true });
       return JobStatus.SUCCESS;
     }


### PR DESCRIPTION
It appears that a new exclusion pattern doesn't take effect for setting assets offline. A regression from #7934 
* Add e2e test case
* Add a check for exclusion pattern in the offline asset cherker
* Bump picomatch
* Cleanup library e2e tests