### PR TITLE
docs: proper value of word-based suggestions setting to setup VSCode

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -106,7 +106,7 @@ in User `settings.json` (`cmd + shift + p` and search for `Open User Settings JS
     "editor.suggest.snippetsPreventQuickSuggestions": false,
     "editor.suggestSelection": "first",
     "editor.tabCompletion": "onlySnippets",
-    "editor.wordBasedSuggestions": false,
+    "editor.wordBasedSuggestions": "off",
     "editor.defaultFormatter": "Dart-Code.dart-code"
   }
 }


### PR DESCRIPTION
Update code snippet with proper setting value according to modern VSCode requirements. Now this option accepts the only following values: `off`, `currentDocument`, `matchingDocuments` and `allDocuments`.