### PR TITLE
feat(server): normalize extensions in storage template

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -240,7 +240,7 @@
     "storage_template_hash_verification_enabled_description": "Enables hash verification, don't disable this unless you're certain of the implications",
     "storage_template_migration": "Storage template migration",
     "storage_template_migration_description": "Apply the current <link>{template}</link> to previously uploaded assets",
-    "storage_template_migration_info": "Template changes will only apply to new assets. To retroactively apply the template to previously uploaded assets, run the <link>{job}</link>.",
+    "storage_template_migration_info": "The storage template will convert all extensions to lowercase. Template changes will only apply to new assets. To retroactively apply the template to previously uploaded assets, run the <link>{job}</link>.",
     "storage_template_migration_job": "Storage Template Migration Job",
     "storage_template_more_details": "For more details about this feature, refer to the <template-link>Storage Template</template-link> and its <implications-link>implications</implications-link>",
     "storage_template_onboarding_description": "When enabled, this feature will auto-organize files based on a user-defined template. Due to stability issues the feature has been turned off by default. For more information, please see the <link>documentation</link>.",

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -105,7 +105,7 @@ describe(StorageTemplateService.name, () => {
     it('should migrate single moving picture', async () => {
       mocks.user.get.mockResolvedValue(userStub.user1);
       const newMotionPicturePath = `upload/library/${userStub.user1.id}/2022/2022-06-19/${assetStub.livePhotoStillAsset.id}.mp4`;
-      const newStillPicturePath = `upload/library/${userStub.user1.id}/2022/2022-06-19/${assetStub.livePhotoStillAsset.id}.jpeg`;
+      const newStillPicturePath = `upload/library/${userStub.user1.id}/2022/2022-06-19/${assetStub.livePhotoStillAsset.id}.jpg`;
 
       mocks.asset.getByIds.mockImplementation((ids) => {
         const assets = [assetStub.livePhotoStillAsset, assetStub.livePhotoMotionAsset];

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -226,7 +226,7 @@ export class StorageTemplateService extends BaseService {
 
     try {
       const source = asset.originalPath;
-      const extension = path.extname(source).split('.').pop()?.toLowerCase() as string;
+      let extension = path.extname(source).split('.').pop()?.toLowerCase() as string;
       const sanitized = sanitize(path.basename(filename, `.${extension}`));
       const rootPath = StorageCore.getLibraryFolder({ id: asset.ownerId, storageLabel });
 

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -226,9 +226,30 @@ export class StorageTemplateService extends BaseService {
 
     try {
       const source = asset.originalPath;
-      const extension = path.extname(source).split('.').pop() as string;
+      const extension = path.extname(source).split('.').pop()?.toLowerCase() as string;
       const sanitized = sanitize(path.basename(filename, `.${extension}`));
       const rootPath = StorageCore.getLibraryFolder({ id: asset.ownerId, storageLabel });
+
+      switch (extension) {
+        case 'jpeg':
+        case 'jpe':
+          extension = 'jpg';
+          break;
+        case 'tif':
+          extension = 'tiff';
+          break;
+        case '3gpp':
+          extension = '3gp';
+          break;
+        case 'mpeg':
+        case 'mpe':
+          extension = 'mpg';
+          break;
+        case 'm2ts':
+        case 'm2t':
+          extension = 'mts';
+          break;
+      }
 
       let albumName = null;
       if (this.template.needsAlbum) {

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -226,8 +226,9 @@ export class StorageTemplateService extends BaseService {
 
     try {
       const source = asset.originalPath;
-      let extension = path.extname(source).split('.').pop()?.toLowerCase() as string;
+      let extension = path.extname(source).split('.').pop() as string;
       const sanitized = sanitize(path.basename(filename, `.${extension}`));
+      extension = extension?.toLowerCase();
       const rootPath = StorageCore.getLibraryFolder({ id: asset.ownerId, storageLabel });
 
       switch (extension) {

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -233,23 +233,28 @@ export class StorageTemplateService extends BaseService {
 
       switch (extension) {
         case 'jpeg':
-        case 'jpe':
+        case 'jpe': {
           extension = 'jpg';
           break;
-        case 'tif':
+        }
+        case 'tif': {
           extension = 'tiff';
           break;
-        case '3gpp':
+        }
+        case '3gpp': {
           extension = '3gp';
           break;
+        }
         case 'mpeg':
-        case 'mpe':
+        case 'mpe': {
           extension = 'mpg';
           break;
+        }
         case 'm2ts':
-        case 'm2t':
+        case 'm2t': {
           extension = 'mts';
           break;
+        }
       }
 
       let albumName = null;


### PR DESCRIPTION
## Description

Normalize file extensions to lowercase and combine common extensions

Fixes #6049

## How Has This Been Tested?

Tested locally, files are uploaded `.JPEG` -> `.jpg`

## Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation if applicable
- [x ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x ] I have written tests for new code (if applicable)
- [x ] I have followed naming conventions/patterns in the surrounding code
- [x ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [x ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
