### PR TITLE
docs: add hint for healthcheck.start_interval

### DIFF
--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -80,6 +80,10 @@ The Compose file './docker-compose.yml' is invalid because:
 See the previous paragraph about installing from the official docker repository.
 :::
 
+:::info Healthcheck start_interval
+If you get an error `can't set healthcheck.start_interval as feature require Docker Engine v25 or later`, it helps to comment out the line for `start_interval` in the PostgreSQL section of the `docker-compose.yml` file.
+:::
+
 :::tip
 For more information on how to use the application, please refer to the [Post Installation](/docs/install/post-install.mdx) guide.
 :::

--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -80,8 +80,8 @@ The Compose file './docker-compose.yml' is invalid because:
 See the previous paragraph about installing from the official docker repository.
 :::
 
-:::info Healthcheck start_interval
-If you get an error `can't set healthcheck.start_interval as feature require Docker Engine v25 or later`, it helps to comment out the line for `start_interval` in the PostgreSQL section of the `docker-compose.yml` file.
+:::info Health check start interval
+If you get an error `can't set healthcheck.start_interval as feature require Docker Engine v25 or later`, it helps to comment out the line for `start_interval` in the `database` section of the `docker-compose.yml` file.
 :::
 
 :::tip


### PR DESCRIPTION
Add a hint to comment out the `healthcheck.start_interval` setting when running with (rootless) Podman and Docker compose.

(https://github.com/immich-app/immich/discussions/12638)