### PR TITLE
fix(mobile): improved the visibility of backup cloud icon on lighter images

### DIFF
--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -208,7 +208,7 @@ class ThumbnailImage extends ConsumerWidget {
                       Shadow(
                         blurRadius: 5.0,
                         color: Colors.black.withOpacity(0.6),
-                        offset: Offset(0.0, 0.0),
+                        offset: const Offset(0.0, 0.0),
                       ),
                     ],
                   ),

--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -204,6 +204,13 @@ class ThumbnailImage extends ConsumerWidget {
                     storageIcon(asset),
                     color: Colors.white.withOpacity(.8),
                     size: 16,
+                    shadows: [
+                      Shadow(
+                        blurRadius: 5.0,
+                        color: Colors.black.withOpacity(0.6),
+                        offset: Offset(0.0, 0.0),
+                      ),
+                    ],
                   ),
                 ),
               if (asset.isFavorite)


### PR DESCRIPTION
Added a slight shadow to the backup indicator cloud icon, improving the visibility of the icon on lighter images.

Resolves https://github.com/immich-app/immich/issues/9316

Screenshots:
Before:
![Screenshot_20250204_012804](https://github.com/user-attachments/assets/8b90bb2e-d227-4d2c-a9b7-21132cd2466e)
After:
![Screenshot_20250204_012846](https://github.com/user-attachments/assets/13850cff-d057-46c5-935c-32e31515dffd)
