### PR TITLE
fix(mobile): retain edited title when album updates

### DIFF
--- a/mobile/lib/widgets/album/album_viewer_editable_title.dart
+++ b/mobile/lib/widgets/album/album_viewer_editable_title.dart
@@ -19,7 +19,8 @@ class AlbumViewerEditableTitle extends HookConsumerWidget {
     final albumViewerState = ref.watch(albumViewerProvider);
 
     final titleTextEditController = useTextEditingController(
-      text: albumViewerState.isEditAlbum && albumViewerState.editTitleText.isNotEmpty
+      text: albumViewerState.isEditAlbum &&
+              albumViewerState.editTitleText.isNotEmpty
           ? albumViewerState.editTitleText
           : albumName,
     );

--- a/mobile/lib/widgets/album/album_viewer_editable_title.dart
+++ b/mobile/lib/widgets/album/album_viewer_editable_title.dart
@@ -16,7 +16,13 @@ class AlbumViewerEditableTitle extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final titleTextEditController = useTextEditingController(text: albumName);
+    final albumViewerState = ref.watch(albumViewerProvider);
+
+    final titleTextEditController = useTextEditingController(
+      text: albumViewerState.isEditAlbum && albumViewerState.editTitleText.isNotEmpty
+          ? albumViewerState.editTitleText
+          : albumName,
+    );
 
     void onFocusModeChange() {
       if (!titleFocusNode.hasFocus && titleTextEditController.text.isEmpty) {


### PR DESCRIPTION
Fixes https://github.com/immich-app/immich/issues/15198

Ensure `AlbumViewerEditableTitle` keeps user input while editing, even when the album updates from another provider. fall back to `albumName` only when not in edit mode.