### PR TITLE
fix(docs): Fix link label to refer to correct location on page

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -282,7 +282,7 @@ The initial backup is the most intensive due to the number of jobs running. The 
   - For facial recognition on new images to work properly, You must re-run the Face Detection job for all images after this.
 - At the container level, you can [set resource constraints](/docs/FAQ#can-i-limit-cpu-and-ram-usage) to lower usage further.
   - It's recommended to only apply these constraints _after_ taking some of the measures here for best performance.
-- If these changes are not enough, see [below](/docs/FAQ#how-can-i-disable-machine-learning) for instructions on how to disable machine learning.
+- If these changes are not enough, see [above](/docs/FAQ#how-can-i-disable-machine-learning) for instructions on how to disable machine learning.
 
 ### Can I limit CPU and RAM usage?
 


### PR DESCRIPTION
Within the "Can I lower CPU and RAM usage?" section on the documentation's FAQ page, the label on the link that leads to instructions on disabling machine learning refers to seeing "below" for instructions, rather than "above", which should be the correct reference, since the linked section appears prior to "Can I lower CPU and RAM usage?".