### PR TITLE
fix(mobile): thumbnail not filled area on tablet

### DIFF
--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -131,9 +131,7 @@ class ThumbnailImage extends ConsumerWidget {
     }
 
     Widget buildImage() {
-      final image = SizedBox(
-        width: 300,
-        height: 300,
+      final image = SizedBox.expand(
         child: Hero(
           tag: isFromDto
               ? '${asset.remoteId}-$heroOffset'


### PR DESCRIPTION
Fix an issue of thumbnail doesn't fill the allowable area when in less than 3 assets per row on tablet layout
