### PR TITLE
fix(web): update recent album after edit

### DIFF
--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -35,6 +35,7 @@
     locale,
     type AlbumViewSettings,
   } from '$lib/stores/preferences.store';
+  import { userInteraction } from '$lib/stores/user.svelte';
   import { goto } from '$app/navigation';
   import { AppRoute } from '$lib/constants';
   import { t } from 'svelte-i18n';
@@ -293,6 +294,15 @@
     sharedAlbums[sharedAlbums.findIndex(({ id }) => id === album.id)] = album;
   };
 
+  const updateRecentAlbumInfo = (album: AlbumResponseDto) => {
+    if (userInteraction.recentAlbums) {
+      const index = userInteraction.recentAlbums.findIndex((recentAlbum) => recentAlbum.id === album.id);
+      if (index !== -1) {
+        userInteraction.recentAlbums[index] = { ...userInteraction.recentAlbums[index], ...album };
+      }
+    }
+  };
+
   const successEditAlbumInfo = (album: AlbumResponseDto) => {
     albumToEdit = null;
 
@@ -308,6 +318,7 @@
     });
 
     updateAlbumInfo(album);
+    updateRecentAlbumInfo(album);
   };
 
   const handleAddUsers = async (albumUsers: AlbumUserAddDto[]) => {

--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -295,10 +295,10 @@
   };
 
   const updateRecentAlbumInfo = (album: AlbumResponseDto) => {
-    if (userInteraction.recentAlbums) {
-      const index = userInteraction.recentAlbums.findIndex((recentAlbum) => recentAlbum.id === album.id);
-      if (index !== -1) {
-        userInteraction.recentAlbums[index] = { ...userInteraction.recentAlbums[index], ...album };
+    for (const cachedAlbum of userInteraction.recentAlbums || []) {
+      if (cachedAlbum.id === album.id) {
+        Object.assign(cachedAlbum, { ...cachedAlbum, ...album });
+        break;
       }
     }
   };


### PR DESCRIPTION
Fixed #15605

- Added `updateRecentAlbumInfo` function, which is called at the end of `successEditAlbumInfo`. This ensures that the `recentAlbums` data in the `userInteraction` store is updated to reflect changes made in the sidebar.