### PR TITLE
refactor(server): telemetry env variables

### DIFF
--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -25,10 +25,10 @@ The metrics in immich are grouped into API (endpoint calls and response times), 
 
 ### Configuration
 
-Immich will not expose an endpoint for metrics by default. To enable this endpoint, you can add the `IMMICH_METRICS=true` environmental variable to your `.env` file. Note that only the server and microservices containers currently use this variable.
+Immich will not expose an endpoint for metrics by default. To enable this endpoint, you can add the `IMMICH_TELEMETRY_INCLUDE=all` environmental variable to your `.env` file. Note that only the server container currently use this variable.
 
 :::tip
-`IMMICH_METRICS` enables all metrics, but there are also [environmental variables](/docs/install/environment-variables.md#prometheus) to toggle specific metric groups. If you'd like to only expose certain kinds of metrics, you can set only those environmental variables to `true`. Explicitly setting the environmental variable for a metric group overrides `IMMICH_METRICS` for that group. For example, setting `IMMICH_METRICS=true` and `IMMICH_API_METRICS=false` will enable all metrics except API metrics.
+`IMMICH_TELEMETRY_INCLUDE=all` enables all metrics. For a more granular configuration you can enumerate the telemetry metrics that should be included as a comma separated list (e.g. `IMMICH_TELEMETRY_INCLUDE=repo,api`). Alternatively, you can also exclude specific metrics with `IMMICH_TELEMETRY_EXCLUDE`. For more information refer to the [environment section](/docs/install/environment-variables.md#prometheus).
 :::
 
 The next step is to configure a new or existing Prometheus instance to scrape this endpoint. The following steps assume that you do not have an existing Prometheus instance, but the steps will be similar either way.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -183,15 +183,10 @@ Other machine learning parameters can be tuned from the admin UI.
 
 ## Prometheus
 
-| Variable                       | Description                                                                                   | Default | Containers | Workers            |
-| :----------------------------- | :-------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
-| `IMMICH_METRICS`<sup>\*1</sup> | Toggle all metrics (one of [`true`, `false`])                                                 |         | server     | api, microservices |
-| `IMMICH_API_METRICS`           | Toggle metrics for endpoints and response times (one of [`true`, `false`])                    |         | server     | api, microservices |
-| `IMMICH_HOST_METRICS`          | Toggle metrics for CPU and memory utilization for host and process (one of [`true`, `false`]) |         | server     | api, microservices |
-| `IMMICH_IO_METRICS`            | Toggle metrics for database queries, image processing, etc. (one of [`true`, `false`])        |         | server     | api, microservices |
-| `IMMICH_JOB_METRICS`           | Toggle metrics for jobs and queues (one of [`true`, `false`])                                 |         | server     | api, microservices |
-
-\*1: Overridden for a metric group when its corresponding environmental variable is set.
+| Variable                   | Description                                                                                                           | Default | Containers | Workers            |
+| :------------------------- | :-------------------------------------------------------------------------------------------------------------------- | :-----: | :--------- | :----------------- |
+| `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all |         | server     | api, microservices |
+| `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`                                          |         | server     | api, microservices |
 
 ## Docker Secrets
 

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -363,3 +363,11 @@ export enum ImmichWorker {
   API = 'api',
   MICROSERVICES = 'microservices',
 }
+
+export enum ImmichTelemetry {
+  HOST = 'host',
+  API = 'api',
+  IO = 'io',
+  REPO = 'repo',
+  JOB = 'job',
+}

--- a/server/src/interfaces/config.interface.ts
+++ b/server/src/interfaces/config.interface.ts
@@ -2,7 +2,7 @@ import { RegisterQueueOptions } from '@nestjs/bullmq';
 import { QueueOptions } from 'bullmq';
 import { RedisOptions } from 'ioredis';
 import { OpenTelemetryModuleOptions } from 'nestjs-otel/lib/interfaces';
-import { ImmichEnvironment, ImmichWorker, LogLevel } from 'src/enum';
+import { ImmichEnvironment, ImmichTelemetry, ImmichWorker, LogLevel } from 'src/enum';
 import { VectorExtension } from 'src/interfaces/database.interface';
 
 export const IConfigRepository = 'IConfigRepository';
@@ -77,11 +77,7 @@ export interface EnvData {
   telemetry: {
     apiPort: number;
     microservicesPort: number;
-    enabled: boolean;
-    apiMetrics: boolean;
-    hostMetrics: boolean;
-    repoMetrics: boolean;
-    jobMetrics: boolean;
+    metrics: Set<ImmichTelemetry>;
   };
 
   storage: {

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -1,3 +1,4 @@
+import { ImmichTelemetry } from 'src/enum';
 import { clearEnvCache, ConfigRepository } from 'src/repositories/config.repository';
 
 const getEnv = () => {
@@ -12,11 +13,8 @@ const resetEnv = () => {
     'IMMICH_TRUSTED_PROXIES',
     'IMMICH_API_METRICS_PORT',
     'IMMICH_MICROSERVICES_METRICS_PORT',
-    'IMMICH_METRICS',
-    'IMMICH_API_METRICS',
-    'IMMICH_HOST_METRICS',
-    'IMMICH_IO_METRICS',
-    'IMMICH_JOB_METRICS',
+    'IMMICH_TELEMETRY_INCLUDE',
+    'IMMICH_TELEMETRY_EXCLUDE',
 
     'DB_URL',
     'DB_HOSTNAME',
@@ -210,11 +208,7 @@ describe('getEnv', () => {
       expect(telemetry).toEqual({
         apiPort: 8081,
         microservicesPort: 8082,
-        enabled: false,
-        apiMetrics: false,
-        hostMetrics: false,
-        jobMetrics: false,
-        repoMetrics: false,
+        metrics: new Set([]),
       });
     });
 
@@ -225,32 +219,29 @@ describe('getEnv', () => {
       expect(telemetry).toMatchObject({
         apiPort: 2001,
         microservicesPort: 2002,
+        metrics: expect.any(Set),
       });
     });
 
     it('should run with telemetry enabled', () => {
-      process.env.IMMICH_METRICS = 'true';
+      process.env.IMMICH_TELEMETRY_INCLUDE = 'all';
       const { telemetry } = getEnv();
-      expect(telemetry).toMatchObject({
-        enabled: true,
-        apiMetrics: true,
-        hostMetrics: true,
-        jobMetrics: true,
-        repoMetrics: true,
-      });
+      expect(telemetry.metrics).toEqual(new Set(Object.values(ImmichTelemetry)));
     });
 
     it('should run with telemetry enabled and jobs disabled', () => {
-      process.env.IMMICH_METRICS = 'true';
-      process.env.IMMICH_JOB_METRICS = 'false';
+      process.env.IMMICH_TELEMETRY_INCLUDE = 'all';
+      process.env.IMMICH_TELEMETRY_EXCLUDE = 'job';
       const { telemetry } = getEnv();
-      expect(telemetry).toMatchObject({
-        enabled: true,
-        apiMetrics: true,
-        hostMetrics: true,
-        jobMetrics: false,
-        repoMetrics: true,
-      });
+      expect(telemetry.metrics).toEqual(
+        new Set([ImmichTelemetry.API, ImmichTelemetry.HOST, ImmichTelemetry.IO, ImmichTelemetry.REPO]),
+      );
+    });
+
+    it('should run with specific telemetry metrics', () => {
+      process.env.IMMICH_TELEMETRY_INCLUDE = 'io, host, api';
+      const { telemetry } = getEnv();
+      expect(telemetry.metrics).toEqual(new Set([ImmichTelemetry.API, ImmichTelemetry.HOST, ImmichTelemetry.IO]));
     });
   });
 });

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
   process.title = 'immich-api';
 
   const { telemetry, network } = new ConfigRepository().getEnv();
-  if (telemetry.enabled) {
+  if (telemetry.metrics.size > 0) {
     bootstrapTelemetry(telemetry.apiPort);
   }
 

--- a/server/src/workers/microservices.ts
+++ b/server/src/workers/microservices.ts
@@ -11,7 +11,7 @@ import { isStartUpError } from 'src/services/storage.service';
 
 export async function bootstrap() {
   const { telemetry } = new ConfigRepository().getEnv();
-  if (telemetry.enabled) {
+  if (telemetry.metrics.size > 0) {
     bootstrapTelemetry(telemetry.microservicesPort);
   }
 

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -73,11 +73,7 @@ const envData: EnvData = {
   telemetry: {
     apiPort: 8081,
     microservicesPort: 8082,
-    enabled: false,
-    hostMetrics: false,
-    apiMetrics: false,
-    jobMetrics: false,
-    repoMetrics: false,
+    metrics: new Set(),
   },
 
   workers: [ImmichWorker.API, ImmichWorker.MICROSERVICES],


### PR DESCRIPTION
> [!CAUTION]
> The following env variables have been removed
> - `IMMICH_METRICS`
> - `IMMICH_API_METRICS`
> - `IMMICH_IO_METRICS`
> - `IMMICH_JOB_METRICS`
> - `IMMICH_REPO_METRICS`
> Use `IMMICH_TELEMETRY_INCLUDE`/`IMMICH_TELEMETRY_EXCLUDE`.
>
> ### Examples:
>
> ```
> IMMICH_TELEMETRY_INCLUDE=all
> ```
>
> ```
> IMMICH_TELEMETRY_INCLUDE=all
> IMMICH_TELEMETRY_EXCLUDE=repo
> ```
>
> ```
> IMMICH_TELEMETRY_INCLUDE=api,repo
> ```
