### PR TITLE
fix(mobile): fix notification icon not displaying properly

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/BackupWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/BackupWorker.kt
@@ -221,7 +221,7 @@ class BackupWorker(ctx: Context, params: WorkerParameters) : ListenableWorker(ct
       .setContentTitle(title)
       .setTicker(title)
       .setContentText(content)
-      .setSmallIcon(R.mipmap.ic_launcher)
+      .setSmallIcon(R.drawable.notification_icon)
       .build()
     notificationManager.notify(individualTag, NOTIFICATION_ERROR_ID, notification)
   }
@@ -260,7 +260,7 @@ class BackupWorker(ctx: Context, params: WorkerParameters) : ListenableWorker(ct
     var builder = if (isDetail) notificationDetailBuilder else notificationBuilder
     if (builder == null) {
       builder = NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
-        .setSmallIcon(R.mipmap.ic_launcher)
+        .setSmallIcon(R.drawable.notification_icon)
         .setOnlyAlertOnce(true)
         .setOngoing(true)
       if (isDetail) {


### PR DESCRIPTION
## Description

Fixes #16691

## How Has This Been Tested?

- [x] Turn on all notifications
- [x] Turn off and turn back on background sync to cause the notification to pop up
- [x] Icon displays properly

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img src="https://github.com/user-attachments/assets/5066ce43-6ca9-4eb0-add0-11373c83d64d" width=300 />
<img src="https://github.com/user-attachments/assets/e07845cf-15ae-4682-9bab-5bcc4e0c7569" width=200 />


</details>