### PR TITLE
fix(server): don't warn about missing timezone

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -601,7 +601,7 @@ export class MetadataService extends BaseService {
     if (timeZone) {
       this.logger.verbose(`Asset ${asset.id} timezone is ${timeZone} (via ${exifTags.tzSource})`);
     } else {
-      this.logger.warn(`Asset ${asset.id} has no time zone information`);
+      this.logger.debug(`Asset ${asset.id} has no time zone information`);
     }
 
     let dateTimeOriginal = dateTime?.toDate();
@@ -641,7 +641,7 @@ export class MetadataService extends BaseService {
     // TODO take ref into account
 
     if (latitude === 0 && longitude === 0) {
-      this.logger.warn('Latitude and longitude of 0, setting to null');
+      this.logger.debug('Latitude and longitude of 0, setting to null');
       latitude = null;
       longitude = null;
     }


### PR DESCRIPTION
The metadata extractor logs to the console with warn level if an asset is missing TZ information or has 0 lat/long. I think this is excessive and am changing this to debug level