### PR TITLE
fix(mobile): set SSL options properly in background backup process (#11870)

### DIFF
--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -349,6 +349,7 @@ class BackgroundService {
   Future<bool> _onAssetsChanged() async {
     final Isar db = await loadDb();
 
+    HttpOverrides.global = HttpSSLCertOverride();
     ApiService apiService = ApiService();
     apiService.setAccessToken(Store.get(StoreKey.accessToken));
     AppSettingsService settingService = AppSettingsService();


### PR DESCRIPTION
Fixing issue #11870 where background backup does not work with client certificate or self-signed server certificate.