### PR TITLE
fix(web): search bar deactivates when focus exits

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -13,7 +13,7 @@
   import CircleIconButton from '$lib/components/elements/buttons/circle-icon-button.svelte';
   import { t } from 'svelte-i18n';
   import { generateId } from '$lib/utils/generate-id';
-  import { tick } from 'svelte';
+  import { onDestroy, tick } from 'svelte';
 
   interface Props {
     value?: string;
@@ -34,6 +34,10 @@
   let isFocus = $state(false);
 
   const listboxId = generateId();
+
+  onDestroy(() => {
+    searchStore.isSearchEnabled = false;
+  });
 
   const handleSearch = async (payload: SmartSearchDto | MetadataSearchDto) => {
     const params = getMetadataSearchQuery(payload);

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -70,17 +70,7 @@
   };
 
   const onFocusOut = () => {
-    const focusOutTimer = setTimeout(() => {
-      if (searchStore.isSearchEnabled) {
-        searchStore.preventRaceConditionSearchBar = true;
-      }
-
-      closeDropdown();
-      searchStore.isSearchEnabled = false;
-      showFilter = false;
-    }, 100);
-
-    clearTimeout(focusOutTimer);
+    searchStore.isSearchEnabled = false;
   };
 
   const onHistoryTermClick = async (searchTerm: string) => {

--- a/web/src/lib/stores/search.svelte.ts
+++ b/web/src/lib/stores/search.svelte.ts
@@ -1,12 +1,10 @@
 class SearchStore {
   savedSearchTerms = $state<string[]>([]);
   isSearchEnabled = $state(false);
-  preventRaceConditionSearchBar = $state(false);
 
   clearCache() {
     this.savedSearchTerms = [];
     this.isSearchEnabled = false;
-    this.preventRaceConditionSearchBar = false;
   }
 }
 

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -19,7 +19,6 @@
   import SearchBar from '$lib/components/shared-components/search-bar/search-bar.svelte';
   import { AppRoute, QueryParameter } from '$lib/constants';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import { searchStore } from '$lib/stores/search.svelte';
   import { shortcut } from '$lib/actions/shortcut';
   import {
     type AlbumResponseDto,
@@ -88,10 +87,7 @@
       assetInteraction.selectedAssets = [];
       return;
     }
-    if (!searchStore.preventRaceConditionSearchBar) {
-      handlePromiseError(goto(previousRoute));
-    }
-    searchStore.preventRaceConditionSearchBar = false;
+    handlePromiseError(goto(previousRoute));
   };
 
   $effect(() => {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixing the visual activation/deactivation of the search bar. The debouncing added in #13684 is no longer needed since the focus out handler no longer affects filters modal visibility. The modal handles the state itself when escape is pressed or there is a click outside.
- Removing `preventRaceConditionSearchBar`, which was added in #3548. The escape key handler in the search bar stops event propagation, so the race condition check is unneeded.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

**Visual activation/deactivation**

1. Click on the search bar. Observe that the search bar colors change to indicate that it's activated.
2. Click away from the search bar. The search bar should visually gray out.

**Remove preventRaceConditionSearchBar**

1. Perform a search
2. On the search results page, put focus in the search bar input. Pressing "Escape" should close the dropdown menu.
3. Move focus outside of the search bar
4. Press "Escape". The search results page should close.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
