### PR TITLE
fix(web): timeline issues on person page

### DIFF
--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -63,14 +63,17 @@
     data: PageData;
   }
 
-  let { data = $bindable() }: Props = $props();
+  let { data }: Props = $props();
 
   let numberOfAssets = $state(data.statistics.assets);
   let { isViewing: showAssetViewer } = assetViewingStore;
 
-  let assetStore = new AssetStore({
-    isArchived: false,
-    personId: data.person.id,
+  const assetStoreOptions = { isArchived: false, personId: data.person.id };
+  const assetStore = new AssetStore(assetStoreOptions);
+
+  $effect(() => {
+    assetStoreOptions.personId = data.person.id;
+    handlePromiseError(assetStore.updateOptions(assetStoreOptions));
   });
 
   const assetInteractionStore = createAssetInteractionStore();
@@ -329,7 +332,6 @@
   $effect(() => {
     if (person) {
       handlePromiseError(updateAssetCount());
-      handlePromiseError(assetStore.updateOptions({ personId: person.id }));
     }
   });
 


### PR DESCRIPTION
Fixes:
1. Archived assets are shown on person page
2. Timeline is empty after redirect from person A to person B (can happen when merging people)