### PR TITLE
feat: resolution selection and default preview playback for 360° panorama videos

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,8 @@
         "@mdi/js": "^7.4.47",
         "@photo-sphere-viewer/core": "^5.11.5",
         "@photo-sphere-viewer/equirectangular-video-adapter": "^5.11.5",
+        "@photo-sphere-viewer/resolution-plugin": "^5.11.5",
+        "@photo-sphere-viewer/settings-plugin": "^5.11.5",
         "@photo-sphere-viewer/video-plugin": "^5.11.5",
         "@zoom-image/svelte": "^0.3.0",
         "dom-to-image": "^2.6.0",
@@ -1667,6 +1669,25 @@
       "peerDependencies": {
         "@photo-sphere-viewer/core": "5.11.5",
         "@photo-sphere-viewer/video-plugin": "5.11.5"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/resolution-plugin": {
+      "version": "5.11.5",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/resolution-plugin/-/resolution-plugin-5.11.5.tgz",
+      "integrity": "sha512-Dbvp5bBtozD3IWt1Q0wORVaZBcB1bV9xUeoOS9A7F7b3EkQ2pkC5/jot/1AyM4wtU5wJ63NWHskQ1d7m6WWazQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.11.5",
+        "@photo-sphere-viewer/settings-plugin": "5.11.5"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/settings-plugin": {
+      "version": "5.11.5",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/settings-plugin/-/settings-plugin-5.11.5.tgz",
+      "integrity": "sha512-ZgYaWjiBMhsoRH5ddW3h+v4J4LPmofsT7BBRq5UCssWw2Fsrvv7mFFRi4UbZ1qzeKmvNUOr8BaFQgX1ZLvUWfQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.11.5"
       }
     },
     "node_modules/@photo-sphere-viewer/video-plugin": {

--- a/web/package.json
+++ b/web/package.json
@@ -72,6 +72,8 @@
     "@mdi/js": "^7.4.47",
     "@photo-sphere-viewer/core": "^5.11.5",
     "@photo-sphere-viewer/equirectangular-video-adapter": "^5.11.5",
+    "@photo-sphere-viewer/resolution-plugin": "^5.11.5",
+    "@photo-sphere-viewer/settings-plugin": "^5.11.5",
     "@photo-sphere-viewer/video-plugin": "^5.11.5",
     "@zoom-image/svelte": "^0.3.0",
     "dom-to-image": "^2.6.0",

--- a/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
@@ -24,7 +24,7 @@
   {:then [data, { default: PhotoSphereViewer }]}
     <PhotoSphereViewer
       panorama={data}
-      originalImageUrl={isWebCompatibleImage(asset) ? getAssetOriginalUrl(asset.id) : undefined}
+      originalPanorama={isWebCompatibleImage(asset) ? getAssetOriginalUrl(asset.id) : undefined}
     />
   {:catch}
     {$t('errors.failed_to_load_asset')}

--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -62,7 +62,7 @@
       container,
       touchmoveTwoFingers: false,
       mousewheelCtrlKey: false,
-      navbar: navbar,
+      navbar,
       minFov: 10,
       maxFov: 120,
       fisheye: false,
@@ -74,7 +74,7 @@
         // zoomLevel range: [0, 100]
         if (Math.round(zoomLevel) >= 75) {
           // Replace the preview with the original
-          resolutionPlugin.setResolution('original');
+          void resolutionPlugin.setResolution('original');
           viewer.removeEventListener(events.ZoomUpdatedEvent.type, zoomHandler);
         }
       };

--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -7,18 +7,21 @@
     type AdapterConstructor,
     type PluginConstructor,
   } from '@photo-sphere-viewer/core';
+  import { SettingsPlugin } from '@photo-sphere-viewer/settings-plugin';
+  import { ResolutionPlugin } from '@photo-sphere-viewer/resolution-plugin';
   import '@photo-sphere-viewer/core/index.css';
+  import '@photo-sphere-viewer/settings-plugin/index.css';
   import { onDestroy, onMount } from 'svelte';
 
   interface Props {
     panorama: string | { source: string };
-    originalImageUrl?: string;
+    originalPanorama?: string | { source: string };
     adapter?: AdapterConstructor | [AdapterConstructor, unknown];
     plugins?: (PluginConstructor | [PluginConstructor, unknown])[];
     navbar?: boolean;
   }
 
-  let { panorama, originalImageUrl, adapter = EquirectangularAdapter, plugins = [], navbar = false }: Props = $props();
+  let { panorama, originalPanorama, adapter = EquirectangularAdapter, plugins = [], navbar = false }: Props = $props();
 
   let container: HTMLDivElement | undefined = $state();
   let viewer: Viewer;
@@ -30,25 +33,48 @@
 
     viewer = new Viewer({
       adapter,
-      plugins,
+      plugins: [
+        SettingsPlugin,
+        [
+          ResolutionPlugin,
+          {
+            defaultResolution: $alwaysLoadOriginalFile && originalPanorama ? 'original' : 'default',
+            resolutions: [
+              {
+                id: 'default',
+                label: 'Default',
+                panorama,
+              },
+              ...(originalPanorama
+                ? [
+                    {
+                      id: 'original',
+                      label: 'Original',
+                      panorama: originalPanorama,
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ],
+        ...plugins,
+      ],
       container,
-      panorama,
       touchmoveTwoFingers: false,
       mousewheelCtrlKey: false,
-      navbar,
+      navbar: navbar,
       minFov: 10,
       maxFov: 120,
       fisheye: false,
     });
+    const resolutionPlugin = viewer.getPlugin(ResolutionPlugin) as ResolutionPlugin;
 
-    if (originalImageUrl && !$alwaysLoadOriginalFile) {
+    if (originalPanorama && !$alwaysLoadOriginalFile) {
       const zoomHandler = ({ zoomLevel }: events.ZoomUpdatedEvent) => {
         // zoomLevel range: [0, 100]
         if (Math.round(zoomLevel) >= 75) {
           // Replace the preview with the original
-          viewer.setPanorama(originalImageUrl, { showLoader: false, speed: 150 }).catch(() => {
-            viewer.setPanorama(panorama, { showLoader: false, speed: 0 }).catch(() => {});
-          });
+          resolutionPlugin.setResolution('original');
           viewer.removeEventListener(events.ZoomUpdatedEvent.type, zoomHandler);
         }
       };

--- a/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-panorama-viewer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getAssetOriginalUrl } from '$lib/utils';
+  import { getAssetPlaybackUrl, getAssetOriginalUrl } from '$lib/utils';
   import { fade } from 'svelte/transition';
   import LoadingSpinner from '../shared-components/loading-spinner.svelte';
   import { t } from 'svelte-i18n';
@@ -22,7 +22,13 @@
   {#await modules}
     <LoadingSpinner />
   {:then [PhotoSphereViewer, adapter, videoPlugin]}
-    <PhotoSphereViewer panorama={{ source: getAssetOriginalUrl(assetId) }} plugins={[videoPlugin]} {adapter} navbar />
+    <PhotoSphereViewer
+      panorama={{ source: getAssetPlaybackUrl(assetId) }}
+      originalPanorama={{ source: getAssetOriginalUrl(assetId) }}
+      plugins={[videoPlugin]}
+      {adapter}
+      navbar
+    />
   {:catch}
     {$t('errors.failed_to_load_asset')}
   {/await}


### PR DESCRIPTION
Hello team, thanks for building this amazing app! I am surprised that it already includes [photo-sphere-viewer](https://photo-sphere-viewer.js.org/) and is even able to play 360° panorama videos.

However I discover that immich is playing original file 360° panorama videos. My 360° panorama videos are 5.6K and suitable formats (HEVC, AV1) are not fully supported. For example linux firefox can't play HEVC: [`Mozilla will not support HEVC while it is encumbered by patents.`](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#hevc_h.265)

Hope we can play transcoded video files in 360° panorama video mode by default and provide option for user to upgrade to full resolution, this is the PR that address this issue:

1. **Resolution Selection for Panorama Viewer**:
   - Integrated `@photo-sphere-viewer/resolution-plugin` and added the ability to switch to the original, full-resolution video for users who want the highest fidelity.

2. **Default Preview Playback**:
   - Panorama videos now load the transcoded preview file (`getAssetPlaybackUrl`) by default to reduce network usage and better compatibility.
   - The original file (`getAssetOriginalUrl`) is loaded only when the user selects the "Original" resolution or zooms in past a threshold (≥75% zoom).

3. **Navbar and Settings Enhancements**:
   - Enhanced the viewer with the `SettingsPlugin` for a more intuitive interface, allowing users to easily access the resolution options.

#### **Changes Made**
- **Dependencies**:
  - Added `@photo-sphere-viewer/resolution-plugin` and `@photo-sphere-viewer/settings-plugin` to both `package.json` and `package-lock.json`.
- **Code Modifications**:
  - Updated `photo-sphere-viewer-adapter.svelte`:
    - Integrated the `ResolutionPlugin` with preview (labeled as default) and original resolutions.
    - Update logic to handle resolution switching on zoom.
  - Updated `image-panorama-viewer.svelte` and `video-panorama-viewer.svelte` to use `originalPanorama` for original resolution.
  - Ensured backward compatibility by defaulting to existing behavior if original files are unavailable.
- **Styling**:
  - Included required CSS files for the new plugins.

#### **Screenshots**

![Screenshot_20250128_171559](https://github.com/user-attachments/assets/2da0209c-2854-4791-b6f3-ff2d7cf9f2e4)


