### PR TITLE
feat: add album start and end dates for storage template

### DIFF
--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -199,6 +199,9 @@ describe(StorageTemplateService.name, () => {
         {
           startDate: asset.fileCreatedAt,
           endDate: asset.fileCreatedAt,
+          albumId: album.id,
+          assetCount: 1,
+          lastModifiedAssetTimestamp: null,
         },
       ]);
 

--- a/server/src/services/storage-template.service.spec.ts
+++ b/server/src/services/storage-template.service.spec.ts
@@ -68,6 +68,7 @@ describe(StorageTemplateService.name, () => {
           '{{y}}/{{MMMM}}-{{dd}}/{{filename}}',
           '{{y}}/{{MM}}/{{filename}}',
           '{{y}}/{{#if album}}{{album}}{{else}}Other/{{MM}}{{/if}}/{{filename}}',
+          '{{#if album}}{{album-startDate-y}}/{{album}}{{else}}{{y}}/Other/{{MM}}{{/if}}/{{filename}}',
           '{{y}}/{{MMM}}/{{filename}}',
           '{{y}}/{{MMMM}}/{{filename}}',
           '{{y}}/{{MM}}/{{dd}}/{{filename}}',

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -54,8 +54,6 @@ interface RenderMetadata {
   filename: string;
   extension: string;
   albumName: string | null;
-  albumCreatedAt: Date | null;
-  albumUpdatedAt: Date | null;
   albumStartDate: Date | null;
   albumEndDate: Date | null;
 }
@@ -104,8 +102,6 @@ export class StorageTemplateService extends BaseService {
         filename: 'IMG_123',
         extension: 'jpg',
         albumName: 'album',
-        albumCreatedAt: new Date(),
-        albumUpdatedAt: new Date(),
         albumStartDate: new Date(),
         albumEndDate: new Date()
       });
@@ -262,8 +258,6 @@ export class StorageTemplateService extends BaseService {
       }
 
       let albumName = null;
-      let albumCreatedAt = null;
-      let albumUpdatedAt = null;
       let albumStartDate = null;
       let albumEndDate = null;
       if (this.template.needsAlbum) {
@@ -271,8 +265,6 @@ export class StorageTemplateService extends BaseService {
         const album = albums?.[0];
         if (album) {
           albumName = album.albumName || null;
-          albumCreatedAt = album.createdAt || null;
-          albumUpdatedAt = album.updatedAt || null;
 
           if (this.template.needsAlbumMetadata) {
             const [metadata] = await this.albumRepository.getMetadataForIds([album.id])
@@ -287,8 +279,6 @@ export class StorageTemplateService extends BaseService {
         filename: sanitized,
         extension,
         albumName,
-        albumCreatedAt,
-        albumUpdatedAt,
         albumStartDate,
         albumEndDate,
       });
@@ -355,7 +345,7 @@ export class StorageTemplateService extends BaseService {
   }
 
   private render(template: HandlebarsTemplateDelegate<any>, options: RenderMetadata) {
-    const { filename, extension, asset, albumName, albumCreatedAt, albumUpdatedAt, albumStartDate, albumEndDate } = options;
+    const { filename, extension, asset, albumName, albumStartDate, albumEndDate } = options;
     const substitutions: Record<string, string> = {
       filename,
       ext: extension,
@@ -375,8 +365,6 @@ export class StorageTemplateService extends BaseService {
       substitutions[token] = dt.toFormat(token);
       if (albumName) {
         // Use system time zone for album dates to ensure all assets get the exact same date.
-        substitutions["album-createdAt-" + token] = albumCreatedAt ? DateTime.fromJSDate(albumCreatedAt, { zone: systemTimeZone }).toFormat(token) : '';
-        substitutions["album-updatedAt-" + token] = albumUpdatedAt ? DateTime.fromJSDate(albumUpdatedAt, { zone: systemTimeZone }).toFormat(token) : '';
         substitutions["album-startDate-" + token] = albumStartDate ? DateTime.fromJSDate(albumStartDate, { zone: systemTimeZone }).toFormat(token) : '';
         substitutions["album-endDate-" + token] = albumEndDate ? DateTime.fromJSDate(albumEndDate, { zone: systemTimeZone }).toFormat(token) : '';
       }

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -28,6 +28,7 @@ const storagePresets = [
   '{{y}}/{{MMMM}}-{{dd}}/{{filename}}',
   '{{y}}/{{MM}}/{{filename}}',
   '{{y}}/{{#if album}}{{album}}{{else}}Other/{{MM}}{{/if}}/{{filename}}',
+  '{{#if album}}{{album-startDate-y}}/{{album}}{{else}}{{y}}/Other/{{MM}}{{/if}}/{{filename}}',
   '{{y}}/{{MMM}}/{{filename}}',
   '{{y}}/{{MMMM}}/{{filename}}',
   '{{y}}/{{MM}}/{{dd}}/{{filename}}',
@@ -103,7 +104,7 @@ export class StorageTemplateService extends BaseService {
         extension: 'jpg',
         albumName: 'album',
         albumStartDate: new Date(),
-        albumEndDate: new Date()
+        albumEndDate: new Date(),
       });
     } catch (error) {
       this.logger.warn(`Storage template validation failed: ${JSON.stringify(error)}`);
@@ -267,7 +268,7 @@ export class StorageTemplateService extends BaseService {
           albumName = album.albumName || null;
 
           if (this.template.needsAlbumMetadata) {
-            const [metadata] = await this.albumRepository.getMetadataForIds([album.id])
+            const [metadata] = await this.albumRepository.getMetadataForIds([album.id]);
             albumStartDate = metadata?.startDate || null;
             albumEndDate = metadata?.endDate || null;
           }
@@ -340,7 +341,7 @@ export class StorageTemplateService extends BaseService {
       raw: template,
       compiled: handlebar.compile(template, { knownHelpers: undefined, strict: true }),
       needsAlbum: template.includes('album'),
-      needsAlbumMetadata: (template.includes('album-startDate') || template.includes('album-endDate')),
+      needsAlbumMetadata: template.includes('album-startDate') || template.includes('album-endDate'),
     };
   }
 
@@ -365,8 +366,12 @@ export class StorageTemplateService extends BaseService {
       substitutions[token] = dt.toFormat(token);
       if (albumName) {
         // Use system time zone for album dates to ensure all assets get the exact same date.
-        substitutions["album-startDate-" + token] = albumStartDate ? DateTime.fromJSDate(albumStartDate, { zone: systemTimeZone }).toFormat(token) : '';
-        substitutions["album-endDate-" + token] = albumEndDate ? DateTime.fromJSDate(albumEndDate, { zone: systemTimeZone }).toFormat(token) : '';
+        substitutions['album-startDate-' + token] = albumStartDate
+          ? DateTime.fromJSDate(albumStartDate, { zone: systemTimeZone }).toFormat(token)
+          : '';
+        substitutions['album-endDate-' + token] = albumEndDate
+          ? DateTime.fromJSDate(albumEndDate, { zone: systemTimeZone }).toFormat(token)
+          : '';
       }
     }
 

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -66,6 +66,7 @@ export class StorageTemplateService extends BaseService {
     compiled: HandlebarsTemplateDelegate<any>;
     raw: string;
     needsAlbum: boolean;
+    needsAlbumMetadata: boolean;
   } | null = null;
 
   private get template() {
@@ -269,12 +270,15 @@ export class StorageTemplateService extends BaseService {
         const albums = await this.albumRepository.getByAssetId(asset.ownerId, asset.id);
         const album = albums?.[0];
         if (album) {
-          const [metadata] = await this.albumRepository.getMetadataForIds([album.id])
           albumName = album.albumName || null;
           albumCreatedAt = album.createdAt || null;
           albumUpdatedAt = album.updatedAt || null;
-          albumStartDate = metadata?.startDate || null;
-          albumEndDate = metadata?.endDate || null;
+
+          if (this.template.needsAlbumMetadata) {
+            const [metadata] = await this.albumRepository.getMetadataForIds([album.id])
+            albumStartDate = metadata?.startDate || null;
+            albumEndDate = metadata?.endDate || null;
+          }
         }
       }
 
@@ -346,6 +350,7 @@ export class StorageTemplateService extends BaseService {
       raw: template,
       compiled: handlebar.compile(template, { knownHelpers: undefined, strict: true }),
       needsAlbum: template.includes('album'),
+      needsAlbumMetadata: (template.includes('album-startDate') || template.includes('album-endDate')),
     };
   }
 

--- a/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/storage-template-settings.svelte
@@ -78,6 +78,8 @@
     };
 
     const dt = luxon.DateTime.fromISO(new Date('2022-02-03T04:56:05.250').toISOString());
+    const albumStartTime = luxon.DateTime.fromISO(new Date('2021-12-31T05:32:41.750').toISOString());
+    const albumEndTime = luxon.DateTime.fromISO(new Date('2023-05-06T09:15:17.100').toISOString());
 
     const dateTokens = [
       ...templateOptions.yearOptions,
@@ -91,6 +93,8 @@
 
     for (const token of dateTokens) {
       substitutions[token] = dt.toFormat(token);
+      substitutions['album-startDate-' + token] = albumStartTime.toFormat(token);
+      substitutions['album-endDate-' + token] = albumEndTime.toFormat(token);
     }
 
     return template(substitutions);

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
@@ -30,11 +30,11 @@
         <li>{`{{assetIdShort}}`} - Asset ID (last 12 characters)</li>
         <li>{`{{album}}`} - Album Name</li>
         <li>
-          {`{{album-startDate-x}}`} - Album Start Date (x is a Date and Time variable (e.g. album-startDate-yy)).
+          {`{{album-startDate-x}}`} - Album Start Date and Time (e.g. album-startDate-yy).
           {$t('admin.storage_template_date_time_sample', { values: { date: '2021-12-31T05:32:41.750' } })}
         </li>
         <li>
-          {`{{album-endDate-x}}`} - Album End Date (x is a Date and Time variable (e.g. album-endDate-MM)).
+          {`{{album-endDate-x}}`} - Album End Date and Time (e.g. album-endDate-MM).
           {$t('admin.storage_template_date_time_sample', { values: { date: '2023-05-06T09:15:17.100' } })}
         </li>
       </ul>

--- a/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-variables-panel.svelte
@@ -29,6 +29,14 @@
         <li>{`{{assetId}}`} - Asset ID</li>
         <li>{`{{assetIdShort}}`} - Asset ID (last 12 characters)</li>
         <li>{`{{album}}`} - Album Name</li>
+        <li>
+          {`{{album-startDate-x}}`} - Album Start Date (x is a Date and Time variable (e.g. album-startDate-yy)).
+          {$t('admin.storage_template_date_time_sample', { values: { date: '2021-12-31T05:32:41.750' } })}
+        </li>
+        <li>
+          {`{{album-endDate-x}}`} - Album End Date (x is a Date and Time variable (e.g. album-endDate-MM)).
+          {$t('admin.storage_template_date_time_sample', { values: { date: '2023-05-06T09:15:17.100' } })}
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This adds all the possible date templates (y, m, d, etc) for album ~~createdAt, updatedAt,~~ startDate, and endDate (last two are calculated automatically from album contents) to the Storage Template.

For example the template could look like this:
{{#if album}}{{album-startDate-y}}/{{album-startDate-MM}} - {{album}}{{else}}{{y}}/{{MM}}/{{/if}}/{{filename}}

## Description

This change adds 4 dates, and all possible date templates to the Storage template so that it's possible to store albums in a single folder that includes date components.

Without this patch the Storage Template can only use date fields from each asset individually, which puts them in different folders even if they are in the same album (if the album spans more than one day).

Fixes the following feature requests:
https://github.com/immich-app/immich/discussions/16721
https://github.com/immich-app/immich/discussions/16843

Fixes # (issue)

## How Has This Been Tested?

- [x] Works with assets without an album
- [x] Places assets in the same album into the same folder using a template containing album-startDate-y (for year) and album-startDate-MM (for  month)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
