### PR TITLE
feat(mobile): Update native_video_player

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1012,8 +1012,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ac78487
-      resolved-ref: ac78487b9a87c9e72cd15b428270a905ac551f29
+      ref: 15919e0
+      resolved-ref: 15919e015b7f871af31c8b7055e1693d04787479
       url: "https://github.com/immich-app/native_video_player"
     source: git
     version: "1.3.1"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   native_video_player:
     git:
       url: https://github.com/immich-app/native_video_player
-      ref: ac78487
+      ref: 15919e0
 
   #image editing packages
   crop_image: ^1.0.13


### PR DESCRIPTION
Hello. 
It would be cool to play HLS/DASH streams (instead of transcoded videos) using Immich app on Android (as I know it's supported on iOS).

Please note that this pull request requires to update native_video_player package: https://github.com/immich-app/native_video_player/pull/6