### PR TITLE
chore(docs): add rename note to synology.md

### DIFF
--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -25,7 +25,7 @@ When you're all done, you should have the following:
 - `./docker/immich-app/postgres`
 - `./docker/immich-app/library`
 
-Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory.
+Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory, and rename example.env to .env. 
 
 ## Step 2 - Populate the .env file with custom values
 

--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -25,7 +25,7 @@ When you're all done, you should have the following:
 - `./docker/immich-app/postgres`
 - `./docker/immich-app/library`
 
-Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory, and rename example.env to .env. 
+Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory, and rename `example.env` to `.env`. 
 
 ## Step 2 - Populate the .env file with custom values
 

--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -25,7 +25,7 @@ When you're all done, you should have the following:
 - `./docker/immich-app/postgres`
 - `./docker/immich-app/library`
 
-Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory, and rename `example.env` to `.env`. 
+Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory, and rename `example.env` to `.env`.
 
 ## Step 2 - Populate the .env file with custom values
 


### PR DESCRIPTION
Make sure to change example.env to .env, this is not trivial for non-Docker experts.

## Description

Doc change to make sure example.env is changed to .env (otherwise the env variables aren't populated during the docker-compose run) causing docker-compose to fail. 

## How Has This Been Tested?

No tests, just a documentation change. Tested on my own NAS with and without this. 

## Checklist:

- [x ] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation if applicable
- [x ] I have no unrelated changes in the PR.
- [x ] I have confirmed that any new dependencies are strictly necessary.
- [ x] I have written tests for new code (if applicable)
- [ x] I have followed naming conventions/patterns in the surrounding code
- [ x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
