### PR TITLE
fix(web): Open huggingface.co link on settings page in new tab

### DIFF
--- a/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/machine-learning-settings/machine-learning-settings.svelte
@@ -110,7 +110,7 @@
               <p class="immich-form-label pb-2 text-sm">
                 <FormatMessage key="admin.machine_learning_clip_model_description">
                   {#snippet children({ message })}
-                    <a href="https://huggingface.co/immich-app"><u>{message}</u></a>
+                    <a target="_blank" href="https://huggingface.co/immich-app"><u>{message}</u></a>
                   {/snippet}
                 </FormatMessage>
               </p>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On the admin settings page, within the machine learning section under "Smart Search," there is a link that redirects users to Immich's page on Hugging Face. Previously, when this link was clicked, it would open in the same tab as the admin settings page, which was inconvenient. Users often lost all unsaved changes while trying to view documentation. To address this issue, the link has now been updated to open in a new tab.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Click hugginface.co link on admin settings page

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
Not appropriate

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
None
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
