### PR TITLE
fix(mobile): check and request permissions when saving files to prevent hard crash

### DIFF
--- a/mobile/lib/providers/asset_viewer/download.provider.dart
+++ b/mobile/lib/providers/asset_viewer/download.provider.dart
@@ -141,7 +141,7 @@ class DownloadStateNotifier extends StateNotifier<DownloadState> {
   }
 
   void downloadAsset(Asset asset, BuildContext context) async {
-    await _downloadService.download(asset);
+    await _downloadService.download(asset, context: context);
   }
 
   void cancelDownload(String id) async {

--- a/mobile/lib/services/download.service.dart
+++ b/mobile/lib/services/download.service.dart
@@ -212,8 +212,14 @@ class DownloadService {
         context: context,
         builder: (context) {
           return AlertDialog(
-            title: const Text('permission_onboarding_request').tr(),
-            content: const Text('permission_onboarding_permission_denied').tr(),
+            title: const Text(
+              'permission_onboarding_request',
+              textAlign: TextAlign.center,
+            ).tr(),
+            content: const Text(
+              'permission_onboarding_permission_denied',
+              textAlign: TextAlign.center,
+            ).tr(),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context, false),


### PR DESCRIPTION
## Description

Hi all,

This is my first PR so please be patient (I am also a web dev by trade, not a flutter dev so I am open to feedback on my code)

I noticed an issue when trying to save images when the permissions were "None" or "Add Photos Only"
The app would act normally until it had written them to the phone. It was still saving however the app would crash (close and do a complete re-open when clicking the icon)

My change implements an alert dialog if the user has denied permissions, to prompt for permissions, or if the permission is permanently denied, it will ask the user to provide more permissions in settings (The screenshot shows the permanently denied dialog)

Please let me know if you have any suggestions or changes

Thanks

## How Has This Been Tested?

- [x] Set permissions to "None" and try saving a file, the alert dialog appears and no crashes
- [x] Set permissions to "Add Photos Only" and try saving a file, the alert dialog appears and no crashes
- [x] Set permissions to "Limited Access" and try saving a file, the file saves with the notifications and no crashes
- [x] Set permissions to "Full Access" and try saving a file, the file saves with the notifications and no crashes

## Screenshots (if appropriate):

<img width="422" alt="Screenshot 2024-12-25 at 5 03 38 PM" src="https://github.com/user-attachments/assets/56310fdb-1fbb-4eee-9ad3-b663bd2369da" />

<img width="419" alt="Screenshot 2024-12-25 at 5 05 19 PM" src="https://github.com/user-attachments/assets/a1458221-3e70-497b-82b9-a73df2304d00" />

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable