### PR TITLE
docs: #15988 follow-up: Use URL constructor to fix Version Switcher URL double slash issue

### DIFF
--- a/docs/src/components/version-switcher.tsx
+++ b/docs/src/components/version-switcher.tsx
@@ -24,10 +24,13 @@ export default function VersionSwitcher(): JSX.Element {
           { label: 'Next', url: 'https://main.preview.immich.app' },
           { label: 'Latest', url: 'https://immich.app' },
           ...archiveVersions,
-        ];
+        ].map(({ label, url }) => ({
+          label,
+          url: new URL(url),
+        }));
         setVersions(allVersions);
 
-        const activeVersion = allVersions.find((version) => new URL(version.url).origin === window.location.origin);
+        const activeVersion = allVersions.find((version) => version.url.origin === window.location.origin);
         if (activeVersion) {
           setLabel(activeVersion.label);
         }
@@ -49,7 +52,7 @@ export default function VersionSwitcher(): JSX.Element {
         mobile={windowSize === 'mobile'}
         items={versions.map(({ label, url }) => ({
           label,
-          to: url + location.pathname + location.hash,
+          to: new URL(location.pathname + location.search + location.hash, url).href,
           target: '_self',
         }))}
       />

--- a/docs/static/archived-versions.json
+++ b/docs/static/archived-versions.json
@@ -20,10 +20,6 @@
     "url": "https://v1.125.5.archive.immich.app"
   },
   {
-    "label": "v1.125.4",
-    "url": "https://v1.125.4.archive.immich.app"
-  },
-  {
     "label": "v1.125.3",
     "url": "https://v1.125.3.archive.immich.app"
   },
@@ -34,10 +30,6 @@
   {
     "label": "v1.125.1",
     "url": "https://v1.125.1.archive.immich.app"
-  },
-  {
-    "label": "v1.125.0",
-    "url": "https://v1.125.0.archive.immich.app"
   },
   {
     "label": "v1.124.2",

--- a/docs/static/archived-versions.json
+++ b/docs/static/archived-versions.json
@@ -201,46 +201,46 @@
   },
   {
     "label": "v1.105.1",
-    "url": "https://v1.105.1.archive.immich.app/"
+    "url": "https://v1.105.1.archive.immich.app"
   },
   {
     "label": "v1.105.0",
-    "url": "https://v1.105.0.archive.immich.app/"
+    "url": "https://v1.105.0.archive.immich.app"
   },
   {
     "label": "v1.104.0",
-    "url": "https://v1.104.0.archive.immich.app/"
+    "url": "https://v1.104.0.archive.immich.app"
   },
   {
     "label": "v1.103.1",
-    "url": "https://v1.103.1.archive.immich.app/"
+    "url": "https://v1.103.1.archive.immich.app"
   },
   {
     "label": "v1.103.0",
-    "url": "https://v1.103.0.archive.immich.app/"
+    "url": "https://v1.103.0.archive.immich.app"
   },
   {
     "label": "v1.102.3",
-    "url": "https://v1.102.3.archive.immich.app/"
+    "url": "https://v1.102.3.archive.immich.app"
   },
   {
     "label": "v1.102.2",
-    "url": "https://v1.102.2.archive.immich.app/"
+    "url": "https://v1.102.2.archive.immich.app"
   },
   {
     "label": "v1.102.1",
-    "url": "https://v1.102.1.archive.immich.app/"
+    "url": "https://v1.102.1.archive.immich.app"
   },
   {
     "label": "v1.102.0",
-    "url": "https://v1.102.0.archive.immich.app/"
+    "url": "https://v1.102.0.archive.immich.app"
   },
   {
     "label": "v1.101.0",
-    "url": "https://v1.101.0.archive.immich.app/"
+    "url": "https://v1.101.0.archive.immich.app"
   },
   {
     "label": "v1.100.0",
-    "url": "https://v1.100.0.archive.immich.app/"
+    "url": "https://v1.100.0.archive.immich.app"
   }
 ]


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Uses `new URL(location.pathname + location.search + location.hash, url).href` instead of `url + location.pathname + location.hash`.

Also, removed slashes from old versions so that those don't have issues and removed versions that don't exist (1.125.0 and 1.125.4).

I noticed the issue after PR #15988 was merged. Sorry about this 3rd PR. Maybe don't merge this until a day after all the comments are addressed so that we don't jinx it. 🤞🤞🤞

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested in dev environment with `npm run start` for docs.
- [X] Tested in PR Preview Docs
    - The versions I removed still show up since it's pulling from main but the Dev instance works.
    - Confirmed that the location properties are working. (On the Dev build it will allow you to run that in what should be server side but is client side for hot reloading).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

Before:
![image](https://github.com/user-attachments/assets/6054bc1a-ce41-4bbe-815c-8fb69397863d)
After:
![image](https://github.com/user-attachments/assets/5ee8c9d6-1802-4b32-90ed-744c89f2815f)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
