### PR TITLE
docs: fixed a wrong path in CLI docs page

### DIFF
--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -112,7 +112,7 @@ You begin by authenticating to your Immich server. For instance:
 immich login http://192.168.1.216:2283/api HFEJ38DNSDUEG
 ```
 
-This will store your credentials in a `auth.yml` file in the configuration directory which defaults to `~/.config/`. The directory can be set with the `-d` option or the environment variable `IMMICH_CONFIG_DIR`. Please keep the file secure, either by performing the logout command after you are done, or deleting it manually.
+This will store your credentials in a `auth.yml` file in the configuration directory which defaults to `~/.config/immich/`. The directory can be set with the `-d` option or the environment variable `IMMICH_CONFIG_DIR`. Please keep the file secure, either by performing the logout command after you are done, or deleting it manually.
 
 Once you are authenticated, you can upload assets to your Immich server.
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixed default config file location written in the CLI Quick Start documentation.
With previous path, it seemed like Immich CLI stored the <code>auth.yml</code> file in the <code>~/.config/</code> directory, which is not true as it's being stored in the <code>~/.config/immich/</code> folder. 

This should reduce confusion around that topic.

## How Has This Been Tested?
N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
