### PR TITLE
fix(mobile): platform-dependent share icons & label

### DIFF
--- a/mobile/lib/widgets/album/album_viewer_appbar.dart
+++ b/mobile/lib/widgets/album/album_viewer_appbar.dart
@@ -189,13 +189,13 @@ class AlbumViewerAppbar extends HookConsumerWidget
           ).tr(),
         ),
         ListTile(
-          leading: const Icon(Icons.share_rounded),
+          leading: const Icon(Icons.link_rounded),
           onTap: () {
             context.pushRoute(SharedLinkEditRoute(albumId: album.remoteId));
             context.pop();
           },
           title: const Text(
-            "control_bottom_app_bar_share",
+            "control_bottom_app_bar_share_link",
             style: TextStyle(fontWeight: FontWeight.w500),
           ).tr(),
         ),

--- a/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
+++ b/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -125,7 +127,9 @@ class ControlBottomAppBar extends HookConsumerWidget {
       return [
         if (hasRemote)
           ControlBoxButton(
-            iconData: Icons.share_rounded,
+            iconData: Platform.isAndroid
+                ? Icons.share_rounded
+                : Icons.ios_share_rounded,
             label: "control_bottom_app_bar_share".tr(),
             onPressed: enabled ? () => onShare(true) : null,
           ),


### PR DESCRIPTION
## Description

In PR #16904 I changed the share icons in the bottom sheet, not realizing that the share icons in the asset viewer are platform-dependant.
This makes the icons in the bottom sheet also platform-dependent to match the behavior on both pages.
Additionally, in the album view's three-dot menu, the Share option is switched to "Share Link" for consistency.