### PR TITLE
fix(server): Allow negative rating (for rejected images)

### DIFF
--- a/e2e/src/api/specs/asset.e2e-spec.ts
+++ b/e2e/src/api/specs/asset.e2e-spec.ts
@@ -701,6 +701,20 @@ describe('/asset', () => {
       expect(status).toEqual(200);
     });
 
+    it('should set the negative rating', async () => {
+      const { status, body } = await request(app)
+        .put(`/assets/${user1Assets[0].id}`)
+        .set('Authorization', `Bearer ${user1.accessToken}`)
+        .send({ rating: -1 });
+      expect(body).toMatchObject({
+        id: user1Assets[0].id,
+        exifInfo: expect.objectContaining({
+          rating: -1,
+        }),
+      });
+      expect(status).toEqual(200);
+    });
+
     it('should reject invalid rating', async () => {
       for (const test of [{ rating: 7 }, { rating: 3.5 }, { rating: null }]) {
         const { status, body } = await request(app)

--- a/mobile/openapi/lib/model/asset_bulk_update_dto.dart
+++ b/mobile/openapi/lib/model/asset_bulk_update_dto.dart
@@ -67,7 +67,7 @@ class AssetBulkUpdateDto {
   ///
   num? longitude;
 
-  /// Minimum value: 0
+  /// Minimum value: -1
   /// Maximum value: 5
   ///
   /// Please note: This property should have been non-nullable! Since the specification file

--- a/mobile/openapi/lib/model/update_asset_dto.dart
+++ b/mobile/openapi/lib/model/update_asset_dto.dart
@@ -73,7 +73,7 @@ class UpdateAssetDto {
   ///
   num? longitude;
 
-  /// Minimum value: 0
+  /// Minimum value: -1
   /// Maximum value: 5
   ///
   /// Please note: This property should have been non-nullable! Since the specification file

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -7951,7 +7951,7 @@
           },
           "rating": {
             "maximum": 5,
-            "minimum": 0,
+            "minimum": -1,
             "type": "number"
           }
         },
@@ -12780,7 +12780,7 @@
           },
           "rating": {
             "maximum": 5,
-            "minimum": 0,
+            "minimum": -1,
             "type": "number"
           }
         },

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -52,7 +52,7 @@ export class UpdateAssetBase {
   @Optional()
   @IsInt()
   @Max(5)
-  @Min(0)
+  @Min(-1)
   rating?: number;
 }
 

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1162,6 +1162,17 @@ describe(MetadataService.name, () => {
         }),
       );
     });
+    it('should handle valid negative rating value', async () => {
+      assetMock.getByIds.mockResolvedValue([assetStub.image]);
+      mockReadTags({ Rating: -1 });
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      expect(assetMock.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rating: -1,
+        }),
+      );
+    });
   });
 
   describe('handleQueueSidecar', () => {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -204,7 +204,7 @@ export class MetadataService extends BaseService {
       // comments
       description: String(exifTags.ImageDescription || exifTags.Description || '').trim(),
       profileDescription: exifTags.ProfileDescription || null,
-      rating: validateRange(exifTags.Rating, 0, 5),
+      rating: validateRange(exifTags.Rating, -1, 5),
 
       // grouping
       livePhotoCID: (exifTags.ContentIdentifier || exifTags.MediaGroupUUID) ?? null,


### PR DESCRIPTION
Resolves (partially) https://github.com/immich-app/immich/discussions/14454. ( _edit:_ also, see relevant [discord discussion](https://discord.com/channels/979116623879368755/994044917355663450/1313234190703263855))

XMP/Exif Metadata allows for negative ratings, with -1 meaning "rejected". See e.g. https://exiftool.org/TagNames/XMP.html#xmp:
| Tag Name | Writable | Values / Notes|
| -- | -- | -- | 
|Rating| 	real| 	_(a value from 0 to 5, or -1 for "rejected")_