### PR TITLE
fix(mobile): typo permanecer

### DIFF
--- a/mobile/assets/i18n/pt-BR.json
+++ b/mobile/assets/i18n/pt-BR.json
@@ -84,7 +84,7 @@
     "login_form_label_email": "Email",
     "login_form_label_password": "Password",
     "login_form_password_hint": "password",
-    "login_form_save_login": "Permaneçer conectado",
+    "login_form_save_login": "Permanecer conectado",
     "monthly_title_text_date_format": "MMMM y",
     "profile_drawer_client_server_up_to_date": "Cliente e Servidor estão atualizados",
     "profile_drawer_sign_out": "Sair",


### PR DESCRIPTION
## Description

Fixes user-facing and non-user-facing typo.

Dictionary reference: https://www.dicio.com.br/permanecer/

## How Has This Been Tested?

Hasn't been tested


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
