### PR TITLE
docs: Add disable iOS low power mode suggestion 

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -49,7 +49,7 @@ The behaviors differ based on your device manufacturer and operating system, but
 On iOS (iPhone and iPad), the operating system determines if a particular app can invoke background tasks based on multiple factors, most of which the Immich app has no control over. To increase the likelihood that the background backup task is run, follow the steps below:
 
 - Enable Background App Refresh for Immich in the iOS settings at `Settings > General > Background App Refresh`.
-- Disable low power mode when not needed as this can reduce the amount apps can do in the background.
+- Disable **Low Power Mode** when not needed, as this can prevent apps from running in the background.
 - Disable Background App Refresh for apps that don't need background tasks to run. This will reduce the competition for background task invocation for Immich.
 - Use the Immich app more often.
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -49,6 +49,7 @@ The behaviors differ based on your device manufacturer and operating system, but
 On iOS (iPhone and iPad), the operating system determines if a particular app can invoke background tasks based on multiple factors, most of which the Immich app has no control over. To increase the likelihood that the background backup task is run, follow the steps below:
 
 - Enable Background App Refresh for Immich in the iOS settings at `Settings > General > Background App Refresh`.
+- Disable low power mode
 - Disable Background App Refresh for apps that don't need background tasks to run. This will reduce the competition for background task invocation for Immich.
 - Use the Immich app more often.
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -49,7 +49,7 @@ The behaviors differ based on your device manufacturer and operating system, but
 On iOS (iPhone and iPad), the operating system determines if a particular app can invoke background tasks based on multiple factors, most of which the Immich app has no control over. To increase the likelihood that the background backup task is run, follow the steps below:
 
 - Enable Background App Refresh for Immich in the iOS settings at `Settings > General > Background App Refresh`.
-- Disable low power mode
+- Disable low power mode when not needed as this can reduce the amount apps can do in the background.
 - Disable Background App Refresh for apps that don't need background tasks to run. This will reduce the competition for background task invocation for Immich.
 - Use the Immich app more often.
 


### PR DESCRIPTION
Just added the suggestion under "Why is background backup on iOS not working?" to also disable low power mode.
I've seen so many people who just have low power mode permanently on, but this can affect background app refresh (https://support.apple.com/en-us/101604)