### PR TITLE
fix(web): clip scrollbar overflow in modals

### DIFF
--- a/web/src/lib/components/shared-components/full-screen-modal.svelte
+++ b/web/src/lib/components/shared-components/full-screen-modal.svelte
@@ -55,24 +55,28 @@
   use:focusTrap
 >
   <div
-    class="z-[9999] max-w-[95vw] max-h-[min(95dvh,56rem)] {modalWidth} overflow-y-auto rounded-3xl bg-immich-bg shadow-md dark:bg-immich-dark-gray dark:text-immich-dark-fg immich-scrollbar"
+    class="z-[9999] max-w-[95vw] {modalWidth} overflow-hidden rounded-3xl bg-immich-bg shadow-md dark:bg-immich-dark-gray dark:text-immich-dark-fg pt-3 pb-4"
     use:clickOutside={{ onOutclick: onClose, onEscape: onClose }}
     tabindex="-1"
     aria-modal="true"
     aria-labelledby={titleId}
-    class:scroll-pb-40={isStickyBottom}
-    class:sm:scroll-p-24={isStickyBottom}
   >
-    <ModalHeader id={titleId} {title} {showLogo} {icon} {onClose} />
-    <div class="p-5 pt-0">
-      <slot />
-    </div>
-    {#if isStickyBottom}
-      <div
-        class="flex flex-col sm:flex-row justify-end w-full gap-2 sm:gap-4 sticky bottom-0 py-4 px-5 bg-immich-bg dark:bg-immich-dark-gray border-t border-gray-200 dark:border-gray-500 shadow"
-      >
-        <slot name="sticky-bottom" />
+    <div
+      class="immich-scrollbar overflow-y-auto max-h-[min(92dvh,56rem)]"
+      class:scroll-pb-40={isStickyBottom}
+      class:sm:scroll-p-24={isStickyBottom}
+    >
+      <ModalHeader id={titleId} {title} {showLogo} {icon} {onClose} />
+      <div class="px-5 pt-0" class:pb-5={isStickyBottom}>
+        <slot />
       </div>
-    {/if}
+      {#if isStickyBottom}
+        <div
+          class="flex flex-col sm:flex-row justify-end w-full gap-2 sm:gap-4 sticky bottom-0 pt-4 px-5 bg-immich-bg dark:bg-immich-dark-gray border-t border-gray-200 dark:border-gray-500 shadow"
+        >
+          <slot name="sticky-bottom" />
+        </div>
+      {/if}
+    </div>
   </div>
 </section>

--- a/web/src/lib/components/shared-components/modal-header.svelte
+++ b/web/src/lib/components/shared-components/modal-header.svelte
@@ -21,7 +21,7 @@
   export let icon: string | undefined = undefined;
 </script>
 
-<div class="flex place-items-center justify-between px-5 py-3">
+<div class="flex place-items-center justify-between px-5 pb-3">
   <div class="flex gap-2 place-items-center">
     {#if showLogo}
       <ImmichLogo noText={true} width={32} />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve the look and feel of the scrollbar in modals.

- visually clip any scrollbar that overflows outside of the rounded corners
- padding on the top and bottom of the scroll container, so the scrollbar doesn't span the whole height of the modal

Prerequisite for #12438.

## Screenshots

<details><summary>Safari example</summary>
<p>

![safari-scrolling-modal](https://github.com/user-attachments/assets/2413b298-839d-40c5-b97c-7fc3c948b89c)

</p>
</details>

<details><summary>Chrome example (MacOS)</summary>
<p>

![chrome-scrolling-modal](https://github.com/user-attachments/assets/72669569-1ed7-4989-ae2a-c6ecca0bbabe)

</p>
</details> 