### PR TITLE
fix(web): add crossorigin to link manifest for PWA

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -86,7 +86,7 @@
 
 <svelte:head>
   <title>{$page.data.meta?.title || 'Web'} - Immich</title>
-  <link rel="manifest" href="/manifest.json" />
+  <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
   <meta name="theme-color" content="currentColor" />
   <AppleHeader />
 


### PR DESCRIPTION
Fixes #13695

As per MDN adds crossorigin to manifest link to fix PWA https://developer.mozilla.org/en-US/docs/Web/Manifest#deploying_a_manifest