### PR TITLE
fix: hide scrollbar when the asset grid is empty

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -762,20 +762,21 @@
 {#if showShortcuts}
   <ShowShortcuts on:close={() => (showShortcuts = !showShortcuts)} />
 {/if}
-
-<Scrubber
-  invisible={showSkeleton}
-  {assetStore}
-  height={safeViewport.height}
-  timelineTopOffset={topSectionHeight}
-  timelineBottomOffset={bottomSectionHeight}
-  {leadout}
-  {scrubOverallPercent}
-  {scrubBucketPercent}
-  {scrubBucket}
-  {onScrub}
-  {stopScrub}
-/>
+{#if assetStore.buckets.length > 0}
+  <Scrubber
+    invisible={showSkeleton}
+    {assetStore}
+    height={safeViewport.height}
+    timelineTopOffset={topSectionHeight}
+    timelineBottomOffset={bottomSectionHeight}
+    {leadout}
+    {scrubOverallPercent}
+    {scrubBucketPercent}
+    {scrubBucket}
+    {onScrub}
+    {stopScrub}
+  />
+{/if}
 
 <!-- Right margin MUST be equal to the width of immich-scrubbable-scrollbar -->
 <section


### PR DESCRIPTION
Hide the scrollbar when there's no assets 

## Screenshots

| Before | After |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/f76ad643-2777-401f-b251-adca1d442649)| ![image](https://github.com/user-attachments/assets/b8f8c4b3-f373-44d6-ba28-0684433cabf2) |
