### PR TITLE
chore(mobile): add timeout when reading video files

### DIFF
--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -313,15 +313,12 @@ class BackupService {
             );
           }
         } else {
-          if (asset.type == AssetType.video) {
-            file = await asset.local!.originFile;
-          } else {
-            file = await asset.local!.originFile
+          file =
+              await asset.local!.originFile.timeout(const Duration(seconds: 5));
+
+          if (asset.local!.isLivePhoto) {
+            livePhotoFile = await asset.local!.originFileWithSubtype
                 .timeout(const Duration(seconds: 5));
-            if (asset.local!.isLivePhoto) {
-              livePhotoFile = await asset.local!.originFileWithSubtype
-                  .timeout(const Duration(seconds: 5));
-            }
           }
         }
 


### PR DESCRIPTION
Add timeout when reading video files as well, to potentially handle case of reading the corrupted files

Fixes #9870
