### PR TITLE
fix: vite > 6.0.8 allowedHosts

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -33,6 +33,7 @@ export default defineConfig({
       '/.well-known/immich': upstream,
       '/custom.css': upstream,
     },
+    allowedHosts: true,
   },
   plugins: [
     sveltekit(),


### PR DESCRIPTION
Enables any host for development environment same as for vite <= 6.0.8