### PR TITLE
fix: skip initial kysely migration for existing installs

### DIFF
--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -2,4 +2,4 @@
 
 ## TypeORM Upgrade
 
-The upgrade to Immich `v2.x.x` has a required upgrade path to `v1.32.0+`. This means it is required to start up the application at least once on version `1.132.0` (or later). Doing so will complete database schema upgrades that are required for `v2.0.0`. After Immich has successfully booted on this version, shut the system down and try the `v2.x.x` upgrade again.
+The upgrade to Immich `v2.x.x` has a required upgrade path to `v1.132.0+`. This means it is required to start up the application at least once on version `1.132.0` (or later). Doing so will complete database schema upgrades that are required for `v2.0.0`. After Immich has successfully booted on this version, shut the system down and try the `v2.x.x` upgrade again.

--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -1,0 +1,5 @@
+# Errors
+
+## TypeORM Upgrade
+
+The upgrade to Immich `v2.x.x` has a required upgrade path to `v1.32.0+`. This means it is required to start up the application at least once on version `1.132.0` (or later). Doing so will complete database schema upgrades that are required for `v2.0.0`. After Immich has successfully booted on this version, shut the system down and try the `v2.x.x` upgrade again.

--- a/server/src/repositories/logging.repository.ts
+++ b/server/src/repositories/logging.repository.ts
@@ -74,9 +74,19 @@ export class MyConsoleLogger extends ConsoleLogger {
 export class LoggingRepository {
   private logger: MyConsoleLogger;
 
-  constructor(@Inject(ClsService) cls: ClsService | undefined, configRepository: ConfigRepository) {
-    const { noColor } = configRepository.getEnv();
+  constructor(
+    @Inject(ClsService) cls: ClsService | undefined,
+    @Inject(ConfigRepository) configRepository: ConfigRepository | undefined,
+  ) {
+    let noColor = false;
+    if (configRepository) {
+      noColor = configRepository.getEnv().noColor;
+    }
     this.logger = new MyConsoleLogger(cls, { context: LoggingRepository.name, color: !noColor });
+  }
+
+  static create() {
+    return new LoggingRepository(undefined, undefined);
   }
 
   setAppName(name: string): void {


### PR DESCRIPTION
- Skip the initial kysely if TypeORM migrations are up to date
- Throw an error if the TypeORM migrations table, but is missing some migrations
- Redirect users to https://immich.app/errors#typeorm-upgrade for more details