### PR TITLE
refactor: rename searchMetadata to searchAssets

### DIFF
--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -299,7 +299,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, {
+      const { assets } = await utils.searchAssets(admin.accessToken, {
         originalPath: `${testAssetDirInternal}/temp/directoryA/assetA.png`,
       });
       expect(assets.count).toBe(1);
@@ -320,7 +320,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(assets.count).toBe(1);
       expect(assets.items[0].originalPath.includes('directoryB'));
@@ -340,7 +340,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(assets.count).toBe(2);
       expect(assets.items.find((asset) => asset.originalPath.includes('directoryA'))).toBeDefined();
@@ -365,7 +365,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(assets.count).toBe(2);
       expect(assets.items.find((asset) => asset.originalPath.includes('folder, a'))).toBeDefined();
@@ -393,7 +393,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(assets.count).toBe(2);
       expect(assets.items.find((asset) => asset.originalPath.includes('folder{ a'))).toBeDefined();
@@ -428,7 +428,7 @@ describe('/libraries', () => {
       await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
       utils.removeImageFile(`${testAssetDir}/temp/directoryA/assetB.jpg`);
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, {
+      const { assets } = await utils.searchAssets(admin.accessToken, {
         libraryId: library.id,
         model: 'NIKON D750',
       });
@@ -460,7 +460,7 @@ describe('/libraries', () => {
       await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
       utils.removeImageFile(`${testAssetDir}/temp/directoryA/assetB.jpg`);
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, {
+      const { assets } = await utils.searchAssets(admin.accessToken, {
         libraryId: library.id,
         model: 'NIKON D750',
       });
@@ -478,7 +478,7 @@ describe('/libraries', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assets.count).toBe(1);
 
       utils.removeImageFile(`${testAssetDir}/temp/offline/offline.png`);
@@ -495,7 +495,7 @@ describe('/libraries', () => {
       expect(trashedAsset.originalPath).toBe(`${testAssetDirInternal}/temp/offline/offline.png`);
       expect(trashedAsset.isOffline).toEqual(true);
 
-      const { assets: newAssets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets: newAssets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(newAssets.items).toEqual([]);
     });
 
@@ -510,7 +510,7 @@ describe('/libraries', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assets.count).toBe(1);
 
       utils.createDirectory(`${testAssetDir}/temp/another-path/`);
@@ -532,7 +532,7 @@ describe('/libraries', () => {
       expect(trashedAsset.originalPath).toBe(`${testAssetDirInternal}/temp/offline/offline.png`);
       expect(trashedAsset.isOffline).toBe(true);
 
-      const { assets: newAssets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets: newAssets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(newAssets.items).toEqual([]);
 
@@ -549,7 +549,7 @@ describe('/libraries', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, {
+      const { assets } = await utils.searchAssets(admin.accessToken, {
         libraryId: library.id,
         originalFileName: 'assetB.png',
       });
@@ -568,7 +568,7 @@ describe('/libraries', () => {
       expect(trashedAsset.originalPath).toBe(`${testAssetDirInternal}/temp/directoryB/assetB.png`);
       expect(trashedAsset.isOffline).toBe(true);
 
-      const { assets: newAssets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets: newAssets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(newAssets.items).toEqual([
         expect.objectContaining({
@@ -586,7 +586,7 @@ describe('/libraries', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets: assetsBefore } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets: assetsBefore } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assetsBefore.count).toBeGreaterThan(1);
 
       const { status } = await request(app)
@@ -597,7 +597,7 @@ describe('/libraries', () => {
 
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
 
       expect(assets).toEqual(assetsBefore);
     });

--- a/e2e/src/api/specs/trash.e2e-spec.ts
+++ b/e2e/src/api/specs/trash.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('/trash', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assets.items.length).toBe(1);
       const asset = assets.items[0];
 
@@ -148,7 +148,7 @@ describe('/trash', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assets.count).toBe(1);
       const assetId = assets.items[0].id;
 
@@ -206,7 +206,7 @@ describe('/trash', () => {
       await scan(admin.accessToken, library.id);
       await utils.waitForQueueFinish(admin.accessToken, 'library');
 
-      const { assets } = await utils.metadataSearch(admin.accessToken, { libraryId: library.id });
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
       expect(assets.count).toBe(1);
       const assetId = assets.items[0].id;
 

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -25,7 +25,7 @@ import {
   getAssetInfo,
   getConfigDefaults,
   login,
-  searchMetadata,
+  searchAssets,
   setBaseUrl,
   signUpAdmin,
   updateAdminOnboarding,
@@ -400,8 +400,8 @@ export const utils = {
   checkExistingAssets: (accessToken: string, checkExistingAssetsDto: CheckExistingAssetsDto) =>
     checkExistingAssets({ checkExistingAssetsDto }, { headers: asBearerAuth(accessToken) }),
 
-  metadataSearch: async (accessToken: string, dto: MetadataSearchDto) => {
-    return searchMetadata({ metadataSearchDto: dto }, { headers: asBearerAuth(accessToken) });
+  searchAssets: async (accessToken: string, dto: MetadataSearchDto) => {
+    return searchAssets({ metadataSearchDto: dto }, { headers: asBearerAuth(accessToken) });
   },
 
   archiveAssets: (accessToken: string, ids: string[]) =>

--- a/mobile/lib/repositories/asset_api.repository.dart
+++ b/mobile/lib/repositories/asset_api.repository.dart
@@ -34,7 +34,7 @@ class AssetApiRepository extends ApiRepository implements IAssetApiRepository {
     int currentPage = 1;
     while (hasNext) {
       final response = await checkNull(
-        _searchApi.searchMetadata(
+        _searchApi.searchAssets(
           MetadataSearchDto(
             personIds: personIds,
             page: currentPage,

--- a/mobile/lib/services/search.service.dart
+++ b/mobile/lib/services/search.service.dart
@@ -77,7 +77,7 @@ class SearchService {
           ),
         );
       } else {
-        response = await _apiService.searchApi.searchMetadata(
+        response = await _apiService.searchApi.searchAssets(
           MetadataSearchDto(
             originalFileName:
                 filter.filename != null && filter.filename!.isNotEmpty

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -166,7 +166,7 @@ Class | Method | HTTP request | Description
 *SearchApi* | [**getAssetsByCity**](doc//SearchApi.md#getassetsbycity) | **GET** /search/cities | 
 *SearchApi* | [**getExploreData**](doc//SearchApi.md#getexploredata) | **GET** /search/explore | 
 *SearchApi* | [**getSearchSuggestions**](doc//SearchApi.md#getsearchsuggestions) | **GET** /search/suggestions | 
-*SearchApi* | [**searchMetadata**](doc//SearchApi.md#searchmetadata) | **POST** /search/metadata | 
+*SearchApi* | [**searchAssets**](doc//SearchApi.md#searchassets) | **POST** /search/metadata | 
 *SearchApi* | [**searchPerson**](doc//SearchApi.md#searchperson) | **GET** /search/person | 
 *SearchApi* | [**searchPlaces**](doc//SearchApi.md#searchplaces) | **GET** /search/places | 
 *SearchApi* | [**searchRandom**](doc//SearchApi.md#searchrandom) | **POST** /search/random | 

--- a/mobile/openapi/lib/api/search_api.dart
+++ b/mobile/openapi/lib/api/search_api.dart
@@ -197,7 +197,7 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [MetadataSearchDto] metadataSearchDto (required):
-  Future<Response> searchMetadataWithHttpInfo(MetadataSearchDto metadataSearchDto,) async {
+  Future<Response> searchAssetsWithHttpInfo(MetadataSearchDto metadataSearchDto,) async {
     // ignore: prefer_const_declarations
     final path = r'/search/metadata';
 
@@ -225,8 +225,8 @@ class SearchApi {
   /// Parameters:
   ///
   /// * [MetadataSearchDto] metadataSearchDto (required):
-  Future<SearchResponseDto?> searchMetadata(MetadataSearchDto metadataSearchDto,) async {
-    final response = await searchMetadataWithHttpInfo(metadataSearchDto,);
+  Future<SearchResponseDto?> searchAssets(MetadataSearchDto metadataSearchDto,) async {
+    final response = await searchAssetsWithHttpInfo(metadataSearchDto,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4409,7 +4409,7 @@
     },
     "/search/metadata": {
       "post": {
-        "operationId": "searchMetadata",
+        "operationId": "searchAssets",
         "parameters": [],
         "requestBody": {
           "content": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2479,7 +2479,7 @@ export function getExploreData(opts?: Oazapfts.RequestOpts) {
         ...opts
     }));
 }
-export function searchMetadata({ metadataSearchDto }: {
+export function searchAssets({ metadataSearchDto }: {
     metadataSearchDto: MetadataSearchDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{

--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -25,7 +25,7 @@ export class SearchController {
   @Post('metadata')
   @HttpCode(HttpStatus.OK)
   @Authenticated()
-  searchMetadata(@Auth() auth: AuthDto, @Body() dto: MetadataSearchDto): Promise<SearchResponseDto> {
+  searchAssets(@Auth() auth: AuthDto, @Body() dto: MetadataSearchDto): Promise<SearchResponseDto> {
     return this.service.searchMetadata(auth, dto);
   }
 

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -22,8 +22,8 @@
   import { shortcut } from '$lib/actions/shortcut';
   import {
     type AssetResponseDto,
+    searchAssets,
     searchSmart,
-    searchMetadata,
     getPerson,
     type SmartSearchDto,
     type MetadataSearchDto,
@@ -152,7 +152,7 @@
       const { albums, assets } =
         'query' in searchDto && $featureFlags.smartSearch
           ? await searchSmart({ smartSearchDto: searchDto })
-          : await searchMetadata({ metadataSearchDto: searchDto });
+          : await searchAssets({ metadataSearchDto: searchDto });
 
       searchResultAlbums.push(...albums.items);
       searchResultAssets.push(...assets.items);


### PR DESCRIPTION
The operation name `searchMetadata` has been renamed to `searchAssets`. The URL, params, and all other parts of the endpoint signature remain unchanged.