### PR TITLE
feat(server): faster folder responses

### DIFF
--- a/server/src/entities/asset-folder.entity.ts
+++ b/server/src/entities/asset-folder.entity.ts
@@ -1,0 +1,21 @@
+import { AssetEntity } from 'src/entities/asset.entity';
+import {
+  Column,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('asset_folders')
+export class AssetFolderEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @OneToMany(() => AssetEntity, (asset) => asset.folder)
+  asset?: AssetEntity;
+
+  @Index('idx_asset_folders_path', { unique: true })
+  @Column()
+  path!: string;
+}

--- a/server/src/entities/asset-folder.entity.ts
+++ b/server/src/entities/asset-folder.entity.ts
@@ -1,11 +1,5 @@
 import { AssetEntity } from 'src/entities/asset.entity';
-import {
-  Column,
-  Entity,
-  Index,
-  OneToMany,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
+import { Column, Entity, Index, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('asset_folders')
 export class AssetFolderEntity {
@@ -16,6 +10,6 @@ export class AssetFolderEntity {
   asset?: AssetEntity;
 
   @Index('idx_asset_folders_path', { unique: true })
-  @Column()
+  @Column({ type: 'text', collation: 'numeric' })
   path!: string;
 }

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -26,6 +26,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
 
@@ -75,6 +76,13 @@ export class AssetEntity {
 
   @OneToMany(() => AssetFileEntity, (assetFile) => assetFile.asset)
   files!: AssetFileEntity[];
+
+  @Index('idx_assets_folder_id')
+  @Column({ select: false })
+  folderId?: string;
+
+  @ManyToOne(() => AssetFolderEntity, (assetFolder) => assetFolder.asset, { onUpdate: 'CASCADE' })
+  folder?: AssetFolderEntity;
 
   @Column({ type: 'bytea', nullable: true })
   thumbhash!: Buffer | null;

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -1,6 +1,7 @@
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetFileEntity } from 'src/entities/asset-files.entity';
+import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
 import { ExifEntity } from 'src/entities/exif.entity';
 import { LibraryEntity } from 'src/entities/library.entity';
@@ -26,11 +27,11 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
 
 @Entity('assets')
+@Index('idx_assets_folder_id_originalfilename', ['folderId', 'originalFileName'])
 // Checksums must be unique per user and library
 @Index(ASSET_CHECKSUM_CONSTRAINT, ['owner', 'checksum'], {
   unique: true,
@@ -77,7 +78,6 @@ export class AssetEntity {
   @OneToMany(() => AssetFileEntity, (assetFile) => assetFile.asset)
   files!: AssetFileEntity[];
 
-  @Index('idx_assets_folder_id')
   @Column({ select: false })
   folderId?: string;
 
@@ -138,8 +138,7 @@ export class AssetEntity {
   @Column({ nullable: true })
   livePhotoVideoId!: string | null;
 
-  @Column({ type: 'varchar' })
-  @Index()
+  @Column({ type: 'varchar', collation: 'numeric' })
   originalFileName!: string;
 
   @Column({ type: 'varchar', nullable: true })

--- a/server/src/entities/index.ts
+++ b/server/src/entities/index.ts
@@ -25,6 +25,7 @@ import { SystemMetadataEntity } from 'src/entities/system-metadata.entity';
 import { TagEntity } from 'src/entities/tag.entity';
 import { UserMetadataEntity } from 'src/entities/user-metadata.entity';
 import { UserEntity } from 'src/entities/user.entity';
+import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 
 export const entities = [
   ActivityEntity,
@@ -34,6 +35,7 @@ export const entities = [
   AssetEntity,
   AssetFaceEntity,
   AssetFileEntity,
+  AssetFolderEntity,
   AssetJobStatusEntity,
   AuditEntity,
   ExifEntity,

--- a/server/src/entities/index.ts
+++ b/server/src/entities/index.ts
@@ -4,6 +4,7 @@ import { AlbumEntity } from 'src/entities/album.entity';
 import { APIKeyEntity } from 'src/entities/api-key.entity';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { AssetFileEntity } from 'src/entities/asset-files.entity';
+import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 import { AssetJobStatusEntity } from 'src/entities/asset-job-status.entity';
 import { AssetEntity } from 'src/entities/asset.entity';
 import { AuditEntity } from 'src/entities/audit.entity';
@@ -25,7 +26,6 @@ import { SystemMetadataEntity } from 'src/entities/system-metadata.entity';
 import { TagEntity } from 'src/entities/tag.entity';
 import { UserMetadataEntity } from 'src/entities/user-metadata.entity';
 import { UserEntity } from 'src/entities/user.entity';
-import { AssetFolderEntity } from 'src/entities/asset-folder.entity';
 
 export const entities = [
   ActivityEntity,

--- a/server/src/interfaces/asset.interface.ts
+++ b/server/src/interfaces/asset.interface.ts
@@ -149,6 +149,7 @@ export const IAssetRepository = 'IAssetRepository';
 export interface IAssetRepository {
   getAssetsByOriginalPath(userId: string, partialPath: string): Promise<AssetEntity[]>;
   getUniqueOriginalPaths(userId: string): Promise<string[]>;
+  removeEmptyFolders(): Promise<void>;
   create(asset: AssetCreate): Promise<AssetEntity>;
   getByIds(
     ids: string[],

--- a/server/src/interfaces/asset.interface.ts
+++ b/server/src/interfaces/asset.interface.ts
@@ -100,10 +100,7 @@ export type AssetWithoutRelations = Omit<
   | 'tags'
 >;
 
-type AssetUpdateWithoutRelations = Pick<AssetWithoutRelations, 'id'> & Partial<AssetWithoutRelations>;
-type AssetUpdateWithLivePhotoRelation = Pick<AssetWithoutRelations, 'id'> & Pick<AssetEntity, 'livePhotoVideo'>;
-
-export type AssetUpdateOptions = AssetUpdateWithoutRelations | AssetUpdateWithLivePhotoRelation;
+export type AssetUpdateOptions = Partial<AssetWithoutRelations & Pick<AssetEntity, 'livePhotoVideo'>>;
 
 export type AssetUpdateAllOptions = Omit<Partial<AssetWithoutRelations>, 'id'>;
 

--- a/server/src/interfaces/job.interface.ts
+++ b/server/src/interfaces/job.interface.ts
@@ -85,6 +85,7 @@ export enum JobName {
   DELETE_FILES = 'delete-files',
   CLEAN_OLD_AUDIT_LOGS = 'clean-old-audit-logs',
   CLEAN_OLD_SESSION_TOKENS = 'clean-old-session-tokens',
+  CLEAN_FOLDER_TABLE = 'clean-folder-table',
 
   // smart search
   QUEUE_SMART_SEARCH = 'queue-smart-search',
@@ -260,6 +261,7 @@ export type JobItem =
   // Cleanup
   | { name: JobName.CLEAN_OLD_AUDIT_LOGS; data?: IBaseJob }
   | { name: JobName.CLEAN_OLD_SESSION_TOKENS; data?: IBaseJob }
+  | { name: JobName.CLEAN_FOLDER_TABLE; data?: IBaseJob }
 
   // Asset Deletion
   | { name: JobName.PERSON_CLEANUP; data?: IBaseJob }

--- a/server/src/migrations/1724802318088-AddAssetFolderRelation.ts
+++ b/server/src/migrations/1724802318088-AddAssetFolderRelation.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAssetFolderRelation1724802318088 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        create or replace function file_parent(path text) returns text as $$
+        begin
+            return array_to_string(trim_array(string_to_array(path, '/'), 1), '/');
+        end;
+        $$
+        language plpgsql
+        parallel safe
+        immutable`);
+
+    // this is so folders are sorted numerically instead of lexicographically, e.g. 1, 2, 10 instead of 1, 10, 2
+    await queryRunner.query(`create collation numeric (provider = icu, locale = 'en-u-kn-true')`);
+
+    await queryRunner.query(`
+        create table asset_folders (
+            id   uuid primary key default gen_random_uuid(),
+            path text not null collate numeric
+        )`);
+
+    // so postgres chooses the right plan
+    await queryRunner.query(`alter table asset_folders alter column path set statistics 500`);
+
+    await queryRunner.query(`
+        alter table assets
+            add column "folderId" uuid
+                references asset_folders (id)
+                on update cascade`);
+
+    await queryRunner.query(`
+        with inserted as (
+            insert into asset_folders (path)
+            select distinct file_parent("originalPath")
+            from assets
+            returning id, path
+        )
+        update assets
+        set "folderId" = inserted.id
+        from inserted
+        where file_parent("originalPath") = inserted.path`);
+
+    await queryRunner.query(`create unique index idx_asset_folders_path on asset_folders (path collate numeric)`);
+
+    await queryRunner.query(`create index idx_assets_folder_id on assets ("folderId")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`drop function file_parent`);
+
+    await queryRunner.query(`drop collation numeric`);
+
+    await queryRunner.query(`alter table assets drop column "folderId"`);
+
+    await queryRunner.query(`drop table asset_folders`);
+  }
+}

--- a/server/src/migrations/1724802318088-AddAssetFolderRelation.ts
+++ b/server/src/migrations/1724802318088-AddAssetFolderRelation.ts
@@ -31,6 +31,7 @@ export class AddAssetFolderRelation1724802318088 implements MigrationInterface {
     await queryRunner.query(`
         alter table assets
             add column "folderId" uuid
+                constraint "FK_8ca281adee62839a757ef23ca15"
                 references asset_folders (id)
                 on update cascade`);
 

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -29,6 +29,7 @@ export const JOBS_TO_QUEUE: Record<JobName, QueueName> = {
   [JobName.CLEAN_OLD_SESSION_TOKENS]: QueueName.BACKGROUND_TASK,
   [JobName.PERSON_CLEANUP]: QueueName.BACKGROUND_TASK,
   [JobName.USER_SYNC_USAGE]: QueueName.BACKGROUND_TASK,
+  [JobName.CLEAN_FOLDER_TABLE]: QueueName.BACKGROUND_TASK,
 
   // conversion
   [JobName.QUEUE_VIDEO_CONVERSION]: QueueName.VIDEO_CONVERSION,

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -318,6 +318,11 @@ export class AssetService {
     await this.jobRepository.queueAll(jobs);
   }
 
+  async handleCleanupFolders() {
+    await this.assetRepository.removeEmptyFolders();
+    return JobStatus.SUCCESS;
+  }
+
   private async updateMetadata(dto: ISidecarWriteJob) {
     const { id, description, dateTimeOriginal, latitude, longitude, rating } = dto;
     const writes = _.omitBy({ description, dateTimeOriginal, latitude, longitude, rating }, _.isUndefined);

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -73,6 +73,7 @@ describe(JobService.name, () => {
         { name: JobName.USER_SYNC_USAGE },
         { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false, nightly: true } },
         { name: JobName.CLEAN_OLD_SESSION_TOKENS },
+        { name: JobName.CLEAN_FOLDER_TABLE },
       ]);
     });
   });

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -212,6 +212,7 @@ export class JobService {
       { name: JobName.USER_SYNC_USAGE },
       { name: JobName.QUEUE_FACIAL_RECOGNITION, data: { force: false, nightly: true } },
       { name: JobName.CLEAN_OLD_SESSION_TOKENS },
+      { name: JobName.CLEAN_FOLDER_TABLE },
     ]);
   }
 

--- a/server/src/services/microservices.service.ts
+++ b/server/src/services/microservices.service.ts
@@ -51,6 +51,7 @@ export class MicroservicesService {
       [JobName.DELETE_FILES]: (data: IDeleteFilesJob) => this.storageService.handleDeleteFiles(data),
       [JobName.CLEAN_OLD_AUDIT_LOGS]: () => this.auditService.handleCleanup(),
       [JobName.CLEAN_OLD_SESSION_TOKENS]: () => this.sessionService.handleCleanup(),
+      [JobName.CLEAN_FOLDER_TABLE]: () => this.assetService.handleCleanupFolders(),
       [JobName.USER_DELETE_CHECK]: () => this.userService.handleUserDeleteCheck(),
       [JobName.USER_DELETION]: (data) => this.userService.handleUserDelete(data),
       [JobName.USER_SYNC_USAGE]: () => this.userService.handleUserSyncUsage(),

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -45,5 +45,6 @@ export const newAssetRepositoryMock = (): Mocked<IAssetRepository> => {
     upsertFile: vitest.fn(),
     getAssetsByOriginalPath: vitest.fn(),
     getUniqueOriginalPaths: vitest.fn(),
+    removeEmptyFolders: vitest.fn(),
   };
 };

--- a/web/src/lib/components/shared-components/tree/tree-items.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-items.svelte
@@ -12,14 +12,12 @@
 
 <ul class="list-none ml-2">
   {#each Object.entries(items) as [path, tree]}
-    {#if path !== '\0'}
-      {@const value = joinPaths(parent, path)}
-      {@const key = value + getColor(value)}
-      {#key key}
-        <li>
-          <Tree {parent} value={path} {tree} {icons} {active} {getLink} {getColor} />
-        </li>
-      {/key}
-    {/if}
+    {@const value = joinPaths(parent, path)}
+    {@const key = value + getColor(value)}
+    {#key key}
+      <li>
+        <Tree {parent} value={path} {tree} {icons} {active} {getLink} {getColor} />
+      </li>
+    {/key}
   {/each}
 </ul>

--- a/web/src/lib/components/shared-components/tree/tree-items.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-items.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Tree from '$lib/components/shared-components/tree/tree.svelte';
-  import { normalizeTreePath, type RecursiveObject } from '$lib/utils/tree-utils';
+  import { joinPaths, type RecursiveObject } from '$lib/utils/tree-utils';
 
   export let items: RecursiveObject;
   export let parent = '';
@@ -12,12 +12,14 @@
 
 <ul class="list-none ml-2">
   {#each Object.entries(items) as [path, tree]}
-    {@const value = normalizeTreePath(`${parent}/${path}`)}
-    {@const key = value + getColor(value)}
-    {#key key}
-      <li>
-        <Tree {parent} value={path} {tree} {icons} {active} {getLink} {getColor} />
-      </li>
-    {/key}
+    {#if path !== '\0'}
+      {@const value = joinPaths(parent, path)}
+      {@const key = value + getColor(value)}
+      {#key key}
+        <li>
+          <Tree {parent} value={path} {tree} {icons} {active} {getLink} {getColor} />
+        </li>
+      {/key}
+    {/if}
   {/each}
 </ul>

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
   import TreeItems from '$lib/components/shared-components/tree/tree-items.svelte';
-  import { normalizeTreePath, type RecursiveObject } from '$lib/utils/tree-utils';
+  import { isLeaf, joinPaths, type RecursiveObject } from '$lib/utils/tree-utils';
   import { mdiChevronDown, mdiChevronRight } from '@mdi/js';
 
   export let tree: RecursiveObject;
@@ -12,7 +12,7 @@
   export let getLink: (path: string) => string;
   export let getColor: (path: string) => string | undefined;
 
-  $: path = normalizeTreePath(`${parent}/${value}`);
+  $: path = joinPaths(parent, value);
   $: isActive = active.startsWith(path);
   $: isOpen = isActive;
   $: isTarget = active === path;
@@ -27,7 +27,7 @@
   <button
     type="button"
     on:click|preventDefault={() => (isOpen = !isOpen)}
-    class={Object.values(tree).length === 0 ? 'invisible' : ''}
+    class={isLeaf(tree) ? 'invisible' : ''}
   >
     <Icon path={isOpen ? mdiChevronDown : mdiChevronRight} class="text-gray-400" size={20} />
   </button>

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -24,11 +24,7 @@
   title={value}
   class={`flex flex-grow place-items-center pl-2 py-1 text-sm rounded-lg hover:bg-slate-200 dark:hover:bg-slate-800 hover:font-semibold ${isTarget ? 'bg-slate-100 dark:bg-slate-700 font-semibold text-immich-primary dark:text-immich-dark-primary' : 'dark:text-gray-200'}`}
 >
-  <button
-    type="button"
-    on:click|preventDefault={() => (isOpen = !isOpen)}
-    class={isLeaf(tree) ? 'invisible' : ''}
-  >
+  <button type="button" on:click|preventDefault={() => (isOpen = !isOpen)} class={isLeaf(tree) ? 'invisible' : ''}>
     <Icon path={isOpen ? mdiChevronDown : mdiChevronRight} class="text-gray-400" size={20} />
   </button>
   <div>

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -1,16 +1,50 @@
-export interface RecursiveObject {
+export type RecursiveObject = {
   [key: string]: RecursiveObject;
-}
+};
 
-export const normalizeTreePath = (path: string) => path.replace(/^\//, '').replace(/\/$/, '');
+export const normalizeTreePath = (path: string) => (path.at(-1) === '/' && path.length > 1 ? path.slice(0, -1) : path);
 
-export function buildTree(paths: string[]) {
+export const getPathParts = (path: string) => {
+  const parts = path.split('/');
+  if (path[0] === '/') {
+    parts[0] = '/';
+  }
+
+  if (path.at(-1) === '/') {
+    parts.pop();
+  }
+
+  return parts;
+};
+
+export const joinPaths = (...paths: string[]) => {
+  const filtered = paths.filter((path) => path.length > 0);
+  if (filtered.length < 2) {
+    return filtered[0] || '';
+  }
+  return filtered.map((path) => (path === '/' ? '' : path)).join('/');
+};
+
+export const getParentPath = (path: string) => {
+  const normalized = normalizeTreePath(path);
+  const last = normalized.lastIndexOf('/');
+  return last === -1 ? '' : normalized.slice(0, last);
+};
+
+export const isLeaf = (tree: RecursiveObject) => {
+  for (const entry in tree) {
+    if (entry !== '\0') {
+      return false;
+    }
+  }
+  return true;
+};
+
+export function buildTree(paths: string[]): RecursiveObject {
   const root: RecursiveObject = {};
 
-  paths.sort();
-
   for (const path of paths) {
-    const parts = path.split('/');
+    const parts = getPathParts(path);
     let current = root;
     for (const part of parts) {
       if (!current[part]) {
@@ -18,6 +52,7 @@ export function buildTree(paths: string[]) {
       }
       current = current[part];
     }
+    current['\0'] = {}; // mark as leaf
   }
   return root;
 }

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -1,5 +1,5 @@
 export type RecursiveObject = {
-  [key: string]: RecursiveObject;
+  [key: string | symbol]: RecursiveObject;
 };
 
 export const normalizeTreePath = (path: string) => (path.at(-1) === '/' && path.length > 1 ? path.slice(0, -1) : path);
@@ -32,13 +32,13 @@ export const getParentPath = (path: string) => {
 };
 
 export const isLeaf = (tree: RecursiveObject) => {
-  for (const entry in tree) {
-    if (entry !== '\0') {
-      return false;
-    }
+  for (const _ in tree) {
+    return false;
   }
   return true;
 };
+
+export const FOLDER_WITH_ASSETS_SYMBOL = Symbol('folder-with-assets');
 
 export function buildTree(paths: string[]): RecursiveObject {
   const root: RecursiveObject = {};
@@ -52,7 +52,7 @@ export function buildTree(paths: string[]): RecursiveObject {
       }
       current = current[part];
     }
-    current['\0'] = {}; // mark as leaf
+    current[FOLDER_WITH_ASSETS_SYMBOL] = {};
   }
   return root;
 }

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -9,7 +9,7 @@
   import { AppRoute, QueryParameter } from '$lib/constants';
   import type { Viewport } from '$lib/stores/assets.store';
   import { foldersStore } from '$lib/stores/folders.store';
-  import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+  import { getPathParts, joinPaths } from '$lib/utils/tree-utils';
   import { type AssetResponseDto } from '@immich/sdk';
   import { mdiFolder, mdiFolderHome, mdiFolderOutline } from '@mdi/js';
   import { onMount } from 'svelte';
@@ -22,8 +22,8 @@
   let selectedAssets: Set<AssetResponseDto> = new Set();
   const viewport: Viewport = { width: 0, height: 0 };
 
-  $: pathSegments = data.path ? data.path.split('/') : [];
-  $: tree = buildTree($foldersStore?.uniquePaths || []);
+  $: pathSegments = data.path ? getPathParts(data.path) : [];
+  $: tree = $foldersStore?.folders || {};
   $: currentPath = $page.url.searchParams.get(QueryParameter.PATH) || '';
 
   onMount(async () => {
@@ -31,7 +31,7 @@
   });
 
   const handleNavigation = async (folderName: string) => {
-    await navigateToView(normalizeTreePath(`${data.path || ''}/${folderName}`));
+    await navigateToView(joinPaths(data.path, folderName));
   };
 
   const getLink = (path: string) => {

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -3,7 +3,7 @@ import { foldersStore } from '$lib/stores/folders.store';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { getPathParts, normalizeTreePath } from '$lib/utils/tree-utils';
+import { FOLDER_WITH_ASSETS_SYMBOL, getPathParts, normalizeTreePath } from '$lib/utils/tree-utils';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ params, url }) => {
@@ -27,7 +27,7 @@ export const load = (async ({ params, url }) => {
     }
 
     // only fetch assets if the folder has assets
-    if (tree['\0']) {
+    if (tree[FOLDER_WITH_ASSETS_SYMBOL]) {
       const { assets } = await foldersStore.fetchAssetsByPath(path);
       pathAssets = assets[path] || null;
     }
@@ -36,7 +36,7 @@ export const load = (async ({ params, url }) => {
   return {
     asset,
     path,
-    currentFolders: Object.keys(tree || {}).filter((name) => name !== '\0'),
+    currentFolders: Object.keys(tree || {}),
     pathAssets,
     meta: {
       title: $t('folders'),

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -15,7 +15,7 @@ export const load = (async ({ params, url }) => {
 
   let pathAssets = null;
 
-  const currentFolders = Object.keys(tree || {})
+  const currentFolders = Object.keys(tree || {});
   const path = url.searchParams.get(QueryParameter.PATH) || currentFolders[0] || '';
   if (tree) {
     const parts = getPathParts(normalizeTreePath(path));

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -3,8 +3,7 @@ import { foldersStore } from '$lib/stores/folders.store';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
-import { get } from 'svelte/store';
+import { getPathParts, normalizeTreePath } from '$lib/utils/tree-utils';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ params, url }) => {
@@ -12,28 +11,32 @@ export const load = (async ({ params, url }) => {
   const asset = await getAssetInfoFromParam(params);
   const $t = await getFormatter();
 
-  await foldersStore.fetchUniquePaths();
-  const { uniquePaths } = get(foldersStore);
+  let { folders: tree } = await foldersStore.fetchUniquePaths();
 
   let pathAssets = null;
 
-  const path = url.searchParams.get(QueryParameter.PATH);
-  if (path) {
-    await foldersStore.fetchAssetsByPath(path);
-    const { assets } = get(foldersStore);
-    pathAssets = assets[path] || null;
-  }
+  const currentFolders = Object.keys(tree || {})
+  const path = url.searchParams.get(QueryParameter.PATH) || currentFolders[0] || '';
+  if (tree) {
+    const parts = getPathParts(normalizeTreePath(path));
+    for (const part of parts) {
+      if (!tree[part]) {
+        break;
+      }
+      tree = tree[part];
+    }
 
-  let tree = buildTree(uniquePaths || []);
-  const parts = normalizeTreePath(path || '').split('/');
-  for (const part of parts) {
-    tree = tree?.[part];
+    // only fetch assets if the folder has assets
+    if (tree['\0']) {
+      const { assets } = await foldersStore.fetchAssetsByPath(path);
+      pathAssets = assets[path] || null;
+    }
   }
 
   return {
     asset,
     path,
-    currentFolders: Object.keys(tree || {}),
+    currentFolders: Object.keys(tree || {}).filter((name) => name !== '\0'),
     pathAssets,
     meta: {
       title: $t('folders'),

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -20,7 +20,7 @@
   import { AppRoute, AssetAction, QueryParameter } from '$lib/constants';
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { AssetStore } from '$lib/stores/assets.store';
-  import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+  import { buildTree, getPathParts, joinPaths } from '$lib/utils/tree-utils';
   import { deleteTag, getAllTags, updateTag, upsertTags, type TagResponseDto } from '@immich/sdk';
   import { mdiPencil, mdiPlus, mdiTag, mdiTagMultiple, mdiTrashCanOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
@@ -30,7 +30,7 @@
 
   export let data: PageData;
 
-  $: pathSegments = data.path ? data.path.split('/') : [];
+  $: pathSegments = data.path ? getPathParts(data.path) : [];
   $: currentPath = $page.url.searchParams.get(QueryParameter.PATH) || '';
 
   const assetInteractionStore = createAssetInteractionStore();
@@ -45,7 +45,7 @@
   $: tree = buildTree(tags.map((tag) => tag.value));
 
   const handleNavigation = async (tag: string) => {
-    await navigateToView(normalizeTreePath(`${data.path || ''}/${tag}`));
+    await navigateToView(joinPaths(data.path || '', tag));
   };
 
   const getLink = (path: string) => {


### PR DESCRIPTION
### Description

* Adds separate `asset_folders` table (many assets to one folder) containing unique parent folders. This ends up being much faster than indexing the main `assets` table for our access patterns when the library is large.
  * Changes asset creation to first insert into this table
  * Nightly job to remove folders that are no longer used by any assets
* Sort responses by `asset_folder`'s `path` and `assets`'s `originalFileName`, treating numbers as numbers (1, 2, 10 instead of 1, 10, 2)
* Distinguish between absolute and relative paths (`/upload` and `upload` are not the same)
  * Added a few helper functions to handle `/` and make path manipulation more ergonomic
* Only query for assets for folders that have assets, using a Symbol in the tree denoting a leaf folder
  * Symbols are unique, don't conflict with string properties and don't appear when listing object keys or entries, making them ideal here

`originalPath` should ideally be removed to have a single source of truth for the file path and make rows narrower in the assets table. However, in the interest of making downgrading possible and giving us more options to fix any possible bugs, I think it's better to keep it in the short-term.

### How Has This Been Tested?

Tested with a large instance containing an external library, storage template assets and a few corrupt images in the upload folder. They all display in the folder sidebar, and navigating each is instant (numbers are response times from the server):
  * 7000-7300ms -> 75ms when getting 35k unique paths for 2m assets in the initial page load
  * 400-600ms -> 8-10ms when going to a folder that contains assets
  * 180-200ms -> 0ms when going to a folder that doesn't contain any assets
 
Folders and files are in natural sorted order as expected.

 The tag page is unchanged.

In draft, pending handling updates to `originalPath` and adding E2E tests.