### PR TITLE
fix(web): use anonymous function in `setTimeout` in ponyfill of `requestIdelCallback`

### DIFF
--- a/web/src/lib/utils/idle-callback-support.ts
+++ b/web/src/lib/utils/idle-callback-support.ts
@@ -9,7 +9,9 @@ interface RequestIdleCallbackOptions {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function fake_requestIdleCallback(cb: (deadline: RequestIdleCallback) => any, _?: RequestIdleCallbackOptions) {
   const start = Date.now();
-  return setTimeout(cb({ didTimeout: false, timeRemaining: () => Math.max(0, 50 - (Date.now() - start)) }), 100);
+  return setTimeout(() => {
+    cb({ didTimeout: false, timeRemaining: () => Math.max(0, 50 - (Date.now() - start)) });
+  }, 100);
 }
 
 function fake_cancelIdleCallback(id: number) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

![Screenshot on dev console for Safari](https://github.com/user-attachments/assets/062a9053-e981-47bc-8b70-381dd3de9d82)

If there is no `script-src 'unsafe-eval'` in the CSP, a warning will appear in the dev console in Safari where `requestIdleCallback` is not available.

This is because a non-function is given as the argument to setTimeout. We will try to improve this by giving an anonymous function.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Open Immich in Safari with `script-src 'self' 'unsafe-inline'` set in CSP in a reverse proxy

<details><summary><h2>

~~Screenshots (if appropriate)~~

</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- ~~I have made corresponding changes to the documentation if applicable~~
- [x] I have no unrelated changes in the PR.
- ~~I have confirmed that any new dependencies are strictly necessary.~~
- ~~I have written tests for new code (if applicable)~~
- [x] I have followed naming conventions/patterns in the surrounding code
- ~~All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.~~
- ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)~~
