### PR TITLE
feat(web): remember last chosen map location when editing

### DIFF
--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -2,6 +2,7 @@
   import ConfirmDialog from './dialog/confirm-dialog.svelte';
   import { timeDebounceOnSearch } from '$lib/constants';
   import { handleError } from '$lib/utils/handle-error';
+  import { lastChosenLocation } from '$lib/stores/asset-editor.store';
 
   import { clickOutside } from '$lib/actions/click-outside';
   import LoadingSpinner from './loading-spinner.svelte';
@@ -13,6 +14,7 @@
   import { t } from 'svelte-i18n';
   import CoordinatesInput from '$lib/components/shared-components/coordinates-input.svelte';
   import Map from '$lib/components/shared-components/map/map.svelte';
+  import { get } from 'svelte/store';
 
   interface Point {
     lng: number;
@@ -36,9 +38,15 @@
   let hideSuggestion = $state(false);
   let mapElement = $state<ReturnType<typeof Map>>();
 
-  let lat = $derived(asset?.exifInfo?.latitude ?? undefined);
-  let lng = $derived(asset?.exifInfo?.longitude ?? undefined);
-  let zoom = $derived(lat !== undefined && lng !== undefined ? 12.5 : 1);
+  let previousLocation = get(lastChosenLocation);
+
+  let assetLat = $derived(asset?.exifInfo?.latitude ?? undefined);
+  let assetLng = $derived(asset?.exifInfo?.longitude ?? undefined);
+
+  let mapLat = $derived(assetLat ?? previousLocation?.lat ?? undefined);
+  let mapLng = $derived(assetLng ?? previousLocation?.lng ?? undefined);
+
+  let zoom = $derived(mapLat !== undefined && mapLng !== undefined ? 12.5 : 1);
 
   $effect(() => {
     if (places) {
@@ -53,6 +61,7 @@
 
   const handleConfirm = () => {
     if (point) {
+      lastChosenLocation.set(point);
       onConfirm(point);
     } else {
       onCancel();
@@ -160,12 +169,12 @@
         {:then { default: Map }}
           <Map
             bind:this={mapElement}
-            mapMarkers={lat !== undefined && lng !== undefined && asset
+            mapMarkers={assetLat !== undefined && assetLng !== undefined && asset
               ? [
                   {
                     id: asset.id,
-                    lat,
-                    lon: lng,
+                    lat: assetLat,
+                    lon: assetLng,
                     city: asset.exifInfo?.city ?? null,
                     state: asset.exifInfo?.state ?? null,
                     country: asset.exifInfo?.country ?? null,
@@ -173,7 +182,7 @@
                 ]
               : []}
             {zoom}
-            center={lat && lng ? { lat, lng } : undefined}
+            center={mapLat && mapLng ? { lat: mapLat, lng: mapLng } : undefined}
             simplified={true}
             clickable={true}
             onClickPoint={(selected) => (point = selected)}
@@ -183,8 +192,8 @@
 
       <div class="grid sm:grid-cols-2 gap-4 text-sm text-left mt-4">
         <CoordinatesInput
-          lat={point ? point.lat : lat}
-          lng={point ? point.lng : lng}
+          lat={point ? point.lat : assetLat}
+          lng={point ? point.lng : assetLng}
           onUpdate={(lat, lng) => {
             point = { lat, lng };
             mapElement?.addClipMapMarker(lng, lat);

--- a/web/src/lib/stores/asset-editor.store.ts
+++ b/web/src/lib/stores/asset-editor.store.ts
@@ -17,6 +17,7 @@ export const normaizedRorateDegrees = derived(rotateDegrees, (v) => {
 export const changedOriention = derived(normaizedRorateDegrees, () => get(normaizedRorateDegrees) % 180 > 0);
 //-----other
 export const showCancelConfirmDialog = writable<boolean | CallableFunction>(false);
+export const lastChosenLocation = writable<{ lng: number; lat: number } | null>(null);
 
 export const editTypes = [
   {


### PR DESCRIPTION
## Description

When adding location data to multiple assets in a row, it can be annoying to have to zoom-in from the top-level zoom everytime, especially when editing photos that were taken in close succession (e.g.: adding location to a travel photos album).

With this commit, the web UI remembers the last location picked by the user and opens the map to this location. The opened map does _not_ include a pin. this "lastChosenLocation" is kept in the asset-editor store and is lost when refreshing the page (by design).

## How Has This Been Tested?

- Added two assets
- Edited one asset's location using the web UI
- Opened location editor for second asset: it show the map around the previous asset's location (but no pin)
- Refreshed page without picking a location 
- Opened location editor for second asset: it show the top-level map.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

https://github.com/user-attachments/assets/88b7ab77-dd1e-42bd-8ded-0d561cbdc869

</details>

## API Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
