### PR TITLE
fix(web): saving pasted coordinates

### DIFF
--- a/web/src/lib/components/shared-components/coordinates-input.svelte
+++ b/web/src/lib/components/shared-components/coordinates-input.svelte
@@ -35,6 +35,7 @@
 
     event.preventDefault();
     [lat, lng] = [latitude, longitude];
+    onInput();
   };
 </script>
 


### PR DESCRIPTION
Fixes #14006 by propagating pasted coordinates like `30.724233,103.81877` to the parent component so they get saved