### PR TITLE
chore(e2e): change e2e ports to some not used by immich-dev

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - redis
       - database
     ports:
-      - 2283:3001
+      - 2285:3001
 
   redis:
     image: redis:6.2-alpine@sha256:e3b17ba9479deec4b7d1eeec1548a253acc5374d68d3b27937fcfe4df8d18c7e
@@ -43,7 +43,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: immich
     ports:
-      - 5433:5432
+      - 5435:5432
 
 volumes:
   model-cache:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'html',
   use: {
-    baseURL: 'http://127.0.0.1:2283',
+    baseURL: 'http://127.0.0.1:2285',
     trace: 'on-first-retry',
   },
 
@@ -54,7 +54,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'docker compose up --build -V --remove-orphans',
-    url: 'http://127.0.0.1:2283',
+    url: 'http://127.0.0.1:2285',
     reuseExistingServer: true,
   },
 });

--- a/e2e/src/api/specs/oauth.e2e-spec.ts
+++ b/e2e/src/api/specs/oauth.e2e-spec.ts
@@ -92,14 +92,14 @@ describe(`/oauth`, () => {
     it('should return a redirect uri', async () => {
       const { status, body } = await request(app)
         .post('/oauth/authorize')
-        .send({ redirectUri: 'http://127.0.0.1:2283/auth/login' });
+        .send({ redirectUri: 'http://127.0.0.1:2285/auth/login' });
       expect(status).toBe(201);
       expect(body).toEqual({ url: expect.stringContaining(`${authServer.internal}/auth?`) });
 
       const params = new URL(body.url).searchParams;
       expect(params.get('client_id')).toBe('client-default');
       expect(params.get('response_type')).toBe('code');
-      expect(params.get('redirect_uri')).toBe('http://127.0.0.1:2283/auth/login');
+      expect(params.get('redirect_uri')).toBe('http://127.0.0.1:2285/auth/login');
       expect(params.get('state')).toBeDefined();
     });
   });

--- a/e2e/src/cli/specs/login.e2e-spec.ts
+++ b/e2e/src/cli/specs/login.e2e-spec.ts
@@ -33,7 +33,7 @@ describe(`immich login`, () => {
     const key = await utils.createApiKey(admin.accessToken, [Permission.All]);
     const { stdout, stderr, exitCode } = await immichCli(['login', app, `${key.secret}`]);
     expect(stdout.split('\n')).toEqual([
-      'Logging in to http://127.0.0.1:2283/api',
+      'Logging in to http://127.0.0.1:2285/api',
       'Logged in as admin@immich.cloud',
       'Wrote auth info to /tmp/immich/auth.yml',
     ]);
@@ -50,8 +50,8 @@ describe(`immich login`, () => {
     const key = await utils.createApiKey(admin.accessToken, [Permission.All]);
     const { stdout, stderr, exitCode } = await immichCli(['login', app.replaceAll('/api', ''), `${key.secret}`]);
     expect(stdout.split('\n')).toEqual([
-      'Logging in to http://127.0.0.1:2283',
-      'Discovered API at http://127.0.0.1:2283/api',
+      'Logging in to http://127.0.0.1:2285',
+      'Discovered API at http://127.0.0.1:2285/api',
       'Logged in as admin@immich.cloud',
       'Wrote auth info to /tmp/immich/auth.yml',
     ]);

--- a/e2e/src/cli/specs/server-info.e2e-spec.ts
+++ b/e2e/src/cli/specs/server-info.e2e-spec.ts
@@ -12,7 +12,7 @@ describe(`immich server-info`, () => {
     const { stderr, stdout, exitCode } = await immichCli(['server-info']);
     expect(stdout.split('\n')).toEqual([
       expect.stringContaining('Server Info (via admin@immich.cloud'),
-      '  Url: http://127.0.0.1:2283/api',
+      '  Url: http://127.0.0.1:2285/api',
       expect.stringContaining('Version:'),
       '  Formats:',
       expect.stringContaining('Images:'),

--- a/e2e/src/setup/auth-server.ts
+++ b/e2e/src/setup/auth-server.ts
@@ -86,14 +86,14 @@ const setup = async () => {
       {
         client_id: OAuthClient.DEFAULT,
         client_secret: OAuthClient.DEFAULT,
-        redirect_uris: ['http://127.0.0.1:2283/auth/login'],
+        redirect_uris: ['http://127.0.0.1:2285/auth/login'],
         grant_types: ['authorization_code'],
         response_types: ['code'],
       },
       {
         client_id: OAuthClient.RS256_TOKENS,
         client_secret: OAuthClient.RS256_TOKENS,
-        redirect_uris: ['http://127.0.0.1:2283/auth/login'],
+        redirect_uris: ['http://127.0.0.1:2285/auth/login'],
         grant_types: ['authorization_code'],
         id_token_signed_response_alg: 'RS256',
         jwks: { keys: [await exportJWK(publicKey)] },
@@ -101,7 +101,7 @@ const setup = async () => {
       {
         client_id: OAuthClient.RS256_PROFILE,
         client_secret: OAuthClient.RS256_PROFILE,
-        redirect_uris: ['http://127.0.0.1:2283/auth/login'],
+        redirect_uris: ['http://127.0.0.1:2285/auth/login'],
         grant_types: ['authorization_code'],
         userinfo_signed_response_alg: 'RS256',
         jwks: { keys: [await exportJWK(publicKey)] },

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -53,8 +53,8 @@ type WaitOptions = { event: EventType; id?: string; total?: number; timeout?: nu
 type AdminSetupOptions = { onboarding?: boolean };
 type FileData = { bytes?: Buffer; filename: string };
 
-const dbUrl = 'postgres://postgres:postgres@127.0.0.1:5433/immich';
-export const baseUrl = 'http://127.0.0.1:2283';
+const dbUrl = 'postgres://postgres:postgres@127.0.0.1:5435/immich';
+export const baseUrl = 'http://127.0.0.1:2285';
 export const shareUrl = `${baseUrl}/share`;
 export const app = `${baseUrl}/api`;
 // TODO move test assets into e2e/assets

--- a/e2e/src/web/specs/websocket.e2e-spec.ts
+++ b/e2e/src/web/specs/websocket.e2e-spec.ts
@@ -13,13 +13,13 @@ test.describe('Websocket', () => {
 
   test('connects using ipv4', async ({ page, context }) => {
     await utils.setAuthCookies(context, admin.accessToken);
-    await page.goto('http://127.0.0.1:2283/');
+    await page.goto('http://127.0.0.1:2285/');
     await expect(page.locator('#sidebar')).toContainText('Server Online');
   });
 
   test('connects using ipv6', async ({ page, context }) => {
     await utils.setAuthCookies(context, admin.accessToken, '[::1]');
-    await page.goto('http://[::1]:2283/');
+    await page.goto('http://[::1]:2285/');
     await expect(page.locator('#sidebar')).toContainText('Server Online');
   });
 });

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 // skip `docker compose up` if `make e2e` was already run
 const globalSetup: string[] = ['src/setup/auth-server.ts'];
 try {
-  await fetch('http://127.0.0.1:2283/api/server-info/ping');
+  await fetch('http://127.0.0.1:2285/api/server-info/ping');
 } catch {
   globalSetup.push('src/setup/docker-compose.ts');
 }


### PR DESCRIPTION
If you run both a prod and dev immich server on the same machine you can't do e2e testing since the ports are taken. This change moves the server and db ports two numbers up.