### PR TITLE
fix(mobile): remain on albums tab after album deletion

### DIFF
--- a/mobile/lib/widgets/album/album_viewer_appbar.dart
+++ b/mobile/lib/widgets/album/album_viewer_appbar.dart
@@ -58,12 +58,7 @@ class AlbumViewerAppbar extends HookConsumerWidget
       final bool success =
           await ref.watch(albumProvider.notifier).deleteAlbum(album);
 
-      if (album.shared) {
-        context.navigateTo(const TabControllerRoute(children: [AlbumsRoute()]));
-      } else {
-        context
-            .navigateTo(const TabControllerRoute(children: [LibraryRoute()]));
-      }
+      context.navigateTo(const TabControllerRoute(children: [AlbumsRoute()]));
 
       if (!success) {
         ImmichToast.show(


### PR DESCRIPTION
## Description

Fixes #16671

## How Has This Been Tested?

- [x] Create an album or navigate to an existing one
- [x] Delete the album
- [x] The user is no longer being redirected to the Library tab