### PR TITLE
docs: fix confustion about libmali in hardware-transcoding.md 

### DIFF
--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -49,7 +49,7 @@ For RKMPP to work:
 
 - You must have a supported Rockchip ARM SoC.
 - Only RK3588 supports hardware tonemapping, other SoCs use slower software tonemapping while still using hardware encoding.
-- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so.1` to be present on your host system. Install [`libmali-valhall-g610-g6p0-gbm`][libmali-rockchip] and modify the [`hwaccel.transcoding.yml`][hw-file] file:
+- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so.1` to be present on your host system. Install [`libmali that correspond to your mail gpu`][libmali-rockchip] and modify the [`hwaccel.transcoding.yml`][hw-file] file:
   - under `rkmpp` uncomment the 3 lines required for OpenCL tonemapping by removing the `#` symbol at the beginning of each line
   - `- /dev/mali0:/dev/mali0`
   - `- /etc/OpenCL:/etc/OpenCL:ro`

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -49,7 +49,7 @@ For RKMPP to work:
 
 - You must have a supported Rockchip ARM SoC.
 - Only RK3588 supports hardware tonemapping, other SoCs use slower software tonemapping while still using hardware encoding.
-- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so.1` to be present on your host system. Install [`libmali that correspond to your mail gpu`][libmali-rockchip] and modify the [`hwaccel.transcoding.yml`][hw-file] file:
+- Tonemapping requires `/usr/lib/aarch64-linux-gnu/libmali.so.1` to be present on your host system. Install the [`libmali`][libmali-rockchip] release that corresponds to your Mali GPU (`libmali-valhall-g610-g13p0-gbm` on RK3588) and modify the [`hwaccel.transcoding.yml`][hw-file] file:
   - under `rkmpp` uncomment the 3 lines required for OpenCL tonemapping by removing the `#` symbol at the beginning of each line
   - `- /dev/mali0:/dev/mali0`
   - `- /etc/OpenCL:/etc/OpenCL:ro`


### PR DESCRIPTION
Update hardware-transcoding.md to prevent newbies from installing the wrong libmali version on different rockchip boards.

Ex. the user might be installing libmali-valhall-g610-g6p0-gbm on rk3566 (Mali-G52) board.