### PR TITLE
fix(web): unable to download live photo as anonymous user

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -229,7 +229,7 @@ export const downloadFile = async (asset: AssetResponseDto) => {
 
   if (asset.livePhotoVideoId) {
     const motionAsset = await getAssetInfo({ id: asset.livePhotoVideoId, key: getKey() });
-    if (!isAndroidMotionVideo(motionAsset) || get(preferences).download.includeEmbeddedVideos) {
+    if (!isAndroidMotionVideo(motionAsset) || get(preferences)?.download.includeEmbeddedVideos) {
       assets.push({
         filename: motionAsset.originalFileName,
         id: asset.livePhotoVideoId,


### PR DESCRIPTION
## Description

As described in the bug report, `get(preferences)` returns `undefined` if the user is not logged in (from a shared album/image link for example). As such, it is impossible to download a live photo in this case: the `downloadFile` function throws an error instead.

Fixes #15836

(Note that I'm a C++/desktop developer, so I'm in unknown territory here :sweat_smile: But the change should be simple enough...)

## How Has This Been Tested?

Manually tested in these conditions:
- [x] Download live photo from logged in user with `includeEmbeddedVideos` option enabled
- [x] Download live photo from logged in user with `includeEmbeddedVideos` option disabled
- [x] Download live photo from shared album link from a private browser session (anonymous user)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
