### PR TITLE
chore(server): explicitly use svt-av1 encoder

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1322,7 +1322,7 @@ describe(MediaService.name, () => {
         expect.objectContaining({
           inputOptions: expect.any(Array),
           outputOptions: expect.arrayContaining([
-            '-c:v av1',
+            '-c:v libsvtav1',
             '-movflags faststart',
             '-fps_mode passthrough',
             '-map 0:0',

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -492,6 +492,10 @@ export class VP9Config extends BaseConfig {
 }
 
 export class AV1Config extends BaseConfig {
+  getVideoCodec(): string {
+    return 'libsvtav1';
+  }
+
   getPresetOptions() {
     const speed = this.getPresetIndex() + 4; // Use 4 as slowest, giving us an effective range of 4-12 which is far more useful than 0-8
     if (speed >= 0) {


### PR DESCRIPTION
SVT-AV1 is much, much faster than the reference libaom encoder. In most real-world cases libaom is too slow to be practical, often struggling to achieve 0.1fps for 1080p content.

I suspect this is what was intended in f1ca1794a182d71e45340a262a450e694f4f1600 when AV1 support was originally added as it sets the `-svtav1-params` flag which is ignored unless using the SVT-AV1 encoder. Furthermore there is lots of discussion about SVT-AV1 in the PR thread.