### PR TITLE
docs(guide): nginx caching proxy

### DIFF
--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -45,7 +45,7 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Nginx caching map server',
-    description: 'Increase privacy by using nginx as a caching proxy in front of a map tile proxy server',
+    description: 'Increase privacy by using nginx as a caching proxy in front of a map tile server',
     url: 'https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html',
   },
 ];

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -43,6 +43,11 @@ const guides: CommunityGuidesProps[] = [
     description: 'Access your local Immich installation over the internet using your own domain',
     url: 'https://github.com/ppr88/immich-guides/blob/main/open-immich-custom-domain.md',
   },
+  {
+    title: 'Nginx caching map server',
+    description: 'Increase privacy by using nginx as caching proxy in front of a map tile proxy server',
+    url: 'https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html',
+  },
 ];
 
 function CommunityGuide({ title, description, url }: CommunityGuidesProps): JSX.Element {

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -45,7 +45,7 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Nginx caching map server',
-    description: 'Increase privacy by using nginx as caching proxy in front of a map tile proxy server',
+    description: 'Increase privacy by using nginx as a caching proxy in front of a map tile proxy server',
     url: 'https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html',
   },
 ];

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -46,7 +46,7 @@ const guides: CommunityGuidesProps[] = [
   {
     title: 'Nginx caching map server',
     description: 'Increase privacy by using nginx as a caching proxy in front of a map tile server',
-    url: 'https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html',
+    url: 'https://github.com/pcouy/pcouy.github.io/blob/main/_posts/2024-08-30-proxying-a-map-tile-server-for-increased-privacy.md',
   },
 ];
 


### PR DESCRIPTION
Following comments on https://github.com/immich-app/immich/pull/11350, I published the guide about configuring nginx to proxy a tile server outside of Immich's repo. It is available at https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html (or at https://github.com/pcouy/pcouy.github.io/blob/main/_posts/2024-08-30-proxying-a-map-tile-server-for-increased-privacy.md if a github link is preferred) (UPDATE : Changed the link to GitHub in the PR)

This PR adds a link to it in community guides.