### PR TITLE
feat(web): Updated Onboarding page

### DIFF
--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -54,7 +54,7 @@
               <div class="w-full flex place-content-start">
                 <Button class="flex gap-2 place-content-center" onclick={() => onPrevious()}>
                   <Icon path={mdiArrowLeft} size="18" />
-                  <p>{$t('theme')}</p>
+                  <p>{$t('privacy')}</p>
                 </Button>
               </div>
               <div class="flex w-full place-content-end">


### PR DESCRIPTION
the "previous" button on the Storage Template page now points to privacy instead of theme
![Screenshot 2025-02-03 195700](https://github.com/user-attachments/assets/26d74d0e-92f6-41f6-9785-305850f19af0)
![Screenshot 2025-02-03 195648](https://github.com/user-attachments/assets/65d46cc7-c7d5-4030-ad54-8cacbdd914ce)
