### PR TITLE
fix: skip places that no longer exist in geo import

### DIFF
--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -247,7 +247,7 @@ export class MapRepository {
     let futures = [];
     for await (const line of lineReader) {
       const lineSplit = line.split('\t');
-      if (lineSplit[7] === 'PPLX' && lineSplit[8] !== 'AU') {
+      if ((lineSplit[7] === 'PPLX' && lineSplit[8] !== 'AU') || lineSplit[7] === 'PPLH') {
         continue;
       }
 


### PR DESCRIPTION
## Description

This would be the 'fix' for [my request](https://github.com/immich-app/immich/discussions/17635) to skip PPLH marked locations in geonames import.

## How Has This Been Tested?

~~Unfortunately I'm not sure how to run the build manually. If someone could point me to where this is described I'm happy to test this... :|~~

I ran `make prod` and used the same SQL query on the imported data I used to detect the issue, the result from the query is now as I would expect, the `PPLH` point in question is not imported.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
