### PR TITLE
refactor(server): access env via repository

### DIFF
--- a/server/src/interfaces/config.interface.ts
+++ b/server/src/interfaces/config.interface.ts
@@ -1,0 +1,14 @@
+import { VectorExtension } from 'src/interfaces/database.interface';
+
+export const IConfigRepository = 'IConfigRepository';
+
+export interface EnvData {
+  database: {
+    skipMigrations: boolean;
+    vectorExtension: VectorExtension;
+  };
+}
+
+export interface IConfigRepository {
+  getEnv(): EnvData;
+}

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { getVectorExtension } from 'src/database.config';
+import { EnvData, IConfigRepository } from 'src/interfaces/config.interface';
+
+@Injectable()
+export class ConfigRepository implements IConfigRepository {
+  getEnv(): EnvData {
+    return {
+      database: {
+        skipMigrations: process.env.DB_SKIP_MIGRATIONS === 'true',
+        vectorExtension: getVectorExtension(),
+      },
+    };
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -5,6 +5,7 @@ import { IAlbumRepository } from 'src/interfaces/album.interface';
 import { IKeyRepository } from 'src/interfaces/api-key.interface';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { IAuditRepository } from 'src/interfaces/audit.interface';
+import { IConfigRepository } from 'src/interfaces/config.interface';
 import { ICryptoRepository } from 'src/interfaces/crypto.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';
 import { IEventRepository } from 'src/interfaces/event.interface';
@@ -39,6 +40,7 @@ import { AlbumRepository } from 'src/repositories/album.repository';
 import { ApiKeyRepository } from 'src/repositories/api-key.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { AuditRepository } from 'src/repositories/audit.repository';
+import { ConfigRepository } from 'src/repositories/config.repository';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
 import { EventRepository } from 'src/repositories/event.repository';
@@ -74,6 +76,7 @@ export const repositories = [
   { provide: IAlbumUserRepository, useClass: AlbumUserRepository },
   { provide: IAssetRepository, useClass: AssetRepository },
   { provide: IAuditRepository, useClass: AuditRepository },
+  { provide: IConfigRepository, useClass: ConfigRepository },
   { provide: ICryptoRepository, useClass: CryptoRepository },
   { provide: IDatabaseRepository, useClass: DatabaseRepository },
   { provide: IEventRepository, useClass: EventRepository },

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -1,0 +1,14 @@
+import { IConfigRepository } from 'src/interfaces/config.interface';
+import { DatabaseExtension } from 'src/interfaces/database.interface';
+import { Mocked, vitest } from 'vitest';
+
+export const newConfigRepositoryMock = (): Mocked<IConfigRepository> => {
+  return {
+    getEnv: vitest.fn().mockReturnValue({
+      database: {
+        skipMigration: false,
+        vectorExtension: DatabaseExtension.VECTORS,
+      },
+    }),
+  };
+};


### PR DESCRIPTION
First of several PRs to move `process.env` reads to use a repository, making it easier to test and manage. Eventually the goal is to have all `process.env` references live in a single file, and apply validation via `class-validator`.