### PR TITLE
feat(web): merge suggestion modal: focus on Yes button by default.

### DIFF
--- a/web/src/lib/components/elements/buttons/button.svelte
+++ b/web/src/lib/components/elements/buttons/button.svelte
@@ -107,19 +107,12 @@
       .filter(Boolean)
       .join(' '),
   );
-
-  let linkOrButton: HTMLAnchorElement | HTMLButtonElement | null = null;
-
-  export function focus() {
-    linkOrButton?.focus();
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <svelte:element
   this={href ? 'a' : 'button'}
   type={href ? undefined : type}
-  bind:this={linkOrButton}
   {href}
   {onclick}
   {onfocus}

--- a/web/src/lib/components/elements/buttons/button.svelte
+++ b/web/src/lib/components/elements/buttons/button.svelte
@@ -107,12 +107,19 @@
       .filter(Boolean)
       .join(' '),
   );
+
+  let linkOrButton: HTMLAnchorElement | HTMLButtonElement | null = null;
+
+  export function focus() {
+    linkOrButton?.focus();
+  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <svelte:element
   this={href ? 'a' : 'button'}
   type={href ? undefined : type}
+  bind:this={linkOrButton}
   {href}
   {onclick}
   {onfocus}

--- a/web/src/lib/components/faces-page/merge-suggestion-modal.svelte
+++ b/web/src/lib/components/faces-page/merge-suggestion-modal.svelte
@@ -4,9 +4,9 @@
   import FullScreenModal from '$lib/components/shared-components/full-screen-modal.svelte';
   import { getPeopleThumbnailUrl } from '$lib/utils';
   import { type PersonResponseDto } from '@immich/sdk';
+  import { Button } from '@immich/ui';
   import { mdiArrowLeft, mdiMerge } from '@mdi/js';
   import ImageThumbnail from '../assets/thumbnail/image-thumbnail.svelte';
-  import Button from '../elements/buttons/button.svelte';
   import CircleIconButton from '../elements/buttons/circle-icon-button.svelte';
   import { t } from 'svelte-i18n';
 
@@ -38,11 +38,9 @@
     choosePersonToMerge = false;
   };
 
-  let confirmButtonRef: Button | null = null;
-
   onMount(async () => {
     await tick();
-    confirmButtonRef?.focus();
+    document.querySelector<HTMLElement>('#merge-confirm-button')?.focus();
   });
 </script>
 
@@ -121,8 +119,8 @@
   </div>
 
   {#snippet stickyBottom()}
-    <Button fullwidth color="gray" onclick={onReject}>{$t('no')}</Button>
-    <Button fullwidth bind:this={confirmButtonRef} onclick={() => onConfirm([personMerge1, personMerge2])}>
+    <Button fullWidth shape="round" color="secondary" onclick={onReject}>{$t('no')}</Button>
+    <Button id="merge-confirm-button" fullWidth shape="round" onclick={() => onConfirm([personMerge1, personMerge2])}>
       {$t('yes')}
     </Button>
   {/snippet}

--- a/web/src/lib/components/faces-page/merge-suggestion-modal.svelte
+++ b/web/src/lib/components/faces-page/merge-suggestion-modal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount, tick } from 'svelte';
   import Icon from '$lib/components/elements/icon.svelte';
   import FullScreenModal from '$lib/components/shared-components/full-screen-modal.svelte';
   import { getPeopleThumbnailUrl } from '$lib/utils';
@@ -36,6 +37,13 @@
     [potentialMergePeople[index], personMerge2] = [personMerge2, potentialMergePeople[index]];
     choosePersonToMerge = false;
   };
+
+  let confirmButtonRef: Button | null = null;
+
+  onMount(async () => {
+    await tick();
+    confirmButtonRef?.focus();
+  });
 </script>
 
 <FullScreenModal title="{$t('merge_people')} - {title}" {onClose}>
@@ -114,6 +122,8 @@
 
   {#snippet stickyBottom()}
     <Button fullwidth color="gray" onclick={onReject}>{$t('no')}</Button>
-    <Button fullwidth onclick={() => onConfirm([personMerge1, personMerge2])}>{$t('yes')}</Button>
+    <Button fullwidth bind:this={confirmButtonRef} onclick={() => onConfirm([personMerge1, personMerge2])}>
+      {$t('yes')}
+    </Button>
   {/snippet}
 </FullScreenModal>


### PR DESCRIPTION
When merging people, I often press <kbd>Enter</kbd> to confirm. However, the modal closes instead of merging because the "Yes" button isn’t focused by default. Right now, I have to press <kbd>Tab</kbd> three times to reach it.

Could we have the "Yes" button automatically focused when the modal opens?

![image](https://github.com/user-attachments/assets/de1a599f-afab-4398-a4ef-42ec86a7c475)

I'm new to Svelte, so if there's a more idiomatic way to implement this, please let me know!
