### PR TITLE
fix(server): add basic auth support

### DIFF
--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -345,6 +345,7 @@ describe(SystemConfigService.name, () => {
       { should: 'with a trailing slash', externalDomain: 'https://demo.immich.app/' },
       { should: 'without a trailing slash', externalDomain: 'https://demo.immich.app' },
       { should: 'with a port', externalDomain: 'https://demo.immich.app:42', result: 'https://demo.immich.app:42' },
+      { should: 'with basic auth', externalDomain: 'https://user:password@example.com:123', result: 'https://user:password@example.com:123'}
     ];
 
     for (const { should, externalDomain, result } of externalDomainTests) {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -345,7 +345,11 @@ describe(SystemConfigService.name, () => {
       { should: 'with a trailing slash', externalDomain: 'https://demo.immich.app/' },
       { should: 'without a trailing slash', externalDomain: 'https://demo.immich.app' },
       { should: 'with a port', externalDomain: 'https://demo.immich.app:42', result: 'https://demo.immich.app:42' },
-      { should: 'with basic auth', externalDomain: 'https://user:password@example.com:123', result: 'https://user:password@example.com:123'}
+      {
+        should: 'with basic auth',
+        externalDomain: 'https://user:password@example.com:123',
+        result: 'https://user:password@example.com:123',
+      },
     ];
 
     for (const { should, externalDomain, result } of externalDomainTests) {

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -117,11 +117,10 @@ const buildConfig = async (repos: RepoDeps) => {
 
   if (config.server.externalDomain.length > 0) {
     const domain = new URL(config.server.externalDomain);
-    if (domain.password && domain.username){
-      config.server.externalDomain = `${domain.protocol}//${domain.username}:${domain.password}@${domain.host}`
-    }
-    else{
-      config.server.externalDomain = domain.origin
+    if (domain.password && domain.username) {
+      config.server.externalDomain = `${domain.protocol}//${domain.username}:${domain.password}@${domain.host}`;
+    } else {
+      config.server.externalDomain = domain.origin;
     }
   }
 

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -117,11 +117,13 @@ const buildConfig = async (repos: RepoDeps) => {
 
   if (config.server.externalDomain.length > 0) {
     const domain = new URL(config.server.externalDomain);
+
+    let externalDomain = domain.origin;
     if (domain.password && domain.username) {
-      config.server.externalDomain = `${domain.protocol}//${domain.username}:${domain.password}@${domain.host}`;
-    } else {
-      config.server.externalDomain = domain.origin;
+      externalDomain = `${domain.protocol}//${domain.username}:${domain.password}@${domain.host}`;
     }
+
+    config.server.externalDomain = externalDomain;
   }
 
   if (!config.ffmpeg.acceptedVideoCodecs.includes(config.ffmpeg.targetVideoCodec)) {

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -116,7 +116,13 @@ const buildConfig = async (repos: RepoDeps) => {
   const config = instanceToPlain(instance) as SystemConfig;
 
   if (config.server.externalDomain.length > 0) {
-    config.server.externalDomain = new URL(config.server.externalDomain).origin;
+    const domain = new URL(config.server.externalDomain);
+    if (domain.password && domain.username){
+      config.server.externalDomain = `${domain.protocol}//${domain.username}:${domain.password}@${domain.host}`
+    }
+    else{
+      config.server.externalDomain = domain.origin
+    }
   }
 
   if (!config.ffmpeg.acceptedVideoCodecs.includes(config.ffmpeg.targetVideoCodec)) {


### PR DESCRIPTION
## Description

Adds support to serialize a URL object into a string with basic auth 

Fixes # ([13456](https://github.com/immich-app/immich/discussions/13456)) 

## How Has This Been Tested?

- Added a simple test that shows it can store & fetch a url with basic auth

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
