### PR TITLE
feat: Add rule on robots.txt to allow robots access og tags

### DIFF
--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,3 +1,8 @@
+# Allow social media access og Tags
+User-agent: *
+Allow: /share/
+Allow: /api/assets/
+
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow: /


### PR DESCRIPTION
Currently, the robots.txt file blocks all bots from accessing the entire website, including the bot that Facebook uses to fetch link previews.

This causes some problems because when users share a link on Facebook, it cannot generate a preview.

In this change, I have excluded the share and assets directories. These directories require a given token for access, so even if bots are allowed, this is not expected to have a significant impact on security.

### Before
![螢幕擷取畫面 2025-01-20 213637](https://github.com/user-attachments/assets/baaf40b4-877f-4410-937d-07e12b89557a)

### After
![螢幕擷取畫面 2025-01-20 213331](https://github.com/user-attachments/assets/44b9744d-d4c1-4e7a-bd6a-437370861fbd)
