### PR TITLE
fix(server): prefer explicit timezone over GPS based guess

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -608,12 +608,10 @@ export class MetadataService {
     }
 
     // timezone
-    let timeZone = exifTags.tz ?? null;
-    if (timeZone == null && dateTime?.rawValue?.endsWith('+00:00')) {
-      // exiftool-vendored returns "no timezone" information even though "+00:00" might be set explicitly
-      // https://github.com/photostructure/exiftool-vendored.js/issues/203
-      timeZone = 'UTC+0';
-    }
+    // exiftool-vendored returns "no timezone" information or one derived from GPS coordinates even though "+00:00"
+    // might be set explicitly
+    // https://github.com/photostructure/exiftool-vendored.js/issues/203
+    const timeZone = dateTime?.rawValue?.endsWith('+00:00') ? 'UTC+0' : (exifTags.tz ?? null);
 
     if (timeZone) {
       this.logger.debug(`Asset ${asset.id} timezone is ${timeZone} (via ${exifTags.tzSource})`);


### PR DESCRIPTION
exiftool-vendored sadly treats the offset +00:00 (used in several countries) as unknown and may return a timezone which is based on GPS coordinates. Because of this, when one manually fixes the timezone offset to +00:00, this fix is overwritten. With this fix, we explicitly prefer +00:00 (if set).

To test: Have an asset with GPS coordinates that exiftool-vendored maps to a timezone (you can check the `exif` database table, column `timeZone`). For this asset, manually change the date to use an offset of +00:00 (e.g. `Atlantic/Reykjavik`). The XMP files correctly includes +00:00. Without this fix, the database still contains the old (wrong?) timezone. With this fix, the timezone is `UTC+0`.