### PR TITLE
chore(docs): Encode db dump in UTF-8 without BOM for Windows

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -49,7 +49,7 @@ docker compose up -d            # Start remainder of Immich apps
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
 
 ```powershell title='Backup'
-docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres | Set-Content -Encoding utf8 "C:\path\to\backup\dump.sql"
+[System.IO.File]::WriteAllLines("C:\absolute\path\to\backup\dump.sql", (docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=postgres))
 ```
 
 ```powershell title='Restore'


### PR DESCRIPTION
Related to #11787 

On Windows, the encoding “utf8” actually means “UTF-8 with BOM”. What we need is “utf8NoBOM”. However it’s not available from the Windows 10 built-in PowerShell.

This change suggests `WriteAllLines` function from the pre-installed .net framework, which uses real UTF-8 encoding by default.

https://learn.microsoft.com/en-us/dotnet/api/system.io.file.writealllines?view=netframework-4.6

> The default behavior of the [WriteAllLines(String, IEnumerable<String>)](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.writealllines?view=netframework-4.6#system-io-file-writealllines(system-string-system-collections-generic-ienumerable((system-string)))) method is to write out data by using UTF-8 encoding without a byte order mark (BOM).