### PR TITLE
fix(mobile): Server endpoint on the login screen. 

### DIFF
--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -150,7 +150,7 @@ class LoginForm extends HookConsumerWidget {
 
     useEffect(
       () {
-        final serverUrl = Store.tryGet(StoreKey.serverUrl);
+        final serverUrl = getServerUrl();
         if (serverUrl != null) {
           serverEndpointController.text = serverUrl;
         }

--- a/mobile/lib/widgets/forms/login/login_form.dart
+++ b/mobile/lib/widgets/forms/login/login_form.dart
@@ -10,7 +10,6 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/oauth.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';


### PR DESCRIPTION
## Description

On the Immich iOS app, the server url upon logout is stored with the /api endpoint, which we no longer expose to / expect the user to set.

On the login screen, after logout, it added the "/api" suffix instead of using the default method getServerUrl, which takes care of sanitizing the URL.

Fixes #15951 

## How Has This Been Tested?

Logged in as regular, logged out, the Server URL now is without the API endpoint.


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
