### PR TITLE
fix: reverse geocoding data import don't use unlogged tables

### DIFF
--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -178,7 +178,7 @@ export class MapRepository implements IMapRepository {
 
     await this.dataSource.query('DROP TABLE IF EXISTS naturalearth_countries_tmp');
     await this.dataSource.query(
-      'CREATE UNLOGGED TABLE naturalearth_countries_tmp (LIKE naturalearth_countries INCLUDING ALL EXCLUDING INDEXES)',
+      'CREATE TABLE naturalearth_countries_tmp (LIKE naturalearth_countries INCLUDING ALL EXCLUDING INDEXES)',
     );
     const entities: Omit<NaturalEarthCountriesTempEntity, 'id'>[] = [];
     for (const feature of geoJSONData.features) {
@@ -216,7 +216,7 @@ export class MapRepository implements IMapRepository {
 
     await this.dataSource.query('DROP TABLE IF EXISTS geodata_places_tmp');
     await this.dataSource.query(
-      'CREATE UNLOGGED TABLE geodata_places_tmp (LIKE geodata_places INCLUDING ALL EXCLUDING INDEXES)',
+      'CREATE TABLE geodata_places_tmp (LIKE geodata_places INCLUDING ALL EXCLUDING INDEXES)',
     );
     await this.loadCities500(admin1, admin2);
     await this.createGeodataIndices();


### PR DESCRIPTION
Using unlogged tables can mean if the database crashes or system hard resets before the database flushes to disk, the data in the unlogged reverse geocoding tables was lost and unrecoverable because there is no WAL. This is also more likely due to the resource intensive nature of the import and indexing process, as well as lots of jobs potentially starting on boot.

Performance implications of this change were minimal on my dev machine, import time changed from 6 seconds to 7 seconds for the rows (excluding indexing time which remained the same).

I also managed to reproduce this problem by force killing the database container straight after the import completed, which resulted in an empty table.