### PR TITLE
fix(web): thumbnail playback stops when hovering over icon then video

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -358,7 +358,7 @@
               enablePlayback={mouseOver && $playVideoThumbnailOnHover}
               curve={selected}
               durationInSeconds={timeToSeconds(asset.duration)}
-              playbackOnIconHover
+              playbackOnIconHover={!$playVideoThumbnailOnHover}
             />
           </div>
         {/if}


### PR DESCRIPTION
## Description

With the "Play video thumbnail on hover" toggle enabled, videos play when you hover over them. When you hover over the play icon, it re-enables playback. Then, when you move off of the icon onto the rest of the video, it stops.

My proposed solution does not alter the behavior when the "Play video thumbnail on hover" toggle is disabled.
![](https://media.discordapp.net/attachments/1071165397228855327/1338335434551459932/image.png?ex=67bdd340&is=67bc81c0&hm=ee5e4a70011b336e4d23096e843f93ffe4f7d47c781a262885d19b1d74987301&=)

## How Has This Been Tested?

- [X] Ran a dev instance

<details><summary><h2>Videos</h2></summary>

## Old Behavior:

https://github.com/user-attachments/assets/c726d420-cae8-4906-a29b-3f3e4a594573

## New Behavior:

https://github.com/user-attachments/assets/596dda3d-8460-48d3-b2b6-e149cc69a64c

</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
