### PR TITLE
chore(ml): downgrade to cuda 12.2

### DIFF
--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -38,7 +38,7 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 
 - The GPU must have compute capability 5.2 or greater.
 - The server must have the official NVIDIA driver installed.
-- The installed driver must be >= 545 (it must support CUDA 12.3.2).
+- The installed driver must be >= 535 (it must support CUDA 12.2).
 - On Linux (except for WSL2), you also need to have [NVIDIA Container Toolkit][nvct] installed.
 
 #### OpenVINO

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -49,7 +49,12 @@ RUN apt-get update && \
     apt-get remove wget -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04@sha256:fa44193567d1908f7ca1f3abf8623ce9c63bc8cba7bcfdb32702eb04d326f7a8 AS prod-cuda
+FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04@sha256:94c1577b2cd9dd6c0312dc04dff9cb2fdce2b268018abc3d7c2dbcacf1155000 AS prod-cuda
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -yqq libcudnn9-cuda-12 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder-cuda /usr/local/bin/python3 /usr/local/bin/python3
 COPY --from=builder-cuda /usr/local/lib/python3.11 /usr/local/lib/python3.11


### PR DESCRIPTION
## Description

This lowers the minimum nvidia driver requirement back down to 535.

## How Has This Been Tested?

Tested that 535 segfaults on main, but works with this image.