### PR TITLE
fix(server): /search/random API returns same assets every call

### DIFF
--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -36,7 +36,7 @@ offset
     and "assets"."deletedAt" is null
     and "assets"."id" < $6
   order by
-    "assets"."id"
+    random()
   limit
     $7
 )
@@ -56,7 +56,7 @@ union all
     and "assets"."deletedAt" is null
     and "assets"."id" > $13
   order by
-    "assets"."id"
+    random()
   limit
     $14
 )

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -72,8 +72,14 @@ export class SearchRepository implements ISearchRepository {
   async searchRandom(size: number, options: AssetSearchOptions): Promise<AssetEntity[]> {
     const uuid = randomUUID();
     const builder = searchAssetBuilder(this.db, options);
-    const lessThan = builder.where('assets.id', '<', uuid).orderBy(sql`random()`).limit(size);
-    const greaterThan = builder.where('assets.id', '>', uuid).orderBy(sql`random()`).limit(size);
+    const lessThan = builder
+      .where('assets.id', '<', uuid)
+      .orderBy(sql`random()`)
+      .limit(size);
+    const greaterThan = builder
+      .where('assets.id', '>', uuid)
+      .orderBy(sql`random()`)
+      .limit(size);
     const { rows } = await sql`${lessThan} union all ${greaterThan} limit ${size}`.execute(this.db);
     return rows as any as AssetEntity[];
   }

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -72,8 +72,8 @@ export class SearchRepository implements ISearchRepository {
   async searchRandom(size: number, options: AssetSearchOptions): Promise<AssetEntity[]> {
     const uuid = randomUUID();
     const builder = searchAssetBuilder(this.db, options);
-    const lessThan = builder.where('assets.id', '<', uuid).orderBy('assets.id').limit(size);
-    const greaterThan = builder.where('assets.id', '>', uuid).orderBy('assets.id').limit(size);
+    const lessThan = builder.where('assets.id', '<', uuid).orderBy(sql`random()`).limit(size);
+    const greaterThan = builder.where('assets.id', '>', uuid).orderBy(sql`random()`).limit(size);
     const { rows } = await sql`${lessThan} union all ${greaterThan} limit ${size}`.execute(this.db);
     return rows as any as AssetEntity[];
   }


### PR DESCRIPTION
### Fixes:
https://github.com/immich-app/immich/issues/15647

### Changes made:
- Modified SQL QueryBuilder code to use Postgre's built-in RANDOM() function for ordering instead of asset.id. Ordering by asset.id returned the same asset images every time instead of being random. I checked the searchRandom controller and it runs the SQL query and then directly returns the results, so no double randomization logic is going on.

Immich Kiosk & searchRandom API endpoint is now working again with this change