### PR TITLE
fix(mobile): fallback authentication client model/type to unknown

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -172,11 +172,14 @@ class ApiService implements Authentication {
       authenticationApi.apiClient
           .addDefaultHeader('deviceModel', iosInfo.utsname.machine);
       authenticationApi.apiClient.addDefaultHeader('deviceType', 'iOS');
-    } else {
+    } else if (Platform.isAndroid) {
       final androidInfo = await deviceInfoPlugin.androidInfo;
       authenticationApi.apiClient
           .addDefaultHeader('deviceModel', androidInfo.model);
       authenticationApi.apiClient.addDefaultHeader('deviceType', 'Android');
+    } else {
+      authenticationApi.apiClient.addDefaultHeader('deviceModel', 'Unknown');
+      authenticationApi.apiClient.addDefaultHeader('deviceType', 'Unknown');
     }
   }
 


### PR DESCRIPTION
Add fallback for client model/type if device is not ios or android

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prevents could not connect to server error if isplatform is not mapped to ios or android. This make it easier to port to future platforms in the future without affecting current platforms.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Adding a linux target
- [x] run without the change will fail at could not connect to server
- [x] run with the change will allow you to connect and login to the server


<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
