### PR TITLE
refactor(server): use exiftool for file date metadata

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -73,7 +73,7 @@ export class MetadataRepository {
     inferTimezoneFromDatestamps: true,
     inferTimezoneFromTimeStamp: true,
     useMWG: true,
-    numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength'],
+    numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength', 'FileSize'],
     /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
     geoTz: (lat, lon) => geotz.find(lat, lon)[0],
     // Enable exiftool LFS to parse metadata for files larger than 2GB.

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -137,7 +137,7 @@ describe(MetadataService.name, () => {
       );
     });
 
-    it('should take the file modification date when missing exif and earliest than creation date', async () => {
+    it('should take the file modification date when missing exif and earlier than creation date', async () => {
       const fileCreatedAt = new Date('2022-01-01T00:00:00.000Z');
       const fileModifiedAt = new Date('2021-01-01T00:00:00.000Z');
       mocks.asset.getByIds.mockResolvedValue([assetStub.image]);
@@ -160,7 +160,7 @@ describe(MetadataService.name, () => {
       });
     });
 
-    it('should take the file creation date when missing exif and earliest than modification date', async () => {
+    it('should take the file creation date when missing exif and earlier than modification date', async () => {
       const fileCreatedAt = new Date('2021-01-01T00:00:00.000Z');
       const fileModifiedAt = new Date('2022-01-01T00:00:00.000Z');
       mocks.asset.getByIds.mockResolvedValue([assetStub.image]);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -172,10 +172,12 @@ export class MetadataService extends BaseService {
     }
 
     const exifTags = await this.getExifTags(asset);
-    if (!exifTags.FileCreateDate || !exifTags.FileModifyDate) {
+    if (!exifTags.FileCreateDate || !exifTags.FileModifyDate || !exifTags.FileSize) {
+      this.logger.warn(`Missing file creation or modification date for asset ${asset.id}: ${asset.originalPath}`);
       const stat = await this.storageRepository.stat(asset.originalPath);
       exifTags.FileCreateDate = stat.ctime.toISOString();
       exifTags.FileModifyDate = stat.mtime.toISOString();
+      exifTags.FileSize = stat.size.toString();
     }
 
     this.logger.verbose('Exif Tags', exifTags);

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -678,7 +678,7 @@ export class MetadataService extends BaseService {
   }
 
   private toDate(date: string | ExifDateTime): Date {
-    return typeof date === 'string' ? new Date(date) : date!.toDate();
+    return typeof date === 'string' ? new Date(date) : date.toDate();
   }
 
   private earliestDate(a: Date, b: Date) {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -172,6 +172,11 @@ export class MetadataService extends BaseService {
     }
 
     const exifTags = await this.getExifTags(asset);
+    if (!exifTags.FileCreateDate || !exifTags.FileModifyDate) {
+      const stat = await this.storageRepository.stat(asset.originalPath);
+      exifTags.FileCreateDate = stat.ctime.toISOString();
+      exifTags.FileModifyDate = stat.mtime.toISOString();
+    }
 
     this.logger.verbose('Exif Tags', exifTags);
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -172,7 +172,7 @@ export class MetadataService extends BaseService {
     }
 
     const exifTags = await this.getExifTags(asset);
-    if (!exifTags.FileCreateDate || !exifTags.FileModifyDate || !exifTags.FileSize) {
+    if (!exifTags.FileCreateDate || !exifTags.FileModifyDate || exifTags.FileSize === undefined) {
       this.logger.warn(`Missing file creation or modification date for asset ${asset.id}: ${asset.originalPath}`);
       const stat = await this.storageRepository.stat(asset.originalPath);
       exifTags.FileCreateDate = stat.ctime.toISOString();

--- a/server/test/medium/specs/metadata.service.spec.ts
+++ b/server/test/medium/specs/metadata.service.spec.ts
@@ -36,7 +36,7 @@ describe(MetadataService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(MetadataService, { metadata: metadataRepository }));
 
-    mocks.storage.stat.mockResolvedValue({ size: 123_456 } as Stats);
+    mocks.storage.stat.mockResolvedValue({ size: 123_456, ctime: new Date(), mtime: new Date() } as Stats);
 
     delete process.env.TZ;
   });
@@ -51,6 +51,8 @@ describe(MetadataService.name, () => {
         description: 'should handle no time zone information',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
+          FileCreateDate: '2022:01:01 00:00:00',
+          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -63,6 +65,8 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'America/Los_Angeles',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
+          FileCreateDate: '2022:01:01 00:00:00',
+          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -75,6 +79,8 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'Europe/Brussels',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
+          FileCreateDate: '2022:01:01 00:00:00',
+          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -87,6 +93,8 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'Europe/Brussels',
         exifData: {
           DateTimeOriginal: '2022:06:01 00:00:00',
+          FileCreateDate: '2022:06:01 00:00:00',
+          FileModifyDate: '2022:06:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-06-01T00:00:00.000Z',
@@ -98,6 +106,8 @@ describe(MetadataService.name, () => {
         description: 'should handle a +13:00 time zone',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00+13:00',
+          FileCreateDate: '2022:01:01 00:00:00+13:00',
+          FileModifyDate: '2022:01:01 00:00:00+13:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',


### PR DESCRIPTION
### Description

There are two redundant `stat` calls in metadata extraction that can instead use the exiftool output (tags starting with `File` are from the file system). Besides generally less file IO, it avoids taking up a thread (or waiting to acquire one) in the all-too-limited libuv threadpool. Based on #16450, which should be merged first.

I tested locally and it works as expected. However, there are cases in the library E2E tests where the tags are undefined. I don't know why this is. The PR falls back to calling `.stat` in this case to handle this.

This is the last of the PRs split off from #14277.