### PR TITLE
chore(web): restore type checks and IDE autocomplete for `$t('...')`

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -28,7 +28,7 @@ interface Element {
   requestFullscreen?(options?: FullscreenOptions): Promise<void>;
 }
 
-import type en from '$lib/en.json';
+import type en from '$i18n/en.json';
 import 'svelte-i18n';
 
 type NestedKeys<T, K = keyof T> = K extends keyof T & string


### PR DESCRIPTION
The `$lib` import got changed to `$i18n` but this wasn't correctly updated