### PR TITLE
feat(server): add pcm_s16le accepted audio codec

### DIFF
--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -19,7 +19,7 @@ The default configuration looks like this:
     "targetVideoCodec": "h264",
     "acceptedVideoCodecs": ["h264"],
     "targetAudioCodec": "aac",
-    "acceptedAudioCodecs": ["aac", "mp3", "libopus"],
+    "acceptedAudioCodecs": ["aac", "mp3", "libopus", "pcm_s16le"],
     "acceptedContainers": ["mov", "ogg", "webm"],
     "targetResolution": "720",
     "maxBitrate": "0",

--- a/mobile/openapi/lib/model/audio_codec.dart
+++ b/mobile/openapi/lib/model/audio_codec.dart
@@ -26,14 +26,14 @@ class AudioCodec {
   static const mp3 = AudioCodec._(r'mp3');
   static const aac = AudioCodec._(r'aac');
   static const libopus = AudioCodec._(r'libopus');
-  static const pcm_s16le = AudioCodec._(r'pcm_s16le');
+  static const pcmS16le = AudioCodec._(r'pcm_s16le');
 
   /// List of all possible values in this [enum][AudioCodec].
   static const values = <AudioCodec>[
     mp3,
     aac,
     libopus,
-    pcm_s16le,
+    pcmS16le,
   ];
 
   static AudioCodec? fromJson(dynamic value) => AudioCodecTypeTransformer().decode(value);
@@ -75,7 +75,7 @@ class AudioCodecTypeTransformer {
         case r'mp3': return AudioCodec.mp3;
         case r'aac': return AudioCodec.aac;
         case r'libopus': return AudioCodec.libopus;
-        case r'pcm_s16le': return AudioCodec.pcm_s16le;
+        case r'pcm_s16le': return AudioCodec.pcmS16le;
         default:
           if (!allowNull) {
             throw ArgumentError('Unknown enum value to decode: $data');

--- a/mobile/openapi/lib/model/audio_codec.dart
+++ b/mobile/openapi/lib/model/audio_codec.dart
@@ -26,12 +26,14 @@ class AudioCodec {
   static const mp3 = AudioCodec._(r'mp3');
   static const aac = AudioCodec._(r'aac');
   static const libopus = AudioCodec._(r'libopus');
+  static const pcm_s16le = AudioCodec._(r'pcm_s16le');
 
   /// List of all possible values in this [enum][AudioCodec].
   static const values = <AudioCodec>[
     mp3,
     aac,
     libopus,
+    pcm_s16le,
   ];
 
   static AudioCodec? fromJson(dynamic value) => AudioCodecTypeTransformer().decode(value);
@@ -73,6 +75,7 @@ class AudioCodecTypeTransformer {
         case r'mp3': return AudioCodec.mp3;
         case r'aac': return AudioCodec.aac;
         case r'libopus': return AudioCodec.libopus;
+        case r'pcm_s16le': return AudioCodec.pcm_s16le;
         default:
           if (!allowNull) {
             throw ArgumentError('Unknown enum value to decode: $data');

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8507,7 +8507,8 @@
         "enum": [
           "mp3",
           "aac",
-          "libopus"
+          "libopus",
+          "pcm_s16le"
         ],
         "type": "string"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3502,7 +3502,7 @@ export enum AudioCodec {
     Mp3 = "mp3",
     Aac = "aac",
     Libopus = "libopus",
-    Pcms16le = "pcm_s16le"
+    PcmS16Le = "pcm_s16le"
 }
 export enum VideoContainer {
     Mov = "mov",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3501,7 +3501,8 @@ export enum TranscodeHWAccel {
 export enum AudioCodec {
     Mp3 = "mp3",
     Aac = "aac",
-    Libopus = "libopus"
+    Libopus = "libopus",
+    Pcms16le = "pcm_s16le"
 }
 export enum VideoContainer {
     Mov = "mov",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -166,7 +166,7 @@ export const defaults = Object.freeze<SystemConfig>({
     targetVideoCodec: VideoCodec.H264,
     acceptedVideoCodecs: [VideoCodec.H264],
     targetAudioCodec: AudioCodec.AAC,
-    acceptedAudioCodecs: [AudioCodec.AAC, AudioCodec.MP3, AudioCodec.LIBOPUS],
+    acceptedAudioCodecs: [AudioCodec.AAC, AudioCodec.MP3, AudioCodec.LIBOPUS, AudioCodec.PCMS16LE],
     acceptedContainers: [VideoContainer.MOV, VideoContainer.OGG, VideoContainer.WEBM],
     targetResolution: '720',
     maxBitrate: '0',

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -256,6 +256,7 @@ export enum AudioCodec {
   MP3 = 'mp3',
   AAC = 'aac',
   LIBOPUS = 'libopus',
+  PCMS16LE = 'pcm_s16le',
 }
 
 export enum VideoContainer {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -49,7 +49,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     threads: 0,
     preset: 'ultrafast',
     targetAudioCodec: AudioCodec.AAC,
-    acceptedAudioCodecs: [AudioCodec.AAC, AudioCodec.MP3, AudioCodec.LIBOPUS],
+    acceptedAudioCodecs: [AudioCodec.AAC, AudioCodec.MP3, AudioCodec.LIBOPUS, AudioCodec.PCMS16LE],
     targetResolution: '720',
     targetVideoCodec: VideoCodec.H264,
     acceptedVideoCodecs: [VideoCodec.H264],

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -145,6 +145,7 @@
             { value: AudioCodec.Aac, text: 'AAC' },
             { value: AudioCodec.Mp3, text: 'MP3' },
             { value: AudioCodec.Libopus, text: 'Opus' },
+            { value: AudioCodec.Pcms16le, text: 'PCM (16 bit)' },
           ]}
           isEdited={!isEqual(sortBy(config.ffmpeg.acceptedAudioCodecs), sortBy(savedConfig.ffmpeg.acceptedAudioCodecs))}
         />

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -146,7 +146,7 @@
             { value: AudioCodec.Aac, text: 'AAC' },
             { value: AudioCodec.Mp3, text: 'MP3' },
             { value: AudioCodec.Libopus, text: 'Opus' },
-            { value: AudioCodec.Pcms16le, text: 'PCM (16 bit)' },
+            { value: AudioCodec.PcmS16Le, text: 'PCM (16 bit)' },
           ]}
           isEdited={!isEqual(sortBy(config.ffmpeg.acceptedAudioCodecs), sortBy(savedConfig.ffmpeg.acceptedAudioCodecs))}
         />

--- a/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/ffmpeg/ffmpeg-settings.svelte
@@ -102,6 +102,7 @@
           onSelect={() => (config.ffmpeg.acceptedVideoCodecs = [config.ffmpeg.targetVideoCodec])}
         />
 
+        <!-- PCM is excluded here since it's a bad choice for users storage-wise -->
         <SettingSelect
           label={$t('admin.transcoding_audio_codec')}
           {disabled}


### PR DESCRIPTION
This adds the PCM audio codec (encoding, rather) to the list of accepted audio codecs in video transcoding settings.

## About PCM
[PCM](https://en.wikipedia.org/wiki/Pulse-code_modulation) is not really a codec but rather a family of non-proprietary encodings, similar to ASCII, that is the standard for how uncompressed audio is stored. This is best known by proxy of the WAV file format, which is a container for several types of uncompressed audio and is [universally supported on the web](https://caniuse.com/wav).

### Use Case
For our purposes, we don't need WAV files, but we do need to support the audio in iOS Live Photo .MOV videos, which is encoded uncompressed (i.e. in PCM). This is currently transcoded by every policy except transcode-none, which quickly accumulates unnecessary copies of these video files, where each original is about 4MB as produced by my iPhone 11.

### About pcm_s16le
Per its [specification](https://stackoverflow.com/a/43939741/6149041), WAV may contain either PCM or one of several proprietary formats (which we can safely assume are irrelevently niche). If it contains PCM then the WAV spec constrains it to ≤8-bit unsigned or ≥9-bit signed little-endian (where bits count the size of each sample, or frame, of audio). In practice, multiples of 8 are used, and 8 is outdated, which leaves 16 as the baseline format (e.g. audio CDs mandate 16-bit PCM), and 24+ for niche uses. That means that WAV audio (and by extension, consumer uncompressed audio) is expected to be signed 16-bit little-endian, which is a format that ffprobe reports with codec_name = pcm_s16le.

## About this Patch
All codec options in video transcoding settings so far have been aliases to codec_name as above, so I have continued that by aliasing the whole concept of uncompressed PCM audio to the codec_name pcm_s16le. I expect it to be rare that any other PCM format will be encountered by users, but that's a bridge that can be crossed if someone needs it. The web settings page calls the codec "PCM (16 bit)".

### PCM as Target Codec
I have for now excluded PCM from the options for target audio codec, on the grounds that it is wasteful of space. There is no lossless audio option, tho FLAC (?) could be considered for adding one day for example. However, if I'm understanding correctly, the OpenAPI spec forces me to include PCM in the AudioCodec enums, which seems to make it available as an option for getting and setting target codecs as well as accepted ones. So PCM could be selectable as a target codec via the API. Options to resolve this would be:
1. Make a new enum to distinguish target from accepted codecs. Adds a lot of complexity.
2. Make PCM an option for target audio codec in the web settings as well. I don't know what would happen if pcm_s16le were passed to ffmpeg for encoding; I have no doubt it supports it, but I don't know how options are specified for audio transcoding.
3. Leave as it is. There'd be an asymmetry between web settings and the API, which could be future cognitive load.

I think I would pick option 2 myself.

### Testing
I don't have a dev setup for the server so just made the edits (including to a .dart file labelled DO NOT EDIT 😇) (**EDIT:** To clarify, “make open-api” hasn’t been run yet). I would appreciate a lookover, and for testing I have included a video (from an iOS Live Photo) with PCM audio, which could be set to transcode on an old build and not on a new build:

https://github.com/user-attachments/assets/006c6036-5c01-4537-bdab-3f2af13a1f39