### PR TITLE
feat(server): deduplicate library and metadata jobs

### DIFF
--- a/server/src/interfaces/job.interface.ts
+++ b/server/src/interfaces/job.interface.ts
@@ -144,7 +144,6 @@ export interface IAssetDeleteJob extends IEntityJob {
 }
 
 export interface ILibraryFileJob extends IEntityJob {
-  ownerId: string;
   assetPath: string;
 }
 

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -216,6 +216,17 @@ export class JobRepository implements IJobRepository {
 
   private getJobOptions(item: JobItem): JobsOptions | null {
     switch (item.name) {
+      case JobName.LIBRARY_QUEUE_SYNC_ASSETS:
+      case JobName.LIBRARY_QUEUE_SYNC_FILES:
+      case JobName.LIBRARY_SYNC_ASSET:
+      case JobName.LIBRARY_DELETE:
+      case JobName.SIDECAR_SYNC:
+      case JobName.SIDECAR_DISCOVERY: {
+        return { jobId: `${item.data.id}-${item.name}` };
+      }
+      case JobName.LIBRARY_SYNC_FILE: {
+        return { jobId: `${item.data.id}-${item.data.assetPath}` };
+      }
       case JobName.NOTIFY_ALBUM_UPDATE: {
         return { jobId: item.data.id, delay: item.data?.delay };
       }
@@ -227,6 +238,11 @@ export class JobRepository implements IJobRepository {
       }
       case JobName.QUEUE_FACIAL_RECOGNITION: {
         return { jobId: JobName.QUEUE_FACIAL_RECOGNITION };
+      }
+      case JobName.LIBRARY_QUEUE_SYNC_ALL:
+      case JobName.LIBRARY_QUEUE_CLEANUP: {
+        // These jobs are globally unique and should only have one instance running at a time
+        return { jobId: item.name };
       }
       default: {
         return null;

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -181,7 +181,6 @@ describe(LibraryService.name, () => {
           name: JobName.LIBRARY_SYNC_FILE,
           data: {
             id: libraryStub.externalLibrary1.id,
-            ownerId: libraryStub.externalLibrary1.owner.id,
             assetPath: '/data/user1/photo.jpg',
           },
         },
@@ -401,7 +400,6 @@ describe(LibraryService.name, () => {
     it('should import a new asset', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
       };
 
@@ -445,7 +443,6 @@ describe(LibraryService.name, () => {
     it('should import a new video', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: '/data/user1/video.mp4',
       };
 
@@ -489,7 +486,6 @@ describe(LibraryService.name, () => {
     it('should not import an asset to a soft deleted library', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
       };
 
@@ -504,7 +500,6 @@ describe(LibraryService.name, () => {
     it('should not refresh a file whose mtime matches existing asset', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: assetStub.hasFileExtension.originalPath,
       };
 
@@ -522,10 +517,9 @@ describe(LibraryService.name, () => {
       expect(jobMock.queueAll).not.toHaveBeenCalled();
     });
 
-    it('should skip existing asset', async () => {
+    it('should skip an existing asset', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: '/data/user1/photo.jpg',
       };
 
@@ -537,7 +531,6 @@ describe(LibraryService.name, () => {
     it('should not refresh an asset trashed by user', async () => {
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: mockUser.id,
         assetPath: assetStub.hasFileExtension.originalPath,
       };
 
@@ -554,7 +547,6 @@ describe(LibraryService.name, () => {
 
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: userStub.admin.id,
         assetPath: '/data/user1/photo.jpg',
       };
 
@@ -572,7 +564,6 @@ describe(LibraryService.name, () => {
 
       const mockLibraryJob: ILibraryFileJob = {
         id: libraryStub.externalLibrary1.id,
-        ownerId: userStub.admin.id,
         assetPath: '/data/user1/photo.jpg',
       };
 
@@ -923,7 +914,6 @@ describe(LibraryService.name, () => {
             data: {
               id: libraryStub.externalLibraryWithImportPaths1.id,
               assetPath: '/foo/photo.jpg',
-              ownerId: libraryStub.externalLibraryWithImportPaths1.owner.id,
             },
           },
         ]);
@@ -948,7 +938,6 @@ describe(LibraryService.name, () => {
             data: {
               id: libraryStub.externalLibraryWithImportPaths1.id,
               assetPath: '/foo/photo.jpg',
-              ownerId: libraryStub.externalLibraryWithImportPaths1.owner.id,
             },
           },
         ]);


### PR DESCRIPTION
This adds jobs ids to several jobs which reduces duplicated work. For example, a large library refresh might go on for such a long time that a cron job kicks in and starts refreshing it before the first refresh finishes. This PR prevents it from happening.

I've also added job ids to metadata extraction and thumbnail generation, so we for instance don't queue a thumb generation for the same asset more than once.