### PR TITLE
fix: improve contrast on disabled input field in light mode (#16368)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -127,7 +127,7 @@ input:focus-visible {
 
 @layer utilities {
   .immich-form-input {
-    @apply rounded-xl bg-slate-200 px-3 py-3 text-sm focus:border-immich-primary disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-200 dark:bg-gray-600 dark:text-immich-dark-fg dark:disabled:bg-gray-800;
+    @apply rounded-xl bg-slate-200 px-3 py-3 text-sm focus:border-immich-primary disabled:cursor-not-allowed disabled:bg-gray-400 disabled:text-gray-400 dark:bg-gray-600 dark:text-immich-dark-fg dark:disabled:bg-gray-800 dark:disabled:text-gray-200;
   }
 
   .immich-form-label {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Modified a css variable on text color to add contrast to the disabled input field in light mode

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #16368 

Linked with immich-app/ui#116

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Created a share link in light mode
- [X] Created a share link in dark mode

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

## Before

![image](https://github.com/user-attachments/assets/d8accd81-1bda-4751-8e2f-308c4f7d30e0)

## After 

![image](https://github.com/user-attachments/assets/2a243da1-c1f9-438c-8109-8fd62668b8ab)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
