### PR TITLE
chore(mobile): suffix to app name on debug builds

### DIFF
--- a/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,10 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
   <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
   <uses-permission android:name="android.permission.INTERNET" />
+
+  <application android:label="Immich-Debug" tools:replace="android:label">
+  </application>
 </manifest>


### PR DESCRIPTION
## Description

Changes the app's name in the launcher for debug builds to `Immich-Debug`, similar to how it works for iOS builds.
This way, when both prod and debug versions are installed on the same phone for development, you do not confuse which one is which.