### PR TITLE
feat: improve performance for GET /api/album & /api/album/:id 

### DIFF
--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -201,19 +201,23 @@ order by
 
 -- AlbumRepository.getMetadataForIds
 select
-  "albums"."id" as "albumId",
-  min("assets"."localDateTime") as "startDate",
-  max("assets"."localDateTime") as "endDate",
+  "album_assets"."albumsId" as "albumId",
+  min(
+    ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)::date
+  ) as "startDate",
+  max(
+    ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)::date
+  ) as "endDate",
+  max("assets"."updatedAt") as "lastModifiedAssetTimestamp",
   count("assets"."id")::int as "assetCount"
 from
-  "albums"
-  inner join "albums_assets_assets" as "album_assets" on "album_assets"."albumsId" = "albums"."id"
-  inner join "assets" on "assets"."id" = "album_assets"."assetsId"
+  "assets"
+  inner join "albums_assets_assets" as "album_assets" on "album_assets"."assetsId" = "assets"."id"
 where
-  "albums"."id" in ($1)
+  "album_assets"."albumsId" in ($1)
   and "assets"."deletedAt" is null
 group by
-  "albums"."id"
+  "album_assets"."albumsId"
 
 -- AlbumRepository.getOwned
 select

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -142,9 +142,9 @@ export class AlbumRepository {
           eb.fn
             .min<any>(
               sql`
-              ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
-                                                  ::date
-            `,
+                ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
+                                                    ::date
+              `,
             )
             .as('startDate'),
         )
@@ -152,9 +152,9 @@ export class AlbumRepository {
           eb.fn
             .max<any>(
               sql`
-              ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
-                                                  ::date
-            `,
+                ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
+                                                    ::date
+              `,
             )
             .as('endDate'),
         )
@@ -163,17 +163,17 @@ export class AlbumRepository {
           eb.fn
             .max<any>(
               sql`
-              ("assets"."updatedAt" AT TIME ZONE 'UTC'::text)
-                                                  ::date
-            `,
+                ("assets"."updatedAt" AT TIME ZONE 'UTC'::text)
+                                                    ::date
+              `,
             )
             .as('lastModifiedAssetTimestamp'),
         )
         .select((eb) =>
           sql<number>`
-          ${eb.fn.count('assets.id')}
-                ::int
-        `.as('assetCount'),
+            ${eb.fn.count('assets.id')}
+                  ::int
+          `.as('assetCount'),
         )
         .where('album_assets.albumsId', 'in', ids)
         .where('assets.deletedAt', 'is', null)

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -138,43 +138,11 @@ export class AlbumRepository {
         .selectFrom('assets')
         .innerJoin('albums_assets_assets as album_assets', 'album_assets.assetsId', 'assets.id')
         .select('album_assets.albumsId as albumId')
-        .select((eb) =>
-          eb.fn
-            .min<any>(
-              sql`
-                ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
-                                                    ::date
-              `,
-            )
-            .as('startDate'),
-        )
-        .select((eb) =>
-          eb.fn
-            .max<any>(
-              sql`
-                ("assets"."localDateTime" AT TIME ZONE 'UTC'::text)
-                                                    ::date
-              `,
-            )
-            .as('endDate'),
-        )
+        .select((eb) => eb.fn.min(sql<Date>`("assets"."localDateTime" AT TIME ZONE 'UTC'::text)::date`).as('startDate'))
+        .select((eb) => eb.fn.max(sql<Date>`("assets"."localDateTime" AT TIME ZONE 'UTC'::text)::date`).as('endDate'))
         // lastModifiedAssetTimestamp is only used in mobile app, please remove if not need
-        .select((eb) =>
-          eb.fn
-            .max<any>(
-              sql`
-                ("assets"."updatedAt" AT TIME ZONE 'UTC'::text)
-                                                    ::date
-              `,
-            )
-            .as('lastModifiedAssetTimestamp'),
-        )
-        .select((eb) =>
-          sql<number>`
-            ${eb.fn.count('assets.id')}
-                  ::int
-          `.as('assetCount'),
-        )
+        .select((eb) => eb.fn.max('assets.updatedAt').as('lastModifiedAssetTimestamp'))
+        .select((eb) => sql<number>`${eb.fn.count('assets.id')}::int`.as('assetCount'))
         .where('album_assets.albumsId', 'in', ids)
         .where('assets.deletedAt', 'is', null)
         .groupBy('album_assets.albumsId')

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -728,17 +728,6 @@ export class AssetRepository {
     return paginationHelper(items as any as AssetEntity[], pagination.take);
   }
 
-  getLastUpdatedAssetForAlbumId(albumId: string): Promise<AssetEntity | undefined> {
-    return this.db
-      .selectFrom('assets')
-      .selectAll('assets')
-      .innerJoin('albums_assets_assets', 'assets.id', 'albums_assets_assets.assetsId')
-      .where('albums_assets_assets.albumsId', '=', asUuid(albumId))
-      .orderBy('updatedAt', 'desc')
-      .limit(1)
-      .executeTakeFirst() as Promise<AssetEntity | undefined>;
-  }
-
   getStatistics(ownerId: string, { isArchived, isFavorite, isTrashed }: AssetStatsOptions): Promise<AssetStats> {
     return this.db
       .selectFrom('assets')

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -41,8 +41,20 @@ describe(AlbumService.name, () => {
     it('gets list of albums for auth user', async () => {
       mocks.album.getOwned.mockResolvedValue([albumStub.empty, albumStub.sharedWithUser]);
       mocks.album.getMetadataForIds.mockResolvedValue([
-        { albumId: albumStub.empty.id, assetCount: 0, startDate: null, endDate: null },
-        { albumId: albumStub.sharedWithUser.id, assetCount: 0, startDate: null, endDate: null },
+        {
+          albumId: albumStub.empty.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
+        {
+          albumId: albumStub.sharedWithUser.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
       ]);
 
       const result = await sut.getAll(authStub.admin, {});
@@ -59,6 +71,7 @@ describe(AlbumService.name, () => {
           assetCount: 1,
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
+          lastModifiedAssetTimestamp: new Date('1970-01-01'),
         },
       ]);
 
@@ -71,7 +84,13 @@ describe(AlbumService.name, () => {
     it('gets list of albums that are shared', async () => {
       mocks.album.getShared.mockResolvedValue([albumStub.sharedWithUser]);
       mocks.album.getMetadataForIds.mockResolvedValue([
-        { albumId: albumStub.sharedWithUser.id, assetCount: 0, startDate: null, endDate: null },
+        {
+          albumId: albumStub.sharedWithUser.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
       ]);
 
       const result = await sut.getAll(authStub.admin, { shared: true });
@@ -83,7 +102,13 @@ describe(AlbumService.name, () => {
     it('gets list of albums that are NOT shared', async () => {
       mocks.album.getNotShared.mockResolvedValue([albumStub.empty]);
       mocks.album.getMetadataForIds.mockResolvedValue([
-        { albumId: albumStub.empty.id, assetCount: 0, startDate: null, endDate: null },
+        {
+          albumId: albumStub.empty.id,
+          assetCount: 0,
+          startDate: null,
+          endDate: null,
+          lastModifiedAssetTimestamp: null,
+        },
       ]);
 
       const result = await sut.getAll(authStub.admin, { shared: false });
@@ -101,6 +126,7 @@ describe(AlbumService.name, () => {
         assetCount: 1,
         startDate: new Date('1970-01-01'),
         endDate: new Date('1970-01-01'),
+        lastModifiedAssetTimestamp: new Date('1970-01-01'),
       },
     ]);
 
@@ -447,6 +473,7 @@ describe(AlbumService.name, () => {
           assetCount: 1,
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
+          lastModifiedAssetTimestamp: new Date('1970-01-01'),
         },
       ]);
 
@@ -468,6 +495,7 @@ describe(AlbumService.name, () => {
           assetCount: 1,
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
+          lastModifiedAssetTimestamp: new Date('1970-01-01'),
         },
       ]);
 
@@ -489,6 +517,7 @@ describe(AlbumService.name, () => {
           assetCount: 1,
           startDate: new Date('1970-01-01'),
           endDate: new Date('1970-01-01'),
+          lastModifiedAssetTimestamp: new Date('1970-01-01'),
         },
       ]);
 

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -58,19 +58,15 @@ export class AlbumService extends BaseService {
       albumMetadata[metadata.albumId] = metadata;
     }
 
-    return Promise.all(
-      albums.map(async (album) => {
-        const lastModifiedAsset = await this.assetRepository.getLastUpdatedAssetForAlbumId(album.id);
-        return {
-          ...mapAlbumWithoutAssets(album),
-          sharedLinks: undefined,
-          startDate: albumMetadata[album.id]?.startDate ?? undefined,
-          endDate: albumMetadata[album.id]?.endDate ?? undefined,
-          assetCount: albumMetadata[album.id]?.assetCount ?? 0,
-          lastModifiedAssetTimestamp: lastModifiedAsset?.updatedAt,
-        };
-      }),
-    );
+    return albums.map((album) => ({
+      ...mapAlbumWithoutAssets(album),
+      sharedLinks: undefined,
+      startDate: albumMetadata[album.id]?.startDate ?? undefined,
+      endDate: albumMetadata[album.id]?.endDate ?? undefined,
+      assetCount: albumMetadata[album.id]?.assetCount ?? 0,
+      // lastModifiedAssetTimestamp is only used in mobile app, please remove if not need
+      lastModifiedAssetTimestamp: albumMetadata[album.id]?.lastModifiedAssetTimestamp ?? undefined,
+    }));
   }
 
   async get(auth: AuthDto, id: string, dto: AlbumInfoDto): Promise<AlbumResponseDto> {

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -75,14 +75,13 @@ export class AlbumService extends BaseService {
     const withAssets = dto.withoutAssets === undefined ? true : !dto.withoutAssets;
     const album = await this.findOrFail(id, { withAssets });
     const [albumMetadataForIds] = await this.albumRepository.getMetadataForIds([album.id]);
-    const lastModifiedAsset = await this.assetRepository.getLastUpdatedAssetForAlbumId(album.id);
 
     return {
       ...mapAlbum(album, withAssets, auth),
       startDate: albumMetadataForIds?.startDate ?? undefined,
       endDate: albumMetadataForIds?.endDate ?? undefined,
       assetCount: albumMetadataForIds?.assetCount ?? 0,
-      lastModifiedAssetTimestamp: lastModifiedAsset?.updatedAt,
+      lastModifiedAssetTimestamp: albumMetadataForIds?.lastModifiedAssetTimestamp ?? undefined,
     };
   }
 

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -21,7 +21,6 @@ export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetReposi
     getByChecksums: vitest.fn(),
     getUploadAssetIdByChecksum: vitest.fn(),
     getRandom: vitest.fn(),
-    getLastUpdatedAssetForAlbumId: vitest.fn(),
     getAll: vitest.fn().mockResolvedValue({ items: [], hasNextPage: false }),
     getAllByDeviceId: vitest.fn(),
     getLivePhotoCount: vitest.fn(),


### PR DESCRIPTION
## Description

Performance improvement for GET /api/albums when there are >10K assets in multiple albums

This is a significant UX improvment for first load page performance and repeated navigation into and out of albums (depending on browser caching)

### Query Times
Average BEFORE 1.78s 
Average AFTER 0.67s
Difference -1.11s

Improvement 62.3%

From:
![image](https://github.com/user-attachments/assets/3b776af7-d564-4fbd-94c1-cbc961252e53)

To:
![image](https://github.com/user-attachments/assets/a188e95e-5b4d-4178-8b4e-d304e7cdcef1)
Fixes # (issue)

## How Has This Been Tested?

Find a server with albums at least 2-3 albums with over 30k assets in each

Remember to disable browser cache just in case
![image](https://github.com/user-attachments/assets/bfa53cf2-4414-410c-a571-3323e48a521b)

- [x] Load the albums page, go into album page, come back. There should be a noticable reduction in lag

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

Thanks to @mertalev for helping with more indepth analysis of SQL queries! :)