### PR TITLE
fix(web): intersection observer not triggered to load more people

### DIFF
--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -145,7 +145,7 @@
     {@const hidden = personIsHidden[person.id]}
     <button
       type="button"
-      class="group relative"
+      class="group relative w-full h-full"
       on:click={() => (personIsHidden[person.id] = !hidden)}
       aria-pressed={hidden}
       aria-label={person.name ? $t('hide_named_person', { values: { name: person.name } }) : $t('hide_person')}

--- a/web/src/lib/components/faces-page/people-infinite-scroll.svelte
+++ b/web/src/lib/components/faces-page/people-infinite-scroll.svelte
@@ -23,7 +23,7 @@
 <div class="w-full grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7 2xl:grid-cols-9 gap-1">
   {#each people as person, index (person.id)}
     {#if hasNextPage && index === people.length - 1}
-      <div bind:this={lastPersonContainer} class="contents">
+      <div bind:this={lastPersonContainer}>
         <slot {person} {index} />
       </div>
     {:else}


### PR DESCRIPTION
Fixes #13557

Intersection Observer doesn't work with `display: content`