### PR TITLE
fix(web): dynamically import wasm module

### DIFF
--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -97,7 +97,7 @@
   {#each dateGroups as dateGroup, groupIndex (dateGroup.date)}
     {@const display =
       dateGroup.intersecting || !!dateGroup.assets.some((asset) => asset.id === $assetStore.pendingScrollAssetId)}
-    {@const geometry = dateGroup.geometry}
+    {@const geometry = dateGroup.geometry!}
 
     <div
       id="date-group"

--- a/web/src/lib/components/photos-page/measure-date-group.svelte
+++ b/web/src/lib/components/photos-page/measure-date-group.svelte
@@ -72,7 +72,7 @@
       <div use:resizeObserver={({ height }) => $assetStore.updateBucketDateGroup(bucket, dateGroup, { height })}>
         <div
           class="flex z-[100] sticky top-[-1px] pt-7 pb-5 h-6 place-items-center text-xs font-medium text-immich-fg bg-immich-bg dark:bg-immich-dark-bg dark:text-immich-dark-fg md:text-sm"
-          style:width={dateGroup.geometry.containerWidth + 'px'}
+          style:width={dateGroup.geometry!.containerWidth + 'px'}
         >
           <span class="w-full truncate first-letter:capitalize">
             {dateGroup.groupTitle}
@@ -81,8 +81,8 @@
 
         <div
           class="relative overflow-clip"
-          style:height={dateGroup.geometry.containerHeight + 'px'}
-          style:width={dateGroup.geometry.containerWidth + 'px'}
+          style:height={dateGroup.geometry!.containerHeight + 'px'}
+          style:width={dateGroup.geometry!.containerWidth + 'px'}
           style:visibility={'hidden'}
         ></div>
       </div>

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -20,7 +20,6 @@
   import { handlePromiseError } from '$lib/utils';
   import DeleteAssetDialog from '../../photos-page/delete-asset-dialog.svelte';
   import type { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
-  import { getJustifiedLayoutFromAssets } from '$lib/utils/layout-utils';
 
   interface Props {
     assets: AssetResponseDto[];

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -12,7 +12,6 @@ import { downloadRequest, getKey, withError } from '$lib/utils';
 import { createAlbum } from '$lib/utils/album-utils';
 import { getByteUnitString } from '$lib/utils/byte-units';
 import { getFormatter } from '$lib/utils/i18n';
-import { JustifiedLayout, type LayoutOptions } from '@immich/justified-layout-wasm';
 import {
   addAssetsToAlbum as addAssets,
   createStack,
@@ -588,13 +587,3 @@ export const copyImageToClipboard = async (source: HTMLImageElement | string) =>
   const blob = source instanceof HTMLImageElement ? await imgToBlob(source) : await urlToBlob(source);
   await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
 };
-
-export function getJustifiedLayoutFromAssets(assets: AssetResponseDto[], options: LayoutOptions) {
-  const aspectRatios = new Float32Array(assets.length);
-  // eslint-disable-next-line unicorn/no-for-loop
-  for (let i = 0; i < assets.length; i++) {
-    const { width, height } = getAssetRatio(assets[i]);
-    aspectRatios[i] = width / height;
-  }
-  return new JustifiedLayout(aspectRatios, options);
-}

--- a/web/src/lib/utils/layout-utils.ts
+++ b/web/src/lib/utils/layout-utils.ts
@@ -1,0 +1,14 @@
+import { getAssetRatio } from '$lib/utils/asset-utils';
+// note: it's important that this is not imported in more than one file due to https://github.com/sveltejs/kit/issues/7805
+import { JustifiedLayout, type LayoutOptions } from '@immich/justified-layout-wasm';
+import type { AssetResponseDto } from '@immich/sdk';
+
+export function getJustifiedLayoutFromAssets(assets: AssetResponseDto[], options: LayoutOptions) {
+  const aspectRatios = new Float32Array(assets.length);
+  // eslint-disable-next-line unicorn/no-for-loop
+  for (let i = 0; i < assets.length; i++) {
+    const { width, height } = getAssetRatio(assets[i]);
+    aspectRatios[i] = width / height;
+  }
+  return new JustifiedLayout(aspectRatios, options);
+}

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -1,6 +1,6 @@
 import type { AssetBucket } from '$lib/stores/assets.store';
 import { locale } from '$lib/stores/preferences.store';
-import { JustifiedLayout } from '@immich/justified-layout-wasm';
+import type { JustifiedLayout } from '@immich/justified-layout-wasm';
 import type { AssetResponseDto } from '@immich/sdk';
 import { groupBy, memoize, sortBy } from 'lodash-es';
 import { DateTime } from 'luxon';
@@ -13,7 +13,7 @@ export type DateGroup = {
   height: number;
   heightActual: boolean;
   intersecting: boolean;
-  geometry: JustifiedLayout;
+  geometry: JustifiedLayout | null;
   bucket: AssetBucket;
 };
 export type ScrubberListener = (
@@ -80,13 +80,6 @@ export function formatGroupTitle(_date: DateTime): string {
   return date.toLocaleString(groupDateFormat);
 }
 
-const emptyGeometry = new JustifiedLayout(Float32Array.from([]), {
-  rowHeight: 1,
-  heightTolerance: 0,
-  rowWidth: 1,
-  spacing: 0,
-});
-
 const formatDateGroupTitle = memoize(formatGroupTitle);
 
 export function splitBucketIntoDateGroups(bucket: AssetBucket, locale: string | undefined): DateGroup[] {
@@ -104,7 +97,7 @@ export function splitBucketIntoDateGroups(bucket: AssetBucket, locale: string | 
       height: 0,
       heightActual: false,
       intersecting: false,
-      geometry: emptyGeometry,
+      geometry: null,
       bucket,
     };
   });


### PR DESCRIPTION
## Description

WebKit currently has a bug when a module with a top-level await is concurrently imported from multiple places. This PR changes the Wasm module to be imported dynamically instead as a temporary workaround.