### PR TITLE
feat(server): Similiar search

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1147,6 +1147,7 @@
   "search_people": "Search people",
   "search_places": "Search places",
   "search_settings": "Search settings",
+  "search_similar_photos": "Search similar photos",
   "search_state": "Search state...",
   "search_tags": "Search tags...",
   "search_timezone": "Search timezone...",

--- a/web/src/lib/components/asset-viewer/actions/search-similar-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/search-similar-action.svelte
@@ -6,21 +6,12 @@
   import type { AssetResponseDto } from '@immich/sdk';
   import { mdiImageSearchOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
-  import { getContext } from 'svelte';
 
   interface Props {
     asset: AssetResponseDto;
   }
 
   let { asset }: Props = $props();
-
-  // Consider moving this somewhere..
-  // target: web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
-  type ParentContext = Partial<{
-    onSearchQueryUpdate: () => Promise<void>;
-  }>;
-
-  const notifyParent = getContext<ParentContext>('onSearchQueryUpdate')?.onSearchQueryUpdate;
 
   function getSearchSimilarUrl() {
     const params = getMetadataSearchQuery({
@@ -33,10 +24,6 @@
     e.stopPropagation();
 
     await goto(getSearchSimilarUrl());
-
-    // consider if we're already on the search page, goto will not (and probably should not) reload the page
-    // this triggers a new search
-    notifyParent && (await notifyParent());
   }
 </script>
 

--- a/web/src/lib/components/asset-viewer/actions/search-similar-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/search-similar-action.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
+  import { AppRoute } from '$lib/constants';
+  import { getMetadataSearchQuery } from '$lib/utils/metadata-search';
+  import type { AssetResponseDto } from '@immich/sdk';
+  import { mdiImageSearchOutline } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+  import { getContext } from 'svelte';
+
+  interface Props {
+    asset: AssetResponseDto;
+  }
+
+  let { asset }: Props = $props();
+
+  // Consider moving this somewhere..
+  // target: web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+  type ParentContext = Partial<{
+    onSearchQueryUpdate: () => Promise<void>;
+  }>;
+
+  const notifyParent = getContext<ParentContext>('onSearchQueryUpdate')?.onSearchQueryUpdate;
+
+  function getSearchSimilarUrl() {
+    const params = getMetadataSearchQuery({
+      query: `similarTo:${asset.id}`,
+    });
+    return `${AppRoute.SEARCH}?${params}`;
+  }
+
+  async function handleClick(e: MouseEvent) {
+    e.stopPropagation();
+
+    await goto(getSearchSimilarUrl());
+
+    // consider if we're already on the search page, goto will not (and probably should not) reload the page
+    // this triggers a new search
+    notifyParent && (await notifyParent());
+  }
+</script>
+
+<a href={getSearchSimilarUrl()} class="icon-link" onclick={handleClick}>
+  <CircleIconButton color="opaque" icon={mdiImageSearchOutline} title={$t('search_similar_photos')} />
+</a>
+
+<style>
+  .icon-link {
+    display: inline-flex;
+    text-decoration: none;
+  }
+</style>

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -8,6 +8,7 @@
   import DownloadAction from '$lib/components/asset-viewer/actions/download-action.svelte';
   import FavoriteAction from '$lib/components/asset-viewer/actions/favorite-action.svelte';
   import RestoreAction from '$lib/components/asset-viewer/actions/restore-action.svelte';
+  import SearchSimilarAction from '$lib/components/asset-viewer/actions/search-similar-action.svelte';
   import SetAlbumCoverAction from '$lib/components/asset-viewer/actions/set-album-cover-action.svelte';
   import SetFeaturedPhotoAction from '$lib/components/asset-viewer/actions/set-person-featured-action.svelte';
   import SetProfilePictureAction from '$lib/components/asset-viewer/actions/set-profile-picture-action.svelte';
@@ -19,7 +20,7 @@
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { AppRoute } from '$lib/constants';
-  import { user } from '$lib/stores/user.store';
+  import { preferences, user } from '$lib/stores/user.store';
   import { photoZoomState } from '$lib/stores/zoom-image.store';
   import { getAssetJobName, getSharedLink } from '$lib/utils';
   import { openFileUploadDialog } from '$lib/utils/file-uploader';
@@ -89,6 +90,8 @@
   const sharedLink = getSharedLink();
   let isOwner = $derived($user && asset.ownerId === $user?.id);
   let showDownloadButton = $derived(sharedLink ? sharedLink.allowDownload : !asset.isOffline);
+  let isSharingEnabled = $derived(!sharedLink && $preferences.sharedLinks.enabled);
+  let isShared = $derived(sharedLink && sharedLink.id);
   // $: showEditorButton =
   //   isOwner &&
   //   asset.type === AssetTypeEnum.Image &&
@@ -107,7 +110,7 @@
     <CloseAction {onClose} />
   </div>
   <div class="flex gap-2 overflow-x-auto text-white" data-testid="asset-viewer-navbar-actions">
-    {#if !asset.isTrashed && $user}
+    {#if !asset.isTrashed && isSharingEnabled}
       <ShareAction {asset} />
     {/if}
     {#if asset.isOffline}
@@ -115,6 +118,9 @@
     {/if}
     {#if asset.livePhotoVideoId}
       {@render motionPhoto?.()}
+    {/if}
+    {#if !isShared}
+      <SearchSimilarAction {asset} />
     {/if}
     {#if asset.type === AssetTypeEnum.Image}
       <CircleIconButton
@@ -164,7 +170,9 @@
           <RestoreAction {asset} {onAction} />
         {:else}
           <AddToAlbumAction {asset} {onAction} />
-          <AddToAlbumAction {asset} {onAction} shared />
+          {#if isSharingEnabled}
+            <AddToAlbumAction {asset} {onAction} shared />
+          {/if}
         {/if}
 
         {#if isOwner}

--- a/web/src/lib/components/elements/buttons/circle-icon-button.svelte
+++ b/web/src/lib/components/elements/buttons/circle-icon-button.svelte
@@ -40,7 +40,7 @@
     'aria-haspopup'?: boolean;
     tabindex?: number | undefined | null;
     role?: string | undefined | null;
-    onclick: (e: MouseEvent) => void;
+    onclick?: (e: MouseEvent) => void;
     disabled?: boolean;
   }
 

--- a/web/src/lib/utils/metadata-search.ts
+++ b/web/src/lib/utils/metadata-search.ts
@@ -1,7 +1,7 @@
 import { QueryParameter } from '$lib/constants';
-import type { MetadataSearchDto } from '@immich/sdk';
+import type { MetadataSearchDto, SmartSearchDto } from '@immich/sdk';
 
-export function getMetadataSearchQuery(metadata: MetadataSearchDto) {
+export function getMetadataSearchQuery(metadata: SmartSearchDto | MetadataSearchDto) {
   const searchParams = new URLSearchParams({
     [QueryParameter.QUERY]: JSON.stringify(metadata),
   });

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -42,7 +42,7 @@
   import AlbumCardGroup from '$lib/components/album-page/album-card-group.svelte';
   import { isAlbumsRoute, isPeopleRoute } from '$lib/utils/navigation';
   import { t } from 'svelte-i18n';
-  import { tick } from 'svelte';
+  import { onMount, tick, setContext } from 'svelte';
   import AssetJobActions from '$lib/components/photos-page/actions/asset-job-actions.svelte';
   import { preferences } from '$lib/stores/user.store';
   import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
@@ -76,7 +76,8 @@
     terms;
     setTimeout(() => {
       handlePromiseError(onSearchQueryUpdate());
-    });
+    }
+    setContext('onSearchQueryUpdate', { onSearchQueryUpdate });
   });
 
   const onEscape = () => {

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -79,8 +79,6 @@
     });
   });
 
-  setContext('onSearchQueryUpdate', { onSearchQueryUpdate });
-
   const onEscape = () => {
     if ($showAssetViewer) {
       return;

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -42,7 +42,7 @@
   import AlbumCardGroup from '$lib/components/album-page/album-card-group.svelte';
   import { isAlbumsRoute, isPeopleRoute } from '$lib/utils/navigation';
   import { t } from 'svelte-i18n';
-  import { onMount, tick, setContext } from 'svelte';
+  import { tick, setContext } from 'svelte';
   import AssetJobActions from '$lib/components/photos-page/actions/asset-job-actions.svelte';
   import { preferences } from '$lib/stores/user.store';
   import TagAction from '$lib/components/photos-page/actions/tag-action.svelte';
@@ -76,9 +76,10 @@
     terms;
     setTimeout(() => {
       handlePromiseError(onSearchQueryUpdate());
-    }
-    setContext('onSearchQueryUpdate', { onSearchQueryUpdate });
+    });
   });
+
+  setContext('onSearchQueryUpdate', { onSearchQueryUpdate });
 
   const onEscape = () => {
     if ($showAssetViewer) {


### PR DESCRIPTION
## Description

Allows search bar in immich to start using googly terms to search for similar photos to the provided assetId.

Example Search Bar Query
```text
similarTo:d49c2299-7881-4598-aee7-447f78eb9f73
```

![image](https://github.com/user-attachments/assets/6b6dd74f-4b92-44c7-bad2-6c759f8711eb)

See screenshots for the output between two types of planes

the current search functionality has two different directions
- metadata search (the popup dialog)
- context search - our original smart search

I'm a bit hesitant to add asset selection to the metadata search section - I like both, but tend to be more at home in the search bar.

## How Has This Been Tested?

unit tests pending, however manual test can be performed via search bar.

I found some random test images here (will be 8000 images, which need to index by the machine learning server!)
https://www.kaggle.com/datasets/prasunroy/natural-images

- [ ] add unit tests
- [ ] try search for some similar images buried in the photolibrary

<details><summary><h2>Screenshots</h2></summary>

All airliners
![image](https://github.com/user-attachments/assets/3dea3e6d-4c4c-4a49-8419-a93865c7d31b)


Prop Planes + A bunch of other similar attributes
![image](https://github.com/user-attachments/assets/f76a22b7-2a4c-4f7d-8c32-d42c1ec02539)

...
![image](https://github.com/user-attachments/assets/ef0f19d5-3933-4e89-b818-8723e88424c3)


</details>

No api endpoint changes, uses the smartsearch api

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
- [ ] Experiement with allowing search terms embeddings to be appended to query
