### PR TITLE
fix(web): clear combobox value when selectedOption is undefined

### DIFF
--- a/web/src/lib/__mocks__/visual-viewport.mock.ts
+++ b/web/src/lib/__mocks__/visual-viewport.mock.ts
@@ -1,0 +1,9 @@
+export const getVisualViewportMock = () => ({
+  height: window.innerHeight,
+  width: window.innerWidth,
+  scale: 1,
+  offsetLeft: 0,
+  offsetTop: 0,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+});

--- a/web/src/lib/components/shared-components/__test__/combobox.spec.ts
+++ b/web/src/lib/components/shared-components/__test__/combobox.spec.ts
@@ -1,0 +1,30 @@
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
+import Combobox from '$lib/components/shared-components/combobox.svelte';
+import { render, screen } from '@testing-library/svelte';
+
+describe('Combobox component', () => {
+  beforeAll(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
+  });
+
+  it('shows selected option', () => {
+    render(Combobox, {
+      label: 'test',
+      selectedOption: { label: 'option-1', value: 'option-1' },
+    });
+
+    expect(screen.getByRole('combobox')).toHaveValue('option-1');
+  });
+
+  it('clears the selected option when set to undefined', async () => {
+    const { rerender } = render(Combobox, {
+      label: 'test',
+      selectedOption: { label: 'option-1', value: 'option-1' },
+    });
+
+    await rerender({ selectedOption: undefined });
+    expect(screen.getByRole('combobox')).toHaveValue('');
+  });
+});

--- a/web/src/lib/components/shared-components/change-date.spec.ts
+++ b/web/src/lib/components/shared-components/change-date.spec.ts
@@ -1,4 +1,5 @@
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { getVisualViewportMock } from '$lib/__mocks__/visual-viewport.mock';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { DateTime } from 'luxon';
 import ChangeDate from './change-date.svelte';
@@ -16,16 +17,7 @@ describe('ChangeDate component', () => {
 
   beforeEach(() => {
     vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
-
-    vi.stubGlobal('visualViewport', {
-      height: window.innerHeight,
-      width: window.innerWidth,
-      scale: 1,
-      offsetLeft: 0,
-      offsetTop: 0,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    });
+    vi.stubGlobal('visualViewport', getVisualViewportMock());
   });
 
   afterEach(() => {

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -218,7 +218,7 @@
   const getInputPosition = () => input?.getBoundingClientRect();
 
   $effect(() => {
-    // searchQuery = selectedOption ? selectedOption.label : '';
+    searchQuery = selectedOption ? selectedOption.label : '';
   });
 
   let filteredOptions = $derived(


### PR DESCRIPTION
Fixes an issue where the combobox does not clear the selected value when `selectedOption` is updated to undefined. This affects the search options, where clicking `Clear all` doesn't clear the country, state and city.