### PR TITLE
docs: add section for Traefik Reverse Proxy

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -80,9 +80,8 @@ entryPoints:
     # this section needs to be added
     transport:
       respondingTimeouts:
-        readTimeout: 600s
-        writeTimeout: 600s
-        idleTimeout: 600s
+        readTimeout: 0
+        idleTimeout: 0
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -69,9 +69,10 @@ Below is an example config for Apache2 site configuration.
 
 The example below is for Traefik version 3.
 
-The most important is to increase the `respondingTimeouts` of the entrypoint used by immich. In this example of entrypoint `websecure` for port `443`. Per default it's set to 60s which leeds to videos stop uploading after 1 minute (Error Code 499). With this config it will fail after 10 minutes which is in most cases enough. Increase it if needed. 
+The most important is to increase the `respondingTimeouts` of the entrypoint used by immich. In this example of entrypoint `websecure` for port `443`. Per default it's set to 60s which leeds to videos stop uploading after 1 minute (Error Code 499). With this config it will fail after 10 minutes which is in most cases enough. Increase it if needed.
 
 `traefik.yaml`
+
 ```yaml
 [...]
 entryPoints:
@@ -88,6 +89,7 @@ entryPoints:
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.
 
 `docker-compose.yml`
+
 ```yaml
 services:
   immich-server:
@@ -95,10 +97,10 @@ services:
     labels:
       traefik.enable: true
       # increase readingTimeouts for the entrypoint used here
-      traefik.http.routers.immich.entrypoints: websecure  
+      traefik.http.routers.immich.entrypoints: websecure
       traefik.http.routers.immich.rule: Host(`immich.your-domain.com`)
       traefik.http.services.immich.loadbalancer.server.port: 3001
 ```
 
 Keep in mind, that Traefik needs to communicate with the network where immich is in, usually done
-by adding the Traefik network to the `immich-server`. 
+by adding the Traefik network to the `immich-server`.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -82,7 +82,7 @@ entryPoints:
       respondingTimeouts:
         readTimeout: 600s
         idleTimeout: 600s
-        writeTimeout: 600s 
+        writeTimeout: 600s
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -69,7 +69,7 @@ Below is an example config for Apache2 site configuration.
 
 The example below is for Traefik version 3.
 
-The most important is to increase the `respondingTimeouts` of the entrypoint used by immich. In this example of entrypoint `websecure` for port `443`. Per default it's set to 60s which leeds to videos stop uploading after 1 minute (Error Code 499). In the example it's set to 10 minutes. Hence video-uploads will fail after 10 minutes instead of one.
+The most important is to increase the `respondingTimeouts` of the entrypoint used by immich. In this example of entrypoint `websecure` for port `443`. Per default it's set to 60s which leeds to videos stop uploading after 1 minute (Error Code 499). With this config it will fail after 10 minutes which is in most cases enough. Increase it if needed. 
 
 `traefik.yaml`
 ```yaml
@@ -80,8 +80,9 @@ entryPoints:
     # this section needs to be added
     transport:
       respondingTimeouts:
-        readTimeout: 0
-        idleTimeout: 0
+        readTimeout: 600s
+        idleTimeout: 600s
+        writeTImeout: 0
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -82,7 +82,7 @@ entryPoints:
       respondingTimeouts:
         readTimeout: 600s
         idleTimeout: 600s
-        writeTImeout: 0
+        writeTimeout: 600s 
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -77,14 +77,6 @@ The most important is to increase the `respondingTimeouts` of the entrypoint use
 entryPoints:
   websecure:
     address: :443
-    AsDefault: true
-    http:
-      tls:
-        certresolver: cloudflare-resolver
-        domains:
-          - main: "*.domain.com"
-            sans: 
-              - "domain.com"
     # this section needs to be added
     transport:
       respondingTimeouts:
@@ -95,32 +87,19 @@ entryPoints:
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add your external network, where traefik is in, inside the `networks` section and add all the traefik labels like in the example.
+Also adding a default network is required now. It needs to be added to every immich container.
 
 `docker-compose.yml`
 ```yaml
 [...]
 services:
   immich-server:
-    container_name: immich_server
-    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
-    volumes:
-      - ${UPLOAD_LOCATION}:/usr/src/app/upload
-      - /etc/localtime:/etc/localtime:ro
-    env_file:
-      - .env
-    ports:
-      - 2283:3001
+    [...]
     networks:
       # this is the network where traefik is in
       - proxy
-      # this is the network where all other immich containers are in
+      # network for all immich containers
       - default
-    depends_on:
-      - redis
-      - database
-    restart: always
-    healthcheck:
-      disable: false
     labels:
       traefik.enable: true
       # increase readingTimeouts for the entrypoint used here

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -83,33 +83,22 @@ entryPoints:
         readTimeout: 600s
         writeTimeout: 600s
         idleTimeout: 600s
-[...]
 ```
 
-The second part is in the `docker-compose.yml` file where immich is in. Add your external network, where traefik is in, inside the `networks` section and add all the traefik labels like in the example.
-Also adding a default network is required now. It needs to be added to every immich container.
+The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.
 
 `docker-compose.yml`
 ```yaml
-[...]
 services:
   immich-server:
     [...]
-    networks:
-      # this is the network where traefik is in
-      - proxy
-      # network for all immich containers
-      - default
     labels:
       traefik.enable: true
       # increase readingTimeouts for the entrypoint used here
       traefik.http.routers.immich.entrypoints: websecure  
       traefik.http.routers.immich.rule: Host(`immich.your-domain.com`)
       traefik.http.services.immich.loadbalancer.server.port: 3001
-[...]
-
-# add the external network where traefik is in
-networks:
-  proxy:
-    external: true 
 ```
+
+Keep in mind, that Traefik needs to communicate with the network where immich is in, usually done
+by adding the Traefik network to the `immich-server`. 


### PR DESCRIPTION
This adds a section for an example Traefik Proxy config. This is needed because the readingTimeouts leed to video-uploads failing after 60 seconds uploading. See [here](https://github.com/immich-app/immich/discussions/12564) for more information. In the example the issue is "resolved" by increasing the default timeout to 600 seconds instead of 60 seconds.