### PR TITLE
fix(server): People count after updating recognized faces count

### DIFF
--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -78,7 +78,7 @@ export interface IPersonRepository {
   getRandomFace(personId: string): Promise<AssetFaceEntity | null>;
   getStatistics(personId: string): Promise<PersonStatistics>;
   reassignFace(assetFaceId: string, newPersonId: string): Promise<number>;
-  getNumberOfPeople(userId: string): Promise<PeopleStatistics>;
+  getNumberOfPeople(userId: string, options: PersonSearchOptions): Promise<PeopleStatistics>;
   reassignFaces(data: UpdateFacesData): Promise<number>;
   unassignFaces(options: UnassignFacesOptions): Promise<void>;
   update(person: Partial<PersonEntity>): Promise<PersonEntity>;

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -45,7 +45,7 @@ import {
 } from 'src/interfaces/job.interface';
 import { BoundingBox } from 'src/interfaces/machine-learning.interface';
 import { CropOptions, ImageDimensions, InputDimensions } from 'src/interfaces/media.interface';
-import { UpdateFacesData } from 'src/interfaces/person.interface';
+import { PersonSearchOptions, UpdateFacesData } from 'src/interfaces/person.interface';
 import { BaseService } from 'src/services/base.service';
 import { checkAccess, requireAccess } from 'src/utils/access';
 import { getAssetFiles } from 'src/utils/asset.util';
@@ -65,11 +65,12 @@ export class PersonService extends BaseService {
     };
 
     const { machineLearning } = await this.getConfig({ withCache: false });
-    const { items, hasNextPage } = await this.personRepository.getAllForUser(pagination, auth.user.id, {
+    const options: PersonSearchOptions = {
       minimumFaceCount: machineLearning.facialRecognition.minFaces,
       withHidden,
-    });
-    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id);
+    };
+    const { items, hasNextPage } = await this.personRepository.getAllForUser(pagination, auth.user.id, options);
+    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id, options);
 
     return {
       people: items.map((person) => mapPerson(person)),


### PR DESCRIPTION
This PR fixes #13245

It updates the query used to fetch the total count of people keeping in consideration the recognized faces setting.