### PR TITLE
chore(mobile): update photo_manager 3.5.0

### DIFF
--- a/mobile/ios/build/XCBuildData/a34f3d77f077776687d3b444cba8f1c4.xcbuilddata/manifest.json
+++ b/mobile/ios/build/XCBuildData/a34f3d77f077776687d3b444cba8f1c4.xcbuilddata/manifest.json
@@ -1,0 +1,1 @@
+{"client":{"name":"basic","version":0,"file-system":"device-agnostic","perform-ownership-analysis":"no"},"targets":{"":["<all>"]},"commands":{"<all>":{"tool":"phony","inputs":["<WorkspaceHeaderMapVFSFilesWritten>"],"outputs":["<all>"]},"P0:::Gate WorkspaceHeaderMapVFSFilesWritten":{"tool":"phony","inputs":[],"outputs":["<WorkspaceHeaderMapVFSFilesWritten>"]}}}

--- a/mobile/lib/repositories/file_media.repository.dart
+++ b/mobile/lib/repositories/file_media.repository.dart
@@ -16,8 +16,12 @@ class FileMediaRepository implements IFileMediaRepository {
     required String title,
     String? relativePath,
   }) async {
-    final entity = await PhotoManager.editor
-        .saveImage(data, title: title, relativePath: relativePath);
+    final entity = await PhotoManager.editor.saveImage(
+      data,
+      filename: title,
+      title: title,
+      relativePath: relativePath,
+    );
     return AssetMediaRepository.toAsset(entity);
   }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1211,10 +1211,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: "1e8bbe46a6858870e34c976aafd85378bed221ce31c1201961eba9ad3d94df9f"
+      sha256: "32a1ce1095aeaaa792a29f28c1f74613aa75109f21c2d4ab85be3ad9964230a4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.5.0"
   photo_manager_image_provider:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   path_provider_ios:
-  photo_manager: ^3.2.3
+  photo_manager: ^3.5.0
   photo_manager_image_provider: ^2.1.1
   flutter_hooks: ^0.20.4
   hooks_riverpod: ^2.4.9


### PR DESCRIPTION
Tested on iOS and Android, assets can be viewed, uploaded and downloaded as previous version