### PR TITLE
chore: add immich-cli docker example 

### DIFF
--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -42,6 +42,12 @@ docker run -it -v "$(pwd)":/import:ro -e IMMICH_INSTANCE_URL=https://your-immich
 
 Please modify the `IMMICH_INSTANCE_URL` and `IMMICH_API_KEY` environment variables as suitable. You can also use a Docker env file to store your sensitive API key.
 
+This `docker run` command will directly run the command `immich` inside the container. You can directly append the desired parameters (see under "usage") to the commandline like this:
+
+```bash
+docker run -it -v "$(pwd)":/import:ro -e IMMICH_INSTANCE_URL=https://your-immich-instance/api -e IMMICH_API_KEY=your-api-key ghcr.io/immich-app/immich-cli:latest upload -a -c 5 --recursive directory/
+```
+
 ## Usage
 
 <details>


### PR DESCRIPTION
## Description

Add some explanation how to use the various usage parameters together with the `immich-cli` in the container. This explanation helps users to use the `immich-cli` without further experimentation.

## How Has This Been Tested?

Markdown preview.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
