### PR TITLE
refactor: rename user model

### DIFF
--- a/mobile/lib/domain/interfaces/user.interface.dart
+++ b/mobile/lib/domain/interfaces/user.interface.dart
@@ -2,19 +2,19 @@ import 'package:immich_mobile/domain/interfaces/db.interface.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 
 abstract interface class IUserRepository implements IDatabaseRepository {
-  Future<bool> insert(User user);
+  Future<bool> insert(UserDto user);
 
-  Future<User?> get(int id);
+  Future<UserDto?> get(int id);
 
-  Future<User?> getByUserId(String id);
+  Future<UserDto?> getByUserId(String id);
 
-  Future<List<User?>> getByUserIds(List<String> ids);
+  Future<List<UserDto?>> getByUserIds(List<String> ids);
 
-  Future<List<User>> getAll({SortUserBy? sortBy});
+  Future<List<UserDto>> getAll({SortUserBy? sortBy});
 
-  Future<bool> updateAll(List<User> users);
+  Future<bool> updateAll(List<UserDto> users);
 
-  Future<User> update(User user);
+  Future<UserDto> update(UserDto user);
 
   Future<void> delete(List<int> ids);
 

--- a/mobile/lib/domain/models/store.model.dart
+++ b/mobile/lib/domain/models/store.model.dart
@@ -5,7 +5,7 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 enum StoreKey<T> {
   version<int>._(0),
   assetETag<String>._(1),
-  currentUser<User>._(2),
+  currentUser<UserDto>._(2),
   deviceIdHash<int>._(3),
   deviceId<String>._(4),
   backupFailedSince<DateTime>._(5),

--- a/mobile/lib/domain/models/user.model.dart
+++ b/mobile/lib/domain/models/user.model.dart
@@ -30,7 +30,8 @@ enum AvatarColor {
       };
 }
 
-class User {
+// TODO: Rename to User once Isar is removed
+class UserDto {
   final String uid;
   final String email;
   final String name;
@@ -52,7 +53,7 @@ class User {
   int get id => fastHash(uid);
   bool get hasQuota => quotaSizeInBytes > 0;
 
-  const User({
+  const UserDto({
     required this.uid,
     required this.email,
     required this.name,
@@ -88,7 +89,7 @@ quotaSizeInBytes: $quotaSizeInBytes,
 }''';
   }
 
-  User copyWith({
+  UserDto copyWith({
     String? uid,
     String? email,
     String? name,
@@ -103,7 +104,7 @@ quotaSizeInBytes: $quotaSizeInBytes,
     int? quotaUsageInBytes,
     int? quotaSizeInBytes,
   }) =>
-      User(
+      UserDto(
         uid: uid ?? this.uid,
         email: email ?? this.email,
         name: name ?? this.name,
@@ -120,7 +121,7 @@ quotaSizeInBytes: $quotaSizeInBytes,
       );
 
   @override
-  bool operator ==(covariant User other) {
+  bool operator ==(covariant UserDto other) {
     if (identical(this, other)) return true;
 
     return other.uid == uid &&

--- a/mobile/lib/extensions/collection_extensions.dart
+++ b/mobile/lib/extensions/collection_extensions.dart
@@ -58,7 +58,7 @@ extension AssetListExtension on Iterable<Asset> {
   /// Returns the assets that are owned by the user passed to the [owner] param
   /// If [owner] is null, an empty list is returned
   Iterable<Asset> ownedOnly(
-    User? owner, {
+    UserDto? owner, {
     void Function()? errorCallback,
   }) {
     if (owner == null) return [];

--- a/mobile/lib/infrastructure/entities/user.entity.dart
+++ b/mobile/lib/infrastructure/entities/user.entity.dart
@@ -40,7 +40,7 @@ class User {
     this.quotaSizeInBytes = 0,
   });
 
-  static User fromDto(model.User dto) => User(
+  static User fromDto(model.UserDto dto) => User(
         id: dto.uid,
         updatedAt: dto.updatedAt,
         email: dto.email,
@@ -56,7 +56,7 @@ class User {
         quotaSizeInBytes: dto.quotaSizeInBytes,
       );
 
-  model.User toDto() => model.User(
+  model.UserDto toDto() => model.UserDto(
         uid: id,
         email: email,
         name: name,

--- a/mobile/lib/infrastructure/entities/user.entity.dart
+++ b/mobile/lib/infrastructure/entities/user.entity.dart
@@ -1,4 +1,3 @@
-import 'package:immich_mobile/domain/models/user.model.dart' as model;
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/utils/hash.dart';
 import 'package:isar/isar.dart';
@@ -18,7 +17,7 @@ class User {
   final bool isAdmin;
   final String profileImagePath;
   @Enumerated(EnumType.ordinal)
-  final model.AvatarColor avatarColor;
+  final AvatarColor avatarColor;
   final bool memoryEnabled;
   final bool inTimeline;
   final int quotaUsageInBytes;
@@ -33,14 +32,14 @@ class User {
     this.isPartnerSharedBy = false,
     this.isPartnerSharedWith = false,
     this.profileImagePath = '',
-    this.avatarColor = model.AvatarColor.primary,
+    this.avatarColor = AvatarColor.primary,
     this.memoryEnabled = true,
     this.inTimeline = false,
     this.quotaUsageInBytes = 0,
     this.quotaSizeInBytes = 0,
   });
 
-  static User fromDto(model.UserDto dto) => User(
+  static User fromDto(UserDto dto) => User(
         id: dto.uid,
         updatedAt: dto.updatedAt,
         email: dto.email,
@@ -56,7 +55,7 @@ class User {
         quotaSizeInBytes: dto.quotaSizeInBytes,
       );
 
-  model.UserDto toDto() => model.UserDto(
+  UserDto toDto() => UserDto(
         uid: id,
         email: email,
         name: name,

--- a/mobile/lib/infrastructure/repositories/store.repository.dart
+++ b/mobile/lib/infrastructure/repositories/store.repository.dart
@@ -78,7 +78,7 @@ class IsarStoreRepository extends IsarDatabaseRepository
         const (DateTime) => entity.intValue == null
             ? null
             : DateTime.fromMillisecondsSinceEpoch(entity.intValue!),
-        const (User) => await IsarUserRepository(_db).get(entity.intValue!),
+        const (UserDto) => await IsarUserRepository(_db).get(entity.intValue!),
         _ => null,
       } as T?;
 
@@ -88,8 +88,8 @@ class IsarStoreRepository extends IsarDatabaseRepository
       const (String) => (null, value as String),
       const (bool) => ((value as bool) ? 1 : 0, null),
       const (DateTime) => ((value as DateTime).millisecondsSinceEpoch, null),
-      const (User) => (
-          (await IsarUserRepository(_db).update(value as User)).id,
+      const (UserDto) => (
+          (await IsarUserRepository(_db).update(value as UserDto)).id,
           null,
         ),
       _ => throw UnsupportedError(

--- a/mobile/lib/infrastructure/repositories/user.repository.dart
+++ b/mobile/lib/infrastructure/repositories/user.repository.dart
@@ -25,12 +25,12 @@ class IsarUserRepository extends IsarDatabaseRepository
   }
 
   @override
-  Future<User?> get(int id) async {
+  Future<UserDto?> get(int id) async {
     return (await _db.users.get(id))?.toDto();
   }
 
   @override
-  Future<List<User>> getAll({SortUserBy? sortBy}) async {
+  Future<List<UserDto>> getAll({SortUserBy? sortBy}) async {
     return (await _db.users
             .where()
             .optional(
@@ -45,17 +45,17 @@ class IsarUserRepository extends IsarDatabaseRepository
   }
 
   @override
-  Future<User?> getByUserId(String id) async {
+  Future<UserDto?> getByUserId(String id) async {
     return (await _db.users.getById(id))?.toDto();
   }
 
   @override
-  Future<List<User?>> getByUserIds(List<String> ids) async {
+  Future<List<UserDto?>> getByUserIds(List<String> ids) async {
     return (await _db.users.getAllById(ids)).map((u) => u?.toDto()).toList();
   }
 
   @override
-  Future<bool> insert(User user) async {
+  Future<bool> insert(UserDto user) async {
     await transaction(() async {
       await _db.users.put(entity.User.fromDto(user));
     });
@@ -63,7 +63,7 @@ class IsarUserRepository extends IsarDatabaseRepository
   }
 
   @override
-  Future<User> update(User user) async {
+  Future<UserDto> update(UserDto user) async {
     await transaction(() async {
       await _db.users.put(entity.User.fromDto(user));
     });
@@ -71,7 +71,7 @@ class IsarUserRepository extends IsarDatabaseRepository
   }
 
   @override
-  Future<bool> updateAll(List<User> users) async {
+  Future<bool> updateAll(List<UserDto> users) async {
     await transaction(() async {
       await _db.users.putAll(users.map(entity.User.fromDto).toList());
     });

--- a/mobile/lib/infrastructure/utils/user.converter.dart
+++ b/mobile/lib/infrastructure/utils/user.converter.dart
@@ -3,7 +3,7 @@ import 'package:openapi/api.dart';
 
 abstract final class UserConverter {
   /// Base user dto used where the complete user object is not required
-  static User fromSimpleUserDto(UserResponseDto dto) => User(
+  static UserDto fromSimpleUserDto(UserResponseDto dto) => UserDto(
         uid: dto.id,
         email: dto.email,
         name: dto.name,
@@ -13,11 +13,11 @@ abstract final class UserConverter {
         avatarColor: dto.avatarColor.toAvatarColor(),
       );
 
-  static User fromAdminDto(
+  static UserDto fromAdminDto(
     UserAdminResponseDto adminDto, [
     UserPreferencesResponseDto? preferenceDto,
   ]) =>
-      User(
+      UserDto(
         uid: adminDto.id,
         email: adminDto.email,
         name: adminDto.name,
@@ -33,7 +33,7 @@ abstract final class UserConverter {
         quotaSizeInBytes: adminDto.quotaSizeInBytes ?? 0,
       );
 
-  static User fromPartnerDto(PartnerResponseDto dto) => User(
+  static UserDto fromPartnerDto(PartnerResponseDto dto) => UserDto(
         uid: dto.id,
         email: dto.email,
         name: dto.name,

--- a/mobile/lib/interfaces/album.interface.dart
+++ b/mobile/lib/interfaces/album.interface.dart
@@ -31,9 +31,9 @@ abstract interface class IAlbumRepository implements IDatabaseRepository {
 
   Future<int> count({bool? local});
 
-  Future<void> addUsers(Album album, List<User> users);
+  Future<void> addUsers(Album album, List<UserDto> users);
 
-  Future<void> removeUsers(Album album, List<User> users);
+  Future<void> removeUsers(Album album, List<UserDto> users);
 
   Future<void> addAssets(Album album, List<Asset> assets);
 

--- a/mobile/lib/interfaces/partner.interface.dart
+++ b/mobile/lib/interfaces/partner.interface.dart
@@ -1,8 +1,8 @@
 import 'package:immich_mobile/domain/models/user.model.dart';
 
 abstract class IPartnerRepository {
-  Future<List<User>> getSharedWith();
-  Future<List<User>> getSharedBy();
-  Stream<List<User>> watchSharedWith();
-  Stream<List<User>> watchSharedBy();
+  Future<List<UserDto>> getSharedWith();
+  Future<List<UserDto>> getSharedBy();
+  Stream<List<UserDto>> watchSharedWith();
+  Stream<List<UserDto>> watchSharedBy();
 }

--- a/mobile/lib/interfaces/partner_api.interface.dart
+++ b/mobile/lib/interfaces/partner_api.interface.dart
@@ -1,9 +1,9 @@
 import 'package:immich_mobile/domain/models/user.model.dart';
 
 abstract interface class IPartnerApiRepository {
-  Future<List<User>> getAll(Direction direction);
-  Future<User> create(String id);
-  Future<User> update(String id, {required bool inTimeline});
+  Future<List<UserDto>> getAll(Direction direction);
+  Future<UserDto> create(String id);
+  Future<UserDto> update(String id, {required bool inTimeline});
   Future<void> delete(String id);
 }
 

--- a/mobile/lib/interfaces/user_api.interface.dart
+++ b/mobile/lib/interfaces/user_api.interface.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import 'package:immich_mobile/domain/models/user.model.dart';
 
 abstract interface class IUserApiRepository {
-  Future<List<User>> getAll();
+  Future<List<UserDto>> getAll();
   Future<({String profileImagePath})> createProfileImage({
     required String name,
     required Uint8List data,

--- a/mobile/lib/models/activities/activity.model.dart
+++ b/mobile/lib/models/activities/activity.model.dart
@@ -8,7 +8,7 @@ class Activity {
   final String? comment;
   final DateTime createdAt;
   final ActivityType type;
-  final User user;
+  final UserDto user;
 
   const Activity({
     required this.id,
@@ -25,7 +25,7 @@ class Activity {
     String? comment,
     DateTime? createdAt,
     ActivityType? type,
-    User? user,
+    UserDto? user,
   }) {
     return Activity(
       id: id ?? this.id,

--- a/mobile/lib/pages/album/album_additional_shared_user_selection.page.dart
+++ b/mobile/lib/pages/album/album_additional_shared_user_selection.page.dart
@@ -21,15 +21,15 @@ class AlbumAdditionalSharedUserSelectionPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<List<User>> suggestedShareUsers =
+    final AsyncValue<List<UserDto>> suggestedShareUsers =
         ref.watch(otherUsersProvider);
-    final sharedUsersList = useState<Set<User>>({});
+    final sharedUsersList = useState<Set<UserDto>>({});
 
     addNewUsersHandler() {
       context.maybePop(sharedUsersList.value.map((e) => e.uid).toList());
     }
 
-    buildTileIcon(User user) {
+    buildTileIcon(UserDto user) {
       if (sharedUsersList.value.contains(user)) {
         return CircleAvatar(
           backgroundColor: context.primaryColor,
@@ -45,7 +45,7 @@ class AlbumAdditionalSharedUserSelectionPage extends HookConsumerWidget {
       }
     }
 
-    buildUserList(List<User> users) {
+    buildUserList(List<UserDto> users) {
       List<Widget> usersChip = [];
 
       for (var user in sharedUsersList.value) {

--- a/mobile/lib/pages/album/album_options.page.dart
+++ b/mobile/lib/pages/album/album_options.page.dart
@@ -67,7 +67,7 @@ class AlbumOptionsPage extends HookConsumerWidget {
       isProcessing.value = false;
     }
 
-    void removeUserFromAlbum(User user) async {
+    void removeUserFromAlbum(UserDto user) async {
       isProcessing.value = true;
 
       try {
@@ -82,7 +82,7 @@ class AlbumOptionsPage extends HookConsumerWidget {
       isProcessing.value = false;
     }
 
-    void handleUserClick(User user) {
+    void handleUserClick(UserDto user) {
       var actions = [];
 
       if (user.uid == userId) {

--- a/mobile/lib/pages/album/album_shared_user_icons.dart
+++ b/mobile/lib/pages/album/album_shared_user_icons.dart
@@ -12,7 +12,7 @@ class AlbumSharedUserIcons extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sharedUsers = useRef<List<User>>(const []);
+    final sharedUsers = useRef<List<UserDto>>(const []);
     sharedUsers.value = ref.watch(
       currentAlbumProvider.select((album) {
         if (album == null) {

--- a/mobile/lib/pages/album/album_shared_user_selection.page.dart
+++ b/mobile/lib/pages/album/album_shared_user_selection.page.dart
@@ -21,7 +21,7 @@ class AlbumSharedUserSelectionPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sharedUsersList = useState<Set<User>>({});
+    final sharedUsersList = useState<Set<UserDto>>({});
     final suggestedShareUsers = ref.watch(otherUsersProvider);
 
     createSharedAlbum() async {
@@ -48,7 +48,7 @@ class AlbumSharedUserSelectionPage extends HookConsumerWidget {
       );
     }
 
-    buildTileIcon(User user) {
+    buildTileIcon(UserDto user) {
       if (sharedUsersList.value.contains(user)) {
         return CircleAvatar(
           backgroundColor: context.primaryColor,
@@ -64,7 +64,7 @@ class AlbumSharedUserSelectionPage extends HookConsumerWidget {
       }
     }
 
-    buildUserList(List<User> users) {
+    buildUserList(List<UserDto> users) {
       List<Widget> usersChip = [];
 
       for (var user in sharedUsersList.value) {

--- a/mobile/lib/pages/library/library.page.dart
+++ b/mobile/lib/pages/library/library.page.dart
@@ -163,7 +163,7 @@ class QuickAccessButtons extends ConsumerWidget {
 class PartnerList extends ConsumerWidget {
   const PartnerList({super.key, required this.partners});
 
-  final List<User> partners;
+  final List<UserDto> partners;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/mobile/lib/pages/library/partner/partner.page.dart
+++ b/mobile/lib/pages/library/partner/partner.page.dart
@@ -16,7 +16,7 @@ class PartnerPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<User> partners = ref.watch(partnerSharedByProvider);
+    final List<UserDto> partners = ref.watch(partnerSharedByProvider);
     final availableUsers = ref.watch(partnerAvailableProvider);
 
     addNewUsersHandler() async {
@@ -29,13 +29,13 @@ class PartnerPage extends HookConsumerWidget {
         return;
       }
 
-      final selectedUser = await showDialog<User>(
+      final selectedUser = await showDialog<UserDto>(
         context: context,
         builder: (context) {
           return SimpleDialog(
             title: const Text("partner_page_select_partner").tr(),
             children: [
-              for (User u in users)
+              for (UserDto u in users)
                 SimpleDialogOption(
                   onPressed: () => context.pop(u),
                   child: Row(
@@ -67,7 +67,7 @@ class PartnerPage extends HookConsumerWidget {
       }
     }
 
-    onDeleteUser(User u) {
+    onDeleteUser(UserDto u) {
       return showDialog(
         context: context,
         builder: (BuildContext context) {
@@ -80,7 +80,7 @@ class PartnerPage extends HookConsumerWidget {
       );
     }
 
-    buildUserList(List<User> users) {
+    buildUserList(List<UserDto> users) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/mobile/lib/pages/library/partner/partner_detail.page.dart
+++ b/mobile/lib/pages/library/partner/partner_detail.page.dart
@@ -15,7 +15,7 @@ import 'package:immich_mobile/widgets/common/immich_toast.dart';
 class PartnerDetailPage extends HookConsumerWidget {
   const PartnerDetailPage({super.key, required this.partner});
 
-  final User partner;
+  final UserDto partner;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/mobile/lib/providers/album/album.provider.dart
+++ b/mobile/lib/providers/album/album.provider.dart
@@ -88,7 +88,7 @@ class AlbumNotifier extends StateNotifier<List<Album>> {
     await albumService.addUsers(album, userIds);
   }
 
-  Future<bool> removeUser(Album album, User user) async {
+  Future<bool> removeUser(Album album, UserDto user) async {
     final isRemoved = await albumService.removeUser(album, user);
 
     if (isRemoved && album.sharedUsers.isEmpty) {

--- a/mobile/lib/providers/album/suggested_shared_users.provider.dart
+++ b/mobile/lib/providers/album/suggested_shared_users.provider.dart
@@ -3,7 +3,8 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/user.service.dart';
 
-final otherUsersProvider = FutureProvider.autoDispose<List<User>>((ref) async {
+final otherUsersProvider =
+    FutureProvider.autoDispose<List<UserDto>>((ref) async {
   UserService userService = ref.watch(userServiceProvider);
   final currentUser = ref.watch(currentUserProvider);
 

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -106,7 +106,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
     String deviceId =
         Store.tryGet(StoreKey.deviceId) ?? await FlutterUdid.consistentUdid;
 
-    User? user = Store.tryGet(StoreKey.currentUser);
+    UserDto? user = Store.tryGet(StoreKey.currentUser);
 
     UserAdminResponseDto? userResponse;
     UserPreferencesResponseDto? userPreferences;

--- a/mobile/lib/providers/partner.provider.dart
+++ b/mobile/lib/providers/partner.provider.dart
@@ -6,12 +6,12 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/providers/album/suggested_shared_users.provider.dart';
 import 'package:immich_mobile/services/partner.service.dart';
 
-class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
+class PartnerSharedWithNotifier extends StateNotifier<List<UserDto>> {
   final PartnerService _partnerService;
-  late final StreamSubscription<List<User>> streamSub;
+  late final StreamSubscription<List<UserDto>> streamSub;
 
   PartnerSharedWithNotifier(this._partnerService) : super([]) {
-    Function eq = const ListEquality<User>().equals;
+    Function eq = const ListEquality<UserDto>().equals;
     _partnerService.getSharedWith().then((partners) {
       if (!eq(state, partners)) {
         state = partners;
@@ -25,7 +25,7 @@ class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
     });
   }
 
-  Future<bool> updatePartner(User partner, {required bool inTimeline}) {
+  Future<bool> updatePartner(UserDto partner, {required bool inTimeline}) {
     return _partnerService.updatePartner(partner, inTimeline: inTimeline);
   }
 
@@ -39,18 +39,18 @@ class PartnerSharedWithNotifier extends StateNotifier<List<User>> {
 }
 
 final partnerSharedWithProvider =
-    StateNotifierProvider<PartnerSharedWithNotifier, List<User>>((ref) {
+    StateNotifierProvider<PartnerSharedWithNotifier, List<UserDto>>((ref) {
   return PartnerSharedWithNotifier(
     ref.watch(partnerServiceProvider),
   );
 });
 
-class PartnerSharedByNotifier extends StateNotifier<List<User>> {
+class PartnerSharedByNotifier extends StateNotifier<List<UserDto>> {
   final PartnerService _partnerService;
-  late final StreamSubscription<List<User>> streamSub;
+  late final StreamSubscription<List<UserDto>> streamSub;
 
   PartnerSharedByNotifier(this._partnerService) : super([]) {
-    Function eq = const ListEquality<User>().equals;
+    Function eq = const ListEquality<UserDto>().equals;
     _partnerService.getSharedBy().then((partners) {
       if (!eq(state, partners)) {
         state = partners;
@@ -74,15 +74,15 @@ class PartnerSharedByNotifier extends StateNotifier<List<User>> {
 }
 
 final partnerSharedByProvider =
-    StateNotifierProvider<PartnerSharedByNotifier, List<User>>((ref) {
+    StateNotifierProvider<PartnerSharedByNotifier, List<UserDto>>((ref) {
   return PartnerSharedByNotifier(ref.watch(partnerServiceProvider));
 });
 
 final partnerAvailableProvider =
-    FutureProvider.autoDispose<List<User>>((ref) async {
+    FutureProvider.autoDispose<List<UserDto>>((ref) async {
   final otherUsers = await ref.watch(otherUsersProvider.future);
   final currentPartners = ref.watch(partnerSharedByProvider);
-  final available = Set<User>.of(otherUsers);
+  final available = Set<UserDto>.of(otherUsers);
   available.removeAll(currentPartners);
   return available.toList();
 });

--- a/mobile/lib/providers/user.provider.dart
+++ b/mobile/lib/providers/user.provider.dart
@@ -9,7 +9,7 @@ import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/timeline.service.dart';
 
-class CurrentUserProvider extends StateNotifier<User?> {
+class CurrentUserProvider extends StateNotifier<UserDto?> {
   CurrentUserProvider(this._apiService) : super(null) {
     state = Store.tryGet(StoreKey.currentUser);
     streamSub =
@@ -17,7 +17,7 @@ class CurrentUserProvider extends StateNotifier<User?> {
   }
 
   final ApiService _apiService;
-  late final StreamSubscription<User?> streamSub;
+  late final StreamSubscription<UserDto?> streamSub;
 
   refresh() async {
     try {
@@ -40,7 +40,7 @@ class CurrentUserProvider extends StateNotifier<User?> {
 }
 
 final currentUserProvider =
-    StateNotifierProvider<CurrentUserProvider, User?>((ref) {
+    StateNotifierProvider<CurrentUserProvider, UserDto?>((ref) {
   return CurrentUserProvider(
     ref.watch(apiServiceProvider),
   );

--- a/mobile/lib/repositories/album.repository.dart
+++ b/mobile/lib/repositories/album.repository.dart
@@ -102,7 +102,7 @@ class AlbumRepository extends DatabaseRepository implements IAlbumRepository {
   Future<Album?> get(int id) => db.albums.get(id);
 
   @override
-  Future<void> removeUsers(Album album, List<User> users) => txn(
+  Future<void> removeUsers(Album album, List<UserDto> users) => txn(
         () => album.sharedUsers.update(unlink: users.map(entity.User.fromDto)),
       );
 
@@ -124,7 +124,7 @@ class AlbumRepository extends DatabaseRepository implements IAlbumRepository {
   }
 
   @override
-  Future<void> addUsers(Album album, List<User> users) =>
+  Future<void> addUsers(Album album, List<UserDto> users) =>
       txn(() => album.sharedUsers.update(link: users.map(entity.User.fromDto)));
 
   @override

--- a/mobile/lib/repositories/partner.repository.dart
+++ b/mobile/lib/repositories/partner.repository.dart
@@ -16,7 +16,7 @@ class PartnerRepository extends DatabaseRepository
   PartnerRepository(super.db);
 
   @override
-  Future<List<User>> getSharedBy() async {
+  Future<List<UserDto>> getSharedBy() async {
     return (await db.users
             .filter()
             .isPartnerSharedByEqualTo(true)
@@ -27,7 +27,7 @@ class PartnerRepository extends DatabaseRepository
   }
 
   @override
-  Future<List<User>> getSharedWith() async {
+  Future<List<UserDto>> getSharedWith() async {
     return (await db.users
             .filter()
             .isPartnerSharedWithEqualTo(true)
@@ -38,13 +38,13 @@ class PartnerRepository extends DatabaseRepository
   }
 
   @override
-  Stream<List<User>> watchSharedBy() {
+  Stream<List<UserDto>> watchSharedBy() {
     return (db.users.filter().isPartnerSharedByEqualTo(true).sortById().watch())
         .map((users) => users.map((u) => u.toDto()).toList());
   }
 
   @override
-  Stream<List<User>> watchSharedWith() {
+  Stream<List<UserDto>> watchSharedWith() {
     return (db.users
             .filter()
             .isPartnerSharedWithEqualTo(true)

--- a/mobile/lib/repositories/partner_api.repository.dart
+++ b/mobile/lib/repositories/partner_api.repository.dart
@@ -19,7 +19,7 @@ class PartnerApiRepository extends ApiRepository
   PartnerApiRepository(this._api);
 
   @override
-  Future<List<User>> getAll(Direction direction) async {
+  Future<List<UserDto>> getAll(Direction direction) async {
     final response = await checkNull(
       _api.getPartners(
         direction == Direction.sharedByMe
@@ -31,7 +31,7 @@ class PartnerApiRepository extends ApiRepository
   }
 
   @override
-  Future<User> create(String id) async {
+  Future<UserDto> create(String id) async {
     final dto = await checkNull(_api.createPartner(id));
     return UserConverter.fromPartnerDto(dto);
   }
@@ -40,7 +40,7 @@ class PartnerApiRepository extends ApiRepository
   Future<void> delete(String id) => _api.removePartner(id);
 
   @override
-  Future<User> update(String id, {required bool inTimeline}) async {
+  Future<UserDto> update(String id, {required bool inTimeline}) async {
     final dto = await checkNull(
       _api.updatePartner(
         id,

--- a/mobile/lib/repositories/user_api.repository.dart
+++ b/mobile/lib/repositories/user_api.repository.dart
@@ -21,7 +21,7 @@ class UserApiRepository extends ApiRepository implements IUserApiRepository {
   UserApiRepository(this._api);
 
   @override
-  Future<List<User>> getAll() async {
+  Future<List<UserDto>> getAll() async {
     final dto = await checkNull(_api.searchUsers());
     return dto.map(UserConverter.fromSimpleUserDto).toList();
   }

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -1162,7 +1162,7 @@ class NativeVideoViewerRouteArgs {
 class PartnerDetailRoute extends PageRouteInfo<PartnerDetailRouteArgs> {
   PartnerDetailRoute({
     Key? key,
-    required User partner,
+    required UserDto partner,
     List<PageRouteInfo>? children,
   }) : super(
           PartnerDetailRoute.name,
@@ -1195,7 +1195,7 @@ class PartnerDetailRouteArgs {
 
   final Key? key;
 
-  final User partner;
+  final UserDto partner;
 
   @override
   String toString() {

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -204,7 +204,7 @@ class AlbumService {
   Future<Album?> createAlbum(
     String albumName,
     Iterable<Asset> assets, [
-    Iterable<User> sharedUsers = const [],
+    Iterable<UserDto> sharedUsers = const [],
   ]) async {
     final Album album = await _albumApiRepository.create(
       albumName,
@@ -358,7 +358,7 @@ class AlbumService {
 
   Future<bool> removeUser(
     Album album,
-    User user,
+    UserDto user,
   ) async {
     try {
       await _albumApiRepository.removeUser(

--- a/mobile/lib/services/asset.service.dart
+++ b/mobile/lib/services/asset.service.dart
@@ -89,7 +89,7 @@ class AssetService {
   /// required. Returns `true` if there were any changes.
   Future<bool> refreshRemoteAssets() async {
     final syncedUserIds = await _etagRepository.getAllIds();
-    final List<User> syncedUsers = syncedUserIds.isEmpty
+    final List<UserDto> syncedUsers = syncedUserIds.isEmpty
         ? []
         : (await _userRepository.getByUserIds(syncedUserIds)).nonNulls.toList();
     final Stopwatch sw = Stopwatch()..start();
@@ -105,7 +105,7 @@ class AssetService {
 
   /// Returns `(null, null)` if changes are invalid -> requires full sync
   Future<(List<Asset>? toUpsert, List<String>? toDelete)>
-      _getRemoteAssetChanges(List<User> users, DateTime since) async {
+      _getRemoteAssetChanges(List<UserDto> users, DateTime since) async {
     final dto = AssetDeltaSyncDto(
       updatedAfter: since,
       userIds: users.map((e) => e.uid).toList(),
@@ -138,7 +138,7 @@ class AssetService {
   }
 
   /// Returns `null` if the server state did not change, else list of assets
-  Future<List<Asset>?> _getRemoteAssets(User user, DateTime until) async {
+  Future<List<Asset>?> _getRemoteAssets(UserDto user, DateTime until) async {
     const int chunkSize = 10000;
     try {
       final List<Asset> allAssets = [];

--- a/mobile/lib/services/partner.service.dart
+++ b/mobile/lib/services/partner.service.dart
@@ -28,23 +28,23 @@ class PartnerService {
     this._partnerRepository,
   );
 
-  Future<List<User>> getSharedWith() async {
+  Future<List<UserDto>> getSharedWith() async {
     return _partnerRepository.getSharedWith();
   }
 
-  Future<List<User>> getSharedBy() async {
+  Future<List<UserDto>> getSharedBy() async {
     return _partnerRepository.getSharedBy();
   }
 
-  Stream<List<User>> watchSharedWith() {
+  Stream<List<UserDto>> watchSharedWith() {
     return _partnerRepository.watchSharedWith();
   }
 
-  Stream<List<User>> watchSharedBy() {
+  Stream<List<UserDto>> watchSharedBy() {
     return _partnerRepository.watchSharedBy();
   }
 
-  Future<bool> removePartner(User partner) async {
+  Future<bool> removePartner(UserDto partner) async {
     try {
       await _partnerApiRepository.delete(partner.uid);
       await _userRepository.update(partner.copyWith(isPartnerSharedBy: false));
@@ -55,7 +55,7 @@ class PartnerService {
     return true;
   }
 
-  Future<bool> addPartner(User partner) async {
+  Future<bool> addPartner(UserDto partner) async {
     try {
       await _partnerApiRepository.create(partner.uid);
       await _userRepository.update(partner.copyWith(isPartnerSharedBy: true));
@@ -66,7 +66,10 @@ class PartnerService {
     return false;
   }
 
-  Future<bool> updatePartner(User partner, {required bool inTimeline}) async {
+  Future<bool> updatePartner(
+    UserDto partner, {
+    required bool inTimeline,
+  }) async {
     try {
       final dto = await _partnerApiRepository.update(
         partner.uid,

--- a/mobile/lib/services/user.service.dart
+++ b/mobile/lib/services/user.service.dart
@@ -43,21 +43,21 @@ class UserService {
     }
   }
 
-  Future<List<User>> getAll() async {
+  Future<List<UserDto>> getAll() async {
     return await _userRepository.getAll();
   }
 
-  Future<List<User>?> getUsersFromServer() async {
-    List<User>? users;
+  Future<List<UserDto>?> getUsersFromServer() async {
+    List<UserDto>? users;
     try {
       users = await _userApiRepository.getAll();
     } catch (e) {
       _log.warning("Failed to fetch users", e);
       users = null;
     }
-    final List<User> sharedBy =
+    final List<UserDto> sharedBy =
         await _partnerApiRepository.getAll(Direction.sharedByMe);
-    final List<User> sharedWith =
+    final List<UserDto> sharedWith =
         await _partnerApiRepository.getAll(Direction.sharedWithMe);
 
     if (users == null) {
@@ -69,34 +69,34 @@ class UserService {
     sharedBy.sortBy((u) => u.uid);
     sharedWith.sortBy((u) => u.uid);
 
-    final updatedSharedBy = <User>[];
+    final updatedSharedBy = <UserDto>[];
 
     diffSortedListsSync(
       users,
       sharedBy,
-      compare: (User a, User b) => a.uid.compareTo(b.uid),
-      both: (User a, User b) {
+      compare: (UserDto a, UserDto b) => a.uid.compareTo(b.uid),
+      both: (UserDto a, UserDto b) {
         updatedSharedBy.add(a.copyWith(isPartnerSharedBy: true));
         return true;
       },
-      onlyFirst: (User a) => updatedSharedBy.add(a),
-      onlySecond: (User b) => updatedSharedBy.add(b),
+      onlyFirst: (UserDto a) => updatedSharedBy.add(a),
+      onlySecond: (UserDto b) => updatedSharedBy.add(b),
     );
 
-    final updatedSharedWith = <User>[];
+    final updatedSharedWith = <UserDto>[];
 
     diffSortedListsSync(
       updatedSharedBy,
       sharedWith,
-      compare: (User a, User b) => a.uid.compareTo(b.uid),
-      both: (User a, User b) {
+      compare: (UserDto a, UserDto b) => a.uid.compareTo(b.uid),
+      both: (UserDto a, UserDto b) {
         updatedSharedWith.add(
           a.copyWith(inTimeline: b.inTimeline, isPartnerSharedWith: true),
         );
         return true;
       },
-      onlyFirst: (User a) => updatedSharedWith.add(a),
-      onlySecond: (User b) => updatedSharedWith.add(b),
+      onlyFirst: (UserDto a) => updatedSharedWith.add(a),
+      onlySecond: (UserDto b) => updatedSharedWith.add(b),
     );
 
     return updatedSharedWith;

--- a/mobile/lib/widgets/common/user_avatar.dart
+++ b/mobile/lib/widgets/common/user_avatar.dart
@@ -6,7 +6,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/services/api.service.dart';
 
-Widget userAvatar(BuildContext context, User u, {double? radius}) {
+Widget userAvatar(BuildContext context, UserDto u, {double? radius}) {
   final url =
       "${Store.get(StoreKey.serverEndpoint)}/users/${u.uid}/profile-image";
   final nameFirstLetter = u.name.isNotEmpty ? u.name[0] : "";

--- a/mobile/lib/widgets/common/user_circle_avatar.dart
+++ b/mobile/lib/widgets/common/user_circle_avatar.dart
@@ -12,7 +12,7 @@ import 'package:immich_mobile/widgets/common/transparent_image.dart';
 
 // ignore: must_be_immutable
 class UserCircleAvatar extends ConsumerWidget {
-  final User user;
+  final UserDto user;
   double radius;
   double size;
 

--- a/mobile/test/fixtures/user.stub.dart
+++ b/mobile/test/fixtures/user.stub.dart
@@ -3,7 +3,7 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 abstract final class UserStub {
   const UserStub._();
 
-  static final admin = User(
+  static final admin = UserDto(
     uid: "admin",
     email: "admin@test.com",
     name: "admin",
@@ -13,7 +13,7 @@ abstract final class UserStub {
     avatarColor: AvatarColor.green,
   );
 
-  static final user1 = User(
+  static final user1 = UserDto(
     uid: "user1",
     email: "user1@test.com",
     name: "user1",
@@ -23,7 +23,7 @@ abstract final class UserStub {
     avatarColor: AvatarColor.red,
   );
 
-  static final user2 = User(
+  static final user2 = UserDto(
     uid: "user2",
     email: "user2@test.com",
     name: "user2",

--- a/mobile/test/infrastructure/repositories/store_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/store_repository_test.dart
@@ -86,7 +86,7 @@ void main() {
     });
 
     test('converts user', () async {
-      User? user = await sut.tryGet(StoreKey.currentUser);
+      UserDto? user = await sut.tryGet(StoreKey.currentUser);
       expect(user, isNull);
       await sut.insert(StoreKey.currentUser, _kTestUser);
       user = await sut.tryGet(StoreKey.currentUser);

--- a/mobile/test/modules/shared/shared_mocks.dart
+++ b/mobile/test/modules/shared/shared_mocks.dart
@@ -3,11 +3,11 @@ import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockCurrentUserProvider extends StateNotifier<User?>
+class MockCurrentUserProvider extends StateNotifier<UserDto?>
     with Mock
     implements CurrentUserProvider {
   MockCurrentUserProvider() : super(null);
 
   @override
-  set state(User? user) => super.state = user;
+  set state(UserDto? user) => super.state = user;
 }

--- a/mobile/test/modules/shared/sync_service_test.dart
+++ b/mobile/test/modules/shared/sync_service_test.dart
@@ -57,7 +57,7 @@ void main() {
         MockAlbumMediaRepository();
     final MockAlbumApiRepository albumApiRepository = MockAlbumApiRepository();
 
-    final owner = User(
+    final owner = UserDto(
       uid: "1",
       updatedAt: DateTime.now(),
       email: "a@b.c",
@@ -253,7 +253,7 @@ void main() {
 }
 
 Future<(List<Asset>?, List<String>?)> _failDiff(
-  List<User> user,
+  List<UserDto> user,
   DateTime time,
 ) =>
     Future.value((null, null));


### PR DESCRIPTION
### Description

Follows #16655 

- Renames the user model to make the distinction between the model and entity clearer. Will be renamed once the Isar entity is removed
