### PR TITLE
fix(web): avoid deleting empty album unexpectedly

### DIFF
--- a/e2e/src/web/specs/album.e2e-spec.ts
+++ b/e2e/src/web/specs/album.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { LoginResponseDto } from '@immich/sdk';
+import { test } from '@playwright/test';
+import { utils } from 'src/utils';
+
+test.describe('Album', () => {
+  let admin: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+  });
+
+  test(`doesn't delete album after canceling add assets`, async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+
+    await page.goto('/albums');
+    await page.getByRole('button', { name: 'Create album' }).click();
+    await page.getByRole('button', { name: 'Select photos' }).click();
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    await page.reload();
+    await page.getByRole('button', { name: 'Select photos' }).waitFor();
+  });
+});

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -419,8 +419,8 @@
     }
   };
 
-  onNavigate(async () => {
-    if (album.assetCount === 0 && !album.albumName) {
+  onNavigate(async ({ to }) => {
+    if (!isAlbumsRoute(to?.route.id) && album.assetCount === 0 && !album.albumName) {
       await deleteAlbum(album);
     }
   });


### PR DESCRIPTION
Fixes #12110, another way to reproduce the issue:
1. Create album
2. Click select photos button
3. Click X in top left corner
4. Reload page

Caused by the `navigate()` calls added in #10646