### PR TITLE
chore(docs): add clarifying note for custom file location migration

### DIFF
--- a/docs/docs/guides/custom-locations.md
+++ b/docs/docs/guides/custom-locations.md
@@ -33,6 +33,8 @@ services:
       - /etc/localtime:/etc/localtime:ro
 ```
 
+If you already have an immich instance running, move all files (including hidden) from the old directories to the new directories.
+
 Restart Immich to register the changes.
 
 ```


### PR DESCRIPTION
Just wanted to add a clarifying note on what to do if an immich instance is running already. I had an instance running and because this guide said nothing about copying files but did specify to "restart" the containers (implying that they were already running at one point), I assumed Immich must have some sort of migration job to run after file paths are updated. I realized this was not the case when my containers failed to start after updating the paths. So I just wanted to add a little line to save anyone else that bit of confusion :) 

Thanks for the great app!