### PR TITLE
chore(mobile): don't show drag scroll date in search page

### DIFF
--- a/mobile/lib/pages/search/search.page.dart
+++ b/mobile/lib/pages/search/search.page.dart
@@ -768,6 +768,7 @@ class SearchResultGrid extends StatelessWidget {
             editEnabled: true,
             favoriteEnabled: true,
             stackEnabled: false,
+            dragScrollLabelEnabled: false,
             emptyIndicator: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: !isSearching

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
@@ -32,6 +32,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
   final Widget? topWidget;
   final bool shrinkWrap;
   final bool showDragScroll;
+  final bool showDragScrollLabel;
   final bool showStack;
 
   const ImmichAssetGrid({
@@ -52,6 +53,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
     this.topWidget,
     this.shrinkWrap = false,
     this.showDragScroll = true,
+    this.showDragScrollLabel = true,
     this.showStack = false,
   });
 
@@ -119,6 +121,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
           shrinkWrap: shrinkWrap,
           showDragScroll: showDragScroll,
           showStack: showStack,
+          showLabel: showDragScrollLabel,
         ),
       );
     }

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -58,6 +58,7 @@ class ImmichAssetGridView extends ConsumerStatefulWidget {
   final bool shrinkWrap;
   final bool showDragScroll;
   final bool showStack;
+  final bool showLabel;
 
   const ImmichAssetGridView({
     super.key,
@@ -78,6 +79,7 @@ class ImmichAssetGridView extends ConsumerStatefulWidget {
     this.shrinkWrap = false,
     this.showDragScroll = true,
     this.showStack = false,
+    this.showLabel = true,
   });
 
   @override
@@ -284,7 +286,7 @@ class ImmichAssetGridViewState extends ConsumerState<ImmichAssetGridView> {
             backgroundColor: context.isDarkTheme
                 ? context.colorScheme.primary.darken(amount: .5)
                 : context.colorScheme.primary,
-            labelTextBuilder: _labelBuilder,
+            labelTextBuilder: widget.showLabel ? _labelBuilder : null,
             padding: appBarOffset()
                 ? const EdgeInsets.only(top: 60)
                 : const EdgeInsets.only(),

--- a/mobile/lib/widgets/asset_grid/multiselect_grid.dart
+++ b/mobile/lib/widgets/asset_grid/multiselect_grid.dart
@@ -36,6 +36,7 @@ class MultiselectGrid extends HookConsumerWidget {
     this.onRemoveFromAlbum,
     this.topWidget,
     this.stackEnabled = false,
+    this.dragScrollLabelEnabled = true,
     this.archiveEnabled = false,
     this.deleteEnabled = true,
     this.favoriteEnabled = true,
@@ -51,6 +52,7 @@ class MultiselectGrid extends HookConsumerWidget {
   final Future<bool> Function(Iterable<Asset>)? onRemoveFromAlbum;
   final Widget? topWidget;
   final bool stackEnabled;
+  final bool dragScrollLabelEnabled;
   final bool archiveEnabled;
   final bool unarchive;
   final bool deleteEnabled;
@@ -430,6 +432,7 @@ class MultiselectGrid extends HookConsumerWidget {
                               ),
                         topWidget: topWidget,
                         showStack: stackEnabled,
+                        showDragScrollLabel: dragScrollLabelEnabled,
                       ),
                 error: (error, _) => Center(child: Text(error.toString())),
                 loading: buildLoadingIndicator ?? buildDefaultLoadingIndicator,


### PR DESCRIPTION
## Description

* When using the drag scroll, the date of the current image is shown. This is now made toggleable.
* For the mobile search result page, the display of the date is now disabled because the results are not sorted by date and therefore a display of the date is not desirable.

Fixes #10379

## How Has This Been Tested?

Tested on virtual mobile device by using the search function. The results are shown in the screenshots below.

<details><summary><h2>Screenshots</h2></summary>
<!-- Images go below this line. -->

The drag scroll on the main screen (as an example):
![mainScreenScroll](https://github.com/user-attachments/assets/3da3f31d-76fa-4b6e-ac87-7943e0cbe7f3)

The drag scroll with disabled label on the search results screen:
![searchResultsScroll](https://github.com/user-attachments/assets/8d6c967b-7835-4125-9f1b-a227213059e0)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
