### PR TITLE
chore(docs): Update nginx example config

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -18,10 +18,11 @@ server {
     client_max_body_size 50000M;
 
     # Set headers
-    proxy_set_header Host              $http_host;
-    proxy_set_header X-Real-IP         $remote_addr;
-    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host                      $http_host;
+    proxy_set_header X-Real-IP                 $remote_addr;
+    proxy_set_header X-Forwarded-For           $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto         $scheme;
+    add_header       'Content-Security-Policy' 'upgrade-insecure-requests';
 
     # enable websockets: http://nginx.org/en/docs/http/websocket.html
     proxy_http_version 1.1;


### PR DESCRIPTION
This tweak in the nginx example should make all requests made by immich web app [go through the SSL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests). 

I stumbled upon the lack of the header when setting up nginx to redirect wan traffic to an immich instance and noticed a lot of tracking still wanting to use HTTP instead of HTTPS protocol.

> I was unsure how to file an improvement for docs properly, so I created this PR instead. Please, if this change is too niche (not universal enough in your eyes) or requires an unnecessary amount of effort on your side to merge, feel free to close the PR.