### PR TITLE
feat: preload fonts

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -23,7 +23,6 @@ export const ONE_HOUR = Duration.fromObject({ hours: 1 });
 export const envName = (process.env.IMMICH_ENV || 'production').toUpperCase();
 export const isDev = () => process.env.IMMICH_ENV === 'development';
 export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload';
-export const WEB_ROOT = process.env.IMMICH_WEB_ROOT || '/usr/src/app/www';
 const HOST_SERVER_PORT = process.env.IMMICH_PORT || '2283';
 export const DEFAULT_EXTERNAL_DOMAIN = 'http://localhost:' + HOST_SERVER_PORT;
 

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -13,6 +13,8 @@
     <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96.png" />
     <link rel="icon" type="image/png" sizes="144x144" href="/favicon-144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180.png" />
+    <link rel="preload" as="font" type="font/ttf" href="%app.font%" />
+    <link rel="preload" as="font" type="font/ttf" href="%app.monofont%" />
     %sveltekit.head%
     <style>
       /* prevent FOUC */

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,0 +1,12 @@
+import overpass from '$lib/assets/fonts/overpass/Overpass.ttf?url';
+import overpassMono from '$lib/assets/fonts/overpass/OverpassMono.ttf?url';
+import type { Handle } from '@sveltejs/kit';
+
+// only used during the build to replace the variables from app.html
+export const handle = (async ({ event, resolve }) => {
+  return resolve(event, {
+    transformPageChunk: ({ html }) => {
+      return html.replace('%app.font%', overpass).replace('%app.monofont%', overpassMono);
+    },
+  });
+}) satisfies Handle;


### PR DESCRIPTION
This PR:
- preload fonts for better loading speed. The `hook.server.ts` is only used to replace the `%app.font%` and `%app.monofont%` variables with the actual location of the `ttf` files.
- remove the `WEB_ROOT` constant which is no longer used.


| Before | After |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/dfb39314-0bba-4a19-96d4-5dd64f36ee57) | ![image](https://github.com/user-attachments/assets/df28d112-2937-4d4b-88b8-38310c41c4ae) |

`index.html`: 

| Before | After |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/44b70ad6-385c-4e79-9c54-575181bffd4e) | ![image](https://github.com/user-attachments/assets/52b92e6e-1024-442d-891c-0cbb7c8dbc7f)|
