### PR TITLE
fix(mobile): Updated formatting of server address in networking

### DIFF
--- a/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
+++ b/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
@@ -101,7 +101,7 @@ class NetworkingSettings extends HookConsumerWidget {
           padding: const EdgeInsets.only(top: 8, left: 16, bottom: 8),
           child: NetworkPreferenceTitle(
             title: "current_server_address".tr().toUpperCase(),
-            icon: currentEndpoint!.startsWith('https')
+            icon: (currentEndpoint?.startsWith('https') ?? false)
                 ? Icons.https_outlined
                 : Icons.http_outlined,
           ),
@@ -118,10 +118,16 @@ class NetworkingSettings extends HookConsumerWidget {
               ),
             ),
             child: ListTile(
-              leading:
-                  const Icon(Icons.check_circle_rounded, color: Colors.green),
+              leading: currentEndpoint != null
+                  ? const Icon(
+                      Icons.check_circle_rounded,
+                      color: Colors.green,
+                    )
+                  : const Icon(
+                      Icons.circle_outlined,
+                    ),
               title: Text(
-                currentEndpoint,
+                currentEndpoint ?? "--",
                 style: TextStyle(
                   fontSize: 16,
                   fontFamily: 'Inconsolata',

--- a/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
+++ b/mobile/lib/widgets/settings/networking_settings/networking_settings.dart
@@ -2,13 +2,12 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/auth/auxilary_endpoint.model.dart';
 import 'package:immich_mobile/providers/network.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
+import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:immich_mobile/widgets/settings/networking_settings/external_network_preference.dart';
 import 'package:immich_mobile/widgets/settings/networking_settings/local_network_preference.dart';
 import 'package:immich_mobile/widgets/settings/settings_switch_list_tile.dart';
@@ -18,7 +17,7 @@ class NetworkingSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentEndpoint = Store.get(StoreKey.serverEndpoint);
+    final currentEndpoint = getServerUrl();
     final featureEnabled =
         useAppSettingsState(AppSettingsEnum.autoEndpointSwitching);
 
@@ -102,7 +101,7 @@ class NetworkingSettings extends HookConsumerWidget {
           padding: const EdgeInsets.only(top: 8, left: 16, bottom: 8),
           child: NetworkPreferenceTitle(
             title: "current_server_address".tr().toUpperCase(),
-            icon: currentEndpoint.startsWith('https')
+            icon: currentEndpoint!.startsWith('https')
                 ? Icons.https_outlined
                 : Icons.http_outlined,
           ),


### PR DESCRIPTION
## Description

Changed the server endpoint to use `getServerUrl` for consistent formatting.

Fixes #16467