### PR TITLE
fix(server): no exif metadata in the deduplication utility

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -306,17 +306,26 @@ order by
 with
   "duplicates" as (
     select
-      "duplicateId",
-      jsonb_agg("assets") as "assets"
+      "assets"."duplicateId",
+      jsonb_agg("asset") as "assets"
     from
       "assets"
+      left join lateral (
+        select
+          "assets".*,
+          "exif" as "exifInfo"
+        from
+          "exif"
+        where
+          "exif"."assetId" = "assets"."id"
+      ) as "asset" on true
     where
-      "ownerId" = $1::uuid
-      and "duplicateId" is not null
-      and "deletedAt" is null
-      and "isVisible" = $2
+      "assets"."ownerId" = $1::uuid
+      and "assets"."duplicateId" is not null
+      and "assets"."deletedAt" is null
+      and "assets"."isVisible" = $2
     group by
-      "duplicateId"
+      "assets"."duplicateId"
   ),
   "unique" as (
     select


### PR DESCRIPTION
## Description

The query didn't include exif metadata, which is problematic as it affects which assets the utility auto-selects for de-duplication.

No e2e test for this as there is no test suite for duplicates, the process of marking an asset as duplicate is closed off from the API, and we don't have machine learning enabled.