### PR TITLE
fix(server): Allow passwordless users when oauth enabled

### DIFF
--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -62,7 +62,6 @@ export class UserAdminCreateDto {
   @Transform(toEmail)
   email!: string;
 
-  @IsNotEmpty()
   @IsString()
   password!: string;
 

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -26,6 +26,10 @@ export class UserAdminService extends BaseService {
 
   async create(dto: UserAdminCreateDto): Promise<UserAdminResponseDto> {
     const { notify, ...rest } = dto;
+    const config = await this.getConfig({ withCache: false });
+    if (!config.oauth.enabled && !rest.password) {
+      throw new BadRequestException('password is required');
+    }
     const user = await createUser({ userRepo: this.userRepository, cryptoRepo: this.cryptoRepository }, rest);
 
     await this.eventRepository.emit('user.signup', {

--- a/web/src/lib/components/forms/create-user-form.svelte
+++ b/web/src/lib/components/forms/create-user-form.svelte
@@ -13,6 +13,7 @@
   export let onClose: () => void;
   export let onSubmit: () => void;
   export let onCancel: () => void;
+  export let oauthEnabled = false;
 
   let error: string;
   let success: string;
@@ -90,12 +91,17 @@
 
     <div class="my-4 flex flex-col gap-2">
       <label class="immich-form-label" for="password">{$t('password')}</label>
-      <PasswordField id="password" bind:password autocomplete="new-password" />
+      <PasswordField id="password" bind:password autocomplete="new-password" required={!oauthEnabled} />
     </div>
 
     <div class="my-4 flex flex-col gap-2">
       <label class="immich-form-label" for="confirmPassword">{$t('confirm_password')}</label>
-      <PasswordField id="confirmPassword" bind:password={confirmPassword} autocomplete="new-password" />
+      <PasswordField
+        id="confirmPassword"
+        bind:password={confirmPassword}
+        autocomplete="new-password"
+        required={!oauthEnabled}
+      />
     </div>
 
     <div class="my-4 flex place-items-center justify-between gap-2">

--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -15,7 +15,7 @@
     notificationController,
   } from '$lib/components/shared-components/notification/notification';
   import { locale } from '$lib/stores/preferences.store';
-  import { serverConfig } from '$lib/stores/server-config.store';
+  import { serverConfig, featureFlags } from '$lib/stores/server-config.store';
   import { user } from '$lib/stores/user.store';
   import { websocketEvents } from '$lib/stores/websocket';
   import { copyToClipboard } from '$lib/utils';
@@ -113,7 +113,7 @@
           onSubmit={onUserCreated}
           onCancel={() => (shouldShowCreateUserForm = false)}
           onClose={() => (shouldShowCreateUserForm = false)}
-          oauthEnabled={data.oauthEnabled}
+          oauthEnabled={$featureFlags.oauth}
         />
       {/if}
 

--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -113,6 +113,7 @@
           onSubmit={onUserCreated}
           onCancel={() => (shouldShowCreateUserForm = false)}
           onClose={() => (shouldShowCreateUserForm = false)}
+          oauthEnabled={data.oauthEnabled}
         />
       {/if}
 

--- a/web/src/routes/admin/user-management/+page.ts
+++ b/web/src/routes/admin/user-management/+page.ts
@@ -1,16 +1,18 @@
 import { authenticate, requestServerInfo } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
-import { searchUsersAdmin } from '@immich/sdk';
+import { searchUsersAdmin, getConfig } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate({ admin: true });
   await requestServerInfo();
   const allUsers = await searchUsersAdmin({ withDeleted: true });
+  const { oauth } = await getConfig();
   const $t = await getFormatter();
 
   return {
     allUsers,
+    oauthEnabled: oauth.enabled,
     meta: {
       title: $t('admin.user_management'),
     },

--- a/web/src/routes/admin/user-management/+page.ts
+++ b/web/src/routes/admin/user-management/+page.ts
@@ -1,18 +1,16 @@
 import { authenticate, requestServerInfo } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
-import { searchUsersAdmin, getConfig } from '@immich/sdk';
+import { searchUsersAdmin } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate({ admin: true });
   await requestServerInfo();
   const allUsers = await searchUsersAdmin({ withDeleted: true });
-  const { oauth } = await getConfig();
   const $t = await getFormatter();
 
   return {
     allUsers,
-    oauthEnabled: oauth.enabled,
     meta: {
       title: $t('admin.user_management'),
     },


### PR DESCRIPTION
This PR fixes : #13274 

It allows creation of passwordless users when Oauth is enabled in config.