### PR TITLE
fix(mobile): locale option causes the datetime filter error out

### DIFF
--- a/mobile/lib/pages/search/search.page.dart
+++ b/mobile/lib/pages/search/search.page.dart
@@ -277,7 +277,6 @@ class SearchPage extends HookConsumerWidget {
         fieldEndHintText: 'end_date'.tr(),
         initialEntryMode: DatePickerEntryMode.calendar,
         keyboardType: TextInputType.text,
-        locale: context.locale,
       );
 
       if (date == null) {


### PR DESCRIPTION
Fixes #15700