### PR TITLE
refactor(server): events

### DIFF
--- a/e2e/src/api/specs/asset.e2e-spec.ts
+++ b/e2e/src/api/specs/asset.e2e-spec.ts
@@ -76,7 +76,6 @@ describe('/asset', () => {
   let user2Assets: AssetMediaResponseDto[];
   let locationAsset: AssetMediaResponseDto;
   let ratingAsset: AssetMediaResponseDto;
-  let facesAsset: AssetMediaResponseDto;
 
   const setupTests = async () => {
     await utils.resetDatabase();
@@ -236,7 +235,7 @@ describe('/asset', () => {
       await updateConfig({ systemConfigDto: config }, { headers: asBearerAuth(admin.accessToken) });
 
       // asset faces
-      facesAsset = await utils.createAsset(admin.accessToken, {
+      const facesAsset = await utils.createAsset(admin.accessToken, {
         assetData: {
           filename: 'portrait.jpg',
           bytes: await readFile(facesAssetFilepath),

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -2,7 +2,6 @@ import { BullModule } from '@nestjs/bullmq';
 import { Inject, Module, OnModuleDestroy, OnModuleInit, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE, ModuleRef } from '@nestjs/core';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import _ from 'lodash';
@@ -42,7 +41,6 @@ const imports = [
   BullModule.registerQueue(...bullQueues),
   ClsModule.forRoot(clsConfig),
   ConfigModule.forRoot(immichAppConfig),
-  EventEmitterModule.forRoot(),
   OpenTelemetryModule.forRoot(otelConfig),
   TypeOrmModule.forRootAsync({
     inject: [ModuleRef],
@@ -114,16 +112,3 @@ export class MicroservicesModule implements OnModuleInit, OnModuleDestroy {
   providers: [...common, ...commands, SchedulerRegistry],
 })
 export class ImmichAdminModule {}
-
-@Module({
-  imports: [
-    ConfigModule.forRoot(immichAppConfig),
-    EventEmitterModule.forRoot(),
-    TypeOrmModule.forRoot(databaseConfig),
-    TypeOrmModule.forFeature(entities),
-    OpenTelemetryModule.forRoot(otelConfig),
-  ],
-  controllers: [...controllers],
-  providers: [...common, ...middleware, SchedulerRegistry],
-})
-export class AppTestModule {}

--- a/server/src/bin/sync-sql.ts
+++ b/server/src/bin/sync-sql.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { INestApplication } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { EventEmitterModule } from '@nestjs/event-emitter';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -85,7 +84,6 @@ class SqlGenerator {
           logger: this.sqlLogger,
         }),
         TypeOrmModule.forFeature(entities),
-        EventEmitterModule.forRoot(),
         OpenTelemetryModule.forRoot(otelConfig),
       ],
       providers: [...repositories, AuthService, SchedulerRegistry],

--- a/server/src/decorators.ts
+++ b/server/src/decorators.ts
@@ -1,11 +1,9 @@
 import { SetMetadata, applyDecorators } from '@nestjs/common';
-import { OnEvent } from '@nestjs/event-emitter';
-import { OnEventOptions } from '@nestjs/event-emitter/dist/interfaces';
 import { ApiExtension, ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
 import _ from 'lodash';
 import { ADDED_IN_PREFIX, DEPRECATED_IN_PREFIX, LIFECYCLE_EXTENSION } from 'src/constants';
 import { MetadataKey } from 'src/enum';
-import { EmitEvent, ServerEvent } from 'src/interfaces/event.interface';
+import { EmitEvent } from 'src/interfaces/event.interface';
 import { setUnion } from 'src/utils/set';
 
 // PostgreSQL uses a 16-bit integer to indicate the number of bound parameters. This means that the
@@ -133,15 +131,14 @@ export interface GenerateSqlQueries {
 /** Decorator to enable versioning/tracking of generated Sql */
 export const GenerateSql = (...options: GenerateSqlQueries[]) => SetMetadata(GENERATE_SQL_KEY, options);
 
-export const OnServerEvent = (event: ServerEvent, options?: OnEventOptions) =>
-  OnEvent(event, { suppressErrors: false, ...options });
-
-export type EmitConfig = {
-  event: EmitEvent;
+export type EventConfig = {
+  name: EmitEvent;
+  /** handle socket.io server events as well  */
+  server?: boolean;
   /** lower value has higher priority, defaults to 0 */
   priority?: number;
 };
-export const OnEmit = (config: EmitConfig) => SetMetadata(MetadataKey.ON_EMIT_CONFIG, config);
+export const OnEvent = (config: EventConfig) => SetMetadata(MetadataKey.EVENT_CONFIG, config);
 
 type LifecycleRelease = 'NEXT_RELEASE' | string;
 type LifecycleMetadata = {

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -310,7 +310,7 @@ export enum MetadataKey {
   ADMIN_ROUTE = 'admin_route',
   SHARED_ROUTE = 'shared_route',
   API_KEY_SECURITY = 'api_key',
-  ON_EMIT_CONFIG = 'on_emit_config',
+  EVENT_CONFIG = 'event_config',
 }
 
 export enum RouteKey {

--- a/server/src/interfaces/event.interface.ts
+++ b/server/src/interfaces/event.interface.ts
@@ -54,8 +54,8 @@ type EventMap = {
   'websocket.connect': [{ userId: string }];
 };
 
-export type ServerEvents = 'config.update';
 export const serverEvents = ['config.update'] as const;
+export type ServerEvents = (typeof serverEvents)[number];
 
 export type EmitEvent = keyof EventMap;
 export type EmitHandler<T extends EmitEvent> = (...args: ArgsOf<T>) => Promise<void> | void;

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -1,6 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   OnGatewayConnection,
   OnGatewayDisconnect,
@@ -13,16 +12,17 @@ import {
   ArgsOf,
   ClientEventMap,
   EmitEvent,
-  EmitHandler,
+  EventItem,
   IEventRepository,
-  ServerEvent,
-  ServerEventMap,
+  serverEvents,
+  ServerEvents,
 } from 'src/interfaces/event.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { AuthService } from 'src/services/auth.service';
 import { Instrumentation } from 'src/utils/instrumentation';
+import { handlePromiseError } from 'src/utils/misc';
 
-type EmitHandlers = Partial<{ [T in EmitEvent]: EmitHandler<T>[] }>;
+type EmitHandlers = Partial<{ [T in EmitEvent]: Array<EventItem<T>> }>;
 
 @Instrumentation()
 @WebSocketGateway({
@@ -39,7 +39,6 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
 
   constructor(
     private moduleRef: ModuleRef,
-    private eventEmitter: EventEmitter2,
     @Inject(ILoggerRepository) private logger: ILoggerRepository,
   ) {
     this.logger.setContext(EventRepository.name);
@@ -48,14 +47,10 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
   afterInit(server: Server) {
     this.logger.log('Initialized websocket server');
 
-    for (const event of Object.values(ServerEvent)) {
-      if (event === ServerEvent.WEBSOCKET_CONNECT) {
-        continue;
-      }
-
-      server.on(event, (data: unknown) => {
+    for (const event of serverEvents) {
+      server.on(event, (...args: ArgsOf<any>) => {
         this.logger.debug(`Server event: ${event} (receive)`);
-        this.eventEmitter.emit(event, data);
+        handlePromiseError(this.onEvent({ name: event, args, server: true }), this.logger);
       });
     }
   }
@@ -72,7 +67,7 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
       if (auth.session) {
         await client.join(auth.session.id);
       }
-      this.serverSend(ServerEvent.WEBSOCKET_CONNECT, { userId: auth.user.id });
+      await this.onEvent({ name: 'websocket.connect', args: [{ userId: auth.user.id }], server: false });
     } catch (error: Error | any) {
       this.logger.error(`Websocket connection error: ${error}`, error?.stack);
       client.emit('error', 'unauthorized');
@@ -85,18 +80,29 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
     await client.leave(client.nsp.name);
   }
 
-  on<T extends EmitEvent>(event: T, handler: EmitHandler<T>): void {
+  on<T extends EmitEvent>(item: EventItem<T>): void {
+    const event = item.event;
+
     if (!this.emitHandlers[event]) {
       this.emitHandlers[event] = [];
     }
 
-    this.emitHandlers[event].push(handler);
+    this.emitHandlers[event].push(item);
   }
 
   async emit<T extends EmitEvent>(event: T, ...args: ArgsOf<T>): Promise<void> {
-    const handlers = this.emitHandlers[event] || [];
-    for (const handler of handlers) {
-      await handler(...args);
+    return this.onEvent({ name: event, args, server: false });
+  }
+
+  private async onEvent<T extends EmitEvent>(event: { name: T; args: ArgsOf<T>; server: boolean }): Promise<void> {
+    const handlers = this.emitHandlers[event.name] || [];
+    for (const { handler, server } of handlers) {
+      // exclude handlers that ignore server events
+      if (!server && event.server) {
+        continue;
+      }
+
+      await handler(...event.args);
     }
   }
 
@@ -108,9 +114,8 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
     this.server?.emit(event, data);
   }
 
-  serverSend<E extends keyof ServerEventMap>(event: E, data: ServerEventMap[E]) {
+  serverSend<T extends ServerEvents>(event: T, ...args: ArgsOf<T>): void {
     this.logger.debug(`Server event: ${event} (send)`);
-    this.server?.serverSideEmit(event, data);
-    return this.eventEmitter.emit(event, data);
+    this.server?.serverSideEmit(event, ...args);
   }
 }

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Duration } from 'luxon';
 import semver from 'semver';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { IConfigRepository } from 'src/interfaces/config.interface';
 import {
   DatabaseExtension,
@@ -74,7 +74,7 @@ export class DatabaseService {
     this.logger.setContext(DatabaseService.name);
   }
 
-  @OnEmit({ event: 'app.bootstrap', priority: -200 })
+  @OnEvent({ name: 'app.bootstrap', priority: -200 })
   async onBootstrap() {
     const version = await this.databaseRepository.getPostgresVersion();
     const current = semver.coerce(version);

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -1,6 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { SystemConfig } from 'src/config';
-import { SystemConfigCore } from 'src/cores/system-config.core';
+import { defaults } from 'src/config';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { IEventRepository } from 'src/interfaces/event.interface';
 import {
@@ -58,6 +57,19 @@ describe(JobService.name, () => {
 
   it('should work', () => {
     expect(sut).toBeDefined();
+  });
+
+  describe('onConfigUpdate', () => {
+    it('should update concurrency', () => {
+      sut.onBootstrap('microservices');
+      sut.onConfigUpdate({ oldConfig: defaults, newConfig: defaults });
+
+      expect(jobMock.setConcurrency).toHaveBeenCalledTimes(14);
+      expect(jobMock.setConcurrency).toHaveBeenNthCalledWith(5, QueueName.FACIAL_RECOGNITION, 1);
+      expect(jobMock.setConcurrency).toHaveBeenNthCalledWith(7, QueueName.DUPLICATE_DETECTION, 1);
+      expect(jobMock.setConcurrency).toHaveBeenNthCalledWith(8, QueueName.BACKGROUND_TASK, 5);
+      expect(jobMock.setConcurrency).toHaveBeenNthCalledWith(9, QueueName.STORAGE_TEMPLATE_MIGRATION, 1);
+    });
   });
 
   describe('handleNightlyJobs', () => {
@@ -237,36 +249,6 @@ describe(JobService.name, () => {
       await sut.init(makeMockHandlers(JobStatus.SUCCESS));
       expect(systemMock.get).toHaveBeenCalled();
       expect(jobMock.addHandler).toHaveBeenCalledTimes(Object.keys(QueueName).length);
-    });
-
-    it('should subscribe to config changes', async () => {
-      await sut.init(makeMockHandlers(JobStatus.FAILED));
-
-      SystemConfigCore.create(newSystemMetadataRepositoryMock(false), newLoggerRepositoryMock()).config$.next({
-        job: {
-          [QueueName.BACKGROUND_TASK]: { concurrency: 10 },
-          [QueueName.SMART_SEARCH]: { concurrency: 10 },
-          [QueueName.METADATA_EXTRACTION]: { concurrency: 10 },
-          [QueueName.FACE_DETECTION]: { concurrency: 10 },
-          [QueueName.SEARCH]: { concurrency: 10 },
-          [QueueName.SIDECAR]: { concurrency: 10 },
-          [QueueName.LIBRARY]: { concurrency: 10 },
-          [QueueName.MIGRATION]: { concurrency: 10 },
-          [QueueName.THUMBNAIL_GENERATION]: { concurrency: 10 },
-          [QueueName.VIDEO_CONVERSION]: { concurrency: 10 },
-          [QueueName.NOTIFICATION]: { concurrency: 5 },
-        },
-      } as SystemConfig);
-
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.BACKGROUND_TASK, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.SMART_SEARCH, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.METADATA_EXTRACTION, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.FACE_DETECTION, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.SIDECAR, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.LIBRARY, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.MIGRATION, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.THUMBNAIL_GENERATION, 10);
-      expect(jobMock.setConcurrency).toHaveBeenCalledWith(QueueName.VIDEO_CONVERSION, 10);
     });
 
     const tests: Array<{ item: JobItem; jobs: JobName[] }> = [

--- a/server/src/services/microservices.service.ts
+++ b/server/src/services/microservices.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { ArgOf } from 'src/interfaces/event.interface';
 import { IDeleteFilesJob, JobName } from 'src/interfaces/job.interface';
 import { AssetService } from 'src/services/asset.service';
@@ -43,7 +43,7 @@ export class MicroservicesService {
     private versionService: VersionService,
   ) {}
 
-  @OnEmit({ event: 'app.bootstrap' })
+  @OnEvent({ name: 'app.bootstrap' })
   async onBootstrap(app: ArgOf<'app.bootstrap'>) {
     if (app !== 'microservices') {
       return;

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -6,7 +6,7 @@ import { AssetFileEntity } from 'src/entities/asset-files.entity';
 import { AssetFileType, UserMetadataKey } from 'src/enum';
 import { IAlbumRepository } from 'src/interfaces/album.interface';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
-import { IEventRepository } from 'src/interfaces/event.interface';
+import { ClientEvent, IEventRepository } from 'src/interfaces/event.interface';
 import { IJobRepository, JobName, JobStatus } from 'src/interfaces/job.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { EmailTemplate, INotificationRepository } from 'src/interfaces/notification.interface';
@@ -98,6 +98,15 @@ describe(NotificationService.name, () => {
 
   it('should work', () => {
     expect(sut).toBeDefined();
+  });
+
+  describe('onConfigUpdate', () => {
+    it('should emit client and server events', () => {
+      const update = { newConfig: defaults };
+      expect(sut.onConfigUpdate(update)).toBeUndefined();
+      expect(eventMock.clientBroadcast).toHaveBeenCalledWith(ClientEvent.CONFIG_UPDATE, {});
+      expect(eventMock.serverSend).toHaveBeenCalledWith('config.update', update);
+    });
   });
 
   describe('onConfigValidateEvent', () => {

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { DEFAULT_EXTERNAL_DOMAIN } from 'src/constants';
 import { SystemConfigCore } from 'src/cores/system-config.core';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { SystemConfigSmtpDto } from 'src/dtos/system-config.dto';
 import { AlbumEntity } from 'src/entities/album.entity';
 import { IAlbumRepository } from 'src/interfaces/album.interface';
@@ -43,7 +43,13 @@ export class NotificationService {
     this.configCore = SystemConfigCore.create(systemMetadataRepository, logger);
   }
 
-  @OnEmit({ event: 'config.validate', priority: -100 })
+  @OnEvent({ name: 'config.update' })
+  onConfigUpdate({ oldConfig, newConfig }: ArgOf<'config.update'>) {
+    this.eventRepository.clientBroadcast(ClientEvent.CONFIG_UPDATE, {});
+    this.eventRepository.serverSend('config.update', { oldConfig, newConfig });
+  }
+
+  @OnEvent({ name: 'config.validate', priority: -100 })
   async onConfigValidate({ oldConfig, newConfig }: ArgOf<'config.validate'>) {
     try {
       if (
@@ -58,74 +64,74 @@ export class NotificationService {
     }
   }
 
-  @OnEmit({ event: 'asset.hide' })
+  @OnEvent({ name: 'asset.hide' })
   onAssetHide({ assetId, userId }: ArgOf<'asset.hide'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_HIDDEN, userId, assetId);
   }
 
-  @OnEmit({ event: 'asset.show' })
+  @OnEvent({ name: 'asset.show' })
   async onAssetShow({ assetId }: ArgOf<'asset.show'>) {
     await this.jobRepository.queue({ name: JobName.GENERATE_THUMBNAIL, data: { id: assetId, notify: true } });
   }
 
-  @OnEmit({ event: 'asset.trash' })
+  @OnEvent({ name: 'asset.trash' })
   onAssetTrash({ assetId, userId }: ArgOf<'asset.trash'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_TRASH, userId, [assetId]);
   }
 
-  @OnEmit({ event: 'asset.delete' })
+  @OnEvent({ name: 'asset.delete' })
   onAssetDelete({ assetId, userId }: ArgOf<'asset.delete'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_DELETE, userId, assetId);
   }
 
-  @OnEmit({ event: 'assets.trash' })
+  @OnEvent({ name: 'assets.trash' })
   onAssetsTrash({ assetIds, userId }: ArgOf<'assets.trash'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_TRASH, userId, assetIds);
   }
 
-  @OnEmit({ event: 'assets.restore' })
+  @OnEvent({ name: 'assets.restore' })
   onAssetsRestore({ assetIds, userId }: ArgOf<'assets.restore'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_RESTORE, userId, assetIds);
   }
 
-  @OnEmit({ event: 'stack.create' })
+  @OnEvent({ name: 'stack.create' })
   onStackCreate({ userId }: ArgOf<'stack.create'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_STACK_UPDATE, userId, []);
   }
 
-  @OnEmit({ event: 'stack.update' })
+  @OnEvent({ name: 'stack.update' })
   onStackUpdate({ userId }: ArgOf<'stack.update'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_STACK_UPDATE, userId, []);
   }
 
-  @OnEmit({ event: 'stack.delete' })
+  @OnEvent({ name: 'stack.delete' })
   onStackDelete({ userId }: ArgOf<'stack.delete'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_STACK_UPDATE, userId, []);
   }
 
-  @OnEmit({ event: 'stacks.delete' })
+  @OnEvent({ name: 'stacks.delete' })
   onStacksDelete({ userId }: ArgOf<'stacks.delete'>) {
     this.eventRepository.clientSend(ClientEvent.ASSET_STACK_UPDATE, userId, []);
   }
 
-  @OnEmit({ event: 'user.signup' })
+  @OnEvent({ name: 'user.signup' })
   async onUserSignup({ notify, id, tempPassword }: ArgOf<'user.signup'>) {
     if (notify) {
       await this.jobRepository.queue({ name: JobName.NOTIFY_SIGNUP, data: { id, tempPassword } });
     }
   }
 
-  @OnEmit({ event: 'album.update' })
+  @OnEvent({ name: 'album.update' })
   async onAlbumUpdate({ id, updatedBy }: ArgOf<'album.update'>) {
     await this.jobRepository.queue({ name: JobName.NOTIFY_ALBUM_UPDATE, data: { id, senderId: updatedBy } });
   }
 
-  @OnEmit({ event: 'album.invite' })
+  @OnEvent({ name: 'album.invite' })
   async onAlbumInvite({ id, userId }: ArgOf<'album.invite'>) {
     await this.jobRepository.queue({ name: JobName.NOTIFY_ALBUM_INVITE, data: { id, recipientId: userId } });
   }
 
-  @OnEmit({ event: 'session.delete' })
+  @OnEvent({ name: 'session.delete' })
   onSessionDelete({ sessionId }: ArgOf<'session.delete'>) {
     // after the response is sent
     setTimeout(() => this.eventRepository.clientSend(ClientEvent.SESSION_DELETE, sessionId, sessionId), 500);

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -3,7 +3,7 @@ import { getBuildMetadata, getServerLicensePublicKey } from 'src/config';
 import { serverVersion } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { SystemConfigCore } from 'src/cores/system-config.core';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { LicenseKeyDto, LicenseResponseDto } from 'src/dtos/license.dto';
 import {
   ServerAboutResponseDto,
@@ -42,7 +42,7 @@ export class ServerService {
     this.configCore = SystemConfigCore.create(systemMetadataRepository, this.logger);
   }
 
-  @OnEmit({ event: 'app.bootstrap' })
+  @OnEvent({ name: 'app.bootstrap' })
   async onBootstrap(): Promise<void> {
     const featureFlags = await this.getFeatures();
     if (featureFlags.configFile) {

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -3,7 +3,6 @@ import handlebar from 'handlebars';
 import { DateTime } from 'luxon';
 import path from 'node:path';
 import sanitize from 'sanitize-filename';
-import { SystemConfig } from 'src/config';
 import {
   supportedDayTokens,
   supportedHourTokens,
@@ -15,7 +14,7 @@ import {
 } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { SystemConfigCore } from 'src/cores/system-config.core';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { AssetEntity } from 'src/entities/asset.entity';
 import { AssetPathType, AssetType, StorageFolder } from 'src/enum';
 import { IAlbumRepository } from 'src/interfaces/album.interface';
@@ -76,7 +75,6 @@ export class StorageTemplateService {
   ) {
     this.logger.setContext(StorageTemplateService.name);
     this.configCore = SystemConfigCore.create(systemMetadataRepository, this.logger);
-    this.configCore.config$.subscribe((config) => this.onConfig(config));
     this.storageCore = StorageCore.create(
       assetRepository,
       cryptoRepository,
@@ -88,7 +86,16 @@ export class StorageTemplateService {
     );
   }
 
-  @OnEmit({ event: 'config.validate' })
+  @OnEvent({ name: 'config.update', server: true })
+  onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
+    const template = newConfig.storageTemplate.template;
+    if (!this._template || template !== this.template.raw) {
+      this.logger.debug(`Compiling new storage template: ${template}`);
+      this._template = this.compile(template);
+    }
+  }
+
+  @OnEvent({ name: 'config.validate' })
   onConfigValidate({ newConfig }: ArgOf<'config.validate'>) {
     try {
       const { compiled } = this.compile(newConfig.storageTemplate.template);
@@ -279,14 +286,6 @@ export class StorageTemplateService {
     } catch (error: any) {
       this.logger.error(`Unable to get template path for ${filename}`, error);
       return asset.originalPath;
-    }
-  }
-
-  private onConfig(config: SystemConfig) {
-    const template = config.storageTemplate.template;
-    if (!this._template || template !== this.template.raw) {
-      this.logger.debug(`Compiling new storage template: ${template}`);
-      this._template = this.compile(template);
     }
   }
 

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { join } from 'node:path';
 import { StorageCore } from 'src/cores/storage.core';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { StorageFolder, SystemMetadataKey } from 'src/enum';
 import { DatabaseLock, IDatabaseRepository } from 'src/interfaces/database.interface';
 import { IDeleteFilesJob, JobStatus } from 'src/interfaces/job.interface';
@@ -21,7 +21,7 @@ export class StorageService {
     this.logger.setContext(StorageService.name);
   }
 
-  @OnEmit({ event: 'app.bootstrap' })
+  @OnEvent({ name: 'app.bootstrap' })
   async onBootstrap() {
     await this.databaseRepository.withLock(DatabaseLock.SystemFileMounts, async () => {
       const flags = (await this.systemMetadata.get(SystemMetadataKey.SYSTEM_FLAGS)) || { mountFiles: false };

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -6,14 +6,13 @@ import {
   CQMode,
   ImageFormat,
   LogLevel,
-  SystemMetadataKey,
   ToneMapping,
   TranscodeHWAccel,
   TranscodePolicy,
   VideoCodec,
   VideoContainer,
 } from 'src/enum';
-import { IEventRepository, ServerEvent } from 'src/interfaces/event.interface';
+import { IEventRepository } from 'src/interfaces/event.interface';
 import { QueueName } from 'src/interfaces/job.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
@@ -376,14 +375,13 @@ describe(SystemConfigService.name, () => {
   });
 
   describe('updateConfig', () => {
-    it('should update the config and emit client and server events', async () => {
+    it('should update the config and emit an event', async () => {
       systemMock.get.mockResolvedValue(partialConfig);
-
       await expect(sut.updateConfig(updatedConfig)).resolves.toEqual(updatedConfig);
-
-      expect(eventMock.clientBroadcast).toHaveBeenCalled();
-      expect(eventMock.serverSend).toHaveBeenCalledWith(ServerEvent.CONFIG_UPDATE, null);
-      expect(systemMock.set).toHaveBeenCalledWith(SystemMetadataKey.SYSTEM_CONFIG, partialConfig);
+      expect(eventMock.emit).toHaveBeenCalledWith(
+        'config.update',
+        expect.objectContaining({ oldConfig: expect.any(Object), newConfig: updatedConfig }),
+      );
     });
 
     it('should throw an error if a config file is in use', async () => {

--- a/server/src/services/trash.service.ts
+++ b/server/src/services/trash.service.ts
@@ -1,5 +1,5 @@
 import { Inject } from '@nestjs/common';
-import { OnEmit } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { BulkIdsDto } from 'src/dtos/asset-ids.response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { TrashResponseDto } from 'src/dtos/trash.dto';
@@ -54,7 +54,7 @@ export class TrashService {
     return { count };
   }
 
-  @OnEmit({ event: 'assets.delete' })
+  @OnEvent({ name: 'assets.delete' })
   async onAssetsDelete() {
     await this.jobRepository.queue({ name: JobName.QUEUE_TRASH_EMPTY, data: {} });
   }

--- a/server/src/services/version.service.ts
+++ b/server/src/services/version.service.ts
@@ -3,11 +3,11 @@ import { DateTime } from 'luxon';
 import semver, { SemVer } from 'semver';
 import { isDev, serverVersion } from 'src/constants';
 import { SystemConfigCore } from 'src/cores/system-config.core';
-import { OnEmit, OnServerEvent } from 'src/decorators';
+import { OnEvent } from 'src/decorators';
 import { ReleaseNotification, ServerVersionResponseDto } from 'src/dtos/server.dto';
 import { VersionCheckMetadata } from 'src/entities/system-metadata.entity';
 import { SystemMetadataKey } from 'src/enum';
-import { ClientEvent, IEventRepository, ServerEvent, ServerEventMap } from 'src/interfaces/event.interface';
+import { ArgOf, ClientEvent, IEventRepository } from 'src/interfaces/event.interface';
 import { IJobRepository, JobName, JobStatus } from 'src/interfaces/job.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
 import { IServerInfoRepository } from 'src/interfaces/server-info.interface';
@@ -37,7 +37,7 @@ export class VersionService {
     this.configCore = SystemConfigCore.create(systemMetadataRepository, this.logger);
   }
 
-  @OnEmit({ event: 'app.bootstrap' })
+  @OnEvent({ name: 'app.bootstrap' })
   async onBootstrap(): Promise<void> {
     await this.handleVersionCheck();
   }
@@ -90,8 +90,8 @@ export class VersionService {
     return JobStatus.SUCCESS;
   }
 
-  @OnServerEvent(ServerEvent.WEBSOCKET_CONNECT)
-  async onWebsocketConnection({ userId }: ServerEventMap[ServerEvent.WEBSOCKET_CONNECT]) {
+  @OnEvent({ name: 'websocket.connect' })
+  async onWebsocketConnection({ userId }: ArgOf<'websocket.connect'>) {
     this.eventRepository.clientSend(ClientEvent.SERVER_VERSION, userId, serverVersion);
     const metadata = await this.systemMetadataRepository.get(SystemMetadataKey.VERSION_CHECK_STATE);
     if (metadata) {

--- a/server/test/repositories/event.repository.mock.ts
+++ b/server/test/repositories/event.repository.mock.ts
@@ -3,7 +3,7 @@ import { Mocked, vitest } from 'vitest';
 
 export const newEventRepositoryMock = (): Mocked<IEventRepository> => {
   return {
-    on: vitest.fn(),
+    on: vitest.fn() as any,
     emit: vitest.fn() as any,
     clientSend: vitest.fn(),
     clientBroadcast: vitest.fn(),


### PR DESCRIPTION
- Simplify the event system
- Remove `EventEmitter2`
- Transition to `.emit` and `.on` for events from other websocket servers (connected api/microservices instances)
- Replace `config$.next` and `config$.subscribe` with `OnEvent({ event: 'config.update' })`
- Add an option to also respond events (`config.update`) from other "server" instances 