### PR TITLE
fix(web): HelpAndFeedback button the same size as Theme button in navbar

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -90,7 +90,7 @@
             shape="round"
             color="secondary"
             variant="ghost"
-            size="large"
+            size="giant"
             title={$t('support_and_feedback')}
             icon={mdiHelpCircleOutline}
             onclick={() => (shouldShowHelpPanel = !shouldShowHelpPanel)}


### PR DESCRIPTION
Changed the size for the Feedback Button to match the size of the Theme button.
Old:
![old - Immich](https://github.com/user-attachments/assets/2c7e35d0-aa06-4a36-8e90-9d1f89169ac1)

New:
![new - Immich](https://github.com/user-attachments/assets/c9d1b588-92b4-4a46-9e41-1d8a871eac8e)
