### PR TITLE
fix(server): duplicate faces, face insert query failing

### DIFF
--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -279,7 +279,7 @@ export class PersonRepository implements IPersonRepository {
     faceIdsToRemove: string[],
     embeddingsToAdd?: FaceSearchEntity[],
   ): Promise<void> {
-    const query = this.faceSearchRepository.createQueryBuilder().select('1');
+    const query = this.faceSearchRepository.createQueryBuilder().select('1').fromDummy();
     if (facesToAdd.length > 0) {
       const insertCte = this.assetFaceRepository.createQueryBuilder().insert().values(facesToAdd);
       query.addCommonTableExpression(insertCte, 'added');
@@ -296,6 +296,7 @@ export class PersonRepository implements IPersonRepository {
     if (embeddingsToAdd?.length) {
       const embeddingCte = this.faceSearchRepository.createQueryBuilder().insert().values(embeddingsToAdd).orIgnore();
       query.addCommonTableExpression(embeddingCte, 'embeddings');
+      query.getQuery(); // typeorm mixes up parameters without this
     }
 
     await query.execute();

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -325,7 +325,7 @@ export class PersonService extends BaseService {
 
       if (match && !mlFaceIds.delete(match.id)) {
         embeddings.push({ faceId: match.id, embedding });
-      } else {
+      } else if (!match) {
         const faceId = this.cryptoRepository.randomUUID();
         facesToAdd.push({
           id: faceId,


### PR DESCRIPTION
## Description

The face detection logic can add a duplicate face when there is a machine learning-sourced match. The query to refresh faces is also buggy because TypeORM doesn't parameterize the second insert cte correctly... unless you call `getQuery` first.

## How Has This Been Tested?

Tested that refreshing and resetting with different thresholds work without any errors or duplicate faces.