### PR TITLE
fix(mobile): hide asset description text field if user is not owner

### DIFF
--- a/mobile/lib/widgets/asset_viewer/description_input.dart
+++ b/mobile/lib/widgets/asset_viewer/description_input.dart
@@ -34,21 +34,21 @@ class DescriptionInput extends HookConsumerWidget {
     final owner = ref.watch(currentUserProvider);
     final hasError = useState(false);
     final assetWithExif = ref.watch(assetDetailProvider(asset));
-    final assetHasDescription = useState(false);
-    final isAssetOwnedByUser = fastHash(owner?.id ?? '') == asset.ownerId;
+    final hasDescription = useState(false);
+    final isOwner = fastHash(owner?.id ?? '') == asset.ownerId;
 
     useEffect(
       () {
         assetService.getDescription(asset).then((value) {
           controller.text = value;
-          assetHasDescription.value = value.isNotEmpty;
+          hasDescription.value = value.isNotEmpty;
         });
         return null;
       },
       [assetWithExif.value],
     );
 
-    if (!isAssetOwnedByUser && !assetHasDescription.value) {
+    if (!isOwner && !hasDescription.value) {
       return const SizedBox.shrink();
     }
 
@@ -89,7 +89,7 @@ class DescriptionInput extends HookConsumerWidget {
     }
 
     return TextField(
-      enabled: isAssetOwnedByUser,
+      enabled: isOwner,
       focusNode: focusNode,
       onTap: () => isFocus.value = true,
       onChanged: (value) {

--- a/mobile/lib/widgets/asset_viewer/description_input.dart
+++ b/mobile/lib/widgets/asset_viewer/description_input.dart
@@ -34,16 +34,23 @@ class DescriptionInput extends HookConsumerWidget {
     final owner = ref.watch(currentUserProvider);
     final hasError = useState(false);
     final assetWithExif = ref.watch(assetDetailProvider(asset));
+    final assetHasDescription = useState(false);
+    final isAssetOwnedByUser = fastHash(owner?.id ?? '') == asset.ownerId;
 
     useEffect(
       () {
-        assetService
-            .getDescription(asset)
-            .then((value) => controller.text = value);
+        assetService.getDescription(asset).then((value) {
+          controller.text = value;
+          assetHasDescription.value = value.isNotEmpty;
+        });
         return null;
       },
       [assetWithExif.value],
     );
+
+    if (!isAssetOwnedByUser && !assetHasDescription.value) {
+      return const SizedBox.shrink();
+    }
 
     submitDescription(String description) async {
       hasError.value = false;
@@ -82,7 +89,7 @@ class DescriptionInput extends HookConsumerWidget {
     }
 
     return TextField(
-      enabled: fastHash(owner?.id ?? '') == asset.ownerId,
+      enabled: isAssetOwnedByUser,
       focusNode: focusNode,
       onTap: () => isFocus.value = true,
       onChanged: (value) {


### PR DESCRIPTION
* If user is not the owner and asset has no description then hide the text field

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #7546 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] When user is owner, the description text field is enabled and loads any existing content in the field.
- [x] When user is NOT the owner and asset already has description then field it is visible but disabled.
- [x] When user is neither owner nor the asset has description then field is hidden
