### PR TITLE
feat(web): info icon next to version number

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/server-status.svelte
+++ b/web/src/lib/components/shared-components/side-bar/server-status.svelte
@@ -11,13 +11,7 @@
     type ServerVersionHistoryResponseDto,
   } from '@immich/sdk';
   import Icon from '$lib/components/elements/icon.svelte';
-  import {
-    mdiAlert,
-    mdiInformation,
-    mdiInformationOffOutline,
-    mdiInformationOutline,
-    mdiInformationOff,
-  } from '@mdi/js';
+  import { mdiAlert, mdiInformationOutline } from '@mdi/js';
   import { userInteraction } from '$lib/stores/user.svelte';
 
   const { serverVersion, connected } = websocketStore;

--- a/web/src/lib/components/shared-components/side-bar/server-status.svelte
+++ b/web/src/lib/components/shared-components/side-bar/server-status.svelte
@@ -11,7 +11,13 @@
     type ServerVersionHistoryResponseDto,
   } from '@immich/sdk';
   import Icon from '$lib/components/elements/icon.svelte';
-  import { mdiAlert } from '@mdi/js';
+  import {
+    mdiAlert,
+    mdiInformation,
+    mdiInformationOffOutline,
+    mdiInformationOutline,
+    mdiInformationOff,
+  } from '@mdi/js';
   import { userInteraction } from '$lib/stores/user.svelte';
 
   const { serverVersion, connected } = websocketStore;
@@ -62,7 +68,7 @@
         {#if isMain}
           <Icon path={mdiAlert} size="1.5em" color="#ffcc4d" /> {info?.sourceRef}
         {:else}
-          {version}
+          {version}<Icon path={mdiInformationOutline} size="1.5em" color="#ffffff" />
         {/if}
       </button>
     {:else}


### PR DESCRIPTION
Added an info icon next to the version number to make it more obvious to the user that it is clickable.

Old:
![Screen Old - Immich](https://github.com/user-attachments/assets/610318f7-c79b-4d98-853a-94e4bfeee9c0)

New:
![Screen New - Immich](https://github.com/user-attachments/assets/94e0796e-1ba4-4a2a-b582-f46a36a38963)
