### PR TITLE
Fix typo in es-US localization

### DIFF
--- a/mobile/assets/i18n/es-US.json
+++ b/mobile/assets/i18n/es-US.json
@@ -414,7 +414,7 @@
   "search_filter_people_title": "Select people",
   "search_page_categories": "Categorías",
   "search_page_favorites": "Favoritos",
-  "search_page_motion_photos": "Fotos en .ovimiento",
+  "search_page_motion_photos": "Fotos en movimiento",
   "search_page_no_objects": "No hay información de objetos disponible",
   "search_page_no_places": "No hay información de lugares disponible",
   "search_page_people": "Personas",


### PR DESCRIPTION
search_page_motion_photos string should be 'Fotos en movimiento' not 'Fotos en .ovimiento'