### PR TITLE
fix: websockets calling on_new_release across all sessions upon new websocket connection.

### DIFF
--- a/web/src/lib/components/shared-components/version-announcement-box.svelte
+++ b/web/src/lib/components/shared-components/version-announcement-box.svelte
@@ -14,6 +14,7 @@
 
   const onAcknowledge = () => {
     localStorage.setItem('appVersion', releaseVersion);
+    sessionStorage.setItem('modalAknowledged', 'true');
     showModal = false;
   };
 
@@ -31,7 +32,7 @@
   let releaseVersion = $derived($release && semverToName($release.releaseVersion));
   let serverVersion = $derived($release && semverToName($release.serverVersion));
   $effect(() => {
-    if ($release?.isAvailable) {
+    if (($release?.isAvailable) && (!sessionStorage.getItem('modalAknowledged'))) {
       handleRelease();
     }
   });

--- a/web/src/lib/components/shared-components/version-announcement-box.svelte
+++ b/web/src/lib/components/shared-components/version-announcement-box.svelte
@@ -14,7 +14,7 @@
 
   const onAcknowledge = () => {
     localStorage.setItem('appVersion', releaseVersion);
-    sessionStorage.setItem('modalAknowledged', 'true');
+    sessionStorage.setItem('modalAcknowledged', 'true');
     showModal = false;
   };
 
@@ -32,7 +32,7 @@
   let releaseVersion = $derived($release && semverToName($release.releaseVersion));
   let serverVersion = $derived($release && semverToName($release.serverVersion));
   $effect(() => {
-    if ($release?.isAvailable && !sessionStorage.getItem('modalAknowledged')) {
+    if ($release?.isAvailable && !sessionStorage.getItem('modalAcknowledged')) {
       handleRelease();
     }
   });

--- a/web/src/lib/components/shared-components/version-announcement-box.svelte
+++ b/web/src/lib/components/shared-components/version-announcement-box.svelte
@@ -32,7 +32,7 @@
   let releaseVersion = $derived($release && semverToName($release.releaseVersion));
   let serverVersion = $derived($release && semverToName($release.serverVersion));
   $effect(() => {
-    if (($release?.isAvailable) && (!sessionStorage.getItem('modalAknowledged'))) {
+    if ($release?.isAvailable && !sessionStorage.getItem('modalAknowledged')) {
       handleRelease();
     }
   });

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -49,11 +49,7 @@ websocket
   .on('connect', () => websocketStore.connected.set(true))
   .on('disconnect', () => websocketStore.connected.set(false))
   .on('on_server_version', (serverVersion) => websocketStore.serverVersion.set(serverVersion))
-  .on('on_new_release', (releaseVersion) => {
-    if (!sessionStorage.getItem('modalAknowledged')) {
-      websocketStore.release.set(releaseVersion);
-    }
-  })
+  .on('on_new_release', (releaseVersion) => websocketStore.release.set(releaseVersion))
   .on('on_session_delete', () => handleLogout(AppRoute.AUTH_LOGIN))
   .on('connect_error', (e) => console.log('Websocket Connect Error', e));
 

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -49,7 +49,11 @@ websocket
   .on('connect', () => websocketStore.connected.set(true))
   .on('disconnect', () => websocketStore.connected.set(false))
   .on('on_server_version', (serverVersion) => websocketStore.serverVersion.set(serverVersion))
-  .on('on_new_release', (releaseVersion) => websocketStore.release.set(releaseVersion))
+  .on('on_new_release', (releaseVersion) => {
+    if (!sessionStorage.getItem('modalAknowledged')) {
+      websocketStore.release.set(releaseVersion);
+    }
+  })
   .on('on_session_delete', () => handleLogout(AppRoute.AUTH_LOGIN))
   .on('connect_error', (e) => console.log('Websocket Connect Error', e));
 


### PR DESCRIPTION
## Description

Added a new variable `modalAcknowledged` to session storage to check against before displaying the new_release window/popup.
### Flow of operations
#### Modal not acknowledged:
- New websocket connection is made
- version-announcement-box.svelte runs the conditional:
```
$effect(() => {
    if (($release?.isAvailable) && (!sessionStorage.getItem('modal Acknowledged'))) {
      handleRelease();
    }
  });
```
- $release?.isAvailable returns true and modalAcknowledged returns false, invoking handleRelease()
- handleRelease sets showModal to true - showing the popup
- When onAcknowledged is invoked, modalAcknowledged is set to true in sessionStorage

#### Modal acknowledged
- New websocket connection is made
- version-announcement-box.svelte runs the conditional:
```
$effect(() => {
    if (($release?.isAvailable) && (!sessionStorage.getItem('modalAcknowledged'))) {
      handleRelease();
    }
  });
```
- $release?.isAvailable returns true and modalAcknowledged returns true, NOT triggering handleRelease.

The same thing could be achieved within the handleRelease() function should you want that to be called
```
const handleRelease = () => {
    try {
      if (localStorage.getItem('appVersion') === releaseVersion) {
        return;
      }

      if (sessionStorage.getItem('modalAcknowledged')) {return;}
      showModal = true;
    } catch (error) {
      console.error('Error [VersionAnnouncementBox]:', error);
    }
  };
```
though I think having it in it's current implementation is better, as it avoids the function being called at all if the modals been acknowledged.


<!--- Why is this change required? What problem does it solve? -->
## Why is this change required? What problem does it solve?
Whenever a new websocket connection is made, and an update for the server is available, the update window pops up on ALL active web sessions. An example would be:
-  you have an outdated Immich version open on your PC
- you dismiss the update reminder.
- You open Immich mobile (Android, in my case)
- The update reminder then reappears on PC.

The same would happen if you opened another immich tab. I believed this to be down to version-announcement-box.svelte being ran whenever ANY new websocket connection is made (I could be wrong, I am tired). In any case, the provided PR should fix the issue.

## Fixes issues:
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #14009 

## How Has This Been Tested?

### Within /web: `npm run test`
Before I made any changes, the output were as follows:
`Test Files  16 failed | 19 passed (35)
      Tests  55 failed | 94 passed (149)
   Start at  06:49:49
   Duration  5.36s (transform 4.41s, setup 16.20s, collect 7.14s, tests 5.28s, environment 26.42s, prepare 4.15s)
`
The failed files were mostly to do with languages.

After I made my changes, the output is as follows:
` Test Files  16 failed | 19 passed (35)
      Tests  55 failed | 94 passed (149)
   Start at  07:48:54
   Duration  4.93s (transform 3.83s, setup 14.23s, collect 6.78s, tests 4.89s, environment 23.68s, prepare 4.09s)
`

### `npm run check:all`
[warn] Code style issues found in 511 files. Run Prettier with --write to fix.

The only changed file in this PR is NOT listed in these files.
## Checklist:

- [True ] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation if applicable
- [True ] I have no unrelated changes in the PR.
- [N/A] I have confirmed that any new dependencies are strictly necessary.
- [N/A] I have written tests for new code (if applicable)
- [True] I have followed naming conventions/patterns in the surrounding code
- [N/A] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)


Please let me know if I've had any oversights, I'll be happy to amend any issues :)