### PR TITLE
feat(mobile): photos group by date in album page view

### DIFF
--- a/mobile/lib/interfaces/timeline.interface.dart
+++ b/mobile/lib/interfaces/timeline.interface.dart
@@ -5,7 +5,8 @@ abstract class ITimelineRepository {
   Stream<RenderList> watchArchiveTimeline(int userId);
   Stream<RenderList> watchFavoriteTimeline(int userId);
   Stream<RenderList> watchTrashTimeline(int userId);
-  Stream<RenderList> watchAlbumTimeline(Album album);
+  Stream<RenderList> watchAlbumTimeline(
+      Album album, GroupAssetsBy groupAssetsBy);
   Stream<RenderList> watchAllVideosTimeline();
 
   Stream<RenderList> watchHomeTimeline(int userId, GroupAssetsBy groupAssetsBy);

--- a/mobile/lib/interfaces/timeline.interface.dart
+++ b/mobile/lib/interfaces/timeline.interface.dart
@@ -6,7 +6,9 @@ abstract class ITimelineRepository {
   Stream<RenderList> watchFavoriteTimeline(int userId);
   Stream<RenderList> watchTrashTimeline(int userId);
   Stream<RenderList> watchAlbumTimeline(
-      Album album, GroupAssetsBy groupAssetsBy);
+    Album album,
+    GroupAssetsBy groupAssetsBy,
+  );
   Stream<RenderList> watchAllVideosTimeline();
 
   Stream<RenderList> watchHomeTimeline(int userId, GroupAssetsBy groupAssetsBy);

--- a/mobile/lib/repositories/timeline.repository.dart
+++ b/mobile/lib/repositories/timeline.repository.dart
@@ -42,14 +42,17 @@ class TimelineRepository extends DatabaseRepository
   }
 
   @override
-  Stream<RenderList> watchAlbumTimeline(Album album) {
+  Stream<RenderList> watchAlbumTimeline(
+    Album album,
+    GroupAssetsBy groupAssetByOption,
+  ) {
     final query = album.assets.filter().isTrashedEqualTo(false);
     final withSortedOption = switch (album.sortOrder) {
       SortOrder.asc => query.sortByFileCreatedAt(),
       SortOrder.desc => query.sortByFileCreatedAtDesc(),
     };
 
-    return _watchRenderList(withSortedOption, GroupAssetsBy.none);
+    return _watchRenderList(withSortedOption, groupAssetByOption);
   }
 
   @override

--- a/mobile/lib/services/timeline.service.dart
+++ b/mobile/lib/services/timeline.service.dart
@@ -50,7 +50,10 @@ class TimelineService {
   }
 
   Stream<RenderList> watchAlbumTimeline(Album album) async* {
-    yield* _timelineRepository.watchAlbumTimeline(album);
+    yield* _timelineRepository.watchAlbumTimeline(
+      album,
+      _getGroupByOption(),
+    );
   }
 
   Stream<RenderList> watchTrashTimeline() async* {


### PR DESCRIPTION
Similar to the home page photo, settings options to group by date will be applied to the album
![album-group-by-date](https://github.com/user-attachments/assets/e0ce42e1-d140-4b5b-a8e3-18285a4dcbb0)
