### PR TITLE
fix(web): update search modal to not jump around

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
@@ -56,7 +56,7 @@
 
 {#await peoplePromise}
   <div id="spinner" class="flex h-60 items-center justify-center -mb-4">
-    <LoadingSpinner size="100" />
+    <LoadingSpinner size="24" />
   </div>
 {:then people}
   {#if people && people.length > 0}

--- a/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
@@ -11,7 +11,6 @@
   import SingleGridRow from '$lib/components/shared-components/single-grid-row.svelte';
   import type { SvelteSet } from 'svelte/reactivity';
   import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
-  import Error from '$lib/components/error.svelte';
 
   interface Props {
     selectedPeople: SvelteSet<string>;

--- a/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-people-section.svelte
@@ -10,6 +10,8 @@
   import { t } from 'svelte-i18n';
   import SingleGridRow from '$lib/components/shared-components/single-grid-row.svelte';
   import type { SvelteSet } from 'svelte/reactivity';
+  import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
+  import Error from '$lib/components/error.svelte';
 
   interface Props {
     selectedPeople: SvelteSet<string>;
@@ -52,13 +54,17 @@
   };
 </script>
 
-{#await peoplePromise then people}
+{#await peoplePromise}
+  <div id="spinner" class="flex h-60 items-center justify-center -mb-4">
+    <LoadingSpinner size="100" />
+  </div>
+{:then people}
   {#if people && people.length > 0}
     {@const peopleList = showAllPeople
       ? filterPeople(people, name)
       : filterPeople(people, name).slice(0, numberOfPeople)}
 
-    <div id="people-selection" class="-mb-4">
+    <div id="people-selection" class="h-60 -mb-4">
       <div class="flex items-center w-full justify-between gap-6">
         <p class="immich-form-label py-3">{$t('people').toUpperCase()}</p>
         <SearchBar bind:name placeholder={$t('filter_people')} showLoadingSpinner={false} />


### PR DESCRIPTION
## Description

When you first open the search options modal, the people selector will not yet be populated. Therefore, users on slower connections might see the UI jump around as the component loads. Instead of that, we can substitute a loading spinner. Additionally, I pinned the height of the component to a constant value (`h-60`). This seems to be what the component was using automatically anyways. This should make the UI experience much more consistent. I would appreciate people trying out these changes on their own devices. I only verified on my laptop and mobile phone.

Fixes #15808 

## How Has This Been Tested?

- [x] All existing tests pass
- [x] Manually tested

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

You can see how the modal is consistent before and after we load all the people.

![Screenshot from 2025-02-24 22-30-40](https://github.com/user-attachments/assets/66a636f4-14bc-4e11-beaa-e60d31618846)

![Screenshot from 2025-02-24 22-30-59](https://github.com/user-attachments/assets/2a8cede6-ad90-4656-99bf-1a51805d8540)

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
