### PR TITLE
chore(server)!: default max bitrate unit to kbps

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1138,6 +1138,22 @@ describe(MediaService.name, () => {
       );
     });
 
+    it('should default max bitrate to kbps if no unit is provided', async () => {
+      mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
+      systemMock.get.mockResolvedValue({ ffmpeg: { maxBitrate: '4500' } });
+      assetMock.getByIds.mockResolvedValue([assetStub.video]);
+      await sut.handleVideoConversion({ id: assetStub.video.id });
+      expect(mediaMock.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        'upload/encoded-video/user-id/as/se/asset-id.mp4',
+        expect.objectContaining({
+          inputOptions: expect.any(Array),
+          outputOptions: expect.arrayContaining(['-c:v h264', '-maxrate 4500k', '-bufsize 9000k']),
+          twoPass: false,
+        }),
+      );
+    });
+
     it('should transcode in two passes for h264/h265 when enabled and max bitrate is above 0', async () => {
       mediaMock.probe.mockResolvedValue(probeStub.matroskaContainer);
       systemMock.get.mockResolvedValue({ ffmpeg: { twoPass: true, maxBitrate: '4500k' } });

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -272,7 +272,7 @@ export class BaseConfig implements VideoCodecSWConfig {
 
   getBitrateUnit() {
     const maxBitrate = this.getMaxBitrateValue();
-    return this.config.maxBitrate.trim().slice(maxBitrate.toString().length); // use inputted unit if provided
+    return this.config.maxBitrate.trim().slice(maxBitrate.toString().length) || 'k'; // use inputted unit if provided, else default to kbps
   }
 
   getMaxBitrateValue() {


### PR DESCRIPTION
## Description

The max bitrate can be set with different units at the end. However, if no unit is provided, the default is to interpret it as bytes. This is almost definitely not what they meant; it's better to assume kbps instead.