### PR TITLE
fix(web): blank locale cause blank timeline to render

### DIFF
--- a/web/src/lib/stores/assets-store.svelte.ts
+++ b/web/src/lib/stores/assets-store.svelte.ts
@@ -267,7 +267,6 @@ export class AssetBucket {
 
     const year = utcDate.get('year');
     const month = utcDate.get('month');
-
     const bucketDateFormatted = utcDate.toJSDate().toLocaleString(get(locale) || 'en-US', {
       month: 'short',
       year: 'numeric',

--- a/web/src/lib/stores/assets-store.svelte.ts
+++ b/web/src/lib/stores/assets-store.svelte.ts
@@ -267,7 +267,8 @@ export class AssetBucket {
 
     const year = utcDate.get('year');
     const month = utcDate.get('month');
-    const bucketDateFormatted = utcDate.toJSDate().toLocaleString(get(locale), {
+
+    const bucketDateFormatted = utcDate.toJSDate().toLocaleString(get(locale) || 'en-US', {
       month: 'short',
       year: 'numeric',
       timeZone: 'UTC',

--- a/web/src/lib/stores/assets-store.svelte.ts
+++ b/web/src/lib/stores/assets-store.svelte.ts
@@ -267,7 +267,7 @@ export class AssetBucket {
 
     const year = utcDate.get('year');
     const month = utcDate.get('month');
-    const bucketDateFormatted = utcDate.toJSDate().toLocaleString(get(locale) || 'en-US', {
+    const bucketDateFormatted = utcDate.toJSDate().toLocaleString(get(locale), {
       month: 'short',
       year: 'numeric',
       timeZone: 'UTC',

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -38,7 +38,7 @@ export const colorTheme = persisted<ThemeSetting>('color-theme', initialTheme, {
 // Locale to use for formatting dates, numbers, etc.
 export const locale = persisted<string | undefined>('locale', undefined, {
   serializer: {
-    parse: (text) => (text === '' ? undefined : text),
+    parse: (text) => text,
     stringify: (object) => object ?? '',
   },
 });

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -38,7 +38,7 @@ export const colorTheme = persisted<ThemeSetting>('color-theme', initialTheme, {
 // Locale to use for formatting dates, numbers, etc.
 export const locale = persisted<string | undefined>('locale', undefined, {
   serializer: {
-    parse: (text) => text,
+    parse: (text) => (text === '' ? undefined : text),
     stringify: (object) => object ?? '',
   },
 });

--- a/web/src/lib/stores/preferences.store.ts
+++ b/web/src/lib/stores/preferences.store.ts
@@ -38,7 +38,7 @@ export const colorTheme = persisted<ThemeSetting>('color-theme', initialTheme, {
 // Locale to use for formatting dates, numbers, etc.
 export const locale = persisted<string | undefined>('locale', undefined, {
   serializer: {
-    parse: (text) => text,
+    parse: (text) => (text == '' ? 'en-US' : text),
     stringify: (object) => object ?? '',
   },
 });


### PR DESCRIPTION
Package change in #17093 treats blank value differently or correctly, causing the timeline not to render anything if the user has a locale key with no value. 

Fixes #17270 