### PR TITLE
fix: broken link on monitoring page

### DIFF
--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -68,7 +68,7 @@ After bringing down the containers with `docker compose down` and back up with `
 :::note
 To see exactly what metrics are made available, you can additionally add `8081:8081` to the server container's ports and `8082:8082` to the microservices container's ports.
 Visiting the `/metrics` endpoint for these services will show the same raw data that Prometheus collects.
-To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](../install/environment-variables/#general).
+To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](../../install/environment-variables/#general).
 :::
 
 ### Usage

--- a/docs/docs/features/monitoring.md
+++ b/docs/docs/features/monitoring.md
@@ -68,7 +68,7 @@ After bringing down the containers with `docker compose down` and back up with `
 :::note
 To see exactly what metrics are made available, you can additionally add `8081:8081` to the server container's ports and `8082:8082` to the microservices container's ports.
 Visiting the `/metrics` endpoint for these services will show the same raw data that Prometheus collects.
-To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](../../install/environment-variables/#general).
+To configure these ports see [`IMMICH_API_METRICS_PORT` & `IMMICH_MICROSERVICES_METRICS_PORT`](/docs/install/environment-variables/#general).
 :::
 
 ### Usage


### PR DESCRIPTION
On [the monitoring page](https://immich.app/docs/features/monitoring/) the link for:

```
…see [IMMICH_API_METRICS_PORT & IMMICH_MICROSERVICES_METRICS_PORT](https://immich.app/docs/features/install/environment-variables/#general).
``` 

goes to the wrong page, `/docs/features/install/environment-variables/#general`, it should be `/docs/features/install/environment-variables/#general`. Note the exclusion of the **features** folder.

follow [absolute link style](https://github.com/immich-app/immich/blob/main/docs/docs/features/automatic-backup.md?plain=1#L19) in use already.