### PR TITLE
chore: use port 2286 for the auth server

### DIFF
--- a/e2e/src/api/specs/oauth.e2e-spec.ts
+++ b/e2e/src/api/specs/oauth.e2e-spec.ts
@@ -13,8 +13,8 @@ import request from 'supertest';
 import { beforeAll, describe, expect, it } from 'vitest';
 
 const authServer = {
-  internal: 'http://auth-server:3000',
-  external: 'http://127.0.0.1:3000',
+  internal: 'http://auth-server:2286',
+  external: 'http://127.0.0.1:2286',
 };
 
 const mobileOverrideRedirectUri = 'https://photos.immich.app/oauth/mobile-redirect';

--- a/e2e/src/setup/auth-server.ts
+++ b/e2e/src/setup/auth-server.ts
@@ -51,7 +51,7 @@ const setup = async () => {
   const { privateKey, publicKey } = await generateKeyPair('RS256');
 
   const redirectUris = ['http://127.0.0.1:2285/auth/login', 'https://photos.immich.app/oauth/mobile-redirect'];
-  const port = 3000;
+  const port = 2286;
   const host = '0.0.0.0';
   const oidc = new Provider(`http://${host}:${port}`, {
     renderError: async (ctx, out, error) => {


### PR DESCRIPTION
This sometimes conflicts with other stuff I am doing on port 3000 (local immich dev stack uses 3000 for vite)