### PR TITLE
fix(mobile): items not deselecting on back button

### DIFF
--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -546,8 +546,14 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
         if (didPop) {
           return;
         } else {
+          /// `preselectedAssets` is only present when opening the asset grid from the
+          /// "add to album" button.
+          ///
+          /// `_selectedAssets` includes `preselectedAssets` on initialization.
           if (_selectedAssets.length >
               (widget.preselectedAssets?.length ?? 0)) {
+            /// `_deselectAll` only deselects the selected assets,
+            /// doesn't affect the preselected ones.
             _deselectAll();
             return;
           } else {

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -546,15 +546,10 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
         if (didPop) {
           return;
         } else {
-          if (widget.preselectedAssets == null) {
-            Navigator.of(context).canPop() ? Navigator.of(context).pop() : null;
-          }
-          if (_selectedAssets.length != widget.preselectedAssets!.length &&
-              !widget.preselectedAssets!.containsAll(_selectedAssets)) {
-            {
-              _deselectAll();
-              return;
-            }
+          if (_selectedAssets.length >
+              (widget.preselectedAssets?.length ?? 0)) {
+            _deselectAll();
+            return;
           } else {
             Navigator.of(context).canPop() ? Navigator.of(context).pop() : null;
           }


### PR DESCRIPTION
## Description
Fixed back-button logic on asset grid.
Before, when items were selected, upon pressing the back button, they wouldn't deselect. This fixes that behavior.

## How Has This Been Tested?

- [x] Select one or more items on the main grid, trash, or in an album, then press the back button - it will deselect the items, but not pop the route
- [x] Go to an album, and press "add photos", on the next screen, select a couple of photos to add, but then press the back button, the selected photos will deselect themselves (but the ones that were preselected will stay). If only preselected are currently selected, it will pop the route. 

<details><summary><h2>Video demo</h2></summary>

https://github.com/user-attachments/assets/edefb635-ad72-4698-b15c-bd415b80f498

</details>

## What's left to fix?
On the search results page, it still doesn't prevent the route from popping when assets are selected.
I cannot figure out why on the search results page, the `_selectedAssets` in `ImmichAssetGridView` is always empty. If someone could take a look at that or point me in the right direction, I would highly appreciate it :)