### PR TITLE
Microservices: do not listen on http port, as we don't use http requests

### DIFF
--- a/server/src/workers/microservices.ts
+++ b/server/src/workers/microservices.ts
@@ -20,7 +20,7 @@ export async function bootstrap() {
   app.useLogger(logger);
   app.useWebSocketAdapter(new WebSocketAdapter(app));
 
-  await app.listen(0);
+  await app.init();
 
   const configRepository = app.get(ConfigRepository);
   const { environment } = configRepository.getEnv();


### PR DESCRIPTION
per NextJs docs `app.init()` should be used instead of `app.listen()` if the application is not accepting http requests.

Fixes: #9559

This allows us not have unused listening network connections
 
## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
