### PR TITLE
fix(mobile): unnecessary rebuilds from partner share notifier

### DIFF
--- a/mobile/lib/providers/partner.provider.dart
+++ b/mobile/lib/providers/partner.provider.dart
@@ -10,13 +10,13 @@ import 'package:isar/isar.dart';
 
 class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
   PartnerSharedWithNotifier(Isar db, this._ps) : super([]) {
+    Function eq = const ListEquality<User>().equals;
     final query = db.users.filter().isPartnerSharedWithEqualTo(true).sortById();
     query.findAll().then((partners) {
-      if (partners.isNotEmpty) {
+      if (!eq(state, partners)) {
         state = partners;
       }
     }).then((_) {
-      Function eq = const ListEquality<User>().equals;
       query.watch().listen((partners) {
         if (!eq(state, partners)) {
           state = partners;
@@ -42,13 +42,13 @@ final partnerSharedWithProvider =
 
 class PartnerSharedByNotifier extends StateNotifier<List<User>> {
   PartnerSharedByNotifier(Isar db) : super([]) {
+    Function eq = const ListEquality<User>().equals;
     final query = db.users.filter().isPartnerSharedByEqualTo(true).sortById();
     query.findAll().then((partners) {
-      if (partners.isNotEmpty) {
+      if (!eq(state, partners)) {
         state = partners;
       }
     }).then((_) {
-      Function eq = const ListEquality<User>().equals;
       streamSub = query.watch().listen((partners) {
         if (!eq(state, partners)) {
           state = partners;

--- a/mobile/lib/providers/partner.provider.dart
+++ b/mobile/lib/providers/partner.provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/album/suggested_shared_users.provider.dart';
 import 'package:immich_mobile/services/partner.service.dart';
@@ -9,9 +10,19 @@ import 'package:isar/isar.dart';
 
 class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
   PartnerSharedWithNotifier(Isar db, this._ps) : super([]) {
-    final query = db.users.filter().isPartnerSharedWithEqualTo(true);
-    query.findAll().then((partners) => state = partners);
-    query.watch().listen((partners) => state = partners);
+    final query = db.users.filter().isPartnerSharedWithEqualTo(true).sortById();
+    Function eq = const ListEquality().equals;
+    query.findAll().then((partners) {
+      if (partners.isNotEmpty) {
+        state = partners;
+      }
+    }).then((_) {
+      query.watch().listen((partners) {
+        if (!eq(state, partners)) {
+          state = partners;
+        }
+      });
+    });
   }
 
   Future<bool> updatePartner(User partner, {required bool inTimeline}) {
@@ -32,8 +43,18 @@ final partnerSharedWithProvider =
 class PartnerSharedByNotifier extends StateNotifier<List<User>> {
   PartnerSharedByNotifier(Isar db) : super([]) {
     final query = db.users.filter().isPartnerSharedByEqualTo(true);
-    query.findAll().then((partners) => state = partners);
-    streamSub = query.watch().listen((partners) => state = partners);
+    Function eq = const ListEquality().equals;
+    query.findAll().then((partners) {
+      if (partners.isNotEmpty) {
+        state = partners;
+      }
+    }).then((_) {
+      streamSub = query.watch().listen((partners) {
+        if (!eq(state, partners)) {
+          state = partners;
+        }
+      });
+    });
   }
 
   late final StreamSubscription<List<User>> streamSub;

--- a/mobile/lib/providers/partner.provider.dart
+++ b/mobile/lib/providers/partner.provider.dart
@@ -42,7 +42,7 @@ final partnerSharedWithProvider =
 
 class PartnerSharedByNotifier extends StateNotifier<List<User>> {
   PartnerSharedByNotifier(Isar db) : super([]) {
-    final query = db.users.filter().isPartnerSharedByEqualTo(true);
+    final query = db.users.filter().isPartnerSharedByEqualTo(true).sortById();
     query.findAll().then((partners) {
       if (partners.isNotEmpty) {
         state = partners;

--- a/mobile/lib/providers/partner.provider.dart
+++ b/mobile/lib/providers/partner.provider.dart
@@ -11,12 +11,12 @@ import 'package:isar/isar.dart';
 class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
   PartnerSharedWithNotifier(Isar db, this._ps) : super([]) {
     final query = db.users.filter().isPartnerSharedWithEqualTo(true).sortById();
-    Function eq = const ListEquality().equals;
     query.findAll().then((partners) {
       if (partners.isNotEmpty) {
         state = partners;
       }
     }).then((_) {
+      Function eq = const ListEquality<User>().equals;
       query.watch().listen((partners) {
         if (!eq(state, partners)) {
           state = partners;
@@ -43,12 +43,12 @@ final partnerSharedWithProvider =
 class PartnerSharedByNotifier extends StateNotifier<List<User>> {
   PartnerSharedByNotifier(Isar db) : super([]) {
     final query = db.users.filter().isPartnerSharedByEqualTo(true);
-    Function eq = const ListEquality().equals;
     query.findAll().then((partners) {
       if (partners.isNotEmpty) {
         state = partners;
       }
     }).then((_) {
+      Function eq = const ListEquality<User>().equals;
       streamSub = query.watch().listen((partners) {
         if (!eq(state, partners)) {
           state = partners;


### PR DESCRIPTION
### Description

I noticed this notifier was triggering a rebuild of the app bar because `[]` is not equal to `[]` (different objects). This PR changes this to use a deep comparison instead. Also makes the watching happen only after the initial query finishes to make sure there's no race condition.