### PR TITLE
feat(mobile): Keep this, delete others

### DIFF
--- a/mobile/assets/i18n/cs-CZ.json
+++ b/mobile/assets/i18n/cs-CZ.json
@@ -320,7 +320,6 @@
   "image_viewer_page_state_provider_share_error": "Chyba sdílení",
   "invalid_date": "Chybné datum",
   "invalid_date_format": "Chybný formát data",
-  "keep_this_delete_others": "Ponechat tuto, odstanit ostatní",
   "library": "Knihovna",
   "library_page_albums": "Alba",
   "library_page_archive": "Archivovat",

--- a/mobile/assets/i18n/cs-CZ.json
+++ b/mobile/assets/i18n/cs-CZ.json
@@ -320,6 +320,7 @@
   "image_viewer_page_state_provider_share_error": "Chyba sdílení",
   "invalid_date": "Chybné datum",
   "invalid_date_format": "Chybný formát data",
+  "keep_this_delete_others": "Ponechat tuto, odstanit ostatní",
   "library": "Knihovna",
   "library_page_albums": "Alba",
   "library_page_archive": "Archivovat",

--- a/mobile/assets/i18n/de-DE.json
+++ b/mobile/assets/i18n/de-DE.json
@@ -320,6 +320,7 @@
   "image_viewer_page_state_provider_share_error": "Fehler beim Teilen",
   "invalid_date": "Ungültiges Datum ",
   "invalid_date_format": "Ungültiges Datumsformat",
+  "keep_this_delete_others": "keep_this_delete_others",
   "library": "Bibliothek",
   "library_page_albums": "Alben",
   "library_page_archive": "Archiv",

--- a/mobile/assets/i18n/de-DE.json
+++ b/mobile/assets/i18n/de-DE.json
@@ -320,7 +320,6 @@
   "image_viewer_page_state_provider_share_error": "Fehler beim Teilen",
   "invalid_date": "Ungültiges Datum ",
   "invalid_date_format": "Ungültiges Datumsformat",
-  "keep_this_delete_others": "keep_this_delete_others",
   "library": "Bibliothek",
   "library_page_albums": "Alben",
   "library_page_archive": "Archiv",

--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -320,6 +320,7 @@
   "image_viewer_page_state_provider_share_error": "Share Error",
   "invalid_date": "Invalid date",
   "invalid_date_format": "Invalid date format",
+  "keep_this_delete_others": "Keep this, delete others",
   "library": "Library",
   "library_page_albums": "Albums",
   "library_page_archive": "Archive",

--- a/mobile/assets/i18n/es-ES.json
+++ b/mobile/assets/i18n/es-ES.json
@@ -320,7 +320,6 @@
   "image_viewer_page_state_provider_share_error": "Error al compartir",
   "invalid_date": "Fecha incorrecta",
   "invalid_date_format": "Formato de fecha incorrecto",
-  "keep_this_delete_others": "Mantener este, eliminar los otros",
   "library": "Biblioteca",
   "library_page_albums": "Álbumes",
   "library_page_archive": "Archivo",

--- a/mobile/assets/i18n/es-ES.json
+++ b/mobile/assets/i18n/es-ES.json
@@ -320,6 +320,7 @@
   "image_viewer_page_state_provider_share_error": "Error al compartir",
   "invalid_date": "Fecha incorrecta",
   "invalid_date_format": "Formato de fecha incorrecto",
+  "keep_this_delete_others": "Mantener este, eliminar los otros",
   "library": "Biblioteca",
   "library_page_albums": "Álbumes",
   "library_page_archive": "Archivo",

--- a/mobile/assets/i18n/pl-PL.json
+++ b/mobile/assets/i18n/pl-PL.json
@@ -320,7 +320,6 @@
   "image_viewer_page_state_provider_share_error": "Udostępnij błąd",
   "invalid_date": "Nieprawidłowa data",
   "invalid_date_format": "Nieprawidłowy format daty",
-  "keep_this_delete_others": "keep_this_delete_others",
   "library": "Biblioteka",
   "library_page_albums": "Albumy",
   "library_page_archive": "Archiwum",

--- a/mobile/assets/i18n/pl-PL.json
+++ b/mobile/assets/i18n/pl-PL.json
@@ -320,6 +320,7 @@
   "image_viewer_page_state_provider_share_error": "Udostępnij błąd",
   "invalid_date": "Nieprawidłowa data",
   "invalid_date_format": "Nieprawidłowy format daty",
+  "keep_this_delete_others": "keep_this_delete_others",
   "library": "Biblioteka",
   "library_page_albums": "Albumy",
   "library_page_archive": "Archiwum",

--- a/mobile/lib/services/stack.service.dart
+++ b/mobile/lib/services/stack.service.dart
@@ -67,6 +67,21 @@ class StackService {
       debugPrint("Error while deleting stack: $error");
     }
   }
+
+  Future<void> keepThisDeleteOthers(Asset keepAsset, String stackId, List<Asset> assets) async {
+    try {
+      final ids = assets
+          .where((e) => e.remoteId != keepAsset.remoteId)
+          .map((e) => e.remoteId!)
+          .toList();
+      final assetBulkDeleteDto = AssetBulkDeleteDto(ids: ids);
+
+      await _api.assetsApi.deleteAssets(assetBulkDeleteDto);
+      await _api.stacksApi.deleteStack(stackId);
+    } catch (error) {
+      debugPrint("Error while keeping this and deleting others: $error");
+    }
+  }
 }
 
 final stackServiceProvider = Provider(

--- a/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
@@ -147,6 +147,16 @@ class BottomGalleryBar extends ConsumerWidget {
           .deleteStack(asset.stackId!, stackItems);
     }
 
+    keepThisDeleteOthers() async {
+      if (asset.stackId == null) {
+        return;
+      }
+
+      await ref
+        .read(stackServiceProvider)
+        .keepThisDeleteOthers(asset, asset.stackId!, stackItems);
+    }
+
     void showStackActionItems() {
       showModalBottomSheet<void>(
         context: context,
@@ -170,6 +180,21 @@ class BottomGalleryBar extends ConsumerWidget {
                     },
                     title: const Text(
                       "viewer_unstack",
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ).tr(),
+                  ),
+                  ListTile(
+                    leading: const Icon(
+                      Icons.push_pin_outlined,
+                      size: 18,
+                    ),
+                    onTap: () async {
+                      await keepThisDeleteOthers();
+                      ctx.pop();
+                      context.maybePop();
+                    },
+                    title: const Text(
+                      "keep_this_delete_others",
                       style: TextStyle(fontWeight: FontWeight.bold),
                     ).tr(),
                   ),


### PR DESCRIPTION
## Description

Implement feature "keep this asset, delete others assets" in Stack on mobile.
It is added as a menu item to menu Stack in viewing an asset in Stack.

Not sure how to handle translations - I have added some from the Weblate web translations but copy pasting all of them doesn´t seem like the proper way to me, please guide me there is a different process.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Go to an image which belongs to a Stack
- [x] Open Stack menu
- [x] Select "Keep this, delete others"
- [x] Other asset from Stack are deleted, only current asset remains, Stack info is removed 

<details><summary><h2>Video showcase</h2></summary>

https://github.com/user-attachments/assets/f2b4ed40-b092-417b-854b-dabf840f2c96


<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
