### PR TITLE
fix(server): email cannot render with pretty flag

### DIFF
--- a/server/src/repositories/notification.repository.ts
+++ b/server/src/repositories/notification.repository.ts
@@ -33,7 +33,7 @@ export class NotificationRepository implements INotificationRepository {
 
   async renderEmail(request: EmailRenderRequest): Promise<{ html: string; text: string }> {
     const component = this.render(request);
-    const html = await render(component, { pretty: true });
+    const html = await render(component, { pretty: false });
     const text = await render(component, { plainText: true });
     return { html, text };
   }


### PR DESCRIPTION
Something is up with pumping the react-email in #14755, so using the flag will trigger an error when rendering the email. There is no observable difference in the rendered email.

Fixes #15154
