### PR TITLE
fix(server): database backups compatible with deduplication

### DIFF
--- a/server/src/services/backup.service.ts
+++ b/server/src/services/backup.service.ts
@@ -97,7 +97,8 @@ export class BackupService extends BaseService {
           env: { PATH: process.env.PATH, PGPASSWORD: isUrlConnection ? undefined : config.password },
         });
 
-        const gzip = this.processRepository.spawn(`gzip`, []);
+        // NOTE: `--rsyncable` is only supported in GNU gzip
+        const gzip = this.processRepository.spawn(`gzip`, ['--rsyncable']);
         pgdump.stdout.pipe(gzip.stdin);
 
         const fileStream = this.storageRepository.createWriteStream(backupFilePath);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

gzip --rsyncable has a slightly worse compression ratio, but allows for efficient deduplication and, as the name implies, faster rsync operations.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] npm run test

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
