### PR TITLE
fix(web): ensure shared link covers are full size

### DIFF
--- a/web/src/lib/components/album-page/__tests__/album-cover.spec.ts
+++ b/web/src/lib/components/album-page/__tests__/album-cover.spec.ts
@@ -19,7 +19,7 @@ describe('AlbumCover component', () => {
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('someName');
     expect(img.getAttribute('loading')).toBe('lazy');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square text');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square text');
     expect(img.getAttribute('src')).toBe('/asdf');
     expect(getAssetThumbnailUrl).toHaveBeenCalledWith({ id: '123' });
   });
@@ -36,7 +36,7 @@ describe('AlbumCover component', () => {
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('unnamed_album');
     expect(img.getAttribute('loading')).toBe('eager');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square asdf');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square asdf');
     expect(img.getAttribute('src')).toStrictEqual(expect.any(String));
   });
 });

--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -44,7 +44,7 @@
     </div>
   {/if}
 
-  <AlbumCover {album} {preload} class="h-full w-full transition-all duration-300 hover:shadow-lg" />
+  <AlbumCover {album} {preload} class="transition-all duration-300 hover:shadow-lg" />
 
   <div class="mt-4">
     <p

--- a/web/src/lib/components/sharedlinks-page/covers/__tests__/asset-cover.spec.ts
+++ b/web/src/lib/components/sharedlinks-page/covers/__tests__/asset-cover.spec.ts
@@ -13,6 +13,6 @@ describe('AssetCover component', () => {
     expect(img.alt).toBe('123');
     expect(img.getAttribute('src')).toBe('wee');
     expect(img.getAttribute('loading')).toBe('eager');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square asdf');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square asdf');
   });
 });

--- a/web/src/lib/components/sharedlinks-page/covers/__tests__/no-cover.spec.ts
+++ b/web/src/lib/components/sharedlinks-page/covers/__tests__/no-cover.spec.ts
@@ -10,7 +10,7 @@ describe('NoCover component', () => {
     });
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('123');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square asdf');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square asdf');
     expect(img.getAttribute('loading')).toBe('eager');
     expect(img.src).toStrictEqual(expect.any(String));
   });

--- a/web/src/lib/components/sharedlinks-page/covers/__tests__/share-cover.spec.ts
+++ b/web/src/lib/components/sharedlinks-page/covers/__tests__/share-cover.spec.ts
@@ -17,7 +17,7 @@ describe('ShareCover component', () => {
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('123');
     expect(img.getAttribute('loading')).toBe('lazy');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square text');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square text');
   });
 
   it('renders an image when the shared link is an individual share', () => {
@@ -30,7 +30,7 @@ describe('ShareCover component', () => {
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('individual_share');
     expect(img.getAttribute('loading')).toBe('lazy');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square text');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square text');
     expect(img.getAttribute('src')).toBe('/asdf');
     expect(getAssetThumbnailUrl).toHaveBeenCalledWith('someId');
   });
@@ -44,7 +44,7 @@ describe('ShareCover component', () => {
     const img = component.getByTestId('album-image') as HTMLImageElement;
     expect(img.alt).toBe('unnamed_share');
     expect(img.getAttribute('loading')).toBe('lazy');
-    expect(img.className).toBe('z-0 rounded-xl object-cover aspect-square text');
+    expect(img.className).toBe('size-full rounded-xl object-cover aspect-square text');
   });
 
   it.skip('renders fallback image when asset is not resized', () => {

--- a/web/src/lib/components/sharedlinks-page/covers/asset-cover.svelte
+++ b/web/src/lib/components/sharedlinks-page/covers/asset-cover.svelte
@@ -16,7 +16,7 @@
   <img
     {alt}
     on:error={() => (isBroken = true)}
-    class="z-0 rounded-xl object-cover aspect-square {className}"
+    class="size-full rounded-xl object-cover aspect-square {className}"
     data-testid="album-image"
     draggable="false"
     loading={preload ? 'eager' : 'lazy'}

--- a/web/src/lib/components/sharedlinks-page/covers/no-cover.svelte
+++ b/web/src/lib/components/sharedlinks-page/covers/no-cover.svelte
@@ -7,7 +7,7 @@
 
 <enhanced:img
   {alt}
-  class="z-0 rounded-xl object-cover aspect-square {className}"
+  class="size-full rounded-xl object-cover aspect-square {className}"
   data-testid="album-image"
   draggable="false"
   loading={preload ? 'eager' : 'lazy'}


### PR DESCRIPTION
| Before | After |
| - | - |
| ![shared_link_before](https://github.com/user-attachments/assets/a8db3a0c-76b0-4223-b4cf-60832579886c) | ![shared_link_after](https://github.com/user-attachments/assets/2353c948-71e4-4d45-a730-a55558ac2ae9) |
