### PR TITLE
fix(server): don't expose source types in face creation api

### DIFF
--- a/mobile/openapi/lib/model/asset_face_create_dto.dart
+++ b/mobile/openapi/lib/model/asset_face_create_dto.dart
@@ -18,7 +18,6 @@ class AssetFaceCreateDto {
     required this.imageHeight,
     required this.imageWidth,
     required this.personId,
-    this.sourceType = SourceType.manual,
     required this.width,
     required this.x,
     required this.y,
@@ -34,8 +33,6 @@ class AssetFaceCreateDto {
 
   String personId;
 
-  SourceType sourceType;
-
   int width;
 
   int x;
@@ -49,7 +46,6 @@ class AssetFaceCreateDto {
     other.imageHeight == imageHeight &&
     other.imageWidth == imageWidth &&
     other.personId == personId &&
-    other.sourceType == sourceType &&
     other.width == width &&
     other.x == x &&
     other.y == y;
@@ -62,13 +58,12 @@ class AssetFaceCreateDto {
     (imageHeight.hashCode) +
     (imageWidth.hashCode) +
     (personId.hashCode) +
-    (sourceType.hashCode) +
     (width.hashCode) +
     (x.hashCode) +
     (y.hashCode);
 
   @override
-  String toString() => 'AssetFaceCreateDto[assetId=$assetId, height=$height, imageHeight=$imageHeight, imageWidth=$imageWidth, personId=$personId, sourceType=$sourceType, width=$width, x=$x, y=$y]';
+  String toString() => 'AssetFaceCreateDto[assetId=$assetId, height=$height, imageHeight=$imageHeight, imageWidth=$imageWidth, personId=$personId, width=$width, x=$x, y=$y]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -77,7 +72,6 @@ class AssetFaceCreateDto {
       json[r'imageHeight'] = this.imageHeight;
       json[r'imageWidth'] = this.imageWidth;
       json[r'personId'] = this.personId;
-      json[r'sourceType'] = this.sourceType;
       json[r'width'] = this.width;
       json[r'x'] = this.x;
       json[r'y'] = this.y;
@@ -98,7 +92,6 @@ class AssetFaceCreateDto {
         imageHeight: mapValueOfType<int>(json, r'imageHeight')!,
         imageWidth: mapValueOfType<int>(json, r'imageWidth')!,
         personId: mapValueOfType<String>(json, r'personId')!,
-        sourceType: SourceType.fromJson(json[r'sourceType'])!,
         width: mapValueOfType<int>(json, r'width')!,
         x: mapValueOfType<int>(json, r'x')!,
         y: mapValueOfType<int>(json, r'y')!,
@@ -154,7 +147,6 @@ class AssetFaceCreateDto {
     'imageHeight',
     'imageWidth',
     'personId',
-    'sourceType',
     'width',
     'x',
     'y',

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -8301,14 +8301,6 @@
             "format": "uuid",
             "type": "string"
           },
-          "sourceType": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SourceType"
-              }
-            ],
-            "default": "manual"
-          },
           "width": {
             "type": "integer"
           },
@@ -8325,7 +8317,6 @@
           "imageHeight",
           "imageWidth",
           "personId",
-          "sourceType",
           "width",
           "x",
           "y"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -529,7 +529,6 @@ export type AssetFaceCreateDto = {
     imageHeight: number;
     imageWidth: number;
     personId: string;
-    sourceType: SourceType;
     width: number;
     x: number;
     y: number;

--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsEnum, IsInt, IsNotEmpty, IsNumber, IsString, Max, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsInt, IsNotEmpty, IsNumber, IsString, Max, Min, ValidateNested } from 'class-validator';
 import { DateTime } from 'luxon';
 import { PropertyLifecycle } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
@@ -194,10 +194,6 @@ export class AssetFaceCreateDto extends AssetFaceUpdateItem {
   @IsNotEmpty()
   @IsNumber()
   height!: number;
-
-  @ApiProperty({ type: 'string', enum: SourceType, enumName: 'SourceType' })
-  @IsEnum(SourceType)
-  sourceType: SourceType = SourceType.MANUAL;
 }
 
 export class AssetFaceDeleteDto {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -736,7 +736,7 @@ export class PersonService extends BaseService {
       boundingBoxX2: dto.x + dto.width,
       boundingBoxY1: dto.y,
       boundingBoxY2: dto.y + dto.height,
-      sourceType: dto.sourceType,
+      sourceType: SourceType.MANUAL,
     });
   }
 

--- a/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
+++ b/web/src/lib/components/asset-viewer/face-editor/face-editor.svelte
@@ -4,7 +4,7 @@
   import { notificationController } from '$lib/components/shared-components/notification/notification';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { getPeopleThumbnailUrl } from '$lib/utils';
-  import { getAllPeople, createFace, type PersonResponseDto, SourceType } from '@immich/sdk';
+  import { getAllPeople, createFace, type PersonResponseDto } from '@immich/sdk';
   import { Button } from '@immich/ui';
   import { Canvas, InteractiveFabricObject, Rect } from 'fabric';
   import { onMount } from 'svelte';
@@ -288,7 +288,6 @@
         assetFaceCreateDto: {
           assetId,
           personId: person.id,
-          sourceType: SourceType.Manual,
           ...data,
         },
       });


### PR DESCRIPTION
## Description

The `machine-learning` and `exif` source types are for internal use. Any face created through the API should be `manual`.