### PR TITLE
docs: update unraid installation steps

### DIFF
--- a/docs/docs/install/unraid.md
+++ b/docs/docs/install/unraid.md
@@ -77,7 +77,7 @@ alt="Select Plugins > Compose.Manager > Add New Stack > Label it Immich"
 7.  Paste the entire contents of the [Immich example.env](https://github.com/immich-app/immich/releases/latest/download/example.env) file into the Unraid editor, then **before saving** edit the following:
 
     - `UPLOAD_LOCATION`: Create a folder in your Images Unraid share and place the **absolute** location here > For example my _"images"_ share has a folder within it called _"immich"_. If I browse to this directory in the terminal and type `pwd` the output is `/mnt/user/images/immich`. This is the exact value I need to enter as my `UPLOAD_LOCATION`
-    - `DB_DATA_LOCATION`: Change this to use an Unraid share (preferably a cache pool, e.g. `/mnt/user/appdata`). If left at default it will try to use Unraid's `/boot/config/plugins/compose.manager/projects/[stack_name]/postgres` folder which it doesn't have permissions to, resulting in this container continuously restarting.
+    - `DB_DATA_LOCATION`: Change this to use an Unraid share (preferably a cache pool, e.g. `/mnt/user/appdata/postgresql/data`). This uses the `appdata` share. Do also create the `postgresql` folder, by running `mkdir /mnt/user/{share_location}/postgresql/data`. If left at default it will try to use Unraid's `/boot/config/plugins/compose.manager/projects/[stack_name]/postgres` folder which it doesn't have permissions to, resulting in this container continuously restarting.
 
       <img
       src={require('./img/unraid05.webp').default}


### PR DESCRIPTION


## Description

Current steps omit this key step, which results in the postgresql docker complaining about the data folder not being empty. (It tries to use the `/mnt/user/appdata` folder as its application data folder.

## How Has This Been Tested?

Run across multiple unraid installs to ensure that it's not just my system.

## Checklist:

- [✔️ ] I have performed a self-review of my own code
- [ ✔️] I have made corresponding changes to the documentation if applicable
- [✔️ ] I have no unrelated changes in the PR.
- [✔️ ] I have confirmed that any new dependencies are strictly necessary.
- [ ✔️] I have written tests for new code (if applicable)
- [✔️ ] I have followed naming conventions/patterns in the surrounding code
- [✔️ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [✔️ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
