### PR TITLE
chore(mobile): rename log enum to lowercase

### DIFF
--- a/mobile/lib/domain/models/log.model.dart
+++ b/mobile/lib/domain/models/log.model.dart
@@ -1,19 +1,15 @@
-// ignore_for_file: constant_identifier_names
-
-import 'package:logging/logging.dart';
-
 /// Log levels according to dart logging [Level]
 enum LogLevel {
-  ALL,
-  FINEST,
-  FINER,
-  FINE,
-  CONFIG,
-  INFO,
-  WARNING,
-  SEVERE,
-  SHOUT,
-  OFF,
+  all,
+  finest,
+  finer,
+  fine,
+  config,
+  info,
+  warning,
+  severe,
+  shout,
+  off,
 }
 
 class LogMessage {

--- a/mobile/lib/domain/services/log.service.dart
+++ b/mobile/lib/domain/services/log.service.dart
@@ -39,29 +39,29 @@ class LogService {
   }
 
   static Future<LogService> init({
-    required ILogRepository logRepo,
-    required IStoreRepository storeRepo,
+    required ILogRepository logRepository,
+    required IStoreRepository storeRepository,
     bool shouldBuffer = true,
   }) async {
     if (_instance != null) {
       return _instance!;
     }
     _instance = await create(
-      logRepo: logRepo,
-      storeRepo: storeRepo,
+      logRepository: logRepository,
+      storeRepository: storeRepository,
       shouldBuffer: shouldBuffer,
     );
     return _instance!;
   }
 
   static Future<LogService> create({
-    required ILogRepository logRepo,
-    required IStoreRepository storeRepo,
+    required ILogRepository logRepository,
+    required IStoreRepository storeRepository,
     bool shouldBuffer = true,
   }) async {
-    final instance = LogService._(logRepo, storeRepo, shouldBuffer);
+    final instance = LogService._(logRepository, storeRepository, shouldBuffer);
     // Truncate logs to 250
-    await logRepo.truncate(limit: kLogTruncateLimit);
+    await logRepository.truncate(limit: kLogTruncateLimit);
     // Get log level from store
     final level = await instance._storeRepository.tryGet(StoreKey.logLevel);
     if (level != null) {

--- a/mobile/lib/domain/services/log.service.dart
+++ b/mobile/lib/domain/services/log.service.dart
@@ -145,7 +145,7 @@ class LoggerUnInitializedException implements Exception {
 extension LevelDomainToInfraExtension on Level {
   LogLevel toLogLevel() =>
       LogLevel.values.elementAtOrNull(Level.LEVELS.indexOf(this)) ??
-      LogLevel.INFO;
+      LogLevel.info;
 }
 
 extension on LogLevel {

--- a/mobile/lib/infrastructure/entities/log.entity.dart
+++ b/mobile/lib/infrastructure/entities/log.entity.dart
@@ -5,28 +5,23 @@ part 'log.entity.g.dart';
 
 @Collection(inheritance: false)
 class LoggerMessage {
-  Id id = Isar.autoIncrement;
-  String message;
-  String? details;
+  final Id id = Isar.autoIncrement;
+  final String message;
+  final String? details;
   @Enumerated(EnumType.ordinal)
-  LogLevel level = LogLevel.INFO;
-  DateTime createdAt;
-  String? context1;
-  String? context2;
+  final LogLevel level;
+  final DateTime createdAt;
+  final String? context1;
+  final String? context2;
 
-  LoggerMessage({
+  const LoggerMessage({
     required this.message,
     required this.details,
-    required this.level,
+    this.level = LogLevel.info,
     required this.createdAt,
     required this.context1,
     required this.context2,
   });
-
-  @override
-  String toString() {
-    return 'LoggerMessage(message: $message, level: $level, createdAt: $createdAt)';
-  }
 
   LogMessage toDto() {
     return LogMessage(

--- a/mobile/lib/infrastructure/entities/log.entity.g.dart
+++ b/mobile/lib/infrastructure/entities/log.entity.g.dart
@@ -117,10 +117,9 @@ LoggerMessage _loggerMessageDeserialize(
     createdAt: reader.readDateTime(offsets[2]),
     details: reader.readStringOrNull(offsets[3]),
     level: _LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offsets[4])] ??
-        LogLevel.ALL,
+        LogLevel.info,
     message: reader.readString(offsets[5]),
   );
-  object.id = id;
   return object;
 }
 
@@ -141,7 +140,7 @@ P _loggerMessageDeserializeProp<P>(
       return (reader.readStringOrNull(offset)) as P;
     case 4:
       return (_LoggerMessagelevelValueEnumMap[reader.readByteOrNull(offset)] ??
-          LogLevel.ALL) as P;
+          LogLevel.info) as P;
     case 5:
       return (reader.readString(offset)) as P;
     default:
@@ -150,28 +149,28 @@ P _loggerMessageDeserializeProp<P>(
 }
 
 const _LoggerMessagelevelEnumValueMap = {
-  'ALL': 0,
-  'FINEST': 1,
-  'FINER': 2,
-  'FINE': 3,
-  'CONFIG': 4,
-  'INFO': 5,
-  'WARNING': 6,
-  'SEVERE': 7,
-  'SHOUT': 8,
-  'OFF': 9,
+  'all': 0,
+  'finest': 1,
+  'finer': 2,
+  'fine': 3,
+  'config': 4,
+  'info': 5,
+  'warning': 6,
+  'severe': 7,
+  'shout': 8,
+  'off': 9,
 };
 const _LoggerMessagelevelValueEnumMap = {
-  0: LogLevel.ALL,
-  1: LogLevel.FINEST,
-  2: LogLevel.FINER,
-  3: LogLevel.FINE,
-  4: LogLevel.CONFIG,
-  5: LogLevel.INFO,
-  6: LogLevel.WARNING,
-  7: LogLevel.SEVERE,
-  8: LogLevel.SHOUT,
-  9: LogLevel.OFF,
+  0: LogLevel.all,
+  1: LogLevel.finest,
+  2: LogLevel.finer,
+  3: LogLevel.fine,
+  4: LogLevel.config,
+  5: LogLevel.info,
+  6: LogLevel.warning,
+  7: LogLevel.severe,
+  8: LogLevel.shout,
+  9: LogLevel.off,
 };
 
 Id _loggerMessageGetId(LoggerMessage object) {
@@ -183,9 +182,7 @@ List<IsarLinkBase<dynamic>> _loggerMessageGetLinks(LoggerMessage object) {
 }
 
 void _loggerMessageAttach(
-    IsarCollection<dynamic> col, Id id, LoggerMessage object) {
-  object.id = id;
-}
+    IsarCollection<dynamic> col, Id id, LoggerMessage object) {}
 
 extension LoggerMessageQueryWhereSort
     on QueryBuilder<LoggerMessage, LoggerMessage, QWhere> {

--- a/mobile/lib/infrastructure/entities/store.entity.dart
+++ b/mobile/lib/infrastructure/entities/store.entity.dart
@@ -5,8 +5,9 @@ part 'store.entity.g.dart';
 /// Internal class for `Store`, do not use elsewhere.
 @Collection(inheritance: false)
 class StoreValue {
-  const StoreValue(this.id, {this.intValue, this.strValue});
   final Id id;
   final int? intValue;
   final String? strValue;
+
+  const StoreValue(this.id, {this.intValue, this.strValue});
 }

--- a/mobile/lib/pages/common/app_log.page.dart
+++ b/mobile/lib/pages/common/app_log.page.dart
@@ -41,16 +41,16 @@ class AppLogPage extends HookConsumerWidget {
     }
 
     Widget buildLeadingIcon(LogLevel level) => switch (level) {
-          LogLevel.INFO => colorStatusIndicator(context.primaryColor),
-          LogLevel.SEVERE => colorStatusIndicator(Colors.redAccent),
-          LogLevel.WARNING => colorStatusIndicator(Colors.orangeAccent),
+          LogLevel.info => colorStatusIndicator(context.primaryColor),
+          LogLevel.severe => colorStatusIndicator(Colors.redAccent),
+          LogLevel.warning => colorStatusIndicator(Colors.orangeAccent),
           _ => colorStatusIndicator(Colors.grey),
         };
 
     Color getTileColor(LogLevel level) => switch (level) {
-          LogLevel.INFO => Colors.transparent,
-          LogLevel.SEVERE => Colors.redAccent.withOpacity(0.25),
-          LogLevel.WARNING => Colors.orangeAccent.withOpacity(0.25),
+          LogLevel.info => Colors.transparent,
+          LogLevel.severe => Colors.redAccent.withOpacity(0.25),
+          LogLevel.warning => Colors.orangeAccent.withOpacity(0.25),
           _ => context.primaryColor.withOpacity(0.1),
         };
 

--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -49,8 +49,8 @@ abstract final class Bootstrap {
   static Future<void> initDomain(Isar db) async {
     await StoreService.init(storeRepository: IsarStoreRepository(db));
     await LogService.init(
-      logRepo: IsarLogRepository(db),
-      storeRepo: IsarStoreRepository(db),
+      logRepository: IsarLogRepository(db),
+      storeRepository: IsarStoreRepository(db),
     );
   }
 }

--- a/mobile/test/domain/services/log_service_test.dart
+++ b/mobile/test/domain/services/log_service_test.dart
@@ -14,14 +14,14 @@ import '../../test_utils.dart';
 
 final _kInfoLog = LogMessage(
   message: '#Info Message',
-  level: LogLevel.INFO,
+  level: LogLevel.info,
   createdAt: DateTime(2025, 2, 26),
   logger: 'Info Logger',
 );
 
 final _kWarnLog = LogMessage(
   message: '#Warn Message',
-  level: LogLevel.WARNING,
+  level: LogLevel.warning,
   createdAt: DateTime(2025, 2, 27),
   logger: 'Warn Logger',
 );
@@ -40,7 +40,7 @@ void main() {
     when(() => mockLogRepo.truncate(limit: any(named: 'limit')))
         .thenAnswer((_) async => {});
     when(() => mockStoreRepo.tryGet<int>(StoreKey.logLevel))
-        .thenAnswer((_) async => LogLevel.FINE.index);
+        .thenAnswer((_) async => LogLevel.fine.index);
     when(() => mockLogRepo.getAll()).thenAnswer((_) async => []);
     when(() => mockLogRepo.insert(any())).thenAnswer((_) async => true);
     when(() => mockLogRepo.insertAll(any())).thenAnswer((_) async => true);
@@ -72,14 +72,14 @@ void main() {
     setUp(() async {
       when(() => mockStoreRepo.insert<int>(StoreKey.logLevel, any()))
           .thenAnswer((_) async => true);
-      await sut.setlogLevel(LogLevel.SHOUT);
+      await sut.setlogLevel(LogLevel.shout);
     });
 
     test('Updates the log level in store', () {
       final index = verify(
         () => mockStoreRepo.insert<int>(StoreKey.logLevel, captureAny()),
       ).captured.firstOrNull;
-      expect(index, LogLevel.SHOUT.index);
+      expect(index, LogLevel.shout.index);
     });
 
     test('Sets log level on logger', () {

--- a/mobile/test/domain/services/log_service_test.dart
+++ b/mobile/test/domain/services/log_service_test.dart
@@ -45,8 +45,10 @@ void main() {
     when(() => mockLogRepo.insert(any())).thenAnswer((_) async => true);
     when(() => mockLogRepo.insertAll(any())).thenAnswer((_) async => true);
 
-    sut =
-        await LogService.create(logRepo: mockLogRepo, storeRepo: mockStoreRepo);
+    sut = await LogService.create(
+      logRepository: mockLogRepo,
+      storeRepository: mockStoreRepo,
+    );
   });
 
   tearDown(() async {
@@ -91,8 +93,8 @@ void main() {
     test('Buffers logs until timer elapses', () {
       TestUtils.fakeAsync((time) async {
         sut = await LogService.create(
-          logRepo: mockLogRepo,
-          storeRepo: mockStoreRepo,
+          logRepository: mockLogRepo,
+          storeRepository: mockStoreRepo,
           shouldBuffer: true,
         );
 
@@ -109,8 +111,8 @@ void main() {
     test('Batch inserts all logs on timer', () {
       TestUtils.fakeAsync((time) async {
         sut = await LogService.create(
-          logRepo: mockLogRepo,
-          storeRepo: mockStoreRepo,
+          logRepository: mockLogRepo,
+          storeRepository: mockStoreRepo,
           shouldBuffer: true,
         );
 
@@ -131,8 +133,8 @@ void main() {
     test('Does not buffer when off', () {
       TestUtils.fakeAsync((time) async {
         sut = await LogService.create(
-          logRepo: mockLogRepo,
-          storeRepo: mockStoreRepo,
+          logRepository: mockLogRepo,
+          storeRepository: mockStoreRepo,
           shouldBuffer: false,
         );
 
@@ -165,8 +167,8 @@ void main() {
     test('Combines result from both DB + Buffer', () {
       TestUtils.fakeAsync((time) async {
         sut = await LogService.create(
-          logRepo: mockLogRepo,
-          storeRepo: mockStoreRepo,
+          logRepository: mockLogRepo,
+          storeRepository: mockStoreRepo,
           shouldBuffer: true,
         );
 

--- a/mobile/test/modules/shared/sync_service_test.dart
+++ b/mobile/test/modules/shared/sync_service_test.dart
@@ -72,8 +72,8 @@ void main() {
       await StoreService.init(storeRepository: IsarStoreRepository(db));
       await Store.put(StoreKey.currentUser, owner);
       await LogService.init(
-        logRepo: IsarLogRepository(db),
-        storeRepo: IsarStoreRepository(db),
+        logRepository: IsarLogRepository(db),
+        storeRepository: IsarStoreRepository(db),
       );
     });
     final List<Asset> initialAssets = [


### PR DESCRIPTION
### Description

- Renamed the `LogLevel` enum to lowercase to maintain consistency and to follows darts convention. 
- Logger message entity is made const