### PR TITLE
fix(mobile): faster device album refresh after initial sync

### DIFF
--- a/mobile/lib/services/sync.service.dart
+++ b/mobile/lib/services/sync.service.dart
@@ -737,6 +737,11 @@ class SyncService {
     album.thumbnail.value = thumb;
     try {
       await _albumRepository.create(album);
+      final int assetCount =
+          await _albumMediaRepository.getAssetCount(album.localId!);
+      await _eTagRepository.upsertAll([
+        ETag(id: album.eTagKeyAssetCount, assetCount: assetCount),
+      ]);
       _log.info("Added a new local album to DB: ${album.name}");
     } catch (e) {
       _log.severe("Failed to add new local album ${album.name} to DB", e);


### PR DESCRIPTION
## Description

- When a new device album is added to the mobile app, the ETag for the album is not stored, resulting in the next refresh being slightly slower than the subsequent refreshes. This PR addresses this by storing the ETag for newly added device albums ensuring further refreshes are fast as long as the album is not modified