### PR TITLE
chore(web): shared links style tweaks

### DIFF
--- a/web/src/lib/components/album-page/user-selection-modal.svelte
+++ b/web/src/lib/components/album-page/user-selection-modal.svelte
@@ -154,16 +154,18 @@
   <hr class="my-4" />
 
   <Stack gap={6}>
-    <div class="flex justify-between items-center">
-      <Text>{$t('shared_links')}</Text>
-      <Link href={AppRoute.SHARED_LINKS} class="text-sm">{$t('view_all')}</Link>
-    </div>
+    {#if sharedLinks.length > 0}
+      <div class="flex justify-between items-center">
+        <Text>{$t('shared_links')}</Text>
+        <Link href={AppRoute.SHARED_LINKS} class="text-sm">{$t('view_all')}</Link>
+      </div>
 
-    <Stack gap={4}>
-      {#each sharedLinks as sharedLink}
-        <AlbumSharedLink {album} {sharedLink} />
-      {/each}
-    </Stack>
+      <Stack gap={4}>
+        {#each sharedLinks as sharedLink}
+          <AlbumSharedLink {album} {sharedLink} />
+        {/each}
+      </Stack>
+    {/if}
 
     <Button leadingIcon={mdiLink} size="small" shape="round" fullWidth onclick={onShare}>{$t('create_link')}</Button>
   </Stack>

--- a/web/src/routes/(user)/shared-links/[[id=id]]/+page.svelte
+++ b/web/src/routes/(user)/shared-links/[[id=id]]/+page.svelte
@@ -97,7 +97,7 @@
     </div>
   {/snippet}
 
-  <div>
+  <div class="w-full max-w-3xl m-auto">
     {#if sharedLinks.length === 0}
       <div
         class="flex place-content-center place-items-center rounded-lg bg-gray-100 dark:bg-immich-dark-gray dark:text-immich-gray p-12"


### PR DESCRIPTION
- Center shared link card on the shared link page, and set a maximum width
- Don't show the Shared Link title and View All button if there is no shared link associated with the album