### PR TITLE
refactor(mobile): assert lists are sorted for diffing

### DIFF
--- a/mobile/lib/services/sync.service.dart
+++ b/mobile/lib/services/sync.service.dart
@@ -138,7 +138,6 @@ class SyncService {
   Future<bool> _syncUsersFromServer(List<User> users) async {
     users.sortBy((u) => u.id);
     final dbUsers = await _userRepository.getAll(sortBy: UserSort.id);
-    assert(dbUsers.isSortedBy((u) => u.id), "dbUsers not sorted!");
     final List<int> toDelete = [];
     final List<User> toUpsert = [];
     final changes = diffSortedListsSync(
@@ -322,8 +321,6 @@ class SyncService {
       ownerId: isShared ? null : me.isarId,
       sortBy: AlbumSort.remoteId,
     );
-    assert(dbAlbums.isSortedBy((e) => e.remoteId!), "dbAlbums not sorted!");
-
     final List<Asset> toDelete = [];
     final List<Asset> existing = [];
 
@@ -512,7 +509,6 @@ class SyncService {
         await _albumRepository.getAll(remote: false, sortBy: AlbumSort.localId);
     final List<Asset> deleteCandidates = [];
     final List<Asset> existing = [];
-    assert(inDb.isSorted((a, b) => a.localId!.compareTo(b.localId!)), "sort!");
     final bool anyChanges = await diffSortedLists(
       onDevice,
       inDb,

--- a/mobile/lib/utils/diff.dart
+++ b/mobile/lib/utils/diff.dart
@@ -1,16 +1,20 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
+
 /// Efficiently compares two sorted lists in O(n), calling the given callback
 /// for each item.
 /// Return `true` if there are any differences found, else `false`
-Future<bool> diffSortedLists<A, B>(
-  List<A> la,
-  List<B> lb, {
-  required int Function(A a, B b) compare,
-  required FutureOr<bool> Function(A a, B b) both,
-  required FutureOr<void> Function(A a) onlyFirst,
-  required FutureOr<void> Function(B b) onlySecond,
+Future<bool> diffSortedLists<T>(
+  List<T> la,
+  List<T> lb, {
+  required int Function(T a, T b) compare,
+  required FutureOr<bool> Function(T a, T b) both,
+  required FutureOr<void> Function(T a) onlyFirst,
+  required FutureOr<void> Function(T b) onlySecond,
 }) async {
+  assert(la.isSorted(compare), "first argument must be sorted");
+  assert(lb.isSorted(compare), "second argument must be sorted");
   bool diff = false;
   int i = 0, j = 0;
   for (; i < la.length && j < lb.length;) {
@@ -38,14 +42,16 @@ Future<bool> diffSortedLists<A, B>(
 /// Efficiently compares two sorted lists in O(n), calling the given callback
 /// for each item.
 /// Return `true` if there are any differences found, else `false`
-bool diffSortedListsSync<A, B>(
-  List<A> la,
-  List<B> lb, {
-  required int Function(A a, B b) compare,
-  required bool Function(A a, B b) both,
-  required void Function(A a) onlyFirst,
-  required void Function(B b) onlySecond,
+bool diffSortedListsSync<T>(
+  List<T> la,
+  List<T> lb, {
+  required int Function(T a, T b) compare,
+  required bool Function(T a, T b) both,
+  required void Function(T a) onlyFirst,
+  required void Function(T b) onlySecond,
 }) {
+  assert(la.isSorted(compare), "first argument must be sorted");
+  assert(lb.isSorted(compare), "second argument must be sorted");
   bool diff = false;
   int i = 0, j = 0;
   for (; i < la.length && j < lb.length;) {


### PR DESCRIPTION
since the recent refactoring to remove any usage of photo manager, we can now improve the diffSortedLists method by requiring both lists to have the same type of elements. This allows to move the assertion to check sortedness into the method