### PR TITLE
chore(web): Revert slight fade in animation when open/close asset-viewer (#16262)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -168,8 +168,3 @@ input:focus-visible {
     scrollbar-gutter: stable both-edges;
   }
 }
-
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation-duration: 250ms;
-}

--- a/web/src/lib/utils/navigation.ts
+++ b/web/src/lib/utils/navigation.ts
@@ -112,7 +112,7 @@ async function navigateAssetRoute(route: AssetRoute, options?: NavOptions) {
   const next = assetId ? currentUrlReplaceAssetId(assetId) : currentUrlWithoutAsset();
   const current = currentUrl();
   if (next !== current || options?.forceNavigate) {
-    await navigateWithTransition(next, options);
+    await goto(next, options);
   }
 }
 
@@ -122,7 +122,7 @@ async function navigateAssetGridRoute(route: AssetGridRoute, options?: NavOption
   const next = replaceScrollTarget(assetUrl, assetGridScrollTarget);
   const current = currentUrl();
   if (next !== current || options?.forceNavigate) {
-    await navigateWithTransition(next, options);
+    await goto(next, options);
   }
 }
 
@@ -134,16 +134,6 @@ export function navigate(change: ImmichRoute, options?: NavOptions): Promise<voi
   }
   // future navigation requests here
   throw `Invalid navigation: ${JSON.stringify(change)}`;
-}
-
-async function navigateWithTransition(url: string, options?: NavOptions) {
-  if (document.startViewTransition) {
-    document.startViewTransition(async () => {
-      await goto(url, options);
-    });
-  } else {
-    await goto(url, options);
-  }
 }
 
 export const clearQueryParam = async (queryParam: string, url: URL) => {


### PR DESCRIPTION
View transition API cause the thumbnails to double flashing when navigating back from the asset viewer

This reverts commit 57829cee26807317d3448abd0502da21fe33097f.
