### PR TITLE
fix(server): do not reset fileCreatedDate

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -511,7 +511,6 @@ export class LibraryService extends BaseService {
       await this.assetRepository.updateAll([asset.id], {
         isOffline: false,
         deletedAt: null,
-        fileCreatedAt: mtime,
         fileModifiedAt: mtime,
         originalFileName: parse(asset.originalPath).base,
       });


### PR DESCRIPTION
When marking an offline asset as online again, do not reset the fileCreatedAt value. This value contains the "true" date, copied from exif.dateTimeOriginal. If we overwrite this value, we'd need to run the metadata extraction job again. Instead, we just leave the old (and correct) value in place.

fixes #15640