### PR TITLE
docs: recommend disabling nginx proxy buffering

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -29,6 +29,12 @@ server {
     proxy_set_header   Connection "upgrade";
     proxy_redirect     off;
 
+    # Disable unnecessary buffering of proxy requests and responses to /tmp. This can cause issues
+    # when the file is larger than the mounted tmpfs, and immich can handle streaming of large files.
+    # Also increases transfer speed since the body is sent to the proxied server immediately.
+    proxy_request_buffering off;
+    proxy_buffering off;
+
     # set timeout
     proxy_read_timeout 600s;
     proxy_send_timeout 600s;


### PR DESCRIPTION
By default, nginx [buffers requests and responses](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering) to proxy servers. This means the whole body is first written to a temporary file in /tmp and then passed to the proxy when it has been received. This PR adds two options to the nginx proxy documentation to disable this buffering.

Buffering causes issues when the proxy server has a tmpfs mounted on `/tmp` (which is almost always the case) and you try uploading files larger than the tmpfs (even if the backend immich instance could handle it). The proxy request will be aborted by nginx if it cannot be stored first. Disabling the buffering also increases transfer speeds as the file will immediately be passed to immich.