### PR TITLE
fix: isar crash on resume from app detach

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -70,6 +70,7 @@ custom_lint:
         - lib/infrastructure/repositories/{store,db,log}.repository.dart
         - lib/providers/infrastructure/db.provider.dart
         # acceptable exceptions for the time being (until Isar is fully replaced)
+        - lib/providers/app_life_cycle.provider.dart
         - integration_test/test_utils/general_helper.dart
         - lib/main.dart
         - lib/pages/album/album_asset_selection.page.dart

--- a/mobile/lib/domain/services/log.service.dart
+++ b/mobile/lib/domain/services/log.service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/interfaces/log.interface.dart';
 import 'package:immich_mobile/domain/interfaces/store.interface.dart';
@@ -91,12 +92,13 @@ class LogService {
   }
 
   /// Flush pending log messages to persistent storage
-  Future<void> flush() async {
+  void flush() {
     if (_flushTimer == null) {
       return;
     }
     _flushTimer!.cancel();
-    await _flushBufferToDatabase();
+    // TODO: Rename enable this after moving to sqlite - #16504
+    // await _flushBufferToDatabase();
   }
 
   Future<void> dispose() {
@@ -106,6 +108,10 @@ class LogService {
   }
 
   void _writeLogToDatabase(LogRecord r) {
+    if (kDebugMode) {
+      debugPrint('[${r.level.name}] [${r.time}] ${r.message}');
+    }
+
     final record = LogMessage(
       message: r.message,
       level: r.level.toLogLevel(),

--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -17,6 +17,7 @@ import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/tab.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/services/background.service.dart';
+import 'package:isar/isar.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 enum AppLifeCycleEnum {
@@ -114,11 +115,13 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
       _ref.read(websocketProvider.notifier).disconnect();
     }
 
-    unawaited(LogService.I.flush());
+    LogService.I.flush();
   }
 
-  void handleAppDetached() {
+  Future<void> handleAppDetached() async {
     state = AppLifeCycleEnum.detached;
+    LogService.I.flush();
+    await Isar.getInstance()?.close();
     // no guarantee this is called at all
     _ref.read(manualUploadProvider.notifier).cancelBackup();
   }


### PR DESCRIPTION
Fixes #16504 

### Description

- Setting log level to anything finer than INFO, results in a large number of log files being emitted which are buffered and flushed to the DB. However, Isar seems to suffer from an issue where if a write transaction is not properly closed on android, it hangs there and crashes when we try to open Isar the next time. Using the back button on android puts the app into detached state, and resuming back to the app will start from `main()`, resulting in us opening Isar again and thereby crashing.
As a workaround, we ignore all the remaining logs in the buffer when the app is moving into the detached state. However, this should be reverted once we move away from Isar

- We used to log messages in the console when on debug mode. This was missed in the refactor and is added now
