### PR TITLE
feat(web): allow horizontal scrolling in memory lane

### DIFF
--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -38,7 +38,8 @@
   <section
     id="memory-lane"
     bind:this={memoryLaneElement}
-    class="relative mt-5 overflow-hidden whitespace-nowrap transition-all"
+    class="relative mt-5 overflow-x-scroll overflow-y-hidden whitespace-nowrap transition-all"
+    style="scrollbar-width:none"
     use:resizeObserver={({ width }) => (offsetWidth = width)}
     onscroll={onScroll}
   >
@@ -72,7 +73,7 @@
       {#each $memoryStore as memory (memory.id)}
         {#if memory.assets.length > 0}
           <a
-            class="memory-card relative mr-8 inline-block aspect-[3/4] md:aspect-video h-[215px] rounded-xl"
+            class="memory-card relative mr-8 inline-block aspect-[3/4] md:aspect-[4/3] h-[215px] rounded-xl"
             href="{AppRoute.MEMORY}?{QueryParameter.ID}={memory.assets[0].id}"
           >
             <img


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows scrolling the memory lane by the native scrolling behavior (mouse wheel, touch, ...)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manual test in Firefox and Chrome

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
[Screencast from 06.03.2025 13:43:47.webm](https://github.com/user-attachments/assets/4e8dcd6d-1be5-443a-bcce-ad747ecaeabb)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
