### PR TITLE
feat(server): Shortened asset ID in storage template

### DIFF
--- a/docs/docs/guides/database-queries.md
+++ b/docs/docs/guides/database-queries.md
@@ -31,6 +31,10 @@ SELECT * FROM "assets" WHERE "originalPath" LIKE 'upload/library/admin/2023/%';
 SELECT * FROM "assets" WHERE "id" = '9f94e60f-65b6-47b7-ae44-a4df7b57f0e9';
 ```
 
+```sql title="Find by partial ID"
+SELECT * FROM "assets" WHERE "id"::text LIKE '%ab431d3a%';
+```
+
 :::note
 You can calculate the checksum for a particular file by using the command `sha1sum <filename>`.
 :::

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -304,6 +304,7 @@ export class StorageTemplateService extends BaseService {
       filetype: asset.type == AssetType.IMAGE ? 'IMG' : 'VID',
       filetypefull: asset.type == AssetType.IMAGE ? 'IMAGE' : 'VIDEO',
       assetId: asset.id,
+      assetIdShort: asset.id.slice(-12),
       //just throw into the root if it doesn't belong to an album
       album: (albumName && sanitize(albumName.replaceAll(/\.+/g, ''))) || '',
     };

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -73,6 +73,7 @@
       filetype: 'IMG',
       filetypefull: 'IMAGE',
       assetId: 'a8312960-e277-447d-b4ea-56717ccba856',
+      assetIdShort: '56717ccba856',
       album: $t('album_name'),
     };
 

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
@@ -27,6 +27,7 @@
       <p class="font-medium text-immich-primary dark:text-immich-dark-primary uppercase">{$t('other').toUpperCase()}</p>
       <ul>
         <li>{`{{assetId}}`} - Asset ID</li>
+        <li>{`{{assetIdShort}}`} - Asset ID (last 12 characters)</li>
         <li>{`{{album}}`} - Album Name</li>
       </ul>
     </div>


### PR DESCRIPTION
## Description

Allow last 12 chars of UUID4/7 for storage template. UUIDv4 and v7 have the same character layout so it is cross compatible

## How Has This Been Tested?

Dev container setup, uploaded image, appeared with correct path

```
./admin/2025/2025-02-28/360_F_143428338_gcxw3Jcd0tJpkvvb53pfEztwtU9sxsgT__f43f320afbb3_--___cf2cb398-236d-4cb9-9651-f43f320afbb3.jpg
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

![image](https://github.com/user-attachments/assets/5a44d615-c81f-419b-8bd8-a86e7d30bd50)

</details>



## Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation if applicable
- [x ] I have no unrelated changes in the PR.
- [x ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x ] I have followed naming conventions/patterns in the surrounding code
- [x ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
