### PR TITLE
fix(docs): show version selection dropdown on mobile

### DIFF
--- a/docs/src/components/version-switcher.tsx
+++ b/docs/src/components/version-switcher.tsx
@@ -44,7 +44,7 @@ export default function VersionSwitcher(): JSX.Element {
   return (
     versions.length > 0 && (
       <DropdownNavbarItem
-        className="navbar__item"
+        className="version-switcher-34ab39"
         label={label}
         mobile={windowSize === 'mobile'}
         items={versions.map(({ label, url }) => ({

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -75,6 +75,11 @@ div[class^='announcementBar_'] {
   font-weight: 500;
 }
 
+/* workaround for version switcher PR 15894 */
+div[class*='navbar__items'] > li:has(a[class*='version-switcher-34ab39']) {
+  display: none;
+}
+
 code {
   font-weight: 600;
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change shows the version selection dropdown in the sidebar with the other navbar components on mobile. Before, this wouldn't work correctly. This also required custom CSS to hide the dropdown in the navbar on mobile because Docusaurus wasn't hiding the dropdown in the navbar like it hides the other elements.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Regular desktop loading of localhost dev instance through `npm run start`
- [x] Inspect Element Dev Console mobile device emulation loading of localhost dev instance through `npm run start`
- [x] Test the above within the PR preview docs
- [x] Tested again after making the CSS less jank and more future-proof. Also, doesn't need a comment in `docs\docusaurus.config.js` since changing position shouldn't be a problem.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Mobile sidebar dropdown:
![image](https://github.com/user-attachments/assets/c2949502-3be4-4984-af4e-79f9cc8018e4)
Mobile navbar properly hiding components with the custom CSS:
![image](https://github.com/user-attachments/assets/f8b4804b-9912-436e-96a6-d8c9b7545a1c)
Desktop version unaffected (I hovered my mouse over the dropdown for this screenshot):
![image](https://github.com/user-attachments/assets/8bdff07f-d225-4c66-a46f-98dcf22f3f22)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
