### PR TITLE
fix(server): account for time zone information when deriving localDateTime

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -835,7 +835,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: dateForTest,
-        localDateTime: dateForTest,
+        localDateTime: new Date('1970-01-01T23:00:00.000Z'),
       });
     });
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -596,7 +596,10 @@ export class MetadataService extends BaseService {
     }
 
     let dateTimeOriginal = dateTime?.toDate();
-    let localDateTime = dateTime?.toDateTime().setZone('UTC', { keepLocalTime: true }).toJSDate();
+    let localDateTime = dateTime
+      ?.toDateTime()
+      .setZone(timeZone || 'UTC', { keepLocalTime: true })
+      .toJSDate();
     if (!localDateTime || !dateTimeOriginal) {
       this.logger.warn(`Asset ${asset.id} has no valid date, falling back to asset.fileCreatedAt`);
       dateTimeOriginal = asset.fileCreatedAt;


### PR DESCRIPTION
Was looking into #13566 and initially thought the a solution would be to sort the images before returning. But noticed it uses localDateTime in the query and it does not account for the time zone. I think the fix is to update the date calculation logic in metadata service to offset with time zone information if any.

**BEFORE**
<img width="1014" alt="Screenshot 2024-10-26 at 9 36 04 AM" src="https://github.com/user-attachments/assets/8f6c97a3-2521-4bce-82a1-d3905d787afd">

**AFTER**
<img width="1014" alt="Screenshot 2024-10-26 at 9 45 45 AM" src="https://github.com/user-attachments/assets/969f600d-d8a0-4dbc-913f-2804dfd82af3">

Conveniently it looks like an adjacent test case covers this scenario so I have updated the expected return object for the failing test.