### PR TITLE
fix(mobile): Revert thumbnail image ui improvements  (#13655)

### DIFF
--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -138,31 +138,10 @@ class ThumbnailImage extends ConsumerWidget {
           tag: isFromDto
               ? '${asset.remoteId}-$heroOffset'
               : asset.id + heroOffset,
-          child: Stack(
-            children: [
-              ImmichThumbnail(
-                asset: asset,
-                height: 250,
-                width: 250,
-              ),
-              Container(
-                height: 250,
-                width: 250,
-                decoration: const BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      Color.fromRGBO(0, 0, 0, 0.1),
-                      Colors.transparent,
-                      Colors.transparent,
-                      Color.fromRGBO(0, 0, 0, 0.1),
-                    ],
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    stops: [0, 0.3, 0.6, 1],
-                  ),
-                ),
-              ),
-            ],
+          child: ImmichThumbnail(
+            asset: asset,
+            height: 250,
+            width: 250,
           ),
         ),
       );
@@ -174,8 +153,11 @@ class ThumbnailImage extends ConsumerWidget {
           color: canDeselect ? assetContainerColor : Colors.grey,
         ),
         child: ClipRRect(
-          borderRadius: const BorderRadius.all(
-            Radius.circular(15.0),
+          borderRadius: const BorderRadius.only(
+            topRight: Radius.circular(15.0),
+            bottomRight: Radius.circular(15.0),
+            bottomLeft: Radius.circular(15.0),
+            topLeft: Radius.zero,
           ),
           child: image,
         ),
@@ -195,33 +177,7 @@ class ThumbnailImage extends ConsumerWidget {
                   )
                 : const Border(),
           ),
-          child: Stack(
-            children: [
-              buildImage(),
-              if (showStorageIndicator)
-                Positioned(
-                  right: 8,
-                  bottom: 5,
-                  child: Icon(
-                    storageIcon(asset),
-                    color: Colors.white.withOpacity(.8),
-                    size: 16,
-                  ),
-                ),
-              if (asset.isFavorite)
-                const Positioned(
-                  left: 8,
-                  bottom: 5,
-                  child: Icon(
-                    Icons.favorite,
-                    color: Colors.white,
-                    size: 16,
-                  ),
-                ),
-              if (!asset.isImage) buildVideoIcon(),
-              if (asset.stackCount > 0) buildStackIcon(),
-            ],
-          ),
+          child: buildImage(),
         ),
         if (multiselectEnabled)
           Padding(
@@ -231,6 +187,28 @@ class ThumbnailImage extends ConsumerWidget {
               child: buildSelectionIcon(asset),
             ),
           ),
+        if (showStorageIndicator)
+          Positioned(
+            right: 8,
+            bottom: 5,
+            child: Icon(
+              storageIcon(asset),
+              color: Colors.white.withOpacity(.8),
+              size: 16,
+            ),
+          ),
+        if (asset.isFavorite)
+          const Positioned(
+            left: 8,
+            bottom: 5,
+            child: Icon(
+              Icons.favorite,
+              color: Colors.white,
+              size: 18,
+            ),
+          ),
+        if (!asset.isImage) buildVideoIcon(),
+        if (asset.stackCount > 0) buildStackIcon(),
       ],
     );
   }


### PR DESCRIPTION
Fixes #13804

The commit causes white spacing around the asset due to using `Stack`

