### PR TITLE
chore: update dev ports

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
     ports:
       - 9230:9230
       - 9231:9231
+      - 2283:2283
     depends_on:
       - redis
       - database
@@ -62,7 +63,7 @@ services:
     env_file:
       - .env
     ports:
-      - 2283:3000
+      - 3000:3000
       - 24678:24678
     volumes:
       - ../web:/usr/src/app

--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -39,11 +39,11 @@ All the services are packaged to run as with single Docker Compose command.
 make dev # required Makefile installed on the system.
 ```
 
-5. Access the dev instance in your browser at http://localhost:2283, or connect via the mobile app.
+5. Access the dev instance in your browser at http://localhost:3000, or connect via the mobile app.
 
 All the services will be started with hot-reloading enabled for a quick feedback loop.
 
-You can access the web from `http://your-machine-ip:2283` or `http://localhost:2283` and access the server from the mobile app at `http://your-machine-ip:2283/api`
+You can access the web from `http://your-machine-ip:3000` or `http://localhost:3000` and access the server from the mobile app at `http://your-machine-ip:3000/api`
 
 **Note:** the "web" development container runs with uid 1000. If that uid does not have read/write permissions on the mounted volumes, you may encounter errors
 


### PR DESCRIPTION
- Always use `2283` for `nestjs` (api)
- Always use `3000` for `vite` (web)