### PR TITLE
fix(mobile): use custom filter to fetch asset path entities

### DIFF
--- a/mobile/assets/i18n/en-US.json
+++ b/mobile/assets/i18n/en-US.json
@@ -17,6 +17,8 @@
   "advanced_settings_proxy_headers_title": "Proxy Headers",
   "advanced_settings_self_signed_ssl_subtitle": "Skips SSL certificate verification for the server endpoint. Required for self-signed certificates.",
   "advanced_settings_self_signed_ssl_title": "Allow self-signed SSL certificates",
+  "advanced_settings_enable_alternate_media_filter_title": "[EXPERIMENTAL] Use alternate device album sync filter",
+  "advanced_settings_enable_alternate_media_filter_subtitle": "Use this option to filter media during sync based on alternate criteria. Only try this if you have issues with the app detecting all albums.",
   "advanced_settings_tile_subtitle": "Advanced user's settings",
   "advanced_settings_tile_title": "Advanced",
   "advanced_settings_troubleshooting_subtitle": "Enable additional features for troubleshooting",

--- a/mobile/lib/domain/models/store.model.dart
+++ b/mobile/lib/domain/models/store.model.dart
@@ -65,7 +65,9 @@ enum StoreKey<T> {
 
   // Video settings
   loadOriginalVideo<bool>._(136),
-  ;
+
+  // Experimental stuff
+  photoManagerCustomFilter<bool>._(1000);
 
   const StoreKey._(this.id);
   final int id;

--- a/mobile/lib/repositories/album_media.repository.dart
+++ b/mobile/lib/repositories/album_media.repository.dart
@@ -8,16 +8,23 @@ import 'package:immich_mobile/interfaces/album_media.interface.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:photo_manager/photo_manager.dart' hide AssetType;
 
-final albumMediaRepositoryProvider = Provider((ref) => AlbumMediaRepository());
+final albumMediaRepositoryProvider =
+    Provider((ref) => const AlbumMediaRepository());
 
 class AlbumMediaRepository implements IAlbumMediaRepository {
+  const AlbumMediaRepository();
+
+  bool get useCustomFilter =>
+      Store.get(StoreKey.photoManagerCustomFilter, false);
+
   @override
   Future<List<Album>> getAll() async {
+    final filter = useCustomFilter
+        ? CustomFilter.sql(where: '${CustomColumns.base.width} > 0')
+        : FilterOptionGroup(containsPathModified: true);
+
     final List<AssetPathEntity> assetPathEntities =
-        await PhotoManager.getAssetPathList(
-      hasAll: true,
-      filterOption: FilterOptionGroup(containsPathModified: true),
-    );
+        await PhotoManager.getAssetPathList(hasAll: true, filterOption: filter);
     return assetPathEntities.map(_toAlbum).toList();
   }
 
@@ -47,18 +54,18 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
     final onDevice = await AssetPathEntity.fromId(
       albumId,
       filterOption: FilterOptionGroup(
-        containsPathModified: true,
-        orders: orderByModificationDate
-            ? [const OrderOption(type: OrderOptionType.updateDate)]
-            : [],
         imageOption: const FilterOption(needTitle: true),
         videoOption: const FilterOption(needTitle: true),
+        containsPathModified: true,
         updateTimeCond: modifiedFrom == null && modifiedUntil == null
             ? null
             : DateTimeCond(
                 min: modifiedFrom ?? DateTime.utc(-271820),
                 max: modifiedUntil ?? DateTime.utc(275760),
               ),
+        orders: orderByModificationDate
+            ? [const OrderOption(type: OrderOptionType.updateDate)]
+            : [],
       ),
     );
 

--- a/mobile/lib/services/app_settings.service.dart
+++ b/mobile/lib/services/app_settings.service.dart
@@ -84,6 +84,11 @@ enum AppSettingsEnum<T> {
   enableHapticFeedback<bool>(StoreKey.enableHapticFeedback, null, true),
   syncAlbums<bool>(StoreKey.syncAlbums, null, false),
   autoEndpointSwitching<bool>(StoreKey.autoEndpointSwitching, null, false),
+  photoManagerCustomFilter<bool>(
+    StoreKey.photoManagerCustomFilter,
+    null,
+    false,
+  ),
   ;
 
   const AppSettingsEnum(this.storeKey, this.hiveKey, this.defaultValue);

--- a/mobile/lib/widgets/settings/advanced_settings.dart
+++ b/mobile/lib/widgets/settings/advanced_settings.dart
@@ -29,6 +29,8 @@ class AdvancedSettings extends HookConsumerWidget {
     final preferRemote = useAppSettingsState(AppSettingsEnum.preferRemoteImage);
     final allowSelfSignedSSLCert =
         useAppSettingsState(AppSettingsEnum.allowSelfSignedSSLCert);
+    final useAlternatePMFilter =
+        useAppSettingsState(AppSettingsEnum.photoManagerCustomFilter);
 
     final logLevel = Level.LEVELS[levelId.value].name;
 
@@ -68,6 +70,12 @@ class AdvancedSettings extends HookConsumerWidget {
       ),
       const CustomeProxyHeaderSettings(),
       SslClientCertSettings(isLoggedIn: ref.read(currentUserProvider) != null),
+      SettingsSwitchListTile(
+        valueNotifier: useAlternatePMFilter,
+        title: "advanced_settings_enable_alternate_media_filter_title".tr(),
+        subtitle:
+            "advanced_settings_enable_alternate_media_filter_subtitle".tr(),
+      ),
     ];
 
     return SettingsSubPageScaffold(settings: advancedSettings);


### PR DESCRIPTION
## Description

- A new experimental setting to use custom filters in `photo_manager` to fix issue with fetching albums on certain android devices