### PR TITLE
fix(server): do not return year with weird timezone info i.e before 1890

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -59,12 +59,14 @@ select
   json_agg("res") as "assets"
 from
   "res"
+where
+  "localDateTime" >= $8
 group by
   ("localDateTime" at time zone 'UTC')::date
 order by
   ("localDateTime" at time zone 'UTC')::date desc
 limit
-  $8
+  $9
 
 -- AssetRepository.getByIds
 select
@@ -258,6 +260,7 @@ with
     where
       "assets"."deletedAt" is null
       and "assets"."isVisible" = $2
+      and "assets"."localDateTime" >= $3
   )
 select
   "timeBucket",

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -137,6 +137,7 @@ export class AssetRepository implements IAssetRepository {
         ),
       )
       .select((eb) => eb.fn.jsonAgg(eb.table('res')).as('assets'))
+      .where('localDateTime', '>=', new Date('1850-01-01'))
       .groupBy(sql`("localDateTime" at time zone 'UTC')::date`)
       .orderBy(sql`("localDateTime" at time zone 'UTC')::date`, 'desc')
       .limit(10)
@@ -585,6 +586,7 @@ export class AssetRepository implements IAssetRepository {
             .$if(!!options.isTrashed, (qb) => qb.where('assets.status', '!=', AssetStatus.DELETED))
             .where('assets.deletedAt', options.isTrashed ? 'is not' : 'is', null)
             .where('assets.isVisible', '=', true)
+            .where('assets.localDateTime', '>=', new Date('1850-01-01'))
             .$if(!!options.albumId, (qb) =>
               qb
                 .innerJoin('albums_assets_assets', 'assets.id', 'albums_assets_assets.assetsId')


### PR DESCRIPTION
Some older years come with a timezone JS time doesn't recognize, rendering an invalid date. This PR adds the year cutoff for queries that could have trouble with the said years