### PR TITLE
feat(web): Add fileCreatedAt to deduplication view

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
@@ -131,7 +131,6 @@
         isSelected={selectedAssetIds.has(asset.id)}
         onViewAsset={(asset) => setAsset(asset)}
       />
-      {console.log(asset.fileCreatedAt)}
     {/each}
   </div>
 

--- a/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicates-compare-control.svelte
@@ -27,6 +27,15 @@
   let selectedAssetIds = $state(new SvelteSet<string>());
   let trashCount = $derived(assets.length - selectedAssetIds.size);
 
+  const uniqueDateTimes = new Set(
+    assets.map((asset) => {
+      const date = new Date(asset.fileCreatedAt);
+      return date.toISOString().slice(0, 16).replace('T', ' '); // Format: YYYY-MM-DD HH:MM
+    }),
+  );
+
+  const showDateConditionally = uniqueDateTimes.size > 1;
+
   onMount(() => {
     const suggestedAsset = suggestDuplicate(assets);
 
@@ -118,9 +127,11 @@
       <DuplicateAsset
         {asset}
         {onSelectAsset}
+        showDate={showDateConditionally}
         isSelected={selectedAssetIds.has(asset.id)}
         onViewAsset={(asset) => setAsset(asset)}
       />
+      {console.log(asset.fileCreatedAt)}
     {/each}
   </div>
 


### PR DESCRIPTION
## Description

This small PR adds a conditional `fileCreatedAt` date to the deduplication viewer. It is shown if there are more than 1 distinct dates, to ensure the UI does not get cluttered.

While iterating my duplicates, and viewing my timeline, i noticed that a lot of my assets have had their dates reset, and is no longer correctly placed on my timeline. While picking duplicates to delete, it is very slow to individually open each asset to inspect their dates.

The purpose of this, is to easily inspect which assets to keep. As seen in the screenshot, i know for certain that the asset shown is not from 2024, without checking. 

## How Has This Been Tested?

Using my existing instance to connect the web to.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![immich_pre](https://github.com/user-attachments/assets/5676c256-7385-450c-b1cc-67bcb4288295)

![immich_post](https://github.com/user-attachments/assets/1ebbc7dc-7181-416c-87bc-d2238b9d5ad1)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
