### PR TITLE
fix(server): encodes iPhone 16 Pro video with unknown audio codec

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -2298,7 +2298,15 @@ describe(MediaService.name, () => {
       assetMock.getByIds.mockResolvedValue([assetStub.video]);
       await sut.handleVideoConversion({ id: assetStub.video.id });
 
-      expect(mediaMock.transcode).toHaveResolved();
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:a copy']),
+          twoPass: false,
+        }),
+      );
     });
   });
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -17,7 +17,7 @@ import {
 import { IAssetRepository, WithoutProperty } from 'src/interfaces/asset.interface';
 import { IJobRepository, JobCounts, JobName, JobStatus } from 'src/interfaces/job.interface';
 import { ILoggerRepository } from 'src/interfaces/logger.interface';
-import { AudioStreamInfo, IMediaRepository, RawImageInfo, VideoStreamInfo } from 'src/interfaces/media.interface';
+import { IMediaRepository, RawImageInfo } from 'src/interfaces/media.interface';
 import { IMoveRepository } from 'src/interfaces/move.interface';
 import { IPersonRepository } from 'src/interfaces/person.interface';
 import { IStorageRepository } from 'src/interfaces/storage.interface';
@@ -2292,6 +2292,14 @@ describe(MediaService.name, () => {
 
       expect(mediaMock.probe).toHaveBeenCalledWith(assetStub.video.originalPath, { countFrames: false });
     });
+
+    it('should process unknown audio stream', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.audioStreamUnknown);
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+
+      expect(mediaMock.transcode).toHaveResolved();
+    });
   });
 
   describe('isSRGB', () => {
@@ -2338,42 +2346,6 @@ describe(MediaService.name, () => {
     it('should return true for 16-bit image with sRGB profile', () => {
       const asset = { ...assetStub.image, exifInfo: { profileDescription: 'sRGB', bitsPerSample: 16 } as ExifEntity };
       expect(sut.isSRGB(asset)).toEqual(true);
-    });
-  });
-
-  describe('getMainStream', () => {
-    it('should return the main stream based on frame count', () => {
-      const streams: VideoStreamInfo[] = [
-        { codecName: 'h264', frameCount: 1000 } as VideoStreamInfo,
-        { codecName: 'h265', frameCount: 1500 } as VideoStreamInfo,
-        { codecName: 'unknown', frameCount: 2000 } as VideoStreamInfo,
-      ];
-
-      const result = sut.getMainStream(streams);
-
-      expect(result).toEqual({ codecName: 'h265', frameCount: 1500 });
-    });
-
-    it('should filter out streams with codecName "unknown"', () => {
-      const streams: AudioStreamInfo[] = [
-        { codecName: 'aac', frameCount: 500 } as AudioStreamInfo,
-        { codecName: 'unknown', frameCount: 1000 } as AudioStreamInfo,
-      ];
-
-      const result = sut.getMainStream(streams);
-
-      expect(result).toEqual({ codecName: 'aac', frameCount: 500 });
-    });
-
-    it('should return undefined if no valid streams are provided', () => {
-      const streams: AudioStreamInfo[] = [
-        { codecName: 'unknown', frameCount: 500 } as AudioStreamInfo,
-        { codecName: 'unknown', frameCount: 1000 } as AudioStreamInfo,
-      ];
-
-      const result = sut.getMainStream(streams);
-
-      expect(result).toBeUndefined();
     });
   });
 });

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -348,14 +348,10 @@ export class MediaService extends BaseService {
     return JobStatus.SUCCESS;
   }
 
-  private getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
-    const validStreams = streams.filter((stream) => stream.codecName !== 'unknown');
-
-    if (validStreams.length === 1) {
-      return validStreams[0];
-    }
-
-    return validStreams.sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];
+  public getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
+    return streams
+      .filter((stream) => stream.codecName !== 'unknown')
+      .sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];
   }
 
   private getTranscodeTarget(

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -289,6 +289,7 @@ export class MediaService extends BaseService {
       countFrames: this.logger.isLevelEnabled(LogLevel.DEBUG), // makes frame count more reliable for progress logs
     });
     const mainVideoStream = this.getMainStream(videoStreams);
+
     const mainAudioStream = this.getMainStream(audioStreams);
     if (!mainVideoStream || !format.formatName) {
       return JobStatus.FAILED;
@@ -349,7 +350,13 @@ export class MediaService extends BaseService {
   }
 
   private getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
-    return streams.sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];
+    const validStreams = streams.filter((stream) => stream.codecName !== 'unknown');
+
+    if (validStreams.length === 1) {
+      return validStreams[0];
+    }
+
+    return validStreams.sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];
   }
 
   private getTranscodeTarget(

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -348,7 +348,7 @@ export class MediaService extends BaseService {
     return JobStatus.SUCCESS;
   }
 
-  public getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
+  getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
     return streams
       .filter((stream) => stream.codecName !== 'unknown')
       .sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -348,7 +348,7 @@ export class MediaService extends BaseService {
     return JobStatus.SUCCESS;
   }
 
-  getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
+  private getMainStream<T extends VideoStreamInfo | AudioStreamInfo>(streams: T[]): T {
     return streams
       .filter((stream) => stream.codecName !== 'unknown')
       .sort((stream1, stream2) => stream2.frameCount - stream1.frameCount)[0];

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -289,7 +289,6 @@ export class MediaService extends BaseService {
       countFrames: this.logger.isLevelEnabled(LogLevel.DEBUG), // makes frame count more reliable for progress logs
     });
     const mainVideoStream = this.getMainStream(videoStreams);
-
     const mainAudioStream = this.getMainStream(audioStreams);
     if (!mainVideoStream || !format.formatName) {
       return JobStatus.FAILED;

--- a/server/test/fixtures/media.stub.ts
+++ b/server/test/fixtures/media.stub.ts
@@ -154,6 +154,13 @@ export const probeStub = {
     ...probeStubDefault,
     audioStreams: [{ index: 1, codecName: 'aac', frameCount: 100 }],
   }),
+  audioStreamUnknown: Object.freeze<VideoInfo>({
+    ...probeStubDefault,
+    audioStreams: [
+      { index: 0, codecName: 'aac', frameCount: 100 },
+      { index: 1, codecName: 'unknown', frameCount: 200 },
+    ],
+  }),
   matroskaContainer: Object.freeze<VideoInfo>({
     ...probeStubDefault,
     format: {


### PR DESCRIPTION
This PR introduces a fix for missing new audio codec from iPhone 16 Pro Max in FFmpeg build by picking the known codec in the audio streams.

Tested on FireFox on video that previously doesn't play because of missing encoded video, now can play successfully with sound