### PR TITLE
feat: Support config via Systemd Credentials

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -198,12 +198,11 @@ Additional machine learning parameters can be tuned from the admin UI.
 | `IMMICH_TELEMETRY_INCLUDE` | Collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`. Note: You can also specify `all` to enable all |         | server     | api, microservices |
 | `IMMICH_TELEMETRY_EXCLUDE` | Do not collect these telemetries. List of `host`, `api`, `io`, `repo`, `job`                                          |         | server     | api, microservices |
 
-## Docker Secrets
+## Secrets
 
-The following variables support the use of [Docker secrets][docker-secrets] for additional security.
+The following variables support reading from files, either via [Systemd Credentials][systemd-creds] or [Docker secrets][docker-secrets] for additional security.
 
-To use any of these, replace the regular environment variable with the equivalent `_FILE` environment variable. The value of
-the `_FILE` variable should be set to the path of a file containing the variable value.
+To use any of these, either set `CREDENTIALS_DIRECTORY` to a directory that contains files whose name is the “regular variable” name, and whose content is the secret. If using Docker Secrets, setting `CREDENTIALS_DIRECTORY=/run/secrets` will cause all secrets present to be used. Alternatively, replace the regular variable with the equivalent `_FILE` environment variable as below. The value of the `_FILE` variable should be set to the path of a file containing the variable value.
 
 | Regular Variable   | Equivalent Docker Secrets '\_FILE' Variable |
 | :----------------- | :------------------------------------------ |
@@ -225,3 +224,4 @@ to use a Docker secret for the password in the Redis container.
 [docker-secrets-docs]: https://github.com/docker-library/docs/tree/master/postgres#docker-secrets
 [docker-secrets]: https://docs.docker.com/engine/swarm/secrets/
 [ioredis]: https://ioredis.readthedocs.io/en/latest/README/#connect-to-redis
+[systemd-creds]: https://systemd.io/CREDENTIALS/

--- a/server/start.sh
+++ b/server/start.sh
@@ -7,8 +7,12 @@ export LD_PRELOAD="$lib_path"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
 
 read_file_and_export() {
-	if [ -n "${!1}" ]; then
-		content="$(cat "${!1}")"
+	fname="${!1}"
+	if [[ -z $fname ]] && [[ -e "$CREDENTIALS_DIRECTORY/$2" ]]; then
+		fname="${CREDENTIALS_DIRECTORY}/$2"
+	fi
+	if [[ -n $fname ]]; then
+		content="$(< "$fname")"
 		export "$2"="${content}"
 		unset "$1"
 	fi


### PR DESCRIPTION

## Description
See https://systemd.io/CREDENTIALS/. This is used as a fallback, so will only be used if the `$*_FILE` var is empty. This could also be used to implicitly use Docker Secrets by settings
`CREDENTIALS_DIRECTORY=/run/secrets` rather than setting individual `$_*FILE` environment variables.

## How Has This Been Tested?

I patched Immich using this change and tested the functionality.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
