### PR TITLE
feat(web): show memories in portrait on small screens

### DIFF
--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -74,7 +74,7 @@
       {#each $memoryStore as memory (memory.yearsAgo)}
         {#if memory.assets.length > 0}
           <a
-            class="memory-card relative mr-8 inline-block aspect-video h-[215px] rounded-xl"
+            class="memory-card relative mr-8 inline-block aspect-[3/4] md:aspect-video h-[215px] rounded-xl"
             href="{AppRoute.MEMORY}?{QueryParameter.ID}={memory.assets[0].id}"
           >
             <img


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Shows the memories in portrait on small screens.
Makes web more similar to the mobile app.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] devtools (see screenshots)

<details><summary><h2>Screenshots</h2></summary>

|before|after|
|------|-----|
|![Screen Shot 2025-02-19 at 13 43 46](https://github.com/user-attachments/assets/df235a63-679b-449e-9625-a3515361c314)|![Screen Shot 2025-02-19 at 13 42 59](https://github.com/user-attachments/assets/c6367e83-5c68-4335-8f79-7ce3d49c4521)|

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
