### PR TITLE
fix(web): prevent combo box dropdowns from staying open when clicking on labels

### DIFF
--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" module>
+  import { get } from 'svelte/store';
+
   export type ComboBoxOption = {
     id?: string;
     label: string;
@@ -28,7 +30,6 @@
   import { generateId } from '$lib/utils/generate-id';
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import { t } from 'svelte-i18n';
-  import { get } from 'svelte/store';
 
   interface Props {
     label: string;
@@ -282,7 +283,6 @@
       class:cursor-pointer={!isActive}
       class="immich-form-input text-sm text-left w-full !pr-12 transition-all"
       id={inputId}
-      onclick={activate}
       onfocus={activate}
       oninput={onInput}
       role="combobox"
@@ -366,7 +366,7 @@
           aria-disabled={true}
           class="text-left w-full px-4 py-2 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-default aria-selected:bg-gray-200 aria-selected:dark:bg-gray-700"
           id={`${listboxId}-${0}`}
-          onclick={() => closeDropdown()}
+          onclick={closeDropdown}
         >
           {allowCreate ? searchQuery : $t('no_results')}
         </li>


### PR DESCRIPTION
## Description
Double clicking on a combobox label caused its dropdown to stay open, letting you continue clicking on other combo boxes to open more than one dropdown at once.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Click search options on Photos, double click Country, double click State - only State dropdown is open

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before:
![image](https://github.com/user-attachments/assets/2e83be04-49d0-469e-bb8b-2ad8a5ce35bc)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
