### PR TITLE
feat(server): better transcoding logs

### DIFF
--- a/server/src/interfaces/logger.interface.ts
+++ b/server/src/interfaces/logger.interface.ts
@@ -6,6 +6,7 @@ export interface ILoggerRepository {
   setAppName(name: string): void;
   setContext(message: string): void;
   setLogLevel(level: LogLevel): void;
+  isLevelEnabled(level: LogLevel): boolean;
 
   verbose(message: any, ...args: any): void;
   debug(message: any, ...args: any): void;

--- a/server/src/interfaces/media.interface.ts
+++ b/server/src/interfaces/media.interface.ts
@@ -62,6 +62,10 @@ export interface TranscodeCommand {
   inputOptions: string[];
   outputOptions: string[];
   twoPass: boolean;
+  progress: {
+    frameCount: number;
+    percentInterval: number;
+  };
 }
 
 export interface BitrateDistribution {
@@ -79,6 +83,10 @@ export interface VideoCodecHWConfig extends VideoCodecSWConfig {
   getSupportedCodecs(): Array<VideoCodec>;
 }
 
+export interface ProbeOptions {
+  countFrames: boolean;
+}
+
 export interface IMediaRepository {
   // image
   extract(input: string, output: string): Promise<boolean>;
@@ -87,6 +95,6 @@ export interface IMediaRepository {
   getImageDimensions(input: string): Promise<ImageDimensions>;
 
   // video
-  probe(input: string): Promise<VideoInfo>;
+  probe(input: string, options?: ProbeOptions): Promise<VideoInfo>;
   transcode(input: string, output: string | Writable, command: TranscodeCommand): Promise<void>;
 }

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -1,15 +1,16 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { exiftool } from 'exiftool-vendored';
 import ffmpeg, { FfprobeData } from 'fluent-ffmpeg';
+import { Duration } from 'luxon';
 import fs from 'node:fs/promises';
 import { Writable } from 'node:stream';
-import { promisify } from 'node:util';
 import sharp from 'sharp';
-import { Colorspace } from 'src/enum';
+import { Colorspace, LogLevel } from 'src/enum';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import {
   IMediaRepository,
   ImageDimensions,
+  ProbeOptions,
   ThumbnailOptions,
   TranscodeCommand,
   VideoInfo,
@@ -17,9 +18,21 @@ import {
 import { Instrumentation } from 'src/utils/instrumentation';
 import { handlePromiseError } from 'src/utils/misc';
 
-const probe = promisify<string, FfprobeData>(ffmpeg.ffprobe);
+const probe = (input: string, options: string[]): Promise<FfprobeData> =>
+  new Promise((resolve, reject) =>
+    ffmpeg.ffprobe(input, options, (error, data) => (error ? reject(error) : resolve(data))),
+  );
 sharp.concurrency(0);
 sharp.cache({ files: 0 });
+
+type ProgressEvent = {
+  frames: number;
+  currentFps: number;
+  currentKbps: number;
+  targetSize: number;
+  timemark: string;
+  percent?: number;
+};
 
 @Instrumentation()
 @Injectable()
@@ -65,8 +78,8 @@ export class MediaRepository implements IMediaRepository {
       .toFile(output);
   }
 
-  async probe(input: string): Promise<VideoInfo> {
-    const results = await probe(input);
+  async probe(input: string, options?: ProbeOptions): Promise<VideoInfo> {
+    const results = await probe(input, options?.countFrames ? ['-count_packets'] : []); // gets frame count quickly: https://stackoverflow.com/a/28376817
     return {
       format: {
         formatName: results.format.format_name,
@@ -83,10 +96,10 @@ export class MediaRepository implements IMediaRepository {
           width: stream.width || 0,
           codecName: stream.codec_name === 'h265' ? 'hevc' : stream.codec_name,
           codecType: stream.codec_type,
-          frameCount: Number.parseInt(stream.nb_frames ?? '0'),
-          rotation: Number.parseInt(`${stream.rotation ?? 0}`),
+          frameCount: Number.parseInt((options?.countFrames ? stream.nb_read_packets : stream.nb_frames) ?? '0') || 0,
+          rotation: Number.parseInt(`${stream.rotation ?? 0}`) || 0,
           isHDR: stream.color_transfer === 'smpte2084' || stream.color_transfer === 'arib-std-b67',
-          bitrate: Number.parseInt(stream.bit_rate ?? '0'),
+          bitrate: Number.parseInt(stream.bit_rate ?? '0') || 0,
         })),
       audioStreams: results.streams
         .filter((stream) => stream.codec_type === 'audio')
@@ -94,7 +107,7 @@ export class MediaRepository implements IMediaRepository {
           index: stream.index,
           codecType: stream.codec_type,
           codecName: stream.codec_name,
-          frameCount: Number.parseInt(stream.nb_frames ?? '0'),
+          frameCount: Number.parseInt((options?.countFrames ? stream.nb_read_packets : stream.nb_frames) ?? '0') || 0,
         })),
     };
   }
@@ -156,10 +169,29 @@ export class MediaRepository implements IMediaRepository {
   }
 
   private configureFfmpegCall(input: string, output: string | Writable, options: TranscodeCommand) {
+    let lastProgressFrame: number = 0;
+    const { frameCount, percentInterval } = options.progress;
+    const frameInterval = Math.ceil(frameCount / (100 / percentInterval));
+    const isDebug = this.logger.isLevelEnabled(LogLevel.DEBUG);
     return ffmpeg(input, { niceness: 10 })
       .inputOptions(options.inputOptions)
       .outputOptions(options.outputOptions)
       .output(output)
-      .on('error', (error, stdout, stderr) => this.logger.error(stderr || error));
+      .on('start', (command: string) => this.logger.debug(command))
+      .on('error', (error, _, stderr) => this.logger.error(stderr || error))
+      .on('progress', (progress: ProgressEvent) => {
+        if (!isDebug || !frameCount || !frameInterval || progress.frames - lastProgressFrame < frameInterval) {
+          return;
+        }
+
+        lastProgressFrame = progress.frames;
+        const percent = ((progress.frames / frameCount) * 100).toFixed(2);
+        const ms = Math.floor((frameCount - progress.frames) / progress.currentFps) * 1000;
+        const duration = ms ? Duration.fromMillis(ms).rescale().toHuman({ unitDisplay: 'narrow' }) : '';
+        const outputText = output instanceof Writable ? 'stream' : output.split('/').pop();
+        this.logger.debug(
+          `Transcoding ${percent}% done${duration ? `, estimated ${duration} remaining` : ''} for output ${outputText}`,
+        );
+      });
   }
 }

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -349,7 +349,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
-        {
+        expect.objectContaining({
           inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
@@ -359,7 +359,7 @@ describe(MediaService.name, () => {
             String.raw`-vf fps=12:eof_action=pass:round=down,thumbnail=12,select=gt(scene\,0.1)-eq(prev_selected_n\,n)+isnan(prev_selected_n)+gt(n\,20),trim=end_frame=2,reverse,scale=-2:1440:flags=lanczos+accurate_rnd+full_chroma_int:out_color_matrix=601:out_range=pc,format=yuv420p`,
           ],
           twoPass: false,
-        },
+        }),
       );
       expect(assetMock.upsertFile).toHaveBeenCalledWith({
         assetId: 'asset-id',
@@ -377,7 +377,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
-        {
+        expect.objectContaining({
           inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
@@ -387,7 +387,7 @@ describe(MediaService.name, () => {
             String.raw`-vf fps=12:eof_action=pass:round=down,thumbnail=12,select=gt(scene\,0.1)-eq(prev_selected_n\,n)+isnan(prev_selected_n)+gt(n\,20),trim=end_frame=2,reverse,zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=601:m=bt470bg:range=pc,format=yuv420p`,
           ],
           twoPass: false,
-        },
+        }),
       );
       expect(assetMock.upsertFile).toHaveBeenCalledWith({
         assetId: 'asset-id',
@@ -407,7 +407,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
-        {
+        expect.objectContaining({
           inputOptions: ['-skip_frame nointra', '-sws_flags accurate_rnd+full_chroma_int'],
           outputOptions: [
             '-fps_mode vfr',
@@ -417,7 +417,7 @@ describe(MediaService.name, () => {
             String.raw`-vf fps=12:eof_action=pass:round=down,thumbnail=12,select=gt(scene\,0.1)-eq(prev_selected_n\,n)+isnan(prev_selected_n)+gt(n\,20),trim=end_frame=2,reverse,zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=601:m=bt470bg:range=pc,format=yuv420p`,
           ],
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -430,11 +430,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/thumbs/user-id/as/se/asset-id-preview.jpeg',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([expect.stringContaining('scale=-2:1440')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -731,21 +731,22 @@ describe(MediaService.name, () => {
 
     it('should transcode the longest stream', async () => {
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      loggerMock.isLevelEnabled.mockReturnValue(false);
       mediaMock.probe.mockResolvedValue(probeStub.multipleVideoStreams);
 
       await sut.handleVideoConversion({ id: assetStub.video.id });
 
-      expect(mediaMock.probe).toHaveBeenCalledWith('/original/path.ext');
+      expect(mediaMock.probe).toHaveBeenCalledWith('/original/path.ext', { countFrames: false });
       expect(systemMock.get).toHaveBeenCalled();
       expect(storageMock.mkdirSync).toHaveBeenCalled();
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-map 0:0', '-map 0:1']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -771,11 +772,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.any(Array),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -786,11 +787,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.any(Array),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -801,11 +802,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.any(Array),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -816,11 +817,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('scale')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -832,11 +833,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=-2:720/)]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -848,11 +849,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=720:-2/)]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -864,11 +865,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=-2:354/)]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -880,11 +881,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([expect.stringMatching(/scale(_.+)?=354:-2/)]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -898,11 +899,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v copy', '-c:a aac']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -920,11 +921,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining(['-tag:v hvc1']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -942,11 +943,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v copy', '-tag:v hvc1']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -958,11 +959,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v h264', '-c:a copy']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -973,11 +974,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v copy', '-c:a copy']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1036,11 +1037,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v h264', '-maxrate 4500k', '-bufsize 9000k']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1052,11 +1053,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v h264', '-b:v 3104k', '-minrate 1552k', '-maxrate 4500k']),
           twoPass: true,
-        },
+        }),
       );
     });
 
@@ -1068,11 +1069,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v h264', '-c:a copy']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1090,11 +1091,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-b:v 3104k', '-minrate 1552k', '-maxrate 4500k']),
           twoPass: true,
-        },
+        }),
       );
     });
 
@@ -1112,11 +1113,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-maxrate')]),
           twoPass: true,
-        },
+        }),
       );
     });
 
@@ -1128,11 +1129,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-cpu-used 2']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1144,11 +1145,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-cpu-used')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1160,11 +1161,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-threads 2']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1176,11 +1177,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-threads 1', '-x264-params frame-threads=1:pools=none']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1192,11 +1193,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-threads')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1208,11 +1209,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v hevc', '-threads 1', '-x265-params frame-threads=1:pools=none']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1224,11 +1225,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-threads')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1240,7 +1241,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([
             '-c:v av1',
@@ -1255,7 +1256,7 @@ describe(MediaService.name, () => {
             '-crf 23',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1267,11 +1268,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-preset 4']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1283,11 +1284,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-svtav1-params mbr=2M']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1299,11 +1300,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-svtav1-params lp=4']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1315,11 +1316,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-svtav1-params lp=4:mbr=2M']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1361,7 +1362,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.arrayContaining([
             '-tune hq',
@@ -1382,7 +1383,7 @@ describe(MediaService.name, () => {
             '-cq:v 23',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1400,11 +1401,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.arrayContaining([expect.stringContaining('-multipass')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1416,11 +1417,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.arrayContaining(['-cq:v 23', '-maxrate 10000k', '-bufsize 6897k']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1432,11 +1433,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.not.stringContaining('-maxrate'),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1448,11 +1449,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-preset')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1464,11 +1465,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device cuda=cuda:0', '-filter_hw_device cuda']),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-multipass')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1482,7 +1483,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-hwaccel cuda',
             '-hwaccel_output_format cuda',
@@ -1491,7 +1492,7 @@ describe(MediaService.name, () => {
           ]),
           outputOptions: expect.arrayContaining([expect.stringContaining('scale_cuda=-2:720:format=nv12')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1505,7 +1506,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-hwaccel cuda', '-hwaccel_output_format cuda']),
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
@@ -1513,7 +1514,7 @@ describe(MediaService.name, () => {
             ),
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1526,7 +1527,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
           outputOptions: expect.arrayContaining([
             `-c:v h264_qsv`,
@@ -1547,7 +1548,7 @@ describe(MediaService.name, () => {
             '-bufsize 20000k',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1566,14 +1567,14 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device qsv=hw,child_device=/dev/dri/renderD128',
             '-filter_hw_device hw',
           ]),
           outputOptions: expect.any(Array),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1586,11 +1587,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-preset')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1603,11 +1604,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-init_hw_device qsv=hw', '-filter_hw_device hw']),
           outputOptions: expect.arrayContaining(['-low_power 1']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1633,7 +1634,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-hwaccel qsv',
             '-hwaccel_output_format qsv',
@@ -1645,7 +1646,7 @@ describe(MediaService.name, () => {
             expect.stringContaining('scale_qsv=-1:720:async_depth=4:mode=hq:format=nv12'),
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1662,7 +1663,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-hwaccel qsv',
             '-hwaccel_output_format qsv',
@@ -1675,7 +1676,7 @@ describe(MediaService.name, () => {
             ),
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1691,11 +1692,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-hwaccel qsv', '-qsv_device /dev/dri/renderD129']),
           outputOptions: expect.any(Array),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1708,7 +1709,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
@@ -1728,7 +1729,7 @@ describe(MediaService.name, () => {
             '-rc_mode 1',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1741,7 +1742,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
@@ -1754,7 +1755,7 @@ describe(MediaService.name, () => {
             '-rc_mode 3',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1767,7 +1768,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
@@ -1780,7 +1781,7 @@ describe(MediaService.name, () => {
             '-rc_mode 1',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1793,14 +1794,14 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
           ]),
           outputOptions: expect.not.arrayContaining([expect.stringContaining('-compression_level')]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1813,14 +1814,14 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/card1',
             '-filter_hw_device accel',
           ]),
           outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1833,14 +1834,14 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD130',
             '-filter_hw_device accel',
           ]),
           outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1855,14 +1856,14 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-init_hw_device vaapi=accel:/dev/dri/renderD128',
             '-filter_hw_device accel',
           ]),
           outputOptions: expect.arrayContaining([`-c:v h264_vaapi`]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1877,11 +1878,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenLastCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining(['-c:v h264']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1904,7 +1905,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining([
             '-hwaccel rkmpp',
             '-hwaccel_output_format drm_prime',
@@ -1927,7 +1928,7 @@ describe(MediaService.name, () => {
             '-qp_init 23',
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1948,11 +1949,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
           outputOptions: expect.arrayContaining([`-c:v hevc_rkmpp`, '-level 153', '-rc_mode AVBR', '-b:v 10000k']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1968,11 +1969,11 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
           outputOptions: expect.arrayContaining([`-c:v h264_rkmpp`, '-level 51', '-rc_mode CQP', '-qp_init 30']),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -1988,7 +1989,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: expect.arrayContaining(['-hwaccel rkmpp', '-hwaccel_output_format drm_prime', '-afbc rga']),
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
@@ -1996,7 +1997,7 @@ describe(MediaService.name, () => {
             ),
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -2012,7 +2013,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: [],
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
@@ -2020,7 +2021,7 @@ describe(MediaService.name, () => {
             ),
           ]),
           twoPass: false,
-        },
+        }),
       );
     });
 
@@ -2036,7 +2037,7 @@ describe(MediaService.name, () => {
       expect(mediaMock.transcode).toHaveBeenCalledWith(
         '/original/path.ext',
         'upload/encoded-video/user-id/as/se/asset-id.mp4',
-        {
+        expect.objectContaining({
           inputOptions: [],
           outputOptions: expect.arrayContaining([
             expect.stringContaining(
@@ -2044,69 +2045,101 @@ describe(MediaService.name, () => {
             ),
           ]),
           twoPass: false,
+        }),
+      );
+    });
+
+    it('should tonemap when policy is required and video is hdr', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.REQUIRED } });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([
+            '-c:v h264',
+            '-c:a copy',
+            '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
+          ]),
+          twoPass: false,
+        }),
+      );
+    });
+
+    it('should tonemap when policy is optimal and video is hdr', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.OPTIMAL } });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([
+            '-c:v h264',
+            '-c:a copy',
+            '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
+          ]),
+          twoPass: false,
+        }),
+      );
+    });
+
+    it('should set npl to 250 for reinhard and mobius tone-mapping algorithms', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
+      systemMock.get.mockResolvedValue({ ffmpeg: { tonemap: ToneMapping.MOBIUS } });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining([
+            '-c:v h264',
+            '-c:a copy',
+            '-vf zscale=t=linear:npl=250,tonemap=mobius:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
+          ]),
+          twoPass: false,
+        }),
+      );
+    });
+
+    it('should count frames for progress when log level is debug', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      loggerMock.isLevelEnabled.mockReturnValue(true);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+
+      expect(mediaMock.probe).toHaveBeenCalledWith(assetStub.video.originalPath, { countFrames: true });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        assetStub.video.originalPath,
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        {
+          inputOptions: expect.any(Array),
+          outputOptions: expect.any(Array),
+          twoPass: false,
+          progress: {
+            frameCount: probeStub.videoStream2160p.videoStreams[0].frameCount,
+            percentInterval: expect.any(Number),
+          },
         },
       );
     });
-  });
 
-  it('should tonemap when policy is required and video is hdr', async () => {
-    mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
-    systemMock.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.REQUIRED } });
-    assetMock.getByIds.mockResolvedValue([assetStub.video]);
-    await sut.handleVideoConversion({ id: assetStub.video.id });
-    expect(mediaMock.transcode).toHaveBeenCalledWith(
-      '/original/path.ext',
-      'upload/encoded-video/user-id/as/se/asset-id.mp4',
-      {
-        inputOptions: expect.any(Array),
-        outputOptions: expect.arrayContaining([
-          '-c:v h264',
-          '-c:a copy',
-          '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-        ]),
-        twoPass: false,
-      },
-    );
-  });
+    it('should not count frames for progress when log level is not debug', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.videoStream2160p);
+      loggerMock.isLevelEnabled.mockReturnValue(false);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
 
-  it('should tonemap when policy is optimal and video is hdr', async () => {
-    mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
-    systemMock.get.mockResolvedValue({ ffmpeg: { transcode: TranscodePolicy.OPTIMAL } });
-    assetMock.getByIds.mockResolvedValue([assetStub.video]);
-    await sut.handleVideoConversion({ id: assetStub.video.id });
-    expect(mediaMock.transcode).toHaveBeenCalledWith(
-      '/original/path.ext',
-      'upload/encoded-video/user-id/as/se/asset-id.mp4',
-      {
-        inputOptions: expect.any(Array),
-        outputOptions: expect.arrayContaining([
-          '-c:v h264',
-          '-c:a copy',
-          '-vf zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-        ]),
-        twoPass: false,
-      },
-    );
-  });
-
-  it('should set npl to 250 for reinhard and mobius tone-mapping algorithms', async () => {
-    mediaMock.probe.mockResolvedValue(probeStub.videoStreamHDR);
-    systemMock.get.mockResolvedValue({ ffmpeg: { tonemap: ToneMapping.MOBIUS } });
-    assetMock.getByIds.mockResolvedValue([assetStub.video]);
-    await sut.handleVideoConversion({ id: assetStub.video.id });
-    expect(mediaMock.transcode).toHaveBeenCalledWith(
-      '/original/path.ext',
-      'upload/encoded-video/user-id/as/se/asset-id.mp4',
-      {
-        inputOptions: expect.any(Array),
-        outputOptions: expect.arrayContaining([
-          '-c:v h264',
-          '-c:a copy',
-          '-vf zscale=t=linear:npl=250,tonemap=mobius:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p',
-        ]),
-        twoPass: false,
-      },
-    );
+      expect(mediaMock.probe).toHaveBeenCalledWith(assetStub.video.originalPath, { countFrames: false });
+    });
   });
 
   describe('isSRGB', () => {

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -80,6 +80,7 @@ export class BaseConfig implements VideoCodecSWConfig {
       inputOptions: this.getBaseInputOptions(videoStream),
       outputOptions: [...this.getBaseOutputOptions(target, videoStream, audioStream), '-v verbose'],
       twoPass: this.eligibleForTwoPass(),
+      progress: { frameCount: videoStream.frameCount, percentInterval: 5 },
     } as TranscodeCommand;
     if ([TranscodeTarget.ALL, TranscodeTarget.VIDEO].includes(target)) {
       const filters = this.getFilterOptions(videoStream);

--- a/server/test/repositories/logger.repository.mock.ts
+++ b/server/test/repositories/logger.repository.mock.ts
@@ -6,7 +6,7 @@ export const newLoggerRepositoryMock = (): Mocked<ILoggerRepository> => {
     setLogLevel: vitest.fn(),
     setContext: vitest.fn(),
     setAppName: vitest.fn(),
-
+    isLevelEnabled: vitest.fn(),
     verbose: vitest.fn(),
     debug: vitest.fn(),
     log: vitest.fn(),


### PR DESCRIPTION
## Description

* Adds progress logs with 5% intervals and estimated remaining time
  * Many videos don't have frame count metadata available, which would limit the usefulness of this feature. To remedy this, I added a setting to make FFprobe count frames when using debug logs. It's otherwise disabled since it adds some overhead to `probe`
* Encoding start log explicitly mentions status of hardware acceleration
* Logs the raw FFmpeg command instead of a JSON object, making it much easier to copy/paste
* Clarifies OpenCL debug log that only affects RKMPP
* Adds verbose log when skipping an asset because it doesn't need to be transcoded
* Fixes handling of `N/A` that resulted in `frameCount` being `NaN`

## How Has This Been Tested?

CPU:
```
immich_server            | [Nest] 7  - 09/27/2024, 7:59:22 PM     LOG [Microservices:MediaService] Encoding video c3acdaf0-3a86-4e54-950f-a33a8241dcaf without hardware acceleration
immich_server            | [Nest] 7  - 09/27/2024, 7:59:22 PM   DEBUG [Microservices:MediaRepository] ffmpeg -n 10 /usr/bin/ffmpeg -i upload/library/admin/2024/2024-03-01/the-black.mkv -y -c:v av1 -c:a aac -movflags faststart -fps_mode passthrough -map 0:0 -strict unofficial -map 0:1 -v verbose -vf scale=-2:720,zscale=t=linear:npl=100,tonemap=hable:desat=0,zscale=p=bt709:t=bt709:m=bt709:range=pc,format=yuv420p -preset 4 -crf 35 upload/encoded-video/ee17565c-e17b-4c82-9607-07902d53c9cd/c3/ac/c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 7:59:29 PM   DEBUG [Microservices:MediaRepository] Transcoding 5.05% done, estimated 2m, 18s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 7:59:37 PM   DEBUG [Microservices:MediaRepository] Transcoding 10.15% done, estimated 2m, 13s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 7:59:44 PM   DEBUG [Microservices:MediaRepository] Transcoding 15.23% done, estimated 2m, 6s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 7:59:49 PM   DEBUG [Microservices:MediaRepository] Transcoding 20.38% done, estimated 1m, 53s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 7:59:57 PM   DEBUG [Microservices:MediaRepository] Transcoding 25.52% done, estimated 1m, 48s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:00:12 PM   DEBUG [Microservices:MediaRepository] Transcoding 30.55% done, estimated 1m, 59s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:00:26 PM   DEBUG [Microservices:MediaRepository] Transcoding 35.79% done, estimated 2m, 1s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:00:35 PM   DEBUG [Microservices:MediaRepository] Transcoding 40.83% done, estimated 1m, 52s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:00:45 PM   DEBUG [Microservices:MediaRepository] Transcoding 46.18% done, estimated 1m, 44s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:00:51 PM   DEBUG [Microservices:MediaRepository] Transcoding 51.54% done, estimated 1m, 29s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:01 PM   DEBUG [Microservices:MediaRepository] Transcoding 56.70% done, estimated 1m, 20s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:08 PM   DEBUG [Microservices:MediaRepository] Transcoding 61.73% done, estimated 1m, 9s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:15 PM   DEBUG [Microservices:MediaRepository] Transcoding 66.99% done, estimated 58s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:20 PM   DEBUG [Microservices:MediaRepository] Transcoding 72.37% done, estimated 47s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:26 PM   DEBUG [Microservices:MediaRepository] Transcoding 77.68% done, estimated 37s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:34 PM   DEBUG [Microservices:MediaRepository] Transcoding 82.78% done, estimated 29s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:42 PM   DEBUG [Microservices:MediaRepository] Transcoding 87.80% done, estimated 20s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:01:55 PM   DEBUG [Microservices:MediaRepository] Transcoding 92.88% done, estimated 12s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:02:07 PM   DEBUG [Microservices:MediaRepository] Transcoding 100.00% done for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:02:08 PM     LOG [Microservices:MediaService] Successfully encoded c3acdaf0-3a86-4e54-950f-a33a8241dcaf
```

NVENC:
```
immich_server            | [Nest] 7  - 09/27/2024, 8:04:41 PM     LOG [Microservices:MediaService] Encoding video c3acdaf0-3a86-4e54-950f-a33a8241dcaf with NVENC acceleration
immich_server            | [Nest] 7  - 09/27/2024, 8:04:41 PM   DEBUG [Microservices:MediaRepository] ffmpeg -n 10 /usr/bin/ffmpeg -hwaccel cuda -hwaccel_output_format cuda -noautorotate -threads 1 -i upload/library/admin/2024/2024-03-01/the-black.mkv -y -tune hq -qmin 0 -rc-lookahead 20 -i_qfactor 0.75 -c:v av1_nvenc -c:a aac -movflags faststart -fps_mode passthrough -map 0:0 -strict unofficial -map 0:1 -bf 3 -g 256 -b_ref_mode middle -b_qfactor 1.1 -temporal-aq 1 -v verbose -vf scale_cuda=-2:720,tonemap_cuda=desat=0:matrix=bt709:primaries=bt709:range=pc:tonemap=hable:transfer=bt709:format=nv12 -preset p7 -cq:v 35 upload/encoded-video/ee17565c-e17b-4c82-9607-07902d53c9cd/c3/ac/c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:48 PM   DEBUG [Microservices:MediaRepository] Transcoding 5.74% done, estimated 1m, 48s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:50 PM   DEBUG [Microservices:MediaRepository] Transcoding 11.14% done, estimated 1m, 8s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:52 PM   DEBUG [Microservices:MediaRepository] Transcoding 16.52% done, estimated 53s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:54 PM   DEBUG [Microservices:MediaRepository] Transcoding 22.41% done, estimated 43s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:56 PM   DEBUG [Microservices:MediaRepository] Transcoding 27.46% done, estimated 38s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:58 PM   DEBUG [Microservices:MediaRepository] Transcoding 32.54% done, estimated 34s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:04:58 PM   DEBUG [Microservices:MediaRepository] Transcoding 37.56% done, estimated 30s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:00 PM   DEBUG [Microservices:MediaRepository] Transcoding 42.62% done, estimated 27s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:02 PM   DEBUG [Microservices:MediaRepository] Transcoding 47.73% done, estimated 24s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:04 PM   DEBUG [Microservices:MediaRepository] Transcoding 53.24% done, estimated 21s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:06 PM   DEBUG [Microservices:MediaRepository] Transcoding 58.37% done, estimated 19s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:08 PM   DEBUG [Microservices:MediaRepository] Transcoding 63.65% done, estimated 16s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:10 PM   DEBUG [Microservices:MediaRepository] Transcoding 69.37% done, estimated 13s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:12 PM   DEBUG [Microservices:MediaRepository] Transcoding 75.54% done, estimated 10s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:14 PM   DEBUG [Microservices:MediaRepository] Transcoding 80.84% done, estimated 8s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:16 PM   DEBUG [Microservices:MediaRepository] Transcoding 85.85% done, estimated 6s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:19 PM   DEBUG [Microservices:MediaRepository] Transcoding 92.04% done, estimated 3s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:21 PM   DEBUG [Microservices:MediaRepository] Transcoding 97.09% done, estimated 1s remaining for output c3acdaf0-3a86-4e54-950f-a33a8241dcaf.mp4
immich_server            | [Nest] 7  - 09/27/2024, 8:05:22 PM     LOG [Microservices:MediaService] Successfully encoded c3acdaf0-3a86-4e54-950f-a33a8241dcaf
```