### PR TITLE
fix(mobile): change share icons for consistency

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -197,7 +197,7 @@
   "control_bottom_app_bar_edit_time": "Edit Date & Time",
   "control_bottom_app_bar_favorite": "Favorite",
   "control_bottom_app_bar_share": "Share",
-  "control_bottom_app_bar_share_to": "Share To",
+  "control_bottom_app_bar_share_link": "Share Link",
   "control_bottom_app_bar_stack": "Stack",
   "control_bottom_app_bar_trash_from_immich": "Move to Trash",
   "control_bottom_app_bar_unarchive": "Unarchive",

--- a/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
+++ b/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
@@ -127,12 +127,12 @@ class ControlBottomAppBar extends HookConsumerWidget {
           ControlBoxButton(
             iconData: Icons.share_rounded,
             label: "control_bottom_app_bar_share".tr(),
-            onPressed: enabled ? () => onShare(false) : null,
+            onPressed: enabled ? () => onShare(true) : null,
           ),
         ControlBoxButton(
-          iconData: Icons.ios_share_rounded,
-          label: "control_bottom_app_bar_share_to".tr(),
-          onPressed: enabled ? () => onShare(true) : null,
+          iconData: Icons.link_rounded,
+          label: "control_bottom_app_bar_share_link".tr(),
+          onPressed: enabled ? () => onShare(false) : null,
         ),
         if (hasRemote && onArchive != null)
           ControlBoxButton(


### PR DESCRIPTION
## Description

Changes the order and label of the share buttons in the "multiple selection bottom sheet".
Therefore, the behavior resembles that of other mainstream apps.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img src="https://github.com/user-attachments/assets/0f8b57f0-e47c-460c-8fa4-75e52a876571" height=150 />

</details>