### PR TITLE
feat(server): prefer tagslist

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -434,6 +434,21 @@ describe(MetadataService.name, () => {
       });
     });
 
+    it('should ignore Keywords when TagsList is present', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({ Keywords: 'Child', TagsList: ['Parent/Child'] });
+      tagMock.upsertValue.mockResolvedValue(tagStub.parent);
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(1, { userId: 'user-id', value: 'Parent', parent: undefined });
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(2, {
+        userId: 'user-id',
+        value: 'Parent/Child',
+        parent: tagStub.parent,
+      });
+    });
+
     it('should not apply motion photos if asset is video', async () => {
       assetMock.getByIds.mockResolvedValue([{ ...assetStub.livePhotoMotionAsset, isVisible: true }]);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -355,9 +355,7 @@ export class MetadataService {
     const tags: unknown[] = [];
     if (exifTags.TagsList) {
       tags.push(...exifTags.TagsList);
-    }
-
-    if (exifTags.Keywords) {
+    } else if (exifTags.Keywords) {
       let keywords = exifTags.Keywords;
       if (!Array.isArray(keywords)) {
         keywords = [keywords];


### PR DESCRIPTION
Prefer sourcing tags from `TagsList` when both `Keywords` and `TagsList` are populated.