### PR TITLE
docs: put Windows restore command on one line

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -77,9 +77,7 @@ docker start immich_postgres                      # Start Postgres server
 sleep 10                                          # Wait for Postgres server to start up
 docker exec -it immich_postgres bash              # Enter the Docker shell and run the following command
 # Check the database user if you deviated from the default. If your backup ends in `.gz`, replace `cat` with `gunzip`
-cat < "/dump.sql" \
-| sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
-| psql --dbname=postgres --username=<DB_USERNAME> # Restore Backup
+cat < "/dump.sql" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | psql --dbname=postgres --username=<DB_USERNAME>
 exit                                              # Exit the Docker shell
 docker compose up -d                              # Start remainder of Immich apps
 ```


### PR DESCRIPTION
Lots of 'unexpected newline' comments when restoring on Windows from other users.

This simply puts the command one one line.