### PR TITLE
fix(docs): logo not loading dark theme variant in production

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
-import { useColorMode } from '@docusaurus/theme-common';
 import { discordPath, discordViewBox } from '@site/src/components/svg-paths';
+import ThemedImage from '@theme/ThemedImage';
 import Icon from '@mdi/react';
 function HomepageHeader() {
-  const { isDarkTheme } = useColorMode();
-
   return (
     <header>
       <div className="top-[calc(12%)]  md:top-[calc(30%)] h-screen w-full absolute -z-10">
@@ -14,8 +12,8 @@ function HomepageHeader() {
         <div className="w-full h-[120vh] absolute left-0 top-0 backdrop-blur-3xl bg-immich-bg/40 dark:bg-transparent"></div>
       </div>
       <section className="text-center pt-12 sm:pt-24 bg-immich-bg/50 dark:bg-immich-dark-bg/80">
-        <img
-          src={isDarkTheme ? 'img/logomark-dark.svg' : 'img/logomark-light.svg'}
+        <ThemedImage
+          sources={{ dark: 'img/logomark-dark.svg', light: 'img/logomark-light.svg' }}
           className="h-[115px] w-[115px] mb-2 antialiased rounded-none"
           alt="Immich logo"
         />
@@ -35,7 +33,6 @@ function HomepageHeader() {
             sacrificing your privacy.
           </p>
         </div>
-
         <div className="flex flex-col sm:flex-row place-items-center place-content-center mt-9 gap-4 ">
           <Link
             className="flex place-items-center place-content-center py-3 px-8 border bg-immich-primary dark:bg-immich-dark-primary rounded-xl no-underline hover:no-underline text-white hover:text-gray-50 dark:text-immich-dark-bg font-bold uppercase"
@@ -58,7 +55,6 @@ function HomepageHeader() {
             Buy Merch
           </Link>
         </div>
-
         <div className="my-12 flex gap-1 font-medium place-items-center place-content-center text-immich-primary dark:text-immich-dark-primary">
           <Icon
             path={discordPath}
@@ -67,22 +63,19 @@ function HomepageHeader() {
           />
           <Link to="https://discord.immich.app/">Join our Discord</Link>
         </div>
-        <img
-          src={isDarkTheme ? '/img/screenshot-dark.webp' : '/img/screenshot-light.webp'}
+        <ThemedImage
+          sources={{ dark: '/img/screenshot-dark.webp', light: '/img/screenshot-light.webp' }}
           alt="screenshots"
           className="w-[95%] lg:w-[85%] xl:w-[70%] 2xl:w-[60%] "
         />
-
         <div className="mx-[25%] m-auto my-14 md:my-28">
           <hr className="border bg-gray-500 dark:bg-gray-400" />
         </div>
-
-        <img
-          src={isDarkTheme ? 'img/logomark-dark.svg' : 'img/logomark-light.svg'}
+        <ThemedImage
+          sources={{ dark: 'img/logomark-dark.svg', light: 'img/logomark-light.svg' }}
           className="h-[115px] w-[115px] mb-2 antialiased rounded-none"
           alt="Immich logo"
         />
-
         <div>
           <p className="font-bold text-2xl md:text-5xl ">Download the mobile app</p>
           <p className="text-lg">
@@ -101,9 +94,8 @@ function HomepageHeader() {
             </a>
           </div>
         </div>
-
-        <img
-          src={isDarkTheme ? '/img/app-qr-code-dark.svg' : '/img/app-qr-code-light.svg'}
+        <ThemedImage
+          sources={{ dark: '/img/app-qr-code-dark.svg', light: '/img/app-qr-code-light.svg' }}
           alt="app qr code"
           width={'150px'}
           className="shadow-lg p-3 my-8 dark:bg-immich-dark-bg "

--- a/docs/src/pages/privacy-policy.tsx
+++ b/docs/src/pages/privacy-policy.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
-import { useColorMode } from '@docusaurus/theme-common';
 function HomepageHeader() {
-  const { isDarkTheme } = useColorMode();
-
   return (
     <header>
       <section className="max-w-[900px] m-4 p-4 md:p-6 md:m-auto md:my-12 border border-red-400 rounded-2xl  bg-slate-200 dark:bg-immich-dark-gray">


### PR DESCRIPTION
## Description

The logo on the docs shows the light theme logo if you open the page or refresh the page with dark theme enabled. If you run `npm run start` it doesn't occur because JS is run on the client.

This PR switches to the official docusaurus component for themed images: https://docusaurus.io/docs/markdown-features/assets#themed-images

## How Has This Been Tested?

- [x] GitHub PR preview docs

<details><summary><h2>Screenshots</h2></summary>

Old behavior (after reloading page or loading with dark theme already enabled):
![Screenshot_20250311_174613](https://github.com/user-attachments/assets/b5512a35-df88-4083-9725-d5fa982987d9)
New behavior:
![Screenshot_20250311_174620](https://github.com/user-attachments/assets/fb7d19e5-da8d-4996-964d-4e83d7c02306)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
