### PR TITLE
fix(web): show upload error message on network error

### DIFF
--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -15,7 +15,7 @@ import {
 import { tick } from 'svelte';
 import { t } from 'svelte-i18n';
 import { get } from 'svelte/store';
-import { getServerErrorMessage, handleError } from './handle-error';
+import { handleError } from './handle-error';
 
 export const addDummyItems = () => {
   uploadAssetsStore.addItem({ id: 'asset-0', file: { name: 'asset0.jpg', size: 123_456 } as File });
@@ -202,10 +202,9 @@ async function fileUploader(assetFile: File, albumId?: string, replaceAssetId?: 
 
     return responseData.id;
   } catch (error) {
-    handleError(error, $t('errors.unable_to_upload_file'));
-    const reason = getServerErrorMessage(error) || error;
+    const errorMessage = handleError(error, $t('errors.unable_to_upload_file'));
     uploadAssetsStore.track('error');
-    uploadAssetsStore.updateItem(deviceAssetId, { state: UploadState.ERROR, error: reason });
+    uploadAssetsStore.updateItem(deviceAssetId, { state: UploadState.ERROR, error: errorMessage });
     return;
   }
 }

--- a/web/src/lib/utils/handle-error.ts
+++ b/web/src/lib/utils/handle-error.ts
@@ -20,11 +20,13 @@ export function handleError(error: unknown, message: string) {
       serverMessage = `${String(serverMessage).slice(0, 75)}\n(Immich Server Error)`;
     }
 
-    notificationController.show({
-      message: serverMessage || message,
-      type: NotificationType.Error,
-    });
+    const errorMessage = serverMessage || message;
+
+    notificationController.show({ message: errorMessage, type: NotificationType.Error });
+
+    return errorMessage;
   } catch (error) {
     console.error(error);
+    return message;
   }
 }


### PR DESCRIPTION
Replaces the previous "[object XMLHttpRequestProgressEvent]" error with a translated value of "Unable to upload file".

Fixes #8356

![image](https://github.com/user-attachments/assets/90e31b53-8de9-4889-b199-e684968cabbf)
