### PR TITLE
fix(mobile): Fixed resolution format in Details

### DIFF
--- a/mobile/lib/widgets/asset_viewer/detail_panel/file_info.dart
+++ b/mobile/lib/widgets/asset_viewer/detail_panel/file_info.dart
@@ -18,7 +18,7 @@ class FileInfo extends StatelessWidget {
     final height = asset.orientatedHeight ?? asset.height;
     final width = asset.orientatedWidth ?? asset.width;
     String resolution =
-        height != null && width != null ? "$height x $width  " : "";
+        height != null && width != null ? "$width x $height  " : "";
     String fileSize = asset.exifInfo?.fileSize != null
         ? formatBytes(asset.exifInfo!.fileSize!)
         : "";


### PR DESCRIPTION
This issue was reported in https://github.com/immich-app/immich/discussions/14920

It looks like the format that the mobile app shows the resolution in `height x width` instead of `width x height`, which conflicts with the web implementation.

<img src="https://github.com/user-attachments/assets/dd26a580-c512-4bcd-acd5-f5d927789737" height="500px" />
