### PR TITLE
fix(web): date alignment on timeline

### DIFF
--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -132,7 +132,7 @@
         </div>
       {/if}
 
-      <span class="w-full truncate first-letter:capitalize" title={getDateLocaleString(dateGroup.date)}>
+      <span class="w-full truncate first-letter:capitalize ml-2.5" title={getDateLocaleString(dateGroup.date)}>
         {dateGroup.groupTitle}
       </span>
     </div>


### PR DESCRIPTION
## Description

Fixes #16921

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<b>Before:</b>
<div>
<img src="https://github.com/user-attachments/assets/ca4b395a-8ce9-4076-9826-4e33dbb70cf6" height=200 />
<div>
<b>After:</b>
<div>
<img src="https://github.com/user-attachments/assets/8ea76b9b-9272-4e24-ba1b-a449dd0fd046" height=200 />
</details>
