### PR TITLE
fix: increase upload timeout

### DIFF
--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -62,7 +62,7 @@ async function bootstrap() {
   app.use(app.get(ApiService).ssr(excludePaths));
 
   const server = await (host ? app.listen(port, host) : app.listen(port));
-  server.requestTimeout = 30 * 60 * 1000;
+  server.requestTimeout = 24 * 60 * 60 * 1000;
 
   logger.log(`Immich Server is listening on ${await app.getUrl()} [v${serverVersion}] [${environment}] `);
 }


### PR DESCRIPTION
Fix an issue where when uploading a large file, the upload would consistently abort after 30 minutes. I changed this timeout from 30 minutes to 1 day. Maybe that's excessive, or maybe the timeout isn't even needed, but the current 30 minute timeout definitely seems way too short.