### PR TITLE
fix(mobile): Fixed zh-Hans not persisting

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -394,10 +394,10 @@ packages:
     dependency: "direct main"
     description:
       name: easy_localization
-      sha256: fa59bcdbbb911a764aa6acf96bbb6fa7a5cf8234354fc45ec1a43a0349ef0201
+      sha256: "0f5239c7b8ab06c66440cfb0e9aa4b4640429c6668d5a42fe389c5de42220b12"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "3.0.7+1"
   easy_logger:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   url_launcher: ^6.2.4
   http: ^1.1.0
   cancellation_token_http: ^2.0.0
-  easy_localization: ^3.0.3
+  easy_localization: ^3.0.7+1
   share_plus: ^10.0.0
   flutter_displaymode: ^0.6.0
   scrollable_positioned_list: ^0.3.8


### PR DESCRIPTION
## Description

Upgraded `easy_localization` package to fix issue #16289

3.0.7 of `easy_localization` fixes the issue:
> add scriptCode to desiredLocale if useOnlyLangCode is true. scriptCode is needed sometimes, for example zh-Hans, zh-Hant

## How Has This Been Tested?

- Set the language to Chinese Simplified
- Restart the app
- App persists the language as expected (before it didn't for zh-Hans only)