### PR TITLE
fix(web): video player on Safari

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -84,9 +84,8 @@
     muted={forceMuted || $videoViewerMuted}
     bind:volume={$videoViewerVolume}
     poster={getAssetThumbnailUrl({ id: assetId, size: AssetMediaSize.Preview, checksum })}
+    src={assetFileUrl}
   >
-    <source src={assetFileUrl} type="video/mp4" />
-    <track kind="captions" />
   </video>
 
   {#if isVideoLoading}


### PR DESCRIPTION
Closes #13223
Fixes #10814

Tested on 
- iOS Safari
- MacOS Safari
- Chrome
- Firefox