### PR TITLE
fix(server): multiple exclusion patterns

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -1064,7 +1064,7 @@ export class AssetRepository {
       .where((eb) =>
         eb.or([
           eb.not(eb.or(paths.map((path) => eb('originalPath', 'like', path)))),
-          eb('originalPath', 'like', exclusions.join('|')),
+          eb.or(exclusions.map((path) => eb('originalPath', 'like', path))),
         ]),
       )
       .executeTakeFirstOrThrow();


### PR DESCRIPTION
Fixes #17186

Turns out that when using multiple exclusion patterns, they did not affect existing assets. This is now fixed.

Workaround for any users affected: Change the import path(s) to an empty directory not containing the current library assets. Scan. Set the import paths back, scan again.