### PR TITLE
chore(mobile): fix store.put type def

### DIFF
--- a/mobile/lib/domain/services/store.service.dart
+++ b/mobile/lib/domain/services/store.service.dart
@@ -75,7 +75,7 @@ class StoreService {
   }
 
   /// Asynchronously stores the value in the DB and synchronously in the cache
-  Future<void> put<T>(StoreKey<T> key, T value) async {
+  Future<void> put<U extends StoreKey<T>, T>(U key, T value) async {
     if (_cache[key.id] == value) return;
     await _storeRepository.insert(key, value);
     _cache[key.id] = value;


### PR DESCRIPTION
### Description

The type definition for `Store.put` was incorrect leading to examples like the following getting ignored by the compiler

```dart
await Store.put(
      StoreKey.accessToken,
      User.fromUserDto(userResponse, userPreferences),
);
```

The change fixes it and strictly enforces the type during compile time