### PR TITLE
fix: docker link

### DIFF
--- a/docs/docs/install/requirements.md
+++ b/docs/docs/install/requirements.md
@@ -8,7 +8,7 @@ Hardware and software requirements for Immich:
 
 ## Software
 
-- [Docker](https://docs.docker.com/get-docker/)
+- [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 :::note


### PR DESCRIPTION
The old link now points to the docker desktop versions, which isn't what people usually want