### PR TITLE
chore: remove unused package

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,6 @@
         "@nestjs/platform-socket.io": "^11.0.4",
         "@nestjs/schedule": "^5.0.0",
         "@nestjs/swagger": "^11.0.2",
-        "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.0.4",
         "@opentelemetry/auto-instrumentations-node": "^0.56.0",
         "@opentelemetry/context-async-hooks": "^1.24.0",
@@ -2918,19 +2917,6 @@
         "@nestjs/platform-express": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nestjs/typeorm": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
-      "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
-        "reflect-metadata": "^0.1.13 || ^0.2.0",
-        "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
       }
     },
     "node_modules/@nestjs/websockets": {

--- a/server/package.json
+++ b/server/package.json
@@ -43,7 +43,6 @@
     "@nestjs/platform-socket.io": "^11.0.4",
     "@nestjs/schedule": "^5.0.0",
     "@nestjs/swagger": "^11.0.2",
-    "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.0.4",
     "@opentelemetry/auto-instrumentations-node": "^0.56.0",
     "@opentelemetry/context-async-hooks": "^1.24.0",


### PR DESCRIPTION
Removed unused package. `typeorm` itself is still used (just for the `new DataSource(...)` object for migrations.