### PR TITLE
fix(web): do not throw error when hash fails

### DIFF
--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -157,7 +157,6 @@ async function fileUploader(
         }
       } catch (error) {
         console.error(`Error calculating sha1 file=${assetFile.name})`, error);
-        throw error;
       }
     }
 


### PR DESCRIPTION
Fixes #15739
Allows failing hashes (e.g. when file size is >2GB) to continue to upload step. 

Current behavior: on a secure origin, failing hashes prevent the upload altogether. On an insecure origin, hashing is skipped, and the file is uploaded. 