### PR TITLE
refactor(mobile): album api repository for album service

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -53,7 +53,7 @@ custom_lint:
         # required / wanted
         - 'lib/repositories/{album,asset,file}_media.repository.dart'
         # acceptable exceptions for the time being
-        # - lib/entities/asset.entity.dart # to provide local AssetEntity for now
+        - lib/entities/asset.entity.dart # to provide local AssetEntity for now
         - lib/providers/image/immich_local_{image,thumbnail}_provider.dart # accesses thumbnails via PhotoManager
         # refactor to make the providers and services testable
         - lib/providers/backup/{backup,manual_upload}.provider.dart # uses only PMProgressHandler
@@ -77,7 +77,7 @@ custom_lint:
         - lib/pages/search/search_input.page.dart
         - lib/providers/asset_viewer/asset_people.provider.dart
         - lib/providers/authentication.provider.dart
-        # - lib/providers/image/immich_remote_{image,thumbnail}_provider.dart
+        - lib/providers/image/immich_remote_{image,thumbnail}_provider.dart
         - lib/providers/map/map_state.provider.dart
         - lib/providers/search/{people,search,search_filter}.provider.dart
         - lib/providers/websocket.provider.dart

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -46,21 +46,46 @@ custom_lint:
     - avoid_public_notifier_properties: false
     - avoid_manual_providers_as_generated_provider_dependency: false
     - unsupported_provider_value: false
-    - photo_manager:
-      exclude:
+    - import_rule_photo_manager:
+      message: photo_manager must only be used in MediaRepositories
+      restrict: package:photo_manager
+      allowed:
         # required / wanted
-        - album_media.repository.dart
-        - asset_media.repository.dart
-        - file_media.repository.dart
-          # acceptable exceptions for the time being
-        - asset.entity.dart # to provide local AssetEntity for now
-        - immich_local_image_provider.dart # accesses thumbnails via PhotoManager
-        - immich_local_thumbnail_provider.dart # accesses thumbnails via PhotoManager
-          # refactor to make the providers and services testable
-        - backup.provider.dart # uses only PMProgressHandler
-        - manual_upload.provider.dart # uses only PMProgressHandler
-        - background.service.dart # uses only PMProgressHandler
-        - backup.service.dart # uses only PMProgressHandler
+        - 'lib/repositories/{album,asset,file}_media.repository.dart'
+        # acceptable exceptions for the time being
+        # - lib/entities/asset.entity.dart # to provide local AssetEntity for now
+        - lib/providers/image/immich_local_{image,thumbnail}_provider.dart # accesses thumbnails via PhotoManager
+        # refactor to make the providers and services testable
+        - lib/providers/backup/{backup,manual_upload}.provider.dart # uses only PMProgressHandler
+        - lib/services/{background,backup}.service.dart # uses only PMProgressHandler
+    - import_rule_openapi:
+      message: openapi must only be used through ApiRepositories
+      restrict: package:openapi
+      allowed:
+        # requried / wanted
+        - lib/repositories/album_api.repository.dart
+        # acceptable exceptions for the time being
+        - lib/entities/{album,asset,exif_info,user}.entity.dart # to convert DTOs to entities
+        - lib/utils/{image_url_builder,openapi_patching}.dart # utils are fine
+        - test/modules/utils/openapi_patching_test.dart # filename is self-explanatory...
+        # refactor
+        - lib/models/activities/activity.model.dart
+        - lib/models/map/map_marker.model.dart
+        - lib/models/search/search_filter.model.dart
+        - lib/models/server_info/server_{config,disk_info,features,version}.model.dart
+        - lib/models/shared_link/shared_link.model.dart
+        - lib/pages/search/search_input.page.dart
+        - lib/providers/asset_viewer/asset_people.provider.dart
+        - lib/providers/authentication.provider.dart
+        # - lib/providers/image/immich_remote_{image,thumbnail}_provider.dart
+        - lib/providers/map/map_state.provider.dart
+        - lib/providers/search/{people,search,search_filter}.provider.dart
+        - lib/providers/websocket.provider.dart
+        - lib/routing/auth_guard.dart
+        - lib/services/{activity,api,asset,asset_description,backup,memory,oauth,partner,person,search,shared_link,stack,trash,user}.service.dart
+        - lib/widgets/album/album_thumbnail_listtile.dart
+        - lib/widgets/forms/login/login_form.dart
+        - lib/widgets/search/search_filter/{camera_picker,location_picker,people_picker}.dart
 
 dart_code_metrics:
   metrics:

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -64,6 +64,7 @@ class ImportRule extends DartLintRule {
     CustomLintContext context,
   ) {
     if (_rootOffset == -1) {
+      print(resolver.path);
       _rootOffset = resolver.path.indexOf("/mobile/lib/") + 8;
     }
     final path = resolver.path.substring(_rootOffset);

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -1,36 +1,61 @@
-import 'dart:collection';
-
 import 'package:analyzer/error/listener.dart';
 import 'package:analyzer/error/error.dart' show ErrorSeverity;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+// ignore: depend_on_referenced_packages
+import 'package:glob/glob.dart';
 
 PluginBase createPlugin() => ImmichLinter();
 
 class ImmichLinter extends PluginBase {
   @override
-  List<LintRule> getLintRules(CustomLintConfigs configs) => [
-        PhotoManagerRule(configs.rules[PhotoManagerRule._code.name]),
-      ];
-}
-
-class PhotoManagerRule extends DartLintRule {
-  PhotoManagerRule(LintOptions? options) : super(code: _code) {
-    final excludeOption = options?.json["exclude"];
-    if (excludeOption is String) {
-      _excludePaths.add(excludeOption);
-    } else if (excludeOption is List) {
-      _excludePaths.addAll(excludeOption.map((option) => option));
+  List<LintRule> getLintRules(CustomLintConfigs configs) {
+    final List<LintRule> rules = [];
+    for (final entry in configs.rules.entries) {
+      if (entry.value.enabled && entry.key.startsWith("import_rule_")) {
+        final code = makeCode(entry.key, entry.value);
+        final allowedPaths = getStrings(entry.value, "allowed");
+        final forbiddenPaths = getStrings(entry.value, "forbidden");
+        final restrict = getStrings(entry.value, "restrict");
+        rules.add(ImportRule(code, buildGlob(allowedPaths),
+            buildGlob(forbiddenPaths), restrict));
+      }
     }
+    return rules;
   }
 
-  final Set<String> _excludePaths = HashSet();
+  static makeCode(String name, LintOptions options) => LintCode(
+        name: name,
+        problemMessage: options.json["message"] as String,
+        errorSeverity: ErrorSeverity.WARNING,
+      );
 
-  static const _code = LintCode(
-    name: 'photo_manager',
-    problemMessage:
-        'photo_manager library must only be used in MediaRepository',
-    errorSeverity: ErrorSeverity.WARNING,
-  );
+  static List<String> getStrings(LintOptions options, String field) {
+    final List<String> result = [];
+    final excludeOption = options.json[field];
+    if (excludeOption is String) {
+      result.add(excludeOption);
+    } else if (excludeOption is List) {
+      result.addAll(excludeOption.map((option) => option));
+    }
+    return result;
+  }
+
+  Glob? buildGlob(List<String> globs) {
+    if (globs.isEmpty) return null;
+    if (globs.length == 1) return Glob(globs[0], caseSensitive: true);
+    return Glob("{${globs.join(",")}}", caseSensitive: true);
+  }
+}
+
+// ignore: must_be_immutable
+class ImportRule extends DartLintRule {
+  ImportRule(LintCode code, this._allowed, this._forbidden, this._restrict)
+      : super(code: code);
+
+  final Glob? _allowed;
+  final Glob? _forbidden;
+  final List<String> _restrict;
+  int _rootOffset = -1;
 
   @override
   void run(
@@ -38,11 +63,22 @@ class PhotoManagerRule extends DartLintRule {
     ErrorReporter reporter,
     CustomLintContext context,
   ) {
-    if (_excludePaths.contains(resolver.source.shortName)) return;
+    if (_rootOffset == -1) {
+      _rootOffset = resolver.path.indexOf("/mobile/lib/") + 8;
+    }
+    final path = resolver.path.substring(_rootOffset);
+
+    if ((_allowed != null && _allowed!.matches(path)) &&
+        (_forbidden == null || !_forbidden!.matches(path))) return;
 
     context.registry.addImportDirective((node) {
-      if (node.uri.stringValue?.startsWith("package:photo_manager") == true) {
-        reporter.atNode(node, code);
+      final uri = node.uri.stringValue;
+      if (uri == null) return;
+      for (final restricted in _restrict) {
+        if (uri.startsWith(restricted) == true) {
+          reporter.atNode(node, code);
+          return;
+        }
       }
     });
   }

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -64,8 +64,8 @@ class ImportRule extends DartLintRule {
     CustomLintContext context,
   ) {
     if (_rootOffset == -1) {
-      print(resolver.path);
-      _rootOffset = resolver.path.indexOf("/mobile/lib/") + 8;
+      const project = "/immich/mobile/";
+      _rootOffset = resolver.path.indexOf(project) + project.length;
     }
     final path = resolver.path.substring(_rootOffset);
 

--- a/mobile/immich_lint/pubspec.lock
+++ b/mobile/immich_lint/pubspec.lock
@@ -159,7 +159,7 @@ packages:
     source: hosted
     version: "2.4.4"
   glob:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: glob
       sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"

--- a/mobile/immich_lint/pubspec.yaml
+++ b/mobile/immich_lint/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   analyzer: ^6.8.0
   analyzer_plugin: ^0.11.3
   custom_lint_builder: ^0.6.4
+  glob: ^2.1.2
 
 dev_dependencies:
   lints: ^4.0.0

--- a/mobile/lib/interfaces/album_api.interface.dart
+++ b/mobile/lib/interfaces/album_api.interface.dart
@@ -1,0 +1,40 @@
+import 'package:immich_mobile/entities/album.entity.dart';
+
+abstract interface class IAlbumApiRepository {
+  Future<Album> get(String id);
+
+  Future<List<Album>> getAll({bool? shared});
+
+  Future<Album> create(
+    String name, {
+    required Iterable<String> assetIds,
+    Iterable<String> sharedUserIds = const [],
+  });
+
+  Future<({List<String> added, List<String> duplicates})> addAssets(
+    String albumId,
+    Iterable<String> assetIds,
+  );
+
+  Future<({List<String> removed, List<String> failed})> removeAssets(
+    String albumId,
+    Iterable<String> assetIds,
+  );
+
+  Future<Album> addUsers(
+    String albumId,
+    Iterable<String> userIds,
+  );
+
+  Future<void> removeUser(String albumId, {required String userId});
+
+  Future<Album> update(
+    String albumId, {
+    String? name,
+    String? thumbnailAssetId,
+    String? description,
+    bool? activityEnabled,
+  });
+
+  Future<void> delete(String albumId);
+}

--- a/mobile/lib/interfaces/album_api.interface.dart
+++ b/mobile/lib/interfaces/album_api.interface.dart
@@ -11,6 +11,16 @@ abstract interface class IAlbumApiRepository {
     Iterable<String> sharedUserIds = const [],
   });
 
+  Future<Album> update(
+    String albumId, {
+    String? name,
+    String? thumbnailAssetId,
+    String? description,
+    bool? activityEnabled,
+  });
+
+  Future<void> delete(String albumId);
+
   Future<({List<String> added, List<String> duplicates})> addAssets(
     String albumId,
     Iterable<String> assetIds,
@@ -27,14 +37,4 @@ abstract interface class IAlbumApiRepository {
   );
 
   Future<void> removeUser(String albumId, {required String userId});
-
-  Future<Album> update(
-    String albumId, {
-    String? name,
-    String? thumbnailAssetId,
-    String? description,
-    bool? activityEnabled,
-  });
-
-  Future<void> delete(String albumId);
 }

--- a/mobile/lib/interfaces/asset.interface.dart
+++ b/mobile/lib/interfaces/asset.interface.dart
@@ -3,6 +3,8 @@ import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/entities/user.entity.dart';
 
 abstract interface class IAssetRepository {
+  Future<Asset?> getByRemoteId(String id);
+  Future<List<Asset>> getAllByRemoteId(Iterable<String> ids);
   Future<List<Asset>> getByAlbum(Album album, {User? notOwnedBy});
   Future<void> deleteById(List<int> ids);
 }

--- a/mobile/lib/interfaces/user.interface.dart
+++ b/mobile/lib/interfaces/user.interface.dart
@@ -2,4 +2,5 @@ import 'package:immich_mobile/entities/user.entity.dart';
 
 abstract interface class IUserRepository {
   Future<List<User>> getByIds(List<String> ids);
+  Future<User?> get(String id);
 }

--- a/mobile/lib/repositories/album_api.repository.dart
+++ b/mobile/lib/repositories/album_api.repository.dart
@@ -1,0 +1,172 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/errors.dart';
+import 'package:immich_mobile/entities/album.entity.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/entities/user.entity.dart';
+import 'package:immich_mobile/interfaces/album_api.interface.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:openapi/api.dart';
+
+final albumApiRepositoryProvider = Provider(
+  (ref) => AlbumApiRepository(ref.watch(apiServiceProvider).albumsApi),
+);
+
+class AlbumApiRepository implements IAlbumApiRepository {
+  final AlbumsApi _api;
+
+  AlbumApiRepository(this._api);
+
+  @override
+  Future<Album> get(String id) async {
+    final dto = await _checkNull(_api.getAlbumInfo(id));
+    return _toAlbum(dto);
+  }
+
+  @override
+  Future<List<Album>> getAll({bool? shared}) async {
+    final dtos = await _checkNull(_api.getAllAlbums(shared: shared));
+    return dtos.map(_toAlbum).toList().cast();
+  }
+
+  @override
+  Future<Album> create(
+    String name, {
+    required Iterable<String> assetIds,
+    Iterable<String> sharedUserIds = const [],
+  }) async {
+    final users = sharedUserIds.map(
+      (id) => AlbumUserCreateDto(userId: id, role: AlbumUserRole.editor),
+    );
+    final responseDto = await _checkNull(
+      _api.createAlbum(
+        CreateAlbumDto(
+          albumName: name,
+          assetIds: assetIds.toList(),
+          albumUsers: users.toList(),
+        ),
+      ),
+    );
+    return _toAlbum(responseDto);
+  }
+
+  @override
+  Future<({List<String> added, List<String> duplicates})> addAssets(
+    String albumId,
+    Iterable<String> assetIds,
+  ) async {
+    final response = await _checkNull(
+      _api.addAssetsToAlbum(
+        albumId,
+        BulkIdsDto(ids: assetIds.toList()),
+      ),
+    );
+
+    final List<String> added = [];
+    final List<String> duplicates = [];
+
+    for (final result in response) {
+      if (result.success) {
+        added.add(result.id);
+      } else if (result.error == BulkIdResponseDtoErrorEnum.duplicate) {
+        duplicates.add(result.id);
+      }
+    }
+    return (added: added, duplicates: duplicates);
+  }
+
+  @override
+  Future<({List<String> removed, List<String> failed})> removeAssets(
+    String albumId,
+    Iterable<String> assetIds,
+  ) async {
+    final response = await _checkNull(
+      _api.removeAssetFromAlbum(
+        albumId,
+        BulkIdsDto(ids: assetIds.toList()),
+      ),
+    );
+    final List<String> removed = [], failed = [];
+    for (final dto in response) {
+      if (dto.success) {
+        removed.add(dto.id);
+      } else {
+        failed.add(dto.id);
+      }
+    }
+    return (removed: removed, failed: failed);
+  }
+
+  @override
+  Future<Album> addUsers(String albumId, Iterable<String> userIds) async {
+    final albumUsers =
+        userIds.map((userId) => AlbumUserAddDto(userId: userId)).toList();
+    final response = await _checkNull(
+      _api.addUsersToAlbum(
+        albumId,
+        AddUsersDto(albumUsers: albumUsers),
+      ),
+    );
+    return _toAlbum(response);
+  }
+
+  @override
+  Future<void> removeUser(String albumId, {required String userId}) {
+    return _api.removeUserFromAlbum(albumId, userId);
+  }
+
+  @override
+  Future<Album> update(
+    String albumId, {
+    String? name,
+    String? thumbnailAssetId,
+    String? description,
+    bool? activityEnabled,
+  }) async {
+    final response = await _checkNull(
+      _api.updateAlbumInfo(
+        albumId,
+        UpdateAlbumDto(
+          albumName: name,
+          albumThumbnailAssetId: thumbnailAssetId,
+          description: description,
+          isActivityEnabled: activityEnabled,
+        ),
+      ),
+    );
+    return _toAlbum(response);
+  }
+
+  @override
+  Future<void> delete(String albumId) {
+    return _api.deleteAlbum(albumId);
+  }
+
+  static Future<T> _checkNull<T>(Future<T?> future) async {
+    final response = await future;
+    if (response == null) throw NoResponseDtoError();
+    return response;
+  }
+
+  static Album _toAlbum(AlbumResponseDto dto) {
+    final Album album = Album(
+      remoteId: dto.id,
+      name: dto.albumName,
+      createdAt: dto.createdAt,
+      modifiedAt: dto.updatedAt,
+      lastModifiedAssetTimestamp: dto.lastModifiedAssetTimestamp,
+      shared: dto.shared,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+      activityEnabled: dto.isActivityEnabled,
+    );
+    album.remoteAssetCount = dto.assetCount;
+    album.owner.value = User.fromSimpleUserDto(dto.owner);
+    album.remoteThumbnailAssetId = dto.albumThumbnailAssetId;
+    final users = dto.albumUsers
+        .map((albumUser) => User.fromSimpleUserDto(albumUser.user));
+    album.sharedUsers.addAll(users);
+    final assets = dto.assets.map(Asset.remote).toList();
+    album.assets.addAll(assets);
+    return album;
+  }
+}

--- a/mobile/lib/repositories/album_api.repository.dart
+++ b/mobile/lib/repositories/album_api.repository.dart
@@ -50,6 +50,33 @@ class AlbumApiRepository implements IAlbumApiRepository {
   }
 
   @override
+  Future<Album> update(
+    String albumId, {
+    String? name,
+    String? thumbnailAssetId,
+    String? description,
+    bool? activityEnabled,
+  }) async {
+    final response = await _checkNull(
+      _api.updateAlbumInfo(
+        albumId,
+        UpdateAlbumDto(
+          albumName: name,
+          albumThumbnailAssetId: thumbnailAssetId,
+          description: description,
+          isActivityEnabled: activityEnabled,
+        ),
+      ),
+    );
+    return _toAlbum(response);
+  }
+
+  @override
+  Future<void> delete(String albumId) {
+    return _api.deleteAlbum(albumId);
+  }
+
+  @override
   Future<({List<String> added, List<String> duplicates})> addAssets(
     String albumId,
     Iterable<String> assetIds,
@@ -112,33 +139,6 @@ class AlbumApiRepository implements IAlbumApiRepository {
   @override
   Future<void> removeUser(String albumId, {required String userId}) {
     return _api.removeUserFromAlbum(albumId, userId);
-  }
-
-  @override
-  Future<Album> update(
-    String albumId, {
-    String? name,
-    String? thumbnailAssetId,
-    String? description,
-    bool? activityEnabled,
-  }) async {
-    final response = await _checkNull(
-      _api.updateAlbumInfo(
-        albumId,
-        UpdateAlbumDto(
-          albumName: name,
-          albumThumbnailAssetId: thumbnailAssetId,
-          description: description,
-          isActivityEnabled: activityEnabled,
-        ),
-      ),
-    );
-    return _toAlbum(response);
-  }
-
-  @override
-  Future<void> delete(String albumId) {
-    return _api.deleteAlbum(albumId);
   }
 
   static Future<T> _checkNull<T>(Future<T?> future) async {

--- a/mobile/lib/repositories/asset.repository.dart
+++ b/mobile/lib/repositories/asset.repository.dart
@@ -28,4 +28,11 @@ class AssetRepository implements IAssetRepository {
   @override
   Future<void> deleteById(List<int> ids) =>
       _db.writeTxn(() => _db.assets.deleteAll(ids));
+
+  @override
+  Future<Asset?> getByRemoteId(String id) => _db.assets.getByRemoteId(id);
+
+  @override
+  Future<List<Asset>> getAllByRemoteId(Iterable<String> ids) =>
+      _db.assets.getAllByRemoteId(ids);
 }

--- a/mobile/lib/repositories/user.repository.dart
+++ b/mobile/lib/repositories/user.repository.dart
@@ -17,4 +17,7 @@ class UserRepository implements IUserRepository {
   @override
   Future<List<User>> getByIds(List<String> ids) async =>
       (await _db.users.getAllById(ids)).cast();
+
+  @override
+  Future<User?> get(String id) => _db.users.getById(id);
 }

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -13,12 +13,14 @@ import 'package:immich_mobile/main.dart';
 import 'package:immich_mobile/models/backup/backup_candidate.model.dart';
 import 'package:immich_mobile/models/backup/success_upload_asset.model.dart';
 import 'package:immich_mobile/repositories/album.repository.dart';
+import 'package:immich_mobile/repositories/album_api.repository.dart';
 import 'package:immich_mobile/repositories/asset.repository.dart';
 import 'package:immich_mobile/repositories/backup.repository.dart';
 import 'package:immich_mobile/repositories/album_media.repository.dart';
 import 'package:immich_mobile/repositories/file_media.repository.dart';
 import 'package:immich_mobile/repositories/user.repository.dart';
 import 'package:immich_mobile/services/album.service.dart';
+import 'package:immich_mobile/services/entity.service.dart';
 import 'package:immich_mobile/services/hash.service.dart';
 import 'package:immich_mobile/services/localization.service.dart';
 import 'package:immich_mobile/entities/backup_album.entity.dart';
@@ -363,23 +365,33 @@ class BackgroundService {
     PartnerService partnerService = PartnerService(apiService, db);
     AlbumRepository albumRepository = AlbumRepository(db);
     AssetRepository assetRepository = AssetRepository(db);
-    UserRepository userRepository = UserRepository(db);
     BackupRepository backupAlbumRepository = BackupRepository(db);
     AlbumMediaRepository albumMediaRepository = AlbumMediaRepository();
     FileMediaRepository fileMediaRepository = FileMediaRepository();
+    UserRepository userRepository = UserRepository(db);
+    AlbumApiRepository albumApiRepository =
+        AlbumApiRepository(apiService.albumsApi);
     HashService hashService = HashService(db, this, albumMediaRepository);
-    SyncService syncSerive = SyncService(db, hashService, albumMediaRepository);
+    EntityService entityService =
+        EntityService(assetRepository, userRepository);
+    SyncService syncSerive = SyncService(
+      db,
+      hashService,
+      entityService,
+      albumMediaRepository,
+      albumApiRepository,
+    );
     UserService userService =
         UserService(apiService, db, syncSerive, partnerService);
     AlbumService albumService = AlbumService(
-      apiService,
       userService,
       syncSerive,
+      entityService,
       albumRepository,
       assetRepository,
-      userRepository,
       backupAlbumRepository,
       albumMediaRepository,
+      albumApiRepository,
     );
     BackupService backupService = BackupService(
       apiService,

--- a/mobile/lib/services/entity.service.dart
+++ b/mobile/lib/services/entity.service.dart
@@ -1,0 +1,52 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/album.entity.dart';
+import 'package:immich_mobile/interfaces/asset.interface.dart';
+import 'package:immich_mobile/interfaces/user.interface.dart';
+import 'package:immich_mobile/repositories/asset.repository.dart';
+import 'package:immich_mobile/repositories/user.repository.dart';
+
+class EntityService {
+  final IAssetRepository _assetRepository;
+  final IUserRepository _userRepository;
+  EntityService(
+    this._assetRepository,
+    this._userRepository,
+  );
+
+  Future<Album> fillAlbumWithDatabaseEntities(Album album) async {
+    final ownerId = album.ownerId;
+    if (ownerId != null) {
+      // replace owner with user from database
+      album.owner.value = await _userRepository.get(ownerId);
+    }
+    final thumbnailAssetId =
+        album.remoteThumbnailAssetId ?? album.thumbnail.value?.remoteId;
+    if (thumbnailAssetId != null) {
+      // set thumbnail with asset from database
+      album.thumbnail.value =
+          await _assetRepository.getByRemoteId(thumbnailAssetId);
+    }
+    if (album.remoteUsers.isNotEmpty) {
+      // replace all users with users from database
+      final users = await _userRepository
+          .getByIds(album.remoteUsers.map((user) => user.id).toList());
+      album.sharedUsers.clear();
+      album.sharedUsers.addAll(users);
+    }
+    if (album.remoteAssets.isNotEmpty) {
+      // replace all assets with assets from database
+      final assets = await _assetRepository
+          .getAllByRemoteId(album.remoteAssets.map((asset) => asset.remoteId!));
+      album.assets.clear();
+      album.assets.addAll(assets);
+    }
+    return album;
+  }
+}
+
+final entityServiceProvider = Provider(
+  (ref) => EntityService(
+    ref.watch(assetRepositoryProvider),
+    ref.watch(userRepositoryProvider),
+  ),
+);

--- a/mobile/test/modules/shared/sync_service_test.dart
+++ b/mobile/test/modules/shared/sync_service_test.dart
@@ -39,8 +39,10 @@ void main() {
   group('Test SyncService grouped', () {
     late final Isar db;
     final MockHashService hs = MockHashService();
+    final MockEntityService entityService = MockEntityService();
     final MockAlbumMediaRepository albumMediaRepository =
         MockAlbumMediaRepository();
+    final MockAlbumApiRepository albumApiRepository = MockAlbumApiRepository();
     final owner = User(
       id: "1",
       updatedAt: DateTime.now(),
@@ -48,6 +50,7 @@ void main() {
       name: "first last",
       isAdmin: false,
     );
+    late SyncService s;
     setUpAll(() async {
       WidgetsFlutterBinding.ensureInitialized();
       db = await TestUtils.initIsar();
@@ -68,9 +71,15 @@ void main() {
         db.assets.clearSync();
         db.assets.putAllSync(initialAssets);
       });
+      s = SyncService(
+        db,
+        hs,
+        entityService,
+        albumMediaRepository,
+        albumApiRepository,
+      );
     });
     test('test inserting existing assets', () async {
-      SyncService s = SyncService(db, hs, albumMediaRepository);
       final List<Asset> remoteAssets = [
         makeAsset(checksum: "a", remoteId: "0-1"),
         makeAsset(checksum: "b", remoteId: "2-1"),
@@ -88,7 +97,6 @@ void main() {
     });
 
     test('test inserting new assets', () async {
-      SyncService s = SyncService(db, hs, albumMediaRepository);
       final List<Asset> remoteAssets = [
         makeAsset(checksum: "a", remoteId: "0-1"),
         makeAsset(checksum: "b", remoteId: "2-1"),
@@ -109,7 +117,6 @@ void main() {
     });
 
     test('test syncing duplicate assets', () async {
-      SyncService s = SyncService(db, hs, albumMediaRepository);
       final List<Asset> remoteAssets = [
         makeAsset(checksum: "a", remoteId: "0-1"),
         makeAsset(checksum: "b", remoteId: "1-1"),
@@ -157,7 +164,6 @@ void main() {
     });
 
     test('test efficient sync', () async {
-      SyncService s = SyncService(db, hs, albumMediaRepository);
       final List<Asset> toUpsert = [
         makeAsset(checksum: "a", remoteId: "0-1"), // changed
         makeAsset(checksum: "f", remoteId: "0-2"), // new

--- a/mobile/test/repository.mocks.dart
+++ b/mobile/test/repository.mocks.dart
@@ -1,4 +1,5 @@
 import 'package:immich_mobile/interfaces/album.interface.dart';
+import 'package:immich_mobile/interfaces/album_api.interface.dart';
 import 'package:immich_mobile/interfaces/album_media.interface.dart';
 import 'package:immich_mobile/interfaces/asset.interface.dart';
 import 'package:immich_mobile/interfaces/asset_media.interface.dart';
@@ -20,3 +21,5 @@ class MockAlbumMediaRepository extends Mock implements IAlbumMediaRepository {}
 class MockAssetMediaRepository extends Mock implements IAssetMediaRepository {}
 
 class MockFileMediaRepository extends Mock implements IFileMediaRepository {}
+
+class MockAlbumApiRepository extends Mock implements IAlbumApiRepository {}

--- a/mobile/test/service.mocks.dart
+++ b/mobile/test/service.mocks.dart
@@ -1,4 +1,5 @@
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/entity.service.dart';
 import 'package:immich_mobile/services/hash.service.dart';
 import 'package:immich_mobile/services/sync.service.dart';
 import 'package:immich_mobile/services/user.service.dart';
@@ -11,3 +12,5 @@ class MockUserService extends Mock implements UserService {}
 class MockSyncService extends Mock implements SyncService {}
 
 class MockHashService extends Mock implements HashService {}
+
+class MockEntityService extends Mock implements EntityService {}

--- a/mobile/test/services/album.service_test.dart
+++ b/mobile/test/services/album.service_test.dart
@@ -8,34 +8,34 @@ import '../service.mocks.dart';
 
 void main() {
   late AlbumService sut;
-  late MockApiService apiService;
   late MockUserService userService;
   late MockSyncService syncService;
+  late MockEntityService entityService;
   late MockAlbumRepository albumRepository;
   late MockAssetRepository assetRepository;
-  late MockUserRepository userRepository;
   late MockBackupRepository backupRepository;
   late MockAlbumMediaRepository albumMediaRepository;
+  late MockAlbumApiRepository albumApiRepository;
 
   setUp(() {
-    apiService = MockApiService();
     userService = MockUserService();
     syncService = MockSyncService();
+    entityService = MockEntityService();
     albumRepository = MockAlbumRepository();
     assetRepository = MockAssetRepository();
-    userRepository = MockUserRepository();
     backupRepository = MockBackupRepository();
     albumMediaRepository = MockAlbumMediaRepository();
+    albumApiRepository = MockAlbumApiRepository();
 
     sut = AlbumService(
-      apiService,
       userService,
       syncService,
+      entityService,
       albumRepository,
       assetRepository,
-      userRepository,
       backupRepository,
       albumMediaRepository,
+      albumApiRepository,
     );
   });
 

--- a/mobile/test/services/album.service_test.dart
+++ b/mobile/test/services/album.service_test.dart
@@ -77,9 +77,12 @@ void main() {
       when(() => userService.refreshUsers()).thenAnswer((_) async => true);
       when(() => albumApiRepository.getAll(shared: null))
           .thenAnswer((_) async => [AlbumStub.oneAsset, AlbumStub.twoAsset]);
-      when(() => syncService.syncRemoteAlbumsToDb(
-              [AlbumStub.oneAsset, AlbumStub.twoAsset], isShared: false))
-          .thenAnswer((_) async => true);
+      when(
+        () => syncService.syncRemoteAlbumsToDb(
+          [AlbumStub.oneAsset, AlbumStub.twoAsset],
+          isShared: false,
+        ),
+      ).thenAnswer((_) async => true);
       final result = await sut.refreshRemoteAlbums(isShared: false);
       expect(result, true);
       verify(() => userService.refreshUsers()).called(1);

--- a/mobile/test/services/album.service_test.dart
+++ b/mobile/test/services/album.service_test.dart
@@ -3,6 +3,8 @@ import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/services/album.service.dart';
 import 'package:mocktail/mocktail.dart';
 import '../fixtures/album.stub.dart';
+import '../fixtures/asset.stub.dart';
+import '../fixtures/user.stub.dart';
 import '../repository.mocks.dart';
 import '../service.mocks.dart';
 
@@ -68,6 +70,124 @@ void main() {
         () => syncService.syncLocalAlbumAssetsToDb([AlbumStub.oneAsset], null),
       ).called(1);
       verifyNoMoreInteractions(syncService);
+    });
+  });
+  group('refreshRemoteAlbums', () {
+    test('isShared: false', () async {
+      when(() => userService.refreshUsers()).thenAnswer((_) async => true);
+      when(() => albumApiRepository.getAll(shared: null))
+          .thenAnswer((_) async => [AlbumStub.oneAsset, AlbumStub.twoAsset]);
+      when(() => syncService.syncRemoteAlbumsToDb(
+              [AlbumStub.oneAsset, AlbumStub.twoAsset], isShared: false))
+          .thenAnswer((_) async => true);
+      final result = await sut.refreshRemoteAlbums(isShared: false);
+      expect(result, true);
+      verify(() => userService.refreshUsers()).called(1);
+      verify(() => albumApiRepository.getAll(shared: null)).called(1);
+      verify(
+        () => syncService.syncRemoteAlbumsToDb(
+          [AlbumStub.oneAsset, AlbumStub.twoAsset],
+          isShared: false,
+        ),
+      ).called(1);
+      verifyNoMoreInteractions(userService);
+      verifyNoMoreInteractions(albumApiRepository);
+      verifyNoMoreInteractions(syncService);
+    });
+  });
+
+  group('createAlbum', () {
+    test('shared with assets', () async {
+      when(
+        () => albumApiRepository.create(
+          "name",
+          assetIds: any(named: "assetIds"),
+          sharedUserIds: any(named: "sharedUserIds"),
+        ),
+      ).thenAnswer((_) async => AlbumStub.oneAsset);
+
+      when(
+        () => entityService.fillAlbumWithDatabaseEntities(AlbumStub.oneAsset),
+      ).thenAnswer((_) async => AlbumStub.oneAsset);
+
+      when(
+        () => albumRepository.create(AlbumStub.oneAsset),
+      ).thenAnswer((_) async => AlbumStub.twoAsset);
+
+      final result =
+          await sut.createAlbum("name", [AssetStub.image1], [UserStub.user1]);
+      expect(result, AlbumStub.twoAsset);
+      verify(
+        () => albumApiRepository.create(
+          "name",
+          assetIds: [AssetStub.image1.remoteId!],
+          sharedUserIds: [UserStub.user1.id],
+        ),
+      ).called(1);
+      verify(
+        () => entityService.fillAlbumWithDatabaseEntities(AlbumStub.oneAsset),
+      ).called(1);
+    });
+  });
+
+  group('addAdditionalAssetToAlbum', () {
+    test('one added, one duplicate', () async {
+      when(
+        () => albumApiRepository.addAssets(AlbumStub.oneAsset.remoteId!, any()),
+      ).thenAnswer(
+        (_) async => (
+          added: [AssetStub.image2.remoteId!],
+          duplicates: [AssetStub.image1.remoteId!]
+        ),
+      );
+      when(
+        () => albumRepository.getById(AlbumStub.oneAsset.id),
+      ).thenAnswer((_) async => AlbumStub.oneAsset);
+      when(
+        () => albumRepository.addAssets(AlbumStub.oneAsset, [AssetStub.image2]),
+      ).thenAnswer((_) async {});
+      when(
+        () => albumRepository.removeAssets(AlbumStub.oneAsset, []),
+      ).thenAnswer((_) async {});
+      when(
+        () => albumRepository.recalculateMetadata(AlbumStub.oneAsset),
+      ).thenAnswer((_) async => AlbumStub.oneAsset);
+      when(
+        () => albumRepository.update(AlbumStub.oneAsset),
+      ).thenAnswer((_) async => AlbumStub.oneAsset);
+
+      final result = await sut.addAdditionalAssetToAlbum(
+        [AssetStub.image1, AssetStub.image2],
+        AlbumStub.oneAsset,
+      );
+
+      expect(result != null, true);
+      expect(result!.alreadyInAlbum, [AssetStub.image1.remoteId!]);
+      expect(result.successfullyAdded, 1);
+    });
+  });
+
+  group('addAdditionalUserToAlbum', () {
+    test('one added', () async {
+      when(
+        () =>
+            albumApiRepository.addUsers(AlbumStub.emptyAlbum.remoteId!, any()),
+      ).thenAnswer(
+        (_) async => AlbumStub.sharedWithUser,
+      );
+      when(
+        () => entityService
+            .fillAlbumWithDatabaseEntities(AlbumStub.sharedWithUser),
+      ).thenAnswer((_) async => AlbumStub.sharedWithUser);
+      when(
+        () => albumRepository.update(AlbumStub.sharedWithUser),
+      ).thenAnswer((_) async => AlbumStub.sharedWithUser);
+
+      final result = await sut.addAdditionalUserToAlbum(
+        [UserStub.user2.id],
+        AlbumStub.emptyAlbum,
+      );
+      expect(result, true);
     });
   });
 }

--- a/mobile/test/services/entity.service_test.dart
+++ b/mobile/test/services/entity.service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/entities/album.entity.dart';
+import 'package:immich_mobile/services/entity.service.dart';
+import 'package:mocktail/mocktail.dart';
+import '../fixtures/asset.stub.dart';
+import '../fixtures/user.stub.dart';
+import '../repository.mocks.dart';
+
+void main() {
+  late EntityService sut;
+  late MockAssetRepository assetRepository;
+  late MockUserRepository userRepository;
+
+  setUp(() {
+    assetRepository = MockAssetRepository();
+    userRepository = MockUserRepository();
+    sut = EntityService(assetRepository, userRepository);
+  });
+
+  group('fillAlbumWithDatabaseEntities', () {
+    test('remote album with owner, thumbnail, sharedUsers and assets',
+        () async {
+      final Album album = Album(
+        name: "album-with-two-assets-and-two-users",
+        localId: "album-with-two-assets-and-two-users-local",
+        remoteId: "album-with-two-assets-and-two-users-remote",
+        createdAt: DateTime(2001),
+        modifiedAt: DateTime(2010),
+        shared: true,
+        activityEnabled: true,
+        startDate: DateTime(2019),
+        endDate: DateTime(2020),
+      )
+        ..remoteThumbnailAssetId = AssetStub.image1.remoteId
+        ..assets.addAll([AssetStub.image1, AssetStub.image1])
+        ..owner.value = UserStub.user1
+        ..sharedUsers.addAll([UserStub.admin, UserStub.admin]);
+
+      when(() => userRepository.get(album.ownerId!))
+          .thenAnswer((_) async => UserStub.admin);
+
+      when(() => assetRepository.getByRemoteId(AssetStub.image1.remoteId!))
+          .thenAnswer((_) async => AssetStub.image1);
+
+      when(() => userRepository.getByIds(any()))
+          .thenAnswer((_) async => [UserStub.user1, UserStub.user2]);
+
+      when(() => assetRepository.getAllByRemoteId(any()))
+          .thenAnswer((_) async => [AssetStub.image1, AssetStub.image2]);
+
+      await sut.fillAlbumWithDatabaseEntities(album);
+      expect(album.owner.value, UserStub.admin);
+      expect(album.thumbnail.value, AssetStub.image1);
+      expect(album.remoteUsers.toSet(), {UserStub.user1, UserStub.user2});
+      expect(album.remoteAssets.toSet(), {AssetStub.image1, AssetStub.image2});
+    });
+
+    test('remote album without any info', () async {
+      makeEmptyAlbum() => Album(
+            name: "album-without-info",
+            localId: "album-without-info-local",
+            remoteId: "album-without-info-remote",
+            createdAt: DateTime(2001),
+            modifiedAt: DateTime(2010),
+            shared: false,
+            activityEnabled: false,
+          );
+
+      final album = makeEmptyAlbum();
+      await sut.fillAlbumWithDatabaseEntities(album);
+      verifyNoMoreInteractions(assetRepository);
+      verifyNoMoreInteractions(userRepository);
+      expect(album, makeEmptyAlbum());
+    });
+  });
+}


### PR DESCRIPTION
- This PR adds a new repository to perform action with the Album API.
- The `AlbumApiRepository` is used in the AlbumService that no longer depends on OpenAPI! :-)
- replaces usage of `AlbumResponseDto` throughout AlbumService and SyncService with `Album` (needed a few nasty tricks to get there, sadly)
- finally add some unit tests for AlbumService methods (now that API access can me easily mocked)
- new linting checking openapi usage (limit to all files still using it as of this PR)