### PR TITLE
feat(server): parse EXIF creation time for some insta360 images

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -42,6 +42,8 @@ const EXIF_DATE_TAGS: Array<keyof Tags> = [
   'SubSecMediaCreateDate',
   'MediaCreateDate',
   'DateTimeCreated',
+  // Undocumented, non-standard tag from insta360 in xmp.GPano namespace
+  'SourceImageCreateTime' as keyof Tags,
 ];
 
 const validate = <T>(value: T): NonNullable<T> | null => {


### PR DESCRIPTION
## Description
Some insta360 panoramas are not placed correctly in the timeline. This is because the creation date is stored in a metadata tag unknown to immich. It seems insta360 stores metadata in XMP GPano tags, with their own non-standard and undocumented addition `SourceImageCreateTime`.

The tag is already parsed by exiftool-vendored. By adding it to `EXIF_DATE_TAGS` it becomes a possible source of the creation date when processing image metadata.

We can find traces of this tag in their [ios-SDK repo](https://github.com/Insta360Develop/CameraSDK-iOS#exif--xmp). There's also a [commit](https://gitlab.com/panoramax/server/geo-picture-tag-reader/-/commit/3ddc6256a9e0c7e9901b6f5f1195cd5dda0e2505) to Panoramax GeoPic Tag Reader that adds support for this tag which may provide context, and another example image.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] npm test
- [x] Upload the image from [example.zip](https://github.com/user-attachments/files/19720710/example.zip) to a fresh instance and ensure it's placed correctly in the timeline


<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
