### PR TITLE
chore: auth unit tests

### DIFF
--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -192,10 +192,6 @@ export class AuthService extends BaseService {
 
   async authorize(dto: OAuthConfigDto): Promise<OAuthAuthorizeResponseDto> {
     const config = await this.getConfig({ withCache: false });
-    if (!config.oauth.enabled) {
-      throw new BadRequestException('OAuth is not enabled');
-    }
-
     const client = await this.getOAuthClient(config);
     const url = client.authorizationUrl({
       redirect_uri: this.normalize(config, dto.redirectUri),


### PR DESCRIPTION
<img width="840" alt="Screenshot 2024-10-05 at 18 01 24" src="https://github.com/user-attachments/assets/c3f718ff-1e76-4819-8157-67e30dcfea66">

The remaining lines are untestable currently because we cannot mock out the OIDC handling, since that isn't abstracted away in a repo.