### PR TITLE
feat(server): support lightroom tags

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -449,6 +449,51 @@ describe(MetadataService.name, () => {
       });
     });
 
+    it('should extract hierarchy from HierarchicalSubject', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({ HierarchicalSubject: ['Parent|Child'] });
+      tagMock.upsertValue.mockResolvedValueOnce(tagStub.parent);
+      tagMock.upsertValue.mockResolvedValueOnce(tagStub.child);
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(1, { userId: 'user-id', value: 'Parent', parent: undefined });
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(2, {
+        userId: 'user-id',
+        value: 'Parent/Child',
+        parent: tagStub.parent,
+      });
+    });
+
+    it('should extract ignore / characters in a HierarchicalSubject tag', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({ HierarchicalSubject: ['Mom/Dad'] });
+      tagMock.upsertValue.mockResolvedValueOnce(tagStub.parent);
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+
+      expect(tagMock.upsertValue).toHaveBeenCalledWith({
+        userId: 'user-id',
+        value: 'Mom|Dad',
+        parent: undefined,
+      });
+    });
+
+    it('should ignore HierarchicalSubject when TagsList is present', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({ HierarchicalSubject: ['Parent2|Child2'], TagsList: ['Parent/Child'] });
+      tagMock.upsertValue.mockResolvedValue(tagStub.parent);
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(1, { userId: 'user-id', value: 'Parent', parent: undefined });
+      expect(tagMock.upsertValue).toHaveBeenNthCalledWith(2, {
+        userId: 'user-id',
+        value: 'Parent/Child',
+        parent: tagStub.parent,
+      });
+    });
+
     it('should not apply motion photos if asset is video', async () => {
       assetMock.getByIds.mockResolvedValue([{ ...assetStub.livePhotoMotionAsset, isVisible: true }]);
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -355,6 +355,16 @@ export class MetadataService {
     const tags: unknown[] = [];
     if (exifTags.TagsList) {
       tags.push(...exifTags.TagsList);
+    } else if (exifTags.HierarchicalSubject) {
+      tags.push(
+        exifTags.HierarchicalSubject.map((tag) =>
+          tag
+            // convert | to /
+            .replaceAll('/', '<PLACEHOLDER>')
+            .replaceAll('|', '/')
+            .replaceAll('<PLACEHOLDER>', '|'),
+        ),
+      );
     } else if (exifTags.Keywords) {
       let keywords = exifTags.Keywords;
       if (!Array.isArray(keywords)) {


### PR DESCRIPTION
Add support for reading tags from `HierarchicalSubject` 
- Treat `|` as hierarchy symbol
- Replace `/` characters with `|` (after parsing hierachy)

Closes #12196