### PR TITLE
fix(web): show focus outline for asset thumbnails again

### DIFF
--- a/e2e/src/web/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/web/specs/shared-link.e2e-spec.ts
@@ -44,7 +44,7 @@ test.describe('Shared Links', () => {
   test('download from a shared link', async ({ page }) => {
     await page.goto(`/share/${sharedLink.key}`);
     await page.getByRole('heading', { name: 'Test Album' }).waitFor();
-    await page.locator('.group').first().hover();
+    await page.locator(`[data-asset-id="${asset.id}"]`).hover();
     await page.waitForSelector('#asset-group-by-date svg');
     await page.getByRole('checkbox').click();
     await page.getByRole('button', { name: 'Download' }).click();

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -175,7 +175,7 @@
   data-int={intersecting}
   style:width="{width}px"
   style:height="{height}px"
-  class="group focus-visible:outline-none flex overflow-hidden {disabled
+  class="focus-visible:outline-none flex overflow-hidden {disabled
     ? 'bg-gray-300'
     : 'bg-immich-primary/20 dark:bg-immich-dark-primary/20'}"
 >
@@ -193,6 +193,7 @@
     <!-- svelte queries for all links on afterNavigate, leading to performance problems in asset-grid which updates
      the navigation url on scroll. Replace this with button for now. -->
     <div
+      class="group"
       class:cursor-not-allowed={disabled}
       class:cursor-pointer={!disabled}
       on:mouseenter={onMouseEnter}


### PR DESCRIPTION
Fixes #12329