### PR TITLE
feat(server): read Android and Sony video camera make/model

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -63,6 +63,14 @@ export interface ImmichTags extends Omit<Tags, TagsWithWrongTypes> {
       Name?: string;
     }[];
   };
+
+  Device?: {
+    Manufacturer?: string;
+    ModelName?: string;
+  };
+
+  AndroidMake?: string;
+  AndroidModel?: string;
 }
 
 @Injectable()

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1048,6 +1048,7 @@ describe(MetadataService.name, () => {
         }),
       );
     });
+
     it('should handle valid negative rating value', async () => {
       mocks.asset.getByIds.mockResolvedValue([assetStub.image]);
       mockReadTags({ Rating: -1 });
@@ -1159,6 +1160,23 @@ describe(MetadataService.name, () => {
         libraryId: 'library-id',
         type: 'VIDEO',
       });
+    });
+
+    it.each([
+      { Make: '1', Model: '2', Device: { Manufacturer: '3', ModelName: '4' }, AndroidMake: '4', AndroidModel: '5' },
+      { Device: { Manufacturer: '1', ModelName: '2' }, AndroidMake: '3', AndroidModel: '4' },
+      { AndroidMake: '1', AndroidModel: '2' },
+    ])('should read camera make and model correct place %s', async (metaData) => {
+      mocks.asset.getByIds.mockResolvedValue([assetStub.image]);
+      mockReadTags(metaData);
+
+      await sut.handleMetadataExtraction({ id: assetStub.image.id });
+      expect(mocks.asset.upsertExif).toHaveBeenCalledWith(
+        expect.objectContaining({
+          make: '1',
+          model: '2',
+        }),
+      );
     });
   });
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -186,8 +186,6 @@ export class MetadataService extends BaseService {
 
     const { width, height } = this.getImageDimensions(exifTags);
 
-    this.logger.debug(`Collecting exif data for ${asset.id}: ${JSON.stringify(exifTags)}`);
-
     const exifData: Insertable<Exif> = {
       assetId: asset.id,
 

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -186,6 +186,8 @@ export class MetadataService extends BaseService {
 
     const { width, height } = this.getImageDimensions(exifTags);
 
+    this.logger.debug(`Collecting exif data for ${asset.id}: ${JSON.stringify(exifTags)}`);
+
     const exifData: Insertable<Exif> = {
       assetId: asset.id,
 
@@ -211,8 +213,8 @@ export class MetadataService extends BaseService {
       colorspace: exifTags.ColorSpace ?? null,
 
       // camera
-      make: exifTags.Make ?? null,
-      model: exifTags.Model ?? null,
+      make: exifTags.Make ?? exifTags?.Device?.Manufacturer ?? exifTags.AndroidMake ?? null,
+      model: exifTags.Model ?? exifTags?.Device?.ModelName ?? exifTags.AndroidModel ?? null,
       fps: validate(Number.parseFloat(exifTags.VideoFrameRate!)),
       iso: validate(exifTags.ISO) as number,
       exposureTime: exifTags.ExposureTime ?? null,


### PR DESCRIPTION
## Description
The Google camera Android app and recent Sony cameras store camera make/model info in different locations in exif data than the images those respective cameras. The server can now read these tags so that videos can have the camera data correctly stored.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit tests
- [x] Manually uploading various videos

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/70cfa8dc-e693-4dc5-b940-6b739083a01d)

![image](https://github.com/user-attachments/assets/1c2c1c13-769d-48d2-b2b6-53dc2b39c861)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
