### PR TITLE
feat: enable PMTiles protocol support

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,6 +27,7 @@
         "justified-layout": "^4.1.0",
         "lodash-es": "^4.17.21",
         "luxon": "^3.4.4",
+        "pmtiles": "^4.3.0",
         "qrcode": "^1.5.4",
         "socket.io-client": "~4.8.0",
         "svelte-gestures": "^5.1.3",
@@ -2481,9 +2482,10 @@
       "dev": true
     },
     "node_modules/@types/leaflet": {
-      "version": "1.9.8",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.8.tgz",
-      "integrity": "sha512-EXdsL4EhoUtGm2GC2ZYtXn+Fzc6pluVgagvo2VC1RHWToLGlTRwVYoDpqS/7QXa01rmDyBjJk3Catpf60VMkwg==",
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.16.tgz",
+      "integrity": "sha512-wzZoyySUxkgMZ0ihJ7IaUIblG8Rdc8AbbZKLneyn+QjYsj5q1QU7TEKYqwTr10BGSzY5LI7tJk9Ifo+mEjdFRw==",
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -6884,12 +6886,12 @@
       }
     },
     "node_modules/pmtiles": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.0.3.tgz",
-      "integrity": "sha512-tj4l3HHJd6/qf9VefzlPK2eYEQgbf+4uXPzNlrj3k7hHvLtibYSxfp51TF6ALt4YezM8MCdiOminnHvdAyqyGg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.3.0.tgz",
+      "integrity": "sha512-wnzQeSiYT/MyO63o7AVxwt7+uKqU0QUy2lHrivM7GvecNy0m1A4voVyGey7bujnEW5Hn+ZzLdvHPoFaqrOzbPA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/leaflet": "^1.9.8",
-        "fflate": "^0.8.0"
+        "fflate": "^0.8.2"
       }
     },
     "node_modules/pngjs": {
@@ -8983,6 +8985,16 @@
         "@deck.gl/mapbox": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svelte-maplibre/node_modules/pmtiles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz",
+      "integrity": "sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/leaflet": "^1.9.8",
+        "fflate": "^0.8.0"
       }
     },
     "node_modules/svelte-parse-markup": {

--- a/web/package.json
+++ b/web/package.json
@@ -84,6 +84,7 @@
     "justified-layout": "^4.1.0",
     "lodash-es": "^4.17.21",
     "luxon": "^3.4.4",
+    "pmtiles": "^4.3.0",
     "qrcode": "^1.5.4",
     "socket.io-client": "~4.8.0",
     "svelte-gestures": "^5.1.3",

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -1,4 +1,8 @@
 <script lang="ts" module>
+  import { Protocol } from 'pmtiles';
+
+  let protocol = new Protocol();
+  void maplibregl.addProtocol('pmtiles', protocol.tile);
   void maplibregl.setRTLTextPlugin(mapboxRtlUrl, true);
 </script>
 


### PR DESCRIPTION
This patch enables PMTiles protocol for MapLibre-GL. Protocol allows to fetch tiles from a single file.  This drastically simplifies the process to self-host own tiles.

## Description

I don't like that Immich fetches tiles from cloud. After some research I found Protomaps.com project. Basically they build and allow to download entire map as a single file (123 GiB, https://maps.protomaps.com/builds/) and by using HTTP Range browser can read tiles one-by-one instead of downloading entire file. This format allows to self-host tiles very easily. Basically I just downloaded pmtiles and official Immich styles in JSON and replaced this:

```json
[...]
"sources": {
  "vector": {
    "type": "vector",
    "url": "https://tiles.immich.cloud/v1.json"
  }
},
[...]
```

By this:

```json
[...]
"sources": {
  "vector": {
    "type": "vector",
    "url": "pmtiles://https://immich.example.org/pmtiles/20250303.pmtiles"
  }
},
[...]
```

After applying my patch Immich started to understand PMTiles protocol.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Changed map style JSON and tested it with my self-hosted pmtiles file.

<details><summary><h2>Screenrecoring with demo</h2></summary>

https://github.com/user-attachments/assets/9a86c88e-34ee-4a42-8c82-9b4e542c46bb

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
