### PR TITLE
add env_file to all docker services for timezone consistency

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -48,6 +48,8 @@ services:
   redis:
     container_name: immich_redis
     image: redis:6.2-alpine@sha256:2d1463258f2764328496376f5d965f20c6a67f66ea2b06dc42af351f75248792
+    env_file:
+      - .env
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,6 +49,8 @@ services:
   redis:
     container_name: immich_redis
     image: docker.io/redis:6.2-alpine@sha256:2d1463258f2764328496376f5d965f20c6a67f66ea2b06dc42af351f75248792
+    env_file:
+      - .env
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always
@@ -56,6 +58,8 @@ services:
   database:
     container_name: immich_postgres
     image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    env_file:
+      - .env
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
This PR adds env_file to all Docker containers to ensure timezone settings are consistent throughout the stack. By centralizing the environment configurations, we avoid any potential issues caused by mismatched timezones between services.