### PR TITLE
fix(web): allow minimizing upload panel

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -17,19 +17,9 @@
 
   let { stats, isDismissible, isUploading, remainingUploads } = uploadAssetsStore;
 
-  const autoHide = () => {
-    if (!$isUploading && showDetail) {
-      showDetail = false;
-    }
-
-    if ($isUploading && !showDetail) {
-      showDetail = true;
-    }
-  };
-
   $effect(() => {
     if ($isUploading) {
-      autoHide();
+      showDetail = true;
     }
   });
 </script>


### PR DESCRIPTION
The upload panel cannot be minimized, because the effect always reopens it