### PR TITLE
fix(server): `sslmode` not working

### DIFF
--- a/server/src/bin/sync-sql.ts
+++ b/server/src/bin/sync-sql.ts
@@ -4,10 +4,12 @@ import { Reflector } from '@nestjs/core';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { Test } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostgresJSDialect } from 'kysely-postgres-js';
 import { KyselyModule } from 'nestjs-kysely';
 import { OpenTelemetryModule } from 'nestjs-otel';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import postgres from 'postgres';
 import { format } from 'sql-formatter';
 import { GENERATE_SQL_KEY, GenerateSqlQueries } from 'src/decorators';
 import { entities } from 'src/entities';
@@ -84,7 +86,7 @@ class SqlGenerator {
     const moduleFixture = await Test.createTestingModule({
       imports: [
         KyselyModule.forRoot({
-          ...database.config.kysely,
+          dialect: new PostgresJSDialect({ postgres: postgres(database.config.kysely) }),
           log: (event) => {
             if (event.level === 'query') {
               this.sqlLogger.logQuery(event.query.sql);

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -81,10 +81,13 @@ describe('getEnv', () => {
       const { database } = getEnv();
       expect(database).toEqual({
         config: {
-          kysely: {
-            dialect: expect.any(PostgresJSDialect),
-            log: expect.any(Function),
-          },
+          kysely: expect.objectContaining({
+            host: 'database',
+            port: 5432,
+            database: 'immich',
+            username: 'postgres',
+            password: 'postgres',
+          }),
           typeorm: expect.objectContaining({
             type: 'postgres',
             host: 'database',
@@ -103,6 +106,72 @@ describe('getEnv', () => {
       process.env.DB_SKIP_MIGRATIONS = 'true';
       const { database } = getEnv();
       expect(database).toMatchObject({ skipMigrations: true });
+    });
+
+    it('should use DB_URL', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich';
+      const { database } = getEnv();
+      expect(database.config.kysely).toMatchObject({
+        host: 'database1',
+        password: 'postgres2',
+        user: 'postgres1',
+        port: 54_320,
+        database: 'immich',
+      });
+    });
+
+    it('should handle sslmode=require', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=require';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=prefer', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=prefer';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=verify-ca', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-ca';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=verify-full', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-full';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=no-verify', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=no-verify';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: { rejectUnauthorized: false } });
+    });
+
+    it('should handle ssl=true', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?ssl=true';
+
+      const { database } = getEnv();
+
+      expect(database.config.kysely).toMatchObject({ ssl: true });
+    });
+
+    it('should reject invalid ssl', () => {
+      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?ssl=invalid';
+
+      expect(() => getEnv()).toThrowError('Invalid ssl option: invalid');
     });
   });
 

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -1,4 +1,3 @@
-import { PostgresJSDialect } from 'kysely-postgres-js';
 import { ImmichTelemetry } from 'src/enum';
 import { clearEnvCache, ConfigRepository } from 'src/repositories/config.repository';
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -103,6 +103,7 @@ export interface EnvData {
   nodeVersion?: string;
 }
 
+type Ssl = 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
 type ParsedPostgresConnection = {
   host?: string;
   password?: string;
@@ -110,7 +111,7 @@ type ParsedPostgresConnection = {
   port?: number;
   database?: string;
   client_encoding?: string;
-  ssl?: 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
+  ssl?: Ssl;
   application_name?: string;
   fallback_application_name?: string;
   options?: string;
@@ -138,7 +139,6 @@ const asSet = <T>(value: string | undefined, defaults: T[]) => {
   return new Set(values.length === 0 ? defaults : (values as T[]));
 };
 
-type Ssl = 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
 const isValidSsl = (ssl?: string | boolean | object): ssl is Ssl =>
   typeof ssl !== 'string' || ssl === 'require' || ssl === 'allow' || ssl === 'prefer' || ssl === 'verify-full';
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -212,7 +212,7 @@ const getEnv = (): EnvData => {
     database: dto.DB_DATABASE_NAME || 'immich',
   } as const;
 
-  let parsedOptions: ParsedPostgresConnection;
+  let parsedOptions: ParsedPostgresConnection = parts;
   if (dto.DB_URL) {
     const parsed = parse(dto.DB_URL);
     if (!isValidSsl(parsed.ssl)) {
@@ -225,14 +225,6 @@ const getEnv = (): EnvData => {
       host: parsed.host ?? undefined,
       port: parsed.port ? Number(parsed.port) : undefined,
       database: parsed.database ?? undefined,
-    };
-  } else {
-    parsedOptions = {
-      host: dto.DB_HOSTNAME || 'database',
-      port: dto.DB_PORT || 5432,
-      user: dto.DB_USERNAME || 'postgres',
-      password: dto.DB_PASSWORD || 'postgres',
-      database: dto.DB_DATABASE_NAME || 'immich',
     };
   }
 

--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -62,8 +62,11 @@ describe(DatabaseService.name, () => {
             database: {
               config: {
                 kysely: {
-                  dialect: expect.any(PostgresJSDialect),
-                  log: ['error'],
+                  host: 'database',
+                  port: 5432,
+                  user: 'postgres',
+                  password: 'postgres',
+                  database: 'immich',
                 },
                 typeorm: {
                   connectionType: 'parts',
@@ -298,8 +301,11 @@ describe(DatabaseService.name, () => {
           database: {
             config: {
               kysely: {
-                dialect: expect.any(PostgresJSDialect),
-                log: ['error'],
+                host: 'database',
+                port: 5432,
+                user: 'postgres',
+                password: 'postgres',
+                database: 'immich',
               },
               typeorm: {
                 connectionType: 'parts',
@@ -328,8 +334,11 @@ describe(DatabaseService.name, () => {
           database: {
             config: {
               kysely: {
-                dialect: expect.any(PostgresJSDialect),
-                log: ['error'],
+                host: 'database',
+                port: 5432,
+                user: 'postgres',
+                password: 'postgres',
+                database: 'immich',
               },
               typeorm: {
                 connectionType: 'parts',

--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -1,4 +1,3 @@
-import { PostgresJSDialect } from 'kysely-postgres-js';
 import {
   DatabaseExtension,
   EXTENSION_NAMES,

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -1,5 +1,3 @@
-import { PostgresJSDialect } from 'kysely-postgres-js';
-import postgres from 'postgres';
 import { ImmichEnvironment, ImmichWorker } from 'src/enum';
 import { DatabaseExtension } from 'src/interfaces/database.interface';
 import { EnvData } from 'src/repositories/config.repository';

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -24,12 +24,7 @@ const envData: EnvData = {
 
   database: {
     config: {
-      kysely: {
-        dialect: new PostgresJSDialect({
-          postgres: postgres({ database: 'immich', host: 'database', port: 5432 }),
-        }),
-        log: ['error'],
-      },
+      kysely: { database: 'immich', host: 'database', port: 5432 },
       typeorm: {
         connectionType: 'parts',
         database: 'immich',


### PR DESCRIPTION
## Description

Postgres.js has its own connection parsing logic that is not as robust as the previous driver. This PR uses the `pg-connection-string` library to do the parsing and passes the results to the Postgres.js driver.

Fixes #15566