### PR TITLE
feat(mobile): Add dismiss action on app_bar_dialog

### DIFF
--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -237,35 +237,40 @@ class ImmichAppBarDialog extends HookConsumerWidget {
       );
     }
 
-    return Dialog(
-      clipBehavior: Clip.hardEdge,
-      alignment: Alignment.topCenter,
-      insetPadding: EdgeInsets.only(
-        top: isHorizontal ? 20 : 40,
-        left: horizontalPadding,
-        right: horizontalPadding,
-        bottom: isHorizontal ? 20 : 100,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: SizedBox(
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(20),
-                child: buildTopRow(),
-              ),
-              const AppBarProfileInfoBox(),
-              buildStorageInformation(),
-              const AppBarServerInfo(),
-              buildAppLogButton(),
-              buildSettingButton(),
-              buildSignOutButton(),
-              buildFooter(),
-            ],
+    return Dismissible(
+      direction: DismissDirection.down,
+      onDismissed: (_) => Navigator.of(context).pop(),
+      key: const Key('app_bar_dialog'),
+      child: Dialog(
+        clipBehavior: Clip.hardEdge,
+        alignment: Alignment.topCenter,
+        insetPadding: EdgeInsets.only(
+          top: isHorizontal ? 20 : 40,
+          left: horizontalPadding,
+          right: horizontalPadding,
+          bottom: isHorizontal ? 20 : 100,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: SizedBox(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(20),
+                  child: buildTopRow(),
+                ),
+                const AppBarProfileInfoBox(),
+                buildStorageInformation(),
+                const AppBarServerInfo(),
+                buildAppLogButton(),
+                buildSettingButton(),
+                buildSignOutButton(),
+                buildFooter(),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
I have intuitively tried to perform this action several times. It bothered me, so now you can close the profile dialog by swiping down.

Note: Since I do not own a mac, it has not been tested on apple devices. However, it has been tested in the Android emulator and on a Samsung A55.

https://github.com/user-attachments/assets/c312c560-5c42-4dfa-8c50-7cfe07bd687f