### PR TITLE
feat(web): show folder navigation in root directory

### DIFF
--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -25,6 +25,7 @@
   $: pathSegments = data.path ? data.path.split('/') : [];
   $: tree = buildTree($foldersStore?.uniquePaths || []);
   $: currentPath = $page.url.searchParams.get(QueryParameter.PATH) || '';
+  $: currentTreeItems = currentPath ? data.currentFolders : Object.keys(tree);
 
   onMount(async () => {
     await foldersStore.fetchUniquePaths();
@@ -63,7 +64,7 @@
   <Breadcrumbs {pathSegments} icon={mdiFolderHome} title={$t('folders')} {getLink} />
 
   <section class="mt-2">
-    <TreeItemThumbnails items={data.currentFolders} icon={mdiFolder} onClick={handleNavigation} />
+    <TreeItemThumbnails items={currentTreeItems} icon={mdiFolder} onClick={handleNavigation} />
 
     <!-- Assets -->
     {#if data.pathAssets && data.pathAssets.length > 0}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Show folder navigation in the root folders page.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Navigate from root directory to leaf folders, verifying that the folders displayed are accurate

## Screenshots

<details><summary>Expand for screenshot</summary>
<p>

![root-folder-navigation](https://github.com/user-attachments/assets/1ae86059-53c9-46a9-a891-40d3d09ba819)

</p>
</details> 

