### PR TITLE
feat(server): consider `JpgFromRaw2` tag for embedded previews

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -43,14 +43,18 @@ export class MediaRepository {
 
   async extract(input: string, output: string): Promise<boolean> {
     try {
-      await exiftool.extractJpgFromRaw(input, output);
+      await exiftool.extractBinaryTag('JpgFromRaw2', input, output);
     } catch (error: any) {
-      this.logger.debug('Could not extract JPEG from image, trying preview', error.message);
       try {
-        await exiftool.extractPreview(input, output);
+        await exiftool.extractJpgFromRaw(input, output);
       } catch (error: any) {
-        this.logger.debug('Could not extract preview from image', error.message);
-        return false;
+        this.logger.debug('Could not extract JPEG from image, trying preview', error.message);
+        try {
+          await exiftool.extractPreview(input, output);
+        } catch (error: any) {
+          this.logger.debug('Could not extract preview from image', error.message);
+          return false;
+        }
       }
     }
 

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -44,7 +44,7 @@ export class MediaRepository {
   async extract(input: string, output: string): Promise<boolean> {
     try {
       await exiftool.extractBinaryTag('JpgFromRaw2', input, output);
-    } catch (error: any) {
+    } catch {
       try {
         await exiftool.extractJpgFromRaw(input, output);
       } catch (error: any) {


### PR DESCRIPTION
## Description

Some cameras have a higher quality embedded preview in this tag, so this PR prefers it when it's available.

## How Has This Been Tested?

Tested with a sample RW2 image containing both `JpgFromRaw` and `JpgFromRaw2`, confirming that the latter was used.