### PR TITLE
feat(web): load original panorama image when zoomed in to 75% or above

### DIFF
--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { getAssetOriginalUrl, getKey } from '$lib/utils';
+  import { isWebCompatibleImage } from '$lib/utils/asset-utils';
   import { AssetMediaSize, AssetTypeEnum, viewAsset, type AssetResponseDto } from '@immich/sdk';
   import type { AdapterConstructor, PluginConstructor } from '@photo-sphere-viewer/core';
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { t } from 'svelte-i18n';
-  export let asset: Pick<AssetResponseDto, 'id' | 'type'>;
+  export let asset: AssetResponseDto;
 
   const photoSphereConfigs =
     asset.type === AssetTypeEnum.Video
@@ -28,14 +29,15 @@
     return url;
   };
 
-  const originalImageUrl = asset.type === AssetTypeEnum.Image ? getAssetOriginalUrl(asset.id) : null;
+  const originalImageUrl =
+    asset.type === AssetTypeEnum.Image && isWebCompatibleImage(asset) ? getAssetOriginalUrl(asset.id) : null;
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   <!-- the photo sphere viewer is quite large, so lazy load it in parallel with loading the data -->
-  {#await Promise.all( [loadAssetData(), originalImageUrl, import('./photo-sphere-viewer-adapter.svelte'), ...photoSphereConfigs], )}
+  {#await Promise.all([loadAssetData(), import('./photo-sphere-viewer-adapter.svelte'), ...photoSphereConfigs])}
     <LoadingSpinner />
-  {:then [data, originalImageUrl, module, adapter, plugins, navbar]}
+  {:then [data, module, adapter, plugins, navbar]}
     <svelte:component
       this={module.default}
       panorama={data}

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -27,14 +27,23 @@
     const url = URL.createObjectURL(data);
     return url;
   };
+
+  const originalImageUrl = asset.type === AssetTypeEnum.Image ? getAssetOriginalUrl(asset.id) : null;
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
   <!-- the photo sphere viewer is quite large, so lazy load it in parallel with loading the data -->
-  {#await Promise.all([loadAssetData(), import('./photo-sphere-viewer-adapter.svelte'), ...photoSphereConfigs])}
+  {#await Promise.all( [loadAssetData(), originalImageUrl, import('./photo-sphere-viewer-adapter.svelte'), ...photoSphereConfigs], )}
     <LoadingSpinner />
-  {:then [data, module, adapter, plugins, navbar]}
-    <svelte:component this={module.default} panorama={data} plugins={plugins ?? undefined} {navbar} {adapter} />
+  {:then [data, originalImageUrl, module, adapter, plugins, navbar]}
+    <svelte:component
+      this={module.default}
+      panorama={data}
+      plugins={plugins ?? undefined}
+      {navbar}
+      {adapter}
+      {originalImageUrl}
+    />
   {:catch}
     {$t('errors.failed_to_load_asset')}
   {/await}

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -6,7 +6,7 @@
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { t } from 'svelte-i18n';
-  export let asset: Pick<AssetResponseDto, 'id' | 'type'>;
+  export let asset: { id: string; type: AssetTypeEnum.Video } | AssetResponseDto;
 
   const photoSphereConfigs =
     asset.type === AssetTypeEnum.Video
@@ -30,9 +30,7 @@
   };
 
   const originalImageUrl =
-    asset.type === AssetTypeEnum.Image && isWebCompatibleImage(asset as AssetResponseDto)
-      ? getAssetOriginalUrl(asset.id)
-      : null;
+    asset.type === AssetTypeEnum.Image && isWebCompatibleImage(asset) ? getAssetOriginalUrl(asset.id) : null;
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">

--- a/web/src/lib/components/asset-viewer/panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/panorama-viewer.svelte
@@ -6,7 +6,7 @@
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { t } from 'svelte-i18n';
-  export let asset: AssetResponseDto;
+  export let asset: Pick<AssetResponseDto, 'id' | 'type'>;
 
   const photoSphereConfigs =
     asset.type === AssetTypeEnum.Video
@@ -30,7 +30,9 @@
   };
 
   const originalImageUrl =
-    asset.type === AssetTypeEnum.Image && isWebCompatibleImage(asset) ? getAssetOriginalUrl(asset.id) : null;
+    asset.type === AssetTypeEnum.Image && isWebCompatibleImage(asset as AssetResponseDto)
+      ? getAssetOriginalUrl(asset.id)
+      : null;
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">

--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -36,7 +36,9 @@
         // zoomLevel range: [0, 100]
         if (Math.round(zoomLevel) >= 75) {
           // Replace the preview with the original
-          viewer.setPanorama(originalImageUrl, { showLoader: false, speed: 150 }).catch(() => {});
+          viewer.setPanorama(originalImageUrl, { showLoader: false, speed: 150 }).catch(() => {
+            viewer.setPanorama(panorama, { showLoader: false, speed: 0 }).catch(() => {});
+          });
           viewer.removeEventListener(events.ZoomUpdatedEvent.type, zoomHandler);
         }
       };

--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     Viewer,
+    events,
     EquirectangularAdapter,
     type PluginConstructor,
     type AdapterConstructor,
@@ -9,6 +10,7 @@
   import { onDestroy, onMount } from 'svelte';
 
   export let panorama: string | { source: string };
+  export let originalImageUrl: string | null;
   export let adapter: AdapterConstructor | [AdapterConstructor, unknown] = EquirectangularAdapter;
   export let plugins: (PluginConstructor | [PluginConstructor, unknown])[] = [];
   export let navbar = false;
@@ -28,6 +30,18 @@
       maxFov: 180,
       fisheye: true,
     });
+
+    if (originalImageUrl) {
+      const zoomHandler = ({ zoomLevel }: events.ZoomUpdatedEvent) => {
+        // zoomLevel range: [0, 100]
+        if (Math.round(zoomLevel) >= 75) {
+          // Replace the preview with the original
+          viewer.setPanorama(originalImageUrl, { showLoader: false, speed: 150 }).catch(() => {});
+          viewer.removeEventListener(events.ZoomUpdatedEvent.type, zoomHandler);
+        }
+      };
+      viewer.addEventListener(events.ZoomUpdatedEvent.type, zoomHandler);
+    }
   });
 
   onDestroy(() => {


### PR DESCRIPTION
## Description
This PR allows the photo sphere viewer to load the original resolution image when the user zooms in to 75% or above. The currently existing photo sphere viewer uses the preview resolution image at all zoom levels, resulting in a loss of quality that is especially noticeable when zoomed in.