### PR TITLE
fix(mobile): Android back gesture closes app

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
   <application android:label="Immich" android:name=".ImmichApp" android:usesCleartextTraffic="true"
     android:icon="@mipmap/ic_launcher" android:requestLegacyExternalStorage="true"
-    android:largeHeap="true" android:enableOnBackInvokedCallback="true">
+    android:largeHeap="true" android:enableOnBackInvokedCallback="false">
 
     <service
       android:name="androidx.work.impl.foreground.SystemForegroundService"


### PR DESCRIPTION
This PR fixes #12186 by opting out of [Android's predictive back gestures](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#opt-predictive) as suggested in this [stack overflow thread](https://stackoverflow.com/questions/67683712/when-pressing-the-back-button-the-application-closes-in-flutter)

