### PR TITLE
fix(web): Reset asset selection when refreshing and changing folder

### DIFF
--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -46,8 +46,6 @@
   let currentPath = $derived($page.url.searchParams.get(QueryParameter.PATH) || '');
   let currentTreeItems = $derived(currentPath ? data.currentFolders : Object.keys(tree));
 
-  $inspect(data).with(console.log);
-
   const assetInteraction = new AssetInteraction();
 
   onMount(async () => {
@@ -66,9 +64,18 @@
     return url.href;
   };
 
+  $effect(() => {
+    // Clear the asset selection when the path changes
+    // Reference the currentPath to trigger the effect
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    currentPath;
+    cancelMultiselect(assetInteraction);
+  });
+
   const navigateToView = (path: string) => goto(getLink(path));
 
   const triggerAssetUpdate = async () => {
+    cancelMultiselect(assetInteraction);
     await foldersStore.refreshAssetsByPath(data.path);
     await invalidateAll();
   };
@@ -91,8 +98,8 @@
       <CreateSharedLink />
       <CircleIconButton title={$t('select_all')} icon={mdiSelectAll} onclick={handleSelectAll} />
       <ButtonContextMenu icon={mdiPlus} title={$t('add_to')}>
-        <AddToAlbum />
-        <AddToAlbum shared />
+        <AddToAlbum onAddToAlbum={() => cancelMultiselect(assetInteraction)} />
+        <AddToAlbum onAddToAlbum={() => cancelMultiselect(assetInteraction)} shared />
       </ButtonContextMenu>
       <FavoriteAction removeFavorite={assetInteraction.isAllFavorite} onFavorite={triggerAssetUpdate} />
 

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto, invalidateAll } from '$app/navigation';
+  import { afterNavigate, goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/stores';
   import UserPageLayout, { headerId } from '$lib/components/layouts/user-page-layout.svelte';
   import GalleryViewer from '$lib/components/shared-components/gallery-viewer/gallery-viewer.svelte';
@@ -64,11 +64,8 @@
     return url.href;
   };
 
-  $effect(() => {
-    // Clear the asset selection when the path changes
-    // Reference the currentPath to trigger the effect
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    currentPath;
+  afterNavigate(() => {
+    // Clear the asset selection when we navigate (like going to another folder)
     cancelMultiselect(assetInteraction);
   });
 


### PR DESCRIPTION
Fixes #15177 

Asset selection in folder view now gets cleared when:
- Assets are updated
- Assets are added to Albums
- navigating to other folder