### PR TITLE
feat(web): delete all assets associated with stack on asset delete

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/delete-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/delete-action.svelte
@@ -11,7 +11,7 @@
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { handleError } from '$lib/utils/handle-error';
-  import { deleteAssets, type AssetResponseDto } from '@immich/sdk';
+  import { deleteStack, getStack, deleteAssets, type AssetResponseDto } from '@immich/sdk';
   import { mdiDeleteForeverOutline, mdiDeleteOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { OnAction } from './action';
@@ -41,7 +41,16 @@
 
   const trashAsset = async () => {
     try {
-      await deleteAssets({ assetBulkDeleteDto: { ids: [asset.id] } });
+      if (asset.stack) {
+        const { assets } = await getStack({ id: asset.stack.id });
+        const assetIds = assets.map((asset) => asset.id);
+
+        await deleteStack({ id: asset.stack.id });
+        await deleteAssets({ assetBulkDeleteDto: { ids: assetIds } });
+      } else {
+        await deleteAssets({ assetBulkDeleteDto: { ids: [asset.id] } });
+      }
+
       onAction({ type: AssetAction.TRASH, asset });
 
       notificationController.show({

--- a/web/src/lib/components/photos-page/actions/delete-assets.svelte
+++ b/web/src/lib/components/photos-page/actions/delete-assets.svelte
@@ -7,6 +7,9 @@
   import { type OnDelete, deleteAssets } from '$lib/utils/actions';
   import DeleteAssetDialog from '../delete-asset-dialog.svelte';
   import { t } from 'svelte-i18n';
+  import { deleteStacks, getStack } from '@immich/sdk';
+
+  import { handleError } from '$lib/utils/handle-error';
 
   interface Props {
     onAssetDelete: OnDelete;
@@ -34,8 +37,36 @@
 
   const handleDelete = async () => {
     loading = true;
-    const ids = [...getOwnedAssets()].map((a) => a.id);
-    await deleteAssets(force, onAssetDelete, ids);
+    const ownedAssets = [...getOwnedAssets()];
+
+    try {
+      const stackIds: string[] = [];
+      const pendingAssetIds: Array<Promise<string[]>> = [];
+      const assetIds: string[] = [];
+      for (const asset of ownedAssets) {
+        let stackId = asset.stack?.id;
+
+        if (stackId) {
+          stackIds.push(stackId);
+
+          const assetIds = getStack({ id: stackId }).then((stack) => stack.assets.map((asset) => asset.id));
+          pendingAssetIds.push(assetIds);
+        } else {
+          assetIds.push(asset.id);
+        }
+      }
+
+      let fetchedAssetIds = await Promise.all(pendingAssetIds);
+      const ids = assetIds.concat(...fetchedAssetIds.flat());
+
+      if (stackIds.length > 0) {
+        await deleteStacks({ bulkIdsDto: { ids: stackIds } });
+      }
+      await deleteAssets(force, onAssetDelete, ids);
+    } catch (error) {
+      handleError(error, $t('errors.unable_to_delete_assets'));
+    }
+
     clearSelect();
     isShowConfirmation = false;
     loading = false;


### PR DESCRIPTION
An attempt to fix this for the web: https://github.com/immich-app/immich/issues/13113
This change deletes both the stack, as well as all the asset ids for a given stack when deleted from either the asset screen, or the photos page.
I went with deleting the stack as I wasn't sure how to get show the stack in the trash page, and thought this was a workable solution. It does have the tradeoff that the user has to restack the images again.

I don't believe this is fully fleshed out yet, but I think the main idea is there.
It would be nice to have some pointers as for what other implications to consider for this PR as I'm not too familiar with the codebase.

I do believe that a query to grab all stack should be added, as opposed to how I have it now (fetch each stack).
I'm also wrapping around the [deleteAssets](https://github.com/leanmiguel/immich/blob/7302510870508dc709bc5f34e1289f61ea0881d2/web/src/lib/components/photos-page/actions/delete-assets.svelte#L64-L66) as I'm not sure if this change should be propagated to other parts. The error handling can be improved.