### PR TITLE
fix: mouse hover over stack

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -590,6 +590,7 @@
                 preloadAssets = index + 1 >= stackedAssets.length ? [] : [stackedAssets[index + 1]];
               }}
               onMouseEvent={({ isMouseOver }) => handleStackedAssetMouseEvent(isMouseOver, stackedAsset)}
+              disableMouseOver
               readonly
               thumbnailSize={stackedAsset.id == asset.id ? 65 : 60}
               showStackedIcon={false}

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -44,6 +44,7 @@
   export let readonly = false;
   export let showArchiveIcon = false;
   export let showStackedIcon = true;
+  export let disableMouseOver = false;
   export let intersectionConfig: {
     root?: HTMLElement;
     bottom?: string;
@@ -207,7 +208,7 @@
       on:click={handleClick}
       role="link"
     >
-      {#if mouseOver}
+      {#if mouseOver && !disableMouseOver}
         <!-- lazy show the url on mouse over-->
         <a
           class="absolute z-30 {className} top-[41px]"


### PR DESCRIPTION
fixes weird glitches when hovering over thumbnail stack from asset viewer.

## Screenshots

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/ac887fb9-6173-4a90-ae04-839c6361b763"> | <video src="https://github.com/user-attachments/assets/c3ccb5dd-d925-47e2-8ebc-b74f433baefb"> |
