### PR TITLE
fix(server): handle invalid directory item

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -520,6 +520,16 @@ describe(MetadataService.name, () => {
       );
     });
 
+    it('should handle an invalid Directory Item', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      metadataMock.readTags.mockResolvedValue({
+        MotionPhoto: 1,
+        ContainerDirectory: [{ Foo: 100 }],
+      });
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.image.id })).resolves.toBe(JobStatus.SUCCESS);
+    });
+
     it('should extract the correct video orientation', async () => {
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       mediaMock.probe.mockResolvedValue(probeStub.videoStreamVertical2160p);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -428,7 +428,7 @@ export class MetadataService {
 
     if (isMotionPhoto && directory) {
       for (const entry of directory) {
-        if (entry.Item.Semantic == 'MotionPhoto') {
+        if (entry?.Item?.Semantic == 'MotionPhoto') {
           length = entry.Item.Length ?? 0;
           padding = entry.Item.Padding ?? 0;
           break;


### PR DESCRIPTION
Fixes #8969 by safely accessing `Directory.Item.Semantic`