### PR TITLE
feat(web): show timezone information in detail view

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -296,10 +296,13 @@
                     weekday: 'short',
                     hour: 'numeric',
                     minute: '2-digit',
-                    timeZoneName: 'longOffset',
                   },
                   { locale: $locale },
                 )}
+                {assetDateTimeOriginal.toFormat('ZZZZZ', { locale: $locale })}
+                {assetDateTimeOriginal.toFormat('ZZZZZ', { locale: $locale }).includes('UTC')
+                  ? ''
+                  : '(' + assetDateTimeOriginal.toFormat('ZZ') + ')'}
               </p>
             </div>
           </div>


### PR DESCRIPTION
before:
Thu, 23:45 GMT-03:00

after:
Thu, 23:45 Chile Summer Time (-03:00)

The timezone name is localized and can be quite long (e.g. "Chilenische Sommerzeit", "Nordamerikanische Ostküsten-Sommerzeit"). This might cause line breaks.

The offset is not included if the timezone name includes "UTC":

* Thu, 23:45 Chile Summer Time (-03:00)
* Thu, 23:45 UTC
* Thu, 23:45 UTC+2

![image](https://github.com/user-attachments/assets/4c79ee25-a8ce-4582-bd70-9f8c0ba22854)
![image](https://github.com/user-attachments/assets/2dd09eac-dcb4-44b2-ab0b-f1327ab4e69d)
