### PR TITLE
feat(mobile): trust user-added CAs

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
 
   <application android:label="Immich" android:name=".ImmichApp" android:usesCleartextTraffic="true"
     android:icon="@mipmap/ic_launcher" android:requestLegacyExternalStorage="true"
+    android:networkSecurityConfig="@xml/network_security_config"
     android:largeHeap="true" android:enableOnBackInvokedCallback="false">
 
     <service

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+    <base-config>
+        <!--
+        Starting with Android N, user-added CAs are not trusted by default.
+        We need this configuration to trust the user-added CAs.
+        -->
+        <trust-anchors>
+            <certificates src="user"/>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This PR allows the Android app to trust user-added CAs without skipping SSL certificate verification.

It is pretty common that a self-hosted Immich server uses an SSL certificate issued by a self-signed CA, such as a company's internal CA.

On Android systems, users can install a custom CA certificate by going to system Settings -> Security & privacy -> More Security and privacy -> Encryption & credentials -> Install a certificate. However, starting with Android N, an app doesn't trust user-added CAs by default unless it explicitly opts in. See
https://developer.android.com/privacy-and-security/security-config for more information.

iOS doesn't have this issue because it always trust user-added CAs. Even Chrome on Android trusts user-added CAs (https://github.com/chromium/chromium/blob/f65f60551faa7e21c176c951cf874ce98278fd0b/chrome/android/java/res_base/xml/network_security_config.xml#L8) so it shouldn't a security concern.