### PR TITLE
fix(server): use stat instead of exiftool for file date metadata

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ContainerDirectoryItem, ExifDateTime, Maybe, Tags } from 'exiftool-vendored';
+import { ContainerDirectoryItem, Maybe, Tags } from 'exiftool-vendored';
 import { firstDateTime } from 'exiftool-vendored/dist/FirstDateTime';
 import { Insertable } from 'kysely';
 import _ from 'lodash';

--- a/server/test/medium/specs/metadata.service.spec.ts
+++ b/server/test/medium/specs/metadata.service.spec.ts
@@ -39,7 +39,12 @@ describe(MetadataService.name, () => {
   beforeEach(() => {
     ({ sut, mocks } = newTestService(MetadataService, { metadata: metadataRepository }));
 
-    mocks.storage.stat.mockResolvedValue({ size: 123_456, ctime: new Date(), mtime: new Date() } as Stats);
+    mocks.storage.stat.mockResolvedValue({
+      size: 123_456,
+      mtime: new Date(654_321),
+      mtimeMs: 654_321,
+      birthtimeMs: 654_322,
+    } as Stats);
 
     delete process.env.TZ;
   });
@@ -54,8 +59,6 @@ describe(MetadataService.name, () => {
         description: 'should handle no time zone information',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
-          FileCreateDate: '2022:01:01 00:00:00',
-          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -68,8 +71,6 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'America/Los_Angeles',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
-          FileCreateDate: '2022:01:01 00:00:00',
-          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -82,8 +83,6 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'Europe/Brussels',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00',
-          FileCreateDate: '2022:01:01 00:00:00',
-          FileModifyDate: '2022:01:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',
@@ -96,8 +95,6 @@ describe(MetadataService.name, () => {
         serverTimeZone: 'Europe/Brussels',
         exifData: {
           DateTimeOriginal: '2022:06:01 00:00:00',
-          FileCreateDate: '2022:06:01 00:00:00',
-          FileModifyDate: '2022:06:01 00:00:00',
         },
         expected: {
           localDateTime: '2022-06-01T00:00:00.000Z',
@@ -109,8 +106,6 @@ describe(MetadataService.name, () => {
         description: 'should handle a +13:00 time zone',
         exifData: {
           DateTimeOriginal: '2022:01:01 00:00:00+13:00',
-          FileCreateDate: '2022:01:01 00:00:00+13:00',
-          FileModifyDate: '2022:01:01 00:00:00+13:00',
         },
         expected: {
           localDateTime: '2022-01-01T00:00:00.000Z',


### PR DESCRIPTION
## Description

#16453 removed two stat calls in metadata extraction in favor of using exiftool. However, in practice, exiftool isn't as reliable in outputting file date metadata. This PR moves back to using `stat`, fetching the file dates concurrently with the exiftool call and only calling it once.

## How Has This Been Tested?

Tested by uploading an image and confirming it has the correct file modification date.