### PR TITLE
fix(server): thumbnail colorspace handling

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -79,13 +79,12 @@ export class MediaRepository implements IMediaRepository {
       failOn: options.processInvalidImages ? 'none' : 'error',
       limitInputPixels: false,
       raw: options.raw,
-    });
+    })
+      .pipelineColorspace(options.colorspace === Colorspace.SRGB ? 'srgb' : 'rgb16')
+      .withIccProfile(options.colorspace);
 
     if (!options.raw) {
-      pipeline = pipeline
-        .pipelineColorspace(options.colorspace === Colorspace.SRGB ? 'srgb' : 'rgb16')
-        .withIccProfile(options.colorspace)
-        .rotate();
+      pipeline = pipeline.rotate();
     }
 
     if (options.crop) {


### PR DESCRIPTION
## Description

The target ICC profile isn't set right now so the output images are in sRGB. Also sets the pipeline colorspace because sharp (incorrectly) assumes the input image is sRGB otherwise.

## How Has This Been Tested?

Tested that a test P3 image had its colorspace preserved after its thumbnail and preview were generated.

Compared to #13012, this used 80MiB more RAM at peak and looks about the same on average. The ~73% speed boost in the earlier test is down to 70%.