### PR TITLE
fix(web): person favorite icon bad placement

### DIFF
--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -65,7 +65,7 @@
         widthStyle="100%"
       />
       {#if person.isFavorite}
-        <div class="absolute bottom-2 left-2 z-10">
+        <div class="absolute top-2 left-2">
           <Icon path={mdiHeart} size="24" class="text-white" />
         </div>
       {/if}

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -64,7 +64,7 @@
                 widthStyle="100%"
               />
               {#if person.isFavorite}
-                <div class="absolute bottom-2 left-2 z-10">
+                <div class="absolute top-2 left-2">
                   <Icon path={mdiHeart} size="24" class="text-white" />
                 </div>
               {/if}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Moves favorite person icon to top left to avoid name.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #16003

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested modification locally.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![image](https://github.com/user-attachments/assets/07a23af5-ef12-49dd-8e5e-8ccede87f7bb)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
