### PR TITLE
fix(server): allow trailing whitespace in filename

### DIFF
--- a/e2e/src/api/specs/library.e2e-spec.ts
+++ b/e2e/src/api/specs/library.e2e-spec.ts
@@ -306,6 +306,26 @@ describe('/libraries', () => {
       expect(assets.count).toBe(1);
     });
 
+    const whitespaces = [' ', '  ', '       '];
+    it.each(whitespaces)('should import new asset with trailing whitespace %s in filename', async (whitespace) => {
+      const library = await utils.createLibrary(admin.accessToken, {
+        ownerId: admin.userId,
+        importPaths: [`${testAssetDirInternal}/temp/folder/`],
+      });
+
+      utils.createImageFile(`${testAssetDir}/temp/folder/assetA.png${whitespace}`);
+
+      await utils.scan(admin.accessToken, library.id);
+
+      const { assets } = await utils.searchAssets(admin.accessToken, { libraryId: library.id });
+
+      expect(assets.items).toEqual(
+        expect.arrayContaining([expect.objectContaining({ originalPath: expect.stringContaining(`assetA.png`) })]),
+      );
+
+      rmSync(`${testAssetDir}/temp/folder`, { recursive: true, force: true });
+    });
+
     it('should process metadata and thumbnails for external asset', async () => {
       const library = await utils.createLibrary(admin.accessToken, {
         ownerId: admin.userId,

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -233,7 +233,10 @@ export class StorageRepository {
 
   private asGlob(pathToCrawl: string): string {
     const escapedPath = escapePath(pathToCrawl).replaceAll('"', '["]').replaceAll("'", "[']").replaceAll('`', '[`]');
-    const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
+    const extensions = `*{${mimeTypes
+      .getSupportedFileExtensions()
+      .map((extension) => `${extension}*( )`)
+      .join(',')}}`;
     return `${escapedPath}/**/${extensions}`;
   }
 }


### PR DESCRIPTION
A discord user was unable to import external library assets. It turns out there were filenames "file.jpg " with spaces after the extension.

This allows such files to be imported in external libraries.