### PR TITLE
fix(server): stringify error log parameter to ensure correct overload

### DIFF
--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -195,7 +195,7 @@ export class JobService extends BaseService {
         await this.onDone(job);
       }
     } catch (error: Error | any) {
-      this.logger.error(`Unable to run job handler (${queueName}/${job.name}): ${error}`, error?.stack, job.data);
+      this.logger.error(`Unable to run job handler (${queueName}/${job.name}): ${error}`, error?.stack, JSON.stringify(job.data));
     } finally {
       this.telemetryRepository.jobs.addToGauge(queueMetric, -1);
     }

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -195,7 +195,11 @@ export class JobService extends BaseService {
         await this.onDone(job);
       }
     } catch (error: Error | any) {
-      this.logger.error(`Unable to run job handler (${queueName}/${job.name}): ${error}`, error?.stack, JSON.stringify(job.data));
+      this.logger.error(
+        `Unable to run job handler (${queueName}/${job.name}): ${error}`,
+        error?.stack,
+        JSON.stringify(job.data),
+      );
     } finally {
       this.telemetryRepository.jobs.addToGauge(queueMetric, -1);
     }


### PR DESCRIPTION
The intended `error(message, stack, context)` overload is only selected if context is a string.