### PR TITLE
refactor: queue asset deletes via stream

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -637,6 +637,14 @@ export class AssetRepository {
     return this.storageTemplateAssetQuery().stream() as AsyncIterableIterator<StorageAsset>;
   }
 
+  streamDeletedAssets(trashedBefore: Date) {
+    return this.db
+      .selectFrom('assets')
+      .select(['id', 'isOffline'])
+      .where('assets.deletedAt', '<=', trashedBefore)
+      .stream();
+  }
+
   @GenerateSql(
     ...Object.values(WithProperty).map((property) => ({
       name: property,

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -46,5 +46,6 @@ export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetReposi
     updateByLibraryId: vitest.fn(),
     streamStorageTemplateAssets: vitest.fn(),
     getStorageTemplateAsset: vitest.fn(),
+    streamDeletedAssets: vitest.fn(),
   };
 };


### PR DESCRIPTION
Use kysely's `.stream()` instead of the old pagination implementation for queuing deleted assets.