### PR TITLE
fix(server): Fix delay with multiple ml servers

### DIFF
--- a/docs/docs/administration/system-settings.md
+++ b/docs/docs/administration/system-settings.md
@@ -98,6 +98,14 @@ The default Immich log level is `Log` (commonly known as `Info`). The Immich adm
 Through this setting, you can manage all the settings related to machine learning in Immich, from the setting of remote machine learning to the model and its parameters
 You can choose to disable a certain type of machine learning, for example smart search or facial recognition.
 
+### URL
+
+The built in (`http://immich-machine-learning:3003`) machine learning server will be configured by default, but you can change this or add additional servers.
+
+Hosting the `immich-machine-learning` container on a machine with a more powerful GPU can be helpful to for processing a large number of photos (such as during batch import) or for faster search.
+
+If more than one URL is provided, each server will be attempted one-at-a-time until one responds successfully, in order from first to last. Servers that don't respond will be temporarily ignored until they come back online.
+
 ### Smart Search
 
 The [smart search](/docs/features/searching) settings allow you to change the [CLIP model](https://openai.com/research/clip). Larger models will typically provide [more accurate search results](https://github.com/immich-app/immich/discussions/11862) but consume more processing power and RAM. When [changing the CLIP model](/docs/FAQ#can-i-use-a-custom-clip-model) it is mandatory to re-run the Smart Search job on all images to fully apply the change.

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -168,8 +168,8 @@ Redis (Sentinel) URL example JSON before encoding:
 | `MACHINE_LEARNING_ANN_TUNING_LEVEL`                         | ARM-NN GPU tuning level (1: rapid, 2: normal, 3: exhaustive)                                        |               `2`               | machine learning |
 | `MACHINE_LEARNING_DEVICE_IDS`<sup>\*4</sup>                 | Device IDs to use in multi-GPU environments                                                         |               `0`               | machine learning |
 | `MACHINE_LEARNING_MAX_BATCH_SIZE__FACIAL_RECOGNITION`       | Set the maximum number of faces that will be processed at once by the facial recognition model      |  None (`1` if using OpenVINO)   | machine learning |
-| `MACHINE_LEARNING_PING_TIMEOUT`                             | How long (ms) to wait for a PING response when checking if an ML server is available                |              `2000`             | server           |
-| `MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME`                | How long to ignore ML servers that are offline before trying again                                  |              `30000`            | server           |
+| `MACHINE_LEARNING_PING_TIMEOUT`                             | How long (ms) to wait for a PING response when checking if an ML server is available                |             `2000`              | server           |
+| `MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME`                | How long to ignore ML servers that are offline before trying again                                  |             `30000`             | server           |
 
 \*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -168,6 +168,8 @@ Redis (Sentinel) URL example JSON before encoding:
 | `MACHINE_LEARNING_ANN_TUNING_LEVEL`                         | ARM-NN GPU tuning level (1: rapid, 2: normal, 3: exhaustive)                                        |               `2`               | machine learning |
 | `MACHINE_LEARNING_DEVICE_IDS`<sup>\*4</sup>                 | Device IDs to use in multi-GPU environments                                                         |               `0`               | machine learning |
 | `MACHINE_LEARNING_MAX_BATCH_SIZE__FACIAL_RECOGNITION`       | Set the maximum number of faces that will be processed at once by the facial recognition model      |  None (`1` if using OpenVINO)   | machine learning |
+| `MACHINE_LEARNING_PING_TIMEOUT`                             | How long (ms) to wait for a PING response when checking if an ML server is available                |              `2000`             | server           |
+| `MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME`                | How long to ignore ML servers that are offline before trying again                                  |              `30000`            | server           |
 
 \*1: It is recommended to begin with this parameter when changing the concurrency levels of the machine learning service and then tune the other ones.
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -131,7 +131,7 @@
     "machine_learning_smart_search_description": "Search for images semantically using CLIP embeddings",
     "machine_learning_smart_search_enabled": "Enable smart search",
     "machine_learning_smart_search_enabled_description": "If disabled, images will not be encoded for smart search.",
-    "machine_learning_url_description": "The URL of the machine learning server. If more than one URL is provided, each server will be attempted one-at-a-time until one responds successfully, in order from first to last.",
+    "machine_learning_url_description": "The URL of the machine learning server. If more than one URL is provided, each server will be attempted one-at-a-time until one responds successfully, in order from first to last. Servers that don't respond will be temporarily ignored until they come back online.",
     "manage_concurrency": "Manage Concurrency",
     "manage_log_settings": "Manage log settings",
     "map_dark_style": "Dark style",

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -38,6 +38,11 @@ export const ONE_HOUR = Duration.fromObject({ hours: 1 });
 
 export const APP_MEDIA_LOCATION = process.env.IMMICH_MEDIA_LOCATION || './upload';
 
+export const MACHINE_LEARNING_PING_TIMEOUT = Number(process.env.MACHINE_LEARNING_PING_TIMEOUT || 2000);
+export const MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME = Number(
+  process.env.MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME || 30_000,
+);
+
 export const citiesFile = 'cities500.txt';
 
 export const MOBILE_REDIRECT = 'app.immich:///oauth-callback';

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -101,8 +101,9 @@ export class MachineLearningRepository {
     let urlCounter = 0;
     for (const url of urls) {
       urlCounter++;
+      const isLast = urlCounter >= urls.length;
       // Only use availability logic if this is not the last (or only) url
-      if (urlCounter < urls.length) {
+      if (!isLast) {
         const availability = this.urlAvailability[url];
         if (availability === undefined) {
           // If this is a new endpoint, then check inline and skip if it fails
@@ -110,7 +111,7 @@ export class MachineLearningRepository {
             continue;
           }
         } else if (
-          availability.active === false &&
+          !availability.active &&
           Date.now() - availability.lastChecked < MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME
         ) {
           // If this is an old inactive endpoint that hasn't been checked in a

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -98,10 +98,11 @@ export class MachineLearningRepository {
 
   private async predict<T>(urls: string[], payload: ModelPayload, config: MachineLearningRequest): Promise<T> {
     const formData = await this.getFormData(payload, config);
-    let iterations = urls.length;
+    let urlCounter = 0;
     for (const url of urls) {
-      // Skip availability logic for the last (or only) URL
-      if (--iterations > 0) {
+      urlCounter++;
+      // Only use availability logic if this is not the last (or only) url
+      if (urlCounter < urls.length) {
         const availability = this.urlAvailability[url];
         if (availability === undefined) {
           // If this is a new endpoint, then check inline and skip if it fails

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -96,26 +96,22 @@ export class MachineLearningRepository {
     return active;
   }
 
-  private async shouldSkipUrl(url: string, isLast: boolean) {
-    // The last (or only) URL should never be skipped, so don't bother checking if last
-    if (!isLast) {
-      const availability = this.urlAvailability[url];
-      if (availability === undefined) {
-        // If this is a new endpoint, then check inline and skip if it fails
-        if (!(await this.checkAvailability(url))) {
-          return true;
-        }
-      } else if (
-        !availability.active &&
-        Date.now() - availability.lastChecked < MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME
-      ) {
-        // If this is an old inactive endpoint that hasn't been checked in a
-        // while then check but don't wait for the result, just skip it
-        // This avoids delays on every search whilst allowing higher priority
-        // ML servers to recover over time.
-        void this.checkAvailability(url);
+  private async shouldSkipUrl(url: string) {
+    const availability = this.urlAvailability[url];
+    if (availability === undefined) {
+      // If this is a new endpoint, then check inline and skip if it fails
+      if (!(await this.checkAvailability(url))) {
         return true;
       }
+      return false;
+    }
+    if (!availability.active && Date.now() - availability.lastChecked < MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME) {
+      // If this is an old inactive endpoint that hasn't been checked in a
+      // while then check but don't wait for the result, just skip it
+      // This avoids delays on every search whilst allowing higher priority
+      // ML servers to recover over time.
+      void this.checkAvailability(url);
+      return true;
     }
     return false;
   }
@@ -126,7 +122,7 @@ export class MachineLearningRepository {
     for (const url of urls) {
       urlCounter++;
       const isLast = urlCounter >= urls.length;
-      if (await this.shouldSkipUrl(url, isLast)) {
+      if (!isLast && (await this.shouldSkipUrl(url))) {
         continue;
       }
 


### PR DESCRIPTION
## Description

Adds a ping and backoff mechanism to ML servers to avoid sending requests to known offline servers. This significantly improves search speed (10s per server) when multiple URL's are configured of which some are offline.

Fixes #16269 

## How Has This Been Tested?

Configure multiple servers and try turning them on and off. Observe search responsiveness over time.

- [x] Test with single URL (no change)
- [x] Test with single URL, try disabling/re-enabling server - server is marked offline but not skipped (since it's the only server)
- [x] Test with multiple URLs, try disabling/re-enabling servers - servers are marked offline, non-final server is skipped if it's offline (after first failure - which takes ~10s), server recovers and receives requests after coming back online (next request goes to secondary server, subsequent requests go to primary)

<details><summary>Logs</h2></summary>
<pre>
[Nest] 17  - 02/24/2025, 3:33:01 PM    WARN [Api:MachineLearningRepository~s6hjuet9] Machine learning request to "http://192.168.xxx.xxx:3003" failed: fetch failed
[Nest] 17  - 02/24/2025, 3:33:01 PM     LOG [Api:MachineLearningRepository~s6hjuet9] Setting http://192.168.xxx.xxx:3003 ML server to inactive.
[Nest] 17  - 02/24/2025, 3:33:02 PM     LOG [Api:MachineLearningRepository~s6hjuet9] Setting http://immich-machine-learning:3003 ML server to active.
[Nest] 17  - 02/24/2025, 3:33:37 PM     LOG [Api:MachineLearningRepository~b8fbaawa] Setting http://192.168.xxx.xxx:3003 ML server to active.
[Nest] 17  - 02/24/2025, 3:34:13 PM    WARN [Api:MachineLearningRepository~nt4fi2qe] Machine learning request to "http://192.168.xxx.xxx:3003" failed: fetch failed
[Nest] 17  - 02/24/2025, 3:34:13 PM     LOG [Api:MachineLearningRepository~nt4fi2qe] Setting http://192.168.xxx.xxx:3003 ML server to inactive.
[Nest] 17  - 02/24/2025, 3:35:38 PM     LOG [Api:MachineLearningRepository~ay7y9rbu] Setting http://192.168.xxx.xxx:3003 ML server to active.
[Nest] 17  - 02/24/2025, 3:36:40 PM    WARN [Api:MachineLearningRepository~hq80o96f] Machine learning request to "http://192.168.xxx.xxx:3003" failed: fetch failed
[Nest] 17  - 02/24/2025, 3:36:40 PM     LOG [Api:MachineLearningRepository~hq80o96f] Setting http://192.168.xxx.xxx:3003 ML server to inactive.
[Nest] 17  - 02/24/2025, 3:36:40 PM    WARN [Api:MachineLearningRepository~hq80o96f] Machine learning request to "http://immich-machine-learning:3003" failed: fetch failed
[Nest] 17  - 02/24/2025, 3:36:40 PM     LOG [Api:MachineLearningRepository~hq80o96f] Setting http://immich-machine-learning:3003 ML server to inactive.
[Nest] 17  - 02/24/2025, 3:36:40 PM   ERROR [Api:ErrorInterceptor~hq80o96f] Unknown error: Error: Machine learning request '{"clip":{"textual":{"modelName":"ViT-L-16-SigLIP-384__webli"}}}' failed for all URLs
Error: Machine learning request '{"clip":{"textual":{"modelName":"ViT-L-16-SigLIP-384__webli"}}}' failed for all URLs
    at MachineLearningRepository.predict (/usr/src/app/dist/repositories/machine-learning.repository.js:89:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async MachineLearningRepository.encodeText (/usr/src/app/dist/repositories/machine-learning.repository.js:112:26)
    at async SearchService.searchSmart (/usr/src/app/dist/services/search.service.js:62:27)
[Nest] 17  - 02/24/2025, 3:37:07 PM     LOG [Api:MachineLearningRepository~vsfkmudg] Setting http://immich-machine-learning:3003 ML server to active.
[Nest] 17  - 02/24/2025, 3:37:37 PM     LOG [Api:MachineLearningRepository~ykubnump] Setting http://192.168.xxx.xxx:3003 ML server to active.
</pre>
</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)


Feedback please (particularly on un-checked items above).

Should we make the 2s (ping timeout) and 30s (backoff time) values configurable?