### PR TITLE
feat(server): default exclusion patterns

### DIFF
--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -83,7 +83,7 @@ describe('/libraries', () => {
           refreshedAt: null,
           assetCount: 0,
           importPaths: [],
-          exclusionPatterns: [],
+          exclusionPatterns: expect.any(Array),
         }),
       );
     });
@@ -270,7 +270,7 @@ describe('/libraries', () => {
           refreshedAt: null,
           assetCount: 0,
           importPaths: [],
-          exclusionPatterns: [],
+          exclusionPatterns: expect.any(Array),
         }),
       );
     });

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -892,7 +892,7 @@ describe(LibraryService.name, () => {
           expect.objectContaining({
             name: expect.any(String),
             importPaths: [],
-            exclusionPatterns: [],
+            exclusionPatterns: expect.any(Array),
           }),
         );
       });
@@ -917,7 +917,7 @@ describe(LibraryService.name, () => {
           expect.objectContaining({
             name: 'My Awesome Library',
             importPaths: [],
-            exclusionPatterns: [],
+            exclusionPatterns: expect.any(Array),
           }),
         );
       });
@@ -947,7 +947,7 @@ describe(LibraryService.name, () => {
           expect.objectContaining({
             name: expect.any(String),
             importPaths: ['/data/images', '/data/videos'],
-            exclusionPatterns: [],
+            exclusionPatterns: expect.any(Array),
           }),
         );
       });

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -241,11 +241,18 @@ export class LibraryService {
   }
 
   async create(dto: CreateLibraryDto): Promise<LibraryResponseDto> {
+    let exclusionPatterns = dto.exclusionPatterns;
+
+    if (!exclusionPatterns) {
+      // Add some useful default exclusion patterns
+      exclusionPatterns = ['**/@eaDir/**', '**/._*'];
+    }
+
     const library = await this.repository.create({
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: dto.exclusionPatterns ?? [],
+      exclusionPatterns: exclusionPatterns,
     });
     return mapLibrary(library);
   }

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -241,18 +241,11 @@ export class LibraryService {
   }
 
   async create(dto: CreateLibraryDto): Promise<LibraryResponseDto> {
-    let exclusionPatterns = dto.exclusionPatterns;
-
-    if (!exclusionPatterns) {
-      // Add some useful default exclusion patterns
-      exclusionPatterns = ['**/@eaDir/**', '**/._*'];
-    }
-
     const library = await this.repository.create({
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: exclusionPatterns,
+      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*'],
     });
     return mapLibrary(library);
   }


### PR DESCRIPTION
So many people are asking how to exclude the synology directory (the @eaDir thing) from external libraries. This PR adds that exclusion pattern as well as all files beginning with "._". New external libraries will be created with those patterns by default.
