### PR TITLE
fix(mobile): show stack child in the album page

### DIFF
--- a/mobile/lib/pages/common/album_viewer.page.dart
+++ b/mobile/lib/pages/common/album_viewer.page.dart
@@ -242,6 +242,7 @@ class AlbumViewerPage extends HookConsumerWidget {
               ),
               onRemoveFromAlbum: onRemoveFromAlbumPressed,
               editEnabled: data.ownerId == userId,
+              stackEnabled: data.ownerId == userId,
             ),
           ),
           AnimatedPositioned(

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -185,7 +185,7 @@ export const mapAlbum = (entity: AlbumEntity, withAssets: boolean, auth?: AuthDt
     hasSharedLink,
     startDate,
     endDate,
-    assets: (withAssets ? assets : []).map((asset) => mapAsset(asset, { auth })),
+    assets: (withAssets ? assets : []).map((asset) => mapAsset(asset, { auth, withStack: true })),
     assetCount: entity.assets?.length || 0,
     isActivityEnabled: entity.isActivityEnabled,
     order: entity.order,

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -46,6 +46,7 @@ export class AlbumRepository implements IAlbumRepository {
     if (options.withAssets) {
       relations.assets = {
         exifInfo: true,
+        stack: { assets: true },
       };
 
       order.assets = {


### PR DESCRIPTION
This PR fixes the issues of stack information not being properly updated and displayed when the stacked asset is in an album.