### PR TITLE
feat(docs): highlight active version in version switcher

### DIFF
--- a/docs/src/components/version-switcher.tsx
+++ b/docs/src/components/version-switcher.tsx
@@ -54,7 +54,7 @@ export default function VersionSwitcher(): JSX.Element {
           label,
           to: new URL(location.pathname + location.search + location.hash, url).href,
           target: '_self',
-          className: label === activeLabel ? 'dropdown__link--active menu__link--active' : '',
+          className: label === activeLabel ? 'dropdown__link--active menu__link--active' : '', // workaround because React Router `<NavLink>` only supports using URL path for checking if active: https://v5.reactrouter.com/web/api/NavLink/isactive-func
         }))}
       />
     )

--- a/docs/src/components/version-switcher.tsx
+++ b/docs/src/components/version-switcher.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 
 export default function VersionSwitcher(): JSX.Element {
   const [versions, setVersions] = useState([]);
-  const [label, setLabel] = useState('Versions');
+  const [activeLabel, setLabel] = useState('Versions');
 
   const windowSize = useWindowSize();
 
@@ -48,12 +48,13 @@ export default function VersionSwitcher(): JSX.Element {
     versions.length > 0 && (
       <DropdownNavbarItem
         className="version-switcher-34ab39"
-        label={label}
+        label={activeLabel}
         mobile={windowSize === 'mobile'}
         items={versions.map(({ label, url }) => ({
           label,
           to: new URL(location.pathname + location.search + location.hash, url).href,
           target: '_self',
+          className: label === activeLabel ? 'dropdown__link--active menu__link--active' : '',
         }))}
       />
     )


### PR DESCRIPTION
## Description

Properly highlights the current docs version on the version switcher list. I mentioned this possibility in #16014
(Hopefully I won't come up with any more "improvements" to this feature so that y'all can have a break. I am sorry for 4 PRs to this same component.)

## How Has This Been Tested?

- [x] Manually override the activeLabel value to force a highlight.
- [x] Change the fallback label to match a label on the list.
- [x] Also tested on mobile.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![Screenshot_20250310_221135](https://github.com/user-attachments/assets/dfa925ed-aa03-466e-ac2e-a2a90ee18477)
![Screenshot_20250310_221235](https://github.com/user-attachments/assets/30285f16-09c5-4ac8-a408-4f25107d99b6)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
