### PR TITLE
fix(web): clicking away closes context menu

### DIFF
--- a/web/src/lib/actions/click-outside.ts
+++ b/web/src/lib/actions/click-outside.ts
@@ -35,12 +35,12 @@ export function clickOutside(node: HTMLElement, options: Options = {}): ActionRe
     }
   };
 
-  document.addEventListener('pointerdown', handleClick, true);
+  document.addEventListener('mousedown', handleClick, true);
   node.addEventListener('keydown', handleKey, false);
 
   return {
     destroy() {
-      document.removeEventListener('pointerdown', handleClick, true);
+      document.removeEventListener('mousedown', handleClick, true);
       node.removeEventListener('keydown', handleKey, false);
     },
   };

--- a/web/src/lib/actions/click-outside.ts
+++ b/web/src/lib/actions/click-outside.ts
@@ -35,12 +35,12 @@ export function clickOutside(node: HTMLElement, options: Options = {}): ActionRe
     }
   };
 
-  document.addEventListener('mousedown', handleClick, true);
+  document.addEventListener('pointerdown', handleClick, true);
   node.addEventListener('keydown', handleKey, false);
 
   return {
     destroy() {
-      document.removeEventListener('mousedown', handleClick, true);
+      document.removeEventListener('pointerdown', handleClick, true);
       node.removeEventListener('keydown', handleKey, false);
     },
   };

--- a/web/src/lib/components/shared-components/context-menu/button-context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/button-context-menu.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { clickOutside } from '$lib/actions/click-outside';
   import { contextMenuNavigation } from '$lib/actions/context-menu-navigation';
   import { shortcuts } from '$lib/actions/shortcut';
   import CircleIconButton, {
@@ -105,6 +104,19 @@
     closeDropdown();
   };
 
+  const handleDocumentClick = (event: MouseEvent) => {
+    if (!isOpen) {
+      return;
+    }
+
+    const target = event.target as Node | null;
+    if (buttonContainer?.contains(target)) {
+      return;
+    }
+
+    closeDropdown();
+  };
+
   const focusButton = () => {
     const button = buttonContainer?.querySelector(`#${buttonId}`) as HTMLButtonElement | null;
     button?.focus();
@@ -118,6 +130,7 @@
 </script>
 
 <svelte:window onresize={onResize} />
+<svelte:document onclick={handleDocumentClick} />
 
 <div
   use:contextMenuNavigation={{
@@ -129,7 +142,6 @@
     selectedId: $selectedIdStore,
     selectionChanged: (id) => ($selectedIdStore = id),
   }}
-  use:clickOutside={{ onOutclick: closeDropdown }}
   onresize={onResize}
   {...restProps}
 >

--- a/web/src/lib/components/shared-components/context-menu/button-context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/button-context-menu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { clickOutside } from '$lib/actions/click-outside';
   import { contextMenuNavigation } from '$lib/actions/context-menu-navigation';
   import { shortcuts } from '$lib/actions/shortcut';
   import CircleIconButton, {
@@ -104,19 +105,6 @@
     closeDropdown();
   };
 
-  const handleDocumentClick = (event: MouseEvent) => {
-    if (!isOpen) {
-      return;
-    }
-
-    const target = event.target as Node | null;
-    if (buttonContainer?.contains(target)) {
-      return;
-    }
-
-    closeDropdown();
-  };
-
   const focusButton = () => {
     const button = buttonContainer?.querySelector(`#${buttonId}`) as HTMLButtonElement | null;
     button?.focus();
@@ -130,7 +118,6 @@
 </script>
 
 <svelte:window onresize={onResize} />
-<svelte:document onclick={handleDocumentClick} />
 
 <div
   use:contextMenuNavigation={{
@@ -142,6 +129,7 @@
     selectedId: $selectedIdStore,
     selectionChanged: (id) => ($selectedIdStore = id),
   }}
+  use:clickOutside={{ onOutclick: closeDropdown }}
   onresize={onResize}
   {...restProps}
 >


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #16147

Using "click" event handler to detect whether there's been a click outside of the context menu, rather than the "mousedown" event in the use:clickOutside Svelte action.

**The cause?**

This bug was likely introduced in #15900, where the clickOutside listener changed was changed from "click" to "mousedown".

The asset viewer page uses the `@zoom-image/svelte` library to handle zooming, which listens for "pointerdown" events and uses [event.preventDefault to override default behavior](https://github.com/willnguyen1312/zoom-image/blob/4c53ae9f28813480cee95a455240c02754fbb65a/packages/core/src/createZoomImageWheel.ts#L365). According to the [MDN docs for PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent#pointer_event_types), this stops the mouse events from firing and therefore breaks the clicking outside behavior in Immich.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Navigate to the asset viewer
2. Open the context menu with the ellipses "..." button in the top right to open the context menu
3. Click away to test that the context menu closes

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
