### PR TITLE
fix: deletedAt not set for offline assets during 1.116.0 migration

### DIFF
--- a/server/src/migrations/1727781844613-IsOfflineSetDeletedAt.ts
+++ b/server/src/migrations/1727781844613-IsOfflineSetDeletedAt.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class IsOfflineSetDeletedAt1727781844613 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `UPDATE assets SET "deletedAt" = now() WHERE "isOffline" = true AND "deletedAt" IS NULL`,
+      );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(
+        `UPDATE assets SET "deletedAt" = null WHERE "isOffline" = true`,
+      );
+    }
+}


### PR DESCRIPTION
Since 1.116.0 we now assume deletedAt is set for offline assets, which makes them show in trash and get hidden in other screens. This PR will add a migration to set deletedAt for all offline files at the time it runs.