### PR TITLE
fix(docs): Update TrueNAS installation docs

### DIFF
--- a/docs/docs/install/truenas.md
+++ b/docs/docs/install/truenas.md
@@ -30,6 +30,8 @@ You can organize these as one parent with seven child datasets, for example `mnt
 
 :::info Permissions
 The **pgData** dataset must be owned by the user `netdata` (UID 999) for postgres to start. The other datasets must be owned by the user `root` (UID 0) or a group that includes the user `root` (UID 0) for immich to have the necessary permissions.
+
+The **library** dataset must have [ACL mode](https://www.truenas.com/docs/core/coretutorials/storage/pools/permissions/#access-control-lists) set to `Passthrough` if you plan on using a [storage template](/docs/administration/storage-template.mdx) and the dataset is configured for network sharing (its ACL type is set to `SMB/NFSv4`). When the template is applied and files need to be moved from **uploads** to **library**, immich performs `chmod` internally and needs to be allowed to execute the command.
 :::
 
 ## Installing the Immich Application


### PR DESCRIPTION
Mention about ACL mode added for the case when the library is located in a dataset with network-sharing capabilities.

I stumbled on the issue when enabling storage template on truenas while having the library located on a ZFS dataset with SMB share (so the library structure can be used in read-only mode by users via the local network). I've based the change in docs on [community issue](https://www.truenas.com/community/threads/immich-app-permissions-to-copy-to-path-inside-smb-share.117253/) and [redit post](https://www.reddit.com/r/truenas/comments/1b1weo9/comment/l132fuj/) where the later actually fixed my issue.

> I was unsure how to file an improvement for docs properly, so I created this PR instead (2nd). Please, if this change requires an unnecessary amount of effort on your side to merge, feel free to close the PR.