### PR TITLE
chore(server): log path when generating external thumbnail

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -255,9 +255,13 @@ export class MediaService {
         throw new UnsupportedMediaTypeException(`Unsupported asset type for thumbnail generation: ${asset.type}`);
       }
     }
+
+    const assetInfo = asset.isExternal ? asset.originalPath : asset.id;
+
     this.logger.log(
-      `Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} ${type} for asset ${asset.id}`,
+      `Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} ${type} in $for asset ${assetInfo}`,
     );
+
     return path;
   }
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -256,10 +256,9 @@ export class MediaService {
       }
     }
 
-    const assetInfo = asset.isExternal ? asset.originalPath : asset.id;
-
+    const assetLabel = asset.isExternal ? asset.originalPath : asset.id;
     this.logger.log(
-      `Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} ${type} in $for asset ${assetInfo}`,
+      `Successfully generated ${format.toUpperCase()} ${asset.type.toLowerCase()} ${type} for asset ${assetLabel}`,
     );
 
     return path;


### PR DESCRIPTION
This improves logging clarity when generating thumbs for external assets.

Question: We could do this for non-external assets as well, I think it might be even clearer than having cryptic asset ids. Agree/disagree?