### PR TITLE
fix(server): gracefully handle unknown jobs

### DIFF
--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -186,11 +186,16 @@ export class JobService {
       this.jobRepository.addHandler(queueName, concurrency, async (item: JobItem): Promise<void> => {
         const { name, data } = item;
 
+        const handler = jobHandlers[name];
+        if (!handler) {
+          this.logger.warn(`Skipping unknown job: "${name}"`);
+          return;
+        }
+
         const queueMetric = `immich.queues.${snakeCase(queueName)}.active`;
         this.metricRepository.jobs.addToGauge(queueMetric, 1);
 
         try {
-          const handler = jobHandlers[name];
           const status = await handler(data);
           const jobMetric = `immich.jobs.${name.replaceAll('-', '_')}.${status}`;
           this.metricRepository.jobs.addToCounter(jobMetric, 1);


### PR DESCRIPTION
Gracefully handle unknown jobs, by verifying there is a valid handler before calling it.

Sometimes there are jobs in redis when Immich is updated. In the case that job names have changed, it leads to errors like:

```
[Nest] 6  - 09/23/2024, 3:51:46 PM   ERROR [Microservices:JobService] Unable to run job handler (backgroundTask/undefined): TypeError: handler is not a function
[Nest] 6  - 09/23/2024, 3:51:46 PM   ERROR [Microservices:JobService] TypeError: handler is not a function
    at /usr/src/app/dist/services/job.service.js:148:42
    at Worker.workerHandler [as processFn] (/usr/src/app/dist/repositories/job.repository.js:90:46)
    at Worker.callProcessJob (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:113:21)
    at Worker.processJob (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:394:39)
    at /usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:202:70
    at Worker.retryIfFailed (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:581:30)
    at Worker.run (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:202:45)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[Nest] 6  - 09/23/2024, 3:51:46 PM   ERROR [Microservices:JobService] Object:
Error: Missing lock for job 28. failed
    at Scripts.finishedErrors (/usr/src/app/node_modules/bullmq/dist/cjs/classes/scripts.js:266:24)
    at Job.moveToFailed (/usr/src/app/node_modules/bullmq/dist/cjs/classes/job.js:427:32)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async handleFailed (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:379:21)
    at async Worker.retryIfFailed (/usr/src/app/node_modules/bullmq/dist/cjs/classes/worker.js:581:24)
    ```