### PR TITLE
fix(mobile): use sets in album refresh, concurrent futures

### DIFF
--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -76,10 +76,16 @@ class AlbumService {
     final Stopwatch sw = Stopwatch()..start();
     bool changes = false;
     try {
-      final List<String> excludedIds = await _backupAlbumRepository
-          .getIdsBySelection(BackupSelection.exclude);
-      final List<String> selectedIds = await _backupAlbumRepository
-          .getIdsBySelection(BackupSelection.select);
+      final (selectedIds, excludedIds, onDevice) = await (
+        _backupAlbumRepository
+            .getIdsBySelection(BackupSelection.select)
+            .then((value) => value.toSet()),
+        _backupAlbumRepository
+            .getIdsBySelection(BackupSelection.exclude)
+            .then((value) => value.toSet()),
+        _albumMediaRepository.getAll()
+      ).wait;
+      _log.info("Found ${onDevice.length} device albums");
       if (selectedIds.isEmpty) {
         final numLocal = await _albumRepository.count(local: true);
         if (numLocal > 0) {
@@ -87,8 +93,6 @@ class AlbumService {
         }
         return false;
       }
-      final List<Album> onDevice = await _albumMediaRepository.getAll();
-      _log.info("Found ${onDevice.length} device albums");
       Set<String>? excludedAssets;
       if (excludedIds.isNotEmpty) {
         if (Platform.isIOS) {
@@ -138,7 +142,7 @@ class AlbumService {
 
   Future<Set<String>> _loadExcludedAssetIds(
     List<Album> albums,
-    List<String> excludedAlbumIds,
+    Set<String> excludedAlbumIds,
   ) async {
     final Set<String> result = HashSet<String>();
     for (Album album in albums) {
@@ -163,11 +167,10 @@ class AlbumService {
     bool changes = false;
     try {
       await _userService.refreshUsers();
-      final List<Album> sharedAlbum =
-          await _albumApiRepository.getAll(shared: true);
-
-      final List<Album> ownedAlbum =
-          await _albumApiRepository.getAll(shared: null);
+      final (sharedAlbum, ownedAlbum) = await (
+        _albumApiRepository.getAll(shared: true),
+        _albumApiRepository.getAll(shared: null)
+      ).wait;
 
       final albums = HashSet<Album>(
         equals: (a, b) => a.remoteId == b.remoteId,

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -119,8 +119,8 @@ class AlbumService {
         // on Android, the virtual "Recent" `lastModified` value is always null
         if (Platform.isAndroid) {
           onDevice.removeWhere((album) => album.isAll);
+          _log.info("'Recents' is selected, keeping all individual albums");
         }
-        _log.info("'Recents' is selected, keeping all individual albums");
       } else {
         // keep only the explicitly selected albums
         onDevice.removeWhere((album) => !selectedIds.contains(album.localId));

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -114,10 +114,11 @@ class AlbumService {
       }
 
       final allAlbum = onDevice.firstWhereOrNull((album) => album.isAll);
-      if (allAlbum != null && selectedIds.contains(allAlbum.localId)) {
-        // remove the virtual "Recent" album and keep and individual albums
-        // on Android, the virtual "Recent" `lastModified` value is always null
+      final hasAll = allAlbum != null && selectedIds.contains(allAlbum.localId);
+      if (hasAll) {
         if (Platform.isAndroid) {
+          // remove the virtual "Recent" album and keep and individual albums
+          // on Android, the virtual "Recent" `lastModified` value is always null
           onDevice.removeWhere((album) => album.isAll);
           _log.info("'Recents' is selected, keeping all individual albums");
         }
@@ -126,7 +127,6 @@ class AlbumService {
         onDevice.removeWhere((album) => !selectedIds.contains(album.localId));
         _log.info("'Recents' is not selected, keeping only selected albums");
       }
-
       changes =
           await _syncService.syncLocalAlbumAssetsToDb(onDevice, excludedAssets);
       _log.info("Syncing completed. Changes: $changes");

--- a/mobile/test/services/album.service_test.dart
+++ b/mobile/test/services/album.service_test.dart
@@ -54,6 +54,7 @@ void main() {
           .thenAnswer((_) async => []);
       when(() => backupRepository.getIdsBySelection(BackupSelection.select))
           .thenAnswer((_) async => []);
+      when(() => albumMediaRepository.getAll()).thenAnswer((_) async => []);
       when(() => albumRepository.count(local: true)).thenAnswer((_) async => 1);
       when(() => syncService.removeAllLocalAlbumsAndAssets())
           .thenAnswer((_) async => true);


### PR DESCRIPTION
## Description

Some of the logic in the album refresh has exponential complexity. I changed the selected and excluded IDs to sets to make it scale better with album count. I'm not sure how much of an impact it will have, but it may help with the issues with many albums.

Also changed some futures to happen concurrently to speed things up further. I only did this for read operations since I'm not familiar enough with the code to know if concurrent write operations are safe.