### PR TITLE
feat: Use video thumbnail for GIF types

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -147,13 +147,10 @@ export class MediaService extends BaseService {
     }
 
     let generated: { previewPath: string; thumbnailPath: string; thumbhash: Buffer };
-    const isGif = asset.originalFileName.endsWith('.gif'); 
-    if (asset.type === AssetType.IMAGE && isGif) {
+    if (asset.type === AssetType.VIDEO || asset.originalFileName.toLowerCase().endsWith('.gif')) {
       generated = await this.generateVideoThumbnails(asset);
     } else if (asset.type === AssetType.IMAGE) {
       generated = await this.generateImageThumbnails(asset);
-    } else if (asset.type === AssetType.VIDEO) {
-      generated = await this.generateVideoThumbnails(asset);
     } else {
       this.logger.warn(`Skipping thumbnail generation for asset ${id}: ${asset.type} is not an image or video`);
       return JobStatus.SKIPPED;

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -147,7 +147,10 @@ export class MediaService extends BaseService {
     }
 
     let generated: { previewPath: string; thumbnailPath: string; thumbhash: Buffer };
-    if (asset.type === AssetType.IMAGE) {
+    const isGif = asset.originalFileName.endsWith('.gif'); 
+    if (asset.type === AssetType.IMAGE && isGif) {
+      generated = await this.generateVideoThumbnails(asset);
+    } else if (asset.type === AssetType.IMAGE) {
       generated = await this.generateImageThumbnails(asset);
     } else if (asset.type === AssetType.VIDEO) {
       generated = await this.generateVideoThumbnails(asset);


### PR DESCRIPTION
fixes - https://github.com/immich-app/immich/issues/12801

In this PR, we add the feature of using the first non-black frame as thumbnail for GIF file types. It utilizes the already existing logic for finding non-black frame from video. 

## Tests 

Checked with a video and a GIF side by side 

Old functionality (GIF using the first frame)

![image](https://github.com/user-attachments/assets/565140d8-4b92-42a3-865c-9d8d442b6fb5)


New feature - (using the first non black frame)

![image](https://github.com/user-attachments/assets/f417133f-2aa7-4c4a-b6d6-aa309db4490b)
