### PR TITLE
fix(server): fix import path truthiness check

### DIFF
--- a/web/src/routes/admin/library-management/+page.svelte
+++ b/web/src/routes/admin/library-management/+page.svelte
@@ -121,7 +121,7 @@
   };
 
   const handleAddImportPath = () => {
-    if (!updateLibraryIndex || !importPathToAdd) {
+    if (updateLibraryIndex === null || !importPathToAdd) {
       return;
     }
 


### PR DESCRIPTION
When creating a library and showing the import path form, it failed to add a new import path due to zero being evaluated as false. This PR explicitly checks against null instead, allowing the path to be added