### PR TITLE
fix(web): delete non-empty album

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -169,12 +169,13 @@
 
   const handleToggleEnableActivity = async () => {
     try {
-      album = await updateAlbumInfo({
+      await updateAlbumInfo({
         id: album.id,
         updateAlbumDto: {
           isActivityEnabled: !album.isActivityEnabled,
         },
       });
+      await refreshAlbum();
       notificationController.show({
         type: NotificationType.Info,
         message: $t('activity_changed', { values: { enabled: album.isActivityEnabled } }),
@@ -277,7 +278,7 @@
   };
 
   const refreshAlbum = async () => {
-    album = await getAlbumInfo({ id: album.id, withoutAssets: true });
+    data.album = await getAlbumInfo({ id: album.id, withoutAssets: true });
   };
 
   const handleAddAssets = async () => {
@@ -330,12 +331,13 @@
 
   const handleAddUsers = async (albumUsers: AlbumUserAddDto[]) => {
     try {
-      album = await addUsersToAlbum({
+      await addUsersToAlbum({
         id: album.id,
         addUsersDto: {
           albumUsers,
         },
       });
+      await refreshAlbum();
 
       viewMode = ViewMode.VIEW;
     } catch (error) {


### PR DESCRIPTION
Page navigation that causes this component to reload could lead to a situation where a stale `album.assetCount` would be 0, causing an album to be deleted that had assets in it.