### PR TITLE
fix(mobile): bump isar maxSize

### DIFF
--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -43,7 +43,7 @@ abstract final class Bootstrap {
         DeviceAssetEntitySchema,
       ],
       directory: dir.path,
-      maxSizeMiB: 1024,
+      maxSizeMiB: 2048,
       inspector: kDebugMode,
     );
   }


### PR DESCRIPTION
## Description

- Increase the maximum size limit of Isar to 2Gib to accommodate users with large number of assets