### PR TITLE
fix: storage template failure after re-upload and previous fail

### DIFF
--- a/server/src/entities/move.entity.ts
+++ b/server/src/entities/move.entity.ts
@@ -10,7 +10,7 @@ export class MoveEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'uuid' })
   entityId!: string;
 
   @Column({ type: 'varchar' })

--- a/server/src/migrations/1741179334403-MoveHistoryUuidEntityId.ts
+++ b/server/src/migrations/1741179334403-MoveHistoryUuidEntityId.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MoveHistoryUuidEntityId1741179334403 implements MigrationInterface {
+  name = 'MoveHistoryUuidEntityId1741179334403';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "move_history" ALTER COLUMN "entityId" TYPE uuid USING "entityId"::uuid;`);
+    await queryRunner.query(`delete from "move_history"
+      where
+        "move_history"."entityId" not in (
+          select
+            "id"
+          from
+            "assets"
+          where
+            "assets"."id" = "move_history"."entityId"
+        )
+        and "move_history"."pathType" = 'original'
+  `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "move_history" ALTER COLUMN "entityId" TYPE character varying`);
+  }
+}
+

--- a/server/src/queries/move.repository.sql
+++ b/server/src/queries/move.repository.sql
@@ -15,3 +15,22 @@ where
   "id" = $1
 returning
   *
+
+-- MoveRepository.cleanMoveHistory
+delete from "move_history"
+where
+  "move_history"."entityId" not in (
+    select
+      "id"
+    from
+      "assets"
+    where
+      "assets"."id" = "move_history"."entityId"
+  )
+  and "move_history"."pathType" = 'original'
+
+-- MoveRepository.cleanMoveHistorySingle
+delete from "move_history"
+where
+  "move_history"."pathType" = 'original'
+  and "entityId" = $1

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -152,6 +152,7 @@ export class StorageTemplateService extends BaseService {
       this.logger.log('Storage template migration disabled, skipping');
       return JobStatus.SKIPPED;
     }
+    await this.moveRepository.cleanMoveHistory();
     const assetPagination = usePagination(JOBS_ASSET_PAGINATION_SIZE, (pagination) =>
       this.assetRepository.getAll(pagination, { withExif: true, withArchived: true }),
     );
@@ -173,6 +174,12 @@ export class StorageTemplateService extends BaseService {
     this.logger.log('Finished storage template migration');
 
     return JobStatus.SUCCESS;
+  }
+
+  @OnEvent({ name: 'asset.delete' })
+  async handleMoveHistoryCleanup({ assetId }: ArgOf<'asset.delete'>) {
+    this.logger.debug(`Cleaning up move history for asset ${assetId}`);
+    await this.moveRepository.cleanMoveHistorySingle(assetId);
   }
 
   async moveAsset(asset: AssetEntity, metadata: MoveAssetMetadata) {

--- a/server/test/repositories/move.repository.mock.ts
+++ b/server/test/repositories/move.repository.mock.ts
@@ -8,5 +8,7 @@ export const newMoveRepositoryMock = (): Mocked<RepositoryInterface<MoveReposito
     getByEntity: vitest.fn(),
     update: vitest.fn(),
     delete: vitest.fn(),
+    cleanMoveHistory: vitest.fn(),
+    cleanMoveHistorySingle: vitest.fn(),
   };
 };


### PR DESCRIPTION
When files had failed to move previously, and were then re-uploaded (or two files had the same path) the storage template system would get itself into a situation where the file could never be moved. This resolves that by cleaning up the move history table when an asset is deleted, and also does a bulk cleanup when the job is run manually.

Fixes #16354