### PR TITLE
chore(web): remove stray dateTimeOriginal reference

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -315,7 +315,7 @@
           </div>
         {/if}
       </button>
-    {:else if !asset.exifInfo?.dateTimeOriginal && isOwner}
+    {:else if !dateTime && isOwner}
       <div class="flex justify-between place-items-start gap-4 py-4">
         <div class="flex gap-4">
           <div>


### PR DESCRIPTION
Basically:
- `asset.fileCreatedAt` should only ever be used for sorting within a bucket
- `dateTimeOriginal` should only be used for displaying in the detail view when there is a timezone, and we can probably deduce this from `localDateTime` itself in the future
- `localDateTime` should be used for everything else 