### PR TITLE
feat(mobile): Made Map Bottom Sheet extendable higher

### DIFF
--- a/mobile/lib/widgets/map/map_bottom_sheet.dart
+++ b/mobile/lib/widgets/map/map_bottom_sheet.dart
@@ -59,9 +59,10 @@ class MapBottomSheet extends HookConsumerWidget {
           child: DraggableScrollableSheet(
             controller: sheetController,
             minChildSize: sheetMinExtent,
-            maxChildSize: 0.5,
+            maxChildSize: 0.8,
             initialChildSize: sheetMinExtent,
             snap: true,
+            snapSizes: [sheetMinExtent, 0.5, 0.8],
             shouldCloseOnMinExtent: false,
             builder: (ctx, scrollController) => MapAssetGrid(
               controller: scrollController,
@@ -78,18 +79,23 @@ class MapBottomSheet extends HookConsumerWidget {
         ),
         ValueListenableBuilder(
           valueListenable: bottomSheetOffset,
-          builder: (ctx, value, child) => Positioned(
-            right: 0,
-            bottom: context.height * (value + 0.02),
-            child: child!,
-          ),
-          child: ElevatedButton(
-            onPressed: onZoomToLocation,
-            style: ElevatedButton.styleFrom(
-              shape: const CircleBorder(),
-            ),
-            child: const Icon(Icons.my_location),
-          ),
+          builder: (context, value, child) {
+            return Positioned(
+              right: 0,
+              bottom: context.height * (value + 0.02),
+              child: AnimatedOpacity(
+                opacity: value < 0.8 ? 1 : 0,
+                duration: const Duration(milliseconds: 150),
+                child: ElevatedButton(
+                  onPressed: onZoomToLocation,
+                  style: ElevatedButton.styleFrom(
+                    shape: const CircleBorder(),
+                  ),
+                  child: const Icon(Icons.my_location),
+                ),
+              ),
+            );
+          },
         ),
       ],
     );


### PR DESCRIPTION
## Description

Modified the Bottom Sheet from the Map screen extendable higher for easier browsing.
It now has 3 different snap sizes: 0.1 (`sheetMinExtent`), 0.5 (medium, previously was maximum), and 0.8 (the new maximum)
When opened to the maximum, the location button (which is floating above the modal) automatically fades away.

<details><summary><h2>Screenshots</h2></summary>
<p>When open in the middle, behaves as before:</p>
<img src="https://github.com/user-attachments/assets/e0ca3ec6-2982-41de-a67d-bcf8f43e5c72" height=300 />
<br />
<br />
<p>But now you can drag the modal to "fully open" to this position:</p>
<img src="https://github.com/user-attachments/assets/3fdb63b5-ed3e-432b-bf81-88a1510985d2" height=300 />
<p>And as seen above, the location button hides</p>
<i>Not sure why the icons don't show lol</i>
</details>