### PR TITLE
fix(server): include deleted assets if searching offline assets

### DIFF
--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -352,7 +352,7 @@ const joinDeduplicationPlugin = new DeduplicateJoinsPlugin();
 /** TODO: This should only be used for search-related queries, not as a general purpose query builder */
 export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuilderOptions) {
   options.isArchived ??= options.withArchived ? undefined : false;
-  options.withDeleted ||= !!(options.trashedAfter || options.trashedBefore);
+  options.withDeleted ||= !!(options.trashedAfter || options.trashedBefore || options.isOffline);
   return kysely
     .withPlugin(joinDeduplicationPlugin)
     .selectFrom('assets')


### PR DESCRIPTION
## Description

Offline assets are also deleted, so providing `isOffline: true` still results in them not being included in search endpoints unless `withDeleted` is also specified.

Fixes #13161