### PR TITLE
fix(web): auto grow area extend when there is no content

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -476,7 +476,7 @@
   <section class="px-6 pt-6 dark:text-immich-dark-fg">
     <p class="pb-4 text-sm">{$t('appears_in').toUpperCase()}</p>
     {#each albums as album}
-      <a data-sveltekit-preload-data="hover" href={`/albums/${album.id}`}>
+      <a href="{AppRoute.ALBUMS}/{album.id}">
         <div class="flex gap-4 pt-2 hover:cursor-pointer items-center">
           <div>
             <img

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -16,7 +16,7 @@
     // re-visit with svelte 5. runes will make this better.
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     newContent;
-    if (textarea) {
+    if (textarea && content.length > 0) {
       void tick().then(() => autoGrowHeight(textarea));
     }
   }

--- a/web/src/lib/components/shared-components/autogrow-textarea.svelte
+++ b/web/src/lib/components/shared-components/autogrow-textarea.svelte
@@ -16,7 +16,7 @@
     // re-visit with svelte 5. runes will make this better.
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     newContent;
-    if (textarea && content.length > 0) {
+    if (textarea && newContent.length > 0) {
       void tick().then(() => autoGrowHeight(textarea));
     }
   }


### PR DESCRIPTION
Fix an issue when navigating to the album from the detail panel. The description field would auto-expand when there is no content
