### PR TITLE
feat: Upgrade devcontainer setup

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,2 @@
+.env
+library

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,16 @@
 ARG BASEIMAGE=mcr.microsoft.com/devcontainers/typescript-node:22@sha256:9791f4aa527774bc370c6bd2f6705ce5a686f1e6f204badd8dfaacce28c631ae
 FROM ${BASEIMAGE}
+
+# Flutter SDK
+# https://flutter.dev/docs/development/tools/sdk/releases?tab=linux
+ENV FLUTTER_CHANNEL="stable"
+ENV FLUTTER_VERSION="3.24.5"
+ENV FLUTTER_HOME=/flutter
+ENV PATH=${PATH}:${FLUTTER_HOME}/bin
+
+# Flutter SDK
+RUN mkdir -p ${FLUTTER_HOME} \
+  && curl -C - --output flutter.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.tar.xz \
+  && tar -xf flutter.tar.xz --strip-components=1 -C ${FLUTTER_HOME} \
+  && rm flutter.tar.xz \
+  && chown -R 1000:1000 ${FLUTTER_HOME}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,30 +7,6 @@
   ],
   "customizations": {
     "vscode": {
-      "settings": {
-        "dart.flutterSdkPath": "/flutter",
-        "editor.formatOnSave": true,
-        "[javascript][typescript][css]": {
-          "editor.defaultFormatter": "esbenp.prettier-vscode",
-          "editor.tabSize": 2,
-          "editor.formatOnSave": true
-        },
-        "[svelte]": {
-          "editor.defaultFormatter": "svelte.svelte-vscode",
-          "editor.tabSize": 2
-        },
-        "svelte.enable-ts-plugin": true,
-        "eslint.validate": ["javascript", "svelte"],
-        "[dart]": {
-          "editor.formatOnSave": true,
-          "editor.selectionHighlight": false,
-          "editor.suggest.snippetsPreventQuickSuggestions": false,
-          "editor.suggestSelection": "first",
-          "editor.tabCompletion": "onlySnippets",
-          "editor.wordBasedSuggestions": "off",
-          "editor.defaultFormatter": "Dart-Code.dart-code"
-        }
-      },
       "extensions": [
         "Dart-Code.dart-code",
         "Dart-Code.flutter",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,50 @@
 {
-	"name": "Immich devcontainers",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			"BASEIMAGE": "mcr.microsoft.com/devcontainers/typescript-node:22"
-		}
-	},
+	"name": "Immich",
+  "service": "immich-devcontainer",
+  "dockerComposeFile": [
+    "docker-compose.yml",
+    "../docker/docker-compose.dev.yml"
+  ],
 	"customizations": {
 		"vscode": {
+      "settings": {
+        "dart.flutterSdkPath": "/flutter",
+        "editor.formatOnSave": true,
+        "[javascript][typescript][css]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.tabSize": 2,
+          "editor.formatOnSave": true
+        },
+        "[svelte]": {
+          "editor.defaultFormatter": "svelte.svelte-vscode",
+          "editor.tabSize": 2
+        },
+        "svelte.enable-ts-plugin": true,
+        "eslint.validate": ["javascript", "svelte"],
+        "[dart]": {
+          "editor.formatOnSave": true,
+          "editor.selectionHighlight": false,
+          "editor.suggest.snippetsPreventQuickSuggestions": false,
+          "editor.suggestSelection": "first",
+          "editor.tabCompletion": "onlySnippets",
+          "editor.wordBasedSuggestions": "off",
+          "editor.defaultFormatter": "Dart-Code.dart-code"
+        }
+      },
 			"extensions": [
+        "Dart-Code.dart-code",
+        "Dart-Code.flutter",
+				"dbaeumer.vscode-eslint",
+        "dcmdev.dcm-vscode-extension",
+        "esbenp.prettier-vscode",
 				"svelte.svelte-vscode"
 			]
 		}
 	},
 	"forwardPorts": [],
-	"postCreateCommand": "make install-all",
-	"remoteUser": "node"
+	"initializeCommand": "bash .devcontainer/scripts/initializeCommand.sh",
+	"onCreateCommand": "bash .devcontainer/scripts/onCreateCommand.sh",
+	"overrideCommand": true,
+  "workspaceFolder": "/immich",
+  "remoteUser": "node"
 }
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
-	"name": "Immich",
+  "name": "Immich",
   "service": "immich-devcontainer",
   "dockerComposeFile": [
     "docker-compose.yml",
     "../docker/docker-compose.dev.yml"
   ],
-	"customizations": {
-		"vscode": {
+  "customizations": {
+    "vscode": {
       "settings": {
         "dart.flutterSdkPath": "/flutter",
         "editor.formatOnSave": true,
@@ -31,20 +31,20 @@
           "editor.defaultFormatter": "Dart-Code.dart-code"
         }
       },
-			"extensions": [
+      "extensions": [
         "Dart-Code.dart-code",
         "Dart-Code.flutter",
-				"dbaeumer.vscode-eslint",
+        "dbaeumer.vscode-eslint",
         "dcmdev.dcm-vscode-extension",
         "esbenp.prettier-vscode",
-				"svelte.svelte-vscode"
-			]
-		}
-	},
-	"forwardPorts": [],
-	"initializeCommand": "bash .devcontainer/scripts/initializeCommand.sh",
-	"onCreateCommand": "bash .devcontainer/scripts/onCreateCommand.sh",
-	"overrideCommand": true,
+        "svelte.svelte-vscode"
+      ]
+    }
+  },
+  "forwardPorts": [],
+  "initializeCommand": "bash .devcontainer/scripts/initializeCommand.sh",
+  "onCreateCommand": "bash .devcontainer/scripts/onCreateCommand.sh",
+  "overrideCommand": true,
   "workspaceFolder": "/immich",
   "remoteUser": "node"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  immich-devcontainer:
+    build:
+      dockerfile: Dockerfile
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    volumes:
+      - ..:/immich:cached

--- a/.devcontainer/scripts/initializeCommand.sh
+++ b/.devcontainer/scripts/initializeCommand.sh
@@ -1,0 +1,4 @@
+# If .env file does not exist, create it by copying example.env from the docker folder
+if [ ! -f ".devcontainer/.env" ]; then
+    cp docker/example.env .devcontainer/.env
+fi

--- a/.devcontainer/scripts/initializeCommand.sh
+++ b/.devcontainer/scripts/initializeCommand.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # If .env file does not exist, create it by copying example.env from the docker folder
 if [ ! -f ".devcontainer/.env" ]; then
     cp docker/example.env .devcontainer/.env

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -1,0 +1,24 @@
+# Enable multiarch for arm64 if necessary
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    sudo dpkg --add-architecture amd64 && \
+    sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends \
+        qemu-user-static \
+        libc6:amd64 \
+        libstdc++6:amd64 \
+        libgcc1:amd64
+fi
+
+# Install DCM
+wget -qO- https://dcm.dev/pgp-key.public | sudo gpg --dearmor -o /usr/share/keyrings/dcm.gpg
+sudo echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+
+sudo apt-get update
+sudo apt-get install dcm
+
+dart --disable-analytics
+
+# Install immich
+cd /immich
+make install-all
+

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -21,5 +21,5 @@ sudo apt-get install dcm
 dart --disable-analytics
 
 # Install immich
-cd /immich
+cd /immich || exit
 make install-all

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Enable multiarch for arm64 if necessary
 if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     sudo dpkg --add-architecture amd64 && \
@@ -21,4 +23,3 @@ dart --disable-analytics
 # Install immich
 cd /immich
 make install-all
-


### PR DESCRIPTION
Upgrades the devcontainer implementation with the following changes:
- Prepares the dev environment fully with all the needed tools and SDKs
- Starts all the immich docker containers directly with the devcontainer
- installs & sets all VSCode extensions and settings from https://immich.app/docs/developer/setup/#vscode
- Included a workaround to run amd64 binaries for aarch64/arm64 machines like an Apple Silicon Mac

To start the immich docker containers there must be an .env file available but I didn't like failing the start of the devcontainer.   Instead if the .env file isn't found under the .devcontainer folder it will copy the example.env from the docker folder and use that instead. Unfortunately the .env file must be existing in the .devcontainer folder - I couldn't find a way to use the .env file from the docker folder.