### PR TITLE
feat(server): add path to metadata logging

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -424,7 +424,7 @@ export class MetadataService extends BaseService {
       return;
     }
 
-    this.logger.debug(`Starting motion photo video extraction (${asset.id})`);
+    this.logger.debug(`Starting motion photo video extraction for asset ${asset.id}: ${asset.originalPath}`);
 
     try {
       const stat = await this.storageRepository.stat(asset.originalPath);
@@ -456,9 +456,9 @@ export class MetadataService extends BaseService {
       });
       if (motionAsset) {
         this.logger.debug(
-          `Asset ${asset.id}'s motion photo video with checksum ${checksum.toString(
+          `Motion photo video with checksum ${checksum.toString(
             'base64',
-          )} already exists in the repository`,
+          )} already exists in the repository for asset ${asset.id}: ${asset.originalPath}`,
         );
 
         // Hide the motion photo video asset if it's not already hidden to prepare for linking
@@ -515,9 +515,12 @@ export class MetadataService extends BaseService {
         await this.jobRepository.queue({ name: JobName.METADATA_EXTRACTION, data: { id: motionAsset.id } });
       }
 
-      this.logger.debug(`Finished motion photo video extraction (${asset.id})`);
+      this.logger.debug(`Finished motion photo video extraction for asset ${asset.id}: ${asset.originalPath}`);
     } catch (error: Error | any) {
-      this.logger.error(`Failed to extract live photo ${asset.originalPath}: ${error}`, error?.stack);
+      this.logger.error(
+        `Failed to extract motion video for ${asset.id}: ${asset.originalPath}: ${error}`,
+        error?.stack,
+      );
     }
   }
 
@@ -570,11 +573,13 @@ export class MetadataService extends BaseService {
 
     const facesToRemove = asset.faces.filter((face) => face.sourceType === SourceType.EXIF).map((face) => face.id);
     if (facesToRemove.length > 0) {
-      this.logger.debug(`Removing ${facesToRemove.length} faces for asset ${asset.id}`);
+      this.logger.debug(`Removing ${facesToRemove.length} faces for asset ${asset.id}: ${asset.originalPath}`);
     }
 
     if (facesToAdd.length > 0) {
-      this.logger.debug(`Creating ${facesToAdd.length} faces from metadata for asset ${asset.id}`);
+      this.logger.debug(
+        `Creating ${facesToAdd.length} faces from metadata for asset ${asset.id}: ${asset.originalPath}`,
+      );
     }
 
     if (facesToRemove.length > 0 || facesToAdd.length > 0) {
@@ -588,7 +593,7 @@ export class MetadataService extends BaseService {
 
   private getDates(asset: AssetEntity, exifTags: ImmichTags) {
     const dateTime = firstDateTime(exifTags as Maybe<Tags>, EXIF_DATE_TAGS);
-    this.logger.verbose(`Asset ${asset.id} date time is ${dateTime}`);
+    this.logger.verbose(`Date and time is ${dateTime} for asset ${asset.id}: ${asset.originalPath}`);
 
     // timezone
     let timeZone = exifTags.tz ?? null;
@@ -599,23 +604,27 @@ export class MetadataService extends BaseService {
     }
 
     if (timeZone) {
-      this.logger.verbose(`Asset ${asset.id} timezone is ${timeZone} (via ${exifTags.tzSource})`);
+      this.logger.verbose(
+        `Found timezone ${timeZone} via ${exifTags.tzSource} for asset ${asset.id}: ${asset.originalPath}`,
+      );
     } else {
-      this.logger.debug(`Asset ${asset.id} has no time zone information`);
+      this.logger.debug(`No timezone information found for asset ${asset.id}: ${asset.originalPath}`);
     }
 
     let dateTimeOriginal = dateTime?.toDate();
     let localDateTime = dateTime?.toDateTime().setZone('UTC', { keepLocalTime: true }).toJSDate();
     if (!localDateTime || !dateTimeOriginal) {
       this.logger.debug(
-        `No valid date found in exif tags from asset ${asset.id}, falling back to earliest timestamp between file creation and file modification`,
+        `No exif date time found, falling back on earliest of file creation and modification for assset ${asset.id}: ${asset.originalPath}`,
       );
       const earliestDate = this.earliestDate(asset.fileModifiedAt, asset.fileCreatedAt);
       dateTimeOriginal = earliestDate;
       localDateTime = earliestDate;
     }
 
-    this.logger.verbose(`Asset ${asset.id} has a local time of ${localDateTime.toISOString()}`);
+    this.logger.verbose(
+      `Found local date time ${localDateTime.toISOString()} for asset ${asset.id}: ${asset.originalPath}`,
+    );
 
     let modifyDate = asset.fileModifiedAt;
     try {
@@ -753,6 +762,7 @@ export class MetadataService extends BaseService {
     }
 
     if (sidecarPath) {
+      this.logger.debug(`Detected sidecar at '${sidecarPath}' for asset ${asset.id}: ${asset.originalPath}`);
       await this.assetRepository.update({ id: asset.id, sidecarPath });
       return JobStatus.SUCCESS;
     }
@@ -761,9 +771,7 @@ export class MetadataService extends BaseService {
       return JobStatus.FAILED;
     }
 
-    this.logger.debug(
-      `Sidecar file was not found. Checked paths '${sidecarPathWithExt}' and '${sidecarPathWithoutExt}'. Removing sidecarPath for asset ${asset.id}`,
-    );
+    this.logger.debug(`No sidecar found for asset ${asset.id}: ${asset.originalPath}`);
     await this.assetRepository.update({ id: asset.id, sidecarPath: null });
 
     return JobStatus.SUCCESS;


### PR DESCRIPTION
This PR adds path information to most log statements made by the metadata service. This makes it easier to see which files have broken metadata, especially with external libraries.

Example:

```
[Microservices:MetadataService] No timezone information found for asset 1072ebc8-8121-4d43-beed-508473cbd2c4: /data/import/bilder/2021/2021-06/2021-06-17/Original/20210617-064140--IMG_0542.PNG
[Microservices:MetadataService] Date and time is 2021-11-12T10:52:29+01:00 for asset 7b61ee91-2847-4ac8-a28c-2667003d10fa: /data/import/bilder/2021/2021-11/2021-11-12/Original/20211112-105229-SM-G973F-20211112_105229.JPG
[Microservices:MetadataService] Found timezone UTC+1 via OffsetTime for asset 7b61ee91-2847-4ac8-a28c-2667003d10fa: /data/import/bilder/2021/2021-11/2021-11-12/Original/20211112-105229-SM-G973F-20211112_105229.JPG
[Microservices:MetadataService] Found local date time 2021-11-12T10:52:29.000Z for asset 7b61ee91-2847-4ac8-a28c-2667003d10fa: /data/import/bilder/2021/2021-11/2021-11-12/Original/20211112-105229-SM-G973F-20211112_105229.JPG
```

I've also reworked and clarified some log statements