### PR TITLE
fix(web): live photo link action

### DIFF
--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -49,7 +49,7 @@
     const isLivePhotoCandidate =
       selection.length === 2 &&
       selection.some((asset) => asset.type === AssetTypeEnum.Image) &&
-      selection.some((asset) => asset.type === AssetTypeEnum.Image);
+      selection.some((asset) => asset.type === AssetTypeEnum.Video);
     isLinkActionAvailable = isAllOwned && (isLivePhoto || isLivePhotoCandidate);
   });
 


### PR DESCRIPTION
The condition was incorrectly changed in this PR 
https://github.com/immich-app/immich/pull/12574/files#diff-e0fa7eb61f910e451c16939eeb38b36766ebf9e79f617e48ae154e0f9bb2f5f7

The server will return the error `Live photo video must be a video` when attempting to link two images, but this change also hides the button in the UI.