### PR TITLE
fix(server): person thumbnail generation always being queued

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -495,7 +495,6 @@ export class AssetRepository implements IAssetRepository {
       .$if(property === WithoutProperty.THUMBNAIL, (qb) =>
         qb
           .innerJoin('asset_job_status as job_status', 'assetId', 'assets.id')
-          .select(withFiles)
           .where('assets.isVisible', '=', true)
           .where((eb) =>
             eb.or([

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -100,7 +100,6 @@ export class PersonRepository implements IPersonRepository {
       .$if(!!options.personId, (qb) => qb.where('asset_faces.personId', '=', options.personId!))
       .$if(!!options.sourceType, (qb) => qb.where('asset_faces.sourceType', '=', options.sourceType!))
       .$if(!!options.assetId, (qb) => qb.where('asset_faces.assetId', '=', options.assetId!))
-      .$if(!!options.assetId, (qb) => qb.where('asset_faces.assetId', '=', options.assetId!))
       .stream() as AsyncIterableIterator<AssetFaceEntity>;
   }
 
@@ -109,7 +108,7 @@ export class PersonRepository implements IPersonRepository {
       .selectFrom('person')
       .selectAll('person')
       .$if(!!options.ownerId, (qb) => qb.where('person.ownerId', '=', options.ownerId!))
-      .$if(!!options.thumbnailPath, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
+      .$if(options.thumbnailPath !== undefined, (qb) => qb.where('person.thumbnailPath', '=', options.thumbnailPath!))
       .$if(options.faceAssetId === null, (qb) => qb.where('person.faceAssetId', 'is', null))
       .$if(!!options.faceAssetId, (qb) => qb.where('person.faceAssetId', '=', options.faceAssetId!))
       .$if(options.isHidden !== undefined, (qb) => qb.where('person.isHidden', '=', options.isHidden!))

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -194,7 +194,7 @@ export class MediaService extends BaseService {
       await Promise.all(pathsToDelete.map((path) => this.storageRepository.unlink(path)));
     }
 
-    if (asset.thumbhash !== generated.thumbhash) {
+    if (!asset.thumbhash || Buffer.compare(asset.thumbhash, generated.thumbhash) !== 0) {
       await this.assetRepository.update({ id: asset.id, thumbhash: generated.thumbhash });
     }
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -194,7 +194,7 @@ export class MediaService extends BaseService {
       await Promise.all(pathsToDelete.map((path) => this.storageRepository.unlink(path)));
     }
 
-    if (asset.thumbhash != generated.thumbhash) {
+    if (asset.thumbhash !== generated.thumbhash) {
       await this.assetRepository.update({ id: asset.id, thumbhash: generated.thumbhash });
     }
 

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -4,7 +4,7 @@ import { Mocked, vitest } from 'vitest';
 export const newMediaRepositoryMock = (): Mocked<IMediaRepository> => {
   return {
     generateThumbnail: vitest.fn().mockImplementation(() => Promise.resolve()),
-    generateThumbhash: vitest.fn().mockImplementation(() => Promise.resolve()),
+    generateThumbhash: vitest.fn().mockResolvedValue(Buffer.from('')),
     decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {} }),
     extract: vitest.fn().mockResolvedValue(false),
     probe: vitest.fn(),


### PR DESCRIPTION
## Description

Queueing missing thumbnails for generation queues person rows with an empty string for `thumbnailPath`. This filter is not added to the query, however, because an empty string is considered falsy and the query builder acts like it wasn't provided.

Fixes #15708