### PR TITLE
fix(server): skip smtp validation if unchanged

### DIFF
--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -1,4 +1,6 @@
+import { plainToInstance } from 'class-transformer';
 import { defaults, SystemConfig } from 'src/config';
+import { SystemConfigDto } from 'src/dtos/system-config.dto';
 import { AlbumUserEntity } from 'src/entities/album-user.entity';
 import { AssetFileEntity } from 'src/entities/asset-files.entity';
 import { AssetFileType, UserMetadataKey } from 'src/enum';
@@ -107,6 +109,14 @@ describe(NotificationService.name, () => {
     it('skips smtp validation when there are no changes', async () => {
       const oldConfig = { ...configs.smtpEnabled };
       const newConfig = { ...configs.smtpEnabled };
+
+      await expect(sut.onConfigValidate({ oldConfig, newConfig })).resolves.not.toThrow();
+      expect(notificationMock.verifySmtp).not.toHaveBeenCalled();
+    });
+
+    it('skips smtp validation with DTO when there are no changes', async () => {
+      const oldConfig = { ...configs.smtpEnabled };
+      const newConfig = plainToInstance(SystemConfigDto, configs.smtpEnabled);
 
       await expect(sut.onConfigValidate({ oldConfig, newConfig })).resolves.not.toThrow();
       expect(notificationMock.verifySmtp).not.toHaveBeenCalled();

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -1,5 +1,4 @@
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
-import { isEqual } from 'lodash';
 import { DEFAULT_EXTERNAL_DOMAIN } from 'src/constants';
 import { SystemConfigCore } from 'src/cores/system-config.core';
 import { OnEmit } from 'src/decorators';
@@ -47,7 +46,7 @@ export class NotificationService {
     try {
       if (
         newConfig.notifications.smtp.enabled &&
-        !isEqual(oldConfig.notifications.smtp, newConfig.notifications.smtp)
+        JSON.stringify(oldConfig.notifications.smtp) !== JSON.stringify(newConfig.notifications.smtp)
       ) {
         await this.notificationRepository.verifySmtp(newConfig.notifications.smtp.transport);
       }

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -22,6 +22,7 @@ import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interf
 import { IUserRepository } from 'src/interfaces/user.interface';
 import { getAssetFiles } from 'src/utils/asset.util';
 import { getFilenameExtension } from 'src/utils/file';
+import { isEqualObject } from 'src/utils/object';
 import { getPreferences } from 'src/utils/preferences';
 
 @Injectable()
@@ -46,7 +47,7 @@ export class NotificationService {
     try {
       if (
         newConfig.notifications.smtp.enabled &&
-        JSON.stringify(oldConfig.notifications.smtp) !== JSON.stringify(newConfig.notifications.smtp)
+        !isEqualObject(oldConfig.notifications.smtp, newConfig.notifications.smtp)
       ) {
         await this.notificationRepository.verifySmtp(newConfig.notifications.smtp.transport);
       }

--- a/server/src/services/system-config.service.ts
+++ b/server/src/services/system-config.service.ts
@@ -18,6 +18,7 @@ import { SystemConfigDto, SystemConfigTemplateStorageOptionDto, mapConfig } from
 import { ArgOf, ClientEvent, IEventRepository, ServerEvent } from 'src/interfaces/event.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
+import { toPlainObject } from 'src/utils/object';
 
 @Injectable()
 export class SystemConfigService {
@@ -63,7 +64,7 @@ export class SystemConfigService {
     const oldConfig = await this.core.getConfig({ withCache: false });
 
     try {
-      await this.eventRepository.emit('config.validate', { newConfig: dto, oldConfig });
+      await this.eventRepository.emit('config.validate', { newConfig: toPlainObject(dto), oldConfig });
     } catch (error) {
       this.logger.warn(`Unable to save system config due to a validation error: ${error}`);
       throw new BadRequestException(error instanceof Error ? error.message : error);

--- a/server/src/utils/object.ts
+++ b/server/src/utils/object.ts
@@ -1,0 +1,15 @@
+import { isEqual, isPlainObject } from 'lodash';
+
+/**
+ * Deeply clones and converts a class instance to a plain object.
+ */
+export function toPlainObject<T extends object>(obj: T): T {
+  return isPlainObject(obj) ? obj : structuredClone(obj);
+}
+
+/**
+ * Performs a deep comparison between objects, converting them to plain objects first if needed.
+ */
+export function isEqualObject(value: object, other: object): boolean {
+  return isEqual(toPlainObject(value), toPlainObject(other));
+}


### PR DESCRIPTION
Skip smtp validation if there are no changes to the smtp config. `isEqual(oldConfig, newConfig)` fails because it compares a plain object with a DTO instance and will always return `false`