### PR TITLE
fix: occasional empty buckets, after canceled loads

### DIFF
--- a/web/src/lib/utils/cancellable-task.ts
+++ b/web/src/lib/utils/cancellable-task.ts
@@ -61,6 +61,9 @@ export class CancellableTask {
 
     try {
       await f(cancelToken.signal);
+      if (cancelToken.signal.aborted) {
+        return 'CANCELED';
+      }
       this.#transitionToExecuted();
       return 'LOADED';
     } catch (error) {


### PR DESCRIPTION
## Description

Fix timeline showing empty buckets, after draging up/down on the scrubber (which canceled these buckets) 
