### PR TITLE
fix(web): Default to context search on web

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-filter-modal.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-filter-modal.svelte
@@ -57,7 +57,7 @@
 
   let filter: SearchFilter = $state({
     query: 'query' in searchQuery ? searchQuery.query : searchQuery.originalFileName || '',
-    queryType: 'query' in searchQuery ? 'smart' : 'metadata',
+    queryType: 'smart',
     personIds: new SvelteSet('personIds' in searchQuery ? searchQuery.personIds : []),
     tagIds: new SvelteSet('tagIds' in searchQuery ? searchQuery.tagIds : []),
     location: {


### PR DESCRIPTION
## Description

Made the behavior consistent between web and mobile.
Search type should default to context, as seen on mobile.

_This was reported on discord, not linked to any issue here._