### PR TITLE
feat(web): make asset grid row height responsive

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -59,11 +59,14 @@
     const _assets = assets;
     updateSlidingWindow();
 
+    const rowWidth = Math.floor(viewport.width);
+    const rowHeight = rowWidth < 850 ? 100 : 235;
+
     geometry = getJustifiedLayoutFromAssets(_assets, {
       spacing: 2,
       heightTolerance: 0.15,
-      rowHeight: 235,
-      rowWidth: Math.floor(viewport.width),
+      rowHeight,
+      rowWidth,
     });
   });
 

--- a/web/src/lib/stores/assets-store.svelte.ts
+++ b/web/src/lib/stores/assets-store.svelte.ts
@@ -32,7 +32,9 @@ export type AssetStoreOptions = Omit<AssetApiGetTimeBucketsRequest, 'size'> & {
   timelineAlbumId?: string;
   deferInit?: boolean;
 };
-
+export type AssetStoreLayoutOptions = {
+  rowHeight: number
+}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function updateObject(target: any, source: any): boolean {
   if (!target) {
@@ -550,6 +552,7 @@ export class AssetStore {
 
   // --- private
   static #INIT_OPTIONS = {};
+  #rowHeight = 235;
   #viewportHeight = $state(0);
   #viewportWidth = $state(0);
   #scrollTop = $state(0);
@@ -592,6 +595,11 @@ export class AssetStore {
     const changed = value !== this.#viewportWidth;
     this.#viewportWidth = value;
     this.suspendTransitions = true;
+    if (value < 850) {
+      this.#rowHeight=100;
+    } else {
+      this.#rowHeight=235;
+    }
     // side-effect - its ok!
     void this.#updateViewportGeometry(changed);
   }
@@ -767,6 +775,11 @@ export class AssetStore {
     this.#updateViewportGeometry(false);
   }
 
+  async updateLayoutOptions(options: AssetStoreLayoutOptions) {
+    this.#rowHeight = options.rowHeight;
+    this.refreshLayout();
+  }
+
   async #init(options: AssetStoreOptions) {
     // doing the following outside of the task reduces flickr
     this.isInitialized = false;
@@ -836,10 +849,11 @@ export class AssetStore {
 
   createLayoutOptions() {
     const viewportWidth = this.viewportWidth;
+    
     return {
       spacing: 2,
       heightTolerance: 0.15,
-      rowHeight: 235,
+      rowHeight: this.#rowHeight,
       rowWidth: Math.floor(viewportWidth),
     };
   }

--- a/web/src/lib/stores/assets-store.svelte.ts
+++ b/web/src/lib/stores/assets-store.svelte.ts
@@ -33,8 +33,8 @@ export type AssetStoreOptions = Omit<AssetApiGetTimeBucketsRequest, 'size'> & {
   deferInit?: boolean;
 };
 export type AssetStoreLayoutOptions = {
-  rowHeight: number
-}
+  rowHeight: number;
+};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function updateObject(target: any, source: any): boolean {
   if (!target) {
@@ -595,11 +595,7 @@ export class AssetStore {
     const changed = value !== this.#viewportWidth;
     this.#viewportWidth = value;
     this.suspendTransitions = true;
-    if (value < 850) {
-      this.#rowHeight=100;
-    } else {
-      this.#rowHeight=235;
-    }
+    this.#rowHeight = value < 850 ? 100 : 235;
     // side-effect - its ok!
     void this.#updateViewportGeometry(changed);
   }
@@ -775,7 +771,7 @@ export class AssetStore {
     this.#updateViewportGeometry(false);
   }
 
-  async updateLayoutOptions(options: AssetStoreLayoutOptions) {
+  updateLayoutOptions(options: AssetStoreLayoutOptions) {
     this.#rowHeight = options.rowHeight;
     this.refreshLayout();
   }
@@ -849,7 +845,7 @@ export class AssetStore {
 
   createLayoutOptions() {
     const viewportWidth = this.viewportWidth;
-    
+
     return {
       spacing: 2,
       heightTolerance: 0.15,


### PR DESCRIPTION
This resizes asset grid's images to be smaller, as the viewport width gets smaller - useful on mobile devices will small screens.

Partially Fixes https://github.com/immich-app/immich/discussions/11731