### PR TITLE
fix(web): fixed formatting of video length

### DIFF
--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -94,10 +94,8 @@
         {Duration.fromObject({ seconds: remainingSeconds }).toFormat('m:ss')}
       {:else if remainingSeconds < 3600}
         {Duration.fromObject({ seconds: remainingSeconds }).toFormat('mm:ss')}
-      {:else if remainingSeconds < 36000}
-        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('h:mm:ss')}
       {:else}
-        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('hh:mm:ss')}
+        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('h:mm:ss')}
       {/if}
     </span>
   {/if}

--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -90,7 +90,15 @@
 <div class="absolute right-0 top-0 z-20 flex place-items-center gap-1 text-xs font-medium text-white">
   {#if showTime}
     <span class="pt-2">
-      {Duration.fromObject({ seconds: remainingSeconds }).toFormat('m:ss')}
+      {#if remainingSeconds < 60}
+        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('m:ss')}
+      {:else if remainingSeconds < 3600}
+        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('mm:ss')}
+      {:else if remainingSeconds < 36000}
+        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('h:mm:ss')}
+      {:else}
+        {Duration.fromObject({ seconds: remainingSeconds }).toFormat('hh:mm:ss')}
+      {/if}
     </span>
   {/if}
 


### PR DESCRIPTION
## Description
Before, the video length was formatted as `m:ss` regardless of the length of the video, causing 1+ hour long videos to show length as `137:50` for example. This was not how it behaved on the mobile, which had the correct formatting.

This PR changes how video length is formatted in the video thumbnail on the web to match the behavior and format of mobile; making the formatting conditional, depending on the length of the actual video.

## How Has This Been Tested?
Tested with videos:
- less than 1 minute
- 1-10 minutes
- 1 hour+

<h2>Screenshots</h2>

![image](https://github.com/user-attachments/assets/bc417a29-7e7a-4d40-82d7-7550c010ad80)
![image](https://github.com/user-attachments/assets/d438ef57-2622-4430-ae8a-b72199d6bfed)
![image](https://github.com/user-attachments/assets/dce74946-1c81-43dd-a7e2-888cbc5cdac5)
