### PR TITLE
docs: add-current-path-to-version-switcher

### DIFF
--- a/docs/src/components/version-switcher.tsx
+++ b/docs/src/components/version-switcher.tsx
@@ -49,7 +49,7 @@ export default function VersionSwitcher(): JSX.Element {
         mobile={windowSize === 'mobile'}
         items={versions.map(({ label, url }) => ({
           label,
-          to: url,
+          to: url + location.pathname,
           target: '_self',
         }))}
       />


### PR DESCRIPTION
## Description
<!-- Description of the proposed changes. -->
Adds the path of the page you are on to the version switcher options so that you can quickly view changes on the page you are on.

### Testing:
<!-- Information on the testing that has been done. -->
Tested in dev environment with `npm run start` for docs.

<details><summary><h2>Images</h2></summary><!-- Images are under this HTML dropdown. -->

<!-- Images go below this line. -->
Links in the version switcher have the current path in them (visible in the bottom left):
![Screenshot 2025-02-02 144126](https://github.com/user-attachments/assets/b1d49b72-6b37-4d9c-8982-9384c13b440b)
</details>

<!-- API endpoint changes (if relevant)
### API Changes
The `/api/something` endpoint is now `/api/something-else`
-->