### PR TITLE
Update synology.md

### DIFF
--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -25,7 +25,7 @@ When you're all done, you should have the following:
 - `./docker/immich-app/postgres`
 - `./docker/immich-app/library`
 
-Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Upload the files to the `./docker/immich-app` directory.
+Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml) and [`example.env`](https://github.com/immich-app/immich/releases/latest/download/example.env) to your computer. Rename example.env file to .env and then upload the files to the `./docker/immich-app` directory.
 
 ## Step 2 - Populate the .env file with custom values
 


### PR DESCRIPTION
For novice users mostly. Nowhere is stated that you need to rename example.env to .env.