### PR TITLE
fix(mobile): bootstrap store inside isolates

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -76,6 +76,7 @@ custom_lint:
         - lib/routing/router.dart
         - lib/services/immich_logger.service.dart # not really a service... more a util
         - lib/utils/{db,migration}.dart
+        - lib/utils/bootstrap.dart
         - lib/widgets/asset_grid/asset_grid_data_structure.dart
         - test/**.dart
         # refactor the remaining providers

--- a/mobile/integration_test/test_utils/general_helper.dart
+++ b/mobile/integration_test/test_utils/general_helper.dart
@@ -7,8 +7,8 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/main.dart' as app;
 import 'package:immich_mobile/providers/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
+import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:isar/isar.dart';
 // ignore: depend_on_referenced_packages
 import 'package:meta/meta.dart';
 
@@ -39,7 +39,8 @@ class ImmichTestHelper {
   static Future<void> loadApp(WidgetTester tester) async {
     await EasyLocalization.ensureInitialized();
     // Clear all data from Isar (reuse existing instance if available)
-    final db = Isar.getInstance() ?? await app.loadDb();
+    final db = await Bootstrap.initIsar();
+    await Bootstrap.initDomain(db);
     await Store.clear();
     await db.writeTxn(() => db.clear());
     // Load main Widget

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -10,20 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/locales.dart';
-import 'package:immich_mobile/domain/services/store.service.dart';
-import 'package:immich_mobile/entities/album.entity.dart';
-import 'package:immich_mobile/entities/android_device_asset.entity.dart';
-import 'package:immich_mobile/entities/asset.entity.dart';
-import 'package:immich_mobile/entities/backup_album.entity.dart';
-import 'package:immich_mobile/entities/duplicated_asset.entity.dart';
-import 'package:immich_mobile/entities/etag.entity.dart';
-import 'package:immich_mobile/entities/exif_info.entity.dart';
-import 'package:immich_mobile/entities/ios_device_asset.entity.dart';
-import 'package:immich_mobile/entities/logger_message.entity.dart';
-import 'package:immich_mobile/entities/user.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
-import 'package:immich_mobile/infrastructure/entities/store.entity.dart';
-import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/providers/app_life_cycle.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/share_intent_upload.provider.dart';
 import 'package:immich_mobile/providers/db.provider.dart';
@@ -37,19 +24,19 @@ import 'package:immich_mobile/services/immich_logger.service.dart';
 import 'package:immich_mobile/services/local_notification.service.dart';
 import 'package:immich_mobile/theme/dynamic_theme.dart';
 import 'package:immich_mobile/theme/theme_data.dart';
+import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/cache/widgets_binding.dart';
 import 'package:immich_mobile/utils/download.dart';
 import 'package:immich_mobile/utils/http_ssl_cert_override.dart';
 import 'package:immich_mobile/utils/migration.dart';
 import 'package:intl/date_symbol_data_local.dart';
-import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:timezone/data/latest.dart';
 
 void main() async {
   ImmichWidgetsBinding();
-  final db = await loadDb();
+  final db = await Bootstrap.initIsar();
+  await Bootstrap.initDomain(db);
   await initApp();
   await migrateDatabaseIfNeeded(db);
   HttpOverrides.global = HttpSSLCertOverride();
@@ -120,29 +107,6 @@ Future<void> initApp() async {
   );
 
   await FileDownloader().trackTasks();
-}
-
-Future<Isar> loadDb() async {
-  final dir = await getApplicationDocumentsDirectory();
-  Isar db = await Isar.open(
-    [
-      StoreValueSchema,
-      ExifInfoSchema,
-      AssetSchema,
-      AlbumSchema,
-      UserSchema,
-      BackupAlbumSchema,
-      DuplicatedAssetSchema,
-      LoggerMessageSchema,
-      ETagSchema,
-      if (Platform.isAndroid) AndroidDeviceAssetSchema,
-      if (Platform.isIOS) IOSDeviceAssetSchema,
-    ],
-    directory: dir.path,
-    maxSizeMiB: 1024,
-  );
-  await StoreService.init(storeRepository: IsarStoreRepository(db));
-  return db;
 }
 
 class ImmichApp extends ConsumerStatefulWidget {

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -15,7 +15,6 @@ import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/backup_album.entity.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/interfaces/backup.interface.dart';
-import 'package:immich_mobile/main.dart';
 import 'package:immich_mobile/models/backup/backup_candidate.model.dart';
 import 'package:immich_mobile/models/backup/current_upload_asset.model.dart';
 import 'package:immich_mobile/models/backup/error_upload_asset.model.dart';
@@ -48,6 +47,7 @@ import 'package:immich_mobile/services/network.service.dart';
 import 'package:immich_mobile/services/sync.service.dart';
 import 'package:immich_mobile/services/user.service.dart';
 import 'package:immich_mobile/utils/backup_progress.dart';
+import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/diff.dart';
 import 'package:immich_mobile/utils/http_ssl_cert_override.dart';
 import 'package:network_info_plus/network_info_plus.dart';
@@ -369,7 +369,8 @@ class BackgroundService {
   }
 
   Future<bool> _onAssetsChanged() async {
-    final db = await loadDb();
+    final db = await Bootstrap.initIsar();
+    await Bootstrap.initDomain(db);
 
     HttpOverrides.global = HttpSSLCertOverride();
     ApiService apiService = ApiService();

--- a/mobile/lib/services/backup_verification.service.dart
+++ b/mobile/lib/services/backup_verification.service.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/repositories/asset.repository.dart';
 import 'package:immich_mobile/repositories/exif_info.repository.dart';
 import 'package:immich_mobile/repositories/file_media.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/diff.dart';
 
 /// Finds duplicates originating from missing EXIF information
@@ -123,6 +124,8 @@ class BackupVerificationService {
     assert(tuple.deleteCandidates.length == tuple.originals.length);
     final List<Asset> result = [];
     BackgroundIsolateBinaryMessenger.ensureInitialized(tuple.rootIsolateToken);
+    final db = await Bootstrap.initIsar();
+    await Bootstrap.initDomain(db);
     await tuple.fileMediaRepository.enableBackgroundAccess();
     final ApiService apiService = ApiService();
     apiService.setEndpoint(tuple.endpoint);

--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/album.entity.dart';
+import 'package:immich_mobile/entities/android_device_asset.entity.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/entities/backup_album.entity.dart';
+import 'package:immich_mobile/entities/duplicated_asset.entity.dart';
+import 'package:immich_mobile/entities/etag.entity.dart';
+import 'package:immich_mobile/entities/exif_info.entity.dart';
+import 'package:immich_mobile/entities/ios_device_asset.entity.dart';
+import 'package:immich_mobile/entities/logger_message.entity.dart';
+import 'package:immich_mobile/entities/user.entity.dart';
+import 'package:immich_mobile/infrastructure/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:isar/isar.dart';
+import 'package:path_provider/path_provider.dart';
+
+abstract final class Bootstrap {
+  static Future<Isar> initIsar() async {
+    if (Isar.getInstance() != null) {
+      return Isar.getInstance()!;
+    }
+
+    final dir = await getApplicationDocumentsDirectory();
+    return await Isar.open(
+      [
+        StoreValueSchema,
+        ExifInfoSchema,
+        AssetSchema,
+        AlbumSchema,
+        UserSchema,
+        BackupAlbumSchema,
+        DuplicatedAssetSchema,
+        LoggerMessageSchema,
+        ETagSchema,
+        if (Platform.isAndroid) AndroidDeviceAssetSchema,
+        if (Platform.isIOS) IOSDeviceAssetSchema,
+      ],
+      directory: dir.path,
+      maxSizeMiB: 1024,
+      inspector: kDebugMode,
+    );
+  }
+
+  static Future<void> initDomain(Isar db) async {
+    await StoreService.init(storeRepository: IsarStoreRepository(db));
+  }
+}


### PR DESCRIPTION
### Description

Fixes an issue where backup verification was failing as Store was not initiated inside the isolate in which the verification was performed. This PR addresses this by refactoring the bootstrap logic to a utility class and initiating them inside isolates. Other parts of the app are refactored to use the new class.