### PR TITLE
fix: duplicated library scan jobs and api server library watch

### DIFF
--- a/server/src/interfaces/database.interface.ts
+++ b/server/src/interfaces/database.interface.ts
@@ -19,7 +19,7 @@ export enum DatabaseLock {
   StorageTemplateMigration = 420,
   VersionHistory = 500,
   CLIPDimSize = 512,
-  LibraryWatch = 1337,
+  Library = 1337,
   GetSystemConfig = 69,
 }
 

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -3,7 +3,7 @@ import { Stats } from 'node:fs';
 import { defaults, SystemConfig } from 'src/config';
 import { mapLibrary } from 'src/dtos/library.dto';
 import { UserEntity } from 'src/entities/user.entity';
-import { AssetType } from 'src/enum';
+import { AssetType, ImmichWorker } from 'src/enum';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';
 import {
@@ -55,7 +55,7 @@ describe(LibraryService.name, () => {
     it('should init cron job and handle config changes', async () => {
       systemMock.get.mockResolvedValue(systemConfigStub.libraryScan);
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
 
       expect(jobMock.addCronJob).toHaveBeenCalled();
       expect(systemMock.get).toHaveBeenCalled();
@@ -91,7 +91,7 @@ describe(LibraryService.name, () => {
         ),
       );
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
 
       expect(storageMock.watch.mock.calls).toEqual(
         expect.arrayContaining([
@@ -104,7 +104,7 @@ describe(LibraryService.name, () => {
     it('should not initialize watcher when watching is disabled', async () => {
       systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchDisabled);
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
 
       expect(storageMock.watch).not.toHaveBeenCalled();
     });
@@ -113,7 +113,7 @@ describe(LibraryService.name, () => {
       systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       databaseMock.tryLock.mockResolvedValue(false);
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
 
       expect(storageMock.watch).not.toHaveBeenCalled();
     });
@@ -122,7 +122,13 @@ describe(LibraryService.name, () => {
       systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       databaseMock.tryLock.mockResolvedValue(false);
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+
+      expect(jobMock.addCronJob).not.toHaveBeenCalled();
+    });
+
+    it('should not initialize watcher or library scan job when running on api', async () => {
+      await sut.onBootstrap(ImmichWorker.API);
 
       expect(jobMock.addCronJob).not.toHaveBeenCalled();
     });
@@ -132,7 +138,7 @@ describe(LibraryService.name, () => {
     beforeEach(async () => {
       systemMock.get.mockResolvedValue(defaults);
       databaseMock.tryLock.mockResolvedValue(true);
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
     });
 
     it('should do nothing if oldConfig is not provided', async () => {
@@ -142,7 +148,7 @@ describe(LibraryService.name, () => {
 
     it('should do nothing if instance does not have the watch lock', async () => {
       databaseMock.tryLock.mockResolvedValue(false);
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
       await sut.onConfigUpdate({ newConfig: systemConfigStub.libraryScan as SystemConfig, oldConfig: defaults });
       expect(jobMock.updateCronJob).not.toHaveBeenCalled();
     });
@@ -702,7 +708,7 @@ describe(LibraryService.name, () => {
       const mockClose = vitest.fn();
       storageMock.watch.mockImplementation(makeMockWatcher({ close: mockClose }));
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
       await sut.delete(libraryStub.externalLibraryWithImportPaths1.id);
 
       expect(mockClose).toHaveBeenCalled();
@@ -836,7 +842,7 @@ describe(LibraryService.name, () => {
         libraryMock.get.mockResolvedValue(libraryStub.externalLibraryWithImportPaths1);
         libraryMock.getAll.mockResolvedValue([]);
 
-        await sut.onBootstrap();
+        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
         await sut.create({
           ownerId: authStub.admin.user.id,
           importPaths: libraryStub.externalLibraryWithImportPaths1.importPaths,
@@ -899,7 +905,7 @@ describe(LibraryService.name, () => {
       systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       libraryMock.getAll.mockResolvedValue([]);
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
     });
 
     it('should throw an error if an import path is invalid', async () => {
@@ -940,7 +946,7 @@ describe(LibraryService.name, () => {
       beforeEach(async () => {
         systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchDisabled);
 
-        await sut.onBootstrap();
+        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
       });
 
       it('should not watch library', async () => {
@@ -956,7 +962,7 @@ describe(LibraryService.name, () => {
       beforeEach(async () => {
         systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
         libraryMock.getAll.mockResolvedValue([]);
-        await sut.onBootstrap();
+        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
       });
 
       it('should watch library', async () => {
@@ -1122,7 +1128,7 @@ describe(LibraryService.name, () => {
       const mockClose = vitest.fn();
       storageMock.watch.mockImplementation(makeMockWatcher({ close: mockClose }));
 
-      await sut.onBootstrap();
+      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
       await sut.onShutdown();
 
       expect(mockClose).toHaveBeenCalledTimes(2);

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -117,6 +117,15 @@ describe(LibraryService.name, () => {
 
       expect(storageMock.watch).not.toHaveBeenCalled();
     });
+
+    it('should not initialize library scan cron job when lock is taken', async () => {
+      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
+      databaseMock.tryLock.mockResolvedValue(false);
+
+      await sut.onBootstrap();
+
+      expect(jobMock.addCronJob).not.toHaveBeenCalled();
+    });
   });
 
   describe('onConfigUpdateEvent', () => {

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -51,12 +51,14 @@ export class LibraryService extends BaseService {
 
     this.watchLibraries = this.watchLock && watch.enabled;
 
-    this.jobRepository.addCronJob(
-      'libraryScan',
-      scan.cronExpression,
-      () => handlePromiseError(this.jobRepository.queue({ name: JobName.LIBRARY_QUEUE_SYNC_ALL }), this.logger),
-      scan.enabled,
-    );
+    if (this.watchLock) {
+      this.jobRepository.addCronJob(
+        'libraryScan',
+        scan.cronExpression,
+        () => handlePromiseError(this.jobRepository.queue({ name: JobName.LIBRARY_QUEUE_SYNC_ALL }), this.logger),
+        scan.enabled,
+      );
+    }
 
     if (this.watchLibraries) {
       await this.watchAll();


### PR DESCRIPTION
The library cron job wasn't created using the lock, so we would create a cron job for every server and microservices instance