### PR TITLE
chore(mobile): clear the backup detail view when no backup is in progress

### DIFF
--- a/mobile/lib/widgets/backup/asset_info_table.dart
+++ b/mobile/lib/widgets/backup/asset_info_table.dart
@@ -19,6 +19,15 @@ class BackupAssetInfoTable extends ConsumerWidget {
       ),
     );
 
+    final isUploadInProgress = ref.watch(
+      backupProvider.select(
+        (value) =>
+            value.backupProgress == BackUpProgressEnum.inProgress ||
+            value.backupProgress == BackUpProgressEnum.inBackground ||
+            value.backupProgress == BackUpProgressEnum.manualInProgress,
+      ),
+    );
+
     final asset = isManualUpload
         ? ref.watch(
             manualUploadProvider.select((value) => value.currentUploadAsset),
@@ -47,7 +56,9 @@ class BackupAssetInfoTable extends ConsumerWidget {
                       fontSize: 10.0,
                     ),
                   ).tr(
-                    args: [asset.fileName, asset.fileType.toLowerCase()],
+                    args: isUploadInProgress
+                        ? [asset.fileName, asset.fileType.toLowerCase()]
+                        : ["-", "-"],
                   ),
                 ),
               ),
@@ -67,7 +78,9 @@ class BackupAssetInfoTable extends ConsumerWidget {
                       fontSize: 10.0,
                     ),
                   ).tr(
-                    args: [_getAssetCreationDate(asset)],
+                    args: [
+                      isUploadInProgress ? _getAssetCreationDate(asset) : "-",
+                    ],
                   ),
                 ),
               ),
@@ -85,7 +98,11 @@ class BackupAssetInfoTable extends ConsumerWidget {
                       fontWeight: FontWeight.bold,
                       fontSize: 10.0,
                     ),
-                  ).tr(args: [asset.id]),
+                  ).tr(
+                    args: [
+                      isUploadInProgress ? asset.id : "-",
+                    ],
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
## Description

* When no backup is in progress, display a simple "-" for the details in the upload file info, instead of the data of the last uploaded asset.
* This prevents confusion if a upload job is stuck or just finished.

Fixes #14614

## How Has This Been Tested?

Take some new images, open immich and start the backup.

<details><summary><h2>Video</h2></summary>

https://github.com/user-attachments/assets/510f07aa-f038-470b-81a4-493b7b95f860

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
