### PR TITLE
fix(server): searching for archived files shows partner's archived

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -108,6 +108,12 @@ export function searchAssetBuilder(
     ),
   );
 
+  if ((isArchived || withArchived) && options.userIds && options.userIds.length > 0) {
+    builder.andWhere(`NOT (${builder.alias}.isArchived = true AND ${builder.alias}.ownerId != :userId)`, {
+      userId: options.userIds[0],
+    });
+  }
+
   if (isNotInAlbum) {
     builder
       .leftJoin(`${builder.alias}.albums`, 'albums')


### PR DESCRIPTION
Right now when searching for archived files you will see your partner's archived files in your search result, but when you click on one it will show an error. This will have the search api not return archived pictures from partners.

Note: I'm not sure if the way I got the userID is okay, but as long as `getUserIdsToSearch` is used to generate the userIDs passed to this function this should work, but if you want me to just add a parameter that passes the correct userID I can do that.