### PR TITLE
refactor(web): remove reactivity triggers

### DIFF
--- a/web/src/lib/components/album-page/user-selection-modal.svelte
+++ b/web/src/lib/components/album-page/user-selection-modal.svelte
@@ -58,7 +58,6 @@
   const handleToggle = (user: UserResponseDto) => {
     if (Object.keys(selectedUsers).includes(user.id)) {
       delete selectedUsers[user.id];
-      selectedUsers = selectedUsers;
     } else {
       selectedUsers[user.id] = { user, role: AlbumUserRole.Editor };
     }
@@ -67,7 +66,6 @@
   const handleChangeRole = (user: UserResponseDto, role: AlbumUserRole | 'none') => {
     if (role === 'none') {
       delete selectedUsers[user.id];
-      selectedUsers = selectedUsers;
     } else {
       selectedUsers[user.id].role = role;
     }

--- a/web/src/lib/components/asset-viewer/activity-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/activity-viewer.svelte
@@ -110,7 +110,6 @@
     try {
       await deleteActivity({ id: reaction.id });
       reactions.splice(index, 1);
-      reactions = reactions;
       if (isLiked && reaction.type === ReactionType.Like && reaction.id == isLiked.id) {
         onDeleteLike();
       } else {
@@ -143,8 +142,6 @@
 
       message = '';
       onAddComment();
-      // Re-render the activity feed
-      reactions = reactions;
     } catch (error) {
       handleError(error, $t('errors.unable_to_add_comment'));
     } finally {

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -90,7 +90,6 @@
       for (const person of people) {
         person.isHidden = personIsHidden[person.id];
       }
-      people = people;
 
       onClose();
     } catch (error) {

--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -101,15 +101,9 @@
   const handleReset = (id: string) => {
     if (selectedPersonToReassign[id]) {
       delete selectedPersonToReassign[id];
-
-      // trigger reactivity
-      selectedPersonToReassign = selectedPersonToReassign;
     }
     if (selectedPersonToCreate[id]) {
       delete selectedPersonToCreate[id];
-
-      // trigger reactivity
-      selectedPersonToCreate = selectedPersonToCreate;
     }
   };
 

--- a/web/src/lib/components/forms/tag-asset-form.svelte
+++ b/web/src/lib/components/forms/tag-asset-form.svelte
@@ -35,12 +35,10 @@
     }
 
     selectedIds.add(option.value);
-    selectedIds = selectedIds;
   };
 
   const handleRemove = (tag: string) => {
     selectedIds.delete(tag);
-    selectedIds = selectedIds;
   };
 
   const onsubmit = (event: Event) => {

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -112,7 +112,6 @@
           assets.findIndex((a) => a.id === action.asset.id),
           1,
         );
-        assets = assets;
         if (assets.length === 0) {
           await goto(AppRoute.PHOTOS);
         } else if (currentViewAssetIndex === assets.length) {

--- a/web/src/lib/components/shared-components/search-bar/search-filter-modal.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-filter-modal.svelte
@@ -7,7 +7,7 @@
   export type SearchFilter = {
     query: string;
     queryType: 'smart' | 'metadata';
-    personIds: Set<string>;
+    personIds: SvelteSet<string>;
     location: SearchLocationFilter;
     camera: SearchCameraFilter;
     date: SearchDateFilter;

--- a/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
@@ -9,9 +9,10 @@
   import { handleError } from '$lib/utils/handle-error';
   import { t } from 'svelte-i18n';
   import SingleGridRow from '$lib/components/shared-components/single-grid-row.svelte';
+  import type { SvelteSet } from 'svelte/reactivity';
 
   interface Props {
-    selectedPeople: Set<string>;
+    selectedPeople: SvelteSet<string>;
   }
 
   let { selectedPeople = $bindable() }: Props = $props();
@@ -43,7 +44,6 @@
     } else {
       selectedPeople.add(id);
     }
-    selectedPeople = selectedPeople;
   }
 
   const filterPeople = (list: PersonResponseDto[], name: string) => {

--- a/web/src/lib/components/user-settings-page/partner-settings.svelte
+++ b/web/src/lib/components/user-settings-page/partner-settings.svelte
@@ -117,7 +117,6 @@
       await updatePartner({ id: partner.user.id, updatePartnerDto: { inTimeline } });
 
       partner.inTimeline = inTimeline;
-      partners = partners;
     } catch (error) {
       handleError(error, $t('errors.unable_to_update_timeline_display_status'));
     }

--- a/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
@@ -35,7 +35,6 @@
     }
 
     selectedAssetIds.add(suggestedAsset.id);
-    selectedAssetIds = selectedAssetIds;
   });
 
   onDestroy(() => {
@@ -48,13 +47,10 @@
     } else {
       selectedAssetIds.add(asset.id);
     }
-
-    selectedAssetIds = selectedAssetIds;
   };
 
   const onSelectNone = () => {
     selectedAssetIds.clear();
-    selectedAssetIds = selectedAssetIds;
   };
 
   const onSelectAll = () => {

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -35,8 +35,6 @@
           person.updatedAt = Date.now().toString();
         }
       });
-      // trigger reactivity
-      people = people;
     });
   });
 </script>

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -74,9 +74,6 @@
           person.updatedAt = new Date().toISOString();
         }
       }
-
-      // trigger reactivity
-      people = people;
     });
   });
 
@@ -146,9 +143,6 @@
           message: $t('change_name_successfully'),
           type: NotificationType.Info,
         });
-
-        // trigger reactivity
-        people = people;
       } catch (error) {
         handleError(error, $t('errors.unable_to_save_name'));
       }

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -156,8 +156,6 @@
 
       searchResultAlbums.push(...albums.items);
       searchResultAssets.push(...assets.items);
-      searchResultAlbums = searchResultAlbums;
-      searchResultAssets = searchResultAssets;
 
       nextPage = assets.nextPage ? Number(assets.nextPage) : null;
     } catch (error) {


### PR DESCRIPTION
Reactivity triggers are no longer needed for objects and arrays when using runes. They can also be removed when using a reactive alternative from `svelte/reactivity` like `SvelteSet`