### PR TITLE
fix: posix compliant command

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -33,7 +33,7 @@
     "sync:open-api": "node ./dist/bin/sync-open-api.js",
     "sync:sql": "node ./dist/bin/sync-sql.js",
     "email:dev": "email dev -p 3050 --dir src/emails",
-    "postinstall": "[[ \"$npm_config_global\" != \"true\" ]] && patch-package || true"
+    "postinstall": "[ \"$npm_config_global\" != \"true\" ] && patch-package || true"
   },
   "dependencies": {
     "@nestjs/bullmq": "^11.0.1",


### PR DESCRIPTION
## Description

#17204 is not working when building the docker image because `[[ ... ]]` is not posix compliant (it doesn't work with sh). Instead, use `[ ... ]` which is posix compliant and works with sh.

## How Has This Been Tested?

let's see the docker logs, it shouldn't have that line https://github.com/immich-app/immich/actions/runs/14178921537/job/39720315706#step:8:698 `sh: 1: [[: not found`
