### PR TITLE
feat(server): hide deleted library assets

### DIFF
--- a/server/src/repositories/library.repository.ts
+++ b/server/src/repositories/library.repository.ts
@@ -82,6 +82,7 @@ export class LibraryRepository {
   }
 
   async softDelete(id: string): Promise<void> {
+    await this.db.updateTable('assets').set({ isVisible: false }).where('assets.libraryId', '=', id).execute();
     await this.db.updateTable('libraries').set({ deletedAt: new Date() }).where('libraries.id', '=', id).execute();
   }
 


### PR DESCRIPTION
Deleting a large external library is quite slow. While the library is deleted, it can take a long time until the assets are removed form the timeline.

This small PR updates all assets in the to-be-deleted library to have isVisible=false which makes the process almost instant from the user's perspective