### PR TITLE
fix(server): assets in multiple albums from being counted more than once

### DIFF
--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -82,6 +82,7 @@ export class MapRepository {
 
     return this.db
       .selectFrom('assets')
+      .distinctOn(['assets.id'])
       .innerJoin('exif', (builder) =>
         builder
           .onRef('assets.id', '=', 'exif.assetId')
@@ -109,6 +110,7 @@ export class MapRepository {
 
         return builder.or(expression);
       })
+      .orderBy('assets.id', 'asc')
       .orderBy('fileCreatedAt', 'desc')
       .execute() as Promise<MapMarker[]>;
   }


### PR DESCRIPTION
## Description

Fixes assets in multiple albums from being counted more than once. Query returns only one row per unique asset.
Tested and working.


Fixes # (issue)
https://github.com/immich-app/immich/issues/16129


## How Has This Been Tested?

Replaced file in current deployed container, restarted, verified fix.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
