### PR TITLE
feat(server): faster metadata extraction

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -85,6 +85,10 @@ export class MetadataRepository {
     this.logger.setContext(MetadataRepository.name);
   }
 
+  setMaxConcurrency(concurrency: number) {
+    this.exiftool.batchCluster.setMaxProcs(concurrency);
+  }
+
   async teardown() {
     await this.exiftool.end();
   }

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -77,7 +77,8 @@ export class MetadataRepository {
     /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
     geoTz: (lat, lon) => geotz.find(lat, lon)[0],
     // Enable exiftool LFS to parse metadata for files larger than 2GB.
-    readArgs: ['-api', 'largefilesupport=1'],
+    // Ensure byte representation is used for file size (as opposed to human-readable format).
+    readArgs: ['-api', 'largefilesupport=1', '-filesize#'],
     writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
   });
 

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -251,7 +251,6 @@ export class JobService extends BaseService {
             this.eventRepository.clientSend('on_asset_update', asset.ownerId, mapAsset(asset));
           }
         }
-        await this.jobRepository.queue({ name: JobName.LINK_LIVE_PHOTOS, data: item.data });
         break;
       }
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -6,7 +6,6 @@ import _ from 'lodash';
 import { Duration } from 'luxon';
 import { constants } from 'node:fs/promises';
 import path from 'node:path';
-import { SystemConfig } from 'src/config';
 import { JOBS_ASSET_PAGINATION_SIZE } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { Exif } from 'src/db';
@@ -76,6 +75,8 @@ const validateRange = (value: number | undefined, min: number, max: number): Non
   return val;
 };
 
+type ImmichTagsWithFaces = ImmichTags & { RegionInfo: NonNullable<ImmichTags['RegionInfo']> };
+
 @Injectable()
 export class MetadataService extends BaseService {
   @OnEvent({ name: 'app.bootstrap', workers: [ImmichWorker.MICROSERVICES] })
@@ -111,13 +112,17 @@ export class MetadataService extends BaseService {
       return JobStatus.FAILED;
     }
 
-    if (!asset.exifInfo.livePhotoCID) {
+    return this.linkLivePhotos(asset, asset.exifInfo);
+  }
+
+  private async linkLivePhotos(asset: AssetEntity, exifInfo: Insertable<Exif>): Promise<JobStatus> {
+    if (!exifInfo.livePhotoCID) {
       return JobStatus.SKIPPED;
     }
 
     const otherType = asset.type === AssetType.VIDEO ? AssetType.IMAGE : AssetType.VIDEO;
     const match = await this.assetRepository.findLivePhotoMatch({
-      livePhotoCID: asset.exifInfo.livePhotoCID,
+      livePhotoCID: exifInfo.livePhotoCID,
       ownerId: asset.ownerId,
       libraryId: asset.libraryId,
       otherAssetId: asset.id,
@@ -129,10 +134,11 @@ export class MetadataService extends BaseService {
     }
 
     const [photoAsset, motionAsset] = asset.type === AssetType.IMAGE ? [asset, match] : [match, asset];
-
-    await this.assetRepository.update({ id: photoAsset.id, livePhotoVideoId: motionAsset.id });
-    await this.assetRepository.update({ id: motionAsset.id, isVisible: false });
-    await this.albumRepository.removeAsset(motionAsset.id);
+    await Promise.all([
+      this.assetRepository.update({ id: photoAsset.id, livePhotoVideoId: motionAsset.id }),
+      this.assetRepository.update({ id: motionAsset.id, isVisible: false }),
+      this.albumRepository.removeAsset(motionAsset.id),
+    ]);
 
     await this.eventRepository.emit('asset.hide', { assetId: motionAsset.id, userId: motionAsset.ownerId });
 
@@ -158,16 +164,20 @@ export class MetadataService extends BaseService {
   }
 
   @OnJob({ name: JobName.METADATA_EXTRACTION, queue: QueueName.METADATA_EXTRACTION })
-  async handleMetadataExtraction({ id }: JobOf<JobName.METADATA_EXTRACTION>): Promise<JobStatus> {
-    const { metadata, reverseGeocoding } = await this.getConfig({ withCache: true });
-    const [asset] = await this.assetRepository.getByIds([id], { faces: { person: false } });
+  async handleMetadataExtraction(data: JobOf<JobName.METADATA_EXTRACTION>): Promise<JobStatus> {
+    const [{ metadata, reverseGeocoding }, [asset]] = await Promise.all([
+      this.getConfig({ withCache: true }),
+      this.assetRepository.getByIds([data.id], { faces: { person: false } }),
+    ]);
+
     if (!asset) {
       return JobStatus.FAILED;
     }
 
-    const stats = await this.storageRepository.stat(asset.originalPath);
-
-    const exifTags = await this.getExifTags(asset);
+    const [stats, exifTags] = await Promise.all([
+      this.storageRepository.stat(asset.originalPath),
+      this.getExifTags(asset),
+    ]);
 
     this.logger.verbose('Exif Tags', exifTags);
 
@@ -180,10 +190,18 @@ export class MetadataService extends BaseService {
     }
 
     const { dateTimeOriginal, localDateTime, timeZone, modifyDate } = this.getDates(asset, exifTags);
-    const { latitude, longitude, country, state, city } = await this.getGeo(exifTags, reverseGeocoding);
-
     const { width, height } = this.getImageDimensions(exifTags);
 
+    let geo: ReverseGeocodeResult = { country: null, state: null, city: null };
+    let latitude: number | null = null;
+    let longitude: number | null = null;
+    if (reverseGeocoding.enabled && this.hasGeo(exifTags)) {
+      latitude = exifTags.GPSLatitude;
+      longitude = exifTags.GPSLongitude;
+      geo = await this.mapRepository.reverseGeocode({ latitude, longitude });
+    }
+
+    const livePhotoCID = (exifTags.ContentIdentifier || exifTags.MediaGroupUUID) ?? null;
     const exifData: Insertable<Exif> = {
       assetId: asset.id,
 
@@ -193,11 +211,11 @@ export class MetadataService extends BaseService {
       timeZone,
 
       // gps
-      latitude,
-      longitude,
-      country,
-      state,
-      city,
+      latitude: exifTags.GPSLatitude ?? null,
+      longitude: exifTags.GPSLongitude ?? null,
+      country: geo.country,
+      state: geo.state,
+      city: geo.city,
 
       // image/file
       fileSizeInByte: stats.size,
@@ -224,31 +242,41 @@ export class MetadataService extends BaseService {
       rating: validateRange(exifTags.Rating, -1, 5),
 
       // grouping
-      livePhotoCID: (exifTags.ContentIdentifier || exifTags.MediaGroupUUID) ?? null,
+      livePhotoCID,
       autoStackId: this.getAutoStackId(exifTags),
     };
 
-    await this.applyTagList(asset, exifTags);
-    await this.applyMotionPhotos(asset, exifTags);
+    const promises: Promise<unknown>[] = [
+      this.assetRepository.upsertExif(exifData),
+      this.assetRepository.update({
+        id: asset.id,
+        duration: exifTags.Duration?.toString() ?? null,
+        localDateTime,
+        fileCreatedAt: exifData.dateTimeOriginal ?? undefined,
+        fileModifiedAt: exifData.modifyDate ?? undefined,
+      }),
+    ];
 
-    await this.assetRepository.upsertExif(exifData);
-
-    await this.assetRepository.update({
-      id: asset.id,
-      duration: exifTags.Duration?.toString() ?? null,
-      localDateTime,
-      fileCreatedAt: exifData.dateTimeOriginal ?? undefined,
-      fileModifiedAt: exifData.modifyDate ?? undefined,
-    });
-
-    await this.assetRepository.upsertJobStatus({
-      assetId: asset.id,
-      metadataExtractedAt: new Date(),
-    });
-
-    if (isFaceImportEnabled(metadata)) {
-      await this.applyTaggedFaces(asset, exifTags);
+    if (this.hasTagList(exifTags)) {
+      promises.push(this.applyTagList(asset, exifTags));
     }
+
+    if (asset.type === AssetType.IMAGE) {
+      promises.push(this.applyMotionPhotos(asset, exifTags));
+    }
+
+    if (isFaceImportEnabled(metadata) && this.hasTaggedFaces(exifTags)) {
+      promises.push(this.applyTaggedFaces(asset, exifTags));
+    }
+
+    await Promise.all(promises);
+    if (livePhotoCID) {
+      await this.linkLivePhotos(asset, exifData);
+    }
+    await Promise.all([
+      this.assetRepository.upsertJobStatus({ assetId: asset.id, metadataExtractedAt: new Date() }),
+      this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data }),
+    ]);
 
     return JobStatus.SUCCESS;
   }
@@ -345,45 +373,60 @@ export class MetadataService extends BaseService {
   }
 
   private async getExifTags(asset: AssetEntity): Promise<ImmichTags> {
-    const mediaTags = await this.metadataRepository.readTags(asset.originalPath);
-    const sidecarTags = asset.sidecarPath ? await this.metadataRepository.readTags(asset.sidecarPath) : {};
-    const videoTags = asset.type === AssetType.VIDEO ? await this.getVideoTags(asset.originalPath) : {};
+    const promises = [this.metadataRepository.readTags(asset.originalPath)];
+    if (asset.sidecarPath) {
+      promises.push(this.metadataRepository.readTags(asset.sidecarPath));
+    }
+    if (asset.type === AssetType.VIDEO) {
+      promises.push(this.getVideoTags(asset.originalPath));
+    }
+
+    const [mediaTags, sidecarTags, videoTags] = await Promise.all(promises);
+    if (!sidecarTags && !videoTags) {
+      return mediaTags;
+    }
 
     // prefer dates from sidecar tags
-    const sidecarDate = firstDateTime(sidecarTags as Tags, EXIF_DATE_TAGS);
-    if (sidecarDate) {
-      for (const tag of EXIF_DATE_TAGS) {
-        delete mediaTags[tag];
+    if (sidecarTags) {
+      const sidecarDate = firstDateTime(sidecarTags as Tags, EXIF_DATE_TAGS);
+      if (sidecarDate) {
+        for (const tag of EXIF_DATE_TAGS) {
+          delete mediaTags[tag];
+        }
       }
     }
 
     // prefer duration from video tags
     delete mediaTags.Duration;
-    delete sidecarTags.Duration;
+    delete sidecarTags?.Duration;
 
     return { ...mediaTags, ...videoTags, ...sidecarTags };
   }
 
+  private hasTagList(tags: ImmichTags): tags is ImmichTags & { TagsList: string[] } {
+    return tags.TagsList !== undefined || tags.HierarchicalSubject !== undefined || tags.Keywords !== undefined;
+  }
+
   private async applyTagList(asset: AssetEntity, exifTags: ImmichTags) {
-    const tags: string[] = [];
+    let tags: string[] = [];
     if (exifTags.TagsList) {
-      tags.push(...exifTags.TagsList.map(String));
+      tags = exifTags.TagsList.map(String);
     } else if (exifTags.HierarchicalSubject) {
-      tags.push(
-        ...exifTags.HierarchicalSubject.map((tag) =>
-          String(tag)
-            // convert | to /
-            .replaceAll('/', '<PLACEHOLDER>')
-            .replaceAll('|', '/')
-            .replaceAll('<PLACEHOLDER>', '|'),
-        ),
+      tags = exifTags.HierarchicalSubject.map((tag) =>
+        typeof tag === 'number'
+          ? String(tag)
+          : tag
+              // convert | to /
+              .replaceAll('/', '<PLACEHOLDER>')
+              .replaceAll('|', '/')
+              .replaceAll('<PLACEHOLDER>', '|'),
       );
     } else if (exifTags.Keywords) {
       let keywords = exifTags.Keywords;
       if (!Array.isArray(keywords)) {
         keywords = [keywords];
       }
-      tags.push(...keywords.map(String));
+      tags = keywords.map(String);
     }
 
     const results = await upsertTags(this.tagRepository, { userId: asset.ownerId, tags });
@@ -525,11 +568,13 @@ export class MetadataService extends BaseService {
     }
   }
 
-  private async applyTaggedFaces(asset: AssetEntity, tags: ImmichTags) {
-    if (!tags.RegionInfo?.AppliedToDimensions || tags.RegionInfo.RegionList.length === 0) {
-      return;
-    }
+  private hasTaggedFaces(tags: ImmichTags): tags is ImmichTagsWithFaces {
+    return (
+      tags.RegionInfo !== undefined && tags.RegionInfo.AppliedToDimensions && tags.RegionInfo.RegionList.length > 0
+    );
+  }
 
+  private async applyTaggedFaces(asset: AssetEntity, tags: ImmichTagsWithFaces) {
     const facesToAdd: (Partial<AssetFaceEntity> & { assetId: string })[] = [];
     const existingNames = await this.personRepository.getDistinctNames(asset.ownerId, { withHidden: true });
     const existingNameMap = new Map(existingNames.map(({ id, name }) => [name.toLowerCase(), id]));
@@ -644,24 +689,12 @@ export class MetadataService extends BaseService {
     return new Date(Math.min(a.valueOf(), b.valueOf()));
   }
 
-  private async getGeo(tags: ImmichTags, reverseGeocoding: SystemConfig['reverseGeocoding']) {
-    let latitude = validate(tags.GPSLatitude);
-    let longitude = validate(tags.GPSLongitude);
-
-    // TODO take ref into account
-
-    if (latitude === 0 && longitude === 0) {
-      this.logger.debug('Latitude and longitude of 0, setting to null');
-      latitude = null;
-      longitude = null;
-    }
-
-    let result: ReverseGeocodeResult = { country: null, state: null, city: null };
-    if (reverseGeocoding.enabled && longitude && latitude) {
-      result = await this.mapRepository.reverseGeocode({ latitude, longitude });
-    }
-
-    return { ...result, latitude, longitude };
+  private hasGeo(tags: ImmichTags): tags is ImmichTags & { GPSLatitude: number; GPSLongitude: number } {
+    return (
+      tags.GPSLatitude !== undefined &&
+      tags.GPSLongitude !== undefined &&
+      (tags.GPSLatitude !== 0 || tags.GPSLatitude !== 0)
+    );
   }
 
   private getAutoStackId(tags: ImmichTags | null): string | null {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -90,6 +90,16 @@ export class MetadataService extends BaseService {
     await this.metadataRepository.teardown();
   }
 
+  @OnEvent({ name: 'config.init', workers: [ImmichWorker.MICROSERVICES] })
+  onConfigInit({ newConfig }: ArgOf<'config.init'>) {
+    this.metadataRepository.setMaxConcurrency(newConfig.job.metadataExtraction.concurrency);
+  }
+
+  @OnEvent({ name: 'config.update', workers: [ImmichWorker.MICROSERVICES], server: true })
+  onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
+    this.metadataRepository.setMaxConcurrency(newConfig.job.metadataExtraction.concurrency);
+  }
+
   private async init() {
     this.logger.log('Initializing metadata service');
 


### PR DESCRIPTION
## Description

* Groups async calls where possible rather than doing them sequentially
* Moves some checks to be done synchronously without `await`
* Extracts live photo logic into a private method that metadata extraction runs
* No longer queues live photo job as part of upload pipeline
* Removes redundant `stat` calls, instead relying on exiftool
* Use async hash function to avoid blocking the event loop

Besides being significantly faster, it also makes job progress more intuitive as the number of waiting jobs goes down as one would expect without other jobs being queued in their place.

### Testing

<img width="488" alt="metadata-extraction-rate" src="https://github.com/user-attachments/assets/8423352f-dbc5-4071-a387-30059476f5a3">

The y-axis is jobs/s. The first part is main and the second is this PR. The jump toward the end is when the queueing job finished queueing assets (the job is somewhat intensive with a large table). There is an increase on main as well if you look closely, but it's more subtle. I canceled both when their progress rate stabilized after the queueing job finished.