### PR TITLE
feat(web): allow tags to be applied in bulk on search, personID, and memory-viewer pages

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -46,6 +46,8 @@
   import { tweened } from 'svelte/motion';
   import { derived as storeDerived } from 'svelte/store';
   import { fade } from 'svelte/transition';
+  import { preferences, user } from '$lib/stores/user.store';
+  import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
 
   type MemoryIndex = {
     memoryIndex: number;
@@ -221,6 +223,7 @@
   $effect(() => {
     handlePromiseError(handleAction(galleryInView ? 'pause' : 'play'));
   });
+  let isAllUserOwned = $derived([...$selectedAssets].every((asset) => asset.ownerId === $user.id));
 </script>
 
 <svelte:window
@@ -253,6 +256,9 @@
         <ChangeDate menuItem />
         <ChangeLocation menuItem />
         <ArchiveAction menuItem unarchive={isAllArchived} onArchive={handleRemove} />
+        {#if $preferences.tags.enabled && isAllUserOwned}
+          <TagAction menuItem />
+        {/if}
         <DeleteAssets menuItem onAssetDelete={handleRemove} />
       </ButtonContextMenu>
     </AssetSelectControlBar>

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -340,7 +340,6 @@
   let isAllArchive = $derived([...$selectedAssets].every((asset) => asset.isArchived));
   let isAllFavorite = $derived([...$selectedAssets].every((asset) => asset.isFavorite));
   let isAllUserOwned = $derived([...$selectedAssets].every((asset) => asset.ownerId === $user.id));
-
 </script>
 
 {#if viewMode === PersonPageViewMode.UNASSIGN_ASSETS}

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -58,6 +58,8 @@
   import { listNavigation } from '$lib/actions/list-navigation';
   import { t } from 'svelte-i18n';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
+  import { preferences, user } from '$lib/stores/user.store';
+  import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
 
   interface Props {
     data: PageData;
@@ -337,6 +339,8 @@
 
   let isAllArchive = $derived([...$selectedAssets].every((asset) => asset.isArchived));
   let isAllFavorite = $derived([...$selectedAssets].every((asset) => asset.isFavorite));
+  let isAllUserOwned = $derived([...$selectedAssets].every((asset) => asset.ownerId === $user.id));
+
 </script>
 
 {#if viewMode === PersonPageViewMode.UNASSIGN_ASSETS}
@@ -391,6 +395,9 @@
         <ChangeDate menuItem />
         <ChangeLocation menuItem />
         <ArchiveAction menuItem unarchive={isAllArchive} onArchive={(assetIds) => $assetStore.removeAssets(assetIds)} />
+        {#if $preferences.tags.enabled && isAllUserOwned}
+          <TagAction menuItem />
+        {/if}
         <DeleteAssets menuItem onAssetDelete={(assetIds) => $assetStore.removeAssets(assetIds)} />
       </ButtonContextMenu>
     </AssetSelectControlBar>

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -232,7 +232,6 @@
     return Object.keys(obj) as (keyof T)[];
   }
   let isAllUserOwned = $derived([...$selectedAssets].every((asset) => asset.ownerId === $user.id));
-
 </script>
 
 <svelte:window use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: onEscape }} bind:scrollY />

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -44,6 +44,8 @@
   import { t } from 'svelte-i18n';
   import { onMount, tick } from 'svelte';
   import AssetJobActions from '$lib/components/photos-page/actions/asset-job-actions.svelte';
+  import { preferences, user } from '$lib/stores/user.store';
+  import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
 
   const MAX_ASSET_COUNT = 5000;
   let { isViewing: showAssetViewer } = assetViewingStore;
@@ -229,6 +231,8 @@
   function getObjectKeys<T extends object>(obj: T): (keyof T)[] {
     return Object.keys(obj) as (keyof T)[];
   }
+  let isAllUserOwned = $derived([...$selectedAssets].every((asset) => asset.ownerId === $user.id));
+
 </script>
 
 <svelte:window use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: onEscape }} bind:scrollY />
@@ -250,6 +254,9 @@
           <ChangeDate menuItem />
           <ChangeLocation menuItem />
           <ArchiveAction menuItem unarchive={isAllArchived} onArchive={triggerAssetUpdate} />
+          {#if $preferences.tags.enabled && isAllUserOwned}
+            <TagAction menuItem />
+          {/if}
           <DeleteAssets menuItem {onAssetDelete} />
           <hr />
           <AssetJobActions />


### PR DESCRIPTION
I have been adding a lot of tags to my photos on my Immich server to help organize photos. However, when I try to add tags based upon a PersonID or when using the search function, I am forced right now to add it to a temporary album and then open the album to then apply the tag. This PR would solve that issue.

Close #14106 