### PR TITLE
fix(web): Device list shows Ubuntu as unknown OS

### DIFF
--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -12,6 +12,7 @@
     mdiLinux,
     mdiMicrosoftWindows,
     mdiTrashCanOutline,
+    mdiUbuntu,
   } from '@mdi/js';
   import { DateTime, type ToRelativeCalendarOptions } from 'luxon';
   import { createEventDispatcher } from 'svelte';
@@ -41,6 +42,8 @@
       <Icon path={mdiMicrosoftWindows} size="40" />
     {:else if device.deviceOS === 'Linux'}
       <Icon path={mdiLinux} size="40" />
+    {:else if device.deviceOS === 'Ubuntu'}
+      <Icon path={mdiUbuntu} size="40" />
     {:else if device.deviceOS === 'Chromium OS' || device.deviceType === 'Chrome' || device.deviceType === 'Chromium'}
       <Icon path={mdiGoogleChrome} size="40" />
     {:else}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #11767 


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Open Immich login page
2. Copy user agent string from #11767 into Firefox (Windows) and Edge, and refresh page
3. Login to Immich
4. Go to user-settings -> authorized-devices 
5. Verify the Ubuntu listing appears correctly
6. Repeated with user agent `Mozilla/5.0 (X11; Ubuntu; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/XX.0.XXXX.XX Safari/537.36`

## Screenshots (if appropriate):
![Screenshot (11)](https://github.com/user-attachments/assets/532ec48e-fca3-4680-a90e-a13c32460bab)



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable