### PR TITLE
chore: reword backup_manual_in_progress

### DIFF
--- a/mobile/assets/i18n/ca-CA.json
+++ b/mobile/assets/i18n/ca-CA.json
@@ -108,7 +108,7 @@
   "backup_info_card_assets": "elements",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "cache_settings_album_thumbnails": "Library page thumbnails ({} assets)",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/ga.json
+++ b/mobile/assets/i18n/ga.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/gl-ES.json
+++ b/mobile/assets/i18n/gl-ES.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/hi-IN.json
+++ b/mobile/assets/i18n/hi-IN.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/lt-LT.json
+++ b/mobile/assets/i18n/lt-LT.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/mn-MN.json
+++ b/mobile/assets/i18n/mn-MN.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/sr-Cyrl.json
+++ b/mobile/assets/i18n/sr-Cyrl.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/sr-Latn.json
+++ b/mobile/assets/i18n/sr-Latn.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "zapisi",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",

--- a/mobile/assets/i18n/sv-FI.json
+++ b/mobile/assets/i18n/sv-FI.json
@@ -133,7 +133,7 @@
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_failed": "Failed",
-  "backup_manual_in_progress": "Upload already in progress. Try after sometime",
+  "backup_manual_in_progress": "Upload already in progress. Try after some time",
   "backup_manual_success": "Success",
   "backup_manual_title": "Upload status",
   "backup_options_page_title": "Backup options",


### PR DESCRIPTION
Split "sometime" into "some time".

## Description

Change "sometime" to "some time". It reads a little better when manually uploading images.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
