### PR TITLE
chore(web): update to newer persisted store package name

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,8 +33,8 @@
         "socket.io-client": "~4.8.0",
         "svelte-gestures": "^5.1.3",
         "svelte-i18n": "^4.0.1",
-        "svelte-local-storage-store": "^0.6.4",
         "svelte-maplibre": "^1.0.0",
+        "svelte-persisted-store": "^0.12.0",
         "thumbhash": "^0.1.1"
       },
       "devDependencies": {
@@ -8877,17 +8877,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
-    "node_modules/svelte-local-storage-store": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/svelte-local-storage-store/-/svelte-local-storage-store-0.6.4.tgz",
-      "integrity": "sha512-45WoY2vSGPQM1sIQJ9jTkPPj20hYeqm+af6mUGRFSPP5WglZf36YYoZqwmZZ8Dt/2SU8lem+BTA8/Z/8TkqNLg==",
-      "engines": {
-        "node": ">=0.14"
-      },
-      "peerDependencies": {
-        "svelte": "^3.48.0 || >4.0.0"
-      }
-    },
     "node_modules/svelte-maplibre": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svelte-maplibre/-/svelte-maplibre-1.0.0.tgz",
@@ -8939,6 +8928,18 @@
       },
       "peerDependencies": {
         "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.1"
+      }
+    },
+    "node_modules/svelte-persisted-store": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/svelte-persisted-store/-/svelte-persisted-store-0.12.0.tgz",
+      "integrity": "sha512-BdBQr2SGSJ+rDWH8/aEV5GthBJDapVP0GP3fuUCA7TjYG5ctcB+O9Mj9ZC0+Jo1oJMfZUd1y9H68NFRR5MyIJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.14"
+      },
+      "peerDependencies": {
+        "svelte": "^3.48.0 || ^4 || ^5"
       }
     },
     "node_modules/svelte-toolbelt": {

--- a/web/package.json
+++ b/web/package.json
@@ -48,8 +48,8 @@
     "socket.io-client": "~4.8.0",
     "svelte-gestures": "^5.1.3",
     "svelte-i18n": "^4.0.1",
-    "svelte-local-storage-store": "^0.6.4",
     "svelte-maplibre": "^1.0.0",
+    "svelte-persisted-store": "^0.12.0",
     "thumbhash": "^0.1.1"
   },
   "devDependencies": {

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -1,7 +1,7 @@
 import { browser } from '$app/environment';
 import { Theme, defaultLang } from '$lib/constants';
 import { getPreferredLocale } from '$lib/utils/i18n';
-import { persisted } from 'svelte-local-storage-store';
+import { persisted } from 'svelte-persisted-store';
 import { get } from 'svelte/store';
 
 export interface ThemeSetting {

--- a/web/src/lib/stores/search.store.ts
+++ b/web/src/lib/stores/search.store.ts
@@ -1,4 +1,4 @@
-import { persisted } from 'svelte-local-storage-store';
+import { persisted } from 'svelte-persisted-store';
 import { writable } from 'svelte/store';
 
 export const savedSearchTerms = persisted<string[]>('search-terms', [], {});

--- a/web/src/lib/stores/slideshow.store.ts
+++ b/web/src/lib/stores/slideshow.store.ts
@@ -1,4 +1,4 @@
-import { persisted } from 'svelte-local-storage-store';
+import { persisted } from 'svelte-persisted-store';
 import { writable } from 'svelte/store';
 
 export enum SlideshowState {


### PR DESCRIPTION
## Description

http://npmjs.com/package/svelte-local-storage-store says:

> Package has been renamed to [svelte-presisted-store](https://www.npmjs.com/package/svelte-persisted-store)

## How Has This Been Tested?

- did a search
- played slideshow

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)