### PR TITLE
fix(web): reset select all button state on escape press

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -6,7 +6,7 @@
   import type { AlbumResponseDto, SharedLinkResponseDto, UserResponseDto } from '@immich/sdk';
   import { createAssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { AssetStore } from '$lib/stores/assets.store';
-  import { downloadAlbum } from '$lib/utils/asset-utils';
+  import { cancelMultiselect, downloadAlbum } from '$lib/utils/asset-utils';
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import DownloadAction from '../photos-page/actions/download-action.svelte';
   import AssetGrid from '../photos-page/asset-grid.svelte';
@@ -49,7 +49,7 @@
     shortcut: { key: 'Escape' },
     onShortcut: () => {
       if (!$showAssetViewer && $isMultiSelectState) {
-        assetInteractionStore.clearMultiselect();
+        cancelMultiselect(assetInteractionStore);
       }
     },
   }}

--- a/web/src/lib/components/photos-page/actions/select-all-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/select-all-assets.svelte
@@ -3,7 +3,7 @@
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { type AssetStore, isSelectingAllAssets } from '$lib/stores/assets.store';
   import { mdiSelectAll, mdiSelectRemove } from '@mdi/js';
-  import { selectAllAssets } from '$lib/utils/asset-utils';
+  import { selectAllAssets, cancelMultiselect } from '$lib/utils/asset-utils';
   import { t } from 'svelte-i18n';
 
   export let assetStore: AssetStore;
@@ -14,8 +14,7 @@
   };
 
   const handleCancel = () => {
-    $isSelectingAllAssets = false;
-    assetInteractionStore.clearMultiselect();
+    cancelMultiselect(assetInteractionStore);
   };
 </script>
 

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -17,7 +17,7 @@
   import { featureFlags } from '$lib/stores/server-config.store';
   import { handlePromiseError } from '$lib/utils';
   import { deleteAssets } from '$lib/utils/actions';
-  import { archiveAssets, selectAllAssets, stackAssets } from '$lib/utils/asset-utils';
+  import { archiveAssets, cancelMultiselect, selectAllAssets, stackAssets } from '$lib/utils/asset-utils';
   import { navigate } from '$lib/utils/navigation';
   import {
     formatGroupTitle,
@@ -589,8 +589,7 @@
   let shiftKeyIsDown = false;
 
   const deselectAllAssets = () => {
-    $isSelectingAllAssets = false;
-    assetInteractionStore.clearMultiselect();
+    cancelMultiselect(assetInteractionStore);
   };
 
   const onKeyDown = (event: KeyboardEvent) => {

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -5,13 +5,7 @@
   import { AppRoute, AssetAction } from '$lib/constants';
   import type { AssetInteractionStore } from '$lib/stores/asset-interaction.store';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import {
-    AssetBucket,
-    AssetStore,
-    isSelectingAllAssets,
-    type BucketListener,
-    type ViewportXY,
-  } from '$lib/stores/assets.store';
+  import { AssetBucket, AssetStore, type BucketListener, type ViewportXY } from '$lib/stores/assets.store';
   import { locale, showDeleteModal } from '$lib/stores/preferences.store';
   import { isSearchEnabled } from '$lib/stores/search.store';
   import { featureFlags } from '$lib/stores/server-config.store';

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -467,6 +467,11 @@ export const selectAllAssets = async (assetStore: AssetStore, assetInteractionSt
   }
 };
 
+export const cancelMultiselect = (assetInteractionStore: AssetInteractionStore) => {
+  isSelectingAllAssets.set(false);
+  assetInteractionStore.clearMultiselect();
+};
+
 export const toggleArchive = async (asset: AssetResponseDto) => {
   const $t = get(t);
   try {

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -40,7 +40,7 @@
   import { SlideshowNavigation, SlideshowState, slideshowStore } from '$lib/stores/slideshow.store';
   import { preferences, user } from '$lib/stores/user.store';
   import { handlePromiseError } from '$lib/utils';
-  import { downloadAlbum } from '$lib/utils/asset-utils';
+  import { downloadAlbum, cancelMultiselect } from '$lib/utils/asset-utils';
   import { openFileUploadDialog } from '$lib/utils/file-uploader';
   import { handleError } from '$lib/utils/handle-error';
   import {
@@ -270,7 +270,7 @@
       return;
     }
     if ($isMultiSelectState) {
-      assetInteractionStore.clearMultiselect();
+      cancelMultiselect(assetInteractionStore);
       return;
     }
     await goto(backUrl);


### PR DESCRIPTION
This PR should resolve #13481 by setting isSelectingAllAssets when escape is pressed.
 
The change is extracting the logic from SelectAllAssets component into a helper and calling them in the album page as well as some other components I thought was suitable as well.