### PR TITLE
fix: address timezone-based flakiness

### DIFF
--- a/web/src/lib/utils/timeline-util.spec.ts
+++ b/web/src/lib/utils/timeline-util.spec.ts
@@ -25,9 +25,9 @@ describe('formatGroupTitle', () => {
   });
 
   it('formats last week', () => {
-    const date = parseUtcDate('2024-07-21T00:00:00Z');
-    expect(formatGroupTitle(date.setLocale('en'))).toBe('Sunday');
-    expect(formatGroupTitle(date.setLocale('ar-SA'))).toBe('الأحد');
+    const date = parseUtcDate('2024-07-22T00:00:00Z');
+    expect(formatGroupTitle(date.setLocale('en'))).toBe('Monday');
+    expect(formatGroupTitle(date.setLocale('ar-SA'))).toBe('الاثنين');
   });
 
   it('formats date 7 days ago', () => {

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -51,7 +51,7 @@ export function formatGroupTitle(_date: DateTime): string {
     return _date.toString();
   }
   const date = _date as DateTime<true>;
-  const today = DateTime.now().startOf('day');
+  const today = DateTime.now();
 
   // Today
   if (today.hasSame(date, 'day')) {


### PR DESCRIPTION
The `formats last week` test would consistently fail on my machine and @jrasm91's machine because of our timezone. Vite mocks the system time, but we all keep our machine time zones. That means `.startOf('day')` returns differently based on which machine it runs on. I'm not sure why that logic was there. If you want to know if something happened in the past day or past 6 days, including that just makes the logic wrong as far as I can tell.