### PR TITLE
feat(web): Context menu scrolls on small devices

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/context-menu.svelte
@@ -65,9 +65,9 @@
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledBy}
     bind:this={menuElement}
-    class:max-h-[100vh]={isVisible}
-    class:max-h-0={!isVisible}
-    class="flex flex-col transition-all duration-[250ms] ease-in-out outline-none"
+    class="{isVisible
+      ? 'max-h-screen max-h-svh'
+      : 'max-h-0'} flex flex-col transition-all duration-[250ms] ease-in-out outline-none overflow-auto"
     role="menu"
     tabindex="-1"
   >


### PR DESCRIPTION
# Description

Context menu can scroll on small devices

## Screenshots

This is **before** the change

![before](https://github.com/user-attachments/assets/4580a15b-1673-4d21-ac25-412da53d9926)

This is **after** the change

![after](https://github.com/user-attachments/assets/83b071e1-d503-443c-9ca7-76c2a290fa7f)

## How I tested

Tested on:

- Android Samsung Galaxy S10e device 
- iPhone 12 Pro
- Macbook Pro (to check nothing breaks on bigger screen)

