### PR TITLE
fix: X years ago ordering

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -87,7 +87,7 @@ WHERE
   )
   AND ("entity"."deletedAt" IS NULL)
 ORDER BY
-  "entity"."localDateTime" ASC
+  "entity"."fileCreatedAt" ASC
 
 -- AssetRepository.getByIds
 SELECT

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -93,7 +93,7 @@ export class AssetRepository implements IAssetRepository {
       )
       .leftJoinAndSelect('entity.exifInfo', 'exifInfo')
       .leftJoinAndSelect('entity.files', 'files')
-      .orderBy('entity.localDateTime', 'ASC')
+      .orderBy('entity.fileCreatedAt', 'ASC')
       .getMany();
   }
 


### PR DESCRIPTION
This PR fixes #13566 by sorting the assets using `fileCreatedAt` instead of `localDateTime`. This is in line with the timeline `getBucket` APIs which also sorts by the same field. 

See https://github.com/immich-app/immich/pull/13741#issuecomment-2439217218 for a more detailed explanation of what `localDateTime` represents