### PR TITLE
docs: clarify file size impact in hardware-transcoding.md

### DIFF
--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -1,7 +1,7 @@
 # Hardware Transcoding [Experimental]
 
 This feature allows you to use a GPU to accelerate transcoding and reduce CPU load.
-Note that hardware transcoding is much less efficient for small file sizes.
+Note that hardware transcoding produces significantly larger videos than software transcoding with similar settings, typically with lower quality. Using slow presets and preferring more efficient codecs can narrow this gap.
 As this is a new feature, it is still experimental and may not work on all systems.
 
 :::info

--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -1,7 +1,7 @@
 # Hardware Transcoding [Experimental]
 
 This feature allows you to use a GPU to accelerate transcoding and reduce CPU load.
-Note that hardware transcoding is much less efficient for file sizes.
+Note that hardware transcoding is much less efficient for small file sizes.
 As this is a new feature, it is still experimental and may not work on all systems.
 
 :::info


### PR DESCRIPTION
GPU transcoding is much less efficient for _**smaller**_ file sizes, i think someone just missed a word.

Love the Project!