### PR TITLE
fix(web): Updated web README.md

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -2,4 +2,4 @@
 
 This project uses the [SvelteKit](https://kit.svelte.dev/) web framework. Please refer to [the SvelteKit docs](https://kit.svelte.dev/docs) for information on getting started as a contributor to this project. In particular, it will help you navigate the project's code if you understand the basics of [SvelteKit routing](https://kit.svelte.dev/docs/routing).
 
-When developing locally, you will run a SvelteKit Node.js server. When this project is deployed to production, it is built as a SPA and deployed as part of [../server](the server project).
+When developing locally, you will run a SvelteKit Node.js server. When this project is deployed to production, it is built as a SPA and deployed as part of [the server project](../server).


### PR DESCRIPTION
`README.md` in the web directory had the markdown link syntax flipped.