### PR TITLE
ci: replace deprecate cloudflare properties on cloudflare_record

### DIFF
--- a/deployment/modules/cloudflare/docs-release/domain.tf
+++ b/deployment/modules/cloudflare/docs-release/domain.tf
@@ -9,6 +9,6 @@ resource "cloudflare_record" "immich_app_release_domain" {
   proxied = true
   ttl = 1
   type = "CNAME"
-  value = data.terraform_remote_state.cloudflare_immich_app_docs.outputs.immich_app_branch_pages_hostname
+  content = data.terraform_remote_state.cloudflare_immich_app_docs.outputs.immich_app_branch_pages_hostname
   zone_id = data.terraform_remote_state.cloudflare_account.outputs.immich_app_zone_id
 }

--- a/deployment/modules/cloudflare/docs/domain.tf
+++ b/deployment/modules/cloudflare/docs/domain.tf
@@ -9,7 +9,7 @@ resource "cloudflare_record" "immich_app_branch_subdomain" {
   proxied = true
   ttl     = 1
   type    = "CNAME"
-  value   = "${replace(var.prefix_name, "/\\/|\\./", "-")}.${local.is_release ? data.terraform_remote_state.cloudflare_account.outputs.immich_app_archive_pages_project_subdomain : data.terraform_remote_state.cloudflare_account.outputs.immich_app_preview_pages_project_subdomain}"
+  content   = "${replace(var.prefix_name, "/\\/|\\./", "-")}.${local.is_release ? data.terraform_remote_state.cloudflare_account.outputs.immich_app_archive_pages_project_subdomain : data.terraform_remote_state.cloudflare_account.outputs.immich_app_preview_pages_project_subdomain}"
   zone_id = data.terraform_remote_state.cloudflare_account.outputs.immich_app_zone_id
 }
 


### PR DESCRIPTION
Cloudflare deprecated the `value` property for cloudflare_record ([and broke it in the process](https://github.com/cloudflare/terraform-provider-cloudflare/issues/3890)). So we are moving to the new `content` property