### PR TITLE
fix(mobile): exif not updated on sync

### DIFF
--- a/mobile/lib/services/sync.service.dart
+++ b/mobile/lib/services/sync.service.dart
@@ -18,9 +18,9 @@ import 'package:immich_mobile/interfaces/album_media.interface.dart';
 import 'package:immich_mobile/interfaces/asset.interface.dart';
 import 'package:immich_mobile/interfaces/etag.interface.dart';
 import 'package:immich_mobile/interfaces/local_files_manager.interface.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/interfaces/partner.interface.dart';
 import 'package:immich_mobile/interfaces/partner_api.interface.dart';
+import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/exif.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart';
 import 'package:immich_mobile/repositories/album.repository.dart';
@@ -29,9 +29,9 @@ import 'package:immich_mobile/repositories/album_media.repository.dart';
 import 'package:immich_mobile/repositories/asset.repository.dart';
 import 'package:immich_mobile/repositories/etag.repository.dart';
 import 'package:immich_mobile/repositories/local_files_manager.repository.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/repositories/partner.repository.dart';
 import 'package:immich_mobile/repositories/partner_api.repository.dart';
+import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/entity.service.dart';
 import 'package:immich_mobile/services/hash.service.dart';
 import 'package:immich_mobile/utils/async_mutex.dart';
@@ -839,13 +839,13 @@ class SyncService {
       _toggleTrashStatusForAssets(assets);
     }
 
-    final exifInfos = assets.map((e) => e.exifInfo).nonNulls.toList();
     try {
       await _assetRepository.transaction(() async {
         await _assetRepository.updateAll(assets);
         for (final Asset added in assets) {
           added.exifInfo = added.exifInfo?.copyWith(assetId: added.id);
         }
+        final exifInfos = assets.map((e) => e.exifInfo).nonNulls.toList();
         await _exifInfoRepository.updateAll(exifInfos);
       });
       _log.info("Upserted ${assets.length} assets into the DB");

--- a/mobile/test/modules/shared/sync_service_test.dart
+++ b/mobile/test/modules/shared/sync_service_test.dart
@@ -274,6 +274,15 @@ void main() {
           List.filled(assets.length, null),
         );
         await s.upsertAssetsWithExif(assets);
+        verify(
+          () => exifInfoRepository.updateAll(
+            any(
+              that: containsAll(
+                assets.map((a) => a.exifInfo!.copyWith(assetId: a.id)),
+              ),
+            ),
+          ),
+        );
         expect(assets.map((a) => a.exifInfo?.assetId), assets.map((a) => a.id));
       });
     });


### PR DESCRIPTION
## Description

ExifInfo list is created before the assetId is populated. Because of this, the exifInfo list that gets passed down into the `_exifInfoRepository.updateAll` does not have the updated value. Could very well be one more reason for the issue - #17374
