### PR TITLE
fix(server): only allow absolute import paths

### DIFF
--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -633,6 +633,29 @@ describe('/libraries', () => {
       });
     });
 
+    it("should fail if path isn't absolute", async () => {
+      const pathToTest = `relative/path`;
+
+      const cwd = process.cwd();
+      // Create directory in cwd
+      utils.createDirectory(`${cwd}/${pathToTest}`);
+
+      const response = await utils.validateLibrary(admin.accessToken, library.id, {
+        importPaths: [pathToTest],
+      });
+
+      utils.removeDirectory(`${cwd}/${pathToTest}`);
+
+      expect(response.importPaths?.length).toEqual(1);
+      const pathResponse = response?.importPaths?.at(0);
+
+      expect(pathResponse).toEqual({
+        importPath: pathToTest,
+        isValid: false,
+        message: expect.stringMatching('Import path must be absolute, try /usr/src/app/relative/path'),
+      });
+    });
+
     it('should fail if path is a file', async () => {
       const pathToTest = `${testAssetDirInternal}/albums/nature/el_torcal_rocks.jpg`;
 

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { R_OK } from 'node:constants';
-import path, { basename, parse } from 'node:path';
+import path, { basename, isAbsolute, parse } from 'node:path';
 import picomatch from 'picomatch';
 import { StorageCore } from 'src/cores/storage.core';
 import { OnEvent } from 'src/decorators';
@@ -265,6 +265,11 @@ export class LibraryService extends BaseService {
 
     if (StorageCore.isImmichPath(importPath)) {
       validation.message = 'Cannot use media upload folder for external libraries';
+      return validation;
+    }
+
+    if (!isAbsolute(importPath)) {
+      validation.message = `Import path must be absolute, try ${path.resolve(importPath)}`;
       return validation;
     }
 

--- a/server/test/fixtures/library.stub.ts
+++ b/server/test/fixtures/library.stub.ts
@@ -68,7 +68,7 @@ export const libraryStub = {
     assets: [],
     owner: userStub.admin,
     ownerId: 'user-id',
-    importPaths: ['upload/thumbs', '/xyz', 'upload/library'],
+    importPaths: ['upload/thumbs', 'xyz', 'upload/library'],
     createdAt: new Date('2023-01-01'),
     updatedAt: new Date('2023-01-01'),
     refreshedAt: null,


### PR DESCRIPTION
I've seen more than one occasion of users specifying relative paths in their library import paths, one example is #13570.

Apparently, the path validator accepts a relative path as input while it fails when we do the actual scan. This PR ensures that relative paths fail validation as well as give a helpful message to the user which path they possibly are referring to

This is possibly a breaking change since users that currently use relative paths will fail validation