### PR TITLE
feat(server): Merge Faces sorted by Similarity

### DIFF
--- a/mobile/openapi/lib/api/people_api.dart
+++ b/mobile/openapi/lib/api/people_api.dart
@@ -66,6 +66,10 @@ class PeopleApi {
   /// Performs an HTTP 'GET /people' operation and returns the [Response].
   /// Parameters:
   ///
+  /// * [String] closestAssetId:
+  ///
+  /// * [String] closestPersonId:
+  ///
   /// * [num] page:
   ///   Page number for pagination
   ///
@@ -73,7 +77,7 @@ class PeopleApi {
   ///   Number of items per page
   ///
   /// * [bool] withHidden:
-  Future<Response> getAllPeopleWithHttpInfo({ num? page, num? size, bool? withHidden, }) async {
+  Future<Response> getAllPeopleWithHttpInfo({ String? closestAssetId, String? closestPersonId, num? page, num? size, bool? withHidden, }) async {
     // ignore: prefer_const_declarations
     final path = r'/people';
 
@@ -84,6 +88,12 @@ class PeopleApi {
     final headerParams = <String, String>{};
     final formParams = <String, String>{};
 
+    if (closestAssetId != null) {
+      queryParams.addAll(_queryParams('', 'closestAssetId', closestAssetId));
+    }
+    if (closestPersonId != null) {
+      queryParams.addAll(_queryParams('', 'closestPersonId', closestPersonId));
+    }
     if (page != null) {
       queryParams.addAll(_queryParams('', 'page', page));
     }
@@ -110,6 +120,10 @@ class PeopleApi {
 
   /// Parameters:
   ///
+  /// * [String] closestAssetId:
+  ///
+  /// * [String] closestPersonId:
+  ///
   /// * [num] page:
   ///   Page number for pagination
   ///
@@ -117,8 +131,8 @@ class PeopleApi {
   ///   Number of items per page
   ///
   /// * [bool] withHidden:
-  Future<PeopleResponseDto?> getAllPeople({ num? page, num? size, bool? withHidden, }) async {
-    final response = await getAllPeopleWithHttpInfo( page: page, size: size, withHidden: withHidden, );
+  Future<PeopleResponseDto?> getAllPeople({ String? closestAssetId, String? closestPersonId, num? page, num? size, bool? withHidden, }) async {
+    final response = await getAllPeopleWithHttpInfo( closestAssetId: closestAssetId, closestPersonId: closestPersonId, page: page, size: size, withHidden: withHidden, );
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3847,6 +3847,15 @@
         "operationId": "getAllPeople",
         "parameters": [
           {
+            "name": "closestPersonId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
             "name": "page",
             "required": false,
             "in": "query",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3847,6 +3847,15 @@
         "operationId": "getAllPeople",
         "parameters": [
           {
+            "name": "closestAssetId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
             "name": "closestPersonId",
             "required": false,
             "in": "query",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2362,7 +2362,8 @@ export function updatePartner({ id, updatePartnerDto }: {
         body: updatePartnerDto
     })));
 }
-export function getAllPeople({ page, size, withHidden }: {
+export function getAllPeople({ closestPersonId, page, size, withHidden }: {
+    closestPersonId?: string;
     page?: number;
     size?: number;
     withHidden?: boolean;
@@ -2371,6 +2372,7 @@ export function getAllPeople({ page, size, withHidden }: {
         status: 200;
         data: PeopleResponseDto;
     }>(`/people${QS.query(QS.explode({
+        closestPersonId,
         page,
         size,
         withHidden

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2362,7 +2362,8 @@ export function updatePartner({ id, updatePartnerDto }: {
         body: updatePartnerDto
     })));
 }
-export function getAllPeople({ closestPersonId, page, size, withHidden }: {
+export function getAllPeople({ closestAssetId, closestPersonId, page, size, withHidden }: {
+    closestAssetId?: string;
     closestPersonId?: string;
     page?: number;
     size?: number;
@@ -2372,6 +2373,7 @@ export function getAllPeople({ closestPersonId, page, size, withHidden }: {
         status: 200;
         data: PeopleResponseDto;
     }>(`/people${QS.query(QS.explode({
+        closestAssetId,
         closestPersonId,
         page,
         size,

--- a/server/src/controllers/person.controller.ts
+++ b/server/src/controllers/person.controller.ts
@@ -31,8 +31,8 @@ export class PersonController {
 
   @Get()
   @Authenticated({ permission: Permission.PERSON_READ })
-  getAllPeople(@Auth() auth: AuthDto, @Query() withHidden: PersonSearchDto): Promise<PeopleResponseDto> {
-    return this.service.getAll(auth, withHidden);
+  getAllPeople(@Auth() auth: AuthDto, @Query() options: PersonSearchDto): Promise<PeopleResponseDto> {
+    return this.service.getAll(auth, options);
   }
 
   @Post()

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -67,6 +67,8 @@ export class MergePersonDto {
 export class PersonSearchDto {
   @ValidateBoolean({ optional: true })
   withHidden?: boolean;
+  @ValidateUUID({ optional: true })
+  closestPersonId?: string;
 
   /** Page number for pagination */
   @ApiPropertyOptional()

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -69,6 +69,8 @@ export class PersonSearchDto {
   withHidden?: boolean;
   @ValidateUUID({ optional: true })
   closestPersonId?: string;
+  @ValidateUUID({ optional: true })
+  closestAssetId?: string;
 
   /** Page number for pagination */
   @ApiPropertyOptional()

--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -10,7 +10,7 @@ export const IPersonRepository = 'IPersonRepository';
 export interface PersonSearchOptions {
   minimumFaceCount: number;
   withHidden: boolean;
-  closestPersonId?: string;
+  closestFaceAssetId?: string;
 }
 
 export interface PersonNameSearchOptions {

--- a/server/src/interfaces/person.interface.ts
+++ b/server/src/interfaces/person.interface.ts
@@ -10,6 +10,7 @@ export const IPersonRepository = 'IPersonRepository';
 export interface PersonSearchOptions {
   minimumFaceCount: number;
   withHidden: boolean;
+  closestPersonId?: string;
 }
 
 export interface PersonNameSearchOptions {

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import _ from 'lodash';
 import { ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
@@ -96,18 +96,12 @@ export class PersonRepository implements IPersonRepository {
       .innerJoin('face.asset', 'asset')
       .andWhere('asset.isArchived = false')
       .orderBy('person.isHidden', 'ASC');
-    if (options?.closestPersonId) {
-      const person = await this.personRepository.findOne({
-        where: { id: options.closestPersonId, ownerId: userId },
-      });
-      if (!person?.faceAssetId) {
-        throw new Error('Person does not exist');
-      }
+    if (options?.closestFaceAssetId) {
       const face = await this.faceSearchRepository.findOne({
-        where: { faceId: person?.faceAssetId || '' },
+        where: { faceId: options.closestFaceAssetId },
       });
       if (!face?.embedding) {
-        throw new Error('Person does not have a face');
+        throw new Error('Face does not exist');
       }
       queryBuilder
         .leftJoin('face.faceSearch', 'search')

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -55,7 +55,7 @@ import { IsNull } from 'typeorm';
 @Injectable()
 export class PersonService extends BaseService {
   async getAll(auth: AuthDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
-    const { withHidden = false, page, size } = dto;
+    const { withHidden = false, closestPersonId, page, size } = dto;
     const pagination = {
       take: size,
       skip: (page - 1) * size,
@@ -65,6 +65,7 @@ export class PersonService extends BaseService {
     const { items, hasNextPage } = await this.personRepository.getAllForUser(pagination, auth.user.id, {
       minimumFaceCount: machineLearning.facialRecognition.minFaces,
       withHidden,
+      closestPersonId,
     });
     const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id);
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -55,17 +55,25 @@ import { IsNull } from 'typeorm';
 @Injectable()
 export class PersonService extends BaseService {
   async getAll(auth: AuthDto, dto: PersonSearchDto): Promise<PeopleResponseDto> {
-    const { withHidden = false, closestPersonId, page, size } = dto;
+    const { withHidden = false, closestAssetId, closestPersonId, page, size } = dto;
+    let closestFaceAssetId = closestAssetId;
     const pagination = {
       take: size,
       skip: (page - 1) * size,
     };
 
+    if (closestPersonId) {
+      const person = await this.personRepository.getById(closestPersonId);
+      if (!person?.faceAssetId) {
+        throw new NotFoundException('Person not found');
+      }
+      closestFaceAssetId = person.faceAssetId;
+    }
     const { machineLearning } = await this.getConfig({ withCache: false });
     const { items, hasNextPage } = await this.personRepository.getAllForUser(pagination, auth.user.id, {
       minimumFaceCount: machineLearning.facialRecognition.minFaces,
       withHidden,
-      closestPersonId,
+      closestFaceAssetId,
     });
     const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id);
 

--- a/web/src/lib/components/faces-page/assign-face-side-panel.svelte
+++ b/web/src/lib/components/faces-page/assign-face-side-panel.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
   import { getPersonNameWithHiddenValue } from '$lib/utils/person';
-  import { getPeopleThumbnailUrl } from '$lib/utils';
-  import { AssetTypeEnum, type AssetFaceResponseDto, type PersonResponseDto } from '@immich/sdk';
+  import { getPeopleThumbnailUrl, handlePromiseError } from '$lib/utils';
+  import { AssetTypeEnum, type AssetFaceResponseDto, type PersonResponseDto, getAllPeople } from '@immich/sdk';
   import { mdiArrowLeftThin, mdiClose, mdiMagnify, mdiPlus } from '@mdi/js';
   import { linear } from 'svelte/easing';
   import { fly } from 'svelte/transition';
@@ -13,9 +13,10 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import { zoomImageToBase64 } from '$lib/utils/people-utils';
   import { t } from 'svelte-i18n';
+  import { handleError } from '$lib/utils/handle-error';
+  import { onMount } from 'svelte';
 
   interface Props {
-    allPeople: PersonResponseDto[];
     editedFace: AssetFaceResponseDto;
     assetId: string;
     assetType: AssetTypeEnum;
@@ -24,7 +25,24 @@
     onReassign: (person: PersonResponseDto) => void;
   }
 
-  let { allPeople, editedFace, assetId, assetType, onClose, onCreatePerson, onReassign }: Props = $props();
+  let { editedFace, assetId, assetType, onClose, onCreatePerson, onReassign }: Props = $props();
+
+  let allPeople: PersonResponseDto[] = $state([]);
+
+  let isShowLoadingPeople = $state(false);
+
+  async function loadPeople() {
+    const timeout = setTimeout(() => (isShowLoadingPeople = true), timeBeforeShowLoadingSpinner);
+    try {
+      const { people } = await getAllPeople({ withHidden: true, closestAssetId: editedFace.id });
+      allPeople = people;
+    } catch (error) {
+      handleError(error, $t('errors.cant_get_faces'));
+    } finally {
+      clearTimeout(timeout);
+    }
+    isShowLoadingPeople = false;
+  }
 
   // loading spinners
   let isShowLoadingNewPerson = $state(false);
@@ -36,6 +54,10 @@
   let searchName = $state('');
 
   let showPeople = $derived(searchName ? searchedPeople : allPeople.filter((person) => !person.isHidden));
+
+  onMount(() => {
+    handlePromiseError(loadPeople());
+  });
 
   const handleCreatePerson = async () => {
     const timeout = setTimeout(() => (isShowLoadingNewPerson = true), timeBeforeShowLoadingSpinner);
@@ -96,31 +118,40 @@
   </div>
   <div class="px-4 py-4 text-sm">
     <h2 class="mb-8 mt-4 uppercase">{$t('all_people')}</h2>
-    <div class="immich-scrollbar mt-4 flex flex-wrap gap-2 overflow-y-auto">
-      {#each showPeople as person (person.id)}
-        {#if !editedFace.person || person.id !== editedFace.person.id}
-          <div class="w-fit">
-            <button type="button" class="w-[90px]" onclick={() => onReassign(person)}>
-              <div class="relative">
-                <ImageThumbnail
-                  curve
-                  shadow
-                  url={getPeopleThumbnailUrl(person)}
-                  altText={$getPersonNameWithHiddenValue(person.name, person.isHidden)}
-                  title={$getPersonNameWithHiddenValue(person.name, person.isHidden)}
-                  widthStyle="90px"
-                  heightStyle="90px"
-                  hidden={person.isHidden}
-                />
-              </div>
+    {#if isShowLoadingPeople}
+      <div class="flex w-full justify-center">
+        <LoadingSpinner />
+      </div>
+    {:else}
+      <div class="immich-scrollbar mt-4 flex flex-wrap gap-2 overflow-y-auto">
+        {#each showPeople as person (person.id)}
+          {#if !editedFace.person || person.id !== editedFace.person.id}
+            <div class="w-fit">
+              <button type="button" class="w-[90px]" onclick={() => onReassign(person)}>
+                <div class="relative">
+                  <ImageThumbnail
+                    curve
+                    shadow
+                    url={getPeopleThumbnailUrl(person)}
+                    altText={$getPersonNameWithHiddenValue(person.name, person.isHidden)}
+                    title={$getPersonNameWithHiddenValue(person.name, person.isHidden)}
+                    widthStyle="90px"
+                    heightStyle="90px"
+                    hidden={person.isHidden}
+                  />
+                </div>
 
-              <p class="mt-1 truncate font-medium" title={$getPersonNameWithHiddenValue(person.name, person.isHidden)}>
-                {person.name}
-              </p>
-            </button>
-          </div>
-        {/if}
-      {/each}
-    </div>
+                <p
+                  class="mt-1 truncate font-medium"
+                  title={$getPersonNameWithHiddenValue(person.name, person.isHidden)}
+                >
+                  {person.name}
+                </p>
+              </button>
+            </div>
+          {/if}
+        {/each}
+      </div>
+    {/if}
   </div>
 </section>

--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -35,7 +35,7 @@
   let peopleToNotShow = $derived([...selectedPeople, person]);
 
   onMount(async () => {
-    const data = await getAllPeople({ withHidden: false });
+    const data = await getAllPeople({ withHidden: false, closestPersonId: person.id  });
     people = data.people;
   });
 

--- a/web/src/lib/components/faces-page/merge-face-selector.svelte
+++ b/web/src/lib/components/faces-page/merge-face-selector.svelte
@@ -35,7 +35,7 @@
   let peopleToNotShow = $derived([...selectedPeople, person]);
 
   onMount(async () => {
-    const data = await getAllPeople({ withHidden: false, closestPersonId: person.id  });
+    const data = await getAllPeople({ withHidden: false, closestPersonId: person.id });
     people = data.people;
   });
 

--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -8,7 +8,6 @@
   import { getPersonNameWithHiddenValue } from '$lib/utils/person';
   import {
     createPerson,
-    getAllPeople,
     getFaces,
     reassignFacesById,
     AssetTypeEnum,
@@ -53,7 +52,6 @@
 
   // search people
   let showSelectedFaces = $state(false);
-  let allPeople: PersonResponseDto[] = $state([]);
 
   // timers
   let loaderLoadingDoneTimeout: ReturnType<typeof setTimeout>;
@@ -64,8 +62,6 @@
   async function loadPeople() {
     const timeout = setTimeout(() => (isShowLoadingPeople = true), timeBeforeShowLoadingSpinner);
     try {
-      const { people } = await getAllPeople({ withHidden: true });
-      allPeople = people;
       peopleWithFaces = await getFaces({ id: assetId });
     } catch (error) {
       handleError(error, $t('errors.cant_get_faces'));
@@ -322,7 +318,6 @@
 
 {#if showSelectedFaces && editedFace}
   <AssignFaceSidePanel
-    {allPeople}
     {editedFace}
     {assetId}
     {assetType}


### PR DESCRIPTION
A new optional parameter on the `/api/people` route allows clients to specify sorting order by similarity to a person. This sorting is used on the merge page to organize photos based on similarity.

Implements: #4347