### PR TITLE
fix(mobile): Misaligned text icon in circle avatar

### DIFF
--- a/mobile/lib/widgets/common/user_circle_avatar.dart
+++ b/mobile/lib/widgets/common/user_circle_avatar.dart
@@ -28,8 +28,7 @@ class UserCircleAvatar extends ConsumerWidget {
     final profileImageUrl =
         '${Store.get(StoreKey.serverEndpoint)}/users/${user.id}/profile-image?d=${Random().nextInt(1024)}';
 
-    final textIcon = Text(
-      user.name[0].toUpperCase(),
+    final textIcon = DefaultTextStyle(
       style: TextStyle(
         fontWeight: FontWeight.bold,
         fontSize: 12,
@@ -37,6 +36,7 @@ class UserCircleAvatar extends ConsumerWidget {
             ? Colors.black
             : Colors.white,
       ),
+      child: Text(user.name[0].toUpperCase()),
     );
     return CircleAvatar(
       backgroundColor: user.avatarColor.toColor(),


### PR DESCRIPTION
This pull request addresses an issue where the text icon on the circle avatar on mobile was not centered due to the chosen font.

### Current behavior:
The current font choice causes the text icon to be misaligned within the circle avatar on mobile devices.
![Screenshot From 2025-01-26 14-16-53](https://github.com/user-attachments/assets/d8c86cac-06ad-44fb-bae1-79be411fa89c) ![Screenshot From 2025-01-26 14-17-02](https://github.com/user-attachments/assets/9296cf22-d193-4c03-a1be-8daaed739afd)

### Proposed solution:
This PR proposes to restore the default font specifically for the circle avatar widget on mobile devices. This change ensures proper text centering and improves the overall visual consistency of the avatar.
![Screenshot From 2025-01-26 14-16-45](https://github.com/user-attachments/assets/b9996aac-85f2-45de-a1ca-811d96ea2678) ![Screenshot From 2025-01-26 14-16-57](https://github.com/user-attachments/assets/8e871837-b5d5-45b5-9b76-bbcb5ddd3162)

By applying this fix, we can achieve better text alignment within the circle avatar on mobile, enhancing the user experience.