### PR TITLE
fix: limit width of logo in emails to 100%

### DIFF
--- a/server/src/emails/components/immich.layout.tsx
+++ b/server/src/emails/components/immich.layout.tsx
@@ -50,7 +50,7 @@ export const ImmichLayout = ({ children, preview }: ImmichLayoutProps) => (
             <Section className="flex justify-center mb-12">
               <Img
                 src="https://immich.app/img/immich-logo-inline-light.png"
-                className="h-12 antialiased rounded-none"
+                className="h-12 antialiased rounded-none w-full"
                 alt="Immich"
               />
             </Section>


### PR DESCRIPTION
## Description

I added w-full to the logo `<img>` classlist for email notifications.

The current live version breaks Yahoo Mail (at least in Firefox). It appears far too large and makes the email unreadable by pushing the text outside of the reading pane.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Set "width=100%" through Inspect Element before implementing in code.
- [x] Implemented the tailwinds class change on my own docker instance, committed it, and re-upped to test it.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before patch: 
![image](https://github.com/user-attachments/assets/b9b51f2c-03ee-4403-a816-d8d73e364ceb)

After patch:
![image](https://github.com/user-attachments/assets/81f89c93-b253-4500-aaa1-e5edd2e48310)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
