### PR TITLE
feat(mobile): Add HLS & DASH support to app

### DIFF
--- a/mobile/lib/models/server_info/server_features.model.dart
+++ b/mobile/lib/models/server_info/server_features.model.dart
@@ -5,12 +5,14 @@ class ServerFeatures {
   final bool map;
   final bool oauthEnabled;
   final bool passwordLogin;
+  final String streamingType;
 
   const ServerFeatures({
     required this.trash,
     required this.map,
     required this.oauthEnabled,
     required this.passwordLogin,
+    required this.streamingType
   });
 
   ServerFeatures copyWith({
@@ -18,25 +20,28 @@ class ServerFeatures {
     bool? map,
     bool? oauthEnabled,
     bool? passwordLogin,
+    String? streamingType
   }) {
     return ServerFeatures(
-      trash: trash ?? this.trash,
-      map: map ?? this.map,
-      oauthEnabled: oauthEnabled ?? this.oauthEnabled,
-      passwordLogin: passwordLogin ?? this.passwordLogin,
+        trash: trash ?? this.trash,
+        map: map ?? this.map,
+        oauthEnabled: oauthEnabled ?? this.oauthEnabled,
+        passwordLogin: passwordLogin ?? this.passwordLogin,
+        streamingType: streamingType ?? this.streamingType
     );
   }
 
   @override
   String toString() {
-    return 'ServerFeatures(trash: $trash, map: $map, oauthEnabled: $oauthEnabled, passwordLogin: $passwordLogin)';
+    return 'ServerFeatures(trash: $trash, map: $map, oauthEnabled: $oauthEnabled, passwordLogin: $passwordLogin, streamingType: $streamingType)';
   }
 
   ServerFeatures.fromDto(ServerFeaturesDto dto)
       : trash = dto.trash,
         map = dto.map,
         oauthEnabled = dto.oauth,
-        passwordLogin = dto.passwordLogin;
+        passwordLogin = dto.passwordLogin,
+        streamingType = dto.streaming;
 
   @override
   bool operator ==(covariant ServerFeatures other) {
@@ -45,14 +50,16 @@ class ServerFeatures {
     return other.trash == trash &&
         other.map == map &&
         other.oauthEnabled == oauthEnabled &&
+        other.streamingType == streamingType &&
         other.passwordLogin == passwordLogin;
   }
 
   @override
   int get hashCode {
     return trash.hashCode ^
-        map.hashCode ^
-        oauthEnabled.hashCode ^
-        passwordLogin.hashCode;
+    map.hashCode ^
+    oauthEnabled.hashCode ^
+    passwordLogin.hashCode ^
+    streamingType.hashCode;
   }
 }

--- a/mobile/lib/models/server_info/server_info.model.dart
+++ b/mobile/lib/models/server_info/server_info.model.dart
@@ -13,16 +13,15 @@ class ServerInfo {
   final bool isNewReleaseAvailable;
   final String versionMismatchErrorMessage;
 
-  ServerInfo({
-    required this.serverVersion,
-    required this.latestVersion,
-    required this.serverFeatures,
-    required this.serverConfig,
-    required this.serverDiskInfo,
-    required this.isVersionMismatch,
-    required this.isNewReleaseAvailable,
-    required this.versionMismatchErrorMessage,
-  });
+  ServerInfo(
+      {required this.serverVersion,
+      required this.latestVersion,
+      required this.serverFeatures,
+      required this.serverConfig,
+      required this.serverDiskInfo,
+      required this.isVersionMismatch,
+      required this.isNewReleaseAvailable,
+      required this.versionMismatchErrorMessage});
 
   ServerInfo copyWith({
     ServerVersion? serverVersion,

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/services/asset.service.dart';
 import 'package:immich_mobile/utils/debounce.dart';
 import 'package:immich_mobile/utils/hooks/interval_hook.dart';
 import 'package:immich_mobile/widgets/asset_viewer/custom_video_player_controls.dart';
+import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:logging/logging.dart';
 import 'package:native_video_player/native_video_player.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -79,10 +80,18 @@ class NativeVideoViewerPage extends HookConsumerWidget {
             ? '$serverEndpoint/assets/${asset.livePhotoVideoId}/video/playback'
             : '$serverEndpoint/assets/${asset.remoteId}/video/playback';
 
+        var headers = ApiService.getRequestHeaders();
+        final serverInfo = ref.read(serverInfoProvider);
+        var type = VideoSourceType.network;
+        if(serverInfo.serverFeatures.streamingType == "hls") {
+          type = VideoSourceType.hls;
+        } else if(serverInfo.serverFeatures.streamingType == "dash") {
+          type = VideoSourceType.dash;
+        }
         final source = await VideoSource.init(
           path: videoUrl,
-          type: VideoSourceType.network,
-          headers: ApiService.getRequestHeaders(),
+          type: type,
+          headers: headers,
         );
         return source;
       } catch (error) {

--- a/mobile/lib/providers/server_info.provider.dart
+++ b/mobile/lib/providers/server_info.provider.dart
@@ -29,6 +29,7 @@ class ServerInfoNotifier extends StateNotifier<ServerInfo> {
               trash: true,
               oauthEnabled: false,
               passwordLogin: true,
+              streamingType: ""
             ),
             serverConfig: const ServerConfig(
               trashDays: 30,

--- a/mobile/openapi/lib/model/server_features_dto.dart
+++ b/mobile/openapi/lib/model/server_features_dto.dart
@@ -26,6 +26,7 @@ class ServerFeaturesDto {
     required this.search,
     required this.sidecar,
     required this.smartSearch,
+    required this.streaming,
     required this.trash,
   });
 
@@ -55,6 +56,8 @@ class ServerFeaturesDto {
 
   bool smartSearch;
 
+  String streaming;
+
   bool trash;
 
   @override
@@ -72,6 +75,7 @@ class ServerFeaturesDto {
     other.search == search &&
     other.sidecar == sidecar &&
     other.smartSearch == smartSearch &&
+    other.streaming == streaming &&
     other.trash == trash;
 
   @override
@@ -90,10 +94,11 @@ class ServerFeaturesDto {
     (search.hashCode) +
     (sidecar.hashCode) +
     (smartSearch.hashCode) +
+    (streaming.hashCode) +
     (trash.hashCode);
 
   @override
-  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, passwordLogin=$passwordLogin, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, trash=$trash]';
+  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, passwordLogin=$passwordLogin, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, streaming=$streaming, trash=$trash]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -110,6 +115,7 @@ class ServerFeaturesDto {
       json[r'search'] = this.search;
       json[r'sidecar'] = this.sidecar;
       json[r'smartSearch'] = this.smartSearch;
+      json[r'streaming'] = this.streaming;
       json[r'trash'] = this.trash;
     return json;
   }
@@ -136,6 +142,7 @@ class ServerFeaturesDto {
         search: mapValueOfType<bool>(json, r'search')!,
         sidecar: mapValueOfType<bool>(json, r'sidecar')!,
         smartSearch: mapValueOfType<bool>(json, r'smartSearch')!,
+        streaming: mapValueOfType<String>(json, r'streaming')!,
         trash: mapValueOfType<bool>(json, r'trash')!,
       );
     }
@@ -197,6 +204,7 @@ class ServerFeaturesDto {
     'search',
     'sidecar',
     'smartSearch',
+    'streaming',
     'trash',
   };
 }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11060,6 +11060,9 @@
           "smartSearch": {
             "type": "boolean"
           },
+          "streaming": {
+            "type": "string"
+          },
           "trash": {
             "type": "boolean"
           }
@@ -11078,6 +11081,7 @@
           "search",
           "sidecar",
           "smartSearch",
+          "streaming",
           "trash"
         ],
         "type": "object"

--- a/server/src/dtos/server.dto.ts
+++ b/server/src/dtos/server.dto.ts
@@ -164,6 +164,7 @@ export class ServerFeaturesDto {
   sidecar!: boolean;
   search!: boolean;
   email!: boolean;
+  streaming!: string;
 }
 
 export interface ReleaseNotification {

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -89,6 +89,7 @@ export class ServerService extends BaseService {
       passwordLogin: passwordLogin.enabled,
       configFile: !!configFile,
       email: notifications.smtp.enabled,
+      streaming: ""
     };
   }
 


### PR DESCRIPTION
Hello. 
This code adds support for HLS/DASH streams (instead of transcoded videos) using Immich app on Android (as I know it's supported on iOS).
There is currently no code for server-side. Personally I use (maybe bad) workaround with Nginx-RTMP with forked Immich server.

I closed recent pull request because it required to update much more code than I actually excepted.
Please note that this pull request requires to update native_video_player package: https://github.com/immich-app/native_video_player/pull/6