### PR TITLE
fix: improve initial loading time

### DIFF
--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -13,7 +13,7 @@
   import { listNavigation } from '$lib/actions/list-navigation';
   import { t } from 'svelte-i18n';
   import CoordinatesInput from '$lib/components/shared-components/coordinates-input.svelte';
-  import Map from '$lib/components/shared-components/map/map.svelte';
+  import type Map from '$lib/components/shared-components/map/map.svelte';
   import { get } from 'svelte/store';
   interface Point {
     lng: number;


### PR DESCRIPTION
## Description

Avoid always loading the maplibre chunk which is ~1MB (223 kB compressed with brotli)
