### PR TITLE
fix(server): remove stacks on stack.deleteAll

### DIFF
--- a/server/src/queries/stack.repository.sql
+++ b/server/src/queries/stack.repository.sql
@@ -32,47 +32,7 @@ where
   "asset_stack"."ownerId" = $1
 
 -- StackRepository.delete
-select
-  *,
-  (
-    select
-      coalesce(json_agg(agg), '[]')
-    from
-      (
-        select
-          "assets".*,
-          (
-            select
-              coalesce(json_agg(agg), '[]')
-            from
-              (
-                select
-                  "tags".*
-                from
-                  "tags"
-                  inner join "tag_asset" on "tags"."id" = "tag_asset"."tagsId"
-                where
-                  "tag_asset"."assetsId" = "assets"."id"
-              ) as agg
-          ) as "tags",
-          to_json("exifInfo") as "exifInfo"
-        from
-          "assets"
-          inner join lateral (
-            select
-              "exif".*
-            from
-              "exif"
-            where
-              "exif"."assetId" = "assets"."id"
-          ) as "exifInfo" on true
-        where
-          "assets"."deletedAt" is null
-          and "assets"."stackId" = "asset_stack"."id"
-      ) as agg
-  ) as "assets"
-from
-  "asset_stack"
+delete from "asset_stack"
 where
   "id" = $1::uuid
 

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -122,39 +122,11 @@ export class StackRepository {
 
   @GenerateSql({ params: [DummyValue.UUID] })
   async delete(id: string): Promise<void> {
-    const stack = await this.getById(id);
-    if (!stack) {
-      return;
-    }
-
-    const assetIds = stack.assets.map(({ id }) => id);
-
     await this.db.deleteFrom('asset_stack').where('id', '=', asUuid(id)).execute();
-    await this.db
-      .updateTable('assets')
-      .set({ stackId: null, updatedAt: new Date() })
-      .where('id', 'in', assetIds)
-      .execute();
   }
 
   async deleteAll(ids: string[]): Promise<void> {
-    const assetIds = [];
-    for (const id of ids) {
-      const stack = await this.getById(id);
-      if (!stack) {
-        continue;
-      }
-
-      assetIds.push(...stack.assets.map(({ id }) => id));
-    }
-
     await this.db.deleteFrom('asset_stack').where('id', 'in', ids).execute();
-    await this.db
-      .updateTable('assets')
-      .set({ updatedAt: new Date(), stackId: null })
-      .where('id', 'in', assetIds)
-      .where('stackId', 'in', ids)
-      .execute();
   }
 
   update(id: string, entity: Updateable<StackEntity>): Promise<StackEntity> {

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -148,6 +148,7 @@ export class StackRepository {
       assetIds.push(...stack.assets.map(({ id }) => id));
     }
 
+    await this.db.deleteFrom('asset_stack').where('id', 'in', ids).execute();
     await this.db
       .updateTable('assets')
       .set({ updatedAt: new Date(), stackId: null })


### PR DESCRIPTION
## Description

The asset_stack entries were not removed on the deleteAll call of the stack repo. This PR updates it to remove the stack entries as well
