### PR TITLE
fix(server): /api/stacks does not handles primaryAssetId query param

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -5712,6 +5712,7 @@
             "required": false,
             "in": "query",
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }

--- a/server/src/dtos/stack.dto.ts
+++ b/server/src/dtos/stack.dto.ts
@@ -12,6 +12,7 @@ export class StackCreateDto {
 }
 
 export class StackSearchDto {
+  @ValidateUUID({ optional: true })
   primaryAssetId?: string;
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Added the missing decorator @ValidateUUID({ optional: true }) for `primaryAssetId` field in StackSearchDto. Without it, the query parameter was empty, and thus, filtering by the query parameter did not work.

I also checked all `@Query` DTOs for a similar issue and didn’t find anything like that.

Fixes https://github.com/immich-app/immich/issues/16690

## How Has This Been Tested?

I didn't write additional tests because this is a feature of the library's behavior. So i checked it manually.

## Checklist:

- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
