### PR TITLE
Added server-wide public albums

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -420,6 +420,8 @@
   "album_viewer_appbar_share_to": "Share To",
   "album_viewer_page_share_add_users": "Add users",
   "album_with_link_access": "Let anyone with the link see photos and people in this album.",
+  "is_album_public_in_instance": "Is album public in instance",
+  "is_album_public_in_instance_description": "If enabled, this album will be visible to all users in the instance",
   "albums": "Albums",
   "albums_count": "{count, plural, one {{count, number} Album} other {{count, number} Albums}}",
   "all": "All",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -7906,6 +7906,9 @@
           "isActivityEnabled": {
             "type": "boolean"
           },
+          "isPublicInInstance": {
+            "type": "boolean"
+          },
           "lastModifiedAssetTimestamp": {
             "format": "date-time",
             "type": "string"
@@ -7946,6 +7949,7 @@
           "hasSharedLink",
           "id",
           "isActivityEnabled",
+          "isPublicInInstance",
           "owner",
           "ownerId",
           "shared",
@@ -9051,6 +9055,9 @@
           },
           "description": {
             "type": "string"
+          },
+          "isPublicInInstance": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -13468,6 +13475,9 @@
             "type": "string"
           },
           "isActivityEnabled": {
+            "type": "boolean"
+          },
+          "isPublicInInstance": {
             "type": "boolean"
           },
           "order": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -297,6 +297,7 @@ export type AlbumResponseDto = {
     id: string;
     isActivityEnabled: boolean;
     lastModifiedAssetTimestamp?: string;
+    isPublicInInstance: boolean;
     order?: AssetOrder;
     owner: UserResponseDto;
     ownerId: string;
@@ -325,6 +326,7 @@ export type UpdateAlbumDto = {
     description?: string;
     isActivityEnabled?: boolean;
     order?: AssetOrder;
+    isPublicInInstance?: boolean;
 };
 export type BulkIdsDto = {
     ids: string[];

--- a/server/src/db.d.ts
+++ b/server/src/db.d.ts
@@ -65,6 +65,7 @@ export interface Albums {
   description: Generated<string>;
   id: Generated<string>;
   isActivityEnabled: Generated<boolean>;
+  isPublicInInstance: Generated<boolean>;
   order: Generated<AssetOrder>;
   ownerId: string;
   updatedAt: Generated<Timestamp>;

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -54,6 +54,9 @@ export class CreateAlbumDto {
 
   @ValidateUUID({ optional: true, each: true })
   assetIds?: string[];
+
+  @ValidateBoolean({ optional: true })
+  isPublicInInstance?: boolean;
 }
 
 export class UpdateAlbumDto {
@@ -75,6 +78,9 @@ export class UpdateAlbumDto {
   @Optional()
   @ApiProperty({ enum: AssetOrder, enumName: 'AssetOrder' })
   order?: AssetOrder;
+
+  @ValidateBoolean({ optional: true })
+  isPublicInInstance?: boolean;
 }
 
 export class GetAlbumsDto {
@@ -140,6 +146,7 @@ export class AlbumResponseDto {
   @Optional()
   @ApiProperty({ enumName: 'AssetOrder', enum: AssetOrder })
   order?: AssetOrder;
+  isPublicInInstance!: boolean;
 }
 
 export type MapAlbumDto = {
@@ -156,6 +163,7 @@ export type MapAlbumDto = {
   owner: User;
   isActivityEnabled: boolean;
   order: AssetOrder;
+  isPublicInInstance: boolean;
 };
 
 export const mapAlbum = (entity: MapAlbumDto, withAssets: boolean, auth?: AuthDto): AlbumResponseDto => {
@@ -203,6 +211,7 @@ export const mapAlbum = (entity: MapAlbumDto, withAssets: boolean, auth?: AuthDt
     assetCount: entity.assets?.length || 0,
     isActivityEnabled: entity.isActivityEnabled,
     order: entity.order,
+    isPublicInInstance: entity.isPublicInInstance,
   };
 };
 

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -165,6 +165,7 @@ export class AlbumRepository {
               .whereRef('album_users.albumsId', '=', 'albums.id')
               .where((eb) => eb.or([eb('albums.ownerId', '=', ownerId), eb('album_users.usersId', '=', ownerId)])),
           ),
+          eb('albums.isPublicInInstance', '=', true),
           eb.exists(
             eb
               .selectFrom('shared_links')
@@ -191,6 +192,7 @@ export class AlbumRepository {
       .selectAll('albums')
       .where('albums.ownerId', '=', ownerId)
       .where('albums.deletedAt', 'is', null)
+      .where('albums.isPublicInInstance', '=', false)
       .where((eb) =>
         eb.not(
           eb.exists(

--- a/server/src/schema/migrations/1745092119358-AddIsPublicInInstance.ts
+++ b/server/src/schema/migrations/1745092119358-AddIsPublicInInstance.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "albums" ADD "isPublicInInstance" boolean NOT NULL DEFAULT false`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "albums" DROP COLUMN "isPublicInInstance"`.execute(db);
+}

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -138,6 +138,7 @@ export class AlbumService extends BaseService {
       albumThumbnailAssetId: dto.albumThumbnailAssetId,
       isActivityEnabled: dto.isActivityEnabled,
       order: dto.order,
+      isPublicInInstance: dto.isPublicInInstance,
     });
 
     return mapAlbumWithoutAssets({ ...updatedAlbum, assets: album.assets });

--- a/web/src/lib/components/album-page/album-share-modal.svelte
+++ b/web/src/lib/components/album-page/album-share-modal.svelte
@@ -11,6 +11,7 @@
     AlbumUserRole,
     getAllSharedLinks,
     searchUsers,
+    updateAlbumInfo,
     type AlbumResponseDto,
     type AlbumUserAddDto,
     type SharedLinkResponseDto,
@@ -21,6 +22,8 @@
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import UserAvatar from '../shared-components/user-avatar.svelte';
+  import SettingSwitch from '$lib/components/shared-components/settings/setting-switch.svelte';
+  import { user } from '$lib/stores/user.store';
 
   interface Props {
     album: AlbumResponseDto;
@@ -73,6 +76,15 @@
     } else {
       selectedUsers[user.id].role = role;
     }
+  };
+
+  const handleTogglePublicInInstance = () => {
+    updateAlbumInfo({
+      id: album.id,
+      updateAlbumDto: {
+        isPublicInInstance: !album.isPublicInInstance,
+      },
+    });
   };
 </script>
 
@@ -165,8 +177,29 @@
         >
       </div>
     {/if}
+    <hr class="my-4" />
+
+    <!-- if is album author -->
+    {#if album.ownerId === $user.id}
+      <Stack gap={6} class="px-4">
+        <SettingSwitch
+          title={$t('is_album_public_in_instance')}
+          subtitle={$t('is_album_public_in_instance_description')}
+          bind:checked={album.isPublicInInstance}
+          onToggle={handleTogglePublicInInstance}
+        />
+      </Stack>
+    {/if}
 
     <hr class="my-4" />
+
+    {#if sharedLinks.length > 0}
+      <div class="flex justify-between items-center">
+        <Text>{$t('shared_links')}</Text>
+        <Link href={AppRoute.SHARED_LINKS} class="text-sm">{$t('view_all')}</Link>
+      </div>
+      <hr class="my-4" />
+    {/if}
 
     <Stack gap={6}>
       {#if sharedLinks.length > 0}

--- a/web/src/lib/components/album-page/albums-list.svelte
+++ b/web/src/lib/components/album-page/albums-list.svelte
@@ -13,7 +13,7 @@
   import RightClickContextMenu from '$lib/components/shared-components/context-menu/right-click-context-menu.svelte';
   import AlbumsTable from '$lib/components/album-page/albums-table.svelte';
   import AlbumCardGroup from '$lib/components/album-page/album-card-group.svelte';
-  import UserSelectionModal from '$lib/components/album-page/user-selection-modal.svelte';
+  import AlbumShareModal from '$lib/components/album-page/album-share-modal.svelte';
   import { handleError } from '$lib/utils/handle-error';
   import { downloadAlbum } from '$lib/utils/asset-utils';
   import { normalizeSearchString } from '$lib/utils/string-utils';
@@ -429,7 +429,7 @@
         onCreated={() => albumToShare && handleSharedLinkCreated(albumToShare)}
       />
     {:else}
-      <UserSelectionModal
+      <AlbumShareModal
         album={albumToShare}
         onSelect={handleAddUsers}
         onShare={() => (showShareByURLModal = true)}

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -6,7 +6,7 @@
   import AlbumSummary from '$lib/components/album-page/album-summary.svelte';
   import AlbumTitle from '$lib/components/album-page/album-title.svelte';
   import ShareInfoModal from '$lib/components/album-page/share-info-modal.svelte';
-  import UserSelectionModal from '$lib/components/album-page/user-selection-modal.svelte';
+  import AlbumShareModal from '$lib/components/album-page/album-share-modal.svelte';
   import ActivityStatus from '$lib/components/asset-viewer/activity-status.svelte';
   import ActivityViewer from '$lib/components/asset-viewer/activity-viewer.svelte';
   import Button from '$lib/components/elements/buttons/button.svelte';
@@ -745,7 +745,7 @@
   {/if}
 </div>
 {#if viewMode === AlbumPageViewMode.SELECT_USERS}
-  <UserSelectionModal
+  <AlbumShareModal
     {album}
     onSelect={handleAddUsers}
     onShare={() => (viewMode = AlbumPageViewMode.LINK_SHARING)}


### PR DESCRIPTION
## Description

This PR adds a feature to share album with whole server at once without need to create share link or manually add people to access list. Albums marked as `isPublicInInstance` will be visible as shared to everyone in the server

## How Has This Been Tested?

Manually tested

- Create album on account A, make it public, view it on account B
- Create album on account B, make it public, view it on account A, make sure its read only

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

<img width="766" alt="image" src="https://github.com/user-attachments/assets/9bee5fb3-04b9-46bf-8731-d25fdc071764" />
<img width="797" alt="image" src="https://github.com/user-attachments/assets/fb9a4ef2-eddb-4d52-ac19-d881cd3b1431" />
<img width="892" alt="image" src="https://github.com/user-attachments/assets/480b21bb-2499-48c0-9c09-fd81710646e2" />



</details>

<!-- API endpoint changes (if relevant)
## API Changes
The PATCH `/api/album/:id` endpoint now accept `isPublicInInstance`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
