### PR TITLE
fix(web): not autoplay after moving playhead on paused video

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -38,6 +38,7 @@
   let isLoading = $state(true);
   let assetFileUrl = $state('');
   let forceMuted = $state(false);
+  let isScrubbing = $state(false);
 
   onMount(() => {
     if (videoPlayer) {
@@ -55,8 +56,10 @@
 
   const handleCanPlay = async (video: HTMLVideoElement) => {
     try {
-      await video.play();
-      onVideoStarted();
+      if (!video.paused && !isScrubbing) {
+        await video.play();
+        onVideoStarted();
+      }
     } catch (error) {
       if (error instanceof DOMException && error.name === 'NotAllowedError' && !forceMuted) {
         await tryForceMutedPlay(video);
@@ -119,6 +122,8 @@
         $videoViewerMuted = e.currentTarget.muted;
       }
     }}
+    onseeking={() => (isScrubbing = true)}
+    onseeked={() => (isScrubbing = false)}
     onclose={() => onClose()}
     muted={forceMuted || $videoViewerMuted}
     bind:volume={$videoViewerVolume}


### PR DESCRIPTION
## Description

When trying to find a specific moment in a video, it is common to try to scrub through the video, moving the playhead while the video is paused. However, in Immich this is hard to do because when releasing the playhead, the video would start playing by itself, even if the video was paused before starting to move it.

This change makes it so it will no longer autoplay if the video is stopped before moving the playhead.

## How Has This Been Tested?

- [x] Play any video, move the playhead: video keeps playing
- [x] Pause that video, move the playhead again: video doesn't autoplay
