### PR TITLE
feat(web): Change relink person icon from minus to pencil

### DIFF
--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -15,9 +15,8 @@
     type AssetFaceResponseDto,
     type PersonResponseDto,
   } from '@immich/sdk';
-  import { mdiAccountOff } from '@mdi/js';
   import Icon from '$lib/components/elements/icon.svelte';
-  import { mdiArrowLeftThin, mdiMinus, mdiRestart } from '@mdi/js';
+  import { mdiAccountOff, mdiArrowLeftThin, mdiPencil, mdiRestart } from '@mdi/js';
   import { onMount } from 'svelte';
   import { linear } from 'svelte/easing';
   import { fly } from 'svelte/transition';
@@ -297,7 +296,7 @@
                 {:else}
                   <CircleIconButton
                     color="primary"
-                    icon={mdiMinus}
+                    icon={mdiPencil}
                     title={$t('select_new_face')}
                     size="18"
                     padding="1"


### PR DESCRIPTION
The re-link person icon is currently a minus symbol. This can be confusing as it looks like a "remove person" button. Changing it to a pencil makes it clear it is an editing operation, not a removing operation.