### PR TITLE
refactor: move fastHash into its own class

### DIFF
--- a/mobile/lib/domain/models/user.model.dart
+++ b/mobile/lib/domain/models/user.model.dart
@@ -49,7 +49,7 @@ class User {
   final int quotaUsageInBytes;
   final int quotaSizeInBytes;
 
-  int get id => fastHash(uid);
+  int get id => HashUtils.fastHash(uid);
   bool get hasQuota => quotaSizeInBytes > 0;
 
   const User({

--- a/mobile/lib/entities/asset.entity.dart
+++ b/mobile/lib/entities/asset.entity.dart
@@ -29,7 +29,7 @@ class Asset {
         height = remote.exifInfo?.exifImageHeight?.toInt(),
         width = remote.exifInfo?.exifImageWidth?.toInt(),
         livePhotoVideoId = remote.livePhotoVideoId,
-        ownerId = fastHash(remote.ownerId),
+        ownerId = HashUtils.fastHash(remote.ownerId),
         exifInfo = remote.exifInfo == null
             ? null
             : ExifDtoConverter.fromDto(remote.exifInfo!),

--- a/mobile/lib/entities/backup_album.entity.dart
+++ b/mobile/lib/entities/backup_album.entity.dart
@@ -12,7 +12,7 @@ class BackupAlbum {
 
   BackupAlbum(this.id, this.lastBackup, this.selection);
 
-  Id get isarId => fastHash(id);
+  Id get isarId => HashUtils.fastHash(id);
 }
 
 enum BackupSelection {

--- a/mobile/lib/entities/duplicated_asset.entity.dart
+++ b/mobile/lib/entities/duplicated_asset.entity.dart
@@ -7,5 +7,5 @@ part 'duplicated_asset.entity.g.dart';
 class DuplicatedAsset {
   String id;
   DuplicatedAsset(this.id);
-  Id get isarId => fastHash(id);
+  Id get isarId => HashUtils.fastHash(id);
 }

--- a/mobile/lib/entities/etag.entity.dart
+++ b/mobile/lib/entities/etag.entity.dart
@@ -6,7 +6,7 @@ part 'etag.entity.g.dart';
 @Collection(inheritance: false)
 class ETag {
   ETag({required this.id, this.assetCount, this.time});
-  Id get isarId => fastHash(id);
+  Id get isarId => HashUtils.fastHash(id);
   @Index(unique: true, replace: true, type: IndexType.hash)
   String id;
   int? assetCount;

--- a/mobile/lib/entities/ios_device_asset.entity.dart
+++ b/mobile/lib/entities/ios_device_asset.entity.dart
@@ -10,5 +10,5 @@ class IOSDeviceAsset extends DeviceAsset {
 
   @Index(replace: true, unique: true, type: IndexType.hash)
   String id;
-  Id get isarId => fastHash(id);
+  Id get isarId => HashUtils.fastHash(id);
 }

--- a/mobile/lib/infrastructure/entities/user.entity.dart
+++ b/mobile/lib/infrastructure/entities/user.entity.dart
@@ -7,7 +7,7 @@ part 'user.entity.g.dart';
 
 @Collection(inheritance: false)
 class User {
-  Id get isarId => fastHash(id);
+  Id get isarId => HashUtils.fastHash(id);
   @Index(unique: true, replace: false, type: IndexType.hash)
   final String id;
   final DateTime updatedAt;

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -146,7 +146,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       _log.severe("Unable to get user information from the server.");
     } else {
       await Store.put(StoreKey.deviceId, deviceId);
-      await Store.put(StoreKey.deviceIdHash, fastHash(deviceId));
+      await Store.put(StoreKey.deviceIdHash, HashUtils.fastHash(deviceId));
       await Store.put(
         StoreKey.currentUser,
         UserConverter.fromAdminDto(userResponse, userPreferences),

--- a/mobile/lib/utils/hash.dart
+++ b/mobile/lib/utils/hash.dart
@@ -1,15 +1,17 @@
-/// FNV-1a 64bit hash algorithm optimized for Dart Strings
-int fastHash(String string) {
-  var hash = 0xcbf29ce484222325;
+abstract final class HashUtils {
+  /// FNV-1a 64bit hash algorithm optimized for Dart Strings
+  static int fastHash(String string) {
+    int hash = 0xcbf29ce484222325;
 
-  var i = 0;
-  while (i < string.length) {
-    final codeUnit = string.codeUnitAt(i++);
-    hash ^= codeUnit >> 8;
-    hash *= 0x100000001b3;
-    hash ^= codeUnit & 0xFF;
-    hash *= 0x100000001b3;
+    int i = 0;
+    while (i < string.length) {
+      final codeUnit = string.codeUnitAt(i++);
+      hash ^= codeUnit >> 8;
+      hash *= 0x100000001b3;
+      hash ^= codeUnit & 0xFF;
+      hash *= 0x100000001b3;
+    }
+
+    return hash;
   }
-
-  return hash;
 }


### PR DESCRIPTION
### Description

- First of many PRs to move global utils into their own namespaces. This one moves the `fastHash` method into a `HashUtils` class