### PR TITLE
chore(web): cleanup SingleGridRow

### DIFF
--- a/web/src/lib/components/shared-components/single-grid-row.svelte
+++ b/web/src/lib/components/shared-components/single-grid-row.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   interface Props {
     class?: string;
-    itemCount?: number;
     children?: import('svelte').Snippet<[{ itemCount: number }]>;
   }
 
-  let { class: className = '', itemCount = $bindable(1), children }: Props = $props();
+  let { class: className = '', children }: Props = $props();
 
   let container: HTMLElement | undefined = $state();
   let contentRect: DOMRectReadOnly | undefined = $state();
@@ -20,22 +19,15 @@
 
   const parsePixels = (style: string) => Number.parseInt(style, 10) || 0;
 
-  const getItemCount = (container: HTMLElement, containerWidth: number) => {
-    if (!container.firstElementChild) {
-      return 1;
+  const itemCount = $derived.by(() => {
+    if (container && container.firstElementChild && contentRect) {
+      const childContentRect = container.firstElementChild.getBoundingClientRect();
+      const childWidth = Math.floor(childContentRect.width || Infinity);
+      const { columnGap } = getGridGap(container);
+
+      return Math.floor((contentRect.width + columnGap) / (childWidth + columnGap)) || 1;
     }
-
-    const childContentRect = container.firstElementChild.getBoundingClientRect();
-    const childWidth = Math.floor(childContentRect.width || Infinity);
-    const { columnGap } = getGridGap(container);
-
-    return Math.floor((containerWidth + columnGap) / (childWidth + columnGap)) || 1;
-  };
-
-  $effect(() => {
-    if (container && contentRect) {
-      itemCount = getItemCount(container, contentRect.width);
-    }
+    return 1;
   });
 </script>
 


### PR DESCRIPTION
## Description

avoid setting state in an effect and remove `itemCount` as unused prop

## How Has This Been Tested?

n/a. code is equivalent

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
