### PR TITLE
fix: do not select album in time bucket query

### DIFF
--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -12,7 +12,6 @@ export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetReposi
     getByDayOfYear: vitest.fn(),
     getByIds: vitest.fn().mockResolvedValue([]),
     getByIdsWithAllRelations: vitest.fn().mockResolvedValue([]),
-    getByAlbumId: vitest.fn(),
     getByDeviceIds: vitest.fn(),
     getByUserId: vitest.fn(),
     getById: vitest.fn(),


### PR DESCRIPTION
The time bucket query was selecting the album for every single asset, which felt bad and made the JS object unnecessarily large (we didn't send it to the client though).