### PR TITLE
fix(docs): tsconfig issues in IDE (VSCode) - migrate tsconfig extends file to current docusaurus implementation

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -28,6 +28,8 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "~3.7.0",
+        "@docusaurus/tsconfig": "^3.7.0",
+        "@docusaurus/types": "^3.7.0",
         "prettier": "^3.2.4",
         "typescript": "^5.1.6"
       },
@@ -3697,6 +3699,13 @@
       "engines": {
         "node": ">=18.0"
       }
+    },
+    "node_modules/@docusaurus/tsconfig": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.7.0.tgz",
+      "integrity": "sha512-vRsyj3yUZCjscgfgcFYjIsTcAru/4h4YH2/XAE8Rs7wWdnng98PgWKvP5ovVc4rmRpRg2WChVW0uOy2xHDvDBQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
       "version": "3.7.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "~3.7.0",
+    "@docusaurus/tsconfig": "^3.7.0",
+    "@docusaurus/types": "^3.7.0",
     "prettier": "^3.2.4",
     "typescript": "^5.1.6"
   },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,9 +1,8 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@tsconfig/docusaurus/tsconfig.json",
+  "extends": "@docusaurus/tsconfig",
 
   "compilerOptions": {
-    "baseUrl": ".",
-    "module": "Node16"
+    "baseUrl": "."
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Migrate from the Docusaurus 2.X `@tsconfig/docusaurus/tsconfig.json` package to the 3.X `@docusaurus/tsconfig` package (the old package was removed in #14755, breaking IDE stuff and not being picked up by tests since it doesn't affect the docs themselves, only the IDE experience). Also remove unnecessary (and outdated) `"module": "Node16"` that was added in #4312

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Ran `npm ci` in PowerShell on Windows and confirmed VSCodium (fork of VSCode with no telemetry, minimal changes) TypeScript editing works and `"extends": "@docusaurus/tsconfig"` in `tsconfig.json` has no issues.
- [X] I ran `npm run start` to be sure this didn't somehow affect the docs (this change should only affect the IDE experience).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
