### PR TITLE
feat(web): squash folder view root

### DIFF
--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -9,7 +9,7 @@
   import { AppRoute, QueryParameter } from '$lib/constants';
   import type { Viewport } from '$lib/stores/assets.store';
   import { foldersStore } from '$lib/stores/folders.svelte';
-  import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+  import { normalizeTreePath } from '$lib/utils/tree-utils';
   import { mdiDotsVertical, mdiFolder, mdiFolderHome, mdiFolderOutline, mdiPlus, mdiSelectAll } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
@@ -42,7 +42,7 @@
   const viewport: Viewport = $state({ width: 0, height: 0 });
 
   let pathSegments = $derived(data.path ? data.path.split('/') : []);
-  let tree = $derived(buildTree(foldersStore.uniquePaths));
+  let tree = $derived(data.tree);
   let currentPath = $derived($page.url.searchParams.get(QueryParameter.PATH) || '');
   let currentTreeItems = $derived(currentPath ? data.currentFolders : Object.keys(tree).sort());
 

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -3,7 +3,7 @@ import { foldersStore } from '$lib/stores/folders.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+import { normalizeTreePath } from '$lib/utils/tree-utils';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ params, url }) => {
@@ -24,16 +24,19 @@ export const load = (async ({ params, url }) => {
     // We should bust the asset cache of the folder store, to make sure we don't show stale data
     foldersStore.bustAssetCache();
   }
-
-  let tree = buildTree(foldersStore.uniquePaths);
+  let tree = foldersStore.tree;
   const parts = normalizeTreePath(path || '').split('/');
+
   for (const part of parts) {
-    tree = tree?.[part];
+    if (part) {
+      tree = tree?.[part];
+    }
   }
 
   return {
     asset,
     path,
+    tree: foldersStore.tree,
     currentFolders: Object.keys(tree || {}).sort(),
     pathAssets,
     meta: {


### PR DESCRIPTION
In the folder view we always start at the container root. In almost every case, this means the user has to navigate one or several folders to get to a folder that doesn't just contain another folder.

Before:
![image](https://github.com/user-attachments/assets/00581dc9-acb5-4cca-8638-ae878de43d76)

which browses down to
![image](https://github.com/user-attachments/assets/943be62b-dade-468f-a74b-0e7367f00b3c)

After:
![image](https://github.com/user-attachments/assets/a7ce518e-4277-49fb-b66c-0c52812e402e)

This PR finds the first non-trivial folder and starts the folder view from there instead. When folder view was launched, I saw a few users requesting this tweak, although I can't find those links now

