### PR TITLE
chore(server): print stack in case of worker error

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -13,7 +13,7 @@ if (immichApp) {
 let apiProcess: ChildProcess | undefined;
 
 const onError = (name: string, error: Error) => {
-  console.error(`${name} worker error: ${error}`);
+  console.error(`${name} worker error: ${error}, stack: ${error.stack}`);
 };
 
 const onExit = (name: string, exitCode: number | null) => {


### PR DESCRIPTION
Sometimes we get an error in the microservices worker, like the following: https://github.com/porsager/postgres/pull/944

Currently, when this happens the error message is very terse, like 

`microservices worker error: TypeError: Cannot read properties of undefined (reading 'replace'),`

This PR also prints the error stack so we instead get

```
microservices worker error: TypeError: Cannot read properties of undefined (reading 'replace'), stack: TypeError: Cannot read properties of undefined (reading 'replace')
    at queryError (/usr/src/app/node_modules/postgres/cjs/src/connection.js:389:48)
    at errored (/usr/src/app/node_modules/postgres/cjs/src/connection.js:384:17)
    at connectTimedOut (/usr/src/app/node_modules/postgres/cjs/src/connection.js:257:5)
    at Timeout.done [as _onTimeout] (/usr/src/app/node_modules/postgres/cjs/src/connection.js:1033:8)
    at listOnTimeout (node:internal/timers:596:11)
    at process.processTimers (node:internal/timers:529:7)
```