### PR TITLE
fix(web): use original image if web compatible

### DIFF
--- a/e2e/src/web/specs/photo-viewer.e2e-spec.ts
+++ b/e2e/src/web/specs/photo-viewer.e2e-spec.ts
@@ -49,7 +49,7 @@ test.describe('Photo Viewer', () => {
     await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('original');
   });
 
-  test('loads full-size photo when zoomed and original is web-incompatible', async ({ page }) => {
+  test('loads redirected preview when zoomed and original is web-incompatible', async ({ page }) => {
     await page.goto(`/photos/${rawAsset.id}`);
     await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('thumbnail');
     const box = await imageLocator(page).boundingBox();
@@ -57,7 +57,8 @@ test.describe('Photo Viewer', () => {
     const { x, y, width, height } = box!;
     await page.mouse.move(x + width / 2, y + height / 2);
     await page.mouse.wheel(0, -1);
-    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('fullsize');
+    // TODO: not sure how to test that it was redirected from fullsize to preview
+    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('preview');
   });
 
   test('reloads photo when checksum changes', async ({ page }) => {

--- a/e2e/src/web/specs/photo-viewer.e2e-spec.ts
+++ b/e2e/src/web/specs/photo-viewer.e2e-spec.ts
@@ -8,12 +8,14 @@ function imageLocator(page: Page) {
 test.describe('Photo Viewer', () => {
   let admin: LoginResponseDto;
   let asset: AssetMediaResponseDto;
+  let rawAsset: AssetMediaResponseDto;
 
   test.beforeAll(async () => {
     utils.initSdk();
     await utils.resetDatabase();
     admin = await utils.adminSetup();
     asset = await utils.createAsset(admin.accessToken);
+    rawAsset = await utils.createAsset(admin.accessToken, { assetData: { filename: 'test.arw' } });
   });
 
   test.beforeEach(async ({ context, page }) => {
@@ -36,8 +38,19 @@ test.describe('Photo Viewer', () => {
     await expect(page.getByTestId('loading-spinner')).toBeVisible();
   });
 
-  test('loads high resolution photo when zoomed', async ({ page }) => {
+  test('loads original photo when zoomed', async ({ page }) => {
     await page.goto(`/photos/${asset.id}`);
+    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('thumbnail');
+    const box = await imageLocator(page).boundingBox();
+    expect(box).toBeTruthy();
+    const { x, y, width, height } = box!;
+    await page.mouse.move(x + width / 2, y + height / 2);
+    await page.mouse.wheel(0, -1);
+    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('original');
+  });
+
+  test('loads full-size photo when zoomed and original is web-incompatible', async ({ page }) => {
+    await page.goto(`/photos/${rawAsset.id}`);
     await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('thumbnail');
     const box = await imageLocator(page).boundingBox();
     expect(box).toBeTruthy();

--- a/e2e/src/web/specs/photo-viewer.e2e-spec.ts
+++ b/e2e/src/web/specs/photo-viewer.e2e-spec.ts
@@ -49,7 +49,7 @@ test.describe('Photo Viewer', () => {
     await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('original');
   });
 
-  test('loads redirected preview when zoomed and original is web-incompatible', async ({ page }) => {
+  test('loads fullsize image when zoomed and original is web-incompatible', async ({ page }) => {
     await page.goto(`/photos/${rawAsset.id}`);
     await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('thumbnail');
     const box = await imageLocator(page).boundingBox();
@@ -57,8 +57,7 @@ test.describe('Photo Viewer', () => {
     const { x, y, width, height } = box!;
     await page.mouse.move(x + width / 2, y + height / 2);
     await page.mouse.wheel(0, -1);
-    // TODO: not sure how to test that it was redirected from fullsize to preview
-    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('preview');
+    await expect.poll(async () => await imageLocator(page).getAttribute('src')).toContain('fullsize');
   });
 
   test('reloads photo when checksum changes', async ({ page }) => {

--- a/web/src/lib/components/asset-viewer/photo-viewer.spec.ts
+++ b/web/src/lib/components/asset-viewer/photo-viewer.spec.ts
@@ -48,7 +48,7 @@ describe('PhotoViewer component', () => {
     expect(getAssetThumbnailUrlSpy).toBeCalledWith({
       id: asset.id,
       size: AssetMediaSize.Preview,
-      cacheKey: asset.checksum,
+      cacheKey: asset.thumbhash,
     });
     expect(getAssetOriginalUrlSpy).not.toBeCalled();
   });
@@ -57,11 +57,8 @@ describe('PhotoViewer component', () => {
     const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif' });
     render(PhotoViewer, { asset });
 
-    expect(getAssetThumbnailUrlSpy).toBeCalledWith({
-      id: asset.id,
-      cacheKey: asset.checksum,
-      size: AssetMediaSize.Fullsize,
-    });
+    expect(getAssetThumbnailUrlSpy).not.toBeCalled();
+    expect(getAssetOriginalUrlSpy).toBeCalledWith({ id: asset.id, cacheKey: asset.thumbhash });
   });
 
   it('loads original for shared link when download permission is true and showMetadata permission is true', () => {
@@ -69,13 +66,8 @@ describe('PhotoViewer component', () => {
     const sharedLink = sharedLinkFactory.build({ allowDownload: true, showMetadata: true, assets: [asset] });
     render(PhotoViewer, { asset, sharedLink });
 
-    expect(getAssetThumbnailUrlSpy).toBeCalledWith({
-      id: asset.id,
-      size: AssetMediaSize.Fullsize,
-      cacheKey: asset.checksum,
-    });
-    // expect(getAssetThumbnailUrlSpy).not.toBeCalled();
-    // expect(getAssetOriginalUrlSpy).toBeCalledWith({ id: asset.id, cacheKey: asset.thumbhash });
+    expect(getAssetThumbnailUrlSpy).not.toBeCalled();
+    expect(getAssetOriginalUrlSpy).toBeCalledWith({ id: asset.id, cacheKey: asset.thumbhash });
   });
 
   it('not loads original image when shared link download permission is false', () => {
@@ -86,7 +78,7 @@ describe('PhotoViewer component', () => {
     expect(getAssetThumbnailUrlSpy).toBeCalledWith({
       id: asset.id,
       size: AssetMediaSize.Preview,
-      cacheKey: asset.checksum,
+      cacheKey: asset.thumbhash,
     });
 
     expect(getAssetOriginalUrlSpy).not.toBeCalled();
@@ -100,7 +92,7 @@ describe('PhotoViewer component', () => {
     expect(getAssetThumbnailUrlSpy).toBeCalledWith({
       id: asset.id,
       size: AssetMediaSize.Preview,
-      cacheKey: asset.checksum,
+      cacheKey: asset.thumbhash,
     });
 
     expect(getAssetOriginalUrlSpy).not.toBeCalled();

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -84,7 +84,7 @@
 
     return targetSize === 'original'
       ? getAssetOriginalUrl({ id, cacheKey })
-      : getAssetThumbnailUrl({ id, size: AssetMediaSize.Preview, cacheKey });
+      : getAssetThumbnailUrl({ id, size: targetSize, cacheKey });
   };
 
   copyImage = async () => {

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -78,9 +78,8 @@
   };
 
   const getAssetUrl = (id: string, targetSize: AssetMediaSize | 'original', cacheKey: string | null) => {
-    let finalAssetMediaSize = targetSize;
     if (sharedLink && (!sharedLink.allowDownload || !sharedLink.showMetadata)) {
-      finalAssetMediaSize = AssetMediaSize.Preview;
+      return getAssetThumbnailUrl({ id, size: AssetMediaSize.Preview, cacheKey });
     }
 
     return targetSize === 'original'
@@ -172,7 +171,7 @@
     };
   });
 
-  let imageLoaderUrl = $derived(getAssetUrl(asset.id, targetImageSize, asset.checksum));
+  let imageLoaderUrl = $derived(getAssetUrl(asset.id, targetImageSize, asset.thumbhash));
 
   let containerWidth = $state(0);
   let containerHeight = $state(0);


### PR DESCRIPTION
## Description

#14446 has a regression in that original images are never displayed. This PR changes the logic to prefer the original over the fullsize image if it's web-compatible. Also reverts back to using the thumbhash as cache key, as it was changed back to checksum in that PR.

Fixes #17334

## How Has This Been Tested?

Tested that an HEIC image is displayed in Safari when zooming in and continues to be displayed after zooming out. Enabling "Display original images" makes it display the HEIC image immediately.