### PR TITLE
feat(docs): add mention to purchase to support immich page

### DIFF
--- a/docs/docs/overview/support-the-project.md
+++ b/docs/docs/overview/support-the-project.md
@@ -18,7 +18,7 @@ If you are a programmer or developer, take a look at Immich's [technology stack]
 
 ## Purchase Immich
 
-You can also [purchase Immich](https://buy.immich.app), for either one user or your entire server. Building Immich takes a lot of time and effort, and we have full-time engineers working on it to make it as good as we possibly can, so any support is greatly appreciated. Don't worry, all features will be free, forever! Nothing will be put benind any paywalls.
+You can also [purchase Immich](https://buy.immich.app), for either one user or your entire server. Building Immich takes a lot of time and effort, and we have full-time engineers working on it to make it as good as we possibly can, so any support is greatly appreciated. Don't worry, all features will be free, forever! Nothing will ever be put behind any paywalls.
 
 [github-issue]: https://github.com/immich-app/immich/issues/new/choose
 [github-langs]: https://github.com/immich-app/immich/tree/main/mobile/assets/i18n

--- a/docs/docs/overview/support-the-project.md
+++ b/docs/docs/overview/support-the-project.md
@@ -16,5 +16,9 @@ Support the project by localizing on [Weblate](https://hosted.weblate.org/projec
 
 If you are a programmer or developer, take a look at Immich's [technology stack](/docs/developer/architecture.mdx) and consider fixing bugs or building new features. The team and I are always looking for new contributors. For information about how to contribute as a developer, see the [Developer](/docs/developer/architecture.mdx) section.
 
+## Purchase Immich
+
+You can also [purchase Immich](https://buy.immich.app), for either one user or your entire server. Building Immich takes a lot of time and effort, and we have full-time engineers working on it to make it as good as we possibly can, so any support is greatly appreciated. Don't worry, all features will be free, forever! Nothing will be put benind any paywalls.
+
 [github-issue]: https://github.com/immich-app/immich/issues/new/choose
 [github-langs]: https://github.com/immich-app/immich/tree/main/mobile/assets/i18n


### PR DESCRIPTION
Add mention to purchasing Immich to the support Immich page in the documentation.
Text in the middle was copied from the buy page.