### PR TITLE
fix(server): show people without thumbnails

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -20,13 +20,12 @@ SELECT
   "person"."isHidden" AS "person_isHidden"
 FROM
   "person" "person"
-  LEFT JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
+  INNER JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
   INNER JOIN "assets" "asset" ON "asset"."id" = "face"."assetId"
   AND ("asset"."deletedAt" IS NULL)
 WHERE
   "person"."ownerId" = $1
   AND "asset"."isArchived" = false
-  AND "person"."thumbnailPath" != ''
   AND "person"."isHidden" = false
 GROUP BY
   "person"."id"
@@ -257,15 +256,12 @@ SELECT
   ) AS "hidden"
 FROM
   "person" "person"
-  LEFT JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
+  INNER JOIN "asset_faces" "face" ON "face"."personId" = "person"."id"
   INNER JOIN "assets" "asset" ON "asset"."id" = "face"."assetId"
   AND ("asset"."deletedAt" IS NULL)
 WHERE
   "person"."ownerId" = $1
   AND "asset"."isArchived" = false
-  AND "person"."thumbnailPath" != ''
-HAVING
-  COUNT("face"."assetId") != 0
 
 -- PersonRepository.getFacesByIds
 SELECT

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -237,7 +237,6 @@ export class PersonRepository implements IPersonRepository {
       .andWhere('asset.isArchived = false')
       .select('COUNT(DISTINCT(person.id))', 'total')
       .addSelect('COUNT(DISTINCT(person.id)) FILTER (WHERE person.isHidden = true)', 'hidden')
-      .having('COUNT(face.assetId) != 0')
       .getRawOne();
 
     if (items == undefined) {

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -86,7 +86,7 @@ export class PersonRepository implements IPersonRepository {
   getAllForUser(pagination: PaginationOptions, userId: string, options?: PersonSearchOptions): Paginated<PersonEntity> {
     const queryBuilder = this.personRepository
       .createQueryBuilder('person')
-      .leftJoin('person.faces', 'face')
+      .innerJoin('person.faces', 'face')
       .where('person.ownerId = :userId', { userId })
       .innerJoin('face.asset', 'asset')
       .andWhere('asset.isArchived = false')
@@ -95,7 +95,6 @@ export class PersonRepository implements IPersonRepository {
       .addOrderBy('COUNT(face.assetId)', 'DESC')
       .addOrderBy("NULLIF(person.name, '')", 'ASC', 'NULLS LAST')
       .addOrderBy('person.createdAt')
-      .andWhere("person.thumbnailPath != ''")
       .having("person.name != '' OR COUNT(face.assetId) >= :faces", { faces: options?.minimumFaceCount || 1 })
       .groupBy('person.id');
     if (!options?.withHidden) {
@@ -232,11 +231,10 @@ export class PersonRepository implements IPersonRepository {
   async getNumberOfPeople(userId: string): Promise<PeopleStatistics> {
     const items = await this.personRepository
       .createQueryBuilder('person')
-      .leftJoin('person.faces', 'face')
+      .innerJoin('person.faces', 'face')
       .where('person.ownerId = :userId', { userId })
       .innerJoin('face.asset', 'asset')
       .andWhere('asset.isArchived = false')
-      .andWhere("person.thumbnailPath != ''")
       .select('COUNT(DISTINCT(person.id))', 'total')
       .addSelect('COUNT(DISTINCT(person.id)) FILTER (WHERE person.isHidden = true)', 'hidden')
       .having('COUNT(face.assetId) != 0')


### PR DESCRIPTION
## Description

If a thumbnail generation job for a person fails, that person will be hidden without any indication to the user. Even if they're aware of this, they need to find a picture containing this person to be able to open their page and regenerate the person's thumbnail. It is better UX to display the person even if they have a missing thumbnail. This makes the user aware of the issue, allows them to correct it more easily, and does not prevent them from exploring their images.

Fixes #9732