### PR TITLE
fix(server): searching for multiple people yields false positives

### DIFF
--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -248,7 +248,7 @@ export function hasPeopleCte(db: Kysely<DB>, personIds: string[]) {
       .select('assetId')
       .where('personId', '=', anyUuid(personIds!))
       .groupBy('assetId')
-      .having((eb) => eb.fn.count('personId'), '>=', personIds.length),
+      .having((eb) => eb.fn.count('personId').distinct(), '=', personIds.length),
   );
 }
 


### PR DESCRIPTION
When searching for multiple people, only images with all of those people in them should show up. However, if an image has one person's face detected multiple times it would still show up because the query wasn't counting distinct personIds.