### PR TITLE
fix(web): stack preview remains visible in asset viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -394,6 +394,7 @@
   let isFullScreen = $derived(fullscreenElement !== null);
   $effect(() => {
     if (asset) {
+      previewStackedAsset = undefined;
       handlePromiseError(refreshStack());
     }
   });


### PR DESCRIPTION
Fixes #14101 and fixes #14339 where hovering or selecting a stacked image and then switching to another asset causes the stacked asset to remain visible