### PR TITLE
fix(server): external libraries queueing two transcode jobs

### DIFF
--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -496,14 +496,6 @@ describe(LibraryService.name, () => {
             },
           },
         ],
-        [
-          {
-            name: JobName.VIDEO_CONVERSION,
-            data: {
-              id: assetStub.video.id,
-            },
-          },
-        ],
       ]);
     });
 

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -431,10 +431,6 @@ export class LibraryService extends BaseService {
     this.logger.debug(`Queueing metadata extraction for: ${asset.originalPath}`);
 
     await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: asset.id, source: 'upload' } });
-
-    if (asset.type === AssetType.VIDEO) {
-      await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id: asset.id } });
-    }
   }
 
   async queueScan(id: string) {


### PR DESCRIPTION
Fixes #13156

Metadata extraction is queued for a new asset or modified asset, which will subsequently queue a video transcoding job for video files. Tested this with new and modified assets with both manual scanning and file watching.