### PR TITLE
fix(mobile): more efficient loading local image on ios

### DIFF
--- a/mobile/lib/providers/image/immich_local_image_provider.dart
+++ b/mobile/lib/providers/image/immich_local_image_provider.dart
@@ -7,8 +7,6 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:photo_manager/photo_manager.dart' show ThumbnailSize;
 
 /// The local image provider for an asset
@@ -18,12 +16,6 @@ class ImmichLocalImageProvider extends ImageProvider<ImmichLocalImageProvider> {
   ImmichLocalImageProvider({
     required this.asset,
   }) : assert(asset.local != null, 'Only usable when asset.local is set');
-
-  /// Whether to show the original file or load a compressed version
-  bool get _useOriginal => Store.get(
-        AppSettingsEnum.loadOriginal.storeKey,
-        AppSettingsEnum.loadOriginal.defaultValue,
-      );
 
   /// Converts an [ImageProvider]'s settings plus an [ImageConfiguration] to a key
   /// that describes the precise image to load.
@@ -68,34 +60,16 @@ class ImmichLocalImageProvider extends ImageProvider<ImmichLocalImageProvider> {
     }
 
     if (asset.isImage) {
-      /// Using 2K thumbnail for local iOS image to avoid double swiping issue
-      if (Platform.isIOS) {
-        final largeImageBytes = _useOriginal
-            ? await asset.local?.originBytes
-            : await asset.local
-                ?.thumbnailDataWithSize(const ThumbnailSize(3840, 2160));
-
-        if (largeImageBytes == null) {
-          throw StateError(
-            "Loading thumb for local photo ${asset.fileName} failed",
-          );
-        }
-        final buffer = await ui.ImmutableBuffer.fromUint8List(largeImageBytes);
+      final File? file = await asset.local?.originFile;
+      if (file == null) {
+        throw StateError("Opening file for asset ${asset.fileName} failed");
+      }
+      try {
+        final buffer = await ui.ImmutableBuffer.fromFilePath(file.path);
         final codec = await decode(buffer);
         yield codec;
-      } else {
-        // Use the original file for Android
-        final File? file = await asset.local?.originFile;
-        if (file == null) {
-          throw StateError("Opening file for asset ${asset.fileName} failed");
-        }
-        try {
-          final buffer = await ui.ImmutableBuffer.fromFilePath(file.path);
-          final codec = await decode(buffer);
-          yield codec;
-        } catch (error) {
-          throw StateError("Loading asset ${asset.fileName} failed");
-        }
+      } catch (error) {
+        throw StateError("Loading asset ${asset.fileName} failed");
       }
     }
 


### PR DESCRIPTION
Fixed the issue with double swiping on iOS to navigate to the new asset in the detail asset viewer.

I added a timer to check the decoding process. It turned out that loading the original files only takes around 25ms, while using `thumbnailDataWithSize` would take from 90ms to 150ms, depending on the specified size of the thumbnail. 

So this PR is one stone hits two birds, optimizing the mechanism and simplifying the code