### PR TITLE
fix(server): set the dev server restart policy of the dev server container to match the other containers

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
       context: ../
       dockerfile: server/Dockerfile
       target: dev
-    restart: always
+    restart: unless-stopped
     volumes:
       - ../server:/usr/src/app
       - ../open-api:/usr/src/open-api


### PR DESCRIPTION
## Description

This was originally set to `restart: unless-stopped` in #3123 but when microservices were removed in #9551 the dev server container was changed to `restart: always`. This PR sets it back to `restart: unless-stopped`.

Fixes https://discord.com/channels/979116623879368755/1071165397228855327/1347400006017093703

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Ran `make dev` and nothing bad happened.
- [x] Rebooted to confirm issue is fixed

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
