### PR TITLE
added redis data volume

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -119,6 +119,8 @@ services:
     image: redis:6.2-alpine@sha256:148bb5411c184abd288d9aaed139c98123eeb8824c5d3fce03cf721db58066d8
     healthcheck:
       test: redis-cli ping || exit 1
+    volumes:
+      - redis-data:/data
 
   database:
     container_name: immich_postgres
@@ -178,3 +180,4 @@ volumes:
   model-cache:
   prometheus-data:
   grafana-data:
+  redis-data:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -60,6 +60,8 @@ services:
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always
+    volumes:
+      - redis-data:/data
 
   database:
     container_name: immich_postgres
@@ -120,3 +122,4 @@ volumes:
   model-cache:
   prometheus-data:
   grafana-data:
+  redis-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always
+    volumes:
+      - redis-data:/data
 
   database:
     container_name: immich_postgres
@@ -87,3 +89,4 @@ services:
 
 volumes:
   model-cache:
+  redis-data:


### PR DESCRIPTION


## Description

redis image requires a volume to be mount at "/data". if no named volume specified, it creates an anonymous one. Maybe its a better idea to define one in all docker compose yaml files.

## How Has This Been Tested?

it was not so far, it more a proposal 

## Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have made corresponding changes to the documentation if applicable
- [ x ] I have no unrelated changes in the PR.
- [ x ] I have confirmed that any new dependencies are strictly necessary.
- [ x ] I have written tests for new code (if applicable)
- [ x ] I have followed naming conventions/patterns in the surrounding code
- [ x ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [ x ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
