### PR TITLE
chore(ml): remove deprecated kwarg when downloading models

### DIFF
--- a/machine-learning/app/models/base.py
+++ b/machine-learning/app/models/base.py
@@ -71,7 +71,6 @@ class InferenceModel(ABC):
             f"immich-app/{clean_name(self.model_name)}",
             cache_dir=self.cache_dir,
             local_dir=self.cache_dir,
-            local_dir_use_symlinks=False,
             ignore_patterns=ignore_patterns,
         )
 

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -124,7 +124,6 @@ class TestBase:
             "immich-app/ViT-B-32__openai",
             cache_dir=encoder.cache_dir,
             local_dir=encoder.cache_dir,
-            local_dir_use_symlinks=False,
             ignore_patterns=["*.armnn"],
         )
 
@@ -136,7 +135,6 @@ class TestBase:
             "immich-app/ViT-B-32__openai",
             cache_dir=encoder.cache_dir,
             local_dir=encoder.cache_dir,
-            local_dir_use_symlinks=False,
             ignore_patterns=[],
         )
 


### PR DESCRIPTION
## Description

The `local_dir_use_symlinks` kwarg was deprecated and has no effect anymore. This PR removes the kwarg to avoid the warning about it.

## How Has This Been Tested?

Tested that there's no warning about this flag being deprecated when a model is being downloaded.