### PR TITLE
docs: Add PowerShell example for running web client only

### DIFF
--- a/docs/docs/developer/setup.md
+++ b/docs/docs/developer/setup.md
@@ -63,6 +63,13 @@ If you only want to do web development connected to an existing, remote backend,
 IMMICH_SERVER_URL=https://demo.immich.app/ npm run dev
 ```
 
+If you're using PowerShell on Windows you may need to set the env var separately like so:
+
+```powershell
+$env:IMMICH_SERVER_URL = "https://demo.immich.app/"
+npm run dev
+```
+
 #### `@immich/ui`
 
 To see local changes to `@immich/ui` in Immich, do the following:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Minor update to docs to add Windows PowerShell example of connecting a local web client to a remote backend.

## How Has This Been Tested?

Relevant change in docs is visible here: https://pr-17546.preview.immich.app/docs/developer/setup#connect-web-to-a-remote-backend

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
