### PR TITLE
fix(server): don't reimport files more than once

### DIFF
--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -227,7 +227,6 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: sidecarDate,
-        fileModifiedAt: new Date('2023-02-23T05:06:29.716Z'),
         localDateTime: sidecarDate,
       });
     });
@@ -247,7 +246,6 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: fileModifiedAt,
-        fileModifiedAt,
         localDateTime: fileModifiedAt,
       });
     });
@@ -265,7 +263,6 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt,
-        fileModifiedAt,
         localDateTime: fileCreatedAt,
       });
     });
@@ -300,7 +297,6 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: assetStub.image.fileCreatedAt,
-        fileModifiedAt: assetStub.image.fileModifiedAt,
         localDateTime: assetStub.image.fileCreatedAt,
       });
     });
@@ -323,7 +319,6 @@ describe(MetadataService.name, () => {
         id: assetStub.withLocation.id,
         duration: null,
         fileCreatedAt: assetStub.withLocation.createdAt,
-        fileModifiedAt: assetStub.withLocation.createdAt,
         localDateTime: new Date('2023-02-22T05:06:29.716Z'),
       });
     });
@@ -845,7 +840,6 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: dateForTest,
-        fileModifiedAt: assetStub.image.fileModifiedAt,
         localDateTime: dateForTest,
       });
     });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -845,7 +845,7 @@ describe(MetadataService.name, () => {
         id: assetStub.image.id,
         duration: null,
         fileCreatedAt: dateForTest,
-        fileModifiedAt: dateForTest,
+        fileModifiedAt: assetStub.image.fileModifiedAt,
         localDateTime: dateForTest,
       });
     });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -238,7 +238,7 @@ export class MetadataService extends BaseService {
       duration: exifTags.Duration?.toString() ?? null,
       localDateTime,
       fileCreatedAt: exifData.dateTimeOriginal ?? undefined,
-      fileModifiedAt: exifData.modifyDate ?? undefined,
+      fileModifiedAt: stats.mtime,
     });
 
     await this.assetRepository.upsertJobStatus({


### PR DESCRIPTION
Whenever a library asset is changed it will be reimported during the next scan. However, the metadata extractor puts the incorrect date in fileModifiedAt, so that the file will be reimported on the next scan, and the next, and the next, no matter if it was changed or not.

This fix puts the correct date in fileModifiedAt so that this won't happen. fileCreatedAt should be derived from the file, and not exif data.

Yes, this is a bug from my previous PR #16225...hope this is correct now. 