### PR TITLE
feat: better spec urls

### DIFF
--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -253,6 +253,8 @@ export const useSwagger = (app: INestApplication, { write }: { write: boolean })
     swaggerOptions: {
       persistAuthorization: true,
     },
+    jsonDocumentUrl: '/api/spec.json',
+    yamlDocumentUrl: '/api/spec.yaml',
     customSiteTitle: 'Immich API Documentation',
   };
 


### PR DESCRIPTION
The API hosts the open api document at `/doc-json`. I can never remember that so I propose changing it to `/api/spec.json`. Since that path is now in the codebase, it's also a lot easier to find/discover.

Technically breaking, although I would be quite surprised to hear that anybody uses it.