### PR TITLE
chore(web): Update the new version announcement text

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1283,7 +1283,7 @@
   "variables": "Variables",
   "version": "Version",
   "version_announcement_closing": "Your friend, Alex",
-  "version_announcement_message": "Hi there! A new version of Immich is available. Please take some time to visit the <link>release notes</link> and ensure both your <code>docker-compose.yml</code> and <code>.env</code> setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your Immich instance automatically.",
+  "version_announcement_message": "Hi there! A new version of Immich is available. Please take some time to read the <link>release notes</link> to ensure your setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your Immich instance automatically.",
   "version_history": "Version History",
   "version_history_item": "Installed {version} on {date}",
   "video": "Video",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1283,7 +1283,7 @@
   "variables": "Variables",
   "version": "Version",
   "version_announcement_closing": "Your friend, Alex",
-  "version_announcement_message": "Hi there! A new version of Immich is available. Please take some time to visit the <link>release notes</link> and ensure both your <code>docker-compose.yml</code> and <code>.env</code> setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your application automatically.",
+  "version_announcement_message": "Hi there! A new version of Immich is available. Please take some time to visit the <link>release notes</link> and ensure both your <code>docker-compose.yml</code> and <code>.env</code> setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your Immich instance automatically.",
   "version_history": "Version History",
   "version_history_item": "Installed {version} on {date}",
   "video": "Video",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1283,7 +1283,7 @@
   "variables": "Variables",
   "version": "Version",
   "version_announcement_closing": "Your friend, Alex",
-  "version_announcement_message": "Hi friend, there is a new version of the application please take your time to visit the <link>release notes</link> and ensure your <code>docker-compose.yml</code>, and <code>.env</code> setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your application automatically.",
+  "version_announcement_message": "Hi there! A new version of Immich is available. Please take some time to visit the <link>release notes</link> and ensure both your <code>docker-compose.yml</code> and <code>.env</code> setup is up-to-date to prevent any misconfigurations, especially if you use WatchTower or any mechanism that handles updating your application automatically.",
   "version_history": "Version History",
   "version_history_item": "Installed {version} on {date}",
   "video": "Video",


### PR DESCRIPTION
The new version announcement text has been updated to fix some errors in the existing language, making it clearer that a new version of Immich (instead of application) is available.

I imagine this is Alex's text so keeping this PR as draft for now to ensure that the change is ok to make.