### PR TITLE
fix(server): searching with both `personIds` and `withPeople`

### DIFF
--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -26,7 +26,7 @@ import { asVector, searchAssetBuilder } from 'src/utils/database';
 import { Instrumentation } from 'src/utils/instrumentation';
 import { Paginated, PaginationResult, paginatedBuilder } from 'src/utils/pagination';
 import { isValidInteger } from 'src/validation';
-import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Repository } from 'typeorm';
 
 @Instrumentation()
 @Injectable()

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -92,7 +92,6 @@ export function searchAssetBuilder(
     withPeople,
     withSmartInfo,
     personIds,
-    withExif,
     withStacked,
     trashedAfter,
     trashedBefore,


### PR DESCRIPTION
## Description

The search builder ends up joining the same table twice. However, even when this is corrected, the query doesn't work because the selected fields are incompatibe with the group by clause. This PR changes this section to use a CTE like for smart search.

Fixes #13149


## How Has This Been Tested?

Called the endpoint with `personIds` and `withPerson` both set and confirmed a successful response.