### PR TITLE
fix(text): Typo fix in translation

### DIFF
--- a/web/src/lib/i18n/es.json
+++ b/web/src/lib/i18n/es.json
@@ -947,7 +947,7 @@
   "options": "Opciones",
   "or": "o",
   "organize_your_library": "Organiza tu biblioteca",
-  "original": "oeiginal",
+  "original": "original",
   "other": "Otro",
   "other_devices": "Otro dispositivo",
   "other_variables": "Otras variables",


### PR DESCRIPTION
A simple typo fix for the spanish translation. It should be `original` rather than `oeiginal`.

![imagen](https://github.com/user-attachments/assets/fb65c0e6-3871-4729-85cd-e4250463216e)
