### PR TITLE
feat(server): synology exclusion patterns

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -223,7 +223,7 @@ export class LibraryService extends BaseService {
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*'],
+      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**'],
     });
     return mapLibrary(library);
   }


### PR DESCRIPTION
This adds two folders to the default exclusion patterns for external libraries

These folders are snapshot replications for Synology NAS that we don't want to import

Idea came from https://www.reddit.com/r/immich/comments/1ib514k/remap_external_library_to_use_another_identical/m9ogrl0/