### PR TITLE
feat(web): Swipe down shows slideshow controlbar on mobile

### DIFF
--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -7,6 +7,7 @@
   import { SlideshowNavigation, slideshowStore } from '$lib/stores/slideshow.store';
   import { mdiChevronLeft, mdiChevronRight, mdiClose, mdiCog, mdiFullscreen, mdiPause, mdiPlay } from '@mdi/js';
   import { onDestroy, onMount } from 'svelte';
+  import { swipe } from 'svelte-gestures';
   import { t } from 'svelte-i18n';
   import { fly } from 'svelte/transition';
 
@@ -107,6 +108,8 @@
     { shortcut: { key: 'ArrowRight' }, onShortcut: onNext },
   ]}
 />
+
+<svelte:body use:swipe on:swipedown={showControlBar} />
 
 {#if showControls}
   <div


### PR DESCRIPTION
## Description

Currently, it's impossible to make the slideshow control bar appear again on the web using a mobile phone without a mouse.
With this little PR, the users make the bar appear again with a swipe down gesture

## How I tested

Just tried the swipe gesture on mobile, the other gestures are still working.

![IMG_0262](https://github.com/user-attachments/assets/f1d2d5ac-ae22-49cf-a17b-59daa566c265)
