### PR TITLE
fix(server): remove unnecessary guc settings for vector search

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -279,13 +279,7 @@ LIMIT
 -- SearchRepository.searchSmart
 START TRANSACTION
 SET
-  LOCAL vectors.enable_prefilter = on;
-
-SET
-  LOCAL vectors.search_mode = vbase;
-
-SET
-  LOCAL vectors.hnsw_ef_search = 100;
+  LOCAL vectors.hnsw_ef_search = 200;
 SELECT
   "asset"."id" AS "asset_id",
   "asset"."deviceAssetId" AS "asset_deviceAssetId",
@@ -369,7 +363,7 @@ WHERE
 ORDER BY
   "search"."embedding" <= > $6 ASC
 LIMIT
-  101
+  201
 COMMIT
 
 -- SearchRepository.searchDuplicates
@@ -405,12 +399,6 @@ WHERE
 -- SearchRepository.searchFaces
 START TRANSACTION
 SET
-  LOCAL vectors.enable_prefilter = on;
-
-SET
-  LOCAL vectors.search_mode = vbase;
-
-SET
   LOCAL vectors.hnsw_ef_search = 100;
 WITH
   "cte" AS (
@@ -436,7 +424,7 @@ WITH
     ORDER BY
       "search"."embedding" <= > $1 ASC
     LIMIT
-      100
+      64
   )
 SELECT
   res.*


### PR DESCRIPTION
### Description

`enable_prefilter` is default on in 0.2.0 and removed in 0.3.0 onward, so it can only cause issues to set it manually. `enable_vbase` is also enabled by default.

Fixes #14234