### PR TITLE
feat(mobile): locate in timeline

### DIFF
--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -332,7 +332,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
       );
     }
 
-    if (index != -1 && index < widget.renderList.elements.length) {
+    if (index < widget.renderList.elements.length) {
       // Not sure why the index is shifted, but it works. :3
       _scrollToIndex(index + 1);
     } else {

--- a/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/album/current_album.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
 import 'package:immich_mobile/widgets/album/add_to_album_bottom_sheet.dart';
 import 'package:immich_mobile/providers/asset_viewer/download.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/show_controls.provider.dart';
@@ -95,6 +96,16 @@ class GalleryAppBar extends ConsumerWidget {
       ref.read(downloadStateProvider.notifier).downloadAsset(asset, context);
     }
 
+    handleLocateAsset() async {
+      // Go back to the gallery
+      while (Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+      context.navigateTo(const TabControllerRoute(children: [PhotosRoute()]));
+      // Scroll to the asset's date
+      scrollToDateNotifierProvider.scrollToDate(asset.fileCreatedAt);
+    }
+
     return IgnorePointer(
       ignoring: !showControls,
       child: AnimatedOpacity(
@@ -107,6 +118,7 @@ class GalleryAppBar extends ConsumerWidget {
             isPartner: isPartner,
             asset: asset,
             onMoreInfoPressed: showInfo,
+            onLocatePressed: handleLocateAsset,
             onFavorite: toggleFavorite,
             onRestorePressed: () => handleRestore(asset),
             onUploadPressed: asset.isLocal ? () => handleUpload(asset) : null,

--- a/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/album/current_album.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
+import 'package:immich_mobile/providers/tab.provider.dart';
 import 'package:immich_mobile/widgets/album/add_to_album_bottom_sheet.dart';
 import 'package:immich_mobile/providers/asset_viewer/download.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/show_controls.provider.dart';
@@ -101,6 +102,7 @@ class GalleryAppBar extends ConsumerWidget {
       await context.maybePop();
       await context
           .navigateTo(const TabControllerRoute(children: [PhotosRoute()]));
+      ref.read(tabProvider.notifier).update((state) => state = TabEnum.home);
       // Scroll to the asset's date
       scrollToDateNotifierProvider.scrollToDate(asset.fileCreatedAt);
     }

--- a/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/gallery_app_bar.dart
@@ -98,10 +98,9 @@ class GalleryAppBar extends ConsumerWidget {
 
     handleLocateAsset() async {
       // Go back to the gallery
-      while (Navigator.canPop(context)) {
-        Navigator.pop(context);
-      }
-      context.navigateTo(const TabControllerRoute(children: [PhotosRoute()]));
+      await context.maybePop();
+      await context
+          .navigateTo(const TabControllerRoute(children: [PhotosRoute()]));
       // Scroll to the asset's date
       scrollToDateNotifierProvider.scrollToDate(asset.fileCreatedAt);
     }

--- a/mobile/lib/widgets/asset_viewer/top_control_app_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/top_control_app_bar.dart
@@ -13,6 +13,7 @@ class TopControlAppBar extends HookConsumerWidget {
     required this.asset,
     required this.onMoreInfoPressed,
     required this.onDownloadPressed,
+    required this.onLocatePressed,
     required this.onAddToAlbumPressed,
     required this.onRestorePressed,
     required this.onFavorite,
@@ -26,6 +27,7 @@ class TopControlAppBar extends HookConsumerWidget {
   final Function onMoreInfoPressed;
   final VoidCallback? onUploadPressed;
   final VoidCallback? onDownloadPressed;
+  final VoidCallback onLocatePressed;
   final VoidCallback onAddToAlbumPressed;
   final VoidCallback onRestorePressed;
   final VoidCallback onActivitiesPressed;
@@ -49,6 +51,18 @@ class TopControlAppBar extends HookConsumerWidget {
         onPressed: () => onFavorite(a),
         icon: Icon(
           a.isFavorite ? Icons.favorite : Icons.favorite_border,
+          color: Colors.grey[200],
+        ),
+      );
+    }
+
+    Widget buildLocateButton() {
+      return IconButton(
+        onPressed: () {
+          onLocatePressed();
+        },
+        icon: Icon(
+          Icons.image_search,
           color: Colors.grey[200],
         ),
       );
@@ -159,6 +173,7 @@ class TopControlAppBar extends HookConsumerWidget {
       shape: const Border(),
       actions: [
         if (asset.isRemote && isOwner) buildFavoriteButton(a),
+        if (isOwner) buildLocateButton(),
         if (asset.livePhotoVideoId != null) const MotionPhotoButton(),
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal && isOwner) buildDownloadButton(),

--- a/mobile/lib/widgets/asset_viewer/top_control_app_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/top_control_app_bar.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/providers/activity_statistics.provider.dart';
 import 'package:immich_mobile/providers/album/current_album.provider.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/providers/asset.provider.dart';
+import 'package:immich_mobile/providers/tab.provider.dart';
 import 'package:immich_mobile/widgets/asset_viewer/motion_photo_button.dart';
 
 class TopControlAppBar extends HookConsumerWidget {
@@ -173,7 +174,8 @@ class TopControlAppBar extends HookConsumerWidget {
       shape: const Border(),
       actions: [
         if (asset.isRemote && isOwner) buildFavoriteButton(a),
-        if (isOwner) buildLocateButton(),
+        if (isOwner && ref.read(tabProvider.notifier).state != TabEnum.home)
+          buildLocateButton(),
         if (asset.livePhotoVideoId != null) const MotionPhotoButton(),
         if (asset.isLocal && !asset.isRemote) buildUploadButton(),
         if (asset.isRemote && !asset.isLocal && isOwner) buildDownloadButton(),


### PR DESCRIPTION
## Description

Implements #15799

Not sure if this is the preferred implementation. It has been requested a couple of times, so I decided to try implementing it. The icon is not very representative, but it matches the one on the web for the same action.

Feel free to modify or request changes!

## How Has This Been Tested?

- [x] Go to an image from search or an album
- [x] Click on the new icon on top
- [x] The app navigates back to the photos view and scrolls to the photo

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img src="https://github.com/user-attachments/assets/40ee44bd-48aa-4abc-8843-18573c5de6e0" height=400 />



</details>