### PR TITLE
fix(web): improve mobile web album viewer padding

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -99,10 +99,10 @@
 </header>
 
 <main
-  class="relative h-dvh overflow-hidden bg-immich-bg px-6 max-md:pt-[var(--navbar-height-md)] pt-[var(--navbar-height)] dark:bg-immich-dark-bg"
+  class="relative h-dvh overflow-hidden bg-immich-bg px-2 md:px-6 max-md:pt-[var(--navbar-height-md)] pt-[var(--navbar-height)] dark:bg-immich-dark-bg"
 >
   <AssetGrid enableRouting={true} {album} {assetStore} {assetInteraction}>
-    <section class="pt-8 md:pt-24">
+    <section class="pt-8 md:pt-24 px-2 md:px-0">
       <!-- ALBUM TITLE -->
       <h1
         class="bg-immich-bg text-2xl md:text-4xl lg:text-6xl text-immich-primary outline-none transition-all dark:bg-immich-dark-bg dark:text-immich-dark-primary"


### PR DESCRIPTION
## Description

Since many people I know doesn't have/use immich, I tend to send them public album links a lot. Since they don't have the app, when the link opens in their browser on their phone, I found the view isn't very pleasant to look at. Specifically, the x-axis margin is too large making the images very small and hard to see (see screenshots). This pr reduces the x-axis margin on small screens. 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
From this:
![Screenshot_20250413_111905](https://github.com/user-attachments/assets/55910beb-6d92-43df-95fb-09dbbbbd72b5)
To this:
![Screenshot_20250413_111908](https://github.com/user-attachments/assets/242476f4-00e4-41b1-8bfd-a338db17d2b6)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
