### PR TITLE
Added verbosity log to thumbnail generation service. Debugging purposes when server crashes.

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -141,6 +141,9 @@ export class MediaService extends BaseService {
   @OnJob({ name: JobName.GENERATE_THUMBNAILS, queue: QueueName.THUMBNAIL_GENERATION })
   async handleGenerateThumbnails({ id }: JobOf<JobName.GENERATE_THUMBNAILS>): Promise<JobStatus> {
     const asset = await this.assetRepository.getById(id, { exifInfo: true, files: true });
+    
+    this.logger.verbose(`Thumbnail generation started for asset ${id} with path ${asset?.originalPath}`);
+
     if (!asset) {
       this.logger.warn(`Thumbnail generation failed for asset ${id}: not found`);
       return JobStatus.FAILED;


### PR DESCRIPTION
Adding this line to debug what is happening when my server crashes. I believe when in verbose mode, the workers should print out what file they are currently processing.

Linked to issue: https://github.com/immich-app/immich/discussions/16936