### PR TITLE
fix(web): menu button size

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -71,7 +71,7 @@
           shape="round"
           color="secondary"
           variant="ghost"
-          size="large"
+          size="medium"
           aria-label={$t('main_menu')}
           icon={mdiMenu}
           onclick={() => {


### PR DESCRIPTION
Adjusting the hamburger menu button size, to match match the other buttons in the navigation bar. I missed this detail in #16768.


| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/1773bea5-e333-47fa-b4da-ec952162afd0" width="200" /> | <img src="https://github.com/user-attachments/assets/8f27670a-068f-4490-b27c-85465af0f51e" width="200" /> |