### PR TITLE
docs: fix typos

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -97,7 +97,7 @@ Make sure to [set your reverse proxy](/docs/administration/reverse-proxy/) to al
 Also, check the disk space of your reverse proxy.
 In some cases, proxies cache requests to disk before passing them on, and if disk space runs out, the request fails.
 
-If you are using Cloudflare Tunnel, please know that they set a maxiumum filesize of 100 MB that cannot be changed.
+If you are using Cloudflare Tunnel, please know that they set a maximum filesize of 100 MB that cannot be changed.
 At times, files larger than this may work, potentially up to 1 GB. However, the official limit is 100 MB.
 If you are having issues, we recommend switching to a different network deployment.
 
@@ -170,7 +170,7 @@ If you aren't able to or prefer not to mount Samba on the host (such as Windows 
 Below is an example in the `docker-compose.yml`.
 
 Change your username, password, local IP, and share name, and see below where the line `- originals:/usr/src/app/originals`,
-corrolates to the section where the volume `originals` was created. You can call this whatever you like, and map it to the docker container as you like.
+correlates to the section where the volume `originals` was created. You can call this whatever you like, and map it to the docker container as you like.
 For example you could change `originals:` to `Photos:`, and change `- originals:/usr/src/app/originals` to `Photos:/usr/src/app/photos`.
 
 ```diff

--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -37,7 +37,7 @@ You can alternatively download these two files from your browser and move them t
 </CodeBlock>
 
 - Populate `UPLOAD_LOCATION` with your preferred location for storing backup assets. It should be a new directory on the server with enough free space.
-- Consider changing `DB_PASSWORD` to a custom value. Postgres is not publically exposed, so this password is only used for local authentication.
+- Consider changing `DB_PASSWORD` to a custom value. Postgres is not publicly exposed, so this password is only used for local authentication.
   To avoid issues with Docker parsing this value, it is best to use only the characters `A-Za-z0-9`. `pwgen` is a handy utility for this.
 - Set your timezone by uncommenting the `TZ=` line.
 - Populate custom database information if necessary.

--- a/docs/docs/install/truenas.md
+++ b/docs/docs/install/truenas.md
@@ -198,7 +198,7 @@ The **CPU** value was specified in a different format with a default of `4000m` 
 The **Memory** value was specified in a different format with a default of `8Gi` which is 8 GiB of RAM. The value was specified in bytes or a number with a measurement suffix. Examples: `129M`, `123Mi`, `1000000000`
 :::
 
-Enable **GPU Configuration** options if you have a GPU that you will use for [Hardware Transcoding](/docs/features/hardware-transcoding) and/or [Hardware-Accelerated Machine Learning](/docs/features/ml-hardware-acceleration.md). More info: [GPU Passtrough Docs for TrueNAS Apps](https://www.truenas.com/docs/truenasapps/#gpu-passthrough)
+Enable **GPU Configuration** options if you have a GPU that you will use for [Hardware Transcoding](/docs/features/hardware-transcoding) and/or [Hardware-Accelerated Machine Learning](/docs/features/ml-hardware-acceleration.md). More info: [GPU Passthrough Docs for TrueNAS Apps](https://www.truenas.com/docs/truenasapps/#gpu-passthrough)
 
 ### Install
 

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     preflight: false, // disable Tailwind's reset
   },
   content: ['./src/**/*.{js,jsx,ts,tsx}', './{docs,blog}/**/*.{md,mdx}'], // my markdown stuff is in ../docs, not /src
-  darkMode: ['class', '[data-theme="dark"]'], // hooks into docusaurus' dark mode settigns
+  darkMode: ['class', '[data-theme="dark"]'], // hooks into docusaurus' dark mode settings
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Description

Fixes user-facing and non-user-facing typos

Found via `codespell -q 3 -S "./i18n,./docs/package-lock.json,./readme_i18n,./mobile/assets/i18n" -L afterall,nd,renderd`

## How Has This Been Tested?

Hasn't been tested

## API Changes

n/a

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
