### PR TITLE
fix(web): remove unnecessary divider in External Library settings

### DIFF
--- a/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
@@ -29,40 +29,27 @@
 
 <div>
   <div in:fade={{ duration: 500 }}>
-    <SettingAccordion
-      key="library-watching"
-      title={$t('admin.library_watching_settings')}
-      subtitle={$t('admin.library_watching_settings_description')}
-      isOpen
-    >
-      <form autocomplete="off" on:submit|preventDefault>
-        <div class="ml-4 mt-4 flex flex-col gap-4">
+    <form autocomplete="off" on:submit|preventDefault>
+      <div class="ml-4 mt-4 flex flex-col gap-4">
+        <SettingAccordion
+          key="library-watching"
+          title={$t('admin.library_watching_settings')}
+          subtitle={$t('admin.library_watching_settings_description')}
+          isOpen
+        >
           <SettingSwitch
             title={$t('admin.library_watching_enable_description')}
             {disabled}
             bind:checked={config.library.watch.enabled}
           />
-        </div>
+        </SettingAccordion>
 
-        <div class="ml-4">
-          <SettingButtonsRow
-            onReset={(options) => onReset({ ...options, configKeys: ['library'] })}
-            onSave={() => onSave({ library: config.library })}
-            showResetToDefault={!isEqual(savedConfig.library, defaultConfig.library)}
-            {disabled}
-          />
-        </div>
-      </form>
-    </SettingAccordion>
-
-    <SettingAccordion
-      key="library-scanning"
-      title={$t('admin.library_scanning')}
-      subtitle={$t('admin.library_scanning_description')}
-      isOpen
-    >
-      <form autocomplete="off" on:submit|preventDefault>
-        <div class="ml-4 mt-4 flex flex-col gap-4">
+        <SettingAccordion
+          key="library-scanning"
+          title={$t('admin.library_scanning')}
+          subtitle={$t('admin.library_scanning_description')}
+          isOpen
+        >
           <SettingSwitch
             title={$t('admin.library_scanning_enable_description')}
             {disabled}
@@ -107,17 +94,15 @@
               </p>
             </svelte:fragment>
           </SettingInputField>
-        </div>
+        </SettingAccordion>
 
-        <div class="ml-4">
-          <SettingButtonsRow
-            onReset={(options) => onReset({ ...options, configKeys: ['library'] })}
-            onSave={() => onSave({ library: config.library })}
-            showResetToDefault={!isEqual(savedConfig.library, defaultConfig.library)}
-            {disabled}
-          />
-        </div>
-      </form>
-    </SettingAccordion>
+        <SettingButtonsRow
+          onReset={(options) => onReset({ ...options, configKeys: ['library'] })}
+          onSave={() => onSave({ library: config.library })}
+          showResetToDefault={!isEqual(savedConfig.library, defaultConfig.library)}
+          {disabled}
+        />
+      </div>
+    </form>
   </div>
 </div>

--- a/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/library-settings/library-settings.svelte
@@ -37,11 +37,13 @@
           subtitle={$t('admin.library_watching_settings_description')}
           isOpen
         >
-          <SettingSwitch
-            title={$t('admin.library_watching_enable_description')}
-            {disabled}
-            bind:checked={config.library.watch.enabled}
-          />
+          <div class="ml-4 mt-4 flex flex-col gap-4">
+            <SettingSwitch
+              title={$t('admin.library_watching_enable_description')}
+              {disabled}
+              bind:checked={config.library.watch.enabled}
+            />
+          </div>
         </SettingAccordion>
 
         <SettingAccordion
@@ -50,50 +52,52 @@
           subtitle={$t('admin.library_scanning_description')}
           isOpen
         >
-          <SettingSwitch
-            title={$t('admin.library_scanning_enable_description')}
-            {disabled}
-            bind:checked={config.library.scan.enabled}
-          />
+          <div class="ml-4 mt-4 flex flex-col gap-4">
+            <SettingSwitch
+              title={$t('admin.library_scanning_enable_description')}
+              {disabled}
+              bind:checked={config.library.scan.enabled}
+            />
 
-          <div class="flex flex-col my-2 dark:text-immich-dark-fg">
-            <label
-              class="font-medium text-immich-primary dark:text-immich-dark-primary text-sm"
-              for="expression-select"
-            >
-              {$t('admin.library_cron_expression_presets')}
-            </label>
-            <select
-              class="p-2 mt-2 text-sm rounded-lg bg-slate-200 hover:cursor-pointer dark:bg-gray-600"
+            <div class="flex flex-col my-2 dark:text-immich-dark-fg">
+              <label
+                class="font-medium text-immich-primary dark:text-immich-dark-primary text-sm"
+                for="expression-select"
+              >
+                {$t('admin.library_cron_expression_presets')}
+              </label>
+              <select
+                class="p-2 mt-2 text-sm rounded-lg bg-slate-200 hover:cursor-pointer dark:bg-gray-600"
+                disabled={disabled || !config.library.scan.enabled}
+                name="expression"
+                id="expression-select"
+                bind:value={config.library.scan.cronExpression}
+              >
+                {#each cronExpressionOptions as { title, expression }}
+                  <option value={expression}>{title}</option>
+                {/each}
+              </select>
+            </div>
+
+            <SettingInputField
+              inputType={SettingInputFieldType.TEXT}
+              required={true}
               disabled={disabled || !config.library.scan.enabled}
-              name="expression"
-              id="expression-select"
+              label={$t('admin.library_cron_expression')}
               bind:value={config.library.scan.cronExpression}
+              isEdited={config.library.scan.cronExpression !== savedConfig.library.scan.cronExpression}
             >
-              {#each cronExpressionOptions as { title, expression }}
-                <option value={expression}>{title}</option>
-              {/each}
-            </select>
+              <svelte:fragment slot="desc">
+                <p class="text-sm dark:text-immich-dark-fg">
+                  <FormatMessage key="admin.library_cron_expression_description" let:message>
+                    <a href="https://crontab.guru" class="underline" target="_blank" rel="noreferrer">
+                      {message}
+                    </a>
+                  </FormatMessage>
+                </p>
+              </svelte:fragment>
+            </SettingInputField>
           </div>
-
-          <SettingInputField
-            inputType={SettingInputFieldType.TEXT}
-            required={true}
-            disabled={disabled || !config.library.scan.enabled}
-            label={$t('admin.library_cron_expression')}
-            bind:value={config.library.scan.cronExpression}
-            isEdited={config.library.scan.cronExpression !== savedConfig.library.scan.cronExpression}
-          >
-            <svelte:fragment slot="desc">
-              <p class="text-sm dark:text-immich-dark-fg">
-                <FormatMessage key="admin.library_cron_expression_description" let:message>
-                  <a href="https://crontab.guru" class="underline" target="_blank" rel="noreferrer">
-                    {message}
-                  </a>
-                </FormatMessage>
-              </p>
-            </svelte:fragment>
-          </SettingInputField>
         </SettingAccordion>
 
         <SettingButtonsRow


### PR DESCRIPTION
Fixes #12458

There was removed unnecessary divider in External Library Settings by refactoring this page.

Before:
![image](https://github.com/user-attachments/assets/79456448-ce41-4b55-98bf-376764a30e67)

After:
![image](https://github.com/user-attachments/assets/d1e9061b-8513-4b52-a9ee-cb0eebe3c2f3)
