### PR TITLE
fix(web): upload info panel covers timeline navigation bar

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -58,7 +58,7 @@
       }
       uploadAssetsStore.reset();
     }}
-    class="fixed bottom-6 right-6 z-[10000]"
+    class="fixed bottom-6 right-16 z-[10000]"
   >
     {#if showDetail}
       <div


### PR DESCRIPTION
Fixes #14606

<img width="391" alt="image" src="https://github.com/user-attachments/assets/ac4f4e7a-064a-436e-9338-e1fe2e082922" />
