### PR TITLE
feat(mobile): backup albums search

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -75,7 +75,6 @@
   "backup_album_selection_page_albums_device": "Albums on device ({})",
   "backup_album_selection_page_albums_tap": "Tap to include, double tap to exclude",
   "backup_album_selection_page_assets_scatter": "Assets can scatter across multiple albums. Thus, albums can be included or excluded during the backup process.",
-  "backup_album_selection_page_search_hint": "Filter albums",
   "backup_album_selection_page_select_albums": "Select albums",
   "backup_album_selection_page_selection_info": "Selection Info",
   "backup_album_selection_page_total_assets": "Total unique assets",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -75,6 +75,7 @@
   "backup_album_selection_page_albums_device": "Albums on device ({})",
   "backup_album_selection_page_albums_tap": "Tap to include, double tap to exclude",
   "backup_album_selection_page_assets_scatter": "Assets can scatter across multiple albums. Thus, albums can be included or excluded during the backup process.",
+  "backup_album_selection_page_search_hint": "Filter albums",
   "backup_album_selection_page_select_albums": "Select albums",
   "backup_album_selection_page_selection_info": "Selection Info",
   "backup_album_selection_page_total_assets": "Total unique assets",

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -290,7 +290,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
           ),
           SliverToBoxAdapter(
             child: Padding(
-              padding: const EdgeInsets.all(8),
+              padding: const EdgeInsets.only(left: 16, right: 16, bottom: 4),
               child: TextField(
                 focusNode: formFocus,
                 onChanged: (value) => searchQuery.value = value,
@@ -330,7 +330,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                     Icons.search_rounded,
                     color: context.colorScheme.primary,
                   ),
-                  hintText: 'backup_album_selection_page_search_hint'.tr(),
+                  hintText: 'search_albums'.tr(),
                 ),
               ),
             ),

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -36,6 +36,10 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
       [],
     );
 
+    var filteredAlbums = albums.where((album) {
+      return album.name.toLowerCase().contains(searchQuery.value.toLowerCase());
+    }).toList();
+
     buildAlbumSelectionList() {
       if (albums.isEmpty) {
         return const SliverToBoxAdapter(
@@ -44,12 +48,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
           ),
         );
       }
-
-      var filteredAlbums = albums.where((album) {
-        return album.name
-            .toLowerCase()
-            .contains(searchQuery.value.toLowerCase());
-      }).toList();
 
       return SliverPadding(
         padding: const EdgeInsets.symmetric(vertical: 12.0),
@@ -74,12 +72,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
           ),
         );
       }
-
-      var filteredAlbums = albums.where((album) {
-        return album.name
-            .toLowerCase()
-            .contains(searchQuery.value.toLowerCase());
-      }).toList();
 
       return SliverPadding(
         padding: const EdgeInsets.all(12.0),
@@ -262,8 +254,9 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                         context: context,
                         builder: (BuildContext context) {
                           return AlertDialog(
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
+                            shape: const RoundedRectangleBorder(
+                              borderRadius:
+                                  BorderRadius.all(Radius.circular(10)),
                             ),
                             elevation: 5,
                             title: Text(
@@ -292,8 +285,6 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                     },
                   ),
                 ),
-
-                // buildSearchBar(),
               ],
             ),
           ),
@@ -312,25 +303,25 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                     color: context.themeData.colorScheme.onSurfaceSecondary,
                   ),
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(25),
+                    borderRadius: const BorderRadius.all(Radius.circular(25)),
                     borderSide: BorderSide(
                       color: context.colorScheme.surfaceContainerHighest,
                     ),
                   ),
                   enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(25),
+                    borderRadius: const BorderRadius.all(Radius.circular(25)),
                     borderSide: BorderSide(
                       color: context.colorScheme.surfaceContainerHighest,
                     ),
                   ),
                   disabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(25),
+                    borderRadius: const BorderRadius.all(Radius.circular(25)),
                     borderSide: BorderSide(
                       color: context.colorScheme.surfaceContainerHighest,
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(25),
+                    borderRadius: const BorderRadius.all(Radius.circular(25)),
                     borderSide: BorderSide(
                       color: context.colorScheme.primary.withAlpha(150),
                     ),

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/providers/album/album.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
@@ -24,6 +25,8 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
         useAppSettingsState(AppSettingsEnum.syncAlbums);
     final isDarkTheme = context.isDarkTheme;
     final albums = ref.watch(backupProvider).availableAlbums;
+    final searchQuery = useState('');
+    final formFocus = useFocusNode();
 
     useEffect(
       () {
@@ -42,16 +45,22 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
         );
       }
 
+      var filteredAlbums = albums.where((album) {
+        return album.name
+            .toLowerCase()
+            .contains(searchQuery.value.toLowerCase());
+      }).toList();
+
       return SliverPadding(
         padding: const EdgeInsets.symmetric(vertical: 12.0),
         sliver: SliverList(
           delegate: SliverChildBuilderDelegate(
             ((context, index) {
               return AlbumInfoListTile(
-                album: albums[index],
+                album: filteredAlbums[index],
               );
             }),
-            childCount: albums.length,
+            childCount: filteredAlbums.length,
           ),
         ),
       );
@@ -66,6 +75,12 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
         );
       }
 
+      var filteredAlbums = albums.where((album) {
+        return album.name
+            .toLowerCase()
+            .contains(searchQuery.value.toLowerCase());
+      }).toList();
+
       return SliverPadding(
         padding: const EdgeInsets.all(12.0),
         sliver: SliverGrid.builder(
@@ -74,10 +89,10 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
             mainAxisSpacing: 12,
             crossAxisSpacing: 12,
           ),
-          itemCount: albums.length,
+          itemCount: filteredAlbums.length,
           itemBuilder: ((context, index) {
             return AlbumInfoCard(
-              album: albums[index],
+              album: filteredAlbums[index],
             );
           }),
         ),
@@ -280,6 +295,53 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
 
                 // buildSearchBar(),
               ],
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: TextField(
+                focusNode: formFocus,
+                onChanged: (value) => searchQuery.value = value,
+                onTapOutside: (_) => formFocus.unfocus(),
+                decoration: InputDecoration(
+                  contentPadding: const EdgeInsets.only(left: 24),
+                  filled: true,
+                  fillColor: context.primaryColor.withValues(alpha: 0.1),
+                  hintStyle: context.textTheme.bodyLarge?.copyWith(
+                    color: context.themeData.colorScheme.onSurfaceSecondary,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(25),
+                    borderSide: BorderSide(
+                      color: context.colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(25),
+                    borderSide: BorderSide(
+                      color: context.colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                  disabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(25),
+                    borderSide: BorderSide(
+                      color: context.colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(25),
+                    borderSide: BorderSide(
+                      color: context.colorScheme.primary.withAlpha(150),
+                    ),
+                  ),
+                  prefixIcon: Icon(
+                    Icons.search_rounded,
+                    color: context.colorScheme.primary,
+                  ),
+                  hintText: 'backup_album_selection_page_search_hint'.tr(),
+                ),
+              ),
             ),
           ),
           SliverLayoutBuilder(

--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -36,7 +36,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
       [],
     );
 
-    var filteredAlbums = albums.where((album) {
+    final filteredAlbums = albums.where((album) {
       return album.name.toLowerCase().contains(searchQuery.value.toLowerCase());
     }).toList();
 


### PR DESCRIPTION
## Description
Added a search field on the "Backup Albums selection" page. Some users have many albums on their phones, this will make it easier for people to find the exact albums they want to select for backup.

Implements #13617

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img src="https://github.com/user-attachments/assets/2bff77d6-401a-44fc-accd-ce07c47b2f9b" height=300 />


</details>