### PR TITLE
fix(mobile): fix uncaught error in getting file cause hashing procses to be aborted entirely

### DIFF
--- a/mobile/lib/services/hash.service.dart
+++ b/mobile/lib/services/hash.service.dart
@@ -65,7 +65,13 @@ class HashService {
       if (hashes[i] != null) {
         continue;
       }
-      final file = await assets[i].local!.originFile;
+
+      File? file;
+
+      try {
+        file = await assets[i].local!.originFile;
+      } catch (_) {}
+
       if (file == null) {
         final fileName = assets[i].fileName;
 

--- a/mobile/lib/services/hash.service.dart
+++ b/mobile/lib/services/hash.service.dart
@@ -70,7 +70,13 @@ class HashService {
 
       try {
         file = await assets[i].local!.originFile;
-      } catch (_) {}
+      } catch (error, stackTrace) {
+        _log.warning(
+          "Error getting file to hash for asset ${assets[i].localId}, name: ${assets[i].fileName}, created on: ${assets[i].fileCreatedAt}, skipping",
+          error,
+          stackTrace,
+        );
+      }
 
       if (file == null) {
         final fileName = assets[i].fileName;


### PR DESCRIPTION
On iOS, some local files might be from the Shared Albums of iOS, which is known to be visible from the phone but actually they could be moved or removed, thus an error is throw when we are trying to read the file content.


### Relevant log

```
2024-09-15 13:35:55.672267 | SEVERE   | ImmichErrorLogger    | PlatformDispatcher - Catch all | PlatformException(Error Domain=PHPhotosErrorDomain Code=-1 "(null)", null, null, null) |
#0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:648)
#1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:334)
<asynchronous suspension>
#2      AssetEntity._getFile (package:photo_manager/src/types/entity.dart:735)
<asynchronous suspension>
#3      HashService._hashAssets (package:immich_mobile/services/hash.service.dart:57)
<asynchronous suspension>
#4      SyncService._addAlbumFromDevice (package:immich_mobile/services/sync.service.dart:687)
<asynchronous suspension>
#5      diffSortedLists (package:immich_mobile/utils/diff.dart:30)
<asynchronous suspension>
#6      SyncService._syncLocalAlbumAssetsToDb (package:immich_mobile/services/sync.service.dart:504)
<asynchronous suspension>
#7      AlbumService.refreshDeviceAlbums (package:immich_mobile/services/album.service.dart:121)
<asynchronous suspension>
#8      Future.wait.<anonymous closure> (dart:async/future.dart:534)
<asynchronous suspension>
``` 