### PR TITLE
fix: duplicate memories

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -7,10 +7,6 @@ export const POSTGRES_VERSION_RANGE = '>=14.0.0';
 export const VECTORS_VERSION_RANGE = '>=0.2 <0.4';
 export const VECTOR_VERSION_RANGE = '>=0.5 <1';
 
-export const ASSET_FILE_CONFLICT_KEYS = ['assetId', 'type'] as const;
-export const EXIF_CONFLICT_KEYS = ['assetId'] as const;
-export const JOB_STATUS_CONFLICT_KEYS = ['assetId'] as const;
-
 export const NEXT_RELEASE = 'NEXT_RELEASE';
 export const LIFECYCLE_EXTENSION = 'x-immich-lifecycle';
 export const DEPRECATED_IN_PREFIX = 'This property was deprecated in ';

--- a/server/src/db.d.ts
+++ b/server/src/db.d.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ColumnType } from 'kysely';
-import { Permission, SyncEntityType } from 'src/enum';
+import { AssetType, Permission, SyncEntityType } from 'src/enum';
 
 export type ArrayType<T> = ArrayTypeImpl<T> extends (infer U)[] ? U[] : ArrayTypeImpl<T>;
 
@@ -145,7 +145,7 @@ export interface Assets {
   stackId: string | null;
   status: Generated<AssetsStatusEnum>;
   thumbhash: Buffer | null;
-  type: string;
+  type: AssetType;
   updatedAt: Generated<Timestamp>;
   updateId: Generated<string>;
 }
@@ -315,7 +315,6 @@ export interface SessionSyncCheckpoints {
   updatedAt: Generated<Timestamp>;
   updateId: Generated<string>;
 }
-
 
 export interface SharedLinkAsset {
   assetsId: string;

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -7,7 +7,6 @@ import { ChunkedArray, DummyValue, GenerateSql } from 'src/decorators';
 import { AssetFaceEntity } from 'src/entities/asset-face.entity';
 import { PersonEntity } from 'src/entities/person.entity';
 import { SourceType } from 'src/enum';
-import { mapUpsertColumns } from 'src/utils/database';
 import { Paginated, PaginationOptions } from 'src/utils/pagination';
 import { FindOptionsRelations } from 'typeorm';
 
@@ -417,7 +416,17 @@ export class PersonRepository {
     await this.db
       .insertInto('person')
       .values(people)
-      .onConflict((oc) => oc.column('id').doUpdateSet(() => mapUpsertColumns('person', people[0], ['id'])))
+      .onConflict((oc) =>
+        oc.column('id').doUpdateSet((eb) => ({
+          birthDate: eb.ref('excluded.birthDate'),
+          color: eb.ref('excluded.color'),
+          faceAssetId: eb.ref('excluded.faceAssetId'),
+          isFavorite: eb.ref('excluded.isFavorite'),
+          isHidden: eb.ref('excluded.isHidden'),
+          name: eb.ref('excluded.name'),
+          thumbnailPath: eb.ref('excluded.thumbnailPath'),
+        })),
+      )
       .execute();
   }
 

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -404,7 +404,7 @@ export class SearchRepository {
           .where('assets.ownerId', '=', anyUuid(userIds))
           .where('assets.isVisible', '=', true)
           .where('assets.isArchived', '=', false)
-          .where('assets.type', '=', 'IMAGE')
+          .where('assets.type', '=', AssetType.IMAGE)
           .where('assets.deletedAt', 'is', null)
           .orderBy('city')
           .limit(1);
@@ -421,7 +421,7 @@ export class SearchRepository {
                 .where('assets.ownerId', '=', anyUuid(userIds))
                 .where('assets.isVisible', '=', true)
                 .where('assets.isArchived', '=', false)
-                .where('assets.type', '=', 'IMAGE')
+                .where('assets.type', '=', AssetType.IMAGE)
                 .where('assets.deletedAt', 'is', null)
                 .whereRef('exif.city', '>', 'cte.city')
                 .orderBy('city')

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -5,7 +5,7 @@ import { DB, UserMetadata as DbUserMetadata, Users } from 'src/db';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { UserMetadata, UserMetadataItem } from 'src/entities/user-metadata.entity';
 import { UserEntity, withMetadata } from 'src/entities/user.entity';
-import { UserStatus } from 'src/enum';
+import { AssetType, UserStatus } from 'src/enum';
 import { asUuid } from 'src/utils/database';
 
 const columns = [
@@ -209,11 +209,11 @@ export class UserRepository {
       .select((eb) => [
         eb.fn
           .countAll()
-          .filterWhere((eb) => eb.and([eb('assets.type', '=', 'IMAGE'), eb('assets.isVisible', '=', true)]))
+          .filterWhere((eb) => eb.and([eb('assets.type', '=', AssetType.IMAGE), eb('assets.isVisible', '=', true)]))
           .as('photos'),
         eb.fn
           .countAll()
-          .filterWhere((eb) => eb.and([eb('assets.type', '=', 'VIDEO'), eb('assets.isVisible', '=', true)]))
+          .filterWhere((eb) => eb.and([eb('assets.type', '=', AssetType.VIDEO), eb('assets.isVisible', '=', true)]))
           .as('videos'),
         eb.fn
           .coalesce(eb.fn.sum('exif.fileSizeInByte').filterWhere('assets.libraryId', 'is', null), eb.lit(0))
@@ -222,7 +222,9 @@ export class UserRepository {
           .coalesce(
             eb.fn
               .sum('exif.fileSizeInByte')
-              .filterWhere((eb) => eb.and([eb('assets.libraryId', 'is', null), eb('assets.type', '=', 'IMAGE')])),
+              .filterWhere((eb) =>
+                eb.and([eb('assets.libraryId', 'is', null), eb('assets.type', '=', AssetType.IMAGE)]),
+              ),
             eb.lit(0),
           )
           .as('usagePhotos'),
@@ -230,7 +232,9 @@ export class UserRepository {
           .coalesce(
             eb.fn
               .sum('exif.fileSizeInByte')
-              .filterWhere((eb) => eb.and([eb('assets.libraryId', 'is', null), eb('assets.type', '=', 'VIDEO')])),
+              .filterWhere((eb) =>
+                eb.and([eb('assets.libraryId', 'is', null), eb('assets.type', '=', AssetType.VIDEO)]),
+              ),
             eb.lit(0),
           )
           .as('usageVideos'),

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -75,7 +75,7 @@ describe(AssetService.name, () => {
           yearsAgo: 15,
           assets: [image4],
         },
-      ]);
+      ] as any);
 
       await expect(sut.getMemoryLane(authStub.admin, { day: 15, month: 1 })).resolves.toEqual([
         { yearsAgo: 1, title: '1 year ago', assets: [mapAsset(image1), mapAsset(image2)] },

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -42,7 +42,7 @@ export class AssetService extends BaseService {
       yearsAgo,
       // TODO move this to clients
       title: `${yearsAgo} year${yearsAgo > 1 ? 's' : ''} ago`,
-      assets: assets.map((asset) => mapAsset(asset, { auth })),
+      assets: assets.map((asset) => mapAsset(asset as AssetEntity, { auth })),
     }));
   }
 

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -108,7 +108,6 @@ export class DatabaseService extends BaseService {
       if (!database.skipMigrations) {
         await this.databaseRepository.runMigrations();
       }
-      this.databaseRepository.init();
     });
   }
 

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -30,19 +30,17 @@ export class MemoryService extends BaseService {
     const start = DateTime.utc().startOf('day').minus({ days: DAYS });
 
     const state = await this.systemMetadataRepository.get(SystemMetadataKey.MEMORIES_STATE);
-    let lastOnThisDayDate = state?.lastOnThisDayDate ? DateTime.fromISO(state?.lastOnThisDayDate) : start;
+    const lastOnThisDayDate = state?.lastOnThisDayDate ? DateTime.fromISO(state.lastOnThisDayDate) : start;
 
     // generate a memory +/- X days from today
-    for (let i = 0; i <= DAYS * 2 + 1; i++) {
+    for (let i = 0; i <= DAYS * 2; i++) {
       const target = start.plus({ days: i });
-      if (lastOnThisDayDate > target) {
+      if (lastOnThisDayDate >= target) {
         continue;
       }
 
       const showAt = target.startOf('day').toISO();
       const hideAt = target.endOf('day').toISO();
-
-      this.logger.log(`Creating memories for month=${target.month}, day=${target.day}`);
 
       for (const [userId, userIds] of Object.entries(userMap)) {
         const memories = await this.assetRepository.getByDayOfYear(userIds, target);
@@ -67,8 +65,6 @@ export class MemoryService extends BaseService {
         ...state,
         lastOnThisDayDate: target.toISO(),
       });
-
-      lastOnThisDayDate = target;
     }
   }
 

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -1,6 +1,4 @@
-import { Expression, RawBuilder, sql, ValueExpression } from 'kysely';
-import { InsertObject } from 'node_modules/kysely/dist/cjs';
-import { DB } from 'src/db';
+import { Expression, sql } from 'kysely';
 import { Between, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
 
 /**
@@ -15,27 +13,6 @@ export function OptionalBetween<T>(from?: T, to?: T) {
   } else if (to) {
     return LessThanOrEqual(to);
   }
-}
-
-// populated by the database repository at bootstrap
-export const UPSERT_COLUMNS = {} as { [T in keyof DB]: { [K in keyof DB[T]]: RawBuilder<unknown> } };
-
-/** Generates the columns for an upsert statement, excluding the conflict keys.
- * Assumes that all entries have the same keys. */
-export function mapUpsertColumns<T extends keyof DB>(
-  table: T,
-  entry: InsertObject<DB, T>,
-  conflictKeys: readonly (keyof DB[T])[],
-) {
-  const columns = UPSERT_COLUMNS[table] as { [K in keyof DB[T]]: RawBuilder<unknown> };
-  const upsertColumns: Partial<Record<keyof typeof entry, RawBuilder<unknown>>> = {};
-  for (const entryColumn in entry) {
-    if (!conflictKeys.includes(entryColumn as keyof DB[T])) {
-      upsertColumns[entryColumn as keyof typeof entry] = columns[entryColumn as keyof DB[T]];
-    }
-  }
-
-  return upsertColumns as Expand<Record<keyof typeof entry, ValueExpression<DB, T, any>>>;
 }
 
 export const asUuid = (id: string | Expression<string>) => sql<string>`${id}::uuid`;

--- a/server/test/factory.ts
+++ b/server/test/factory.ts
@@ -1,13 +1,16 @@
 import { Insertable, Kysely } from 'kysely';
+import { DateTime } from 'luxon';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { Writable } from 'node:stream';
-import { Assets, DB, Sessions, Users } from 'src/db';
+import { AssetJobStatus, Assets, DB, Exif, Sessions, Users } from 'src/db';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { AssetType } from 'src/enum';
+import { AssetFileType, AssetType } from 'src/enum';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
+import { MemoryRepository } from 'src/repositories/memory.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
 import { SyncRepository } from 'src/repositories/sync.repository';
+import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { UserRepository } from 'src/repositories/user.repository';
 
 class CustomWritable extends Writable {
@@ -26,19 +29,53 @@ class CustomWritable extends Writable {
       .map((x) => JSON.parse(x));
   }
 }
-
-type Asset = Insertable<Assets>;
+//  deviceAssetId, deviceId, originalFileName, originalPath, type
+type Asset = Omit<
+  Insertable<Assets>,
+  'checksum' | 'deviceAssetId' | 'deviceId' | 'originalFileName' | 'originalPath' | 'type'
+> & {
+  checksum?: Buffer;
+  deviceAssetId?: string;
+  deviceId?: string;
+  originalFileName?: string;
+  originalPath?: string;
+  type?: AssetType;
+};
 type User = Partial<Insertable<Users>>;
 type Session = Omit<Insertable<Sessions>, 'token'> & { token?: string };
+type JobStatus = Omit<Partial<Insertable<AssetJobStatus>>, 'assetId'> & { assetId: string };
+type AssetFile = { assetId: string; type: AssetFileType; path: string };
+type AssetExif = Insertable<Exif>;
+type FactoryOptions = { assetJobStatus?: boolean; assetFiles?: boolean; assetExif?: boolean };
+
+const DEFAULT_OPTIONS = {
+  assetJobStatus: false,
+  assetFiles: false,
+  assetExif: false,
+};
 
 export const newUuid = () => randomUUID() as string;
 
 export class TestFactory {
   private assets: Asset[] = [];
+  private assetJobs: JobStatus[] = [];
+  private assetFiles: AssetFile[] = [];
+  private assetExif: AssetExif[] = [];
+  private options: FactoryOptions = DEFAULT_OPTIONS;
   private sessions: Session[] = [];
   private users: User[] = [];
 
   private constructor(private context: TestContext) {}
+
+  private clear() {
+    this.assets = [];
+    this.assetJobs = [];
+    this.assetFiles = [];
+    this.assetExif = [];
+    this.options = DEFAULT_OPTIONS;
+    this.sessions = [];
+    this.users = [];
+  }
 
   static create(context: TestContext) {
     return new TestFactory(context);
@@ -50,14 +87,13 @@ export class TestFactory {
 
   static asset(asset: Asset) {
     const assetId = asset.id || newUuid();
-    const defaults: Insertable<Assets> = {
-      deviceAssetId: '',
-      deviceId: '',
-      originalFileName: '',
+    const defaults: Omit<Insertable<Assets>, 'ownerId'> = {
+      deviceAssetId: newUuid(),
+      deviceId: newUuid(),
+      originalFileName: `${assetId}-file.jpg`,
       checksum: randomBytes(32),
       type: AssetType.IMAGE,
       originalPath: '/path/to/something.jpg',
-      ownerId: '@immich.cloud',
       isVisible: true,
     };
 
@@ -65,6 +101,22 @@ export class TestFactory {
       ...defaults,
       ...asset,
       id: assetId,
+    };
+  }
+
+  static assetJobStatus(job: JobStatus): Insertable<AssetJobStatus> {
+    const date = DateTime.now().minus({ days: 15 }).toISO();
+    const defaults: Omit<Insertable<AssetJobStatus>, 'assetId'> = {
+      duplicatesDetectedAt: date,
+      facesRecognizedAt: date,
+      metadataExtractedAt: date,
+      previewAt: date,
+      thumbnailAt: date,
+    };
+
+    return {
+      ...defaults,
+      ...job,
     };
   }
 
@@ -100,8 +152,28 @@ export class TestFactory {
     };
   }
 
+  withOptions(options: Partial<FactoryOptions>) {
+    this.options = { ...this.options, ...options };
+    return this;
+  }
+
   withAsset(asset: Asset) {
     this.assets.push(asset);
+    return this;
+  }
+
+  withAssets(assets: Asset[]) {
+    this.assets.push(...assets);
+    return this;
+  }
+
+  withAssetJob(job: JobStatus) {
+    this.assetJobs.push(job);
+    return this;
+  }
+
+  withAssetJobs(jobs: JobStatus[]) {
+    this.assetJobs.push(...jobs);
     return this;
   }
 
@@ -116,17 +188,45 @@ export class TestFactory {
   }
 
   async create() {
-    for (const asset of this.assets) {
-      await this.context.createAsset(asset);
-    }
-
     for (const user of this.users) {
       await this.context.createUser(user);
+    }
+
+    for (const asset of this.assets) {
+      const entity = await this.context.createAsset(asset);
+      if (this.options.assetJobStatus) {
+        this.assetJobs.push({ assetId: entity.id });
+      }
+
+      if (this.options.assetFiles) {
+        this.assetFiles.push(
+          { assetId: entity.id, type: AssetFileType.PREVIEW, path: '/path/to/preview.jpg' },
+          { assetId: entity.id, type: AssetFileType.THUMBNAIL, path: '/path/to/thumbnail.jpg' },
+        );
+      }
+
+      if (this.options.assetExif) {
+        this.assetExif.push({ assetId: entity.id, make: 'Cannon' });
+      }
+    }
+
+    for (const assetJob of this.assetJobs) {
+      await this.context.createAssetJobStatus(assetJob);
+    }
+
+    for (const assetFile of this.assetFiles) {
+      await this.context.createAssetFile(assetFile);
+    }
+
+    for (const assetExif of this.assetExif) {
+      await this.context.createAssetExif(assetExif);
     }
 
     for (const session of this.sessions) {
       await this.context.createSession(session);
     }
+
+    this.clear();
 
     return this.context;
   }
@@ -136,15 +236,19 @@ export class TestContext {
   userRepository: UserRepository;
   assetRepository: AssetRepository;
   albumRepository: AlbumRepository;
+  memoryRepository: MemoryRepository;
   sessionRepository: SessionRepository;
   syncRepository: SyncRepository;
+  systemMetadataRepository: SystemMetadataRepository;
 
   private constructor(private db: Kysely<DB>) {
     this.userRepository = new UserRepository(this.db);
     this.assetRepository = new AssetRepository(this.db);
     this.albumRepository = new AlbumRepository(this.db);
+    this.memoryRepository = new MemoryRepository(this.db);
     this.sessionRepository = new SessionRepository(this.db);
     this.syncRepository = new SyncRepository(this.db);
+    this.systemMetadataRepository = new SystemMetadataRepository(this.db);
   }
 
   static from(db: Kysely<DB>) {
@@ -161,6 +265,18 @@ export class TestContext {
 
   createAsset(asset: Asset) {
     return this.assetRepository.create(TestFactory.asset(asset));
+  }
+
+  createAssetJobStatus(jobStatus: JobStatus) {
+    return this.assetRepository.upsertJobStatus(TestFactory.assetJobStatus(jobStatus));
+  }
+
+  createAssetFile(assetFile: AssetFile) {
+    return this.assetRepository.upsertFile(assetFile);
+  }
+
+  createAssetExif(assetExif: AssetExif) {
+    return this.assetRepository.upsertExif(assetExif);
   }
 
   createSession(session: Session) {

--- a/server/test/medium/specs/memory.service.spec.ts
+++ b/server/test/medium/specs/memory.service.spec.ts
@@ -1,0 +1,114 @@
+import { DateTime } from 'luxon';
+import { MemoryService } from 'src/services/memory.service';
+import { TestContext, TestFactory } from 'test/factory';
+import { getKyselyDB, newTestService } from 'test/utils';
+
+const setup = async () => {
+  const db = await getKyselyDB();
+
+  const context = await TestContext.from(db).withUser({ isAdmin: true }).create();
+  const { sut } = newTestService(MemoryService, context);
+
+  return { sut, context };
+};
+
+describe(MemoryService.name, () => {
+  describe('onMemoryCreate', () => {
+    it('should work on an empty database', async () => {
+      const { sut } = await setup();
+      await expect(sut.onMemoriesCreate()).resolves.not.toThrow();
+    });
+
+    it('should create a memory from an asset', async () => {
+      const { sut, context } = await setup();
+
+      const now = DateTime.fromObject({ year: 2025, month: 2, day: 25 }, { zone: 'utc' });
+      const userDto = TestFactory.user();
+      const assetDto = TestFactory.asset({ ownerId: userDto.id, localDateTime: now.minus({ years: 1 }).toISO() });
+
+      await context
+        .getFactory()
+        .withAsset(assetDto)
+        .withUser(userDto)
+        .withOptions({
+          assetFiles: true,
+          assetJobStatus: true,
+          assetExif: true,
+        })
+        .create();
+
+      vi.setSystemTime(now.toJSDate());
+
+      await sut.onMemoriesCreate();
+
+      const memories = await context.memoryRepository.search(userDto.id, {});
+      expect(memories.length).toBe(1);
+      expect(memories[0]).toEqual(
+        expect.objectContaining({
+          id: expect.any(String),
+          createdAt: expect.any(Date),
+          memoryAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          deletedAt: null,
+          ownerId: userDto.id,
+          assets: expect.arrayContaining([expect.objectContaining({ id: assetDto.id })]),
+          isSaved: false,
+          showAt: now.startOf('day').toJSDate(),
+          hideAt: now.endOf('day').toJSDate(),
+          seenAt: null,
+          type: 'on_this_day',
+          data: { year: 2024 },
+        }),
+      );
+    });
+
+    it('should not generate a memory twice for the same day', async () => {
+      const { sut, context } = await setup();
+
+      const now = DateTime.fromObject({ year: 2025, month: 2, day: 20 }, { zone: 'utc' });
+      const userDto = TestFactory.user();
+
+      await context
+        .getFactory()
+        .withAssets([
+          {
+            ownerId: userDto.id,
+            localDateTime: now.minus({ year: 1 }).plus({ days: 3 }).toISO(),
+          },
+          {
+            ownerId: userDto.id,
+            localDateTime: now.minus({ year: 1 }).plus({ days: 4 }).toISO(),
+          },
+          {
+            ownerId: userDto.id,
+            localDateTime: now.minus({ year: 1 }).plus({ days: 5 }).toISO(),
+          },
+        ])
+        .withUser(userDto)
+        .withOptions({
+          assetFiles: true,
+          assetJobStatus: true,
+          assetExif: true,
+        })
+        .create();
+
+      vi.setSystemTime(now.toJSDate());
+
+      await sut.onMemoriesCreate();
+
+      const memories = await context.memoryRepository.search(userDto.id, {});
+      expect(memories.length).toBe(1);
+
+      await sut.onMemoriesCreate();
+      const memoriesAfter = await context.memoryRepository.search(userDto.id, {});
+      expect(memoriesAfter.length).toBe(1);
+    });
+  });
+
+  describe('onMemoriesCleanup', () => {
+    it('should run without error', async () => {
+      const { sut } = await setup();
+      await expect(sut.onMemoriesCleanup()).resolves.not.toThrow();
+    });
+  });
+});

--- a/server/test/repositories/database.repository.mock.ts
+++ b/server/test/repositories/database.repository.mock.ts
@@ -4,7 +4,6 @@ import { Mocked, vitest } from 'vitest';
 
 export const newDatabaseRepositoryMock = (): Mocked<RepositoryInterface<DatabaseRepository>> => {
   return {
-    init: vitest.fn(),
     shutdown: vitest.fn(),
     reconnect: vitest.fn(),
     getExtensionVersion: vitest.fn(),

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -94,9 +94,12 @@ import { Mocked, vitest } from 'vitest';
 
 type Overrides = {
   worker?: ImmichWorker;
+  assetRepository?: AssetRepository;
+  systemMetadataRepository?: SystemMetadataRepository;
   metadataRepository?: MetadataRepository;
   syncRepository?: SyncRepository;
   userRepository?: UserRepository;
+  memoryRepository?: MemoryRepository;
 };
 type BaseServiceArgs = ConstructorParameters<typeof BaseService>;
 type Constructor<Type, Args extends Array<any>> = {
@@ -151,7 +154,14 @@ export const newTestService = <T extends BaseService>(
   Service: Constructor<T, BaseServiceArgs>,
   overrides?: Overrides,
 ) => {
-  const { metadataRepository, userRepository, syncRepository } = overrides || {};
+  const {
+    assetRepository,
+    systemMetadataRepository,
+    metadataRepository,
+    memoryRepository,
+    userRepository,
+    syncRepository,
+  } = overrides || {};
 
   const accessMock = newAccessRepositoryMock();
   const loggerMock = newLoggingRepositoryMock();
@@ -172,9 +182,7 @@ export const newTestService = <T extends BaseService>(
   const mapMock = newMapRepositoryMock();
   const mediaMock = newMediaRepositoryMock();
   const memoryMock = newMemoryRepositoryMock();
-  const metadataMock = (metadataRepository || newMetadataRepositoryMock()) as Mocked<
-    RepositoryInterface<MetadataRepository>
-  >;
+  const metadataMock = newMetadataRepositoryMock();
   const moveMock = newMoveRepositoryMock();
   const notificationMock = newNotificationRepositoryMock();
   const oauthMock = newOAuthRepositoryMock();
@@ -187,12 +195,12 @@ export const newTestService = <T extends BaseService>(
   const sharedLinkMock = newSharedLinkRepositoryMock();
   const stackMock = newStackRepositoryMock();
   const storageMock = newStorageRepositoryMock();
-  const syncMock = (syncRepository || newSyncRepositoryMock()) as Mocked<RepositoryInterface<SyncRepository>>;
+  const syncMock = newSyncRepositoryMock();
   const systemMock = newSystemMetadataRepositoryMock();
   const tagMock = newTagRepositoryMock();
   const telemetryMock = newTelemetryRepositoryMock();
   const trashMock = newTrashRepositoryMock();
-  const userMock = (userRepository || newUserRepositoryMock()) as Mocked<RepositoryInterface<UserRepository>>;
+  const userMock = newUserRepositoryMock();
   const versionHistoryMock = newVersionHistoryRepositoryMock();
   const viewMock = newViewRepositoryMock();
 
@@ -203,7 +211,7 @@ export const newTestService = <T extends BaseService>(
     auditMock as RepositoryInterface<AuditRepository> as AuditRepository,
     albumMock as RepositoryInterface<AlbumRepository> as AlbumRepository,
     albumUserMock as RepositoryInterface<AlbumUserRepository> as AlbumUserRepository,
-    assetMock as RepositoryInterface<AssetRepository> as AssetRepository,
+    assetRepository || (assetMock as RepositoryInterface<AssetRepository> as AssetRepository),
     configMock as RepositoryInterface<ConfigRepository> as ConfigRepository,
     cronMock as RepositoryInterface<CronRepository> as CronRepository,
     cryptoMock as RepositoryInterface<CryptoRepository> as CryptoRepository,
@@ -215,8 +223,8 @@ export const newTestService = <T extends BaseService>(
     machineLearningMock as RepositoryInterface<MachineLearningRepository> as MachineLearningRepository,
     mapMock as RepositoryInterface<MapRepository> as MapRepository,
     mediaMock as RepositoryInterface<MediaRepository> as MediaRepository,
-    memoryMock as RepositoryInterface<MemoryRepository> as MemoryRepository,
-    metadataMock as RepositoryInterface<MetadataRepository> as MetadataRepository,
+    memoryRepository || (memoryMock as RepositoryInterface<MemoryRepository> as MemoryRepository),
+    metadataRepository || (metadataMock as RepositoryInterface<MetadataRepository> as MetadataRepository),
     moveMock as RepositoryInterface<MoveRepository> as MoveRepository,
     notificationMock as RepositoryInterface<NotificationRepository> as NotificationRepository,
     oauthMock as RepositoryInterface<OAuthRepository> as OAuthRepository,
@@ -229,12 +237,13 @@ export const newTestService = <T extends BaseService>(
     sharedLinkMock as RepositoryInterface<SharedLinkRepository> as SharedLinkRepository,
     stackMock as RepositoryInterface<StackRepository> as StackRepository,
     storageMock as RepositoryInterface<StorageRepository> as StorageRepository,
-    syncMock as RepositoryInterface<SyncRepository> as SyncRepository,
-    systemMock as RepositoryInterface<SystemMetadataRepository> as SystemMetadataRepository,
+    syncRepository || (syncMock as RepositoryInterface<SyncRepository> as SyncRepository),
+    systemMetadataRepository ||
+      (systemMock as RepositoryInterface<SystemMetadataRepository> as SystemMetadataRepository),
     tagMock as RepositoryInterface<TagRepository> as TagRepository,
     telemetryMock as unknown as TelemetryRepository,
     trashMock as RepositoryInterface<TrashRepository> as TrashRepository,
-    userMock as RepositoryInterface<UserRepository> as UserRepository,
+    userRepository || (userMock as RepositoryInterface<UserRepository> as UserRepository),
     versionHistoryMock as RepositoryInterface<VersionHistoryRepository> as VersionHistoryRepository,
     viewMock as RepositoryInterface<ViewRepository> as ViewRepository,
   );


### PR DESCRIPTION
- Fix issue where memories get generated twice for the same day.
- Add medium test for this scenario
- Other code changes in order to get medium tests to work correctly, most notably the migration of the automatic `onConflict` to implemention to a more explicit one.