### PR TITLE
fix(server): set unit test timezone to UTC

### DIFF
--- a/server/test/vitest.config.mjs
+++ b/server/test/vitest.config.mjs
@@ -2,6 +2,9 @@ import swc from 'unplugin-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+// Set the timezone to UTC to avoid timezone issues during testing
+process.env.TZ = 'UTC';
+
 export default defineConfig({
   test: {
     root: './',


### PR DESCRIPTION
This fixes failing unit tests that assert based on new Date() that have a different value depending on your timezone.