### PR TITLE
feat: log SOURCE_REF immediately in container startup

### DIFF
--- a/server/start.sh
+++ b/server/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Initializing Immich $IMMICH_SOURCE_REF"
+
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 export LD_PRELOAD="$lib_path"
 


### PR DESCRIPTION
This change makes sure the ref should be in pretty much any log we might get sent, making it easier to catch people running the wrong version.