### PR TITLE
refactor: logger service and remove dynamic

### DIFF
--- a/mobile/lib/domain/interfaces/store.interface.dart
+++ b/mobile/lib/domain/interfaces/store.interface.dart
@@ -6,9 +6,11 @@ abstract interface class IStoreRepository implements IDatabaseRepository {
 
   Future<T?> tryGet<T>(StoreKey<T> key);
 
+  Future<List<StoreDto<Object>>> getAll();
+
   Stream<T?> watch<T>(StoreKey<T> key);
 
-  Stream<StoreUpdateEvent> watchAll();
+  Stream<StoreDto<Object>> watchAll();
 
   Future<bool> update<T>(StoreKey<T> key, T value);
 

--- a/mobile/lib/domain/models/store.model.dart
+++ b/mobile/lib/domain/models/store.model.dart
@@ -75,23 +75,23 @@ enum StoreKey<T> {
   Type get type => T;
 }
 
-class StoreUpdateEvent<T> {
+class StoreDto<T> {
   final StoreKey<T> key;
   final T? value;
 
-  const StoreUpdateEvent(this.key, this.value);
+  const StoreDto(this.key, this.value);
 
   @override
   String toString() {
     return '''
-StoreUpdateEvent: {
+StoreDto: {
   key: $key,
   value: ${value ?? '<NA>'},
 }''';
   }
 
   @override
-  bool operator ==(covariant StoreUpdateEvent<T> other) {
+  bool operator ==(covariant StoreDto<T> other) {
     if (identical(this, other)) return true;
 
     return other.key == key && other.value == value;

--- a/mobile/lib/domain/models/sync_event.model.dart
+++ b/mobile/lib/domain/models/sync_event.model.dart
@@ -2,8 +2,7 @@ import 'package:openapi/api.dart';
 
 class SyncEvent {
   final SyncEntityType type;
-  // ignore: avoid-dynamic
-  final dynamic data;
+  final Object data;
   final String ack;
 
   const SyncEvent({required this.type, required this.data, required this.ack});

--- a/mobile/lib/domain/services/sync_stream.service.dart
+++ b/mobile/lib/domain/services/sync_stream.service.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid-passing-async-when-sync-expected
-
 import 'dart:async';
 
 import 'package:immich_mobile/domain/interfaces/sync_api.interface.dart';
@@ -59,8 +57,7 @@ class SyncStreamService {
 
   Future<void> _handleSyncData(
     SyncEntityType type,
-    // ignore: avoid-dynamic
-    Iterable<dynamic> data,
+    Iterable<Object> data,
   ) async {
     _logger.fine("Processing sync data for $type of length ${data.length}");
     switch (type) {

--- a/mobile/lib/infrastructure/repositories/sync_api.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_api.repository.dart
@@ -65,8 +65,7 @@ class SyncApiRepository implements ISyncApiRepository {
     }
 
     try {
-      final response =
-          await client.send(request).timeout(const Duration(seconds: 20));
+      final response = await client.send(request);
 
       if (response.statusCode != 200) {
         final errorBody = await response.stream.bytesToString();
@@ -130,8 +129,7 @@ class SyncApiRepository implements ISyncApiRepository {
   }
 }
 
-// ignore: avoid-dynamic
-const _kResponseMap = <SyncEntityType, Function(dynamic)>{
+const _kResponseMap = <SyncEntityType, Function(Object)>{
   SyncEntityType.userV1: SyncUserV1.fromJson,
   SyncEntityType.userDeleteV1: SyncUserDeleteV1.fromJson,
   SyncEntityType.partnerV1: SyncPartnerV1.fromJson,

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/services/log.service.dart';
 import 'package:immich_mobile/providers/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/cancel.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
@@ -58,9 +59,7 @@ Cancelable<T?> runInIsolateGentle<T>({
         stack,
       );
     } finally {
-      // Wait for the logs to flush
-      await Future.delayed(const Duration(seconds: 2));
-      // Always close the new db connection on Isolate end
+      await LogService.I.flushBuffer();
       ref.read(driftProvider).close();
       ref.read(isarProvider).close();
     }

--- a/mobile/lib/widgets/settings/advanced_settings.dart
+++ b/mobile/lib/widgets/settings/advanced_settings.dart
@@ -41,7 +41,7 @@ class AdvancedSettings extends HookConsumerWidget {
     useValueChanged(
       levelId.value,
       (_, __) =>
-          LogService.I.setlogLevel(Level.LEVELS[levelId.value].toLogLevel()),
+          LogService.I.setLogLevel(Level.LEVELS[levelId.value].toLogLevel()),
     );
 
     Future<bool> checkAndroidVersion() async {

--- a/mobile/test/domain/services/log_service_test.dart
+++ b/mobile/test/domain/services/log_service_test.dart
@@ -74,7 +74,7 @@ void main() {
     setUp(() async {
       when(() => mockStoreRepo.insert<int>(StoreKey.logLevel, any()))
           .thenAnswer((_) async => true);
-      await sut.setlogLevel(LogLevel.shout);
+      await sut.setLogLevel(LogLevel.shout);
     });
 
     test('Updates the log level in store', () {

--- a/mobile/test/infrastructure/repositories/store_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/store_repository_test.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid-dynamic
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/interfaces/store.interface.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
@@ -146,32 +144,21 @@ void main() {
       expectLater(
         stream,
         emitsInAnyOrder([
+          emits(const StoreDto<Object>(StoreKey.version, _kTestVersion)),
           emits(
-            const StoreUpdateEvent<dynamic>(StoreKey.version, _kTestVersion),
+            StoreDto<Object>(StoreKey.backupFailedSince, _kTestBackupFailed),
           ),
           emits(
-            StoreUpdateEvent<dynamic>(
-              StoreKey.backupFailedSince,
-              _kTestBackupFailed,
-            ),
+            const StoreDto<Object>(StoreKey.accessToken, _kTestAccessToken),
           ),
           emits(
-            const StoreUpdateEvent<dynamic>(
-              StoreKey.accessToken,
-              _kTestAccessToken,
-            ),
-          ),
-          emits(
-            const StoreUpdateEvent<dynamic>(
+            const StoreDto<Object>(
               StoreKey.colorfulInterface,
               _kTestColorfulInterface,
             ),
           ),
           emits(
-            const StoreUpdateEvent<dynamic>(
-              StoreKey.version,
-              _kTestVersion + 10,
-            ),
+            const StoreDto<Object>(StoreKey.version, _kTestVersion + 10),
           ),
         ]),
       );


### PR DESCRIPTION
#### Changes made

- Removed few `dynamic` usages and replaced them with `Object` instead
- The `flushBuffer` method in the logger is made public and used in Isolates before termination
- A `getAll` method is introduced to store repo to populate the Store service cache during initialisation
-  Renamed `StoreUpdateEvent` to `StoreDto` since it is now also used by the `getAll` method
- Method names are simplified and moved around in log service
- Comments are slightly updated in store service