### PR TITLE
fix(web): properly project profile picture

### DIFF
--- a/web/src/lib/components/shared-components/profile-image-cropper.svelte
+++ b/web/src/lib/components/shared-components/profile-image-cropper.svelte
@@ -27,12 +27,12 @@
     imgElement.style.width = '100%';
   });
 
-  const hasTransparentPixels = async (blob: Blob, heightOfImage:number, widthOfImage:number) => {
+  const hasTransparentPixels = async (blob: Blob, heightOfImage: number, widthOfImage: number) => {
     const img = new Image();
     img.src = URL.createObjectURL(blob);
     await img.decode();
     const canvas = document.createElement('canvas');
-    canvas.width =widthOfImage;
+    canvas.width = widthOfImage;
     canvas.height = heightOfImage;
     const context = canvas.getContext('2d');
     if (!context) {
@@ -47,8 +47,9 @@
     for (let index = 0; index < data.length; index += 4) {
       if (data[index + 3] < 255) {
         return {
-          hasTransparency: true, croppedBlob: blob
-        }
+          hasTransparency: true,
+          croppedBlob: blob,
+        };
       }
     }
     // Convert canvas to Blob
@@ -62,7 +63,8 @@
       }, 'image/png');
     });
     return {
-      hasTransparency: false, croppedBlob
+      hasTransparency: false,
+      croppedBlob,
     };
   };
 
@@ -72,8 +74,8 @@
     }
 
     try {
-      const imgElementHeight = imgElement.offsetHeight
-      const imgElementWidth = imgElement.offsetWidth
+      const imgElementHeight = imgElement.offsetHeight;
+      const imgElementWidth = imgElement.offsetWidth;
       const blob = await domtoimage.toBlob(imgElement);
       const { hasTransparency, croppedBlob } = await hasTransparentPixels(blob, imgElementWidth, imgElementHeight);
 

--- a/web/src/lib/components/shared-components/profile-image-cropper.svelte
+++ b/web/src/lib/components/shared-components/profile-image-cropper.svelte
@@ -46,7 +46,7 @@
     }
     for (let index = 0; index < data.length; index += 4) {
       if (data[index + 3] < 255) {
-       return true;
+        return true;
       }
     }
     return false;
@@ -62,7 +62,7 @@
       const imgElementWidth = imgElement.offsetWidth;
       const blob = await domtoimage.toBlob(imgElement, {
         width: imgElementWidth,
-        height: imgElementHeight
+        height: imgElementHeight,
       });
 
       if (await hasTransparentPixels(blob)) {


### PR DESCRIPTION
## **Description**  

This PR fixes an issue where users were unable to set a profile picture due to incorrect transparency detection. The issue originates from the `hasTransparentPixels` function in [profile-image-cropper.svelte](https://github.com/immich-app/immich/blob/main/web/src/lib/components/shared-components/profile-image-cropper.svelte).  

### **Root Cause**  

The issue occurs because the blob generated in the `handleSetProfilePicture` function does not accurately represent the portion of the image selected by the user. Users can zoom and drag the image in the `photo-viewer` component, but the generated blob includes additional image areas and empty canvas space, leading to incorrect transparency detection.  

When the blob is projected onto a canvas for transparency checking, the canvas contains:  

1. The user-selected portion of the image.  
2. Additional unwanted portions of the image.  
3. Empty space around the image, leading to incorrect transparency detection.  

Since the `hasTransparentPixels` function evaluates the entire canvas, the presence of empty space causes false positives, preventing users from setting their profile pictures.  

### **Solution**  

1. When the blob is generated it uses the `imgElement` height and width to only get portion of the image that the user has selected.


This fix ensures both transparency detection and the final profile picture selection work as expected.  

Fixes [#15812](https://github.com/immich-app/immich/issues/15812).  

## **How Has This Been Tested?**  

This PR has been tested manually with different image types:  

- ✅ Transparent images  
- ✅ Semi-transparent images  
- ✅ Standard images (JPG, PNG, WEBP)  

### **Before the Fix:**  

1. **User-selected image:**  
   <img width="292" alt="Screenshot 2025-02-13 at 5 40 22 PM" src="https://github.com/user-attachments/assets/5ffebc8f-903b-4e35-8d5f-a96f0f240a65" />  

2. **Image projected onto canvas (incorrect):**  
   *Note: Contains empty space and additional image areas beyond the user’s selection.*  
   <img width="407" alt="Screenshot 2025-02-13 at 5 40 33 PM" src="https://github.com/user-attachments/assets/2617a24f-e852-4619-aab0-56c24ce8149d" />  

### **After Transparency Fix:**  

1. **User-selected image:**  
   <img width="298" alt="Screenshot 2025-02-13 at 5 41 02 PM" src="https://github.com/user-attachments/assets/66188b3c-8b0f-4d6f-9eba-d65452bd9c01" />  

2. **Image projected onto canvas (corrected):**  
   *Note: Now accurately reflects only the selected portion of the image.*  
   <img width="262" alt="Screenshot 2025-02-13 at 5 41 17 PM" src="https://github.com/user-attachments/assets/eb8757ec-e0a5-4db1-b650-68700daf9ea9" />  


### **After Fix:**  

*Note: The selected profile pic now correctly matches the user’s selection.*  
<img width="50" alt="Screenshot 2025-02-13 at 6 48 14 PM" src="https://github.com/user-attachments/assets/9b5a9549-4981-4b15-9113-bb6e06e2b1a9" />  


### **Further Considerations**  

⚠️⚠️⚠️⚠️
> **Note:** The root issue may actually stem from how the blob is initially generated, as it does not perfectly preserve the user’s selected image. A more comprehensive fix could involve refactoring the `photo-viewer` component to ensure the blob represents only the exact area chosen by the user. However, this PR provides a targeted fix by adjusting the height and width of the generated blob to correctly reflect the selected image.  

## **Checklist:**  

- [x] I have performed a self-review of my own code.  
- [x] I have made corresponding changes to the documentation, if applicable.  
- [x] I have no unrelated changes in the PR.  
- [x] I have confirmed that any new dependencies are strictly necessary.  
- [x] I have followed naming conventions and patterns in the surrounding code.  