### PR TITLE
feat(web): shared breadcrumbs component for folders and tags

### DIFF
--- a/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
+++ b/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
+  import Icon from '$lib/components/elements/icon.svelte';
+  import { mdiArrowUpLeft, mdiChevronRight } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  export let pathSegments: string[] = [];
+  export let getLink: (path: string) => string;
+  export let title: string;
+  export let icon: string;
+
+  $: isRoot = pathSegments.length === 0;
+</script>
+
+<nav class="flex items-center py-2">
+  {#if !isRoot}
+    <div>
+      <CircleIconButton
+        icon={mdiArrowUpLeft}
+        title={$t('to_parent')}
+        href={getLink(pathSegments.slice(0, -1).join('/'))}
+        class="mr-2"
+        padding="2"
+      />
+    </div>
+  {/if}
+
+  <div
+    class="bg-gray-50 dark:bg-immich-dark-gray/50 w-full p-2 rounded-2xl border border-gray-100 dark:border-gray-900 overflow-y-auto immich-scrollbar"
+  >
+    <ol class="flex gap-2 items-center">
+      <li>
+        <CircleIconButton
+          {icon}
+          href={getLink('')}
+          {title}
+          size="1.25em"
+          padding="2"
+          aria-current={isRoot ? 'page' : undefined}
+        />
+      </li>
+      {#each pathSegments as segment, index}
+        {@const isLastSegment = index === pathSegments.length - 1}
+        <li
+          class="flex gap-2 items-center font-mono text-sm text-nowrap text-immich-primary dark:text-immich-dark-primary"
+        >
+          <Icon path={mdiChevronRight} class="text-gray-500 dark:text-gray-300" size={16} ariaHidden />
+          {#if isLastSegment}
+            <p class="cursor-default">{segment}</p>
+          {:else}
+            <a class="underline hover:font-semibold" href={getLink(pathSegments.slice(0, index + 1).join('/'))}>
+              {segment}
+            </a>
+          {/if}
+        </li>
+      {/each}
+    </ol>
+  </div>
+</nav>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1191,7 +1191,7 @@
   "to_change_password": "Change password",
   "to_favorite": "Favorite",
   "to_login": "Login",
-  "to_root": "To root",
+  "to_parent": "Go to parent",
   "to_trash": "Trash",
   "toggle_settings": "Toggle settings",
   "toggle_theme": "Toggle dark theme",

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -21,17 +21,10 @@
 
   let selectedAssets: Set<AssetResponseDto> = new Set();
   const viewport: Viewport = { width: 0, height: 0 };
-  let currentTreeItems: string[] = [];
 
   $: pathSegments = data.path ? data.path.split('/') : [];
   $: tree = buildTree($foldersStore?.uniquePaths || []);
   $: currentPath = $page.url.searchParams.get(QueryParameter.PATH) || '';
-  $: {
-    currentTreeItems = data.currentFolders;
-    if (data.currentFolders.length === 0 && !currentPath) {
-      currentTreeItems = Object.keys(tree);
-    }
-  }
 
   onMount(async () => {
     await foldersStore.fetchUniquePaths();
@@ -70,7 +63,7 @@
   <Breadcrumbs {pathSegments} icon={mdiFolderHome} title={$t('folders')} {getLink} />
 
   <section class="mt-2">
-    <TreeItemThumbnails items={currentTreeItems} icon={mdiFolder} onClick={handleNavigation} />
+    <TreeItemThumbnails items={data.currentFolders} icon={mdiFolder} onClick={handleNavigation} />
 
     <!-- Assets -->
     {#if data.pathAssets && data.pathAssets.length > 0}

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
-  import Icon from '$lib/components/elements/icon.svelte';
   import UserPageLayout from '$lib/components/layouts/user-page-layout.svelte';
   import GalleryViewer from '$lib/components/shared-components/gallery-viewer/gallery-viewer.svelte';
   import SideBarSection from '$lib/components/shared-components/side-bar/side-bar-section.svelte';
@@ -13,19 +11,27 @@
   import { foldersStore } from '$lib/stores/folders.store';
   import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
   import { type AssetResponseDto } from '@immich/sdk';
-  import { mdiArrowUpLeft, mdiChevronRight, mdiFolder, mdiFolderHome, mdiFolderOutline } from '@mdi/js';
+  import { mdiFolder, mdiFolderHome, mdiFolderOutline } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
+  import Breadcrumbs from '$lib/components/shared-components/tree/breadcrumbs.svelte';
 
   export let data: PageData;
 
   let selectedAssets: Set<AssetResponseDto> = new Set();
   const viewport: Viewport = { width: 0, height: 0 };
+  let currentTreeItems: string[] = [];
 
   $: pathSegments = data.path ? data.path.split('/') : [];
   $: tree = buildTree($foldersStore?.uniquePaths || []);
   $: currentPath = $page.url.searchParams.get(QueryParameter.PATH) || '';
+  $: {
+    currentTreeItems = data.currentFolders;
+    if (data.currentFolders.length === 0 && !currentPath) {
+      currentTreeItems = Object.keys(tree);
+    }
+  }
 
   onMount(async () => {
     await foldersStore.fetchUniquePaths();
@@ -35,20 +41,11 @@
     await navigateToView(normalizeTreePath(`${data.path || ''}/${folderName}`));
   };
 
-  const handleBackNavigation = async () => {
-    if (data.path) {
-      const parentPath = data.path.split('/').slice(0, -1).join('/');
-      await navigateToView(parentPath);
-    }
-  };
-
-  const handleBreadcrumbNavigation = async (targetPath: string) => {
-    await navigateToView(targetPath);
-  };
-
   const getLink = (path: string) => {
     const url = new URL(AppRoute.FOLDERS, window.location.href);
-    url.searchParams.set(QueryParameter.PATH, path);
+    if (path) {
+      url.searchParams.set(QueryParameter.PATH, path);
+    }
     return url.href;
   };
 
@@ -70,36 +67,10 @@
     </section>
   </SideBarSection>
 
-  <section id="path-summary" class="text-immich-primary dark:text-immich-dark-primary rounded-xl flex">
-    {#if data.path}
-      <CircleIconButton icon={mdiArrowUpLeft} title="Back" on:click={handleBackNavigation} class="mr-2" padding="2" />
-    {/if}
-
-    <div
-      class="flex place-items-center gap-2 bg-gray-50 dark:bg-immich-dark-gray/50 w-full py-2 px-4 rounded-2xl border border-gray-100 dark:border-gray-900"
-    >
-      <a href={`${AppRoute.FOLDERS}`} title={$t('to_root')}>
-        <Icon path={mdiFolderHome} class="text-immich-primary dark:text-immich-dark-primary mr-2" size={28} />
-      </a>
-      {#each pathSegments as segment, index}
-        <button
-          class="text-sm font-mono underline hover:font-semibold"
-          on:click={() => handleBreadcrumbNavigation(pathSegments.slice(0, index + 1).join('/'))}
-          type="button"
-        >
-          {segment}
-        </button>
-        <p class="text-gray-500">
-          {#if index < pathSegments.length - 1}
-            <Icon path={mdiChevronRight} class="text-gray-500 dark:text-gray-300" size={16} />
-          {/if}
-        </p>
-      {/each}
-    </div>
-  </section>
+  <Breadcrumbs {pathSegments} icon={mdiFolderHome} title={$t('folders')} {getLink} />
 
   <section class="mt-2">
-    <TreeItemThumbnails items={data.currentFolders} icon={mdiFolder} onClick={handleNavigation} />
+    <TreeItemThumbnails items={currentTreeItems} icon={mdiFolder} onClick={handleNavigation} />
 
     <!-- Assets -->
     {#if data.pathAssets && data.pathAssets.length > 0}

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -22,10 +22,11 @@
   import { AssetStore } from '$lib/stores/assets.store';
   import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
   import { deleteTag, getAllTags, updateTag, upsertTags, type TagResponseDto } from '@immich/sdk';
-  import { mdiChevronRight, mdiPencil, mdiPlus, mdiTag, mdiTagMultiple, mdiTrashCanOutline } from '@mdi/js';
+  import { mdiPencil, mdiPlus, mdiTag, mdiTagMultiple, mdiTrashCanOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
   import { dialogController } from '$lib/components/shared-components/dialog/dialog';
+  import Breadcrumbs from '$lib/components/shared-components/tree/breadcrumbs.svelte';
 
   export let data: PageData;
 
@@ -47,13 +48,11 @@
     await navigateToView(normalizeTreePath(`${data.path || ''}/${tag}`));
   };
 
-  const handleBreadcrumbNavigation = async (targetPath: string) => {
-    await navigateToView(targetPath);
-  };
-
   const getLink = (path: string) => {
     const url = new URL(AppRoute.TAGS, window.location.href);
-    url.searchParams.set(QueryParameter.PATH, path);
+    if (path) {
+      url.searchParams.set(QueryParameter.PATH, path);
+    }
     return url.href;
   };
 
@@ -149,14 +148,13 @@
       </div>
     </LinkButton>
 
-    <LinkButton on:click={handleEdit}>
-      <div class="flex place-items-center gap-2 text-sm">
-        <Icon path={mdiPencil} size="18" />
-        <p class="hidden md:block">{$t('edit_tag')}</p>
-      </div>
-    </LinkButton>
-
     {#if pathSegments.length > 0 && tag}
+      <LinkButton on:click={handleEdit}>
+        <div class="flex place-items-center gap-2 text-sm">
+          <Icon path={mdiPencil} size="18" />
+          <p class="hidden md:block">{$t('edit_tag')}</p>
+        </div>
+      </LinkButton>
       <LinkButton on:click={handleDelete}>
         <div class="flex place-items-center gap-2 text-sm">
           <Icon path={mdiTrashCanOutline} size="18" />
@@ -166,27 +164,7 @@
     {/if}
   </section>
 
-  <section
-    class="flex place-items-center gap-2 mt-2 text-immich-primary dark:text-immich-dark-primary rounded-2xl bg-gray-50 dark:bg-immich-dark-gray/50 w-full py-2 px-4 border border-gray-100 dark:border-gray-900"
-  >
-    <a href={`${AppRoute.TAGS}`} title={$t('to_root')}>
-      <Icon path={mdiTagMultiple} class="text-immich-primary dark:text-immich-dark-primary mr-2" size={28} />
-    </a>
-    {#each pathSegments as segment, index}
-      <button
-        class="text-sm font-mono underline hover:font-semibold"
-        on:click={() => handleBreadcrumbNavigation(pathSegments.slice(0, index + 1).join('/'))}
-        type="button"
-      >
-        {segment}
-      </button>
-      <p class="text-gray-500">
-        {#if index < pathSegments.length - 1}
-          <Icon path={mdiChevronRight} class="text-gray-500 dark:text-gray-300" size={16} />
-        {/if}
-      </p>
-    {/each}
-  </section>
+  <Breadcrumbs {pathSegments} icon={mdiTagMultiple} title={$t('tags')} {getLink} />
 
   <section class="mt-2 h-full">
     {#key $page.url.href}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Create a shared `Breadcrumbs` component that both Tags and Folders use to show hierarchy.

**Benefits of the new breadcrumbs component include:**

* Consistent UX for both folders and tags. For example, both experiences now have a button to navigate up one level.
* All breadcrumbs are links instead of buttons, to give users better indication of what they do.
* The breadcrumb for the current page is not clickable, because a link is not needed for the user's current page.
* Horizontal scrolling within breadcrumbs container when the length of the breadcrumbs overflows the width of the page.
* Wrap the breadcrumbs in a `nav` component, to create a "navigation" landmark region on the page that's easy for screen reader users to find. 
* All the breadcrumbs are inside of an ordered list, to show hierarchy.
* Using `CircleIconButton` for all buttons with an icon in them, for better accessibility and consistent look+feel with other buttons in immich.

**Other changes include:**

* Hiding "Edit tag" button on the root tags page

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Navigate from the root of the tree all the way to leaves in both the /folders and /tags pages
- [x] Use both the breadcrumbs and the "Go to parent" button to navigate up the tree
- [x] Use the root directory button to get to the base folders/tags pages

## Screenshots

<details><summary>Breadcrumbs for nested tags</summary>
<p>

![nested-breadcrumbs](https://github.com/user-attachments/assets/7936aac6-496e-4592-b7ed-12d939fb76ee)

</p>
</details> 

<details><summary>Overflowing breadcrumbs</summary>
<p>

![overflowing-breadcrumbs](https://github.com/user-attachments/assets/42f6a8bf-2de0-4e47-affe-0a053df36971)

</p>
</details> 