### PR TITLE
feat(mobile): add ability to force view original videos

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -527,6 +527,8 @@
   "settings_require_restart": "Please restart Immich to apply this setting",
   "setting_video_viewer_looping_subtitle": "Enable to automatically loop a video in the detail viewer.",
   "setting_video_viewer_looping_title": "Looping",
+  "setting_video_viewer_original_video_title": "Force original video",
+  "setting_video_viewer_original_video_subtitle": "Enable to force the original video to be played in the detail viewer.",
   "setting_video_viewer_title": "Videos",
   "share_add": "Add",
   "share_add_photos": "Add photos",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -528,7 +528,7 @@
   "setting_video_viewer_looping_subtitle": "Enable to automatically loop a video in the detail viewer.",
   "setting_video_viewer_looping_title": "Looping",
   "setting_video_viewer_original_video_title": "Force original video",
-  "setting_video_viewer_original_video_subtitle": "Enable to force the original video to be played in the detail viewer.",
+  "setting_video_viewer_original_video_subtitle": "When streaming a video from the server, play the original even when a transcode is available. May lead to buffering. Videos available locally are played in original quality regardless of this setting.",
   "setting_video_viewer_title": "Videos",
   "share_add": "Add",
   "share_add_photos": "Add photos",

--- a/mobile/lib/entities/store.entity.dart
+++ b/mobile/lib/entities/store.entity.dart
@@ -242,6 +242,9 @@ enum StoreKey<T> {
   preferredWifiName<String>(133, type: String),
   localEndpoint<String>(134, type: String),
   externalEndpointList<String>(135, type: String),
+
+  // Video settings
+  loadOriginalVideo<bool>(136, type: bool),
   ;
 
   const StoreKey(

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -53,6 +53,7 @@ class NativeVideoViewerPage extends HookConsumerWidget {
 
     final log = Logger('NativeVideoViewerPage');
 
+
     Future<VideoSource?> createSource() async {
       if (!context.mounted) {
         return null;
@@ -75,9 +76,14 @@ class NativeVideoViewerPage extends HookConsumerWidget {
 
         // Use a network URL for the video player controller
         final serverEndpoint = Store.get(StoreKey.serverEndpoint);
+        final isOriginalVideo = ref
+            .read(appSettingsServiceProvider)
+            .getSetting<bool>(AppSettingsEnum.loadOriginalVideo);
+        final String postfixUrl =
+            isOriginalVideo ? 'original' : 'video/playback';
         final String videoUrl = asset.livePhotoVideoId != null
-            ? '$serverEndpoint/assets/${asset.livePhotoVideoId}/video/playback'
-            : '$serverEndpoint/assets/${asset.remoteId}/video/playback';
+            ? '$serverEndpoint/assets/${asset.livePhotoVideoId}/$postfixUrl'
+            : '$serverEndpoint/assets/${asset.remoteId}/$postfixUrl';
 
         final source = await VideoSource.init(
           path: videoUrl,

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -53,7 +53,6 @@ class NativeVideoViewerPage extends HookConsumerWidget {
 
     final log = Logger('NativeVideoViewerPage');
 
-
     Future<VideoSource?> createSource() async {
       if (!context.mounted) {
         return null;

--- a/mobile/lib/services/app_settings.service.dart
+++ b/mobile/lib/services/app_settings.service.dart
@@ -63,6 +63,11 @@ enum AppSettingsEnum<T> {
   logLevel<int>(StoreKey.logLevel, null, 5), // Level.INFO = 5
   preferRemoteImage<bool>(StoreKey.preferRemoteImage, null, false),
   loopVideo<bool>(StoreKey.loopVideo, "loopVideo", true),
+  loadOriginalVideo<bool>(
+    StoreKey.loadOriginalVideo,
+    "loadOriginalVideo",
+    false,
+  ),
   mapThemeMode<int>(StoreKey.mapThemeMode, null, 0),
   mapShowFavoriteOnly<bool>(StoreKey.mapShowFavoriteOnly, null, false),
   mapIncludeArchived<bool>(StoreKey.mapIncludeArchived, null, false),

--- a/mobile/lib/widgets/settings/asset_viewer_settings/video_viewer_settings.dart
+++ b/mobile/lib/widgets/settings/asset_viewer_settings/video_viewer_settings.dart
@@ -15,6 +15,8 @@ class VideoViewerSettings extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final useLoopVideo = useAppSettingsState(AppSettingsEnum.loopVideo);
+    final useOriginalVideo =
+        useAppSettingsState(AppSettingsEnum.loadOriginalVideo);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -24,6 +26,12 @@ class VideoViewerSettings extends HookConsumerWidget {
           valueNotifier: useLoopVideo,
           title: "setting_video_viewer_looping_title".tr(),
           subtitle: "setting_video_viewer_looping_subtitle".tr(),
+          onChanged: (_) => ref.invalidate(appSettingsServiceProvider),
+        ),
+        SettingsSwitchListTile(
+          valueNotifier: useOriginalVideo,
+          title: "setting_video_viewer_original_video_title".tr(),
+          subtitle: "setting_video_viewer_original_video_subtitle".tr(),
           onChanged: (_) => ref.invalidate(appSettingsServiceProvider),
         ),
       ],


### PR DESCRIPTION
Hi there, I discovered some interesting use case with AV1 videos on older (iphone 14 and below) devices: https://github.com/immich-app/immich/discussions/15048

If I transcode my library to av1, (which I do becouse browsers don't support original .MOV files) I lose ability to view videos on my iphone, it tries to open av1, but video doesn't work (shows a single frame with audio).  

With this PR user still would be able to view original high quality HDR .MOV videos natively supported on iphone and also would be able to access transcoded videos in browsers.

This is my first PR so feel free to comment any uncertainties.