### PR TITLE
fix: remove archived images from people page

### DIFF
--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -81,7 +81,7 @@
   $: thumbnailData = getPeopleThumbnailUrl(person);
   $: if (person) {
     handlePromiseError(updateAssetCount());
-    handlePromiseError(assetStore.updateOptions({ personId: person.id }));
+    handlePromiseError(assetStore.updateOptions({ personId: person.id, isArchived: false }));
   }
 
   const assetInteractionStore = createAssetInteractionStore();


### PR DESCRIPTION
fixes: #12463 

## Overview 
This PR addresses a bug where archived images were still appearing in the person page, leading to confusion for users.

## Changes Made:
Add `isArchived: false` parameter in updateOptions to populate images in person page