### PR TITLE
ci: don't auto-update mapbox-gl-rtl-text

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "groupName": "typescript-projects",
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackagePrefixes": ["exiftool", "reflect-metadata"],
-      "excludePackageNames": ["node", "@types/node"],
+      "excludePackageNames": ["node", "@types/node", "@mapbox/mapbox-gl-rtl-text"],
       "schedule": "on tuesday"
     },
     {


### PR DESCRIPTION
Thought we could do this in the dependency dashboard but can't because of grouping