### PR TITLE
fix: live photo hiding

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -646,7 +646,7 @@ export class AssetRepository {
     const { ownerId, otherAssetId, livePhotoCID, type } = options;
     return this.db
       .selectFrom('assets')
-      .select('assets.id')
+      .select(['assets.id', 'assets.ownerId'])
       .innerJoin('exif', 'assets.id', 'exif.assetId')
       .where('id', '!=', asUuid(otherAssetId))
       .where('ownerId', '=', asUuid(ownerId))


### PR DESCRIPTION
Found this while working on types. It is used [here](https://github.com/immich-app/immich/blob/main/server/src/services/metadata.service.ts#L160) and IIRC there have even been reports of the motion part not becoming hidden.