### PR TITLE
docs: add developer notes about rootless docker setup

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -7,7 +7,7 @@ name: immich-dev
 services:
   immich-server:
     container_name: immich_server
-    command: ['/usr/src/app/bin/immich-dev']
+    command: [ '/usr/src/app/bin/immich-dev' ]
     image: immich-server-dev:latest
     # extends:
     #   file: hwaccel.transcoding.yml
@@ -53,9 +53,11 @@ services:
   immich-web:
     container_name: immich_web
     image: immich-web-dev:latest
+    # Needed for rootless docker setup, see https://github.com/moby/moby/issues/45919
+    # user: 0:0
     build:
       context: ../web
-    command: ['/usr/src/app/bin/immich-web']
+    command: [ '/usr/src/app/bin/immich-web' ]
     env_file:
       - .env
     ports:
@@ -122,23 +124,7 @@ services:
       interval: 5m
       start_interval: 30s
       start_period: 5m
-    command:
-      [
-        'postgres',
-        '-c',
-        'shared_preload_libraries=vectors.so',
-        '-c',
-        'search_path="$$user", public, vectors',
-        '-c',
-        'logging_collector=on',
-        '-c',
-        'max_wal_size=2GB',
-        '-c',
-        'shared_buffers=512MB',
-        '-c',
-        'wal_compression=on',
-      ]
-
+    command: [ 'postgres', '-c', 'shared_preload_libraries=vectors.so', '-c', 'search_path="$$user", public, vectors', '-c', 'logging_collector=on', '-c', 'max_wal_size=2GB', '-c', 'shared_buffers=512MB', '-c', 'wal_compression=on' ]
   # set IMMICH_METRICS=true in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
     # user: 0:0
     build:
       context: ../web
-    command: [ '/usr/src/app/bin/immich-web' ]
+    command: ['/usr/src/app/bin/immich-web']
     env_file:
       - .env
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -7,7 +7,7 @@ name: immich-dev
 services:
   immich-server:
     container_name: immich_server
-    command: [ '/usr/src/app/bin/immich-dev' ]
+    command: ['/usr/src/app/bin/immich-dev']
     image: immich-server-dev:latest
     # extends:
     #   file: hwaccel.transcoding.yml

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -124,7 +124,22 @@ services:
       interval: 5m
       start_interval: 30s
       start_period: 5m
-    command: [ 'postgres', '-c', 'shared_preload_libraries=vectors.so', '-c', 'search_path="$$user", public, vectors', '-c', 'logging_collector=on', '-c', 'max_wal_size=2GB', '-c', 'shared_buffers=512MB', '-c', 'wal_compression=on' ]
+    command:
+      [
+        'postgres',
+        '-c',
+        'shared_preload_libraries=vectors.so',
+        '-c',
+        'search_path="$$user", public, vectors',
+        '-c',
+        'logging_collector=on',
+        '-c',
+        'max_wal_size=2GB',
+        '-c',
+        'shared_buffers=512MB',
+        '-c',
+        'wal_compression=on',
+      ]
   # set IMMICH_METRICS=true in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -140,6 +140,7 @@ services:
         '-c',
         'wal_compression=on',
       ]
+
   # set IMMICH_METRICS=true in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -46,8 +46,9 @@ All the services will be started with hot-reloading enabled for a quick feedback
 You can access the web from `http://your-machine-ip:2283` or `http://localhost:2283` and access the server from the mobile app at `http://your-machine-ip:2283/api`
 
 **Notes:**
- - The "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
- - In case of rootless docker setup, you need to use root within the container, otherwise you will encounter read/write permission related errors, see comments in `docker/docker-compose.dev.yml`.
+
+- The "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
+- In case of rootless docker setup, you need to use root within the container, otherwise you will encounter read/write permission related errors, see comments in `docker/docker-compose.dev.yml`.
 
 #### Connect web to a remote backend
 

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -45,7 +45,9 @@ All the services will be started with hot-reloading enabled for a quick feedback
 
 You can access the web from `http://your-machine-ip:2283` or `http://localhost:2283` and access the server from the mobile app at `http://your-machine-ip:2283/api`
 
-**Note:** the "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
+**Notes:**
+ - The "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
+ - In case of rootless docker setup, you need to use root within the container, otherwise you will encounter read/write permission related errors, see comments in `docker/docker-compose.dev.yml`.
 
 #### Connect web to a remote backend
 


### PR DESCRIPTION

Based on the earlier developer setup guide, after executing `make dev`, permission problems can occur in the web service, like the following:
```
immich_web               | failed to load config from /usr/src/app/vite.config.js
immich_web               | error when starting dev server:
immich_web               | Error: EACCES: permission denied, open '/usr/src/app/vite.config.js.timestamp-1727939078397-b40dceb29345c.mjs'
```

This is expected when using rootless docker, see https://github.com/moby/moby/issues/45919.
In this PR the developer guide is extended with notes to mitigate the problem, and comments are added to the dev composer file as well.
