### PR TITLE
fix: remove duplicateIds on unique assets

### DIFF
--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -31,10 +31,22 @@ describe(SearchService.name, () => {
 
   describe('getDuplicates', () => {
     it('should get duplicates', async () => {
-      assetMock.getDuplicates.mockResolvedValue([assetStub.hasDupe]);
+      assetMock.getDuplicates.mockResolvedValue([assetStub.hasDupe, assetStub.hasDupe]);
       await expect(sut.getDuplicates(authStub.admin)).resolves.toEqual([
-        { duplicateId: assetStub.hasDupe.duplicateId, assets: [expect.objectContaining({ id: assetStub.hasDupe.id })] },
+        {
+          duplicateId: assetStub.hasDupe.duplicateId,
+          assets: [
+            expect.objectContaining({ id: assetStub.hasDupe.id }),
+            expect.objectContaining({ id: assetStub.hasDupe.id }),
+          ],
+        },
       ]);
+    });
+
+    it('should update assets with duplicateId', async () => {
+      assetMock.getDuplicates.mockResolvedValue([assetStub.hasDupe]);
+      await expect(sut.getDuplicates(authStub.admin)).resolves.toEqual([]);
+      expect(assetMock.updateAll).toHaveBeenCalledWith([assetStub.hasDupe.id], { duplicateId: null });
     });
   });
 

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -16,13 +16,15 @@ export class DuplicateService extends BaseService {
   async getDuplicates(auth: AuthDto): Promise<DuplicateResponseDto[]> {
     const res = await this.assetRepository.getDuplicates({ userIds: [auth.user.id] });
     const uniqueAssetIds: string[] = [];
-    const duplicates = mapDuplicateResponse(res.map((a) => mapAsset(a, { auth, withStack: true }))).filter((duplicate) => {
-      if (duplicate.assets.length === 1) {
-        uniqueAssetIds.push(duplicate.assets[0].id);
-        return false;
-      }
-      return true;
-    });
+    const duplicates = mapDuplicateResponse(res.map((a) => mapAsset(a, { auth, withStack: true }))).filter(
+      (duplicate) => {
+        if (duplicate.assets.length === 1) {
+          uniqueAssetIds.push(duplicate.assets[0].id);
+          return false;
+        }
+        return true;
+      },
+    );
     if (uniqueAssetIds.length > 0) {
       void this.assetRepository.updateAll(uniqueAssetIds, { duplicateId: null });
     }

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -26,7 +26,11 @@ export class DuplicateService extends BaseService {
       },
     );
     if (uniqueAssetIds.length > 0) {
-      void this.assetRepository.updateAll(uniqueAssetIds, { duplicateId: null });
+      try {
+        await this.assetRepository.updateAll(uniqueAssetIds, { duplicateId: null });
+      } catch (error: any) {
+        this.logger.error(`Failed to remove duplicateId from assets: ${error.message}`);
+      }
     }
     return duplicates;
   }

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -4,18 +4,23 @@ import { getAssetInfoFromParam } from '$lib/utils/navigation';
 import { getAssetDuplicates, updateAssets, type DuplicateResponseDto } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
-const rectifyDuplicate = (duplicate: DuplicateResponseDto) => {
-  updateAssets({ assetBulkUpdateDto: { ids: duplicate.assets.map((asset) => asset.id), duplicateId: null } });
+const rectifyDuplicate = (uniqueAssetIds: string[]) => {
+  if (uniqueAssetIds.length > 0) {
+    updateAssets({ assetBulkUpdateDto: { ids: uniqueAssetIds, duplicateId: null } });
+  }
 };
 
 const processDuplicates = (duplicates: DuplicateResponseDto[]) => {
-  return duplicates.filter((duplicate) => {
+  let uniqueAssetIds: string[] = [];
+  const validDuplicates = duplicates.filter((duplicate) => {
     if (duplicate.assets.length <= 1) {
-      rectifyDuplicate(duplicate);
+      uniqueAssetIds.push(duplicate.assets[0].id);
       return false;
     }
     return true;
   });
+  rectifyDuplicate(uniqueAssetIds);
+  return validDuplicates;
 };
 
 export const load = (async ({ params }) => {

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -1,13 +1,28 @@
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { getAssetDuplicates } from '@immich/sdk';
+import { getAssetDuplicates, updateAssets, type DuplicateResponseDto } from '@immich/sdk';
 import type { PageLoad } from './$types';
+
+const rectifyDuplicate = (duplicate: DuplicateResponseDto) => {
+  updateAssets({ assetBulkUpdateDto: { ids: duplicate.assets.map((asset) => asset.id), duplicateId: null } });
+};
+
+const processDuplicates = (duplicates: DuplicateResponseDto[]) => {
+  return duplicates.filter((duplicate) => {
+    if (duplicate.assets.length <= 1) {
+      rectifyDuplicate(duplicate);
+      return false;
+    }
+    return true;
+  });
+};
 
 export const load = (async ({ params }) => {
   await authenticate();
   const asset = await getAssetInfoFromParam(params);
-  const duplicates = await getAssetDuplicates();
+  const Allduplicates = await getAssetDuplicates();
+  const duplicates = processDuplicates(Allduplicates);
   const $t = await getFormatter();
 
   return {

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -6,12 +6,12 @@ import type { PageLoad } from './$types';
 
 const rectifyDuplicate = (uniqueAssetIds: string[]) => {
   if (uniqueAssetIds.length > 0) {
-    updateAssets({ assetBulkUpdateDto: { ids: uniqueAssetIds, duplicateId: null } });
+    void updateAssets({ assetBulkUpdateDto: { ids: uniqueAssetIds, duplicateId: null } });
   }
 };
 
 const processDuplicates = (duplicates: DuplicateResponseDto[]) => {
-  let uniqueAssetIds: string[] = [];
+  const uniqueAssetIds: string[] = [];
   const validDuplicates = duplicates.filter((duplicate) => {
     if (duplicate.assets.length <= 1) {
       uniqueAssetIds.push(duplicate.assets[0].id);

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -1,7 +1,7 @@
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { getAssetDuplicates, updateAssets, type DuplicateResponseDto } from '@immich/sdk';
+import { getAssetDuplicates } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ params }) => {

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -4,30 +4,10 @@ import { getAssetInfoFromParam } from '$lib/utils/navigation';
 import { getAssetDuplicates, updateAssets, type DuplicateResponseDto } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
-const rectifyDuplicate = (uniqueAssetIds: string[]) => {
-  if (uniqueAssetIds.length > 0) {
-    void updateAssets({ assetBulkUpdateDto: { ids: uniqueAssetIds, duplicateId: null } });
-  }
-};
-
-const processDuplicates = (duplicates: DuplicateResponseDto[]) => {
-  const uniqueAssetIds: string[] = [];
-  const validDuplicates = duplicates.filter((duplicate) => {
-    if (duplicate.assets.length <= 1) {
-      uniqueAssetIds.push(duplicate.assets[0].id);
-      return false;
-    }
-    return true;
-  });
-  rectifyDuplicate(uniqueAssetIds);
-  return validDuplicates;
-};
-
 export const load = (async ({ params }) => {
   await authenticate();
   const asset = await getAssetInfoFromParam(params);
-  const Allduplicates = await getAssetDuplicates();
-  const duplicates = processDuplicates(Allduplicates);
+  const duplicates = await getAssetDuplicates();
   const $t = await getFormatter();
 
   return {


### PR DESCRIPTION
fixes: #11637 

## Issue Overview
A bug was identified in the review duplicates utility where, after manually deleting a duplicate image, the corresponding group was still displayed with a single leftover image. 

## Changes 
We validate the duplicates in duplicates utility page by checking if each duplicate set has atleast 2 assets. If not we update the assets to remove duplicates ids from them and do not show them on the page.