### PR TITLE
fix(server): skip stacked assets in duplicate detection

### DIFF
--- a/server/src/migrations/1740654480319-UnsetStackedAssetsFromDuplicateStatus.ts
+++ b/server/src/migrations/1740654480319-UnsetStackedAssetsFromDuplicateStatus.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UnsetStackedAssetsFromDuplicateStatus1740654480319 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            update assets
+            set "duplicateId" = null
+            where "stackId" is not null`);
+  }
+
+  public async down(): Promise<void> {
+    // No need to revert this migration
+  }
+}

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -333,6 +333,7 @@ with
       and "assets"."duplicateId" is not null
       and "assets"."deletedAt" is null
       and "assets"."isVisible" = $2
+      and "assets"."stackId" is null
     group by
       "assets"."duplicateId"
   ),

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -112,6 +112,7 @@ with
       and "assets"."isVisible" = $3
       and "assets"."type" = $4
       and "assets"."id" != $5::uuid
+      and "assets"."stackId" is null
     order by
       smart_search.embedding <=> $6
     limit

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -794,6 +794,7 @@ export class AssetRepository {
             .where('assets.duplicateId', 'is not', null)
             .where('assets.deletedAt', 'is', null)
             .where('assets.isVisible', '=', true)
+            .where('assets.stackId', 'is', null)
             .groupBy('assets.duplicateId'),
         )
         .with('unique', (qb) =>

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -318,6 +318,7 @@ export class SearchRepository {
           .where('assets.isVisible', '=', true)
           .where('assets.type', '=', type)
           .where('assets.id', '!=', asUuid(assetId))
+          .where('assets.stackId', 'is', null)
           .orderBy(sql`smart_search.embedding <=> ${embedding}`)
           .limit(64),
       )

--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -173,6 +173,16 @@ describe(SearchService.name, () => {
       expect(mocks.logger.error).toHaveBeenCalledWith(`Asset ${assetStub.image.id} not found`);
     });
 
+    it('should skip if asset is part of stack', async () => {
+      const id = assetStub.primaryImage.id;
+      mocks.asset.getById.mockResolvedValue(assetStub.primaryImage);
+
+      const result = await sut.handleSearchDuplicates({ id });
+
+      expect(result).toBe(JobStatus.SKIPPED);
+      expect(mocks.logger.debug).toHaveBeenCalledWith(`Asset ${id} is part of a stack, skipping`);
+    });
+
     it('should skip if asset is not visible', async () => {
       const id = assetStub.livePhotoMotionAsset.id;
       mocks.asset.getById.mockResolvedValue(assetStub.livePhotoMotionAsset);

--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -59,6 +59,11 @@ export class DuplicateService extends BaseService {
       return JobStatus.FAILED;
     }
 
+    if (asset.stackId) {
+      this.logger.debug(`Asset ${id} is part of a stack, skipping`);
+      return JobStatus.SKIPPED;
+    }
+
     if (!asset.isVisible) {
       this.logger.debug(`Asset ${id} is not visible, skipping`);
       return JobStatus.SKIPPED;

--- a/server/test/fixtures/asset.stub.ts
+++ b/server/test/fixtures/asset.stub.ts
@@ -184,6 +184,7 @@ export const assetStub = {
       exifImageHeight: 1000,
       exifImageWidth: 1000,
     } as ExifEntity,
+    stackId: 'stack-1',
     stack: stackStub('stack-1', [
       { id: 'primary-asset-id' } as AssetEntity,
       { id: 'stack-child-asset-1' } as AssetEntity,


### PR DESCRIPTION
## Description

After the Kysely migration, assets were no longer stacked in the `getDuplicates` response, leading to errors in some cases when using the deduplication utility.

However, even before this, stacks were not handled by duplicate detection in the server or by the deduplication logic in the client:
* Users who perform the "stack" action on a set of duplicates would see those assets once again marked as duplicates of each other after running duplicate detection
* A stack where the primary asset was not marked duplicate but some of its members were would not show up in the utility
* A duplicate group where all assets were part of the same stack would show up as one asset
* Deduplicating only trashed the primary asset and not others (which, combined with the above, are the likely reasons behind straggling "1 asset" duplicate groups for so many people)
* I'm not sure how the utility behaves when stacking already stacked assets

Pending more robust stack handling in this area, this PR skips assets part of a stack to align with the implementation assumptions.

Fixes #15735
Fixes #15868
Fixes #16359