### PR TITLE
fix(mobile): playing a live photo causes the gallery to redraw the wrong image

### DIFF
--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -286,7 +286,7 @@ class GalleryViewerPage extends HookConsumerWidget {
         body: Stack(
           children: [
             PhotoViewGallery.builder(
-              key: ValueKey(isPlayingMotionVideo),
+              key: const ValueKey('gallery'),
               scaleStateChangedCallback: (state) {
                 final asset = ref.read(currentAssetProvider);
                 if (asset == null) {


### PR DESCRIPTION
This fixes an issue (regression?) where playing a live photo would redraw the gallery with a reset index.

To reproduce:
- Open an image via any album/gallery
- Swipe to a new image that is a live photo
- Tap the play icon (or double tap photo) to begin playing
- The gallery resets to the first photo you viewed (with "play" enabled)

This fix just reverts a change from 3053d84e49e2e0a8f7f54c51e5d236d1cdc2a8a2 which set the gallery key to the boolean value of `isPlayingMotionVideo` instead of the static value `gallery`, which resulted in a redraw every time that value changed.

@mertalev , could you confirm that I'm not missing some hidden intent behind the original change? 