### PR TITLE
fix(server): add ld_library_path in start.sh

### DIFF
--- a/server/start.sh
+++ b/server/start.sh
@@ -4,6 +4,7 @@ echo "Initializing Immich $IMMICH_SOURCE_REF"
 
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 export LD_PRELOAD="$lib_path"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
 
 read_file_and_export() {
 	if [ -n "${!1}" ]; then


### PR DESCRIPTION
## Description

It's apparently possible for `LD_LIBRARY_PATH` to get stripped/overwritten from containers at startup. This PR sets this env in `start.sh` to be *super duper sure* that it's set.