### PR TITLE
fix(web): downloading partner assets

### DIFF
--- a/web/src/routes/(user)/partners/[userId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/partners/[userId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -31,7 +31,10 @@
 
 <main class="grid h-screen bg-immich-bg pt-18 dark:bg-immich-dark-bg">
   {#if assetInteraction.selectionActive}
-    <AssetSelectControlBar assets={assetInteraction.selectedAssets} clearSelect={assetInteraction.clearMultiselect}>
+    <AssetSelectControlBar
+      assets={assetInteraction.selectedAssets}
+      clearSelect={() => assetInteraction.clearMultiselect()}
+    >
       <CreateSharedLink />
       <ButtonContextMenu icon={mdiPlus} title={$t('add')}>
         <AddToAlbum />


### PR DESCRIPTION
Fixes #14797 where an error is thrown when downloading partner assets via the timeline (`/partners/:partnerId` page)