### PR TITLE
fix: test_sets_default_sess_options fails if compiling with globally enabled cuda

### DIFF
--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -278,8 +278,8 @@ class TestOrtSession:
 
         assert session.provider_options == []
 
-    def test_sets_default_sess_options(self) -> None:
-        session = OrtSession("ViT-B-32__openai")
+    def test_sets_default_sess_options_if_cpu(self) -> None:
+        session = OrtSession("ViT-B-32__openai", providers=["CPUExecutionProvider"])
 
         assert session.sess_options.execution_mode == ort.ExecutionMode.ORT_SEQUENTIAL
         assert session.sess_options.inter_op_num_threads == 1


### PR DESCRIPTION

Coming from nixos, this test fails when cuda is enabled. https://github.com/NixOS/nixpkgs/pull/382896

Solution as proposed by @mertalev

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm not super familiar with how the plumbing of this all works, but in nixos tests are failing when we build the system with cuda support, so lets limit this test to the CPU provider only. I think that makes sense to only assume sess options when using the cpu provider, anyways.

Fixes https://github.com/NixOS/nixpkgs/issues/352113

## How Has This Been Tested?

Running my builds with this PR as patch now. I will update here when finished.

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
