### PR TITLE
fix(mobile): do not pause audio on app start

### DIFF
--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -18,13 +18,6 @@ import UIKit
       UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
     }
 
-    do {
-      try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-      try AVAudioSession.sharedInstance().setActive(true)
-    } catch {
-      print("Failed to set audio session category. Error: \(error)")
-    }
-
     GeneratedPluginRegistrant.register(with: self)
     BackgroundServicePlugin.registerBackgroundProcessing()
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1012,8 +1012,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4530808"
-      resolved-ref: "4530808a6d04c9992de184c423c9e87fbf6a53eb"
+      ref: "5459d54"
+      resolved-ref: "5459d54cdc1cf4d99e2193b310052f1ebb5dcf43"
       url: "https://github.com/immich-app/native_video_player"
     source: git
     version: "1.3.1"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   native_video_player:
     git:
       url: https://github.com/immich-app/native_video_player
-      ref: '4530808'
+      ref: '5459d54'
 
   #image editing packages
   crop_image: ^1.0.13


### PR DESCRIPTION
Fixes #14766

## Description

- Moves the activating Audio session logic to the native video player so it is not triggered on app startup, but rather, deferred to when a video is actually played