### PR TITLE
fix(web): prevent infinite loop when modifying stacked asset

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -32,7 +32,7 @@
     type AssetResponseDto,
     type StackResponseDto,
   } from '@immich/sdk';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { t } from 'svelte-i18n';
   import { fly } from 'svelte/transition';
   import Thumbnail from '../assets/thumbnail/thumbnail.svelte';
@@ -120,9 +120,11 @@
       stack = null;
     }
 
-    if (stack && stack?.assets.length > 1) {
-      preloadAssets.push(stack.assets[1]);
-    }
+    untrack(() => {
+      if (stack && stack?.assets.length > 1) {
+        preloadAssets.push(stack.assets[1]);
+      }
+    });
   };
 
   const handleAddComment = () => {


### PR DESCRIPTION
To reproduce:
1. Use `GalleryViewer` to open a stacked asset, like the search page
2. Change description, rating, date, etc.
3. Page freezes because of infinite loop