### PR TITLE
fix(mobile): set custom headers on external url (#14707)

### DIFF
--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -57,13 +57,18 @@ class AuthService {
 
   Future<bool> validateAuxilaryServerUrl(String url) async {
     final httpclient = HttpClient();
-    final accessToken = _authRepository.getAccessToken();
     bool isValid = false;
 
     try {
       final uri = Uri.parse('$url/users/me');
       final request = await httpclient.getUrl(uri);
-      request.headers.add('x-immich-user-token', accessToken);
+
+      // add auth token + any configured custom headers
+      final customHeaders = ApiService.getRequestHeaders();
+      customHeaders.forEach((key, value) {
+        request.headers.add(key, value);
+      });
+
       final response = await request.close();
       if (response.statusCode == 200) {
         isValid = true;


### PR DESCRIPTION
This change fixes it so that when entering an External Network endpoint for Automatic URL switching that it uses all the headers from `ApiService.getRequestHeaders()` instead of hard-coding only `x-immich-user-token`

This way the server test will include both `x-immich-user-token` AND any custom proxy headers that are configured, since `ApiService.getRequestHeaders()` returns a map containing all of these.

This is necessary if the external network endpoint you are trying to configure **requires** these custom proxy headers (such as if you are using Cloudflare with Service Auth headers)

Without this fix, it's impossible to configure such a server as an external endpoint since the call to `$url/users/me` will fail (due to missing custom headers) and the endpoint won't be added.


Close #14707
