### PR TITLE
fix(mobile): Make icons consistent (all outlined)

### DIFF
--- a/mobile/lib/pages/search/search.page.dart
+++ b/mobile/lib/pages/search/search.page.dart
@@ -701,19 +701,19 @@ class SearchPage extends HookConsumerWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 children: [
                   SearchFilterChip(
-                    icon: Icons.people_alt_rounded,
+                    icon: Icons.people_alt_outlined,
                     onTap: showPeoplePicker,
                     label: 'search_filter_people'.tr(),
                     currentFilter: peopleCurrentFilterWidget.value,
                   ),
                   SearchFilterChip(
-                    icon: Icons.location_pin,
+                    icon: Icons.location_on_outlined,
                     onTap: showLocationPicker,
                     label: 'search_filter_location'.tr(),
                     currentFilter: locationCurrentFilterWidget.value,
                   ),
                   SearchFilterChip(
-                    icon: Icons.camera_alt_rounded,
+                    icon: Icons.camera_alt_outlined,
                     onTap: showCameraPicker,
                     label: 'search_filter_camera'.tr(),
                     currentFilter: cameraCurrentFilterWidget.value,

--- a/mobile/lib/pages/search/search.page.dart
+++ b/mobile/lib/pages/search/search.page.dart
@@ -719,7 +719,7 @@ class SearchPage extends HookConsumerWidget {
                     currentFilter: cameraCurrentFilterWidget.value,
                   ),
                   SearchFilterChip(
-                    icon: Icons.date_range_rounded,
+                    icon: Icons.date_range_outlined,
                     onTap: showDatePicker,
                     label: 'search_filter_date'.tr(),
                     currentFilter: dateRangeCurrentFilterWidget.value,

--- a/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
+++ b/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
@@ -136,7 +136,8 @@ class ControlBottomAppBar extends HookConsumerWidget {
         ),
         if (hasRemote && onArchive != null)
           ControlBoxButton(
-            iconData: unarchive ? Icons.unarchive : Icons.archive,
+            iconData:
+                unarchive ? Icons.unarchive_outlined : Icons.archive_outlined,
             label: (unarchive
                     ? "control_bottom_app_bar_unarchive"
                     : "control_bottom_app_bar_archive")
@@ -194,7 +195,7 @@ class ControlBottomAppBar extends HookConsumerWidget {
           ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 85),
             child: ControlBoxButton(
-              iconData: Icons.no_cell_rounded,
+              iconData: Icons.no_cell_outlined,
               label: "control_bottom_app_bar_delete_from_local".tr(),
               onPressed: enabled
                   ? () {


### PR DESCRIPTION
## Description

The app icons are not consistent. Some of the are outlined and other are filled. Most of them are outline so I changed the remaining icons to be outlined

## Screenshots

### Before
![photo_5978744400911649342_y](https://github.com/user-attachments/assets/cf8ddae4-1981-49c7-8606-bd4aee6d0f88)
![-2147483648_-210038](https://github.com/user-attachments/assets/30c1017b-0c30-4ceb-8288-467f1cbcd959)

### After
![photo_5978744400911649341_y](https://github.com/user-attachments/assets/d736b5e0-f123-480e-bc70-1150f8095024)
![Screenshot_20250322_171558](https://github.com/user-attachments/assets/92df9c37-6320-44bb-8fad-9a8bcaa05298)
