### PR TITLE
fix(web): auth on navigation from shared link to timeline

### DIFF
--- a/e2e/src/web/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/web/specs/shared-link.e2e-spec.ts
@@ -69,4 +69,15 @@ test.describe('Shared Links', () => {
     await page.goto('/share/invalid');
     await page.getByRole('heading', { name: 'Invalid share key' }).waitFor();
   });
+
+  test('auth on navigation from shared link to timeline', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+
+    await page.goto(`/share/${sharedLink.key}`);
+    await page.getByRole('heading', { name: 'Test Album' }).waitFor();
+
+    await page.locator('a[href="/"]').click();
+    await page.waitForURL('/photos');
+    await page.locator(`[data-asset-id="${asset.id}"]`).waitFor();
+  });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -156,7 +156,7 @@ export const getJobName = derived(t, ($t) => {
 let _key: string | undefined;
 let _sharedLink: SharedLinkResponseDto | undefined;
 
-export const setKey = (key: string) => (_key = key);
+export const setKey = (key?: string) => (_key = key);
 export const getKey = (): string | undefined => _key;
 export const setSharedLink = (sharedLink: SharedLinkResponseDto) => (_sharedLink = sharedLink);
 export const getSharedLink = (): SharedLinkResponseDto | undefined => _sharedLink;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -71,6 +71,8 @@
   }
 
   beforeNavigate(({ from, to }) => {
+    setKey(isSharedLinkRoute(to?.route.id) ? to?.params?.key : undefined);
+
     if (isAssetViewerRoute(from) && isAssetViewerRoute(to)) {
       return;
     }


### PR DESCRIPTION
Visiting a shared link as a logged in user and then navigating back using the Immich logo results in authentication errors. Fixes #12138 by removing the shared link key when navigating back.