### PR TITLE
fix(web): hide tree view text overflow with ellipsis

### DIFF
--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -39,7 +39,7 @@
       size={20}
     />
   </div>
-  <span class="text-nowrap overflow-clip font-mono pl-1 pt-1">{value}</span>
+  <span class="text-nowrap overflow-hidden text-ellipsis font-mono pl-1 pt-1">{value}</span>
 </a>
 
 {#if isOpen}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Truncate text in the tree with an ellipsis if the name is too long. This is similar to the behavior in GitHub for pull request diffs.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Create a couple of nested, long tag names. For example: `supercalifragilisticexpialidocious/supercalifragilisticexpialidocious/supercalifragilisticexpialidocious`
2. Verify that the sidebar never overflows or allows horizontal scrolling

## Screenshots

<details><summary>Expand for screenshot</summary>
<p>

![sidebar-ellipsis](https://github.com/user-attachments/assets/14130cc4-0456-4e10-abb0-ccc2e202cc7c)

</p>
</details> 