### PR TITLE
fix(server): remove thumbnailAt in asset_job_status for missing thumbnails

### DIFF
--- a/server/src/migrations/1725327902980-RemoveThumbailAtForMissingThumbnails.ts
+++ b/server/src/migrations/1725327902980-RemoveThumbailAtForMissingThumbnails.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveThumbailAtForMissingThumbnails1725327902980 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE "asset_job_status" j SET "thumbnailAt" = NULL WHERE j."thumbnailAt" IS NOT NULL AND NOT EXISTS ( SELECT 1 FROM public.asset_files f WHERE j."assetId" = f."assetId" AND f."type" = 'thumbnail' AND f."path" IS NOT NULL )`);
+    }
+
+   public async down(): Promise<void> {
+   }
+
+}

--- a/server/src/migrations/1725327902980-RemoveThumbailAtForMissingThumbnails.ts
+++ b/server/src/migrations/1725327902980-RemoveThumbailAtForMissingThumbnails.ts
@@ -6,7 +6,8 @@ export class RemoveThumbailAtForMissingThumbnails1725327902980 implements Migrat
         await queryRunner.query(`UPDATE "asset_job_status" j SET "thumbnailAt" = NULL WHERE j."thumbnailAt" IS NOT NULL AND NOT EXISTS ( SELECT 1 FROM public.asset_files f WHERE j."assetId" = f."assetId" AND f."type" = 'thumbnail' AND f."path" IS NOT NULL )`);
     }
 
-   public async down(): Promise<void> {
-   }
+    public async down(): Promise<void> {
+        // do nothing
+    }
 
 }


### PR DESCRIPTION
Similar to https://github.com/immich-app/immich/pull/12225, I realized some assets had `thumbnailAt` set, but had no thumbnail file in `asset_files`. In https://github.com/immich-app/immich/pull/11908/files#diff-99da4a5a2a767c94716e167a5d49f089778c22365cf403e92808711beb6125b9, `thumbnailAt` was set to `NOW()` if `thumbnailPath IS NOT NULL`, whereas `asset_file` was only created when `"thumbnailPath" IS NOT NULL AND "thumbnailPath" != ''` in https://github.com/immich-app/immich/pull/11861/files#diff-09097609a560037cd9fc82b6d5de63f184101d01c8d14a53182de0d5e649d4e0. This PR fixes actually missing thumbnails to be recognized as missing, again.

```
UPDATE "asset_job_status" j
SET "thumbnailAt" = NULL
WHERE j."thumbnailAt" IS NOT NULL
AND NOT EXISTS (
	SELECT 1 FROM public.asset_files f
	WHERE j."assetId" = f."assetId"
	AND f."type" = 'thumbnail'
	AND f."path" IS NOT NULL
)
```