### PR TITLE
fix(server): Fix for sorting faces during merging

### DIFF
--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -133,10 +133,6 @@ export class PersonRepository implements IPersonRepository {
       )
       .where('person.ownerId', '=', userId)
       .orderBy('person.isHidden', 'asc')
-      .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
-      .orderBy((eb) => eb.fn.count('asset_faces.assetId'), 'desc')
-      .orderBy(sql`NULLIF(person.name, '')`, sql`asc nulls last`)
-      .orderBy('person.createdAt')
       .having((eb) =>
         eb.or([
           eb('person.name', '!=', ''),
@@ -161,6 +157,10 @@ export class PersonRepository implements IPersonRepository {
           ),
         ),
       )
+      .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
+      .orderBy((eb) => eb.fn.count('asset_faces.assetId'), 'desc')
+      .orderBy(sql`NULLIF(person.name, '')`, sql`asc nulls last`)
+      .orderBy('person.createdAt')
       .$if(!options?.withHidden, (qb) => qb.where('person.isHidden', '=', false))
       .offset(pagination.skip ?? 0)
       .limit(pagination.take + 1)

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -157,10 +157,13 @@ export class PersonRepository implements IPersonRepository {
           ),
         ),
       )
-      .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
-      .orderBy((eb) => eb.fn.count('asset_faces.assetId'), 'desc')
-      .orderBy(sql`NULLIF(person.name, '')`, sql`asc nulls last`)
-      .orderBy('person.createdAt')
+      .$if(!options?.closestFaceAssetId, (qb) =>
+        qb
+          .orderBy(sql`NULLIF(person.name, '') is null`, 'asc')
+          .orderBy((eb) => eb.fn.count('asset_faces.assetId'), 'desc')
+          .orderBy(sql`NULLIF(person.name, '')`, sql`asc nulls last`)
+          .orderBy('person.createdAt'),
+      )
       .$if(!options?.withHidden, (qb) => qb.where('person.isHidden', '=', false))
       .offset(pagination.skip ?? 0)
       .limit(pagination.take + 1)


### PR DESCRIPTION
The order of the orderBy clauses means that the distance is currently being used as the very last tie breaker which will almost never happen. This moves the orderBy for the face distance up ahead of the other oderBys.