### PR TITLE
fix(web): German translation for explorer

### DIFF
--- a/web/src/lib/i18n/de.json
+++ b/web/src/lib/i18n/de.json
@@ -716,7 +716,7 @@
   "expired": "Verfallen",
   "expires_date": "Läuft am {date} ab",
   "explore": "Erkunden",
-  "explorer": "Entdeccker",
+  "explorer": "Explorer",
   "export": "Exportieren",
   "export_as_json": "Als JSON exportieren",
   "extension": "Erweiterung",


### PR DESCRIPTION
Hi, the German translation for "explore" is off. "Entdeccker" as it is now is a misspelling of the German word "Entdecker" which means Explorer, but in an adventurer kind of way. In German we use the word "Explorer" (same as in English) to refer to the file app on Windows, and I think that would be the Best choice here.

Translation in context:
![image](https://github.com/user-attachments/assets/cb80996c-a86d-40dd-8b6c-a437a29482e3)

I am a native German speaker, so I'm relatively confident that what I am saying up there is correct.
