### PR TITLE
fix(server): include partner assets in random endpoint

### DIFF
--- a/server/src/interfaces/asset.interface.ts
+++ b/server/src/interfaces/asset.interface.ts
@@ -175,7 +175,7 @@ export interface IAssetRepository {
     libraryId?: string,
     withDeleted?: boolean,
   ): Paginated<AssetEntity>;
-  getRandom(userId: string, count: number): Promise<AssetEntity[]>;
+  getRandom(userIds: string[], count: number): Promise<AssetEntity[]>;
   getFirstAssetForAlbumId(albumId: string): Promise<AssetEntity | null>;
   getLastUpdatedAssetForAlbumId(albumId: string): Promise<AssetEntity | null>;
   getExternalLibraryAssetPaths(pagination: PaginationOptions, libraryId: string): Paginated<AssetPathEntity>;

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -623,14 +623,9 @@ export class AssetRepository implements IAssetRepository {
     return result;
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, DummyValue.NUMBER] })
-  getRandom(ownerId: string, count: number): Promise<AssetEntity[]> {
-    const builder = this.getBuilder({
-      userIds: [ownerId],
-      exifInfo: true,
-    });
-
-    return builder.orderBy('RANDOM()').limit(count).getMany();
+  @GenerateSql({ params: [[DummyValue.UUID], DummyValue.NUMBER] })
+  getRandom(userIds: string[], count: number): Promise<AssetEntity[]> {
+    return this.getBuilder({ userIds, exifInfo: true }).orderBy('RANDOM()').limit(count).getMany();
   }
 
   @GenerateSql({ params: [{ size: TimeBucketSize.MONTH }] })

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -98,7 +98,12 @@ export class AssetService {
   }
 
   async getRandom(auth: AuthDto, count: number): Promise<AssetResponseDto[]> {
-    const assets = await this.assetRepository.getRandom(auth.user.id, count);
+    const partnerIds = await getMyPartnerIds({
+      userId: auth.user.id,
+      repository: this.partnerRepository,
+      timelineEnabled: true,
+    });
+    const assets = await this.assetRepository.getRandom([auth.user.id, ...partnerIds], count);
     return assets.map((a) => mapAsset(a, { auth }));
   }
 


### PR DESCRIPTION
Fixes #8293 by including partners assets (if timeline=true) in the `/asset/random` endpoint.