### PR TITLE
fix(mobile): don't crash android app when video player throws exception

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1012,8 +1012,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: ac78487
-      resolved-ref: ac78487b9a87c9e72cd15b428270a905ac551f29
+      ref: "4530808"
+      resolved-ref: "4530808a6d04c9992de184c423c9e87fbf6a53eb"
       url: "https://github.com/immich-app/native_video_player"
     source: git
     version: "1.3.1"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   native_video_player:
     git:
       url: https://github.com/immich-app/native_video_player
-      ref: ac78487
+      ref: '4530808'
 
   #image editing packages
   crop_image: ^1.0.13


### PR DESCRIPTION
## Description

Updates the native_video_player commit ref to include the fix added [here](https://github.com/immich-app/native_video_player/pull/8).