### PR TITLE
feat(mobile): auto api endpoint

### DIFF
--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -94,9 +94,8 @@ class LoginForm extends HookConsumerWidget {
         );
       }
 
-      // Automatically add /api to URL
-      if (!serverUrl.endsWith('/api') && 
-          !serverUrl.endsWith('/api/')) {
+      // Automatically add /api to URL if missing
+      if (!serverUrl.endsWith('/api') || serverUrl.endsWith('/api/')) {
         if (!serverUrl.endsWith('/')) {
           serverUrl = String($sanitizedUrl + '/api');
         }

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -98,9 +98,9 @@ class LoginForm extends HookConsumerWidget {
       if (!serverUrl.endsWith('/api') && 
           !serverUrl.endsWith('/api/')) {
         if (!serverUrl.endsWith('/')) {
-          serverUrl = String($sanitizedUrl + '/api/');
+          serverUrl = String($sanitizedUrl + '/api');
         }
-        serverUrl = String($sanitizedUrl + 'api/');
+        serverUrl = String($sanitizedUrl + 'api');
       }
 
 

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -94,12 +94,14 @@ class LoginForm extends HookConsumerWidget {
         );
       }
 
-      // Automatically add /api to URL if missing
-      if (!serverUrl.endsWith('/api') || serverUrl.endsWith('/api/')) {
-        if (!serverUrl.endsWith('/')) {
-          serverUrl = String($sanitizedUrl + '/api');
-        }
-        serverUrl = String($sanitizedUrl + 'api');
+      // Automatically add /api to serverUrl if missing
+      serverUrl = serverUrl.trim();
+
+      // Check if the string ends with '/api/' and remove the trailing slash if it does or add '/api' if the string doesn't end with '/api'
+      if (serverUrl.endsWith('/api/')) {
+        serverUrl = serverUrl.substring(0, serverUrl.length - 1);
+      } else if (!serverUrl.endsWith('/api')) {
+        serverUrl = '$serverUrl/api';
       }
 
 

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -94,6 +94,16 @@ class LoginForm extends HookConsumerWidget {
         );
       }
 
+      // Automatically add /api to URL
+      if (!serverUrl.endsWith('/api') && 
+          !serverUrl.endsWith('/api/')) {
+        if (!serverUrl.endsWith('/')) {
+          serverUrl = String($sanitizedUrl + '/api/');
+        }
+        serverUrl = String($sanitizedUrl + 'api/');
+      }
+
+
       try {
         isLoadingServer.value = true;
         final endpoint =


### PR DESCRIPTION
## Code Addition: Automatically Adjust `serverUrl` with `/api`

This code addition ensures that the `serverUrl` string is correctly formatted to include `/api` at the end if it is missing, or remove any extra trailing slashes if the URL already ends with `/api/`.

### Explanation

- **Trimming Whitespace:**  
  The `serverUrl` is trimmed of any leading or trailing whitespace using `serverUrl.trim()`. This ensures there are no accidental spaces that could cause issues when checking or modifying the URL.

- **Handling `/api/` and `/api`:**  
  The logic checks if the `serverUrl` ends with `/api/`. If it does, the trailing slash is removed to standardize the URL format.
  
  If the `serverUrl` does not end with `/api`, the code appends `/api` to the URL. This ensures that the URL always contains `/api` at the end when needed.

### Example Workflow

1. If `serverUrl = "http://example.com/api/"`, it will be trimmed to `http://example.com/api`.
2. If `serverUrl = "http://example.com"`, it will be changed to `http://example.com/api`.
3. If `serverUrl = "http://example.com/api"`, it will remain unchanged.

This addition helps prevent issues with inconsistent server URLs by ensuring they always contain the proper `/api` endpoint suffix. Additionally this alleviates confusion when inviting friends/family to use your Immich server and you wish to just share your server URL without the /api at the end.