### PR TITLE
feat: use dateTimeOriginal to calculate album date

### DIFF
--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -7,6 +7,7 @@ import { AuthDto } from 'src/dtos/auth.dto';
 import { UserResponseDto, mapUser } from 'src/dtos/user.dto';
 import { AlbumEntity } from 'src/entities/album.entity';
 import { AlbumUserRole, AssetOrder } from 'src/enum';
+import { getAssetDateTime } from 'src/utils/date-time';
 import { Optional, ValidateBoolean, ValidateUUID } from 'src/validation';
 
 export class AlbumInfoDto {
@@ -164,8 +165,8 @@ export const mapAlbum = (entity: AlbumEntity, withAssets: boolean, auth?: AuthDt
   const hasSharedLink = entity.sharedLinks?.length > 0;
   const hasSharedUser = sharedUsers.length > 0;
 
-  let startDate = assets.at(0)?.fileCreatedAt || undefined;
-  let endDate = assets.at(-1)?.fileCreatedAt || undefined;
+  let startDate = getAssetDateTime(assets.at(0));
+  let endDate = getAssetDateTime(assets.at(-1));
   // Swap dates if start date is greater than end date.
   if (startDate && endDate && startDate > endDate) {
     [startDate, endDate] = [endDate, startDate];

--- a/server/src/utils/date-time.ts
+++ b/server/src/utils/date-time.ts
@@ -1,0 +1,5 @@
+import { AssetEntity } from 'src/entities/asset.entity';
+
+export const getAssetDateTime = (asset: AssetEntity | undefined) => {
+  return asset?.exifInfo?.dateTimeOriginal || asset?.fileCreatedAt;
+};


### PR DESCRIPTION
The UI is using this field to show the date in the info panel, and updates it when changing the date of an asset. Album dates should use this info to be consistent with asset dates.