### PR TITLE
fix(web): recent albums sort

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
+++ b/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
@@ -1,0 +1,28 @@
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import RecentAlbums from '$lib/components/shared-components/side-bar/recent-albums.svelte';
+import { albumFactory } from '@test-data/factories/album-factory';
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+describe('RecentAlbums component', () => {
+  it('sorts albums by most recently updated', async () => {
+    const albums = [
+      albumFactory.build({ updatedAt: '2024-01-01T00:00:00Z' }),
+      albumFactory.build({ updatedAt: '2024-01-09T00:00:01Z' }),
+      albumFactory.build({ updatedAt: '2024-01-10T00:00:00Z' }),
+      albumFactory.build({ updatedAt: '2024-01-09T00:00:00Z' }),
+    ];
+
+    sdkMock.getAllAlbums.mockResolvedValueOnce([...albums]);
+    render(RecentAlbums);
+
+    expect(sdkMock.getAllAlbums).toBeCalledTimes(1);
+    await tick();
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(3);
+    expect(links[0]).toHaveAttribute('href', `/albums/${albums[2].id}`);
+    expect(links[1]).toHaveAttribute('href', `/albums/${albums[1].id}`);
+    expect(links[2]).toHaveAttribute('href', `/albums/${albums[3].id}`);
+  });
+});

--- a/web/src/lib/components/shared-components/side-bar/recent-albums.svelte
+++ b/web/src/lib/components/shared-components/side-bar/recent-albums.svelte
@@ -10,9 +10,7 @@
   onMount(async () => {
     try {
       const allAlbums = await getAllAlbums({});
-      albums = allAlbums
-        .sort((album1, album2) => (album1.lastModifiedAssetTimestamp! > album2.lastModifiedAssetTimestamp! ? 1 : 0))
-        .slice(0, 3);
+      albums = allAlbums.sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1)).slice(0, 3);
     } catch (error) {
       handleError(error, $t('failed_to_load_assets'));
     }


### PR DESCRIPTION
Fixes #14541 by sorting the recent albums based on the album's modify date, instead of the album's last modified asset date. I think this makes more sense, especially since `lastModifiedAssetTimestamp` can be undefined when an album has no assets.