### PR TITLE
feat: native arm and amd64 server builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,7 +87,6 @@ jobs:
           TAG_NEW=${{ github.event.number == 0 && github.ref_name ||  format('pr-{0}', github.event.number)  }}${{ matrix.suffix }}
           docker buildx imagetools create -t $REGISTRY_NAME/$REPOSITORY:$TAG_NEW $REGISTRY_NAME/$REPOSITORY:$TAG_OLD
 
-
   build_and_push_ml:
     name: Build and Push ML
     needs: pre-job
@@ -195,33 +194,38 @@ jobs:
 
   build_and_push_server:
     name: Build and Push Server
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: pre-job
     if: ${{ needs.pre-job.outputs.should_run_server == 'true' }}
     env:
       image: immich-server
       context: .
       file: server/Dockerfile
+      GHCR_REPO: ghcr.io/${{ github.repository_owner }}/immich-server
+      DOCKER_REPO: altran1502/immich-server
     strategy:
       fail-fast: false
       matrix:
         include:
-          - platforms: linux/amd64,linux/arm64
-            device: cpu
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.4.0
-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.9.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        # Only push to Docker Hub when making a release
-        if: ${{ github.event_name == 'release' }}
         uses: docker/login-action@v3
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -235,16 +239,81 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6.13.0
+        with:
+          context: ${{ env.context }}
+          file: ${{ env.file }}
+          platforms: ${{ matrix.platform }}
+          # Skip pushing when PR from a fork
+          push: ${{ !github.event.pull_request.head.repo.fork }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          outputs: type=image,"name=${{ env.GHCR_REPO }},${{ env.DOCKER_REPO }}",push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            DEVICE=cpu
+            BUILD_ID=${{ github.run_id }}
+            BUILD_IMAGE=${{ github.event_name == 'release' && github.ref_name || steps.metadata.outputs.tags }}
+            BUILD_SOURCE_REF=${{ github.ref_name }}
+            BUILD_SOURCE_COMMIT=${{ github.sha }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_server:
+    name: Merge & Push Server
+    runs-on: ubuntu-latest
+    if: ${{ needs.pre-job.outputs.should_run_server == 'true' && !github.event.pull_request.head.repo.fork }}
+    env:
+      GHCR_REPO: ghcr.io/${{ github.repository_owner }}/immich-server
+      DOCKER_REPO: altran1502/immich-server
+    needs:
+      - build_and_push_server
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Generate docker image tags
-        id: metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
           flavor: |
             # Disable latest tag
             latest=false
           images: |
-            name=ghcr.io/${{ github.repository_owner }}/${{env.image}}
-            name=altran1502/${{env.image}},enable=${{ github.event_name == 'release' }}
+            name=${{ env.GHCR_REPO }}
+            name=${{ env.DOCKER_REPO }},enable=${{ github.event_name == 'release' }}
           tags: |
             # Tag with branch name
             type=ref,event=branch,suffix=${{ matrix.suffix }}
@@ -254,38 +323,16 @@ jobs:
             type=ref,event=tag,suffix=${{ matrix.suffix }}
             type=raw,value=release,enable=${{ github.event_name == 'release' }},suffix=${{ matrix.suffix }}
 
-      - name: Determine build cache output
-        id: cache-target
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Essentially just ignore the cache output (PR can't write to registry cache)
-            echo "cache-to=type=local,dest=/tmp/discard,ignore-error=true" >> $GITHUB_OUTPUT
-          else
-            echo "cache-to=type=registry,mode=max,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{ env.image }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6.13.0
-        with:
-          context: ${{ env.context }}
-          file: ${{ env.file }}
-          platforms: ${{ matrix.platforms }}
-          # Skip pushing when PR from a fork
-          push: ${{ !github.event.pull_request.head.repo.fork }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/immich-build-cache:${{env.image}}
-          cache-to: ${{ steps.cache-target.outputs.cache-to }}
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          build-args: |
-            DEVICE=${{ matrix.device }}
-            BUILD_ID=${{ github.run_id }}
-            BUILD_IMAGE=${{ github.event_name == 'release' && github.ref_name || steps.metadata.outputs.tags }}
-            BUILD_SOURCE_REF=${{ github.ref_name }}
-            BUILD_SOURCE_COMMIT=${{ github.sha }}
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *) \
+            $(printf '${{ env.DOCKER_REPO }}@sha256:%s ' *)
 
   success-check-server:
     name: Docker Build & Push Server Success
-    needs: [build_and_push_server, retag_server]
+    needs: [merge_server, retag_server]
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
Splits the server build into two seperate actions, running on the new native ARM runners, drops build time to around 2-3 minutes.