### PR TITLE
fix(web): make custom css textarea optional

### DIFF
--- a/web/src/lib/components/admin-page/settings/theme/theme-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/theme/theme-settings.svelte
@@ -32,7 +32,6 @@
           label={$t('admin.theme_custom_css_settings')}
           description={$t('admin.theme_custom_css_settings_description')}
           bind:value={config.theme.customCss}
-          required={true}
           isEdited={config.theme.customCss !== savedConfig.theme.customCss}
         />
 


### PR DESCRIPTION
Saving empty css works, this just gets rid of the browser notification

![image](https://github.com/user-attachments/assets/8ed58545-1b98-4420-9b03-32bb500bfef1)