### PR TITLE
fix(server): support import paths with special chars

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -214,7 +214,7 @@ export class StorageRepository implements IStorageRepository {
   }
 
   private asGlob(pathToCrawl: string): string {
-    const escapedPath = escapePath(pathToCrawl);
+    const escapedPath = escapePath(pathToCrawl).replaceAll('"', '["]').replaceAll("'", "[']").replaceAll('`', '[`]');
     const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
     return `${escapedPath}/**/${extensions}`;
   }


### PR DESCRIPTION
Fixes #14588

It was not possible to have an import path with apostrope, double quote, asterisk and so on. Now it works.

Also adds support for several other special characters, except for backslash which seems like a special category of difficult
