### PR TITLE
fix(mobile): prefer remote orientation

### DIFF
--- a/mobile/lib/services/asset.service.dart
+++ b/mobile/lib/services/asset.service.dart
@@ -390,9 +390,7 @@ class AssetService {
   Future<double> getAspectRatio(Asset asset) async {
     if (asset.isRemote) {
       asset = await loadExif(asset);
-    }
-
-    if (asset.isLocal) {
+    } else if (asset.isLocal) {
       await asset.localAsync;
     }
 

--- a/mobile/lib/services/asset.service.dart
+++ b/mobile/lib/services/asset.service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -389,12 +388,11 @@ class AssetService {
   }
 
   Future<double> getAspectRatio(Asset asset) async {
-    // platform_manager always returns 0 for orientation on iOS, so only prefer it on Android
-    if (asset.isLocal && Platform.isAndroid) {
-      await asset.localAsync;
-    } else if (asset.isRemote) {
+    if (asset.isRemote) {
       asset = await loadExif(asset);
-    } else if (asset.isLocal) {
+    }
+
+    if (asset.isLocal) {
       await asset.localAsync;
     }
 


### PR DESCRIPTION
## Description

- If an asset is already backed up, prefer the orientation from the server as it is more likely to be correct than the one from `photo_manager`, which might return invalid values
