### PR TITLE
feat(server): Allow orientation change via sidecar

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -219,7 +219,7 @@ export class MediaService extends BaseService {
       const colorspace = this.isSRGB(asset) ? Colorspace.SRGB : image.colorspace;
       const processInvalidImages = process.env.IMMICH_PROCESS_INVALID_IMAGES === 'true';
 
-      const orientation = useExtracted && asset.exifInfo?.orientation ? Number(asset.exifInfo.orientation) : undefined;
+      const orientation = asset.exifInfo?.orientation ? Number(asset.exifInfo.orientation) : undefined;
       const decodeOptions = { colorspace, processInvalidImages, size: image.preview.size, orientation };
       const { data, info } = await this.mediaRepository.decodeImage(inputPath, decodeOptions);
 


### PR DESCRIPTION
Without this change, EXIF orientation is taken into account only directly from an asset, or when a RAW file's preview is used for creating thumbnails. This PR allow users to perform orientation changes by manipulating sidecar files, without having to touch the actual asset file.

After changing the orientation in a sidecar file, users have to first refresh the asset's metadata, then regernerate its thumbnails.

This coule be a first step towards providing users means to change an asset's orientation via the UI, which could store this information in the sidecar too. Let me know if you're interested in this at all. Happy to work on this.