### PR TITLE
fix(server): set modifydate

### DIFF
--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -10,7 +10,7 @@ where
   and "isVisible" = $3
   and "isArchived" = $4
   and "deletedAt" is null
-  and "fileModifiedAt" is not null
+  and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
 
@@ -26,7 +26,7 @@ where
   and "isVisible" = $2
   and "isArchived" = $3
   and "deletedAt" is null
-  and "fileModifiedAt" is not null
+  and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
   and "originalPath" like $4

--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -18,7 +18,7 @@ export class ViewRepository {
       .where('isVisible', '=', true)
       .where('isArchived', '=', false)
       .where('deletedAt', 'is', null)
-      .where('fileModifiedAt', 'is not', null)
+      .where('fileCreatedAt', 'is not', null)
       .where('fileModifiedAt', 'is not', null)
       .where('localDateTime', 'is not', null)
       .execute();
@@ -38,7 +38,7 @@ export class ViewRepository {
       .where('isVisible', '=', true)
       .where('isArchived', '=', false)
       .where('deletedAt', 'is', null)
-      .where('fileModifiedAt', 'is not', null)
+      .where('fileCreatedAt', 'is not', null)
       .where('fileModifiedAt', 'is not', null)
       .where('localDateTime', 'is not', null)
       .where('originalPath', 'like', `%${normalizedPath}/%`)

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -227,6 +227,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: sidecarDate,
+        fileModifiedAt: new Date('2023-02-23T05:06:29.716Z'),
         localDateTime: sidecarDate,
       });
     });
@@ -246,6 +247,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: fileModifiedAt,
+        fileModifiedAt,
         localDateTime: fileModifiedAt,
       });
     });
@@ -263,6 +265,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt,
+        fileModifiedAt,
         localDateTime: fileCreatedAt,
       });
     });
@@ -297,6 +300,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: assetStub.image.fileCreatedAt,
+        fileModifiedAt: assetStub.image.fileModifiedAt,
         localDateTime: assetStub.image.fileCreatedAt,
       });
     });
@@ -319,6 +323,7 @@ describe(MetadataService.name, () => {
         id: assetStub.withLocation.id,
         duration: null,
         fileCreatedAt: assetStub.withLocation.createdAt,
+        fileModifiedAt: assetStub.withLocation.createdAt,
         localDateTime: new Date('2023-02-22T05:06:29.716Z'),
       });
     });
@@ -840,6 +845,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: dateForTest,
+        fileModifiedAt: dateForTest,
         localDateTime: dateForTest,
       });
     });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -238,6 +238,7 @@ export class MetadataService extends BaseService {
       duration: exifTags.Duration?.toString() ?? null,
       localDateTime,
       fileCreatedAt: exifData.dateTimeOriginal ?? undefined,
+      fileModifiedAt: exifData.modifyDate ?? undefined,
     });
 
     await this.assetRepository.upsertJobStatus({


### PR DESCRIPTION
I found a bug in #15669 where fileModifiedAt was missed in an update query. The bug caused some scanned assets not showing up in the timeline.

Also, there was a typo in the view repository that is also fixed here.
