### PR TITLE
fix(server): metadata extraction job on missing does not include file with missing nullable field

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -683,8 +683,15 @@ export class AssetRepository {
       .$if(property === WithoutProperty.EXIF, (qb) =>
         qb
           .leftJoin('asset_job_status as job_status', 'assets.id', 'job_status.assetId')
-          .where((eb) => eb.or([eb('job_status.metadataExtractedAt', 'is', null), eb('assetId', 'is', null)]))
-          .where('assets.isVisible', '=', true),
+          .where((eb) =>
+            eb.or([
+              eb('job_status.metadataExtractedAt', 'is', null),
+              eb('assetId', 'is', null),
+              eb('assets.fileCreatedAt', 'is', null),
+              eb('assets.fileModifiedAt', 'is', null),
+              eb('assets.localDateTime', 'is', null),
+            ]),
+          ),
       )
       .$if(property === WithoutProperty.FACES, (qb) =>
         qb


### PR DESCRIPTION
Fixes an issue where metadata extraction is interrupted and, upon restarting, doesn't include assets that have nullable fields that shouldn't be null after the job is run. If those fields are null, the mobile app won't be able to fetch all assets successfully due to the null check

## Tests

- Set those fields to null, run metadata extraction job for missing, the fields are populated