### PR TITLE
feat(server): parse offset from "Image_UTC_Data" (Samsung)

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1121,10 +1121,11 @@
       }
     },
     "node_modules/@photostructure/tz-lookup": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-10.0.0.tgz",
-      "integrity": "sha512-8ZAjoj/irCuvUlyEinQ/HB6A8hP3bD1dgTOZvfl1b9nAwqniutFDHOQRcGM6Crea68bOwPj010f0Z4KkmuLHEA==",
-      "dev": true
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.0.0.tgz",
+      "integrity": "sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3246,27 +3247,27 @@
       }
     },
     "node_modules/exiftool-vendored": {
-      "version": "28.2.1",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.2.1.tgz",
-      "integrity": "sha512-D3YsKErr3BbjKeJzUVsv6CVZ+SQNgAJKPFWVLXu0CBtr24FNuE3CZBXWKWysGu0MjzeDCNwQrQI5+bXUFeiYVA==",
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.3.0.tgz",
+      "integrity": "sha512-2DOSOvj5c1gkbKtubAnlGglxdYp9h55n0GxjK2nypVivoaCdgP/le3MOZRKgEUNObfJHmYHj4u/NnYVneu/gUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@photostructure/tz-lookup": "^10.0.0",
+        "@photostructure/tz-lookup": "^11.0.0",
         "@types/luxon": "^3.4.2",
         "batch-cluster": "^13.0.0",
         "he": "^1.2.0",
         "luxon": "^3.5.0"
       },
       "optionalDependencies": {
-        "exiftool-vendored.exe": "12.91.0",
-        "exiftool-vendored.pl": "12.91.0"
+        "exiftool-vendored.exe": "12.96.0",
+        "exiftool-vendored.pl": "12.96.0"
       }
     },
     "node_modules/exiftool-vendored.exe": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.91.0.tgz",
-      "integrity": "sha512-nxcoGBaJL/D+Wb0jVe8qwyV8QZpRcCzU0aCKhG0S1XNGWGjJJJ4QV851aobcfDwI4NluFOdqkjTSf32pVijvHg==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.96.0.tgz",
+      "integrity": "sha512-pKPN9F/Evw2yyO5/+ml3spbXIqejzOxyF7jEnj8tLU2JPSmIlziPUZ75XIhcPbilX86jVKmuiso7FUDicOg8pQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3275,9 +3276,9 @@
       ]
     },
     "node_modules/exiftool-vendored.pl": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.91.0.tgz",
-      "integrity": "sha512-GZMy9+Jiv8/C7R4uYe1kWtXsAaJdgVezTwYa+wDeoqvReHiX2t5uzkCrzWdjo4LGl5mPQkyKhN7/uPLYk5Ak6w==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.96.0.tgz",
+      "integrity": "sha512-v4nGnovAMBsTfOWhwAcOiRiq/8kuJOo3GUMHNpug7Mr4jLz3tmWEo7DdNyOYmpcvWbA6smOTG0SmwsrY8fsW+A==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4198,9 +4198,9 @@
       }
     },
     "node_modules/@photostructure/tz-lookup": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-10.0.0.tgz",
-      "integrity": "sha512-8ZAjoj/irCuvUlyEinQ/HB6A8hP3bD1dgTOZvfl1b9nAwqniutFDHOQRcGM6Crea68bOwPj010f0Z4KkmuLHEA=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.0.0.tgz",
+      "integrity": "sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8497,34 +8497,34 @@
       }
     },
     "node_modules/exiftool-vendored": {
-      "version": "28.2.1",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.2.1.tgz",
-      "integrity": "sha512-D3YsKErr3BbjKeJzUVsv6CVZ+SQNgAJKPFWVLXu0CBtr24FNuE3CZBXWKWysGu0MjzeDCNwQrQI5+bXUFeiYVA==",
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.3.0.tgz",
+      "integrity": "sha512-2DOSOvj5c1gkbKtubAnlGglxdYp9h55n0GxjK2nypVivoaCdgP/le3MOZRKgEUNObfJHmYHj4u/NnYVneu/gUw==",
       "dependencies": {
-        "@photostructure/tz-lookup": "^10.0.0",
+        "@photostructure/tz-lookup": "^11.0.0",
         "@types/luxon": "^3.4.2",
         "batch-cluster": "^13.0.0",
         "he": "^1.2.0",
         "luxon": "^3.5.0"
       },
       "optionalDependencies": {
-        "exiftool-vendored.exe": "12.91.0",
-        "exiftool-vendored.pl": "12.91.0"
+        "exiftool-vendored.exe": "12.96.0",
+        "exiftool-vendored.pl": "12.96.0"
       }
     },
     "node_modules/exiftool-vendored.exe": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.91.0.tgz",
-      "integrity": "sha512-nxcoGBaJL/D+Wb0jVe8qwyV8QZpRcCzU0aCKhG0S1XNGWGjJJJ4QV851aobcfDwI4NluFOdqkjTSf32pVijvHg==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.96.0.tgz",
+      "integrity": "sha512-pKPN9F/Evw2yyO5/+ml3spbXIqejzOxyF7jEnj8tLU2JPSmIlziPUZ75XIhcPbilX86jVKmuiso7FUDicOg8pQ==",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/exiftool-vendored.pl": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.91.0.tgz",
-      "integrity": "sha512-GZMy9+Jiv8/C7R4uYe1kWtXsAaJdgVezTwYa+wDeoqvReHiX2t5uzkCrzWdjo4LGl5mPQkyKhN7/uPLYk5Ak6w==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.96.0.tgz",
+      "integrity": "sha512-v4nGnovAMBsTfOWhwAcOiRiq/8kuJOo3GUMHNpug7Mr4jLz3tmWEo7DdNyOYmpcvWbA6smOTG0SmwsrY8fsW+A==",
       "optional": true,
       "os": [
         "!win32"
@@ -17860,9 +17860,9 @@
       }
     },
     "@photostructure/tz-lookup": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-10.0.0.tgz",
-      "integrity": "sha512-8ZAjoj/irCuvUlyEinQ/HB6A8hP3bD1dgTOZvfl1b9nAwqniutFDHOQRcGM6Crea68bOwPj010f0Z4KkmuLHEA=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@photostructure/tz-lookup/-/tz-lookup-11.0.0.tgz",
+      "integrity": "sha512-QMV5/dWtY/MdVPXZs/EApqzyhnqDq1keYEqpS+Xj2uidyaqw2Nk/fWcsszdruIXjdqp1VoWNzsgrO6bUHU1mFw=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -21004,29 +21004,29 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "exiftool-vendored": {
-      "version": "28.2.1",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.2.1.tgz",
-      "integrity": "sha512-D3YsKErr3BbjKeJzUVsv6CVZ+SQNgAJKPFWVLXu0CBtr24FNuE3CZBXWKWysGu0MjzeDCNwQrQI5+bXUFeiYVA==",
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored/-/exiftool-vendored-28.3.0.tgz",
+      "integrity": "sha512-2DOSOvj5c1gkbKtubAnlGglxdYp9h55n0GxjK2nypVivoaCdgP/le3MOZRKgEUNObfJHmYHj4u/NnYVneu/gUw==",
       "requires": {
-        "@photostructure/tz-lookup": "^10.0.0",
+        "@photostructure/tz-lookup": "^11.0.0",
         "@types/luxon": "^3.4.2",
         "batch-cluster": "^13.0.0",
-        "exiftool-vendored.exe": "12.91.0",
-        "exiftool-vendored.pl": "12.91.0",
+        "exiftool-vendored.exe": "12.96.0",
+        "exiftool-vendored.pl": "12.96.0",
         "he": "^1.2.0",
         "luxon": "^3.5.0"
       }
     },
     "exiftool-vendored.exe": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.91.0.tgz",
-      "integrity": "sha512-nxcoGBaJL/D+Wb0jVe8qwyV8QZpRcCzU0aCKhG0S1XNGWGjJJJ4QV851aobcfDwI4NluFOdqkjTSf32pVijvHg==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.exe/-/exiftool-vendored.exe-12.96.0.tgz",
+      "integrity": "sha512-pKPN9F/Evw2yyO5/+ml3spbXIqejzOxyF7jEnj8tLU2JPSmIlziPUZ75XIhcPbilX86jVKmuiso7FUDicOg8pQ==",
       "optional": true
     },
     "exiftool-vendored.pl": {
-      "version": "12.91.0",
-      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.91.0.tgz",
-      "integrity": "sha512-GZMy9+Jiv8/C7R4uYe1kWtXsAaJdgVezTwYa+wDeoqvReHiX2t5uzkCrzWdjo4LGl5mPQkyKhN7/uPLYk5Ak6w==",
+      "version": "12.96.0",
+      "resolved": "https://registry.npmjs.org/exiftool-vendored.pl/-/exiftool-vendored.pl-12.96.0.tgz",
+      "integrity": "sha512-v4nGnovAMBsTfOWhwAcOiRiq/8kuJOo3GUMHNpug7Mr4jLz3tmWEo7DdNyOYmpcvWbA6smOTG0SmwsrY8fsW+A==",
       "optional": true
     },
     "express": {

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -15,6 +15,7 @@ export class MetadataRepository implements IMetadataRepository {
     defaultVideosToUTC: true,
     backfillTimezones: true,
     inferTimezoneFromDatestamps: true,
+    inferTimezoneFromTimeStamp: true,
     useMWG: true,
     numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength'],
     /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */


### PR DESCRIPTION
A Samsung phone might provide the local time (e.g. 09:00) without any timezone or
offset information. If the file also includes the non-standard trailer tag
"TimeStamp" in "Image_UTC_Data", we can use the unix timestamp contained within to
deduce the offset.

As an example, if the local date/time is "2024-09-15T09:00" and the unix timestamp is
1726408800 (which is 2024-09-15T16:00 UTC), we know that the offset is -07:00.

The actual computation/fix is done in exiftool-vendored.

Also see
https://github.com/exiftool/exiftool/blob/0f63a780906abcccba796761fc2e66a0737e2f16/lib/Image/ExifTool/Samsung.pm#L996-L1001
https://github.com/photostructure/exiftool-vendored.js/issues/209