### PR TITLE
fix: invert asset path link nesting

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -377,14 +377,14 @@
           {/if}
         </p>
         {#if showAssetPath}
-          <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')}>
-            <p
-              class="text-xs opacity-50 break-all pb-2 hover:dark:text-immich-dark-primary hover:text-immich-primary"
-              transition:slide={{ duration: 250 }}
-            >
+          <p
+            class="text-xs opacity-50 break-all pb-2 hover:dark:text-immich-dark-primary hover:text-immich-primary"
+            transition:slide={{ duration: 250 }}
+          >
+            <a href={getAssetFolderHref(asset)} title={$t('go_to_folder')}>
               {asset.originalPath}
-            </p>
-          </a>
+            </a>
+          </p>
         {/if}
         {#if (asset.exifInfo?.exifImageHeight && asset.exifInfo?.exifImageWidth) || asset.exifInfo?.fileSizeInByte}
           <div class="flex gap-2 text-sm">


### PR DESCRIPTION
With the previous nesting, selecting the path text to copy it was challenging as the whole element was clickable.

rel: #15161