### PR TITLE
fix: preloading fonts

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -13,8 +13,8 @@
     <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96.png" />
     <link rel="icon" type="image/png" sizes="144x144" href="/favicon-144.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180.png" />
-    <link rel="preload" as="font" type="font/ttf" href="%app.font%" />
-    <link rel="preload" as="font" type="font/ttf" href="%app.monofont%" />
+    <link rel="preload" as="font" type="font/ttf" href="%app.font%" crossorigin="anonymous" />
+    <link rel="preload" as="font" type="font/ttf" href="%app.monofont%" crossorigin="anonymous" />
     %sveltekit.head%
     <style>
       /* prevent FOUC */


### PR DESCRIPTION
Avoid fetching the fonts twice and solve this console warning: `The resource at “http://localhost:2283/src/lib/assets/fonts/overpass/Overpass.ttf” preloaded with link preload was not used within a few seconds. Make sure all attributes of the preload tag are set correctly.`

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin