### PR TITLE
fix(server): Exclude album assets in shared link payload

### DIFF
--- a/e2e/src/api/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/api/specs/shared-link.e2e-spec.ts
@@ -246,15 +246,7 @@ describe('/shared-links', () => {
       const { status, body } = await request(app).get('/shared-links/me').query({ key: linkWithMetadata.key });
 
       expect(status).toBe(200);
-      expect(body.assets).toHaveLength(1);
-      expect(body.assets[0]).toEqual(
-        expect.objectContaining({
-          originalFileName: 'example.png',
-          localDateTime: expect.any(String),
-          fileCreatedAt: expect.any(String),
-          exifInfo: expect.any(Object),
-        }),
-      );
+      expect(body.assets).toHaveLength(0);
       expect(body.album).toBeDefined();
     });
 

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -104,9 +104,6 @@ export class SharedLinkResponseDto {
 
 export function mapSharedLink(sharedLink: SharedLinkEntity): SharedLinkResponseDto {
   const linkAssets = sharedLink.assets || [];
-  const albumAssets = (sharedLink?.album?.assets || []).map((asset) => asset);
-
-  const assets = _.uniqBy([...linkAssets, ...albumAssets], (asset) => asset.id);
 
   return {
     id: sharedLink.id,
@@ -117,7 +114,7 @@ export function mapSharedLink(sharedLink: SharedLinkEntity): SharedLinkResponseD
     type: sharedLink.type,
     createdAt: sharedLink.createdAt,
     expiresAt: sharedLink.expiresAt,
-    assets: assets.map((asset) => mapAsset(asset)),
+    assets: linkAssets.map((asset) => mapAsset(asset)),
     album: sharedLink.album ? mapAlbumWithoutAssets(sharedLink.album) : undefined,
     allowUpload: sharedLink.allowUpload,
     allowDownload: sharedLink.allowDownload,


### PR DESCRIPTION
## Description

Removes album asset details when a [publicly shared link is opened](https://github.com/immich-app/immich/blob/6fa0cb534a1d6434159705c105b0447633eca20b/web/src/routes/(user)/share/%5Bkey%5D/%5B%5Bphotos%3Dphotos%5D%5D/%5B%5BassetId%3Did%5D%5D/%2Bpage.ts#L15).


Screenshots at 2500 assets in shared album:
Before
![image](https://github.com/user-attachments/assets/771508ee-9e1a-457a-9ce2-fab1725c64f6)

After
![image](https://github.com/user-attachments/assets/560879a2-879d-4601-a238-104935845cd9)

Each time when you open a shared link to an album with thousands of assets or navigate to one of these assets afterwards, multiple Megabytes are being sent in a single request (calling `/api/shared-links/me?key=...`) on each page load, even though this info is never really used. In my case, I have an album with almost 5000 assets which results in 7 MB of payload each time I change the asset I want to look at.

A simple operation of
1. open shared link to an album
2. click on an asset
3. go back to the album view
4. open another asset

results in 4 of these calls, with a rough delay of 500-1000ms each. In contrast, clicking on an asset in the normal album view (i.e. not the shared link) opens the asset instantly.

If we merge this PR as-is, there is one small caveat that the [asset count will now exclude the asset count of albums](https://github.com/immich-app/immich/blob/6fa0cb534a1d6434159705c105b0447633eca20b/web/src/routes/(user)/share/%5Bkey%5D/%5B%5Bphotos%3Dphotos%5D%5D/%5B%5BassetId%3Did%5D%5D/%2Bpage.ts#L27). Let me know how you want this to behave. Some options:
- Ignore asset count of albums (now)
- Include asset count of albums (as before, but calculate that number server-side)
- Instead of displaying asset count of albums, set the description `$t('shared_photos_and_videos_count')` to sth along the lines "# albums and # individually shared photos & videos."

## How Has This Been Tested?

Tested locally and confirmed shared links still work even without the album asset details.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
