### PR TITLE
fix(mobile): deletion of single assets

### DIFF
--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -262,6 +262,11 @@ class GalleryViewerPage extends HookConsumerWidget {
 
     PhotoViewGalleryPageOptions buildAsset(BuildContext context, int index) {
       var newAsset = loadAsset(index);
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref.read(currentAssetProvider.notifier).set(newAsset);
+      });
+
       final stackId = newAsset.stackId;
       if (stackId != null && currentIndex.value == index) {
         final stackElements =


### PR DESCRIPTION
Fixes #14623

When deleting a picture, the app jumps to the next image, but the reference to the asset is not updated in currentAssetProvider (which is used by the delete functionality), but only after swiping to another image (onPageChanged callback). That means it will try to delete the same image again when hitting the delete button the next time.

Note: I'm not sure this is the right approach here, but I'm happy to take hints and will also look further, hence the draft 