### PR TITLE
feat(mobile): add deduplication hash to backup headers

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/BackgroundServicePlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/BackgroundServicePlugin.kt
@@ -40,7 +40,7 @@ class BackgroundServicePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     methodChannel = null
   }
 
-  private fun digestFile(buf, digest, path) {
+  private fun digestFile(buf: ByteArray, digest: MessageDigest, path: String): ByteArray? {
     var len = 0
     try {
       val file = FileInputStream(path)
@@ -55,8 +55,9 @@ class BackgroundServicePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
       return digest.digest()
     } catch (e: Exception) {
       // skip this file
-      Log.w(TAG, "Failed to hash file ${args[i]}: $e")
+      Log.w(TAG, "Failed to hash file ${path}: $e")
     }
+    return null
   }
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {

--- a/mobile/ios/Runner/BackgroundSync/BackgroundServicePlugin.swift
+++ b/mobile/ios/Runner/BackgroundSync/BackgroundServicePlugin.swift
@@ -12,9 +12,9 @@ import CryptoKit
 import Network
 
 class BackgroundServicePlugin: NSObject, FlutterPlugin {
-    
+
     public static var flutterPluginRegistrantCallback: FlutterPluginRegistrantCallback?
-    
+
     public static func setPluginRegistrantCallback(_ callback: FlutterPluginRegistrantCallback) {
         flutterPluginRegistrantCallback = callback
     }
@@ -27,11 +27,11 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
     // Tested on a physical device, not a simulator
     // This will submit either the Fetch or Processing command to the BGTaskScheduler for immediate processing.
     // In my tests, I can only get app.alextran.immich.backgroundProcessing simulated by running the above command
-    
+
     // This is the task ID in Info.plist to register as our background task ID
     public static let backgroundFetchTaskID = "app.alextran.immich.backgroundFetch"
     public static let backgroundProcessingTaskID = "app.alextran.immich.backgroundProcessing"
-    
+
     // Establish communication with the main isolate and set up the channel call
     // to this BackgroundServicePlugion()
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -44,7 +44,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
     }
-    
+
     // Registers the Flutter engine with the plugins, used by the other Background Flutter engine
     public static func register(engine: FlutterEngine) {
         GeneratedPluginRegistrant.register(with: engine)
@@ -52,7 +52,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
 
     // Registers the task IDs from the system so that we can process them here in this class
     public static func registerBackgroundProcessing() {
- 
+
         let processingRegisterd = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundProcessingTaskID,
             using: nil) { task in
@@ -60,7 +60,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 handleBackgroundProcessing(task: task as! BGProcessingTask)
             }
         }
-        
+
         let fetchRegisterd = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundFetchTaskID,
             using: nil) { task in
@@ -104,6 +104,9 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
             case "backgroundAppRefreshEnabled":
                 handleBackgroundRefreshStatus(call: call, result: result)
                 break
+            case "digestFile":
+                handleDigestFile(call: call, result: result)
+                break
             case "digestFiles":
                 handleDigestFiles(call: call, result: result)
                 break
@@ -112,18 +115,29 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 break
         }
     }
-    
+
+    func handleDigestFile(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Parse the arguments or else fail
+        guard let path = call.arguments as? String else {
+            print("Cannot parse args as string: \(String(describing: call.arguments))")
+            result(FlutterError(code: "Malformed",
+                                message: "Received args is not an String",
+                                details: nil))
+            return
+        }
+
+        // Compute hash in background thread
+        DispatchQueue.global(qos: .background).async {
+            var hash: FlutterStandardTypedData? = self.internalHandleDigestFile(path)
+            // Return result in main thread
+            DispatchQueue.main.async {
+                result(hash)
+            }
+        }
+    }
+
     // Calculates the SHA-1 hash of each file from the list of paths provided
     func handleDigestFiles(call: FlutterMethodCall, result: @escaping FlutterResult) {
-        
-        let bufsize = 2 * 1024 * 1024
-        // Private error to throw if file cannot be read
-        enum DigestError: String, LocalizedError {
-            case NoFileHandle = "Cannot Open File Handle"
-
-            public var errorDescription: String? { self.rawValue }
-        }
-        
         // Parse the arguments or else fail
         guard let args = call.arguments as? Array<String> else {
             print("Cannot parse args as array: \(String(describing: call.arguments))")
@@ -132,109 +146,121 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                                 details: nil))
             return
         }
-        
+
         // Compute hash in background thread
         DispatchQueue.global(qos: .background).async {
             var hashes: [FlutterStandardTypedData?] = Array(repeating: nil, count: args.count)
             for i in (0 ..< args.count) {
-                do {
-                    guard let file = FileHandle(forReadingAtPath: args[i]) else { throw DigestError.NoFileHandle }
-                    var hasher = Insecure.SHA1.init();
-                    while autoreleasepool(invoking: {
-                        let chunk = file.readData(ofLength: bufsize)
-                        guard !chunk.isEmpty else { return false } // EOF
-                        hasher.update(data: chunk)
-                        return true // continue
-                    }) { }
-                    let digest = hasher.finalize()
-                    hashes[i] = FlutterStandardTypedData(bytes: Data(Array(digest.makeIterator())))
-                } catch {
-                    print("Cannot calculate the digest of the file \(args[i]) due to \(error.localizedDescription)")
-                }
+               hashes[i] = self.internalHandleDigestFile(args[i])
             }
-            
+
             // Return result in main thread
             DispatchQueue.main.async {
                 result(Array(hashes))
             }
         }
     }
-    
+
+    func internalHandleDigestFile(_ path: String) -> FlutterStandardTypedData? {
+        // Private error to throw if file cannot be read
+        enum DigestError: String, LocalizedError {
+          case NoFileHandle = "Cannot Open File Handle"
+
+          public var errorDescription: String? { self.rawValue }
+        }
+        let bufsize = 2 * 1024 * 1024
+        do {
+            guard let file = FileHandle(forReadingAtPath: path) else { throw DigestError.NoFileHandle }
+            var hasher = Insecure.SHA1.init();
+            while autoreleasepool(invoking: {
+                let chunk = file.readData(ofLength: bufsize)
+                guard !chunk.isEmpty else { return false } // EOF
+                hasher.update(data: chunk)
+                return true // continue
+            }) { }
+            let digest = hasher.finalize()
+            return FlutterStandardTypedData(bytes: Data(Array(digest.makeIterator())))
+        } catch {
+            print("Cannot calculate the digest of the file \(path) due to \(error.localizedDescription)")
+        }
+        return nil
+    }
+
     // Called by the flutter code when enabled so that we can turn on the backround services
     // and save the callback information to communicate on this method channel
     public func handleBackgroundEnable(call: FlutterMethodCall, result: FlutterResult) {
-        
+
         // Needs to parse the arguments from the method call
         guard let args = call.arguments as? Array<Any> else {
             print("Cannot parse args as array: \(call.arguments)")
             result(FlutterMethodNotImplemented)
             return
         }
-        
+
         // Requires 3 arguments in the array
         guard args.count == 3 else {
             print("Requires 3 arguments and received \(args.count)")
             result(FlutterMethodNotImplemented)
             return
         }
-                
+
         // Parses the arguments
         let callbackHandle = args[0] as? Int64
         let notificationTitle = args[1] as? String
         let instant = args[2] as? Bool
-        
+
         // Write enabled to settings
         let defaults = UserDefaults.standard
-        
+
         // We are now enabled, so store this
         defaults.set(true, forKey: "background_service_enabled")
-        
+
         // The callback handle is an int64 address to communicate with the main isolate's
         // entry function
         defaults.set(callbackHandle, forKey: "callback_handle")
-        
+
         // This is not used yet and will need to be implemented
         defaults.set(notificationTitle, forKey: "notification_title")
-        
+
         // Schedule the background services
         BackgroundServicePlugin.scheduleBackgroundSync()
         BackgroundServicePlugin.scheduleBackgroundFetch()
 
         result(true)
     }
-    
+
     // Called by the flutter code at launch to see if the background service is enabled or not
     func handleIsEnabled(call: FlutterMethodCall, result: FlutterResult) {
         let defaults = UserDefaults.standard
         let enabled = defaults.value(forKey: "background_service_enabled") as? Bool
-        
+
         // False by default
         result(enabled ?? false)
     }
-    
+
     // Called by the Flutter code whenever a change in configuration is set
     func handleConfigure(call: FlutterMethodCall, result: FlutterResult) {
-        
+
         // Needs to be able to parse the arguments or else fail
         guard let args = call.arguments as? Array<Any> else {
             print("Cannot parse args as array: \(call.arguments)")
             result(FlutterError())
             return
         }
-        
+
         // Needs to have 4 arguments in the call or else fail
         guard args.count == 4 else {
             print("Not enough arguments, 4 required: \(args.count) given")
             result(FlutterError())
             return
         }
-        
+
         // Parse the arguments from the method call
         let requireUnmeteredNetwork = args[0] as? Bool
         let requireCharging = args[1] as? Bool
         let triggerUpdateDelay = args[2] as? Int
         let triggerMaxDelay = args[3] as? Int
-        
+
         // Store the values from the call in the defaults
         let defaults = UserDefaults.standard
         defaults.set(requireUnmeteredNetwork, forKey: "require_unmetered_network")
@@ -248,7 +274,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         BackgroundServicePlugin.scheduleBackgroundFetch()
         result(true)
     }
-    
+
     // Returns the number of currently scheduled background processes to Flutter, striclty
     // for debugging
     func handleNumberOfProcesses(call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -256,16 +282,16 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
             result(requests.count)
         }
     }
-    
+
     // Disables the service, cancels all the task requests
     func handleDisable(call: FlutterMethodCall, result: FlutterResult) {
         let defaults = UserDefaults.standard
         defaults.set(false, forKey: "background_service_enabled")
-        
+
         BGTaskScheduler.shared.cancelAllTaskRequests()
         result(true)
     }
-  
+
     // Checks the status of the Background App Refresh from the system
     // Returns true if the service is enabled for Immich, and false otherwise
     func handleBackgroundRefreshStatus(call: FlutterMethodCall, result: FlutterResult) {
@@ -285,39 +311,39 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         }
     }
 
-    
+
     // Schedules a short-running background sync to sync only a few photos
     static func scheduleBackgroundFetch() {
         // We will schedule this task to run no matter the charging or wifi requirents from the end user
         // 1. They can set Background App Refresh to Off / Wi-Fi / Wi-Fi & Cellular Data from Settings
         // 2. We will check the battery connectivity when we begin running the background activity
         let backgroundFetch = BGAppRefreshTaskRequest(identifier: BackgroundServicePlugin.backgroundFetchTaskID)
-        
+
         // Use 5 minutes from now as earliest begin date
         backgroundFetch.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60)
-        
+
         do {
             try BGTaskScheduler.shared.submit(backgroundFetch)
         } catch {
             print("Could not schedule the background task \(error.localizedDescription)")
         }
     }
-    
+
     // Schedules a long-running background sync for syncing all of the photos
     static func scheduleBackgroundSync() {
         let backgroundProcessing = BGProcessingTaskRequest(identifier: BackgroundServicePlugin.backgroundProcessingTaskID)
-        
+
         // We need the values for requiring charging
         let defaults = UserDefaults.standard
         let requireCharging = defaults.value(forKey: "require_charging") as? Bool
-        
+
         // Always require network connectivity, and set the require charging from the above
         backgroundProcessing.requiresNetworkConnectivity = true
         backgroundProcessing.requiresExternalPower = requireCharging ?? true
-                
+
         // Use 15 minutes from now as earliest begin date
         backgroundProcessing.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
-        
+
         do {
             // Submit the task to the scheduler
             try BGTaskScheduler.shared.submit(backgroundProcessing)
@@ -325,16 +351,16 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
             print("Could not schedule the background task \(error.localizedDescription)")
         }
     }
-    
+
     // This function runs when the system kicks off the BGAppRefreshTask from the Background Task Scheduler
     static func handleBackgroundFetch(task: BGAppRefreshTask) {
         // Schedule the next sync task so we can run this again later
         scheduleBackgroundFetch()
-        
+
         // Log the time of last background processing to now
         let defaults = UserDefaults.standard
         defaults.set(Date().timeIntervalSince1970, forKey: "last_background_fetch_run_time")
-        
+
         // If we have required charging, we should check the charging status
         let requireCharging = defaults.value(forKey: "require_charging") as? Bool ?? false
         if (requireCharging) {
@@ -347,7 +373,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 return
             }
         }
-        
+
         // If we have required Wi-Fi, we can check the isExpensive property
         let requireWifi = defaults.value(forKey: "require_wifi") as? Bool ?? false
         if (requireWifi) {
@@ -361,14 +387,14 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 return
             }
         }
-        
+
         // Schedule the next sync task so we can run this again later
         scheduleBackgroundFetch()
-        
+
         // The background sync task should only run for 20 seconds at most
         BackgroundServicePlugin.runBackgroundSync(task, maxSeconds: 20)
     }
-    
+
     // This function runs when the system kicks off the BGProcessingTask from the Background Task Scheduler
     static func handleBackgroundProcessing(task: BGProcessingTask) {
         // Schedule the next sync task so we run this again later
@@ -377,11 +403,11 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         // Log the time of last background processing to now
         let defaults = UserDefaults.standard
         defaults.set(Date().timeIntervalSince1970, forKey: "last_background_processing_run_time")
-        
+
         // We won't specify a max time for the background sync service, so this can run for longer
         BackgroundServicePlugin.runBackgroundSync(task, maxSeconds: nil)
     }
-    
+
     // This is a synchronous function which uses a semaphore to run the background sync worker's run
     // function, which will create a background Isolate and communicate with the Flutter code to back
     // up the assets. When it completes, we signal the semaphore and complete the execution allowing the
@@ -397,7 +423,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 backgroundWorker.cancel()
                 task.setTaskCompleted(success: true)
             }
-            
+
             backgroundWorker.run(maxSeconds: maxSeconds)
             task.setTaskCompleted(success: true)
         }

--- a/mobile/ios/Runner/BackgroundSync/BackgroundServicePlugin.swift
+++ b/mobile/ios/Runner/BackgroundSync/BackgroundServicePlugin.swift
@@ -12,9 +12,9 @@ import CryptoKit
 import Network
 
 class BackgroundServicePlugin: NSObject, FlutterPlugin {
-
+    
     public static var flutterPluginRegistrantCallback: FlutterPluginRegistrantCallback?
-
+    
     public static func setPluginRegistrantCallback(_ callback: FlutterPluginRegistrantCallback) {
         flutterPluginRegistrantCallback = callback
     }
@@ -27,11 +27,11 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
     // Tested on a physical device, not a simulator
     // This will submit either the Fetch or Processing command to the BGTaskScheduler for immediate processing.
     // In my tests, I can only get app.alextran.immich.backgroundProcessing simulated by running the above command
-
+    
     // This is the task ID in Info.plist to register as our background task ID
     public static let backgroundFetchTaskID = "app.alextran.immich.backgroundFetch"
     public static let backgroundProcessingTaskID = "app.alextran.immich.backgroundProcessing"
-
+    
     // Establish communication with the main isolate and set up the channel call
     // to this BackgroundServicePlugion()
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -44,7 +44,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
     }
-
+    
     // Registers the Flutter engine with the plugins, used by the other Background Flutter engine
     public static func register(engine: FlutterEngine) {
         GeneratedPluginRegistrant.register(with: engine)
@@ -52,7 +52,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
 
     // Registers the task IDs from the system so that we can process them here in this class
     public static func registerBackgroundProcessing() {
-
+ 
         let processingRegisterd = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundProcessingTaskID,
             using: nil) { task in
@@ -60,7 +60,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 handleBackgroundProcessing(task: task as! BGProcessingTask)
             }
         }
-
+        
         let fetchRegisterd = BGTaskScheduler.shared.register(
             forTaskWithIdentifier: backgroundFetchTaskID,
             using: nil) { task in
@@ -146,7 +146,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                                 details: nil))
             return
         }
-
+        
         // Compute hash in background thread
         DispatchQueue.global(qos: .background).async {
             var hashes: [FlutterStandardTypedData?] = Array(repeating: nil, count: args.count)
@@ -185,82 +185,82 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         }
         return nil
     }
-
+    
     // Called by the flutter code when enabled so that we can turn on the backround services
     // and save the callback information to communicate on this method channel
     public func handleBackgroundEnable(call: FlutterMethodCall, result: FlutterResult) {
-
+        
         // Needs to parse the arguments from the method call
         guard let args = call.arguments as? Array<Any> else {
             print("Cannot parse args as array: \(call.arguments)")
             result(FlutterMethodNotImplemented)
             return
         }
-
+        
         // Requires 3 arguments in the array
         guard args.count == 3 else {
             print("Requires 3 arguments and received \(args.count)")
             result(FlutterMethodNotImplemented)
             return
         }
-
+                
         // Parses the arguments
         let callbackHandle = args[0] as? Int64
         let notificationTitle = args[1] as? String
         let instant = args[2] as? Bool
-
+        
         // Write enabled to settings
         let defaults = UserDefaults.standard
-
+        
         // We are now enabled, so store this
         defaults.set(true, forKey: "background_service_enabled")
-
+        
         // The callback handle is an int64 address to communicate with the main isolate's
         // entry function
         defaults.set(callbackHandle, forKey: "callback_handle")
-
+        
         // This is not used yet and will need to be implemented
         defaults.set(notificationTitle, forKey: "notification_title")
-
+        
         // Schedule the background services
         BackgroundServicePlugin.scheduleBackgroundSync()
         BackgroundServicePlugin.scheduleBackgroundFetch()
 
         result(true)
     }
-
+    
     // Called by the flutter code at launch to see if the background service is enabled or not
     func handleIsEnabled(call: FlutterMethodCall, result: FlutterResult) {
         let defaults = UserDefaults.standard
         let enabled = defaults.value(forKey: "background_service_enabled") as? Bool
-
+        
         // False by default
         result(enabled ?? false)
     }
-
+    
     // Called by the Flutter code whenever a change in configuration is set
     func handleConfigure(call: FlutterMethodCall, result: FlutterResult) {
-
+        
         // Needs to be able to parse the arguments or else fail
         guard let args = call.arguments as? Array<Any> else {
             print("Cannot parse args as array: \(call.arguments)")
             result(FlutterError())
             return
         }
-
+        
         // Needs to have 4 arguments in the call or else fail
         guard args.count == 4 else {
             print("Not enough arguments, 4 required: \(args.count) given")
             result(FlutterError())
             return
         }
-
+        
         // Parse the arguments from the method call
         let requireUnmeteredNetwork = args[0] as? Bool
         let requireCharging = args[1] as? Bool
         let triggerUpdateDelay = args[2] as? Int
         let triggerMaxDelay = args[3] as? Int
-
+        
         // Store the values from the call in the defaults
         let defaults = UserDefaults.standard
         defaults.set(requireUnmeteredNetwork, forKey: "require_unmetered_network")
@@ -274,7 +274,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         BackgroundServicePlugin.scheduleBackgroundFetch()
         result(true)
     }
-
+    
     // Returns the number of currently scheduled background processes to Flutter, striclty
     // for debugging
     func handleNumberOfProcesses(call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -282,16 +282,16 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
             result(requests.count)
         }
     }
-
+    
     // Disables the service, cancels all the task requests
     func handleDisable(call: FlutterMethodCall, result: FlutterResult) {
         let defaults = UserDefaults.standard
         defaults.set(false, forKey: "background_service_enabled")
-
+        
         BGTaskScheduler.shared.cancelAllTaskRequests()
         result(true)
     }
-
+  
     // Checks the status of the Background App Refresh from the system
     // Returns true if the service is enabled for Immich, and false otherwise
     func handleBackgroundRefreshStatus(call: FlutterMethodCall, result: FlutterResult) {
@@ -311,39 +311,39 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         }
     }
 
-
+    
     // Schedules a short-running background sync to sync only a few photos
     static func scheduleBackgroundFetch() {
         // We will schedule this task to run no matter the charging or wifi requirents from the end user
         // 1. They can set Background App Refresh to Off / Wi-Fi / Wi-Fi & Cellular Data from Settings
         // 2. We will check the battery connectivity when we begin running the background activity
         let backgroundFetch = BGAppRefreshTaskRequest(identifier: BackgroundServicePlugin.backgroundFetchTaskID)
-
+        
         // Use 5 minutes from now as earliest begin date
         backgroundFetch.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60)
-
+        
         do {
             try BGTaskScheduler.shared.submit(backgroundFetch)
         } catch {
             print("Could not schedule the background task \(error.localizedDescription)")
         }
     }
-
+    
     // Schedules a long-running background sync for syncing all of the photos
     static func scheduleBackgroundSync() {
         let backgroundProcessing = BGProcessingTaskRequest(identifier: BackgroundServicePlugin.backgroundProcessingTaskID)
-
+        
         // We need the values for requiring charging
         let defaults = UserDefaults.standard
         let requireCharging = defaults.value(forKey: "require_charging") as? Bool
-
+        
         // Always require network connectivity, and set the require charging from the above
         backgroundProcessing.requiresNetworkConnectivity = true
         backgroundProcessing.requiresExternalPower = requireCharging ?? true
-
+                
         // Use 15 minutes from now as earliest begin date
         backgroundProcessing.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
-
+        
         do {
             // Submit the task to the scheduler
             try BGTaskScheduler.shared.submit(backgroundProcessing)
@@ -351,16 +351,16 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
             print("Could not schedule the background task \(error.localizedDescription)")
         }
     }
-
+    
     // This function runs when the system kicks off the BGAppRefreshTask from the Background Task Scheduler
     static func handleBackgroundFetch(task: BGAppRefreshTask) {
         // Schedule the next sync task so we can run this again later
         scheduleBackgroundFetch()
-
+        
         // Log the time of last background processing to now
         let defaults = UserDefaults.standard
         defaults.set(Date().timeIntervalSince1970, forKey: "last_background_fetch_run_time")
-
+        
         // If we have required charging, we should check the charging status
         let requireCharging = defaults.value(forKey: "require_charging") as? Bool ?? false
         if (requireCharging) {
@@ -373,7 +373,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 return
             }
         }
-
+        
         // If we have required Wi-Fi, we can check the isExpensive property
         let requireWifi = defaults.value(forKey: "require_wifi") as? Bool ?? false
         if (requireWifi) {
@@ -387,14 +387,14 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 return
             }
         }
-
+        
         // Schedule the next sync task so we can run this again later
         scheduleBackgroundFetch()
-
+        
         // The background sync task should only run for 20 seconds at most
         BackgroundServicePlugin.runBackgroundSync(task, maxSeconds: 20)
     }
-
+    
     // This function runs when the system kicks off the BGProcessingTask from the Background Task Scheduler
     static func handleBackgroundProcessing(task: BGProcessingTask) {
         // Schedule the next sync task so we run this again later
@@ -403,11 +403,11 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
         // Log the time of last background processing to now
         let defaults = UserDefaults.standard
         defaults.set(Date().timeIntervalSince1970, forKey: "last_background_processing_run_time")
-
+        
         // We won't specify a max time for the background sync service, so this can run for longer
         BackgroundServicePlugin.runBackgroundSync(task, maxSeconds: nil)
     }
-
+    
     // This is a synchronous function which uses a semaphore to run the background sync worker's run
     // function, which will create a background Isolate and communicate with the Flutter code to back
     // up the assets. When it completes, we signal the semaphore and complete the execution allowing the
@@ -423,7 +423,7 @@ class BackgroundServicePlugin: NSObject, FlutterPlugin {
                 backgroundWorker.cancel()
                 task.setTaskCompleted(success: true)
             }
-
+            
             backgroundWorker.run(maxSeconds: maxSeconds)
             task.setTaskCompleted(success: true)
         }

--- a/mobile/lib/entities/asset.entity.dart
+++ b/mobile/lib/entities/asset.entity.dart
@@ -571,6 +571,8 @@ extension AssetsHelper on IsarCollection<Asset> {
       ids.isEmpty ? Future.value([]) : remote(ids).findAll();
   Future<List<Asset>> getAllByLocalId(Iterable<String> ids) =>
       ids.isEmpty ? Future.value([]) : local(ids).findAll();
+  Future<Asset?> getByLocalId(String id) =>
+      where().localIdEqualTo(id).findFirst();
   Future<Asset?> getByRemoteId(String id) =>
       where().remoteIdEqualTo(id).findFirst();
 

--- a/mobile/lib/interfaces/asset.interface.dart
+++ b/mobile/lib/interfaces/asset.interface.dart
@@ -6,6 +6,8 @@ import 'package:immich_mobile/interfaces/database.interface.dart';
 abstract interface class IAssetRepository implements IDatabaseRepository {
   Future<Asset?> getByRemoteId(String id);
 
+  Future<Asset?> getByLocalId(String id);
+
   Future<Asset?> getByOwnerIdChecksum(int ownerId, String checksum);
 
   Future<List<Asset>> getAllByRemoteId(

--- a/mobile/lib/repositories/asset.repository.dart
+++ b/mobile/lib/repositories/asset.repository.dart
@@ -210,6 +210,9 @@ class AssetRepository extends DatabaseRepository implements IAssetRepository {
         .thenByFileCreatedAtDesc()
         .findAll();
   }
+
+  @override
+  Future<Asset?> getByLocalId(String id) => db.assets.getByLocalId(id);
 }
 
 Future<List<Asset>> _getMatchesImpl(

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -160,9 +160,8 @@ class BackgroundService {
     }
   }
 
-  // Yet to be implemented
   Future<Uint8List?> digestFile(String path) {
-    return _foregroundChannel.invokeMethod<Uint8List>("digestFile", [path]);
+    return _foregroundChannel.invokeMethod<Uint8List>("digestFile", path);
   }
 
   Future<List<Uint8List?>?> digestFiles(List<String> paths) {
@@ -423,6 +422,7 @@ class BackgroundService {
       apiService,
       settingsService,
       albumService,
+      this,
       albumMediaRepository,
       fileMediaRepository,
       assetRepository,

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -269,7 +269,6 @@ class BackupService {
     final String deviceId = Store.get(StoreKey.deviceId);
     final String savedEndpoint = Store.get(StoreKey.serverEndpoint);
     final List<String> duplicatedAssetIds = [];
-    final List<Asset> localAssets = await _assetRepository.getAllLocal();
     bool anyErrors = false;
 
     final hasPermission = await _checkPermissions();
@@ -281,6 +280,7 @@ class BackupService {
     if (isBackground) {
       candidates = _sortPhotosFirst(candidates);
     }
+
 
     for (final candidate in candidates) {
       final Asset asset = candidate.asset;
@@ -341,9 +341,9 @@ class BackupService {
             }
           }
 
-          final localAsset = localAssets.firstWhereOrNull(
-            (localAsset) => localAsset.localId == asset.localId,
-          );
+          final localAsset = asset.localId != null
+              ? await _assetRepository.getByLocalId(asset.localId!)
+              : null;
 
           String? base64Hash;
 

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -281,7 +281,6 @@ class BackupService {
       candidates = _sortPhotosFirst(candidates);
     }
 
-
     for (final candidate in candidates) {
       final Asset asset = candidate.asset;
       File? file;


### PR DESCRIPTION
## Description

This PR introduces a mechanism to prevent duplicated asset uploads to the server. It leverages the existing x-immich-checksum header to send the asset’s SHA-1 checksum for validation before the full upload takes place.

Additionally, this PR implements a single-file checksum bridge between iOS and Android for Flutter, ensuring consistency across platforms.

By preventing unnecessary uploads, especially of large files, this change optimizes bandwidth usage and improves overall efficiency.

**Next Steps**

Since images with different resolutions or compression settings generate distinct SHA-1 checksums, the next step will be to explore a more robust approach to image deduplication.

**Fixes** 
#1553 - Move to client side hashing

## How Has This Been Tested?

I ran the iOS and Android app, tested the backup with new images, tested uploading an image to the server through the web, and then added the same asset to the device. I tried to back up this new file, and it detected the duplicate.



## Checklist:

- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [N/A] I have confirmed that any new dependencies are strictly necessary.
- [N/A] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
