### PR TITLE
fix: asset update race condition

### DIFF
--- a/server/src/db.d.ts
+++ b/server/src/db.d.ts
@@ -143,6 +143,7 @@ export interface Assets {
   isFavorite: Generated<boolean>;
   isOffline: Generated<boolean>;
   isVisible: Generated<boolean>;
+  isDirty: Generated<boolean>;
   libraryId: string | null;
   livePhotoVideoId: string | null;
   localDateTime: Timestamp | null;

--- a/server/src/entities/asset.entity.ts
+++ b/server/src/entities/asset.entity.ts
@@ -125,6 +125,9 @@ export class AssetEntity {
   @Column({ type: 'boolean', default: false })
   isOffline!: boolean;
 
+  @Column({ type: 'boolean', default: false })
+  isDirty!: boolean;
+
   @Column({ type: 'bytea' })
   @Index()
   checksum!: Buffer; // sha1 checksum

--- a/server/src/migrations/1742127949957-AddAssetIsDirty.ts
+++ b/server/src/migrations/1742127949957-AddAssetIsDirty.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAssetIsDirty1742127949957 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "assets" ADD "isDirty" boolean NOT NULL DEFAULT false`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "assets" DROP COLUMN "isDirty"`);
+  }
+}

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -264,7 +264,7 @@ describe(AssetService.name, () => {
 
       await sut.update(authStub.admin, 'asset-1', { isFavorite: true });
 
-      expect(mocks.asset.update).toHaveBeenCalledWith({ id: 'asset-1', isFavorite: true });
+      expect(mocks.asset.update).toHaveBeenCalledWith({ id: 'asset-1', isFavorite: true, isDirty: true });
     });
 
     it('should update the exif description', async () => {
@@ -371,6 +371,7 @@ describe(AssetService.name, () => {
       expect(mocks.asset.update).toHaveBeenCalledWith({
         id: assetStub.livePhotoStillAsset.id,
         livePhotoVideoId: assetStub.livePhotoMotionAsset.id,
+        isDirty: true,
       });
     });
 
@@ -392,6 +393,7 @@ describe(AssetService.name, () => {
       expect(mocks.asset.update).toHaveBeenCalledWith({
         id: assetStub.livePhotoStillAsset.id,
         livePhotoVideoId: null,
+        isDirty: true,
       });
       expect(mocks.asset.update).toHaveBeenCalledWith({ id: assetStub.livePhotoMotionAsset.id, isVisible: true });
       expect(mocks.event.emit).toHaveBeenCalledWith('asset.show', {
@@ -429,7 +431,7 @@ describe(AssetService.name, () => {
 
       await sut.updateAll(authStub.admin, { ids: ['asset-1', 'asset-2'], isArchived: true });
 
-      expect(mocks.asset.updateAll).toHaveBeenCalledWith(['asset-1', 'asset-2'], { isArchived: true });
+      expect(mocks.asset.updateAll).toHaveBeenCalledWith(['asset-1', 'asset-2'], { isArchived: true, isDirty: true });
     });
 
     it('should not update Assets table if no relevant fields are provided', async () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -117,7 +117,7 @@ export class AssetService extends BaseService {
 
     await this.updateMetadata({ id, description, dateTimeOriginal, latitude, longitude, rating });
 
-    const asset = await this.assetRepository.update({ id, ...rest });
+    const asset = await this.assetRepository.update({ id, isDirty: true, ...rest });
 
     if (previousMotion) {
       await onAfterUnlink(repos, { userId: auth.user.id, livePhotoVideoId: previousMotion.id });
@@ -144,7 +144,7 @@ export class AssetService extends BaseService {
       options.duplicateId != undefined ||
       options.rating != undefined
     ) {
-      await this.assetRepository.updateAll(ids, options);
+      await this.assetRepository.updateAll(ids, { isDirty: true, ...options });
     }
   }
 

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -90,6 +90,7 @@ export class TagService extends BaseService {
 
     const results = await this.tagRepository.upsertAssetIds(items);
     for (const assetId of new Set(results.map((item) => item.assetsId))) {
+      await this.assetRepository.update({ id: assetId, isDirty: true });
       await this.eventRepository.emit('asset.tag', { assetId });
     }
 
@@ -107,6 +108,7 @@ export class TagService extends BaseService {
 
     for (const { id: assetId, success } of results) {
       if (success) {
+        await this.assetRepository.update({ id: assetId, isDirty: true });
         await this.eventRepository.emit('asset.tag', { assetId });
       }
     }
@@ -125,6 +127,7 @@ export class TagService extends BaseService {
 
     for (const { id: assetId, success } of results) {
       if (success) {
+        await this.assetRepository.update({ id: assetId, isDirty: true });
         await this.eventRepository.emit('asset.untag', { assetId });
       }
     }

--- a/server/src/utils/asset.util.ts
+++ b/server/src/utils/asset.util.ts
@@ -4,6 +4,7 @@ import { BulkIdErrorReason, BulkIdResponseDto } from 'src/dtos/asset-ids.respons
 import { UploadFieldName } from 'src/dtos/asset-media.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetFileEntity } from 'src/entities/asset-files.entity';
+import { AssetEntity } from 'src/entities/asset.entity';
 import { AssetFileType, AssetType, Permission } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { AccessRepository } from 'src/repositories/access.repository';
@@ -16,6 +17,8 @@ import { checkAccess } from 'src/utils/access';
 const getFileByType = (files: AssetFileEntity[] | undefined, type: AssetFileType) => {
   return (files || []).find((file) => file.type === type);
 };
+
+export const getSidecarPath = (asset: AssetEntity) => `${asset.originalPath}.xmp`;
 
 export const getAssetFiles = (files?: AssetFileEntity[]) => ({
   previewFile: getFileByType(files, AssetFileType.PREVIEW),

--- a/server/test/fixtures/asset.stub.ts
+++ b/server/test/fixtures/asset.stub.ts
@@ -88,6 +88,7 @@ export const assetStub = {
     isExternal: false,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   noWebpPath: Object.freeze<AssetEntity>({
@@ -126,6 +127,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   noThumbhash: Object.freeze<AssetEntity>({
@@ -161,6 +163,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   primaryImage: Object.freeze<AssetEntity>({
@@ -207,6 +210,7 @@ export const assetStub = {
     ]),
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   image: Object.freeze<AssetEntity>({
@@ -247,6 +251,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   trashed: Object.freeze<AssetEntity>({
@@ -287,6 +292,7 @@ export const assetStub = {
     duplicateId: null,
     isOffline: false,
     status: AssetStatus.TRASHED,
+    isDirty: false,
   }),
 
   trashedOffline: Object.freeze<AssetEntity>({
@@ -328,6 +334,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: true,
+    isDirty: false,
   }),
   archived: Object.freeze<AssetEntity>({
     id: 'asset-id',
@@ -367,6 +374,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   external: Object.freeze<AssetEntity>({
@@ -406,6 +414,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   image1: Object.freeze<AssetEntity>({
@@ -444,6 +453,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   imageFrom2015: Object.freeze<AssetEntity>({
@@ -482,6 +492,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   video: Object.freeze<AssetEntity>({
@@ -522,6 +533,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   livePhotoMotionAsset: Object.freeze({
@@ -613,6 +625,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   sidecar: Object.freeze<AssetEntity>({
@@ -648,6 +661,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   sidecarWithoutExt: Object.freeze<AssetEntity>({
@@ -683,6 +697,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   hasEncodedVideo: Object.freeze<AssetEntity>({
@@ -721,6 +736,7 @@ export const assetStub = {
     deletedAt: null,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   hasFileExtension: Object.freeze<AssetEntity>({
@@ -760,6 +776,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   imageDng: Object.freeze<AssetEntity>({
@@ -800,6 +817,7 @@ export const assetStub = {
     } as ExifEntity,
     duplicateId: null,
     isOffline: false,
+    isDirty: false,
   }),
 
   hasEmbedding: Object.freeze<AssetEntity>({
@@ -842,6 +860,7 @@ export const assetStub = {
       embedding: '[1, 2, 3, 4]',
     },
     isOffline: false,
+    isDirty: false,
   }),
 
   hasDupe: Object.freeze<AssetEntity>({
@@ -884,5 +903,6 @@ export const assetStub = {
       embedding: '[1, 2, 3, 4]',
     },
     isOffline: false,
+    isDirty: false,
   }),
 };

--- a/server/test/fixtures/shared-link.stub.ts
+++ b/server/test/fixtures/shared-link.stub.ts
@@ -247,6 +247,7 @@ export const sharedLinkStub = {
           sidecarPath: null,
           deletedAt: null,
           duplicateId: null,
+          isDirty: false,
         },
       ],
     },

--- a/server/test/medium/specs/metadata.service.spec.ts
+++ b/server/test/medium/specs/metadata.service.spec.ts
@@ -123,7 +123,7 @@ describe(MetadataService.name, () => {
       process.env.TZ = serverTimeZone ?? undefined;
 
       const { filePath } = await createTestFile(exifData);
-      mocks.asset.getByIds.mockResolvedValue([{ id: 'asset-1', originalPath: filePath } as AssetEntity]);
+      mocks.asset.getById.mockResolvedValue({ id: 'asset-1', originalPath: filePath } as AssetEntity);
 
       await sut.handleMetadataExtraction({ id: 'asset-1' });
 

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -105,6 +105,7 @@ const assetFactory = (asset: Partial<Asset> = {}) => ({
   isFavorite: false,
   isOffline: false,
   isVisible: true,
+  isDirty: false,
   libraryId: null,
   livePhotoVideoId: null,
   localDateTime: newDate(),


### PR DESCRIPTION
Fixes #16747; a race condition between updating an asset and metadata extraction:

1. Asset gets uploaded, `METADATA_EXTRACTION` is queued
2. Asset exif data is updated using the API; `SIDECAR_WRITE` is queued
3. `METADATA_EXTRACTION` is scheduled, updating and overriding all changes to the asset in the database
4. `SIDECAR_WRITE` is scheduled, but the changes are already lost