### PR TITLE
fix(web): fix input autofocus

### DIFF
--- a/web/src/lib/components/shared-components/settings/setting-input-field.svelte
+++ b/web/src/lib/components/shared-components/settings/setting-input-field.svelte
@@ -63,7 +63,7 @@
   onMount(() => {
     if (autofocus) {
       tick()
-        .then(() => input?.focus())
+        .then(() => setTimeout(() => input?.focus(), 0))
         .catch((_) => {});
     }
   });


### PR DESCRIPTION
applies to tag creation modal, and possibly other places