### PR TITLE
feat(web): improve individual share ux

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -54,6 +54,7 @@
     album?: AlbumResponseDto | null;
     person?: PersonResponseDto | null;
     stack?: StackResponseDto | null;
+    showCloseButton?: boolean;
     showDetailButton: boolean;
     showSlideshow?: boolean;
     onZoomImage: () => void;
@@ -73,6 +74,7 @@
     album = null,
     person = null,
     stack = null,
+    showCloseButton = true,
     showDetailButton,
     showSlideshow = false,
     onZoomImage,
@@ -89,6 +91,7 @@
   const sharedLink = getSharedLink();
   let isOwner = $derived($user && asset.ownerId === $user?.id);
   let showDownloadButton = $derived(sharedLink ? sharedLink.allowDownload : !asset.isOffline);
+
   // $: showEditorButton =
   //   isOwner &&
   //   asset.type === AssetTypeEnum.Image &&
@@ -104,7 +107,9 @@
   class="z-[1001] flex h-16 place-items-center justify-between bg-gradient-to-b from-black/40 px-3 transition-transform duration-200"
 >
   <div class="text-white">
-    <CloseAction {onClose} />
+    {#if showCloseButton}
+      <CloseAction {onClose} />
+    {/if}
   </div>
   <div class="flex gap-2 overflow-x-auto text-white" data-testid="asset-viewer-navbar-actions">
     {#if !asset.isTrashed && $user}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -61,6 +61,7 @@
     preAction?: PreAction | undefined;
     onAction?: OnAction | undefined;
     reactions?: ActivityResponseDto[];
+    showCloseButton?: boolean;
     onClose: (dto: { asset: AssetResponseDto }) => void;
     onNext: () => Promise<HasAsset>;
     onPrevious: () => Promise<HasAsset>;
@@ -79,6 +80,7 @@
     preAction = undefined,
     onAction = undefined,
     reactions = $bindable([]),
+    showCloseButton,
     onClose,
     onNext,
     onPrevious,
@@ -431,6 +433,7 @@
         {album}
         {person}
         {stack}
+        {showCloseButton}
         showDetailButton={enableDetailPanel}
         showSlideshow={true}
         onZoomImage={zoomToggle}

--- a/web/src/lib/components/share-page/individual-shared-viewer.svelte
+++ b/web/src/lib/components/share-page/individual-shared-viewer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { AppRoute } from '$lib/constants';
+  import type { Action } from '$lib/components/asset-viewer/actions/action';
+  import { AppRoute, AssetAction } from '$lib/constants';
   import { dragAndDropFilesStore } from '$lib/stores/drag-and-drop-files.store';
   import { getKey, handlePromiseError } from '$lib/utils';
   import { downloadArchive } from '$lib/utils/asset-utils';
@@ -14,6 +15,7 @@
   import AssetSelectControlBar from '../photos-page/asset-select-control-bar.svelte';
   import ControlAppBar from '../shared-components/control-app-bar.svelte';
   import GalleryViewer from '../shared-components/gallery-viewer/gallery-viewer.svelte';
+  import AssetViewer from '../asset-viewer/asset-viewer.svelte';
   import { cancelMultiselect } from '$lib/utils/asset-utils';
   import ImmichLogoSmallLink from '$lib/components/shared-components/immich-logo-small-link.svelte';
   import { NotificationType, notificationController } from '../shared-components/notification/notification';
@@ -72,44 +74,67 @@
   const handleSelectAll = () => {
     assetInteraction.selectAssets(assets);
   };
+
+  const handleAction = async (action: Action) => {
+    switch (action.type) {
+      case AssetAction.ARCHIVE:
+      case AssetAction.DELETE:
+      case AssetAction.TRASH: {
+        await goto(AppRoute.PHOTOS);
+        break;
+      }
+    }
+  };
 </script>
 
 <section class="bg-immich-bg dark:bg-immich-dark-bg">
-  {#if assetInteraction.selectionActive}
-    <AssetSelectControlBar
-      assets={assetInteraction.selectedAssets}
-      clearSelect={() => cancelMultiselect(assetInteraction)}
-    >
-      <CircleIconButton title={$t('select_all')} icon={mdiSelectAll} onclick={handleSelectAll} />
-      {#if sharedLink?.allowDownload}
-        <DownloadAction filename="immich-shared.zip" />
-      {/if}
-      {#if isOwned}
-        <RemoveFromSharedLink bind:sharedLink />
-      {/if}
-    </AssetSelectControlBar>
-  {:else}
-    <ControlAppBar onClose={() => goto(AppRoute.PHOTOS)} backIcon={mdiArrowLeft} showBackButton={false}>
-      {#snippet leading()}
-        <ImmichLogoSmallLink />
-      {/snippet}
-
-      {#snippet trailing()}
-        {#if sharedLink?.allowUpload}
-          <CircleIconButton
-            title={$t('add_photos')}
-            onclick={() => handleUploadAssets()}
-            icon={mdiFileImagePlusOutline}
-          />
-        {/if}
-
+  {#if sharedLink?.allowUpload || assets.length > 1}
+    {#if assetInteraction.selectionActive}
+      <AssetSelectControlBar
+        assets={assetInteraction.selectedAssets}
+        clearSelect={() => cancelMultiselect(assetInteraction)}
+      >
+        <CircleIconButton title={$t('select_all')} icon={mdiSelectAll} onclick={handleSelectAll} />
         {#if sharedLink?.allowDownload}
-          <CircleIconButton title={$t('download')} onclick={downloadAssets} icon={mdiFolderDownloadOutline} />
+          <DownloadAction filename="immich-shared.zip" />
         {/if}
-      {/snippet}
-    </ControlAppBar>
+        {#if isOwned}
+          <RemoveFromSharedLink bind:sharedLink />
+        {/if}
+      </AssetSelectControlBar>
+    {:else}
+      <ControlAppBar onClose={() => goto(AppRoute.PHOTOS)} backIcon={mdiArrowLeft} showBackButton={false}>
+        {#snippet leading()}
+          <ImmichLogoSmallLink />
+        {/snippet}
+
+        {#snippet trailing()}
+          {#if sharedLink?.allowUpload}
+            <CircleIconButton
+              title={$t('add_photos')}
+              onclick={() => handleUploadAssets()}
+              icon={mdiFileImagePlusOutline}
+            />
+          {/if}
+
+          {#if sharedLink?.allowDownload}
+            <CircleIconButton title={$t('download')} onclick={downloadAssets} icon={mdiFolderDownloadOutline} />
+          {/if}
+        {/snippet}
+      </ControlAppBar>
+    {/if}
+    <section class="my-[160px] mx-4" bind:clientHeight={viewport.height} bind:clientWidth={viewport.width}>
+      <GalleryViewer {assets} {assetInteraction} {viewport} />
+    </section>
+  {:else}
+    <AssetViewer
+      asset={assets[0]}
+      showCloseButton={false}
+      onAction={handleAction}
+      onPrevious={() => Promise.resolve(false)}
+      onNext={() => Promise.resolve(false)}
+      onRandom={() => Promise.resolve(undefined)}
+      onClose={() => {}}
+    />
   {/if}
-  <section class="my-[160px] mx-4" bind:clientHeight={viewport.height} bind:clientWidth={viewport.width}>
-    <GalleryViewer {assets} {assetInteraction} {viewport} />
-  </section>
 </section>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Renders share assets of type INDIVIDUAL directly with AssetViewer instead of going through the GalleryViewer. This makes sharing an individual image a bit cleaner, as the person you share it with sees it directly when they open it, instead of having to click through the gallery. If public upload is enabled, then the GalleryViewer is still used. To keep the functionality consistent, some small changes were made to the AssetViewer as well.

note: most of this diff is indentation, i recommend reviewing with the "hide whitespace" option (append `?w=1` to the files url).

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A - single image + no public upload
- [x] Test B - multiple image + no public upload
- [x] Test C - single image + public upload
- [x] Test D - multiple image + public upload

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

![image](https://github.com/user-attachments/assets/bb76e3e9-1cf9-4d3f-91bf-240dea2d1739)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
