### PR TITLE
fix(server): increase person search limit

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -215,19 +215,14 @@ SELECT
   "person"."isHidden" AS "person_isHidden"
 FROM
   "person" "person"
-  LEFT JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
 WHERE
   "person"."ownerId" = $1
   AND (
     LOWER("person"."name") LIKE $2
     OR LOWER("person"."name") LIKE $3
   )
-GROUP BY
-  "person"."id"
-ORDER BY
-  COUNT("face"."assetId") DESC
 LIMIT
-  20
+  1000
 
 -- PersonRepository.getDistinctNames
 SELECT DISTINCT

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -184,14 +184,11 @@ export class PersonRepository implements IPersonRepository {
   getByName(userId: string, personName: string, { withHidden }: PersonNameSearchOptions): Promise<PersonEntity[]> {
     const queryBuilder = this.personRepository
       .createQueryBuilder('person')
-      .leftJoin('person.faces', 'face')
       .where(
         'person.ownerId = :userId AND (LOWER(person.name) LIKE :nameStart OR LOWER(person.name) LIKE :nameAnywhere)',
         { userId, nameStart: `${personName.toLowerCase()}%`, nameAnywhere: `% ${personName.toLowerCase()}%` },
       )
-      .groupBy('person.id')
-      .orderBy('COUNT(face.assetId)', 'DESC')
-      .limit(20);
+      .limit(1000);
 
     if (!withHidden) {
       queryBuilder.andWhere('person.isHidden = false');

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -94,7 +94,7 @@ export enum ActionQueryParameterValue {
   MERGE = 'merge',
 }
 
-export const maximumLengthSearchPeople: number = 20;
+export const maximumLengthSearchPeople = 1000;
 
 // time to load the map before displaying the loading spinner
 export const timeToLoadTheMap: number = 100;


### PR DESCRIPTION
Increase the person search results from 20 to 500. In the future we can look at making this endpoint paginated if needed.

Fixes #8822