### PR TITLE
feat(web): stable json settings export

### DIFF
--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -65,15 +65,16 @@
   type SettingsComponent = ComponentType<SvelteComponent<SettingsComponentProps>>;
 
   // https://stackoverflow.com/questions/16167581/sort-object-properties-and-json-stringify/43636793#43636793
-  const jsonReplacer = (key, value) =>
-  value instanceof Object && !(value instanceof Array) ? 
-      Object.keys(value)
-      .sort()
-      .reduce((sorted, key) => {
-          sorted[key] = value[key];
-          return sorted 
-      }, {}) :
-      value;
+  const jsonReplacer = (key: string, value: unknown) =>
+    value instanceof Object && !Array.isArray(value)
+      ? Object.keys(value)
+          .sort()
+          // eslint-disable-next-line unicorn/no-array-reduce
+          .reduce((sorted: { [key: string]: unknown }, key) => {
+            sorted[key] = (value as { [key: string]: unknown })[key];
+            return sorted;
+          }, {})
+      : value;
 
   const downloadConfig = () => {
     const blob = new Blob([JSON.stringify(config, jsonReplacer, 2)], { type: 'application/json' });

--- a/web/src/routes/admin/system-settings/+page.svelte
+++ b/web/src/routes/admin/system-settings/+page.svelte
@@ -64,8 +64,19 @@
 
   type SettingsComponent = ComponentType<SvelteComponent<SettingsComponentProps>>;
 
+  // https://stackoverflow.com/questions/16167581/sort-object-properties-and-json-stringify/43636793#43636793
+  const jsonReplacer = (key, value) =>
+  value instanceof Object && !(value instanceof Array) ? 
+      Object.keys(value)
+      .sort()
+      .reduce((sorted, key) => {
+          sorted[key] = value[key];
+          return sorted 
+      }, {}) :
+      value;
+
   const downloadConfig = () => {
-    const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(config, jsonReplacer, 2)], { type: 'application/json' });
     const downloadKey = 'immich-config.json';
     downloadManager.add(downloadKey, blob.size);
     downloadManager.update(downloadKey, blob.size);
@@ -240,7 +251,7 @@
       <div class="hidden lg:block">
         <SearchBar placeholder={$t('search_settings')} bind:name={searchQuery} showLoadingSpinner={false} />
       </div>
-      <LinkButton on:click={() => copyToClipboard(JSON.stringify(config, null, 2))}>
+      <LinkButton on:click={() => copyToClipboard(JSON.stringify(config, jsonReplacer, 2))}>
         <div class="flex place-items-center gap-2 text-sm">
           <Icon path={mdiContentCopy} size="18" />
           {$t('copy_to_clipboard')}


### PR DESCRIPTION
When exporting settings to json (or copying to clipboard), json output isn't stable between immich versions and keys are sometimes re-ordered.

Proposal: sort (recursively) the json output (equivalent to `jq -S`).