### PR TITLE
feat(web): Enable selection interactions in folder view

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -756,6 +756,7 @@
   "getting_started": "Getting Started",
   "go_back": "Go back",
   "go_to_search": "Go to search",
+  "go_to_folder": "Go to folder",
   "group_albums_by": "Group albums by...",
   "group_no": "No grouping",
   "group_owner": "Group by owner",

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -31,9 +31,6 @@
     mdiClose,
     mdiEye,
     mdiEyeOff,
-    mdiFolder,
-    mdiFolderEyeOutline,
-    mdiFolderOpen,
     mdiImageOutline,
     mdiInformationOutline,
     mdiPencil,
@@ -48,8 +45,6 @@
   import UserAvatar from '../shared-components/user-avatar.svelte';
   import AlbumListItemDetails from './album-list-item-details.svelte';
   import Portal from '$lib/components/shared-components/portal/portal.svelte';
-  import { page } from '$app/state';
-  import { includes } from 'lodash-es';
 
   interface Props {
     asset: AssetResponseDto;
@@ -382,9 +377,13 @@
           {/if}
         </p>
         {#if showAssetPath}
-          <p class="text-xs opacity-50 break-all pb-2" transition:slide={{ duration: 250 }}>
+          <a
+            href={getAssetFolderHref(asset)}
+            class="text-xs opacity-50 break-all pb-2 hover:dark:text-immich-dark-primary hover:text-immich-primary"
+            transition:slide={{ duration: 250 }}
+          >
             {asset.originalPath}
-          </p>
+          </a>
         {/if}
         {#if (asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth) || asset.exifInfo?.fileSizeInByte}
           <div class="flex gap-2 text-sm">
@@ -404,24 +403,6 @@
         {/if}
       </div>
     </div>
-
-    {#if $preferences.folders.enabled && $preferences.folders.sidebarWeb && !page.url.pathname.includes(AppRoute.FOLDERS)}
-      <a
-        class="flex w-full text-left justify-between place-items-start gap-4 py-4"
-        href={getAssetFolderHref(asset)}
-        title={$t('go_to_folder')}
-        class:hover:dark:text-immich-dark-primary={isOwner}
-        class:hover:text-immich-primary={isOwner}
-      >
-        <div><Icon path={mdiFolderOpen} size="24" /></div>
-
-        <div>
-          <p class="text-pretty flex place-items-center gap-2">
-            {asset.originalPath.split('/').slice(0, -1).join('/')}
-          </p>
-        </div>
-      </a>
-    {/if}
 
     {#if asset.exifInfo?.make || asset.exifInfo?.model || asset.exifInfo?.fNumber}
       <div class="flex gap-4 py-4">

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -377,12 +377,13 @@
           {/if}
         </p>
         {#if showAssetPath}
-          <a
-            href={getAssetFolderHref(asset)}
-            class="text-xs opacity-50 break-all pb-2 hover:dark:text-immich-dark-primary hover:text-immich-primary"
-            transition:slide={{ duration: 250 }}
-          >
-            {asset.originalPath}
+          <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')}>
+            <p
+              class="text-xs opacity-50 break-all pb-2 hover:dark:text-immich-dark-primary hover:text-immich-primary"
+              transition:slide={{ duration: 250 }}
+            >
+              {asset.originalPath}
+            </p>
           </a>
         {/if}
         {#if (asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth) || asset.exifInfo?.fileSizeInByte}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -31,6 +31,9 @@
     mdiClose,
     mdiEye,
     mdiEyeOff,
+    mdiFolder,
+    mdiFolderEyeOutline,
+    mdiFolderOpen,
     mdiImageOutline,
     mdiInformationOutline,
     mdiPencil,
@@ -45,6 +48,8 @@
   import UserAvatar from '../shared-components/user-avatar.svelte';
   import AlbumListItemDetails from './album-list-item-details.svelte';
   import Portal from '$lib/components/shared-components/portal/portal.svelte';
+  import { page } from '$app/state';
+  import { includes } from 'lodash-es';
 
   interface Props {
     asset: AssetResponseDto;
@@ -130,6 +135,14 @@
       unassignedFaces = data?.unassignedFaces || [];
     });
     showEditFaces = false;
+  };
+
+  const getAssetFolderHref = (asset: AssetResponseDto) => {
+    const folderUrl = new URL(AppRoute.FOLDERS, globalThis.location.href);
+    // Remove the last part of the path to get the parent path
+    const assetParentPath = asset.originalPath.split('/').slice(0, -1).join('/');
+    folderUrl.searchParams.set(QueryParameter.PATH, assetParentPath);
+    return folderUrl.href;
   };
 
   const toggleAssetPath = () => (showAssetPath = !showAssetPath);
@@ -391,6 +404,24 @@
         {/if}
       </div>
     </div>
+
+    {#if $preferences.folders.enabled && $preferences.folders.sidebarWeb && !page.url.pathname.includes(AppRoute.FOLDERS)}
+      <a
+        class="flex w-full text-left justify-between place-items-start gap-4 py-4"
+        href={getAssetFolderHref(asset)}
+        title={$t('go_to_folder')}
+        class:hover:dark:text-immich-dark-primary={isOwner}
+        class:hover:text-immich-primary={isOwner}
+      >
+        <div><Icon path={mdiFolderOpen} size="24" /></div>
+
+        <div>
+          <p class="text-pretty flex place-items-center gap-2">
+            {asset.originalPath.split('/').slice(0, -1).join('/')}
+          </p>
+        </div>
+      </a>
+    {/if}
 
     {#if asset.exifInfo?.make || asset.exifInfo?.model || asset.exifInfo?.fNumber}
       <div class="flex gap-4 py-4">

--- a/web/src/lib/stores/folders.svelte.ts
+++ b/web/src/lib/stores/folders.svelte.ts
@@ -27,6 +27,17 @@ class FoldersStore {
     this.uniquePaths.sort();
   }
 
+  bustAssetCache() {
+    this.assets = {};
+  }
+
+  async refreshAssetsByPath(path: string | null) {
+    if (!path) {
+      return;
+    }
+    this.assets[path] = await getAssetsByOriginalPath({ path });
+  }
+
   async fetchAssetsByPath(path: string) {
     if (this.assets[path]) {
       return;

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto, invalidate, invalidateAll } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/stores';
   import UserPageLayout, { headerId } from '$lib/components/layouts/user-page-layout.svelte';
   import GalleryViewer from '$lib/components/shared-components/gallery-viewer/gallery-viewer.svelte';

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -19,6 +19,10 @@ export const load = (async ({ params, url }) => {
   if (path) {
     await foldersStore.fetchAssetsByPath(path);
     pathAssets = foldersStore.assets[path] || null;
+  } else {
+    // If no path is provided, we we're at the root level
+    // We should bust the asset cache of the folder store, to make sure we don't show stale data
+    foldersStore.bustAssetCache();
   }
 
   let tree = buildTree(foldersStore.uniquePaths);


### PR DESCRIPTION
So I don't know if this was intentionally omitted, or just wasn't implemented yet.

I hope it's the latter, since I would find this very useful, aswell as a few other people in #14307

I haven't been able to test it completely, since I'm on windows and my bind mounts seem to be a lil fucked up, resulting in folders with only one image in it, so some other testers would be greatly appreciated.

If this was indeed intentionally omitted, feel free to close the PR

#### Edit
I also added a button in the Asset View Detail Pane that links to the containing folder. That way, when you open an asset from the timeline or search, you can jump straight into the folder view to the correct folder.

This button only shows up, if folders are enabled and the Folder sidebar link is also activated.

Closes #14307