### PR TITLE
feat(deployment): no env_file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,8 +19,11 @@ services:
       # Do not edit the next line. If you want to change the media storage location on your system, edit the value of UPLOAD_LOCATION in the .env file
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
       - /etc/localtime:/etc/localtime:ro
-    env_file:
-      - .env
+    environment:
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_USERNAME: ${DB_DATABASE_NAME}
+      TZ: $TZ
     ports:
       - '2283:2283'
     depends_on:
@@ -40,8 +43,6 @@ services:
     #   service: cpu # set to one of [armnn, cuda, openvino, openvino-wsl] for accelerated inference - use the `-wsl` version for WSL2 where applicable
     volumes:
       - model-cache:/cache
-    env_file:
-      - .env
     restart: always
     healthcheck:
       disable: false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_USERNAME: ${DB_DATABASE_NAME}
-      TZ: $TZ
+      TZ: ${TZ}
     ports:
       - '2283:2283'
     depends_on:

--- a/docker/example.env
+++ b/docker/example.env
@@ -5,8 +5,8 @@ UPLOAD_LOCATION=./library
 # The location where your database files are stored
 DB_DATA_LOCATION=./postgres
 
-# To set a timezone, uncomment the next line and change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
-# TZ=Etc/UTC
+# To set a timezone, change Etc/UTC to a TZ identifier from this list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+TZ=Etc/UTC
 
 # The Immich version to use. You can pin this to a specific version like "v1.71.0"
 IMMICH_VERSION=release


### PR DESCRIPTION
With container consolidations, at this point the `env_file` directive is causing increased support burden for no benefit. I propose that we remove it and expressly declare the necessary variables.

The only thing that we lose by removing env_file from ML is the `TZ`, which I don't believe is needed. open to any discussion. This should be a non-breaking change, even for our copy pasters

Not too sure how exactly to apply it to the dev and prod YAMLs but should be very easy, I can work on it if we move forward. One big benefit is eliminating a setup step for portainer users.