### PR TITLE
fix(web): slow add-to-album modal load, improve album navigation load speed 

### DIFF
--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -44,6 +44,7 @@
   import { onMount, type Snippet } from 'svelte';
   import { t } from 'svelte-i18n';
   import { run } from 'svelte/legacy';
+  import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
 
   interface Props {
     ownedAlbums?: AlbumResponseDto[];
@@ -293,20 +294,6 @@
     await Promise.allSettled(albumsToRemove.map((album) => handleDeleteAlbum(album)));
   };
 
-  const updateAlbumInfo = (album: AlbumResponseDto) => {
-    ownedAlbums[ownedAlbums.findIndex(({ id }) => id === album.id)] = album;
-    sharedAlbums[sharedAlbums.findIndex(({ id }) => id === album.id)] = album;
-  };
-
-  const updateRecentAlbumInfo = (album: AlbumResponseDto) => {
-    for (const cachedAlbum of userInteraction.recentAlbums || []) {
-      if (cachedAlbum.id === album.id) {
-        Object.assign(cachedAlbum, { ...cachedAlbum, ...album });
-        break;
-      }
-    }
-  };
-
   const successEditAlbumInfo = (album: AlbumResponseDto) => {
     albumToEdit = null;
 
@@ -321,8 +308,7 @@
       },
     });
 
-    updateAlbumInfo(album);
-    updateRecentAlbumInfo(album);
+    albumListingStore.updateAlbumLocally(album);
   };
 
   const handleAddUsers = async (albumUsers: AlbumUserAddDto[]) => {
@@ -336,7 +322,7 @@
           albumUsers,
         },
       });
-      updateAlbumInfo(album);
+      albumListingStore.updateAlbumLocally(album);
     } catch (error) {
       handleError(error, $t('errors.unable_to_add_album_users'));
     } finally {
@@ -347,7 +333,7 @@
   const handleSharedLinkCreated = (album: AlbumResponseDto) => {
     album.shared = true;
     album.hasSharedLink = true;
-    updateAlbumInfo(album);
+    albumListingStore.updateAlbumLocally(album);
   };
 
   const openShareModal = async () => {

--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -365,11 +365,7 @@
 </script>
 
 {#if isLoading}
-  <div
-    class="absolute flex place-items-center place-content-center top-5 right-5 h-8 pointer-events-none"
-    in:fade
-    out:fade
-  >
+  <div class="absolute top-7 right-5 pointer-events-none" in:fade out:fade>
     <LoadingSpinner />
   </div>
 {/if}
@@ -401,7 +397,7 @@
     <!-- Album Table -->
     <AlbumsTable {groupedAlbums} {albumGroupOption} onShowContextMenu={showAlbumContextMenu} />
   {/if}
-{:else}
+{:else if !isLoading}
   <!-- Empty Message -->
   {@render empty?.()}
 {/if}

--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -14,6 +14,7 @@
   import AlbumShareModal from '$lib/modals/AlbumShareModal.svelte';
   import QrCodeModal from '$lib/modals/QrCodeModal.svelte';
   import SharedLinkCreateModal from '$lib/modals/SharedLinkCreateModal.svelte';
+  import LoadingSpinner from '$lib/components/shared-components/loading-spinner.svelte';
   import {
     AlbumFilter,
     AlbumGroupBy,
@@ -52,6 +53,7 @@
     allowEdit?: boolean;
     showOwner?: boolean;
     albumGroupIds?: string[];
+    isLoading?: boolean;
     empty?: Snippet;
   }
 
@@ -63,6 +65,7 @@
     allowEdit = false,
     showOwner = false,
     albumGroupIds = $bindable([]),
+    isLoading = false,
     empty,
   }: Props = $props();
 
@@ -374,6 +377,16 @@
     }
   };
 </script>
+
+{#if isLoading}
+  <div
+    class="absolute flex place-items-center place-content-center top-5 right-5 h-8 pointer-events-none"
+    in:fade
+    out:fade
+  >
+    <LoadingSpinner />
+  </div>
+{/if}
 
 {#if albums.length > 0}
   {#if userSettings.view === AlbumViewMode.Cover}

--- a/web/src/lib/components/shared-components/album-selection/album-selection-modal.svelte
+++ b/web/src/lib/components/shared-components/album-selection/album-selection-modal.svelte
@@ -6,13 +6,13 @@
     isSelectableRowType,
   } from '$lib/components/shared-components/album-selection/album-selection-utils';
   import FullScreenModal from '$lib/components/shared-components/full-screen-modal.svelte';
+  import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
   import { albumViewSettings } from '$lib/stores/preferences.store';
-  import { type AlbumResponseDto, getAllAlbums } from '@immich/sdk';
+  import { type AlbumResponseDto } from '@immich/sdk';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import AlbumListItem from '../../asset-viewer/album-list-item.svelte';
   import NewAlbumListItem from './new-album-list-item.svelte';
-  import { albumListingStore } from '$lib/stores/album-listing.store';
 
   let search = $state('');
   let selectedRowIndex: number = $state(-1);

--- a/web/src/lib/components/shared-components/album-selection/album-selection-modal.svelte
+++ b/web/src/lib/components/shared-components/album-selection/album-selection-modal.svelte
@@ -16,7 +16,7 @@
 
   let { ensureLoaded: albumsEnsureLoaded, albums, isLoading } = albumListingStore;
   let recentAlbums: AlbumResponseDto[] = $derived(
-    $albums.sort((a, b) => (new Date(a.createdAt) > new Date(b.createdAt) ? -1 : 1)).slice(0, 3),
+    albums.sort((a, b) => (new Date(a.createdAt) > new Date(b.createdAt) ? -1 : 1)).slice(0, 3),
   );
 
   let search = $state('');
@@ -36,7 +36,7 @@
   });
 
   const rowConverter = new AlbumModalRowConverter(shared, $albumViewSettings.sortBy, $albumViewSettings.sortOrder);
-  const albumModalRows = $derived(rowConverter.toModalRows(search, recentAlbums, $albums, selectedRowIndex));
+  const albumModalRows = $derived(rowConverter.toModalRows(search, recentAlbums, albums, selectedRowIndex));
   const selectableRowCount = $derived(albumModalRows.filter((row) => isSelectableRowType(row.type)).length);
 
   const onkeydown = (e: KeyboardEvent) => {
@@ -83,7 +83,7 @@
 
 <FullScreenModal title={shared ? $t('add_to_shared_album') : $t('add_to_album')} {onClose}>
   <div class="mb-2 flex max-h-[400px] flex-col">
-    {#if $isLoading}
+    {#if isLoading}
       <!-- eslint-disable-next-line svelte/require-each-key -->
       {#each { length: 3 } as _}
         <div class="flex animate-pulse gap-4 px-6 py-2">

--- a/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
+++ b/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
@@ -1,5 +1,6 @@
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import RecentAlbums from '$lib/components/shared-components/side-bar/recent-albums.svelte';
+import type { AlbumResponseDto } from '@immich/sdk';
 import { albumFactory } from '@test-data/factories/album-factory';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
@@ -13,11 +14,13 @@ describe('RecentAlbums component', () => {
       albumFactory.build({ updatedAt: '2024-01-09T00:00:00Z' }),
     ];
 
-    sdkMock.getAllAlbums.mockImplementation(async ({ shared }) => {
-      if (shared) {
-        return [];
-      }
-      return [...albums];
+    sdkMock.getAllAlbums.mockImplementation(({ shared }): Promise<AlbumResponseDto[]> => {
+      return new Promise<AlbumResponseDto[]>((res) => {
+        if (shared) {
+          res([]);
+        }
+        res([...albums]);
+      });
     });
     render(RecentAlbums);
     await tick();

--- a/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
+++ b/web/src/lib/components/shared-components/side-bar/recent-albums.spec.ts
@@ -13,10 +13,16 @@ describe('RecentAlbums component', () => {
       albumFactory.build({ updatedAt: '2024-01-09T00:00:00Z' }),
     ];
 
-    sdkMock.getAllAlbums.mockResolvedValueOnce([...albums]);
+    sdkMock.getAllAlbums.mockImplementation(async ({ shared }) => {
+      if (shared) {
+        return [];
+      }
+      return [...albums];
+    });
     render(RecentAlbums);
+    await tick();
 
-    expect(sdkMock.getAllAlbums).toBeCalledTimes(1);
+    expect(sdkMock.getAllAlbums).toBeCalledTimes(2);
     await tick();
 
     const links = screen.getAllByRole('link');

--- a/web/src/lib/components/shared-components/side-bar/recent-albums.svelte
+++ b/web/src/lib/components/shared-components/side-bar/recent-albums.svelte
@@ -1,29 +1,22 @@
 <script lang="ts">
   import { userInteraction } from '$lib/stores/user.svelte';
   import { getAssetThumbnailUrl } from '$lib/utils';
+  import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
   import { handleError } from '$lib/utils/handle-error';
   import { getAllAlbums, type AlbumResponseDto } from '@immich/sdk';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
 
-  let albums: AlbumResponseDto[] = $state([]);
-
   onMount(async () => {
-    if (userInteraction.recentAlbums) {
-      albums = userInteraction.recentAlbums;
-      return;
-    }
     try {
-      const allAlbums = await getAllAlbums({});
-      albums = allAlbums.sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1)).slice(0, 3);
-      userInteraction.recentAlbums = albums;
+      await albumListingStore.ensureLoaded();
     } catch (error) {
       handleError(error, $t('failed_to_load_assets'));
     }
   });
 </script>
 
-{#each albums as album (album.id)}
+{#each albumListingStore.recentAlbums as album (album.id)}
   <a
     href={'/albums/' + album.id}
     title={album.albumName}

--- a/web/src/lib/stores/album-listing.store.svelte.ts
+++ b/web/src/lib/stores/album-listing.store.svelte.ts
@@ -65,10 +65,10 @@ function createAlbumListingStore() {
     albums: readonly(albums),
     sharedAlbums: readonly(sharedAlbums),
     isLoading: readonly(isLoading),
-    getAlbums: getAlbums,
-    refetchAlbums: refetchAlbums,
-    ensureLoaded: ensureLoaded,
-    reset: reset,
+    getAlbums,
+    refetchAlbums,
+    ensureLoaded,
+    reset,
   };
 }
 

--- a/web/src/lib/stores/album-listing.store.svelte.ts
+++ b/web/src/lib/stores/album-listing.store.svelte.ts
@@ -8,76 +8,71 @@ import { getAllAlbums, type AlbumResponseDto } from '@immich/sdk';
 type AlbumsListingResponse = {
   albums: AlbumResponseDto[];
   sharedAlbums: AlbumResponseDto[];
+  recentAlbums: AlbumResponseDto[];
   isCached: boolean;
 };
 
-function createAlbumListingStore() {
-  let isLoadedAtLeastOnce = $state(false);
-  let isLoading = $state(false);
-  let albums = $state<AlbumResponseDto[]>([]);
-  let sharedAlbums = $state<AlbumResponseDto[]>([]);
+class AlbumListingStore {
+  isLoadedAtLeastOnce = $state(false);
+  isLoading = $state(false);
+  albums = $state<AlbumResponseDto[]>([]);
+  sharedAlbums = $state<AlbumResponseDto[]>([]);
+  recentAlbums = $state<AlbumResponseDto[]>([]);
 
-  // data must be cleared on logout
-  const reset = () => {
-    albums = [];
-    sharedAlbums = [];
-    isLoadedAtLeastOnce = false;
-    isLoading = false;
-  };
-
-  const fetchJob = () =>
-    Promise.all([getAllAlbums({}), getAllAlbums({ shared: true })]).then(([_albums, _sharedAlbums]) => {
-      albums = _albums;
-      sharedAlbums = _sharedAlbums;
+  async #parallelFetch() {
+    return Promise.all([getAllAlbums({}), getAllAlbums({ shared: true })]).then(([_albums, _sharedAlbums]) => {
+      this.albums = _albums;
+      this.recentAlbums = _albums.sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1)).slice(0, 3);
+      this.sharedAlbums = _sharedAlbums;
       return [_albums, _sharedAlbums];
     });
+  }
 
-  const refetchAlbums = async (): Promise<void> => {
-    if (isLoading) {
+  async refetchAlbums(): Promise<void> {
+    if (this.isLoading) {
       return;
     }
-    isLoading = true;
+    this.isLoading = true;
     try {
-      await fetchJob();
-      isLoadedAtLeastOnce = true;
+      await this.#parallelFetch();
+      this.isLoadedAtLeastOnce = true;
     } finally {
-      isLoading = false;
+      this.isLoading = false;
     }
-  };
+  }
 
-  const getAlbums = async (): Promise<AlbumsListingResponse> => {
-    if (isLoadedAtLeastOnce) {
+  public updateAlbumLocally(album: AlbumResponseDto) {
+    this.albums[this.albums.findIndex(({ id }) => id === album.id)] = album;
+    this.sharedAlbums[this.sharedAlbums.findIndex(({ id }) => id === album.id)] = album;
+  }
+
+  public async getAlbums(): Promise<AlbumsListingResponse> {
+    if (this.isLoadedAtLeastOnce) {
       return {
-        albums: $state.snapshot(albums),
-        sharedAlbums: $state.snapshot(sharedAlbums),
+        albums: this.albums,
+        sharedAlbums: this.sharedAlbums,
+        recentAlbums: this.recentAlbums,
         isCached: true,
       };
     }
-    await refetchAlbums();
+    await this.refetchAlbums();
     return {
-      albums: $state.snapshot(albums),
-      sharedAlbums: $state.snapshot(sharedAlbums),
+      albums: this.albums,
+      sharedAlbums: this.sharedAlbums,
+      recentAlbums: this.recentAlbums,
       isCached: false,
     };
-  };
+  }
 
-  const ensureLoaded = () => getAlbums();
+  public ensureLoaded = () => this.getAlbums();
 
-  return {
-    get albums() {
-      return $state.snapshot(albums);
-    },
-    get sharedAlbums() {
-      return $state.snapshot(sharedAlbums);
-    },
-    get isLoading() {
-      return $state.snapshot(isLoading);
-    },
-    getAlbums,
-    refetchAlbums,
-    ensureLoaded,
-    reset,
-  };
+  // data must be cleared on logout
+  public reset() {
+    this.albums = [];
+    this.sharedAlbums = [];
+    this.isLoadedAtLeastOnce = false;
+    this.isLoading = false;
+  }
 }
 
-export const albumListingStore = createAlbumListingStore();
+export const albumListingStore = new AlbumListingStore();

--- a/web/src/lib/stores/album-listing.store.ts
+++ b/web/src/lib/stores/album-listing.store.ts
@@ -1,0 +1,75 @@
+import { getAllAlbums, type AlbumResponseDto } from '@immich/sdk';
+import { get, readonly, writable } from 'svelte/store';
+
+// Album Listing Store
+// For use in ui elements such as
+// - +Page /albums (loads both shared and owned albums)
+// - AddToAlbumAction's AlbumSelectionModal
+
+type AlbumsListingResponse = {
+  albums: AlbumResponseDto[];
+  sharedAlbums: AlbumResponseDto[];
+  isCached: boolean;
+};
+
+function createAlbumListingStore() {
+  const isLoadedAtLeastOnce = writable<boolean>(false);
+  const isLoading = writable<boolean>(false);
+  const albums = writable<AlbumResponseDto[]>([]);
+  const sharedAlbums = writable<AlbumResponseDto[]>([]);
+
+  // data must be cleared on logout
+  const reset = () => {
+    albums.set([]);
+    sharedAlbums.set([]);
+    isLoadedAtLeastOnce.set(false);
+    isLoading.set(false);
+  };
+
+  const fetchJob = () =>
+    Promise.all([getAllAlbums({}), getAllAlbums({ shared: true })]).then(([_albums, _sharedAlbums]) => {
+      albums.set(_albums);
+      sharedAlbums.set(_sharedAlbums);
+      return [_albums, _sharedAlbums];
+    });
+
+  const refetchAlbums = async (): Promise<AlbumsListingResponse> => {
+    isLoading.set(true);
+    try {
+      const [_albums, _sharedAlbums] = await fetchJob();
+      isLoadedAtLeastOnce.set(true);
+      return {
+        albums: _albums,
+        sharedAlbums: _sharedAlbums,
+        isCached: false,
+      };
+    } finally {
+      isLoading.set(false);
+    }
+  };
+
+  const getAlbums = async (): Promise<AlbumsListingResponse> => {
+    if (get(isLoadedAtLeastOnce)) {
+      return {
+        albums: get(albums),
+        sharedAlbums: get(sharedAlbums),
+        isCached: true,
+      };
+    }
+    return refetchAlbums();
+  };
+
+  const ensureLoaded = () => getAlbums();
+
+  return {
+    albums: readonly(albums),
+    sharedAlbums: readonly(sharedAlbums),
+    isLoading: readonly(isLoading),
+    getAlbums: getAlbums,
+    refetchAlbums: refetchAlbums,
+    ensureLoaded: ensureLoaded,
+    reset: reset,
+  };
+}
+
+export const albumListingStore = createAlbumListingStore();

--- a/web/src/lib/stores/user.store.ts
+++ b/web/src/lib/stores/user.store.ts
@@ -2,6 +2,7 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import { purchaseStore } from '$lib/stores/purchase.store';
 import { type UserAdminResponseDto, type UserPreferencesResponseDto } from '@immich/sdk';
 import { writable } from 'svelte/store';
+import { albumListingStore } from '$lib/stores/album-listing.store';
 
 export const user = writable<UserAdminResponseDto>();
 export const preferences = writable<UserPreferencesResponseDto>();
@@ -14,6 +15,7 @@ export const resetSavedUser = () => {
   user.set(undefined as unknown as UserAdminResponseDto);
   preferences.set(undefined as unknown as UserPreferencesResponseDto);
   purchaseStore.setPurchaseStatus(false);
+  albumListingStore.reset();
 };
 
 eventManager.on('auth.logout', () => resetSavedUser());

--- a/web/src/lib/stores/user.store.ts
+++ b/web/src/lib/stores/user.store.ts
@@ -1,8 +1,8 @@
 import { eventManager } from '$lib/managers/event-manager.svelte';
+import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
 import { purchaseStore } from '$lib/stores/purchase.store';
 import { type UserAdminResponseDto, type UserPreferencesResponseDto } from '@immich/sdk';
 import { writable } from 'svelte/store';
-import { albumListingStore } from '$lib/stores/album-listing.store';
 
 export const user = writable<UserAdminResponseDto>();
 export const preferences = writable<UserPreferencesResponseDto>();

--- a/web/src/lib/stores/user.svelte.ts
+++ b/web/src/lib/stores/user.svelte.ts
@@ -7,14 +7,12 @@ import type {
 } from '@immich/sdk';
 
 interface UserInteractions {
-  recentAlbums?: AlbumResponseDto[];
   versions?: ServerVersionHistoryResponseDto[];
   aboutInfo?: ServerAboutResponseDto;
   serverInfo?: ServerStorageResponseDto;
 }
 
 const defaultUserInteraction: UserInteractions = {
-  recentAlbums: undefined,
   versions: undefined,
   aboutInfo: undefined,
   serverInfo: undefined,

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -40,7 +40,12 @@ import { t, type Translations } from 'svelte-i18n';
 import { get } from 'svelte/store';
 import { handleError } from './handle-error';
 
-export const addAssetsToAlbum = async (albumId: string, assetIds: string[], showNotification = true) => {
+export const addAssetsToAlbum = async (
+  albumId: string,
+  assetIds: string[],
+  showNotification = true,
+  showNavigationButton = true,
+) => {
   const result = await addAssets({
     id: albumId,
     bulkIdsDto: {
@@ -59,12 +64,15 @@ export const addAssetsToAlbum = async (albumId: string, assetIds: string[], show
         count > 0
           ? $t('assets_added_to_album_count', { values: { count } })
           : $t('assets_were_part_of_album_count', { values: { count: assetIds.length } }),
-      button: {
-        text: $t('view_album'),
-        onClick() {
-          return goto(`${AppRoute.ALBUMS}/${albumId}`);
-        },
-      },
+
+      button: showNavigationButton
+        ? {
+            text: $t('view_album'),
+            onClick() {
+              return goto(`${AppRoute.ALBUMS}/${albumId}`);
+            },
+          }
+        : undefined,
     });
   }
 };

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -11,7 +11,7 @@
   import SearchBar from '$lib/components/elements/search-bar.svelte';
   import { AppRoute } from '$lib/constants';
   import { t } from 'svelte-i18n';
-  import { albumListingStore } from '$lib/stores/album-listing.store';
+  import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
 
   interface Props {
     data: PageData;

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -11,12 +11,14 @@
   import SearchBar from '$lib/components/elements/search-bar.svelte';
   import { AppRoute } from '$lib/constants';
   import { t } from 'svelte-i18n';
+  import { albumListingStore } from '$lib/stores/album-listing.store';
 
   interface Props {
     data: PageData;
   }
 
   let { data }: Props = $props();
+  let { albums, sharedAlbums } = albumListingStore;
 
   let searchQuery = $state('');
   let albumGroups: string[] = $state([]);
@@ -44,8 +46,8 @@
   </div>
 
   <Albums
-    ownedAlbums={data.albums}
-    sharedAlbums={data.sharedAlbums}
+    ownedAlbums={$albums}
+    sharedAlbums={$sharedAlbums}
     userSettings={$albumViewSettings}
     allowEdit
     {searchQuery}

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -47,6 +47,7 @@
   <Albums
     ownedAlbums={albumListingStore.albums}
     sharedAlbums={albumListingStore.sharedAlbums}
+    isLoading={albumListingStore.isLoading}
     userSettings={$albumViewSettings}
     allowEdit
     {searchQuery}

--- a/web/src/routes/(user)/albums/+page.svelte
+++ b/web/src/routes/(user)/albums/+page.svelte
@@ -18,7 +18,6 @@
   }
 
   let { data }: Props = $props();
-  let { albums, sharedAlbums } = albumListingStore;
 
   let searchQuery = $state('');
   let albumGroups: string[] = $state([]);
@@ -46,8 +45,8 @@
   </div>
 
   <Albums
-    ownedAlbums={$albums}
-    sharedAlbums={$sharedAlbums}
+    ownedAlbums={albumListingStore.albums}
+    sharedAlbums={albumListingStore.sharedAlbums}
     userSettings={$albumViewSettings}
     allowEdit
     {searchQuery}

--- a/web/src/routes/(user)/albums/+page.ts
+++ b/web/src/routes/(user)/albums/+page.ts
@@ -9,8 +9,8 @@ export const load = (async () => {
   const $t = await getFormatter();
 
   if (isCached) {
-    // The album data might be old, refetch
-    // non-awaited async
+    // The album data might be old, refetch but don't wait as we have data already
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     albumListingStore.refetchAlbums();
   }
 

--- a/web/src/routes/(user)/albums/+page.ts
+++ b/web/src/routes/(user)/albums/+page.ts
@@ -1,4 +1,4 @@
-import { albumListingStore } from '$lib/stores/album-listing.store';
+import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import type { PageLoad } from './$types';

--- a/web/src/routes/(user)/albums/+page.ts
+++ b/web/src/routes/(user)/albums/+page.ts
@@ -1,17 +1,20 @@
+import { albumListingStore } from '$lib/stores/album-listing.store';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
-import { getAllAlbums } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate();
-  const sharedAlbums = await getAllAlbums({ shared: true });
-  const albums = await getAllAlbums({});
+  const { isCached } = await albumListingStore.getAlbums();
   const $t = await getFormatter();
 
+  if (isCached) {
+    // The album data might be old, refetch
+    // non-awaited async
+    albumListingStore.refetchAlbums();
+  }
+
   return {
-    albums,
-    sharedAlbums,
     meta: {
       title: $t('albums'),
     },

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -206,21 +206,12 @@
   const refreshAlbum = async () => {
     album = await getAlbumInfo({ id: album.id, withoutAssets: true });
   };
+
   const handleAddAssets = async () => {
     const assetIds = timelineInteraction.selectedAssets.map((asset) => asset.id);
 
     try {
-      const results = await addAssetsToAlbum({
-        id: album.id,
-        bulkIdsDto: { ids: assetIds },
-      });
-
-      const count = results.filter(({ success }) => success).length;
-      notificationController.show({
-        type: NotificationType.Info,
-        message: $t('assets_added_count', { values: { count } }),
-      });
-
+      await addAssetsToAlbum(album.id, assetIds, true, false);
       await refreshAlbum();
 
       timelineInteraction.clearMultiselect();

--- a/web/src/routes/(user)/sharing/+page.ts
+++ b/web/src/routes/(user)/sharing/+page.ts
@@ -1,11 +1,12 @@
+import { albumListingStore } from '$lib/stores/album-listing.store.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
-import { PartnerDirection, getAllAlbums, getPartners } from '@immich/sdk';
+import { PartnerDirection, getPartners } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
 export const load = (async () => {
   await authenticate();
-  const sharedAlbums = await getAllAlbums({ shared: true });
+  const sharedAlbums = albumListingStore.sharedAlbums;
   const partners = await getPartners({ direction: PartnerDirection.SharedWith });
   const $t = await getFormatter();
 


### PR DESCRIPTION
## Problem
add-to-album modal is delayed (0.4 -> +1sec) _on every open_ because it is refreshing album data from an expensive backend aggregation query.

This is significant if the user(s) is organizing hundred of photos using the popup modal, for every image -> opening modal is slow despite data being unchanged.

## Result

We improve this by using a svelte store to loosely store data and doing associated refactorings to use the store. The implementation uses the current efforts to migrate to classed based Svelte 5 Runes (@alextran1502 suggestion for future maintainability).

![image](https://github.com/user-attachments/assets/0ac31043-edab-4aaa-9187-399c665eb853)

Recent album list calcuation has been moved to use the store as well.
![image](https://github.com/user-attachments/assets/84582c0e-d668-4366-85a4-7203be09a7e9)

The original behaviour is preserved where `for each vist of albums page do GET /api/albums + GET /api/albums?shared=true` but this is run in parallel instead if data already exists, meaning the albums page is instant to revisit.

## Summary

/albums page load performance is improved
add-to-album modal (press keyboard L when in asset-viewer) appears instantly

## How Has This Been Tested?

- [x] Deploy to prod/staging with sizable test collection
- [x] Go Albums -> AnyAlbum -> Choose Photo -> Press L to load popup, Expect this to be instant
- [x] Select an album -> delete / add assets -> return to albums list should be **instant**, then updated stats will show.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
