### PR TITLE
fix(web): Update shared link Exif capitalization to match existing capitalization

### DIFF
--- a/web/src/lib/components/album-page/album-shared-link.svelte
+++ b/web/src/lib/components/album-page/album-shared-link.svelte
@@ -12,29 +12,30 @@
   };
 
   const { album, sharedLink }: Props = $props();
+
+  const getShareProperties = () =>
+    [
+      DateTime.fromISO(sharedLink.createdAt).toLocaleString(
+        {
+          month: 'long',
+          day: 'numeric',
+          year: 'numeric',
+        },
+        { locale: $locale },
+      ),
+      sharedLink.allowUpload && $t('upload'),
+      sharedLink.allowDownload && $t('download'),
+      sharedLink.showMetadata && $t('exif').toUpperCase(),
+      sharedLink.password && $t('password'),
+    ]
+      .filter(Boolean)
+      .join(' • ');
 </script>
 
 <div class="flex justify-between items-center">
   <div class="flex flex-col gap-1">
     <Text size="small">{sharedLink.description || album.albumName}</Text>
-    <Text size="tiny" color="muted"
-      >{[
-        DateTime.fromISO(sharedLink.createdAt).toLocaleString(
-          {
-            month: 'long',
-            day: 'numeric',
-            year: 'numeric',
-          },
-          { locale: $locale },
-        ),
-        sharedLink.allowUpload && $t('upload'),
-        sharedLink.allowDownload && $t('download'),
-        sharedLink.showMetadata && $t('exif'),
-        sharedLink.password && $t('password'),
-      ]
-        .filter(Boolean)
-        .join(' • ')}</Text
-    >
+    <Text size="tiny" color="muted">{getShareProperties()}</Text>
   </div>
   <SharedLinkCopy link={sharedLink} />
 </div>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The capitalization of the word Exif in the Share modal now matches the capitalization in the Shared links page.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Navigated to shared link modal in the UI

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

![image](https://github.com/user-attachments/assets/7808f727-6347-413e-abdd-b5606f2318f4)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
