### PR TITLE
fix(web): svelte-i18n formatting does not trigger inside single quotes

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "عنوان URL الخاص بجهة الإصدار",
     "oauth_mobile_redirect_uri": "عنوان URI لإعادة التوجيه على الهاتف",
     "oauth_mobile_redirect_uri_override": "تجاوز عنوان URI لإعادة التوجيه على الهاتف",
-    "oauth_mobile_redirect_uri_override_description": "قم بتفعيله عندما لا يسمح موفر OAuth بمعرف URI للجوال، مثل '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "قم بتفعيله عندما لا يسمح موفر OAuth بمعرف URI للجوال، مثل ''{callback}''",
     "oauth_profile_signing_algorithm": "خوارزمية توقيع الملف الشخصي",
     "oauth_profile_signing_algorithm_description": "الخوارزمية المستخدمة للتوقيع على ملف تعريف المستخدم.",
     "oauth_scope": "النطاق",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL на издателя",
     "oauth_mobile_redirect_uri": "URI за мобилно пренасочване",
     "oauth_mobile_redirect_uri_override": "URI пренасочване за мобилни устройства",
-    "oauth_mobile_redirect_uri_override_description": "Разреши когато доставчика за OAuth удостоверяване не позволява за мобилни URI идентификатори, като '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Разреши когато доставчика за OAuth удостоверяване не позволява за мобилни URI идентификатори, като ''{callback}''",
     "oauth_profile_signing_algorithm": "Алгоритъм за създаване на профили",
     "oauth_profile_signing_algorithm_description": "Алгоритъм използван за вписване на потребителски профил.",
     "oauth_scope": "Област/обхват на приложение",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL de l'emissor",
     "oauth_mobile_redirect_uri": "URI de redirecció mòbil",
     "oauth_mobile_redirect_uri_override": "Sobreescriu l'URI de redirecció mòbil",
-    "oauth_mobile_redirect_uri_override_description": "Habilita quan el proveïdor d'OAuth no permet una URI mòbil, com ara '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Habilita quan el proveïdor d'OAuth no permet una URI mòbil, com ara ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritme de signatura del perfil",
     "oauth_profile_signing_algorithm_description": "Algoritme utilitzat per signar el perfil d’usuari.",
     "oauth_scope": "Abast",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL vydavatele",
     "oauth_mobile_redirect_uri": "Mobilní přesměrování URI",
     "oauth_mobile_redirect_uri_override": "Přepsat mobilní přesměrování URI",
-    "oauth_mobile_redirect_uri_override_description": "Povolit, pokud poskytovatel OAuth nepovoluje mobilní URI, například '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Povolit, pokud poskytovatel OAuth nepovoluje mobilní URI, například ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmus podepisování profilu",
     "oauth_profile_signing_algorithm_description": "Algoritmus použitý k podepsání profilu uživatele.",
     "oauth_scope": "Rozsah",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Udsteder-URL",
     "oauth_mobile_redirect_uri": "Mobilomdiregerings-URL",
     "oauth_mobile_redirect_uri_override": "Tilsidesættelse af mobil omdiregerings-URL",
-    "oauth_mobile_redirect_uri_override_description": "Aktiver, når OAuth-udbyderen ikke tillader en mobil URI, som '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Aktiver, når OAuth-udbyderen ikke tillader en mobil URI, som ''{callback}''",
     "oauth_profile_signing_algorithm": "Log-ind-algoritme",
     "oauth_profile_signing_algorithm_description": "Algoritme til signering af brugerprofilen.",
     "oauth_scope": "Omfang",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Aussteller-URL",
     "oauth_mobile_redirect_uri": "Mobile Umleitungs-URI",
     "oauth_mobile_redirect_uri_override": "Mobile Umleitungs-URI überschreiben",
-    "oauth_mobile_redirect_uri_override_description": "Einschalten, wenn der OAuth-Anbieter keine mobile URI wie '{callback}' erlaubt",
+    "oauth_mobile_redirect_uri_override_description": "Einschalten, wenn der OAuth-Anbieter keine mobile URI wie ''{callback}'' erlaubt",
     "oauth_profile_signing_algorithm": "Algorithmus zur Profilsignierung",
     "oauth_profile_signing_algorithm_description": "Dieser Algorithmus wird für die Signatur des Benutzerprofils verwendet.",
     "oauth_scope": "Umfang",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Διεύθυνση URL εκδότη",
     "oauth_mobile_redirect_uri": "URI Ανακατεύθυνσης για κινητά τηλέφωνα",
     "oauth_mobile_redirect_uri_override": "Προσπέλαση URI ανακατεύθυνσης για κινητά τηλέφωνα",
-    "oauth_mobile_redirect_uri_override_description": "Ενεργοποιήστε το όταν ο πάροχος OAuth δεν επιτρέπει μια URI για κινητά, όπως το '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Ενεργοποιήστε το όταν ο πάροχος OAuth δεν επιτρέπει μια URI για κινητά, όπως το ''{callback}''",
     "oauth_profile_signing_algorithm": "Αλγόριθμος σύνδεσης προφίλ",
     "oauth_profile_signing_algorithm_description": "Αλγόριθμος που χρησιμοποιείται για την σύνδεση των χρηστών.",
     "oauth_scope": "Εύρος",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Issuer URL",
     "oauth_mobile_redirect_uri": "Mobile redirect URI",
     "oauth_mobile_redirect_uri_override": "Mobile redirect URI override",
-    "oauth_mobile_redirect_uri_override_description": "Enable when OAuth provider does not allow a mobile URI, like '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Enable when OAuth provider does not allow a mobile URI, like ''{callback}''",
     "oauth_profile_signing_algorithm": "Profile signing algorithm",
     "oauth_profile_signing_algorithm_description": "Algorithm used to sign the user profile.",
     "oauth_scope": "Scope",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL del emisor",
     "oauth_mobile_redirect_uri": "URI de redireccionamiento móvil",
     "oauth_mobile_redirect_uri_override": "Sobreescribir URI de redirección móvil",
-    "oauth_mobile_redirect_uri_override_description": "Habilitar cuando el proveedor de OAuth no permite una URI móvil, como '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Habilitar cuando el proveedor de OAuth no permite una URI móvil, como ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmo de firma de perfiles",
     "oauth_profile_signing_algorithm_description": "Algoritmo utilizado para firmar el perfil del usuario.",
     "oauth_scope": "Ámbito",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Väljastaja URL",
     "oauth_mobile_redirect_uri": "Mobiilne ümbersuunamise URI",
     "oauth_mobile_redirect_uri_override": "Mobiilse ümbersuunamise URI ülekirjutamine",
-    "oauth_mobile_redirect_uri_override_description": "Lülita sisse, kui OAuth pakkuja ei luba mobiilset URI-d, näiteks '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Lülita sisse, kui OAuth pakkuja ei luba mobiilset URI-d, näiteks ''{callback}''",
     "oauth_profile_signing_algorithm": "Profiili allkirjastamise algoritm",
     "oauth_profile_signing_algorithm_description": "Algoritm, mida kasutatakse kasutajaprofiili allkirjastamiseks.",
     "oauth_scope": "Skoop",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Toimitsijan URL",
     "oauth_mobile_redirect_uri": "Mobiilin uudellenohjaus-URI",
     "oauth_mobile_redirect_uri_override": "Ohita mobiilin uudelleenohjaus-URI",
-    "oauth_mobile_redirect_uri_override_description": "Ota käyttöön kun OAuth tarjoaja ei salli mobiili URI:a, kuten '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Ota käyttöön kun OAuth tarjoaja ei salli mobiili URI:a, kuten ''{callback}''",
     "oauth_profile_signing_algorithm": "Profiilin allekirjoitusalgoritmi",
     "oauth_profile_signing_algorithm_description": "Algoritmi, jota käytetään käyttäjäprofiilin allekirjoittamiseen.",
     "oauth_scope": "Skooppi (Scope)",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "כתובת אתר המנפיק",
     "oauth_mobile_redirect_uri": "URI להפניה מחדש בנייד",
     "oauth_mobile_redirect_uri_override": "עקיפת URI להפניה מחדש בנייד",
-    "oauth_mobile_redirect_uri_override_description": "אפשר כאשר ספק OAuth לא מאפשר כתובת URI לנייד, כמו '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "אפשר כאשר ספק OAuth לא מאפשר כתובת URI לנייד, כמו ''{callback}''",
     "oauth_profile_signing_algorithm": "אלגוריתם חתימת פרופיל",
     "oauth_profile_signing_algorithm_description": "אלגוריתם המשמש לחתימה על פרופיל המשתמש.",
     "oauth_scope": "רמת הרשאה",

--- a/i18n/hr.json
+++ b/i18n/hr.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL Izdavatelja",
     "oauth_mobile_redirect_uri": "Mobilnog Preusmjeravanja URI",
     "oauth_mobile_redirect_uri_override": "Nadjačavanje URI-preusmjeravanja za mobilne uređaje",
-    "oauth_mobile_redirect_uri_override_description": "Omogući kada pružatelj OAuth ne dopušta mobilni URI, poput '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Omogući kada pružatelj OAuth ne dopušta mobilni URI, poput ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritam za potpisivanje profila",
     "oauth_profile_signing_algorithm_description": "Algoritam koji se koristi za potpisivanje korisničkog profila.",
     "oauth_scope": "Opseg",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Kibocsátó URL",
     "oauth_mobile_redirect_uri": "Mobil átirányítási URI",
     "oauth_mobile_redirect_uri_override": "Mobil átirányítási URI felülírás",
-    "oauth_mobile_redirect_uri_override_description": "Engedélyezd, ha az OAuth szolgáltató tiltja a mobil URI-t, mint például '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Engedélyezd, ha az OAuth szolgáltató tiltja a mobil URI-t, mint például ''{callback}''",
     "oauth_profile_signing_algorithm": "Profil aláíró algoritmus",
     "oauth_profile_signing_algorithm_description": "A felhasználói profil aláírásához használt algoritmus.",
     "oauth_scope": "Hatókör",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL Penerbit",
     "oauth_mobile_redirect_uri": "URI pengalihan ponsel",
     "oauth_mobile_redirect_uri_override": "Penimpaan URI penerusan ponsel",
-    "oauth_mobile_redirect_uri_override_description": "Aktifkan ketika provider OAuth tidak mengizinkan tautan mobile, seperti '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Aktifkan ketika provider OAuth tidak mengizinkan tautan mobile, seperti ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritma penandatanganan profil",
     "oauth_profile_signing_algorithm_description": "Algoritma yang digunakan untuk menandatangani profil pengguna.",
     "oauth_scope": "Cakupan",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL emittente",
     "oauth_mobile_redirect_uri": "URI reindirizzamento mobile",
     "oauth_mobile_redirect_uri_override": "Sovrascrivi URI reindirizzamento cellulare",
-    "oauth_mobile_redirect_uri_override_description": "Abilita quando il gestore OAuth non consente un URL come '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Abilita quando il gestore OAuth non consente un URL come ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmo firma profilo",
     "oauth_profile_signing_algorithm_description": "L'algoritmo usato per firmare il profilo utente.",
     "oauth_scope": "Ambito di autorizzazione",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -162,7 +162,7 @@
     "oauth_issuer_url": "発行元URL",
     "oauth_mobile_redirect_uri": "モバイル用リダイレクトURI",
     "oauth_mobile_redirect_uri_override": "モバイル用リダイレクトURI（上書き）",
-    "oauth_mobile_redirect_uri_override_description": "'{callback}'など、モバイルURIがOAuthプロバイダーによって許可されていない場合に有効にしてください",
+    "oauth_mobile_redirect_uri_override_description": "''{callback}''など、モバイルURIがOAuthプロバイダーによって許可されていない場合に有効にしてください",
     "oauth_profile_signing_algorithm": "プロファイルの署名アルゴリズム",
     "oauth_profile_signing_algorithm_description": "ユーザープロファイルを署名するのに使用するアルゴリズム。",
     "oauth_scope": "スコープ",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "발급자 URL",
     "oauth_mobile_redirect_uri": "모바일 리다이렉트 URI",
     "oauth_mobile_redirect_uri_override": "모바일 리다이렉트 URI 재정의",
-    "oauth_mobile_redirect_uri_override_description": "OAuth 공급자가 '{callback}'과 같은 모바일 URI를 제공하지 않는 경우 활성화하세요.",
+    "oauth_mobile_redirect_uri_override_description": "OAuth 공급자가 ''{callback}''과 같은 모바일 URI를 제공하지 않는 경우 활성화하세요.",
     "oauth_profile_signing_algorithm": "사용자 정보 서명 알고리즘",
     "oauth_profile_signing_algorithm_description": "사용자 정보 서명에 사용되는 알고리즘을 선택합니다.",
     "oauth_scope": "스코프",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -182,7 +182,7 @@
     "oauth_issuer_url": "Teikėjo URL",
     "oauth_mobile_redirect_uri": "Mobiliojo peradresavimo URI",
     "oauth_mobile_redirect_uri_override": "Mobiliojo peradresavimo URI pakeitimas",
-    "oauth_mobile_redirect_uri_override_description": "Įjunkite, kai OAuth teikėjas nepalaiko mobiliojo URI, tokio kaip '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Įjunkite, kai OAuth teikėjas nepalaiko mobiliojo URI, tokio kaip ''{callback}''",
     "oauth_profile_signing_algorithm": "Profilio registracijos algoritmas",
     "oauth_profile_signing_algorithm_description": "Algoritmas naudojamas vartotojo profilio registracijai.",
     "oauth_scope": "Apimtis",

--- a/i18n/ms.json
+++ b/i18n/ms.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL Pengeluar",
     "oauth_mobile_redirect_uri": "URI ubah hala mudah alih",
     "oauth_mobile_redirect_uri_override": "Penggantian URI ubah hala mudah alih",
-    "oauth_mobile_redirect_uri_override_description": "Aktifkan apabila pembekal OAuth tidak membenarkan URI mudah alih, seperti '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Aktifkan apabila pembekal OAuth tidak membenarkan URI mudah alih, seperti ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritma tandatangan profil",
     "oauth_profile_signing_algorithm_description": "Algoritma digunakan untuk menandatangani profil pengguna.",
     "oauth_scope": "Skop",

--- a/i18n/nb_NO.json
+++ b/i18n/nb_NO.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Utgiverens URL",
     "oauth_mobile_redirect_uri": "Mobil omdirigerings-URI",
     "oauth_mobile_redirect_uri_override": "Mobil omdirigerings-URI overstyring",
-    "oauth_mobile_redirect_uri_override_description": "Aktiver når OAuth-leverandøren ikke tillater en mobil URI, som '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Aktiver når OAuth-leverandøren ikke tillater en mobil URI, som ''{callback}''",
     "oauth_profile_signing_algorithm": "Profilsigneringsalgoritme",
     "oauth_profile_signing_algorithm_description": "Algoritme brukt for å signere brukerprofilen.",
     "oauth_scope": "Omfang",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Uitgever URL",
     "oauth_mobile_redirect_uri": "Omleidings URI voor mobiel",
     "oauth_mobile_redirect_uri_override": "Omleidings URI voor mobiele app overschrijven",
-    "oauth_mobile_redirect_uri_override_description": "Inschakelen wanneer de OAuth-provider geen mobiele URI toestaat, zoals '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Inschakelen wanneer de OAuth-provider geen mobiele URI toestaat, zoals ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritme voor profielondertekening",
     "oauth_profile_signing_algorithm_description": "Algoritme voor het ondertekenen van het gebruikersprofiel.",
     "oauth_scope": "Scope",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Adres URL wydawcy",
     "oauth_mobile_redirect_uri": "Mobilny adres zwrotny",
     "oauth_mobile_redirect_uri_override": "Zapasowy URI przekierowania mobilnego",
-    "oauth_mobile_redirect_uri_override_description": "Włącz, gdy dostawca OAuth nie pozwala na mobilne identyfikatory URI typu '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Włącz, gdy dostawca OAuth nie pozwala na mobilne identyfikatory URI typu ''{callback}''",
     "oauth_profile_signing_algorithm": "Algorytm logowania do profilu",
     "oauth_profile_signing_algorithm_description": "Algorytm używany podczas logowania do profilu użytkownika.",
     "oauth_scope": "Zakres",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL do emissor",
     "oauth_mobile_redirect_uri": "URI de redirecionamento móvel",
     "oauth_mobile_redirect_uri_override": "Substituição de URI de redirecionamento móvel",
-    "oauth_mobile_redirect_uri_override_description": "Ative quando o provedor do OAuth não permite um URI móvel, como '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Ative quando o provedor do OAuth não permite um URI móvel, como ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmo de assinatura de perfis",
     "oauth_profile_signing_algorithm_description": "Algoritmo utilizado para assinar o perfil de utilizador.",
     "oauth_scope": "Escopo",

--- a/i18n/pt_BR.json
+++ b/i18n/pt_BR.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL do emissor",
     "oauth_mobile_redirect_uri": "URI de redirecionamento móvel",
     "oauth_mobile_redirect_uri_override": "Substituição de URI de redirecionamento móvel",
-    "oauth_mobile_redirect_uri_override_description": "Ative quando o provedor do OAuth não suportar uma URI de aplicativo, por exemplo '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Ative quando o provedor do OAuth não suportar uma URI de aplicativo, por exemplo ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmo de assinatura de perfis",
     "oauth_profile_signing_algorithm_description": "Algoritmo usado para assinar o perfil do usuário.",
     "oauth_scope": "Escopo",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Emitentul URL",
     "oauth_mobile_redirect_uri": "URI de redirecționare mobilă",
     "oauth_mobile_redirect_uri_override": "Înlocuire URI de redirecționare mobilă",
-    "oauth_mobile_redirect_uri_override_description": "Activați atunci când furnizorul OAuth nu permite un URI mobil, precum '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Activați atunci când furnizorul OAuth nu permite un URI mobil, precum ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritm de semnare a profilului",
     "oauth_profile_signing_algorithm_description": "Algoritm folosit pentru a semna profilul utilizatorului.",
     "oauth_scope": "Domeniul de aplicare",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL-адрес эмитента",
     "oauth_mobile_redirect_uri": "URI редиректа для мобильных",
     "oauth_mobile_redirect_uri_override": "Перенаправление URI для мобильных устройств",
-    "oauth_mobile_redirect_uri_override_description": "Включите, если поставщик OAuth не разрешает использование мобильного URI, например, '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Включите, если поставщик OAuth не разрешает использование мобильного URI, например, ''{callback}''",
     "oauth_profile_signing_algorithm": "Алгоритм подписи профиля",
     "oauth_profile_signing_algorithm_description": "Алгоритм, используемый для входа в профиль пользователя.",
     "oauth_scope": "Разрешения",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Adresa URL vydavateľa",
     "oauth_mobile_redirect_uri": "URI mobilného presmerovania",
     "oauth_mobile_redirect_uri_override": "Prepísanie URI mobilného presmerovania",
-    "oauth_mobile_redirect_uri_override_description": "Povoľte, keď poskytovateľ protokolu OAuth nepovoľuje identifikátor URI pre mobilné zariadenia, napríklad '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Povoľte, keď poskytovateľ protokolu OAuth nepovoľuje identifikátor URI pre mobilné zariadenia, napríklad ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritmus podpisovania profilu",
     "oauth_profile_signing_algorithm_description": "Algoritmus používaný na prihlásenie užívateľského profilu.",
     "oauth_scope": "Rozsah",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL izdajatelja",
     "oauth_mobile_redirect_uri": "Mobilni preusmeritveni URI",
     "oauth_mobile_redirect_uri_override": "Preglasitev URI preusmeritve za mobilne naprave",
-    "oauth_mobile_redirect_uri_override_description": "Omogoči, ko ponudnik OAuth ne dovoli mobilnega URI-ja, kot je '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Omogoči, ko ponudnik OAuth ne dovoli mobilnega URI-ja, kot je ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritem za podpisovanje profila",
     "oauth_profile_signing_algorithm_description": "Algoritem, ki se uporablja za podpisovanje uporabniškega profila.",
     "oauth_scope": "Področje uporabe",

--- a/i18n/sr_Cyrl.json
+++ b/i18n/sr_Cyrl.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "УРЛ издавача",
     "oauth_mobile_redirect_uri": "УРИ за преусмеравање мобилних уређаја",
     "oauth_mobile_redirect_uri_override": "Замена УРИ-ја мобилног преусмеравања",
-    "oauth_mobile_redirect_uri_override_description": "Омогући када ОАuth добављач (provider) не дозвољава мобилни URI, као што је '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Омогући када ОАuth добављач (provider) не дозвољава мобилни URI, као што је ''{callback}''",
     "oauth_profile_signing_algorithm": "Алгоритам за потписивање профила",
     "oauth_profile_signing_algorithm_description": "Алгоритам који се користи за потписивање корисничког профила.",
     "oauth_scope": "Обим",

--- a/i18n/sr_Latn.json
+++ b/i18n/sr_Latn.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL izdavača",
     "oauth_mobile_redirect_uri": "URI za preusmeravanje mobilnih uređaja",
     "oauth_mobile_redirect_uri_override": "Zamena URI-ja mobilnog preusmeravanja",
-    "oauth_mobile_redirect_uri_override_description": "Omogući kada OAuth dobavljač (provider) ne dozvoljava mobilni URI, kao što je '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Omogući kada OAuth dobavljač (provider) ne dozvoljava mobilni URI, kao što je ''{callback}''",
     "oauth_profile_signing_algorithm": "Algoritam za potpisivanje profila",
     "oauth_profile_signing_algorithm_description": "Algoritam koji se koristi za potpisivanje korisničkog profila.",
     "oauth_scope": "Obim",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Utfärdar-URL",
     "oauth_mobile_redirect_uri": "Telefonomdirigernings-URI",
     "oauth_mobile_redirect_uri_override": "Telefonomdirigerings-URI överrskridning",
-    "oauth_mobile_redirect_uri_override_description": "Aktivera om OAuth-leverantören inte tillåter mobila URI:er, så som '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Aktivera om OAuth-leverantören inte tillåter mobila URI:er, så som ''{callback}''",
     "oauth_profile_signing_algorithm": "Profilsigneringsalgorithm",
     "oauth_profile_signing_algorithm_description": "Algorithm som används för att signera användarprofilen.",
     "oauth_scope": "Omfattning",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "Yayınlayıcı URL",
     "oauth_mobile_redirect_uri": "Mobil yönlendirme URL'si",
     "oauth_mobile_redirect_uri_override": "Mobilde zorla kullanılacak Yönlendirme Adresi",
-    "oauth_mobile_redirect_uri_override_description": "Mobil URI'ye izin vermeyen OAuth sağlayıcısı olduğunda etkinleştir, örneğin '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Mobil URI'ye izin vermeyen OAuth sağlayıcısı olduğunda etkinleştir, örneğin ''{callback}''",
     "oauth_profile_signing_algorithm": "Profil imzalama algoritması",
     "oauth_profile_signing_algorithm_description": "Kullanıcının profilini imzalarken kullanılacak güvenlik algoritması.",
     "oauth_scope": "Kapsam",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "URL видачі",
     "oauth_mobile_redirect_uri": "URI мобільного перенаправлення",
     "oauth_mobile_redirect_uri_override": "Перевизначення URI мобільного перенаправлення",
-    "oauth_mobile_redirect_uri_override_description": "Увімкнути, якщо OAuth-провайдер не підтримує мобільний URI, як '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Увімкнути, якщо OAuth-провайдер не підтримує мобільний URI, як ''{callback}''",
     "oauth_profile_signing_algorithm": "Алгоритм підписання профілю",
     "oauth_profile_signing_algorithm_description": "Алгоритм, який використовується для підпису профілю користувача.",
     "oauth_scope": "Масштаб",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -186,7 +186,7 @@
     "oauth_issuer_url": "Địa chỉ nhà cung cấp OAuth",
     "oauth_mobile_redirect_uri": "URI chuyển hướng trên thiết bị di động",
     "oauth_mobile_redirect_uri_override": "Ghi đè URI chuyển hướng cho thiết bị di động",
-    "oauth_mobile_redirect_uri_override_description": "Bật khi nhà cung cấp OAuth không cho phép URI di động, như '{callback}'",
+    "oauth_mobile_redirect_uri_override_description": "Bật khi nhà cung cấp OAuth không cho phép URI di động, như ''{callback}''",
     "oauth_profile_signing_algorithm": "Thuật toán ký vào hồ sơ người dùng",
     "oauth_profile_signing_algorithm_description": "Thuật toán được sử dụng để ký vào hồ sơ người dùng.",
     "oauth_scope": "Phạm vi",

--- a/i18n/zh_Hant.json
+++ b/i18n/zh_Hant.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "簽發者網址",
     "oauth_mobile_redirect_uri": "移動端重定向 URI",
     "oauth_mobile_redirect_uri_override": "移動端重定向 URI 覆蓋",
-    "oauth_mobile_redirect_uri_override_description": "當 OAuth 提供者不允許使用行動 URI（如「'{callback}'」）時啟用",
+    "oauth_mobile_redirect_uri_override_description": "當 OAuth 提供者不允許使用行動 URI（如「{callback}」）時啟用",
     "oauth_profile_signing_algorithm": "設定檔簽章演算法",
     "oauth_profile_signing_algorithm_description": "用於簽署使用者設定檔的演算法。",
     "oauth_scope": "範圍",

--- a/i18n/zh_SIMPLIFIED.json
+++ b/i18n/zh_SIMPLIFIED.json
@@ -187,7 +187,7 @@
     "oauth_issuer_url": "提供方 URL",
     "oauth_mobile_redirect_uri": "移动端重定向 URI",
     "oauth_mobile_redirect_uri_override": "移动端重定向 URI 覆盖",
-    "oauth_mobile_redirect_uri_override_description": "当 OAuth 提供商不允许使用移动 URI 时启用，如“'{callback}'”",
+    "oauth_mobile_redirect_uri_override_description": "当 OAuth 提供商不允许使用移动 URI 时启用，如“{callback}”",
     "oauth_profile_signing_algorithm": "配置文件签名算法",
     "oauth_profile_signing_algorithm_description": "用于签署用户配置文件的算法。",
     "oauth_scope": "范围",


### PR DESCRIPTION
## Description

This PR fixes a formatting issue in the setting description for the mobile redirect uri override in the OAuth Administration panel.

Fixes #16779

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Ran the web app locally and saw the fix

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Previously:
![Image](https://github.com/user-attachments/assets/8c10864b-10cd-4d8e-8755-5544d3534716)

Now:
![image](https://github.com/user-attachments/assets/a1f4ebcb-8749-4d05-8419-80eaaedd3d03)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
