### PR TITLE
fix(server): parse time zone with explicit zero offset

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1,4 +1,4 @@
-import { BinaryField } from 'exiftool-vendored';
+import { BinaryField, ExifDateTime } from 'exiftool-vendored';
 import { randomBytes } from 'node:crypto';
 import { Stats } from 'node:fs';
 import { constants } from 'node:fs/promises';
@@ -746,6 +746,8 @@ describe(MetadataService.name, () => {
     });
 
     it('should save all metadata', async () => {
+      const dateForTest = new Date('1970-01-01T00:00:00.000-11:30');
+
       const tags: ImmichTags = {
         BitsPerSample: 1,
         ComponentBitDepth: 1,
@@ -753,7 +755,7 @@ describe(MetadataService.name, () => {
         BitDepth: 1,
         ColorBitDepth: 1,
         ColorSpace: '1',
-        DateTimeOriginal: new Date('1970-01-01').toISOString(),
+        DateTimeOriginal: ExifDateTime.fromISO(dateForTest.toISOString()),
         ExposureTime: '100ms',
         FocalLength: 20,
         ImageDescription: 'test description',
@@ -762,11 +764,11 @@ describe(MetadataService.name, () => {
         MediaGroupUUID: 'livePhoto',
         Make: 'test-factory',
         Model: "'mockel'",
-        ModifyDate: new Date('1970-01-01').toISOString(),
+        ModifyDate: ExifDateTime.fromISO(dateForTest.toISOString()),
         Orientation: 0,
         ProfileDescription: 'extensive description',
         ProjectionType: 'equirectangular',
-        tz: '+02:00',
+        tz: 'UTC-11:30',
         Rating: 3,
       };
       assetMock.getByIds.mockResolvedValue([assetStub.image]);
@@ -779,7 +781,7 @@ describe(MetadataService.name, () => {
         bitsPerSample: expect.any(Number),
         autoStackId: null,
         colorspace: tags.ColorSpace,
-        dateTimeOriginal: new Date('1970-01-01'),
+        dateTimeOriginal: dateForTest,
         description: tags.ImageDescription,
         exifImageHeight: null,
         exifImageWidth: null,
@@ -805,8 +807,8 @@ describe(MetadataService.name, () => {
       expect(assetMock.update).toHaveBeenCalledWith({
         id: assetStub.image.id,
         duration: null,
-        fileCreatedAt: new Date('1970-01-01'),
-        localDateTime: new Date('1970-01-01'),
+        fileCreatedAt: dateForTest,
+        localDateTime: dateForTest,
       });
     });
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -531,12 +531,16 @@ export class MetadataService {
 
     this.logger.verbose('Exif Tags', exifTags);
 
+    const dateTimeOriginalWithRawValue = this.getDateTimeOriginalWithRawValue(exifTags);
+    const dateTimeOriginal = dateTimeOriginalWithRawValue.exifDate ?? asset.fileCreatedAt;
+    const timeZone = this.getTimeZone(exifTags, dateTimeOriginalWithRawValue.rawValue);
+
     const exifData = {
       // altitude: tags.GPSAltitude ?? null,
       assetId: asset.id,
       bitsPerSample: this.getBitsPerSample(exifTags),
       colorspace: exifTags.ColorSpace ?? null,
-      dateTimeOriginal: this.getDateTimeOriginal(exifTags) ?? asset.fileCreatedAt,
+      dateTimeOriginal,
       description: String(exifTags.ImageDescription || exifTags.Description || '').trim(),
       exifImageHeight: validate(exifTags.ImageHeight),
       exifImageWidth: validate(exifTags.ImageWidth),
@@ -557,7 +561,7 @@ export class MetadataService {
       orientation: validate(exifTags.Orientation)?.toString() ?? null,
       profileDescription: exifTags.ProfileDescription || null,
       projectionType: exifTags.ProjectionType ? String(exifTags.ProjectionType).toUpperCase() : null,
-      timeZone: exifTags.tz ?? null,
+      timeZone,
       rating: exifTags.Rating ?? null,
     };
 
@@ -578,10 +582,25 @@ export class MetadataService {
   }
 
   private getDateTimeOriginal(tags: ImmichTags | Tags | null) {
+    return this.getDateTimeOriginalWithRawValue(tags).exifDate;
+  }
+
+  private getDateTimeOriginalWithRawValue(tags: ImmichTags | Tags | null): { exifDate: Date | null; rawValue: string } {
     if (!tags) {
-      return null;
+      return { exifDate: null, rawValue: '' };
     }
-    return exifDate(firstDateTime(tags as Tags, EXIF_DATE_TAGS));
+    const first = firstDateTime(tags as Tags, EXIF_DATE_TAGS);
+    return { exifDate: exifDate(first), rawValue: first?.rawValue ?? '' };
+  }
+
+  private getTimeZone(exifTags: ImmichTags, rawValue: string) {
+    const timeZone = exifTags.tz ?? null;
+    if (timeZone == null && rawValue.endsWith('+00:00')) {
+      // exiftool-vendored returns "no timezone" information even though "+00:00" might be set explicitly
+      // https://github.com/photostructure/exiftool-vendored.js/issues/203
+      return 'UTC+0';
+    }
+    return timeZone;
   }
 
   private getBitsPerSample(tags: ImmichTags): number | null {


### PR DESCRIPTION
The tool used to parse EXIF information, exiftool-vendored, sadly treats unknown time zone offsets, "Z" (Zulu for UTC) and the explicit "+00:00" offset exactly the same, returning them as "UTC" or "unknown". If an asset includes the "+00:00" offset explicitly, for example for photos taken in Iceland, this is now parsed, forwarded, and persisted accordingly.

To benefit from this also for already imported assets, a metadata rescan is necessary.

Immich treats unknown time zones/offsets differently from assets where this is known. For assets with an unknown time zone offset, the times are always converted to the local time. This only happens for the UTC/Z/"+00:00" case, not for any other (known) offset.

This PR fixes this by not having those special rules apply to assets with an explicit "+00:00" offset, anymore. 

Note that currently the web UI does not write the "+00:00" offset even when setting one of the matching time zones explicitly (e.g. Iceland). This will be fixed in a separate PR. Furthermore, code dealing with time zones in general has a few issues, which also remain open for future work. Also note that not all cameras/phones set "+00:00" in a way that can be differentiated from the default unknown/Z/UTC/empty time zone offset. For assets produced by these devices, nothing changes.

Related: https://github.com/photostructure/exiftool-vendored.js/issues/203