### PR TITLE
chore: Add viteconfig-timestamp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ mobile/openapi/.openapi-generator/FILES
 open-api/typescript-sdk/build
 mobile/android/fastlane/report.xml
 mobile/ios/fastlane/report.xml
+
+vite.config.js.timestamp-*


### PR DESCRIPTION
Ignore the spurious vite configs that sometimes pop up after testing
![image](https://github.com/user-attachments/assets/6534404f-9e73-4a60-825e-e71425a152f8)
