### PR TITLE
chore(mobile): clean up

### DIFF
--- a/mobile/lib/providers/album/album.provider.dart
+++ b/mobile/lib/providers/album/album.provider.dart
@@ -30,11 +30,6 @@ class AlbumNotifier extends StateNotifier<List<Album>> {
   late final StreamSubscription<List<Album>> _streamSub;
 
   Future<void> refreshRemoteAlbums() async {
-    final isRefresing =
-        ref.read(isRefreshingRemoteAlbumProvider.notifier).state;
-
-    if (isRefresing) return;
-
     ref.read(isRefreshingRemoteAlbumProvider.notifier).state = true;
     await _albumService.refreshRemoteAlbums();
     ref.read(isRefreshingRemoteAlbumProvider.notifier).state = false;

--- a/mobile/lib/services/sync.service.dart
+++ b/mobile/lib/services/sync.service.dart
@@ -797,8 +797,7 @@ class SyncService {
     assets.sort(Asset.compareByOwnerChecksumCreatedModified);
     assets.uniqueConsecutive(
       compare: Asset.compareByOwnerChecksum,
-      onDuplicate: (a, b) =>
-          _log.info("Ignoring duplicate assets on device:\n$a\n$b"),
+      onDuplicate: (a, b) => {},
     );
     final int duplicates = before - assets.length;
     if (duplicates > 0) {


### PR DESCRIPTION
- Clean up unncessary log information that is not being used in debugging
- Removed processing state check since it is already implemented in the service
