### PR TITLE
feat(cli): watch paths for auto uploading daemon

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,9 +9,12 @@
       "version": "2.2.52",
       "license": "GNU Affero General Public License version 3",
       "dependencies": {
+        "chokidar": "^4.0.3",
         "fast-glob": "^3.3.2",
         "fastq": "^1.17.1",
-        "lodash-es": "^4.17.21"
+        "lodash-es": "^4.17.21",
+        "micromatch": "^4.0.8",
+        "p-throttle": "^7.0.0"
       },
       "bin": {
         "immich": "dist/index.js"
@@ -23,6 +26,7 @@
         "@types/byte-size": "^8.1.0",
         "@types/cli-progress": "^3.11.0",
         "@types/lodash-es": "^4.17.12",
+        "@types/micromatch": "^4.0.9",
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^22.13.4",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -1427,6 +1431,13 @@
         "win32"
       ]
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
+      "integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/byte-size": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/byte-size/-/byte-size-8.1.2.tgz",
@@ -1470,6 +1481,16 @@
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.9.tgz",
+      "integrity": "sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/braces": "*"
       }
     },
     "node_modules/@types/mock-fs": {
@@ -2087,6 +2108,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ci-info": {
@@ -3414,6 +3450,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-throttle": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
+      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -3754,6 +3802,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/regexp-tree": {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -13,8 +13,7 @@
         "fast-glob": "^3.3.2",
         "fastq": "^1.17.1",
         "lodash-es": "^4.17.21",
-        "micromatch": "^4.0.8",
-        "p-throttle": "^7.0.0"
+        "micromatch": "^4.0.8"
       },
       "bin": {
         "immich": "dist/index.js"
@@ -3445,18 +3444,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-throttle": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-7.0.0.tgz",
-      "integrity": "sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,6 +19,7 @@
     "@types/byte-size": "^8.1.0",
     "@types/cli-progress": "^3.11.0",
     "@types/lodash-es": "^4.17.12",
+    "@types/micromatch": "^4.0.9",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^22.13.4",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -62,9 +63,11 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "chokidar": "^4.0.3",
     "fast-glob": "^3.3.2",
     "fastq": "^1.17.1",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "micromatch": "^4.0.8"
   },
   "volta": {
     "node": "22.14.0"

--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -216,9 +216,9 @@ describe('startWatch', () => {
       ],
     });
     vi.mocked(getSupportedMediaTypes).mockResolvedValue({
-      image: ['jpg'],
-      sidecar: ['xmp'],
-      video: ['mp4'],
+      image: ['.jpg'],
+      sidecar: ['.xmp'],
+      video: ['.mp4'],
     });
     try {
       await startWatch([testFolder], { concurrency: 1 }, { batchSize: 1, debounceTimeMs: 10 });

--- a/cli/src/commands/asset.spec.ts
+++ b/cli/src/commands/asset.spec.ts
@@ -1,14 +1,13 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Action, checkBulkUpload, defaults, getSupportedMediaTypes, Reason } from '@immich/sdk';
 import createFetchMock from 'vitest-fetch-mock';
 
 import { checkForDuplicates, getAlbumName, startWatch, uploadFiles, UploadOptionsDto } from 'src/commands/asset';
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 vi.mock('@immich/sdk');
 

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -169,17 +169,19 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
     return { newFiles: files, duplicates: [] };
   }
 
-  const multiBar = new MultiBar(
-    { format: '{message} | {bar} | {percentage}% | ETA: {eta}s | {value}/{total} assets' },
-    Presets.shades_classic,
-  );
+  let multiBar: MultiBar | undefined;
 
-  const hashProgressBar = progress
-    ? multiBar.create(files.length, 0, { message: 'Hashing files          ' })
-    : undefined;
-  const checkProgressBar = progress
-    ? multiBar.create(files.length, 0, { message: 'Checking for duplicates' })
-    : undefined;
+  if (progress) {
+    multiBar = new MultiBar(
+      { format: '{message} | {bar} | {percentage}% | ETA: {eta}s | {value}/{total} assets' },
+      Presets.shades_classic,
+    );
+  } else {
+    console.log(`Received ${files.length} files, hashing...`);
+  }
+
+  const hashProgressBar = multiBar?.create(files.length, 0, { message: 'Hashing files          ' });
+  const checkProgressBar = multiBar?.create(files.length, 0, { message: 'Checking for duplicates' });
 
   const newFiles: string[] = [];
   const duplicates: Asset[] = [];
@@ -237,7 +239,7 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
 
   await checkBulkUploadQueue.drained();
 
-  multiBar.stop();
+  multiBar?.stop();
 
   console.log(`Found ${newFiles.length} new files and ${duplicates.length} duplicate${s(duplicates.length)}`);
 

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -22,8 +22,8 @@ import path, { basename } from 'node:path';
 import { Queue } from 'src/queue';
 import { BaseOptions, Batcher, authenticate, crawl, sha1 } from 'src/utils';
 
-export const UPLOAD_WATCH_BATCH_SIZE = 100;
-export const UPLOAD_WATCH_DEBOUNCE_TIME_MS = 10_000;
+const UPLOAD_WATCH_BATCH_SIZE = 100;
+const UPLOAD_WATCH_DEBOUNCE_TIME_MS = 10_000;
 
 const s = (count: number) => (count === 1 ? '' : 's');
 

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -102,7 +102,11 @@ export const startWatch = async (
     if (!ext || !extensions.has(ext)) {
       return;
     }
-    console.log(`Change detected: ${path}`);
+
+    if (!options.progress) {
+      // logging when progress is disabled as it can cause issues with the progress bar rendering
+      console.log(`Change detected: ${path}`);
+    }
     pathsBatcher.add(path);
   };
   const fsWatcher = watchFs(paths, {

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -94,7 +94,7 @@ export const startWatch = async (
     },
   });
 
-  const fsWatchListener = async (path: string, stats?: Stats) => {
+  const onFile = async (path: string, stats?: Stats) => {
     if (stats?.isDirectory()) {
       return;
     }
@@ -113,8 +113,8 @@ export const startWatch = async (
     depth: options.recursive ? undefined : 1,
     persistent: true,
   })
-    .on('add', fsWatchListener)
-    .on('change', fsWatchListener)
+    .on('add', onFile)
+    .on('change', onFile)
     .on('error', (error) => console.error(`Watcher error: ${error}`));
 
   process.on('SIGINT', async () => {

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -98,7 +98,7 @@ export const startWatch = async (
     if (stats?.isDirectory()) {
       return;
     }
-    const ext = path.split('.').pop()?.toLowerCase();
+    const ext = '.' + path.split('.').pop()?.toLowerCase();
     if (!extensions.has(ext ?? '')) {
       return;
     }

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -99,7 +99,7 @@ export const startWatch = async (
       return;
     }
     const ext = '.' + path.split('.').pop()?.toLowerCase();
-    if (!extensions.has(ext ?? '')) {
+    if (!ext || !extensions.has(ext)) {
       return;
     }
     console.log(`Change detected: ${path}`);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,6 +69,9 @@ program
       .default(4),
   )
   .addOption(new Option('--delete', 'Delete local assets after upload').env('IMMICH_DELETE_ASSETS'))
+  .addOption(
+    new Option('--watch', 'Watch for changes and upload automatically').env('IMMICH_WATCH_CHANGES').default(false),
+  )
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => upload(paths, program.opts(), options));
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -69,8 +69,12 @@ program
       .default(4),
   )
   .addOption(new Option('--delete', 'Delete local assets after upload').env('IMMICH_DELETE_ASSETS'))
+  .addOption(new Option('--no-progress', 'Hide progress bars').env('IMMICH_PROGRESS_BAR').default(true))
   .addOption(
-    new Option('--watch', 'Watch for changes and upload automatically').env('IMMICH_WATCH_CHANGES').default(false),
+    new Option('--watch', 'Watch for changes and upload automatically')
+      .env('IMMICH_WATCH_CHANGES')
+      .default(false)
+      .implies({ progress: false }),
   )
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
   .action((paths, options) => upload(paths, program.opts(), options));

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -178,7 +178,7 @@ export const sha1 = (filepath: string) => {
  * when the batch size is reached or the debounce time has passed.
  */
 export class Batcher<T = unknown> {
-  private readonly items: T[] = [];
+  private items: T[] = [];
   private readonly batchSize: number;
   private readonly debounceTimeMs?: number;
   private readonly onBatch: (items: T[]) => void;
@@ -228,8 +228,8 @@ export class Batcher<T = unknown> {
       return;
     }
 
-    this.onBatch([...this.items]);
+    this.onBatch(this.items);
 
-    this.items.length = 0;
+    this.items = [];
   }
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -172,3 +172,64 @@ export const sha1 = (filepath: string) => {
     rs.on('end', () => resolve(hash.digest('hex')));
   });
 };
+
+/**
+ * Batches items and calls onBatch to process them
+ * when the batch size is reached or the debounce time has passed.
+ */
+export class Batcher<T = unknown> {
+  private readonly items: T[] = [];
+  private readonly batchSize: number;
+  private readonly debounceTimeMs?: number;
+  private readonly onBatch: (items: T[]) => void;
+  private debounceTimer?: NodeJS.Timeout;
+
+  constructor({
+    batchSize,
+    debounceTimeMs,
+    onBatch,
+  }: {
+    batchSize: number;
+    debounceTimeMs?: number;
+    onBatch: (items: T[]) => Promise<void>;
+  }) {
+    this.batchSize = batchSize;
+    this.debounceTimeMs = debounceTimeMs;
+    this.onBatch = onBatch;
+  }
+
+  private setDebounceTimer() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    if (this.debounceTimeMs) {
+      this.debounceTimer = setTimeout(() => this.flush(), this.debounceTimeMs);
+    }
+  }
+
+  private clearDebounceTimer() {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+  }
+
+  add(item: T) {
+    this.items.push(item);
+    this.setDebounceTimer();
+    if (this.items.length >= this.batchSize) {
+      this.flush();
+    }
+  }
+
+  flush() {
+    this.clearDebounceTimer();
+    if (this.items.length === 0) {
+      return;
+    }
+
+    this.onBatch([...this.items]);
+
+    this.items.length = 0;
+  }
+}


### PR DESCRIPTION
Adds a `--watch` flag to continue watching for changes after initial upload.
- Example: `immich upload ./assets/ --watch`
- Initial upload behaves just like without `--watch`, as it batch uploads all current items in one go.
- The script then starts watching for file change/addition, with a simple batching logic for performance:
  - A batch will be fired on 100 file changes
  - Or 10 seconds after the last change
  - The numbers above are hardcoded for now, they are fine and probably not necessary to make it configurable?
- Another `--no-progress` flag to hide progress bars to make logs cleaner when running as a daemon
  - This is implied by the `--watch` flag
- Docker image: https://github.com/eligao/immich/pkgs/container/immich-cli
