### PR TITLE
fix(web): prevent accidental modal closures on mouseup outside

### DIFF
--- a/web/src/lib/actions/click-outside.ts
+++ b/web/src/lib/actions/click-outside.ts
@@ -35,12 +35,12 @@ export function clickOutside(node: HTMLElement, options: Options = {}): ActionRe
     }
   };
 
-  document.addEventListener('click', handleClick, true);
+  document.addEventListener('mousedown', handleClick, true);
   node.addEventListener('keydown', handleKey, false);
 
   return {
     destroy() {
-      document.removeEventListener('click', handleClick, true);
+      document.removeEventListener('mousedown', handleClick, true);
       node.removeEventListener('keydown', handleKey, false);
     },
   };


### PR DESCRIPTION
Many times I close modals by accident when selecting text, because the listener is click (does not matter when the mousedown began, only where the mouseup ends), for example:


https://github.com/user-attachments/assets/bd7a862a-9833-402f-a2b0-36a506d244e6



This is a suggested fix.