### PR TITLE
fix(server): remove hidden assets from albums

### DIFF
--- a/server/src/migrations/1725730782681-RemoveHiddenAssetsFromAlbums.ts
+++ b/server/src/migrations/1725730782681-RemoveHiddenAssetsFromAlbums.ts
@@ -2,10 +2,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class RemoveHiddenAssetsFromAlbums1725730782681 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DELETE FROM "albums_assets_assets" WHERE "assetsId" IN (SELECT "id" FROM "assets" WHERE "isVisible" = false)`);
+    await queryRunner.query(
+      `DELETE FROM "albums_assets_assets" WHERE "assetsId" IN (SELECT "id" FROM "assets" WHERE "isVisible" = false)`,
+    );
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(): Promise<void> {
     // noop
   }
 }

--- a/server/src/migrations/1725730782681-RemoveHiddenAssetsFromAlbums.ts
+++ b/server/src/migrations/1725730782681-RemoveHiddenAssetsFromAlbums.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveHiddenAssetsFromAlbums1725730782681 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "albums_assets_assets" WHERE "assetsId" IN (SELECT "id" FROM "assets" WHERE "isVisible" = false)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // noop
+  }
+}


### PR DESCRIPTION
Fixes #8348 by removing assets from albums that are "isVisible: false". This is likely only a problem for old instance with live photos whose motion portion was added prior to #3702.