### PR TITLE
fix: Add debouncing to the search popup form

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -66,13 +66,17 @@
   };
 
   const onFocusOut = () => {
-    if ($isSearchEnabled) {
-      $preventRaceConditionSearchBar = true;
-    }
+    const focusOutTimer = setTimeout(() => {
+      if ($isSearchEnabled) {
+        $preventRaceConditionSearchBar = true;
+      }
 
-    closeDropdown();
-    $isSearchEnabled = false;
-    showFilter = false;
+      closeDropdown();
+      $isSearchEnabled = false;
+      showFilter = false;
+    }, 100);
+
+    clearTimeout(focusOutTimer);
   };
 
   const onHistoryTermClick = async (searchTerm: string) => {


### PR DESCRIPTION
fixes: #12636 

## Problem:
When selecting a date in the first date picker and then immediately clicking on the second date picker, the search popup form closes unexpectedly. This happens because the focus-out event is triggered on the form before the focus-in event of the second date picker, causing the form to close prematurely.

## Solution:
This PR adds a 100ms debouncing mechanism to the focus-out event handler of the search popup form. This delay ensures that the focus-in event of the second date picker has time to fire before the form is closed.

## Changes:
Added a setTimeout in the onFocusOut handler with a 100ms delay before closing the form.
This debouncing ensures the form remains open when switching between date pickers.

## Tests 

Ran the tests locally to verify this is fixing the issue

### Current version 
(Bug - Clicking second date field just after updating the other date field on search form closes the popup)

https://github.com/user-attachments/assets/7585416a-2bcb-4d33-81c7-5bacfe977a01

### Fix 
(The click does not close the popup)

https://github.com/user-attachments/assets/f1c17d88-5494-4c03-90f9-f872699540e5

