### PR TITLE
docs: note about Nginx reverse proxy compatibility with Let's Encrypt

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -48,7 +48,7 @@ location ~ /.well-known {
 }
 ```
 
-This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for authentication. Usual error message for this case is: "Your app major version is not compatible with the server". To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
+This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for discovery. Usual error message for this case is: "Your app major version is not compatible with the server". To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
 
 ```nginx
 location /.well-known/immich {

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -41,7 +41,9 @@ server {
 ```
 
 #### Compatibility with Let's Encrypt
+
 In the event that your nginx configuration includes a section for Let's Encrypt, it's likely that you have a segment similar to the following:
+
 ```nginx
 location ~ /.well-known {
     ...

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -48,7 +48,7 @@ location ~ /.well-known {
 }
 ```
 
-This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for authentication. To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
+This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for authentication. Usual error message for this case is: "Your app major version is not compatible with the server". To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
 
 ```nginx
 location /.well-known/immich {

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -40,6 +40,24 @@ server {
 }
 ```
 
+#### Compatibility with Let's Encrypt
+In the event that your nginx configuration includes a section for Let's Encrypt, it's likely that you have a segment similar to the following:
+```nginx
+location ~ /.well-known {
+    ...
+}
+```
+
+This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for authentication. To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
+
+```nginx
+location /.well-known/immich {
+    proxy_pass http://<backend_url>:2283;
+}
+```
+
+By doing so, you'll maintain the functionality of Let's Encrypt while allowing mobile clients to access the necessary Immich path without obstruction.
+
 ### Caddy example config
 
 As an alternative to nginx, you can also use [Caddy](https://caddyserver.com/) as a reverse proxy (with automatic HTTPS configuration). Below is an example config.

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -51,7 +51,7 @@ location ~ /.well-known {
 This particular `location` directive can inadvertently prevent mobile clients from reaching the `/.well-known/immich` path, which is crucial for discovery. Usual error message for this case is: "Your app major version is not compatible with the server". To remedy this, you should introduce an additional location block specifically for this path, ensuring that requests are correctly proxied to the Immich server:
 
 ```nginx
-location /.well-known/immich {
+location = /.well-known/immich {
     proxy_pass http://<backend_url>:2283;
 }
 ```


### PR DESCRIPTION
## Description

Adding additional documentation for nginx reverse proxy configuration in case /.well-known is already used for Let's Encrypt.
Helps users to resolve the problem on the early stage.

Fixes #13597, #11036, #10799, #10657

## How Has This Been Tested?

This is a documentation change

## Checklist:

- [x] I have made corresponding changes to the documentation if applicable