### PR TITLE
fix(mobile): background backup failing due to store

### DIFF
--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -720,7 +720,6 @@ enum IosBackgroundTask { fetch, processing }
 /// entry point called by Kotlin/Java code; needs to be a top-level function
 @pragma('vm:entry-point')
 void _nativeEntry() {
-  HttpOverrides.global = HttpSSLCertOverride();
   WidgetsFlutterBinding.ensureInitialized();
   DartPluginRegistrant.ensureInitialized();
   BackgroundService backgroundService = BackgroundService();


### PR DESCRIPTION
## Description

HttpOveride is performed before the Store is initiated in the background service, resulting in background upload not working. We already override them again in the callback handler, hence the redundant override is removed.