### PR TITLE
chore(mobile): add orientation tests for exif

### DIFF
--- a/mobile/test/fixtures/exif.stub.dart
+++ b/mobile/test/fixtures/exif.stub.dart
@@ -1,0 +1,18 @@
+import 'package:immich_mobile/domain/models/exif.model.dart';
+
+abstract final class ExifStub {
+  static final size = const ExifInfo(assetId: 1, fileSize: 1000);
+
+  static final gps = const ExifInfo(
+    assetId: 2,
+    latitude: 20,
+    longitude: 20,
+    city: 'city',
+    state: 'state',
+    country: 'country',
+  );
+
+  static final rotated90CW = const ExifInfo(assetId: 3, orientation: "90");
+
+  static final rotated270CW = const ExifInfo(assetId: 4, orientation: "-90");
+}

--- a/mobile/test/fixtures/user.stub.dart
+++ b/mobile/test/fixtures/user.stub.dart
@@ -1,6 +1,6 @@
 import 'package:immich_mobile/entities/user.entity.dart';
 
-final class UserStub {
+abstract final class UserStub {
   const UserStub._();
 
   static final admin = User(
@@ -8,9 +8,9 @@ final class UserStub {
     updatedAt: DateTime(2021),
     email: "admin@test.com",
     name: "admin",
-    avatarColor: AvatarColorEnum.green,
-    profileImagePath: '',
     isAdmin: true,
+    profileImagePath: '',
+    avatarColor: AvatarColorEnum.green,
   );
 
   static final user1 = User(
@@ -18,9 +18,9 @@ final class UserStub {
     updatedAt: DateTime(2022),
     email: "user1@test.com",
     name: "user1",
-    avatarColor: AvatarColorEnum.red,
-    profileImagePath: '',
     isAdmin: false,
+    profileImagePath: '',
+    avatarColor: AvatarColorEnum.red,
   );
 
   static final user2 = User(
@@ -28,8 +28,8 @@ final class UserStub {
     updatedAt: DateTime(2023),
     email: "user2@test.com",
     name: "user2",
-    avatarColor: AvatarColorEnum.primary,
-    profileImagePath: '',
     isAdmin: false,
+    profileImagePath: '',
+    avatarColor: AvatarColorEnum.primary,
   );
 }

--- a/mobile/test/infrastructure/repositories/exif_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/exif_repository_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/interfaces/exif.interface.dart';
+import 'package:immich_mobile/infrastructure/entities/exif.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/exif.repository.dart';
+import 'package:isar/isar.dart';
+
+import '../../fixtures/exif.stub.dart';
+import '../../test_utils.dart';
+
+Future<void> _populateExifTable(Isar db) async {
+  await db.writeTxn(() async {
+    await db.exifInfos.putAll([
+      ExifInfo.fromDto(ExifStub.size),
+      ExifInfo.fromDto(ExifStub.gps),
+      ExifInfo.fromDto(ExifStub.rotated90CW),
+      ExifInfo.fromDto(ExifStub.rotated270CW),
+    ]);
+  });
+}
+
+void main() {
+  late Isar db;
+  late IExifInfoRepository sut;
+
+  setUp(() async {
+    db = await TestUtils.initIsar();
+    sut = IsarExifRepository(db);
+  });
+
+  group("Return with proper orientation", () {
+    setUp(() async {
+      await _populateExifTable(db);
+    });
+
+    test("isFlipped true for 90CW", () async {
+      final exif = await sut.get(ExifStub.rotated90CW.assetId!);
+      expect(exif!.isFlipped, true);
+    });
+
+    test("isFlipped true for 270CW", () async {
+      final exif = await sut.get(ExifStub.rotated270CW.assetId!);
+      expect(exif!.isFlipped, true);
+    });
+
+    test("isFlipped false for the original non-rotated image", () async {
+      final exif = await sut.get(ExifStub.size.assetId!);
+      expect(exif!.isFlipped, false);
+    });
+  });
+}


### PR DESCRIPTION
### Description

- Adds tests for the exif info repository in mobile. Currently, only tests for checking if the orientation is properly parsed to assign the isFlipped value is added.
