### PR TITLE
fix(web): map marker positioning in details pane

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -249,7 +249,11 @@
       >
         {#snippet children({ feature }: { feature: Feature<Geometry, GeoJsonProperties> })}
           {#if useLocationPin}
-            <Icon path={mdiMapMarker} size="50px" class="dark:text-immich-dark-primary text-immich-primary" />
+            <Icon
+              path={mdiMapMarker}
+              size="50px"
+              class="dark:text-immich-dark-primary text-immich-primary -translate-y-[50%]"
+            />
           {:else}
             <img
               src={getAssetThumbnailUrl(feature.properties?.id)}


### PR DESCRIPTION
## Description
Fixed the alignment of the marker to the map in the details pane of a photo.
The bottom of the pin stays in the place where the photo was taken on the map, not centered incorrectly as it was before.

## Screenshots

<table border="1" cellspacing="0" cellpadding="8">
  <thead>
    <tr>
      <th></th>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><b>Zoomed in</b></td>
      <td><img src="https://github.com/user-attachments/assets/45d05976-1430-471e-8fac-b968d7d825fa" height="200" /></td>
      <td><img src="https://github.com/user-attachments/assets/7d6fa339-52ff-4502-a6c4-5a6fcbb266d5" height="200" /></td>
    </tr>
    <tr>
      <td><b>Zoomed out</b></td>
      <td><img src="https://github.com/user-attachments/assets/1a467a5c-013c-433b-9e22-81f17da5ca52" height="200" /></td>
      <td><img src="https://github.com/user-attachments/assets/9b3cdd6c-df11-46e9-a897-de63ca3127ea" height="200" /></td>
    </tr>
  </tbody>
</table>

All the screenshots show the metadata of the same photo
For reference, photo was taken [here](https://maps.app.goo.gl/CfPjero2aYEfj8Ya8)