### PR TITLE
fix: use correct head sha on PR commit tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -250,6 +250,8 @@ jobs:
       - name: Generate docker image tags
         id: meta
         uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: "true"
         with:
           flavor: |
             # Disable latest tag
@@ -401,6 +403,8 @@ jobs:
       - name: Generate docker image tags
         id: meta
         uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: "true"
         with:
           flavor: |
             # Disable latest tag


### PR DESCRIPTION
Because of course the reasonable default is to use the sha of the hidden merge commit :upside_down_face: 