### PR TITLE
fix(server): deprioritize METADATA_EXTRACTION to let LINK_LIVE_PHOTOS complete first

### DIFF
--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -253,6 +253,9 @@ export class JobRepository implements IJobRepository {
       case JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE: {
         return { jobId: item.data.id };
       }
+      case JobName.METADATA_EXTRACTION: {
+        return { priority: 1 };
+      }
       case JobName.GENERATE_PERSON_THUMBNAIL: {
         return { priority: 1 };
       }


### PR DESCRIPTION
Least intrusive change to partially fix https://github.com/immich-app/immich/issues/12306.

When stopping and clearing the METADATA_EXTRACTION queue midway, METADATA_EXTRACTION queue must be forcefully filled and run again to LINK_LIVE_PHOTOS as LINK_LIVE_PHOTOS jobs are processed after all the METADATA_EXTRACTION jobs. Hence, LINK_LIVE_PHOTOS jobs should be prioritized over METADATA_EXTRACTION.

This also fixes UX such that the queue size actually decreases on the job status page evenly over time.