### PR TITLE
docs: Switch github link with actual post

### DIFF
--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -46,7 +46,7 @@ const guides: CommunityGuidesProps[] = [
   {
     title: 'Nginx caching map server',
     description: 'Increase privacy by using nginx as a caching proxy in front of a map tile server',
-    url: 'https://github.com/pcouy/pcouy.github.io/blob/main/_posts/2024-08-30-proxying-a-map-tile-server-for-increased-privacy.md',
+    url: 'https://pierre-couy.dev/server-admin/2024/08/proxying-a-map-tile-server-for-increased-privacy.html',
   },
 ];
 


### PR DESCRIPTION
changelog:
swap out github link with actual blogpost

I thought it was a little strange reading the template of this guide instead of the actual webpage, so I propose to switch the links.
Feel free to disagree. :-)