### PR TITLE
refactor: config init event for first config load

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -78,11 +78,11 @@ class BaseModule implements OnModuleInit, OnModuleDestroy {
     }
 
     this.eventRepository.setup({ services });
-    await this.eventRepository.emit('app.bootstrap', this.worker);
+    await this.eventRepository.emit('app.bootstrap');
   }
 
   async onModuleDestroy() {
-    await this.eventRepository.emit('app.shutdown', this.worker);
+    await this.eventRepository.emit('app.shutdown');
     await teardownTelemetry();
   }
 }

--- a/server/src/interfaces/event.interface.ts
+++ b/server/src/interfaces/event.interface.ts
@@ -12,12 +12,12 @@ type EventMap = {
   'app.bootstrap': [ImmichWorker];
   'app.shutdown': [ImmichWorker];
 
+  'config.init': [{ newConfig: SystemConfig }];
   // config events
   'config.update': [
     {
       newConfig: SystemConfig;
-      /** When the server starts, `oldConfig` is `undefined` */
-      oldConfig?: SystemConfig;
+      oldConfig: SystemConfig;
     },
   ];
   'config.validate': [{ newConfig: SystemConfig; oldConfig: SystemConfig }];
@@ -88,6 +88,13 @@ export type EventItem<T extends EmitEvent> = {
   handler: EmitHandler<T>;
   server: boolean;
 };
+
+export enum BootstrapEventPriority {
+  // Database service should be initialized before anything else, most other services need database access
+  DatabaseService = -200,
+  // Initialise config after other bootstrap services, stop other services from using config on bootstrap
+  SystemConfig = 100,
+}
 
 export interface IEventRepository {
   setup(options: { services: ClassConstructor<unknown>[] }): void;

--- a/server/src/interfaces/event.interface.ts
+++ b/server/src/interfaces/event.interface.ts
@@ -2,15 +2,14 @@ import { ClassConstructor } from 'class-transformer';
 import { SystemConfig } from 'src/config';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { ReleaseNotification, ServerVersionResponseDto } from 'src/dtos/server.dto';
-import { ImmichWorker } from 'src/enum';
 import { JobItem, QueueName } from 'src/interfaces/job.interface';
 
 export const IEventRepository = 'IEventRepository';
 
 type EventMap = {
   // app events
-  'app.bootstrap': [ImmichWorker];
-  'app.shutdown': [ImmichWorker];
+  'app.bootstrap': [];
+  'app.shutdown': [];
 
   'config.init': [{ newConfig: SystemConfig }];
   // config events

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -9,6 +9,7 @@ import {
   VectorExtension,
   VectorIndex,
 } from 'src/interfaces/database.interface';
+import { BootstrapEventPriority } from 'src/interfaces/event.interface';
 import { BaseService } from 'src/services/base.service';
 
 type CreateFailedArgs = { name: string; extension: string; otherName: string };
@@ -64,7 +65,7 @@ const RETRY_DURATION = Duration.fromObject({ seconds: 5 });
 export class DatabaseService extends BaseService {
   private reconnection?: NodeJS.Timeout;
 
-  @OnEvent({ name: 'app.bootstrap', priority: -200 })
+  @OnEvent({ name: 'app.bootstrap', priority: BootstrapEventPriority.DatabaseService })
   async onBootstrap() {
     const version = await this.databaseRepository.getPostgresVersion();
     const current = semver.coerce(version);

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -31,7 +31,7 @@ describe(JobService.name, () => {
 
   describe('onConfigUpdate', () => {
     it('should update concurrency', () => {
-      sut.onConfigUpdate({ oldConfig: defaults, newConfig: defaults });
+      sut.onConfigInitOrUpdate({ newConfig: defaults });
 
       expect(jobMock.setConcurrency).toHaveBeenCalledTimes(15);
       expect(jobMock.setConcurrency).toHaveBeenNthCalledWith(5, QueueName.FACIAL_RECOGNITION, 1);

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -38,8 +38,9 @@ const asJobItem = (dto: JobCreateDto): JobItem => {
 
 @Injectable()
 export class JobService extends BaseService {
+  @OnEvent({ name: 'config.init' })
   @OnEvent({ name: 'config.update', server: true })
-  onConfigUpdate({ newConfig: config }: ArgOf<'config.update'>) {
+  onConfigInitOrUpdate({ newConfig: config }: ArgOf<'config.init'>) {
     if (this.worker !== ImmichWorker.MICROSERVICES) {
       return;
     }

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -5,6 +5,7 @@ import { mapLibrary } from 'src/dtos/library.dto';
 import { UserEntity } from 'src/entities/user.entity';
 import { AssetType, ImmichWorker } from 'src/enum';
 import { IAssetRepository } from 'src/interfaces/asset.interface';
+import { IConfigRepository } from 'src/interfaces/config.interface';
 import { IDatabaseRepository } from 'src/interfaces/database.interface';
 import {
   IJobRepository,
@@ -16,7 +17,6 @@ import {
 } from 'src/interfaces/job.interface';
 import { ILibraryRepository } from 'src/interfaces/library.interface';
 import { IStorageRepository } from 'src/interfaces/storage.interface';
-import { ISystemMetadataRepository } from 'src/interfaces/system-metadata.interface';
 import { LibraryService } from 'src/services/library.service';
 import { assetStub } from 'test/fixtures/asset.stub';
 import { authStub } from 'test/fixtures/auth.stub';
@@ -35,30 +35,28 @@ describe(LibraryService.name, () => {
   let sut: LibraryService;
 
   let assetMock: Mocked<IAssetRepository>;
+  let configMock: Mocked<IConfigRepository>;
   let databaseMock: Mocked<IDatabaseRepository>;
   let jobMock: Mocked<IJobRepository>;
   let libraryMock: Mocked<ILibraryRepository>;
   let storageMock: Mocked<IStorageRepository>;
-  let systemMock: Mocked<ISystemMetadataRepository>;
 
   beforeEach(() => {
-    ({ sut, assetMock, databaseMock, jobMock, libraryMock, storageMock, systemMock } = newTestService(LibraryService));
+    ({ sut, assetMock, configMock, databaseMock, jobMock, libraryMock, storageMock } = newTestService(LibraryService));
 
     databaseMock.tryLock.mockResolvedValue(true);
+    configMock.getWorker.mockReturnValue(ImmichWorker.MICROSERVICES);
   });
 
   it('should work', () => {
     expect(sut).toBeDefined();
   });
 
-  describe('onBootstrapEvent', () => {
+  describe('onConfigInit', () => {
     it('should init cron job and handle config changes', async () => {
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryScan);
-
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: defaults });
 
       expect(jobMock.addCronJob).toHaveBeenCalled();
-      expect(systemMock.get).toHaveBeenCalled();
 
       await sut.onConfigUpdate({
         oldConfig: defaults,
@@ -82,7 +80,6 @@ describe(LibraryService.name, () => {
         libraryStub.externalLibraryWithImportPaths2,
       ]);
 
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       libraryMock.get.mockImplementation((id) =>
         Promise.resolve(
           [libraryStub.externalLibraryWithImportPaths1, libraryStub.externalLibraryWithImportPaths2].find(
@@ -91,7 +88,7 @@ describe(LibraryService.name, () => {
         ),
       );
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
 
       expect(storageMock.watch.mock.calls).toEqual(
         expect.arrayContaining([
@@ -102,33 +99,30 @@ describe(LibraryService.name, () => {
     });
 
     it('should not initialize watcher when watching is disabled', async () => {
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchDisabled);
-
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchDisabled as SystemConfig });
 
       expect(storageMock.watch).not.toHaveBeenCalled();
     });
 
     it('should not initialize watcher when lock is taken', async () => {
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       databaseMock.tryLock.mockResolvedValue(false);
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
 
       expect(storageMock.watch).not.toHaveBeenCalled();
     });
 
     it('should not initialize library scan cron job when lock is taken', async () => {
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       databaseMock.tryLock.mockResolvedValue(false);
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
 
       expect(jobMock.addCronJob).not.toHaveBeenCalled();
     });
 
     it('should not initialize watcher or library scan job when running on api', async () => {
-      await sut.onBootstrap(ImmichWorker.API);
+      configMock.getWorker.mockReturnValue(ImmichWorker.API);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryScan as SystemConfig });
 
       expect(jobMock.addCronJob).not.toHaveBeenCalled();
     });
@@ -136,19 +130,13 @@ describe(LibraryService.name, () => {
 
   describe('onConfigUpdateEvent', () => {
     beforeEach(async () => {
-      systemMock.get.mockResolvedValue(defaults);
       databaseMock.tryLock.mockResolvedValue(true);
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
-    });
-
-    it('should do nothing if oldConfig is not provided', async () => {
-      await sut.onConfigUpdate({ newConfig: systemConfigStub.libraryScan as SystemConfig });
-      expect(jobMock.updateCronJob).not.toHaveBeenCalled();
+      await sut.onConfigInit({ newConfig: defaults });
     });
 
     it('should do nothing if instance does not have the watch lock', async () => {
       databaseMock.tryLock.mockResolvedValue(false);
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: defaults });
       await sut.onConfigUpdate({ newConfig: systemConfigStub.libraryScan as SystemConfig, oldConfig: defaults });
       expect(jobMock.updateCronJob).not.toHaveBeenCalled();
     });
@@ -156,9 +144,7 @@ describe(LibraryService.name, () => {
     it('should update cron job and enable watching', async () => {
       libraryMock.getAll.mockResolvedValue([]);
       await sut.onConfigUpdate({
-        newConfig: {
-          library: { ...systemConfigStub.libraryScan.library, ...systemConfigStub.libraryWatchEnabled.library },
-        } as SystemConfig,
+        newConfig: systemConfigStub.libraryScanAndWatch as SystemConfig,
         oldConfig: defaults,
       });
 
@@ -172,15 +158,11 @@ describe(LibraryService.name, () => {
     it('should update cron job and disable watching', async () => {
       libraryMock.getAll.mockResolvedValue([]);
       await sut.onConfigUpdate({
-        newConfig: {
-          library: { ...systemConfigStub.libraryScan.library, ...systemConfigStub.libraryWatchEnabled.library },
-        } as SystemConfig,
+        newConfig: systemConfigStub.libraryScanAndWatch as SystemConfig,
         oldConfig: defaults,
       });
       await sut.onConfigUpdate({
-        newConfig: {
-          library: { ...systemConfigStub.libraryScan.library, ...systemConfigStub.libraryWatchDisabled.library },
-        } as SystemConfig,
+        newConfig: systemConfigStub.libraryScan as SystemConfig,
         oldConfig: defaults,
       });
 
@@ -703,12 +685,10 @@ describe(LibraryService.name, () => {
       libraryMock.get.mockResolvedValue(libraryStub.externalLibraryWithImportPaths1);
       libraryMock.getAll.mockResolvedValue([libraryStub.externalLibraryWithImportPaths1]);
 
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
-
       const mockClose = vitest.fn();
       storageMock.watch.mockImplementation(makeMockWatcher({ close: mockClose }));
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
       await sut.delete(libraryStub.externalLibraryWithImportPaths1.id);
 
       expect(mockClose).toHaveBeenCalled();
@@ -837,12 +817,11 @@ describe(LibraryService.name, () => {
       });
 
       it('should create watched with import paths', async () => {
-        systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
         libraryMock.create.mockResolvedValue(libraryStub.externalLibraryWithImportPaths1);
         libraryMock.get.mockResolvedValue(libraryStub.externalLibraryWithImportPaths1);
         libraryMock.getAll.mockResolvedValue([]);
 
-        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+        await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
         await sut.create({
           ownerId: authStub.admin.user.id,
           importPaths: libraryStub.externalLibraryWithImportPaths1.importPaths,
@@ -902,10 +881,9 @@ describe(LibraryService.name, () => {
 
   describe('update', () => {
     beforeEach(async () => {
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       libraryMock.getAll.mockResolvedValue([]);
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
     });
 
     it('should throw an error if an import path is invalid', async () => {
@@ -944,9 +922,7 @@ describe(LibraryService.name, () => {
 
     describe('watching disabled', () => {
       beforeEach(async () => {
-        systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchDisabled);
-
-        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+        await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchDisabled as SystemConfig });
       });
 
       it('should not watch library', async () => {
@@ -960,9 +936,8 @@ describe(LibraryService.name, () => {
 
     describe('watching enabled', () => {
       beforeEach(async () => {
-        systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
         libraryMock.getAll.mockResolvedValue([]);
-        await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+        await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
       });
 
       it('should watch library', async () => {
@@ -1114,7 +1089,6 @@ describe(LibraryService.name, () => {
         libraryStub.externalLibraryWithImportPaths2,
       ]);
 
-      systemMock.get.mockResolvedValue(systemConfigStub.libraryWatchEnabled);
       libraryMock.get.mockResolvedValue(libraryStub.externalLibrary1);
 
       libraryMock.get.mockImplementation((id) =>
@@ -1128,7 +1102,7 @@ describe(LibraryService.name, () => {
       const mockClose = vitest.fn();
       storageMock.watch.mockImplementation(makeMockWatcher({ close: mockClose }));
 
-      await sut.onBootstrap(ImmichWorker.MICROSERVICES);
+      await sut.onConfigInit({ newConfig: systemConfigStub.libraryWatchEnabled as SystemConfig });
       await sut.onShutdown();
 
       expect(mockClose).toHaveBeenCalledTimes(2);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -80,12 +80,12 @@ const validateRange = (value: number | undefined, min: number, max: number): Non
 @Injectable()
 export class MetadataService extends BaseService {
   @OnEvent({ name: 'app.bootstrap' })
-  async onBootstrap(app: ArgOf<'app.bootstrap'>) {
-    if (app !== ImmichWorker.MICROSERVICES) {
+  async onBootstrap() {
+    if (this.worker !== ImmichWorker.MICROSERVICES) {
       return;
     }
-    const config = await this.getConfig({ withCache: false });
-    await this.init(config);
+    this.logger.log('Bootstrapping metadata service');
+    await this.init();
   }
 
   @OnEvent({ name: 'app.shutdown' })
@@ -93,17 +93,8 @@ export class MetadataService extends BaseService {
     await this.metadataRepository.teardown();
   }
 
-  @OnEvent({ name: 'config.update' })
-  async onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
-    await this.init(newConfig);
-  }
-
-  private async init({ reverseGeocoding }: SystemConfig) {
-    const { enabled } = reverseGeocoding;
-
-    if (!enabled) {
-      return;
-    }
+  private async init() {
+    this.logger.log('Initializing metadata service');
 
     try {
       await this.jobRepository.pause(QueueName.METADATA_EXTRACTION);

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -77,7 +77,7 @@ describe(NotificationService.name, () => {
 
   describe('onConfigUpdate', () => {
     it('should emit client and server events', () => {
-      const update = { newConfig: defaults };
+      const update = { oldConfig: defaults, newConfig: defaults };
       expect(sut.onConfigUpdate(update)).toBeUndefined();
       expect(eventMock.clientBroadcast).toHaveBeenCalledWith('on_config_update');
       expect(eventMock.serverSend).toHaveBeenCalledWith('config.update', update);

--- a/server/src/services/smart-info.service.ts
+++ b/server/src/services/smart-info.service.ts
@@ -13,17 +13,12 @@ import { usePagination } from 'src/utils/pagination';
 
 @Injectable()
 export class SmartInfoService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap' })
-  async onBootstrap(app: ArgOf<'app.bootstrap'>) {
-    if (app !== ImmichWorker.MICROSERVICES) {
-      return;
-    }
-
-    const config = await this.getConfig({ withCache: false });
-    await this.init(config);
+  @OnEvent({ name: 'config.init' })
+  async onConfigInit({ newConfig }: ArgOf<'config.init'>) {
+    await this.init(newConfig);
   }
 
-  @OnEvent({ name: 'config.update' })
+  @OnEvent({ name: 'config.update', server: true })
   async onConfigUpdate({ oldConfig, newConfig }: ArgOf<'config.update'>) {
     await this.init(newConfig, oldConfig);
   }
@@ -40,7 +35,7 @@ export class SmartInfoService extends BaseService {
   }
 
   private async init(newConfig: SystemConfig, oldConfig?: SystemConfig) {
-    if (!isSmartSearchEnabled(newConfig.machineLearning)) {
+    if (this.worker !== ImmichWorker.MICROSERVICES || !isSmartSearchEnabled(newConfig.machineLearning)) {
       return;
     }
 

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -38,7 +38,7 @@ describe(StorageTemplateService.name, () => {
 
     systemMock.get.mockResolvedValue({ storageTemplate: { enabled: true } });
 
-    sut.onConfigUpdate({ newConfig: defaults });
+    sut.onConfigInitOrUpdate({ newConfig: defaults });
   });
 
   describe('onConfigValidate', () => {
@@ -171,7 +171,7 @@ describe(StorageTemplateService.name, () => {
       const config = structuredClone(defaults);
       config.storageTemplate.template = '{{y}}/{{#if album}}{{album}}{{else}}other/{{MM}}{{/if}}/{{filename}}';
 
-      sut.onConfigUpdate({ oldConfig: defaults, newConfig: config });
+      sut.onConfigInitOrUpdate({ newConfig: config });
 
       userMock.get.mockResolvedValue(user);
       assetMock.getByIds.mockResolvedValueOnce([asset]);
@@ -192,7 +192,7 @@ describe(StorageTemplateService.name, () => {
       const user = userStub.user1;
       const config = structuredClone(defaults);
       config.storageTemplate.template = '{{y}}/{{#if album}}{{album}}{{else}}other//{{MM}}{{/if}}/{{filename}}';
-      sut.onConfigUpdate({ oldConfig: defaults, newConfig: config });
+      sut.onConfigInitOrUpdate({ newConfig: config });
 
       userMock.get.mockResolvedValue(user);
       assetMock.getByIds.mockResolvedValueOnce([asset]);

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -74,8 +74,9 @@ export class StorageTemplateService extends BaseService {
     return this._template;
   }
 
+  @OnEvent({ name: 'config.init' })
   @OnEvent({ name: 'config.update', server: true })
-  onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
+  onConfigInitOrUpdate({ newConfig }: ArgOf<'config.init'>) {
     const template = newConfig.storageTemplate.template;
     if (!this._template || template !== this.template.raw) {
       this.logger.debug(`Compiling new storage template: ${template}`);

--- a/server/test/fixtures/system-config.stub.ts
+++ b/server/test/fixtures/system-config.stub.ts
@@ -54,6 +54,9 @@ export const systemConfigStub = {
   },
   libraryWatchEnabled: {
     library: {
+      scan: {
+        enabled: false,
+      },
       watch: {
         enabled: true,
       },
@@ -61,6 +64,9 @@ export const systemConfigStub = {
   },
   libraryWatchDisabled: {
     library: {
+      scan: {
+        enabled: false,
+      },
       watch: {
         enabled: false,
       },
@@ -71,6 +77,20 @@ export const systemConfigStub = {
       scan: {
         enabled: true,
         cronExpression: '0 0 * * *',
+      },
+      watch: {
+        enabled: false,
+      },
+    },
+  },
+  libraryScanAndWatch: {
+    library: {
+      scan: {
+        enabled: true,
+        cronExpression: '0 0 * * *',
+      },
+      watch: {
+        enabled: true,
       },
     },
   },
@@ -86,6 +106,15 @@ export const systemConfigStub = {
   machineLearningDisabled: {
     machineLearning: {
       enabled: false,
+    },
+  },
+  machineLearningEnabled: {
+    machineLearning: {
+      enabled: true,
+      clip: {
+        modelName: 'ViT-B-16__openai',
+        enabled: true,
+      },
     },
   },
 } satisfies Record<string, DeepPartial<SystemConfig>>;


### PR DESCRIPTION
This replaces the current config.update usage where it gets called on first start with oldConfig: undefined. Instead, we have a specific config.init event, which should be used when services need to do initialisation on startup and have the config defined. app.bootstrap can be used for services that need to run before config initialisation happens, or just don't need config at all.

As a side effect of these changes, geodata updates now shouldn't block the api server from starting.

Related to #13867, these changes will now allow the server to start and make the web accessible while geodata loads in the background.