### PR TITLE
Adds a new flag to allow deleting duplicates such as those that have already been uploaded.

### DIFF
--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -66,7 +66,14 @@ export const upload = async (paths: string[], baseOptions: BaseOptions, options:
   const { newFiles, duplicates } = await checkForDuplicates(scanFiles, options);
   const newAssets = await uploadFiles(newFiles, options);
   await updateAlbums([...newAssets, ...duplicates], options);
-  await deleteFiles(newFiles, options);
+
+  // if there were new files found in this run, then delete them if requested, leaving duplicates on disk
+  // otherwise if there were no new files, and everything is a duplicate, delete the files that are duplicates
+  if (!options.deleteDuplicates) {
+    await deleteFiles(newFiles, options);
+  } else {
+    await deleteFiles([...newFiles, ...duplicates], options);
+  }
 };
 
 const scan = async (pathsToCrawl: string[], options: UploadOptionsDto) => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,6 +69,7 @@ program
       .default(4),
   )
   .addOption(new Option('--delete', 'Delete local assets after upload').env('IMMICH_DELETE_ASSETS'))
+  .addOption(new Option('--delete-duplicates', 'Delete duplicate assets as well or those that already exist on the server').env('IMMICH_DELETE_DUPLICATES'))
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => upload(paths, program.opts(), options));
 


### PR DESCRIPTION
Currently once you have uploaded files to Immich, if you want to delete those after verifying them within Immich, you are unable to as they are marked as duplicates, and immich-cli only deletes new files.

This adds a new flag to allow deleting duplicates along with the new files, so that if you have already uploaded them to Immich you can now delete them locally.

Here is example usage showing a dry run of what this would do:

```
oot@5a237b7d69b0:/dropbox/Camera Uploads/2018-07# immich upload . -a -n --delete
Crawling for assets...
Checking files | ████████████████████████████████████████ | 100% | ETA: 0s | 172/172 assets
Found 172 new files and 0 duplicates
Would have uploaded 172 assets (1.1 GB)
Would have created 1 new album
Would have updated albums of 172 assets
Would have deleted 172 local assets
root@5a237b7d69b0:/dropbox/Camera Uploads/2018-07# cd /dropbox/Photos/2004\ Engagement\:Wedding\ Photos/
root@5a237b7d69b0:/dropbox/Photos/2004 Engagement:Wedding Photos# immich upload . -a -n --delete
Crawling for assets...
Checking files | ████████████████████████████████████████ | 100% | ETA: 0s | 42/42 assets
Found 0 new files and 42 duplicates
All assets were already uploaded, nothing to do.
Would have created 0 new albums
Would have updated albums of 42 assets
Would have deleted 0 local assets
root@5a237b7d69b0:/dropbox/Photos/2004 Engagement:Wedding Photos# immich upload . -a -n --delete --delete-duplicates
Crawling for assets...
Checking files | ████████████████████████████████████████ | 100% | ETA: 0s | 42/42 assets
Found 0 new files and 42 duplicates
All assets were already uploaded, nothing to do.
Would have created 0 new albums
Would have updated albums of 42 assets
Would have deleted 42 local assets
```