### PR TITLE
fix(mobile): `selectedIcon` not set when the device is landscape

### DIFF
--- a/mobile/lib/pages/common/tab_controller.page.dart
+++ b/mobile/lib/pages/common/tab_controller.page.dart
@@ -131,6 +131,7 @@ class TabControllerPage extends HookConsumerWidget {
               (e) => NavigationRailDestination(
                 icon: e.icon,
                 label: Text(e.label),
+                selectedIcon: e.selectedIcon,
               ),
             )
             .toList(),


### PR DESCRIPTION
## Description
As per title, quite simple fix