### PR TITLE
fix(server): invalid timezone returned from database

### DIFF
--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { DateTime } from 'luxon';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { ExifResponseDto, mapExif } from 'src/dtos/exif.dto';
@@ -139,9 +140,9 @@ export function mapAsset(entity: AssetEntity, options: AssetMapOptions = {}): As
     originalFileName: entity.originalFileName,
     originalMimeType: mimeTypes.lookup(entity.originalFileName),
     thumbhash: entity.thumbhash ? hexOrBufferToBase64(entity.thumbhash) : null,
-    fileCreatedAt: entity.fileCreatedAt,
-    fileModifiedAt: entity.fileModifiedAt,
-    localDateTime: entity.localDateTime,
+    fileCreatedAt: DateTime.fromJSDate(entity.fileCreatedAt).isValid ? entity.fileCreatedAt : new Date('1970-01-01'),
+    fileModifiedAt: DateTime.fromJSDate(entity.fileModifiedAt).isValid ? entity.fileModifiedAt : new Date('1970-01-01'),
+    localDateTime: DateTime.fromJSDate(entity.localDateTime).isValid ? entity.fileModifiedAt : new Date('1970-01-01'),
     updatedAt: entity.updatedAt,
     isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
     isArchived: entity.isArchived,


### PR DESCRIPTION
Fixes an issue where database return time with invalid timezone when the database tz setting is different from UTC. This is a temporary fix until we find a better solution.

Without this fix, the mobile app won't be able to render the timeline becasue of the `fileCreatedAt`, `fileModifiedAt` and `localDateTime` returned as `null` while those property is not-null in the response dto
