### PR TITLE
docs: Extend non-root guide and create dedicated compose file for it

### DIFF
--- a/docker/docker-compose.non-root.yml
+++ b/docker/docker-compose.non-root.yml
@@ -1,0 +1,81 @@
+#
+# WARNING: Make sure to use the docker-compose.non-root.yml of the current release:
+#
+# https://github.com/immich-app/immich/releases/latest/download/docker-compose.non-root.yml
+#
+# The compose file on main may not be compatible with the latest release.
+#
+
+name: immich
+
+services:
+  immich-server:
+    container_name: immich_server
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+    user: ${USER_ID}:${GROUP_ID}
+    # extends:
+    #   file: hwaccel.transcoding.yml
+    #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
+    volumes:
+      # Do not edit the next line. If you want to change the media storage location on your system, edit the value of UPLOAD_LOCATION in the .env file
+      - ${UPLOAD_LOCATION}:/usr/src/app/upload
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    ports:
+      - 2283:3001
+    depends_on:
+      - redis
+      - database
+    restart: always
+    healthcheck:
+      disable: false
+
+  immich-machine-learning:
+    user: ${USER_ID}:${GROUP_ID}
+    container_name: immich_machine_learning
+    # For hardware acceleration, add one of -[armnn, cuda, openvino] to the image tag.
+    # Example tag: ${IMMICH_VERSION:-release}-cuda
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    # extends: # uncomment this section for hardware acceleration - see https://immich.app/docs/features/ml-hardware-acceleration
+    #   file: hwaccel.ml.yml
+    #   service: cpu # set to one of [armnn, cuda, openvino, openvino-wsl] for accelerated inference - use the `-wsl` version for WSL2 where applicable
+    volumes:
+      - ${MODEL_CACHE_LOCATION}:/cache
+      - ${ML_CONFIG_LOCATION}:/.config
+    env_file:
+      - .env
+    restart: always
+    healthcheck:
+      disable: false
+
+  redis:
+    user: ${USER_ID}:${GROUP_ID}
+    container_name: immich_redis
+    image: docker.io/redis:6.2-alpine@sha256:2d1463258f2764328496376f5d965f20c6a67f66ea2b06dc42af351f75248792
+    volumes:
+      - ${REDIS_DATA_LOCATION}:/data
+    healthcheck:
+      test: redis-cli ping || exit 1
+    restart: always
+
+  database:
+    user: 999:999
+    container_name: immich_postgres
+    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_DB: ${DB_DATABASE_NAME}
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    volumes:
+      # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready --dbname='${DB_DATABASE_NAME}' --username='${DB_USERNAME}' || exit 1; Chksum="$$(psql --dbname='${DB_DATABASE_NAME}' --username='${DB_USERNAME}' --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')"; echo "checksum failure count is $$Chksum"; [ "$$Chksum" = '0' ] || exit 1
+      interval: 5m
+      start_interval: 30s
+      start_period: 5m
+    command: ["postgres", "-c", "shared_preload_libraries=vectors.so", "-c", 'search_path="$$user", public, vectors', "-c", "logging_collector=on", "-c", "max_wal_size=2GB", "-c", "shared_buffers=512MB", "-c", "wal_compression=on"]
+    restart: always
+

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -326,14 +326,15 @@ To decrease Redis logs, you can add the following line to the `redis:` section o
 
 ### How can I run Immich as a non-root user?
 
-You can change the user in the container by setting the `user` argument in `docker-compose.yml` for each service.
-You may need to add mount points or docker volumes for the following internal container paths:
+You need to use the `docker-compose.non-root.yml` and extend the .env file with the following variables:
+- REDIS_DATA_LOCATION
+- MODEL_CACHE_LOCATION
+- ML_CONFIG_LOCATION
+- USER_ID
+- GROUP_ID
 
-- `immich-machine-learning:/.config`
-- `immich-machine-learning:/.cache`
-- `redis:/data`
-
-The non-root user/group needs read/write access to the volume mounts, including `UPLOAD_LOCATION` and `/cache` for machine-learning.
+The given `USER_ID`/`GROUP_ID` needs read/write access to the `_LOCATION` postfixed variable's directories,
+except the DB_DATA_LOCATION which needs to be owned by the 999 userid.
 
 :::note Docker Compose Volumes
 The Docker Compose top level volume element does not support non-root access, all of the above volumes must be local volume mounts.


### PR DESCRIPTION
Based on discussion [13124](https://github.com/immich-app/immich/discussions/13124), creating a dedicated compose file for easier non-root setup guide and refining the relevant FAQ item.