### PR TITLE
feat(web): add image rotation icon in photo-viewer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1349,5 +1349,6 @@
   "years_ago": "{years, plural, one {# year} other {# years}} ago",
   "yes": "Yes",
   "you_dont_have_any_shared_links": "You don't have any shared links",
-  "zoom_image": "Zoom Image"
+  "zoom_image": "Zoom Image",
+  "rotate_image": "Rotate Image"
 }

--- a/web/src/lib/actions/zoom-image.ts
+++ b/web/src/lib/actions/zoom-image.ts
@@ -1,8 +1,8 @@
-import { photoZoomState, zoomed } from '$lib/stores/zoom-image.store';
+import { photoZoomState, rotated, zoomed } from '$lib/stores/zoom-image.store';
 import { useZoomImageWheel } from '@zoom-image/svelte';
 import { get } from 'svelte/store';
 
-export { zoomed } from '$lib/stores/zoom-image.store';
+export { rotated, zoomed } from '$lib/stores/zoom-image.store';
 
 export const zoomImageAction = (node: HTMLElement) => {
   const { createZoomImage, zoomImageState, setZoomImageState } = useZoomImageWheel();
@@ -19,6 +19,7 @@ export const zoomImageAction = (node: HTMLElement) => {
 
   const unsubscribes = [
     zoomed.subscribe((state) => setZoomImageState({ currentZoom: state ? 2 : 1 })),
+    rotated.subscribe((state) => setZoomImageState({ currentRotation: state * 90 })),
     zoomImageState.subscribe((state) => photoZoomState.set(state)),
   ];
   return {

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.spec.ts
@@ -14,6 +14,7 @@ describe('AssetViewerNavBar component', () => {
     showMotionPlayButton: false,
     showShareButton: false,
     onZoomImage: () => {},
+    onRotateImage: () => {},
     onCopyImage: () => {},
     onAction: () => {},
     onRunJob: () => {},

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -44,6 +44,7 @@
     mdiMagnifyPlusOutline,
     mdiPresentationPlay,
     mdiUpload,
+    mdiRotateRight,
   } from '@mdi/js';
   import { canCopyImageToClipboard } from '$lib/utils/asset-utils';
   import { t } from 'svelte-i18n';
@@ -57,6 +58,7 @@
     showDetailButton: boolean;
     showSlideshow?: boolean;
     onZoomImage: () => void;
+    onRotateImage: () => void;
     onCopyImage?: () => Promise<void>;
     onAction: OnAction;
     onRunJob: (name: AssetJobName) => void;
@@ -75,6 +77,7 @@
     showDetailButton,
     showSlideshow = false,
     onZoomImage,
+    onRotateImage,
     onCopyImage,
     onAction,
     onRunJob,
@@ -121,6 +124,13 @@
         icon={$photoZoomState && $photoZoomState.currentZoom > 1 ? mdiMagnifyMinusOutline : mdiMagnifyPlusOutline}
         title={$t('zoom_image')}
         onclick={onZoomImage}
+      />
+      <CircleIconButton
+        color="opaque"
+        hideMobile={true}
+        icon={mdiRotateRight}
+        title={$t('rotate_image')}
+        onclick={onRotateImage}
       />
     {/if}
     {#if canCopyImageToClipboard() && asset.type === AssetTypeEnum.Image}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -110,6 +110,7 @@
   let stack: StackResponseDto | null = $state(null);
 
   let zoomToggle = $state(() => void 0);
+  let rotateToggle = $state(() => void 0);
 
   const refreshStack = async () => {
     if (isSharedLink()) {
@@ -429,6 +430,7 @@
         showDetailButton={enableDetailPanel}
         showSlideshow={true}
         onZoomImage={zoomToggle}
+        onRotateImage={rotateToggle}
         onCopyImage={copyImage}
         onAction={handleAction}
         onRunJob={handleRunJob}
@@ -471,6 +473,7 @@
         {#if previewStackedAsset.type === AssetTypeEnum.Image}
           <PhotoViewer
             bind:zoomToggle
+            bind:rotateToggle
             bind:copyImage
             asset={previewStackedAsset}
             {preloadAssets}
@@ -516,6 +519,7 @@
           {:else}
             <PhotoViewer
               bind:zoomToggle
+              bind:rotateToggle
               bind:copyImage
               {asset}
               {preloadAssets}

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { shortcuts } from '$lib/actions/shortcut';
-  import { zoomImageAction, zoomed } from '$lib/actions/zoom-image';
+  import { zoomImageAction, zoomed, rotated } from '$lib/actions/zoom-image';
   import BrokenAsset from '$lib/components/assets/broken-asset.svelte';
   import { photoViewer } from '$lib/stores/assets.store';
   import { boundingBoxesArray } from '$lib/stores/people.store';
@@ -30,6 +30,7 @@
     onNextAsset?: (() => void) | null;
     copyImage?: () => Promise<void>;
     zoomToggle?: (() => void) | null;
+    rotateToggle?: (() => void) | null;
     onClose?: () => void;
   }
 
@@ -43,6 +44,7 @@
     onNextAsset = null,
     copyImage = $bindable(),
     zoomToggle = $bindable(),
+    rotateToggle = $bindable(),
   }: Props = $props();
 
   const { slideshowState, slideshowLook } = slideshowStore;
@@ -61,6 +63,7 @@
     currentPositionY: 0,
   });
   $zoomed = false;
+  $rotated = 0;
 
   onDestroy(() => {
     $boundingBoxesArray = [];
@@ -104,6 +107,10 @@
 
   zoomToggle = () => {
     $zoomed = $zoomed ? false : true;
+  };
+
+  rotateToggle = () => {
+    $rotated = ($rotated + 1) % 4;
   };
 
   const onCopyShortcut = (event: KeyboardEvent) => {
@@ -163,6 +170,8 @@
 
 <svelte:window
   use:shortcuts={[
+    { shortcut: { key: 'z' }, onShortcut: zoomToggle, preventDefault: false },
+    { shortcut: { key: 'r' }, onShortcut: rotateToggle, preventDefault: false },
     { shortcut: { key: 'c', ctrl: true }, onShortcut: onCopyShortcut, preventDefault: false },
     { shortcut: { key: 'c', meta: true }, onShortcut: onCopyShortcut, preventDefault: false },
   ]}

--- a/web/src/lib/stores/zoom-image.store.ts
+++ b/web/src/lib/stores/zoom-image.store.ts
@@ -3,3 +3,4 @@ import { writable } from 'svelte/store';
 
 export const photoZoomState = writable<ZoomImageWheelState>();
 export const zoomed = writable<boolean>();
+export const rotated = writable<number>();


### PR DESCRIPTION
- clicking rotate icon rotates image clockwise  in 90 degree increments
- (visual rotation only; image isn't modified)
- add shortcuts for zoom/rotate
  - z: toggle zoom
  - r: toggle rotate clockwise

related to https://github.com/immich-app/immich/discussions/1695