### PR TITLE
feat(web): Added tag button to the context menu in the favorites page

### DIFF
--- a/web/src/routes/(user)/favorites/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/favorites/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -20,6 +20,8 @@
   import { mdiDotsVertical, mdiPlus } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import { onDestroy } from 'svelte';
+  import { preferences } from '$lib/stores/user.store';
+  import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
 
   interface Props {
     data: PageData;
@@ -53,6 +55,9 @@
       <ChangeDate menuItem />
       <ChangeLocation menuItem />
       <ArchiveAction menuItem unarchive={isAllArchive} onArchive={(assetIds) => assetStore.removeAssets(assetIds)} />
+      {#if $preferences.tags.enabled}
+        <TagAction menuItem />
+      {/if}
       <DeleteAssets menuItem onAssetDelete={(assetIds) => assetStore.removeAssets(assetIds)} />
     </ButtonContextMenu>
   </AssetSelectControlBar>


### PR DESCRIPTION
This PR adds the tag button that exists in the context menu of the main timeline view to the context menu of the favorites page
Timeline view:
![image](https://github.com/user-attachments/assets/c6afc5d6-578e-471e-840d-c78f653271f3)
Favorites view:
![image](https://github.com/user-attachments/assets/bc8e6b38-099d-45ae-8203-02cf4fb50f5e)
