### PR TITLE
refactor(server): link live photos as part of metadata extraction instead of queueing job

### DIFF
--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -437,7 +437,6 @@ export enum JobName {
   // metadata
   QUEUE_METADATA_EXTRACTION = 'queue-metadata-extraction',
   METADATA_EXTRACTION = 'metadata-extraction',
-  LINK_LIVE_PHOTOS = 'link-live-photos',
 
   // user
   USER_DELETION = 'user-deletion',

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -236,10 +236,6 @@ describe(JobService.name, () => {
         jobs: [JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE],
       },
       {
-        item: { name: JobName.LINK_LIVE_PHOTOS, data: { id: 'asset-1' } },
-        jobs: [JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE],
-      },
-      {
         item: { name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: { id: 'asset-1', source: 'upload' } },
         jobs: [JobName.GENERATE_THUMBNAILS],
       },

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -233,7 +233,7 @@ describe(JobService.name, () => {
       },
       {
         item: { name: JobName.METADATA_EXTRACTION, data: { id: 'asset-1' } },
-        jobs: [JobName.LINK_LIVE_PHOTOS],
+        jobs: [],
       },
       {
         item: { name: JobName.LINK_LIVE_PHOTOS, data: { id: 'asset-1' } },

--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -233,7 +233,7 @@ describe(JobService.name, () => {
       },
       {
         item: { name: JobName.METADATA_EXTRACTION, data: { id: 'asset-1' } },
-        jobs: [],
+        jobs: [JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE],
       },
       {
         item: { name: JobName.LINK_LIVE_PHOTOS, data: { id: 'asset-1' } },

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -251,6 +251,7 @@ export class JobService extends BaseService {
             this.eventRepository.clientSend('on_asset_update', asset.ownerId, mapAsset(asset));
           }
         }
+        await this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: item.data });
         break;
       }
 

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -251,7 +251,6 @@ export class JobService extends BaseService {
             this.eventRepository.clientSend('on_asset_update', asset.ownerId, mapAsset(asset));
           }
         }
-        await this.jobRepository.queue({ name: JobName.LINK_LIVE_PHOTOS, data: item.data });
         break;
       }
 

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -255,11 +255,6 @@ export class JobService extends BaseService {
         break;
       }
 
-      case JobName.LINK_LIVE_PHOTOS: {
-        await this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: item.data });
-        break;
-      }
-
       case JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE: {
         if (item.data.source === 'upload' || item.data.source === 'copy') {
           await this.jobRepository.queue({ name: JobName.GENERATE_THUMBNAILS, data: item.data });

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -539,7 +539,7 @@ describe(MetadataService.name, () => {
         faces: { person: false },
       });
       expect(mocks.storage.createOrOverwriteFile).not.toHaveBeenCalled();
-      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.asset.update).not.toHaveBeenCalledWith(
         expect.objectContaining({ assetType: AssetType.VIDEO, isVisible: false }),
@@ -750,7 +750,7 @@ describe(MetadataService.name, () => {
       expect(mocks.storage.createOrOverwriteFile).toHaveBeenCalledTimes(0);
       // The still asset gets saved by handleMetadataExtraction, but not the video
       expect(mocks.asset.update).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).toHaveBeenCalledTimes(0);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
     });
 
     it('should link and hide motion video asset to still asset if the hash of the extracted video matches an existing asset', async () => {

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -539,7 +539,7 @@ describe(MetadataService.name, () => {
         faces: { person: false },
       });
       expect(mocks.storage.createOrOverwriteFile).not.toHaveBeenCalled();
-      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).not.toHaveBeenCalled();
       expect(mocks.job.queueAll).not.toHaveBeenCalled();
       expect(mocks.asset.update).not.toHaveBeenCalledWith(
         expect.objectContaining({ assetType: AssetType.VIDEO, isVisible: false }),
@@ -746,11 +746,11 @@ describe(MetadataService.name, () => {
       mocks.storage.checkFileExists.mockResolvedValue(true);
 
       await sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id });
-      expect(mocks.asset.create).toHaveBeenCalledTimes(0);
-      expect(mocks.storage.createOrOverwriteFile).toHaveBeenCalledTimes(0);
+      expect(mocks.asset.create).not.toHaveBeenCalled();
+      expect(mocks.storage.createOrOverwriteFile).not.toHaveBeenCalled();
       // The still asset gets saved by handleMetadataExtraction, but not the video
       expect(mocks.asset.update).toHaveBeenCalledTimes(1);
-      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).not.toHaveBeenCalled();
     });
 
     it('should link and hide motion video asset to still asset if the hash of the extracted video matches an existing asset', async () => {

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -76,125 +76,6 @@ describe(MetadataService.name, () => {
     });
   });
 
-  describe('handleLivePhotoLinking', () => {
-    it('should handle an asset that could not be found', async () => {
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.image.id })).resolves.toBe(JobStatus.FAILED);
-      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.image.id], { exifInfo: true });
-      expect(mocks.asset.findLivePhotoMatch).not.toHaveBeenCalled();
-      expect(mocks.asset.update).not.toHaveBeenCalled();
-      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
-    });
-
-    it('should handle an asset without exif info', async () => {
-      mocks.asset.getByIds.mockResolvedValue([{ ...assetStub.image, exifInfo: undefined }]);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.image.id })).resolves.toBe(JobStatus.FAILED);
-      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.image.id], { exifInfo: true });
-      expect(mocks.asset.findLivePhotoMatch).not.toHaveBeenCalled();
-      expect(mocks.asset.update).not.toHaveBeenCalled();
-      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
-    });
-
-    it('should handle livePhotoCID not set', async () => {
-      mocks.asset.getByIds.mockResolvedValue([{ ...assetStub.image }]);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.image.id })).resolves.toBe(JobStatus.SKIPPED);
-      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.image.id], { exifInfo: true });
-      expect(mocks.asset.findLivePhotoMatch).not.toHaveBeenCalled();
-      expect(mocks.asset.update).not.toHaveBeenCalled();
-      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
-    });
-
-    it('should handle not finding a match', async () => {
-      mocks.asset.getByIds.mockResolvedValue([
-        {
-          ...assetStub.livePhotoMotionAsset,
-          exifInfo: { livePhotoCID: assetStub.livePhotoStillAsset.id } as ExifEntity,
-        },
-      ]);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.livePhotoMotionAsset.id })).resolves.toBe(
-        JobStatus.SKIPPED,
-      );
-      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.livePhotoMotionAsset.id], { exifInfo: true });
-      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
-        livePhotoCID: assetStub.livePhotoStillAsset.id,
-        ownerId: assetStub.livePhotoMotionAsset.ownerId,
-        otherAssetId: assetStub.livePhotoMotionAsset.id,
-        type: AssetType.IMAGE,
-      });
-      expect(mocks.asset.update).not.toHaveBeenCalled();
-      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
-    });
-
-    it('should link photo and video', async () => {
-      mocks.asset.getByIds.mockResolvedValue([
-        {
-          ...assetStub.livePhotoStillAsset,
-          exifInfo: { livePhotoCID: assetStub.livePhotoMotionAsset.id } as ExifEntity,
-        },
-      ]);
-      mocks.asset.findLivePhotoMatch.mockResolvedValue(assetStub.livePhotoMotionAsset);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
-        JobStatus.SUCCESS,
-      );
-      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.livePhotoStillAsset.id], { exifInfo: true });
-      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
-        livePhotoCID: assetStub.livePhotoMotionAsset.id,
-        ownerId: assetStub.livePhotoStillAsset.ownerId,
-        otherAssetId: assetStub.livePhotoStillAsset.id,
-        type: AssetType.VIDEO,
-      });
-      expect(mocks.asset.update).toHaveBeenCalledWith({
-        id: assetStub.livePhotoStillAsset.id,
-        livePhotoVideoId: assetStub.livePhotoMotionAsset.id,
-      });
-      expect(mocks.asset.update).toHaveBeenCalledWith({ id: assetStub.livePhotoMotionAsset.id, isVisible: false });
-      expect(mocks.album.removeAsset).toHaveBeenCalledWith(assetStub.livePhotoMotionAsset.id);
-    });
-
-    it('should notify clients on live photo link', async () => {
-      mocks.asset.getByIds.mockResolvedValue([
-        {
-          ...assetStub.livePhotoStillAsset,
-          exifInfo: { livePhotoCID: assetStub.livePhotoMotionAsset.id } as ExifEntity,
-        },
-      ]);
-      mocks.asset.findLivePhotoMatch.mockResolvedValue(assetStub.livePhotoMotionAsset);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
-        JobStatus.SUCCESS,
-      );
-      expect(mocks.event.emit).toHaveBeenCalledWith('asset.hide', {
-        userId: assetStub.livePhotoMotionAsset.ownerId,
-        assetId: assetStub.livePhotoMotionAsset.id,
-      });
-    });
-
-    it('should search by libraryId', async () => {
-      mocks.asset.getByIds.mockResolvedValue([
-        {
-          ...assetStub.livePhotoStillAsset,
-          libraryId: 'library-id',
-          exifInfo: { livePhotoCID: 'CID' } as ExifEntity,
-        },
-      ]);
-
-      await expect(sut.handleLivePhotoLinking({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
-        JobStatus.SKIPPED,
-      );
-
-      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
-        ownerId: 'user-id',
-        otherAssetId: 'live-photo-still-asset',
-        livePhotoCID: 'CID',
-        libraryId: 'library-id',
-        type: 'VIDEO',
-      });
-    });
-  });
-
   describe('handleQueueMetadataExtraction', () => {
     it('should queue metadata extraction for all assets without exif values', async () => {
       mocks.asset.getWithout.mockResolvedValue({ items: [assetStub.image], hasNextPage: false });
@@ -1177,6 +1058,107 @@ describe(MetadataService.name, () => {
           rating: -1,
         }),
       );
+    });
+
+    it('should handle livePhotoCID not set', async () => {
+      mocks.asset.getByIds.mockResolvedValue([assetStub.image]);
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.image.id })).resolves.toBe(JobStatus.SUCCESS);
+
+      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.image.id], { faces: { person: false } });
+      expect(mocks.asset.findLivePhotoMatch).not.toHaveBeenCalled();
+      expect(mocks.asset.update).not.toHaveBeenCalledWith(expect.objectContaining({ isVisible: false }));
+      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
+    });
+
+    it('should handle not finding a match', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.videoStreamVertical2160p);
+      mocks.asset.getByIds.mockResolvedValue([assetStub.livePhotoMotionAsset]);
+      mockReadTags({ ContentIdentifier: 'CID' });
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.livePhotoMotionAsset.id })).resolves.toBe(
+        JobStatus.SUCCESS,
+      );
+
+      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.livePhotoMotionAsset.id], {
+        faces: { person: false },
+      });
+      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
+        livePhotoCID: 'CID',
+        ownerId: assetStub.livePhotoMotionAsset.ownerId,
+        otherAssetId: assetStub.livePhotoMotionAsset.id,
+        type: AssetType.IMAGE,
+      });
+      expect(mocks.asset.update).not.toHaveBeenCalledWith(expect.objectContaining({ isVisible: false }));
+      expect(mocks.album.removeAsset).not.toHaveBeenCalled();
+    });
+
+    it('should link photo and video', async () => {
+      mocks.asset.getByIds.mockResolvedValue([assetStub.livePhotoStillAsset]);
+      mocks.asset.findLivePhotoMatch.mockResolvedValue(assetStub.livePhotoMotionAsset);
+      mockReadTags({ ContentIdentifier: 'CID' });
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
+        JobStatus.SUCCESS,
+      );
+
+      expect(mocks.asset.getByIds).toHaveBeenCalledWith([assetStub.livePhotoStillAsset.id], {
+        faces: { person: false },
+      });
+      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
+        livePhotoCID: 'CID',
+        ownerId: assetStub.livePhotoStillAsset.ownerId,
+        otherAssetId: assetStub.livePhotoStillAsset.id,
+        type: AssetType.VIDEO,
+      });
+      expect(mocks.asset.update).toHaveBeenCalledWith({
+        id: assetStub.livePhotoStillAsset.id,
+        livePhotoVideoId: assetStub.livePhotoMotionAsset.id,
+      });
+      expect(mocks.asset.update).toHaveBeenCalledWith({ id: assetStub.livePhotoMotionAsset.id, isVisible: false });
+      expect(mocks.album.removeAsset).toHaveBeenCalledWith(assetStub.livePhotoMotionAsset.id);
+    });
+
+    it('should notify clients on live photo link', async () => {
+      mocks.asset.getByIds.mockResolvedValue([
+        {
+          ...assetStub.livePhotoStillAsset,
+          exifInfo: { livePhotoCID: assetStub.livePhotoMotionAsset.id } as ExifEntity,
+        },
+      ]);
+      mocks.asset.findLivePhotoMatch.mockResolvedValue(assetStub.livePhotoMotionAsset);
+      mockReadTags({ ContentIdentifier: 'CID' });
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
+        JobStatus.SUCCESS,
+      );
+
+      expect(mocks.event.emit).toHaveBeenCalledWith('asset.hide', {
+        userId: assetStub.livePhotoMotionAsset.ownerId,
+        assetId: assetStub.livePhotoMotionAsset.id,
+      });
+    });
+
+    it('should search by libraryId', async () => {
+      mocks.asset.getByIds.mockResolvedValue([
+        {
+          ...assetStub.livePhotoStillAsset,
+          libraryId: 'library-id',
+        },
+      ]);
+      mockReadTags({ ContentIdentifier: 'CID' });
+
+      await expect(sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id })).resolves.toBe(
+        JobStatus.SUCCESS,
+      );
+
+      expect(mocks.asset.findLivePhotoMatch).toHaveBeenCalledWith({
+        ownerId: 'user-id',
+        otherAssetId: 'live-photo-still-asset',
+        livePhotoCID: 'CID',
+        libraryId: 'library-id',
+        type: 'VIDEO',
+      });
     });
   });
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -264,10 +264,7 @@ export class MetadataService extends BaseService {
       await this.applyTaggedFaces(asset, exifTags);
     }
 
-    await Promise.all([
-      this.assetRepository.upsertJobStatus({ assetId: asset.id, metadataExtractedAt: new Date() }),
-      this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data }),
-    ]);
+    await this.assetRepository.upsertJobStatus({ assetId: asset.id, metadataExtractedAt: new Date() });
 
     return JobStatus.SUCCESS;
   }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -303,7 +303,6 @@ export type JobItem =
   // Metadata Extraction
   | { name: JobName.QUEUE_METADATA_EXTRACTION; data: IBaseJob }
   | { name: JobName.METADATA_EXTRACTION; data: IEntityJob }
-  | { name: JobName.LINK_LIVE_PHOTOS; data: IEntityJob }
   // Sidecar Scanning
   | { name: JobName.QUEUE_SIDECAR; data: IBaseJob }
   | { name: JobName.SIDECAR_DISCOVERY; data: IEntityJob }


### PR DESCRIPTION
## Description

The overhead of queueing jobs for individual assets can be significant. This PR moves live photo linking to metadata extraction instead, taking care to do this *after* asset metadata has been updated in the DB. Besides being faster, this also makes job progress more intuitive as the number of waiting jobs goes down as one would expect without other jobs being queued in their place.

A major benefit I didn't realize is that the linking is more likely to happen before downstream jobs: jobs that are skipped for invisible assets can still end up running if the linking hasn't happened yet (which is likely given the link jobs are at the back of the queue).

Split off from #14277