### PR TITLE
chore(mobile): revert upgrade gradle (#13901)

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
-    id 'com.google.devtools.ksp'
+    id "kotlin-kapt"
 }
 
 def localProperties = new Properties()
@@ -31,13 +31,12 @@ android {
     compileSdkVersion 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = '17'
+        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -75,7 +74,6 @@ android {
             signingConfig signingConfigs.release
         }
     }
-    namespace 'app.alextran.immich'
 }
 
 flutter {
@@ -83,11 +81,11 @@ flutter {
 }
 
 dependencies {
-    def kotlin_version = '2.0.20'
-    def kotlin_coroutines_version = '1.9.0'
-    def work_version = '2.9.1'
-    def concurrent_version = '1.2.0'
-    def guava_version = '33.3.1-android'
+    def kotlin_version = '1.9.24'
+    def kotlin_coroutines_version = '1.8.1'
+    def work_version = '2.9.0'
+    def concurrent_version = '1.1.0'
+    def guava_version = '33.2.0-android'
     def glide_version = '4.16.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -96,8 +94,7 @@ dependencies {
     implementation "androidx.concurrent:concurrent-futures:$concurrent_version"
     implementation "com.google.guava:guava:$guava_version"
     implementation "com.github.bumptech.glide:glide:$glide_version"
-    ksp "com.github.bumptech.glide:ksp:$glide_version"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.2'
+    kapt "com.github.bumptech.glide:compiler:$glide_version"
 }
 
 // This is uncommented in F-Droid build script

--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="app.alextran.immich">
   <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="app.alextran.immich"
   xmlns:tools="http://schemas.android.com/tools">
 
   <uses-permission android:name="android.permission.INTERNET" />

--- a/mobile/android/app/src/profile/AndroidManifest.xml
+++ b/mobile/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="app.alextran.immich">
   <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    ext.kotlin_version = '2.0.20' 
+    ext.kotlin_version = '1.9.24' 
 
     repositories {
         google()

--- a/mobile/android/gradle.properties
+++ b/mobile/android/gradle.properties
@@ -1,5 +1,3 @@
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
-networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionSha256Sum=fe696c020f241a5f69c30f763c5a7f38eec54b490db19cd2b0962dda420d7d12

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -18,9 +18,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.7.2' apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
-    id 'com.google.devtools.ksp' version '2.0.20-1.0.24' apply false
+    id "com.android.application" version "7.4.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.kapt" version "1.9.0" apply false
 }
 
 include ":app"

--- a/mobile/lib/entities/album.entity.g.dart
+++ b/mobile/lib/entities/album.entity.g.dart
@@ -131,7 +131,7 @@ const AlbumSchema = CollectionSchema(
   getId: _albumGetId,
   getLinks: _albumGetLinks,
   attach: _albumAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _albumEstimateSize(

--- a/mobile/lib/entities/android_device_asset.entity.g.dart
+++ b/mobile/lib/entities/android_device_asset.entity.g.dart
@@ -49,7 +49,7 @@ const AndroidDeviceAssetSchema = CollectionSchema(
   getId: _androidDeviceAssetGetId,
   getLinks: _androidDeviceAssetGetLinks,
   attach: _androidDeviceAssetAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _androidDeviceAssetEstimateSize(

--- a/mobile/lib/entities/asset.entity.g.dart
+++ b/mobile/lib/entities/asset.entity.g.dart
@@ -180,7 +180,7 @@ const AssetSchema = CollectionSchema(
   getId: _assetGetId,
   getLinks: _assetGetLinks,
   attach: _assetAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _assetEstimateSize(

--- a/mobile/lib/entities/backup_album.entity.g.dart
+++ b/mobile/lib/entities/backup_album.entity.g.dart
@@ -45,7 +45,7 @@ const BackupAlbumSchema = CollectionSchema(
   getId: _backupAlbumGetId,
   getLinks: _backupAlbumGetLinks,
   attach: _backupAlbumAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _backupAlbumEstimateSize(

--- a/mobile/lib/entities/duplicated_asset.entity.g.dart
+++ b/mobile/lib/entities/duplicated_asset.entity.g.dart
@@ -34,7 +34,7 @@ const DuplicatedAssetSchema = CollectionSchema(
   getId: _duplicatedAssetGetId,
   getLinks: _duplicatedAssetGetLinks,
   attach: _duplicatedAssetAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _duplicatedAssetEstimateSize(

--- a/mobile/lib/entities/etag.entity.g.dart
+++ b/mobile/lib/entities/etag.entity.g.dart
@@ -58,7 +58,7 @@ const ETagSchema = CollectionSchema(
   getId: _eTagGetId,
   getLinks: _eTagGetLinks,
   attach: _eTagAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _eTagEstimateSize(

--- a/mobile/lib/entities/exif_info.entity.g.dart
+++ b/mobile/lib/entities/exif_info.entity.g.dart
@@ -109,7 +109,7 @@ const ExifInfoSchema = CollectionSchema(
   getId: _exifInfoGetId,
   getLinks: _exifInfoGetLinks,
   attach: _exifInfoAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _exifInfoEstimateSize(

--- a/mobile/lib/entities/ios_device_asset.entity.g.dart
+++ b/mobile/lib/entities/ios_device_asset.entity.g.dart
@@ -66,7 +66,7 @@ const IOSDeviceAssetSchema = CollectionSchema(
   getId: _iOSDeviceAssetGetId,
   getLinks: _iOSDeviceAssetGetLinks,
   attach: _iOSDeviceAssetAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _iOSDeviceAssetEstimateSize(

--- a/mobile/lib/entities/logger_message.entity.g.dart
+++ b/mobile/lib/entities/logger_message.entity.g.dart
@@ -60,7 +60,7 @@ const LoggerMessageSchema = CollectionSchema(
   getId: _loggerMessageGetId,
   getLinks: _loggerMessageGetLinks,
   attach: _loggerMessageAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _loggerMessageEstimateSize(

--- a/mobile/lib/entities/store.entity.g.dart
+++ b/mobile/lib/entities/store.entity.g.dart
@@ -39,7 +39,7 @@ const StoreValueSchema = CollectionSchema(
   getId: _storeValueGetId,
   getLinks: _storeValueGetLinks,
   attach: _storeValueAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _storeValueEstimateSize(

--- a/mobile/lib/entities/user.entity.g.dart
+++ b/mobile/lib/entities/user.entity.g.dart
@@ -129,7 +129,7 @@ const UserSchema = CollectionSchema(
   getId: _userGetId,
   getLinks: _userGetLinks,
   attach: _userAttach,
-  version: '3.1.8',
+  version: '3.1.0+1',
 );
 
 int _userEstimateSize(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -548,10 +548,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      sha256: dd6676d8c2926537eccdf9f72128bbb2a9d0814689527b17f92c248ff192eaf3
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.4"
+    version: "17.2.1+2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -876,26 +876,26 @@ packages:
     dependency: "direct main"
     description:
       name: isar
-      sha256: e17a9555bc7f22ff26568b8c64d019b4ffa2dc6bd4cb1c8d9b269aefd32e53ad
-      url: "https://pub.isar-community.dev"
+      sha256: "99165dadb2cf2329d3140198363a7e7bff9bbd441871898a87e26914d25cf1ea"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.0+1"
   isar_flutter_libs:
     dependency: "direct main"
     description:
       name: isar_flutter_libs
-      sha256: "78710781e658ce4bff59b3f38c5b2735e899e627f4e926e1221934e77b95231a"
-      url: "https://pub.isar-community.dev"
+      sha256: bc6768cc4b9c61aabff77152e7f33b4b17d2fc93134f7af1c3dd51500fe8d5e8
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.0+1"
   isar_generator:
     dependency: "direct dev"
     description:
       name: isar_generator
-      sha256: "484e73d3b7e81dbd816852fe0b9497333118a9aeb646fd2d349a62cc8980ffe1"
-      url: "https://pub.isar-community.dev"
+      sha256: "76c121e1295a30423604f2f819bc255bc79f852f3bc8743a24017df6068ad133"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.0+1"
   js:
     dependency: transitive
     description:
@@ -1211,10 +1211,10 @@ packages:
     dependency: "direct main"
     description:
       name: photo_manager
-      sha256: f5ef2618870e9a50d8bfeb81a02c242d580ae8614bd5ea9e1b80dbb7e49d4260
+      sha256: "70159eee32203e8162d49d588232f0299ed3f383c63eef1e899cb6b83dee6b26"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "3.5.1"
   photo_manager_image_provider:
     dependency: "direct main"
     description:
@@ -1712,18 +1712,18 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "4a8c3492d734f7c39c2588a3206707a05ee80cef52e8c7f3b2078d430c84bc17"
+      sha256: e30df0d226c4ef82e2c150ebf6834b3522cf3f654d8e2f9419d376cdc071425d
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.2"
+    version: "2.9.1"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
+      sha256: "4de50df9ee786f5891d3281e1e633d7b142ef1acf47392592eb91cba5d355849"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.16"
+    version: "2.6.0"
   video_player_avfoundation:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -8,14 +8,12 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
   flutter: 3.24.4
 
-isar_version: &isar_version 3.1.8 # define the version to be used
-
 dependencies:
   flutter:
     sdk: flutter
 
   path_provider_ios:
-  photo_manager: ^3.6.1
+  photo_manager: ^3.5.1
   photo_manager_image_provider: ^2.2.0
   flutter_hooks: ^0.20.4
   hooks_riverpod: ^2.4.9
@@ -25,7 +23,7 @@ dependencies:
   intl: ^0.19.0
   auto_route: ^9.2.0
   fluttertoast: ^8.2.4
-  video_player: ^2.9.2
+  video_player: ^2.8.2
   chewie: ^1.7.4
   socket_io_client: ^2.0.3+1
   maplibre_gl: 0.19.0+2
@@ -46,12 +44,8 @@ dependencies:
   http_parser: ^4.0.2
   flutter_web_auth: ^0.6.0
   easy_image_viewer: ^1.4.0
-  isar:
-    version: *isar_version
-    hosted: https://pub.isar-community.dev/
-  isar_flutter_libs: # contains Isar Core
-    version: *isar_version
-    hosted: https://pub.isar-community.dev/
+  isar: ^3.1.0+1
+  isar_flutter_libs: ^3.1.0+1
   permission_handler: ^11.2.0
   device_info_plus: ^11.0.0
   connectivity_plus: ^6.0.0
@@ -98,9 +92,7 @@ dev_dependencies:
   auto_route_generator: ^9.0.0
   flutter_launcher_icons: ^0.14.0
   flutter_native_splash: ^2.3.9
-  isar_generator:
-    version: *isar_version
-    hosted: https://pub.isar-community.dev/
+  isar_generator: ^3.1.0+1
   integration_test:
     sdk: flutter
   custom_lint: ^0.6.4


### PR DESCRIPTION
This reverts commit b36de7d7d4a8295df077d3afa94e7e61d56b45c8.

Gradle upgrades cause vertical video sizes not to extend to the edges of the screen. Will re-add this after merging the native video player
