### PR TITLE
fix(web): folder view navigation refresh

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -58,9 +58,16 @@
   let shiftKeyIsDown = $state(false);
   let lastAssetMouseEvent: AssetResponseDto | null = $state(null);
 
+  // loads in savedIndex
+  const savedIndex = localStorage.getItem('galleryViewerIndex');
+  if (savedIndex) {
+    currentViewAssetIndex = parseInt(savedIndex);
+  }
+
   const viewAssetHandler = async (asset: AssetResponseDto) => {
     currentViewAssetIndex = assets.findIndex((a) => a.id == asset.id);
     setAsset(assets[currentViewAssetIndex]);
+    localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
     await navigate({ targetRoute: 'current', assetId: $viewingAsset.id });
   };
 
@@ -218,6 +225,7 @@
         return false;
       }
 
+      localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
       await navigateToAsset(asset);
       return true;
     } catch (error) {

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -58,7 +58,7 @@
   let shiftKeyIsDown = $state(false);
   let lastAssetMouseEvent: AssetResponseDto | null = $state(null);
 
-  // loads in savedIndex
+  // loads in savedIndex from localStorage
   const savedIndex = localStorage.getItem('galleryViewerIndex');
   if (savedIndex) {
     currentViewAssetIndex = parseInt(savedIndex);
@@ -219,13 +219,13 @@
       } else {
         currentViewAssetIndex = currentViewAssetIndex + 1;
         asset = currentViewAssetIndex < assets.length ? assets[currentViewAssetIndex] : undefined;
+        localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
       }
 
       if (!asset) {
         return false;
       }
 
-      localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
       await navigateToAsset(asset);
       return true;
     } catch (error) {
@@ -266,6 +266,7 @@
       } else {
         currentViewAssetIndex = currentViewAssetIndex - 1;
         asset = currentViewAssetIndex >= 0 ? assets[currentViewAssetIndex] : undefined;
+        localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
       }
 
       if (!asset) {
@@ -302,6 +303,7 @@
           await handlePrevious();
         } else {
           setAsset(assets[currentViewAssetIndex]);
+          localStorage.setItem('galleryViewerIndex', currentViewAssetIndex.toString());
         }
         break;
       }


### PR DESCRIPTION
## Description

In the gallery-viewer component in the web directory, I saved the "currentViewAssetIndex" variable to localStorage whenever it was changed and set the variable to the value in localStorage upon page load (if it exists).

This change fixes a bug, where upon loading the page while navigating between images in folder view, the currentViewAssetIndex would be set to 0 by default, so using the right/left arrows to navigate between images results in the wrong ones.

Fixes [#15222](https://github.com/immich-app/immich/issues/15222) 

## How Has This Been Tested?

I went to folder view opened up images at varying positions, navigated between them, and deleted them, refreshing the page after each action to check if I continue at the proper index. I also checked navigation on other views to ensure these changes did not break them

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

N/A

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)