### PR TITLE
fix: remove no longer needed LD_LIBRARY_PATH

### DIFF
--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -51,5 +51,4 @@ services:
     volumes:
       - /usr/lib/wsl:/usr/lib/wsl
     environment:
-      - LD_LIBRARY_PATH=/usr/lib/wsl/lib
       - LIBVA_DRIVER_NAME=d3d12


### PR DESCRIPTION
Fixes #11247 (LD_LIBRARY_PATH already includes wsl in the base image)