### PR TITLE
docs: fix typos

### DIFF
--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -18,7 +18,7 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 | `JPEG 2000` | `.jp2`                        | :white_check_mark: |                 |
 | `JPEG`      | `.webp` `.jpg` `.jpe` `.insp` | :white_check_mark: |                 |
 | `JPEG XL`   | `.jxl`                        | :white_check_mark: |                 |
-| `PNG`       | `.webp`                       | :white_check_mark: |                 |
+| `PNG`       | `.png`                        | :white_check_mark: |                 |
 | `PSD`       | `.psd`                        | :white_check_mark: | Adobe Photoshop |
 | `RAW`       | `.raw`                        | :white_check_mark: |                 |
 | `RW2`       | `.rw2`                        | :white_check_mark: |                 |


### PR DESCRIPTION
Fix PNG file extension

- Corrected the PNG file extension from .webp to .png