### PR TITLE
fix(ml): set face detection threshold correctly in locust

### DIFF
--- a/machine-learning/app/models/facial_recognition/recognition.py
+++ b/machine-learning/app/models/facial_recognition/recognition.py
@@ -20,9 +20,8 @@ class FaceRecognizer(InferenceModel):
     depends = [(ModelType.DETECTION, ModelTask.FACIAL_RECOGNITION)]
     identity = (ModelType.RECOGNITION, ModelTask.FACIAL_RECOGNITION)
 
-    def __init__(self, model_name: str, min_score: float = 0.7, **model_kwargs: Any) -> None:
+    def __init__(self, model_name: str, **model_kwargs: Any) -> None:
         super().__init__(model_name, **model_kwargs)
-        self.min_score = model_kwargs.pop("minScore", min_score)
         max_batch_size = settings.max_batch_size.facial_recognition if settings.max_batch_size else None
         self.batch_size = max_batch_size if max_batch_size else self._batch_size_default
 

--- a/machine-learning/app/test_main.py
+++ b/machine-learning/app/test_main.py
@@ -324,7 +324,7 @@ class TestAnnSession:
         session.run(None, input_feed)
 
         ann_session.return_value.execute.assert_called_once_with(123, [input1, input2])
-        np_spy.call_count == 2
+        assert np_spy.call_count == 2
         np_spy.assert_has_calls([mock.call(input1), mock.call(input2)])
 
 
@@ -457,11 +457,14 @@ class TestCLIP:
 
 
 class TestFaceRecognition:
-    def test_set_min_score(self, mocker: MockerFixture) -> None:
-        mocker.patch.object(FaceRecognizer, "load")
-        face_recognizer = FaceRecognizer("buffalo_s", cache_dir="test_cache", min_score=0.5)
+    def test_set_min_score(self, snapshot_download: mock.Mock, ort_session: mock.Mock, path: mock.Mock) -> None:
+        path.return_value.__truediv__.return_value.__truediv__.return_value.suffix = ".onnx"
 
-        assert face_recognizer.min_score == 0.5
+        face_detector = FaceDetector("buffalo_s", min_score=0.5, cache_dir="test_cache")
+        face_detector.load()
+
+        assert face_detector.min_score == 0.5
+        assert face_detector.model.det_thresh == 0.5
 
     def test_detection(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceDetector, "load")

--- a/machine-learning/locustfile.py
+++ b/machine-learning/locustfile.py
@@ -15,12 +15,6 @@ def _(parser: ArgumentParser) -> None:
     parser.add_argument("--clip-model", type=str, default="ViT-B-32::openai")
     parser.add_argument("--face-model", type=str, default="buffalo_l")
     parser.add_argument(
-        "--tag-min-score",
-        type=int,
-        default=0.0,
-        help="Returns all tags at or above this score. The default returns all tags.",
-    )
-    parser.add_argument(
         "--face-min-score",
         type=int,
         default=0.034,

--- a/machine-learning/locustfile.py
+++ b/machine-learning/locustfile.py
@@ -74,10 +74,10 @@ class RecognitionFormDataLoadTest(InferenceLoadTest):
             "facial-recognition": {
                 "recognition": {
                     "modelName": self.environment.parsed_options.face_model,
-                    "options": {"minScore": self.environment.parsed_options.face_min_score},
                 },
                 "detection": {
                     "modelName": self.environment.parsed_options.face_model,
+                    "options": {"minScore": self.environment.parsed_options.face_min_score},
                 },
             }
         }


### PR DESCRIPTION
### Description

The detection threshold is in the `recognition` options, but it needs to be in the `detection` options instead. Also fixes and tightens the face detection unit test.