### PR TITLE
fix(server): Skip errors when scanning library files

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -30,9 +30,12 @@ services:
       - database
     ports:
       - 2285:3001
+    cap_drop:
+      # We need this to perform testing on permission errors
+      - DAC_OVERRIDE
 
   redis:
-    image: redis:6.2-alpine@sha256:2ba50e1ac3a0ea17b736ce9db2b0a9f6f8b85d4c27d5f5accc6a416d8f42c6d5
+    image: redis:6.2-alpine@sha256:2d1463258f2764328496376f5d965f20c6a67f66ea2b06dc42af351f75248792
 
   database:
     image: tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -182,6 +182,7 @@ export class StorageRepository implements IStorageRepository {
       onlyFiles: true,
       dot: includeHidden,
       ignore: exclusionPatterns,
+      suppressErrors: true,
     });
 
     let batch: string[] = [];


### PR DESCRIPTION
Fixes #12713 

There's only a master switch in fast-glob to either ignore all errors or none. Ideally I'd like it to at least log an error when something happens, but I'm out of ideas.