### PR TITLE
chore(mobile): disable Impeller on Android

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
 
     <meta-data
       android:name="io.flutter.embedding.android.EnableImpeller"
-      android:value="true" />
+      android:value="false" />
 
     <meta-data
       android:name="com.google.firebase.messaging.default_notification_icon"


### PR DESCRIPTION
Disable Impeller since video player library hasn't been adapted to play video correctly
