### PR TITLE
fix(web): wrong timeline timezone

### DIFF
--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -34,7 +34,7 @@ export type ScrollTargetListener = ({
 }) => void;
 
 export const fromLocalDateTime = (localDateTime: string) =>
-  DateTime.fromISO(localDateTime, { zone: 'UTC', locale: get(locale) });
+  DateTime.fromISO(localDateTime, { zone: 'local', locale: get(locale) });
 
 export const fromDateTimeOriginal = (dateTimeOriginal: string, timeZone: string) =>
   DateTime.fromISO(dateTimeOriginal, { zone: timeZone });


### PR DESCRIPTION
Fixed #15634

- Fixed the `fromLocalDateTime` function which forced the use of the `UTC` zone instead of the `local` one, which caused misalignments in the display of data especially close to midnight (some images from the current day were displayed as from the previous day or vice versa)

I tested it using different timezones and uploading photos with a date with which I could replicate the bug, and it seems to have been fixed.

The `fromLocalDateTime` function is also used in other files besides the timeline ones, so I think that if this date inconsistency was present there too it has been resolved.