### PR TITLE
fix(server): queue android motion assets for transcoding

### DIFF
--- a/server/src/services/job.service.spec.ts
+++ b/server/src/services/job.service.spec.ts
@@ -230,7 +230,7 @@ describe(JobService.name, () => {
       expect(mocks.logger.error).not.toHaveBeenCalled();
     });
 
-    const tests: Array<{ item: JobItem; jobs: JobName[] }> = [
+    const tests: Array<{ item: JobItem; jobs: JobName[]; stub?: any }> = [
       {
         item: { name: JobName.SIDECAR_SYNC, data: { id: 'asset-1' } },
         jobs: [JobName.METADATA_EXTRACTION],
@@ -258,14 +258,22 @@ describe(JobService.name, () => {
       {
         item: { name: JobName.GENERATE_THUMBNAILS, data: { id: 'asset-1' } },
         jobs: [],
+        stub: [assetStub.image],
+      },
+      {
+        item: { name: JobName.GENERATE_THUMBNAILS, data: { id: 'asset-1' } },
+        jobs: [],
+        stub: [assetStub.video],
+      },
+      {
+        item: { name: JobName.GENERATE_THUMBNAILS, data: { id: 'asset-1', source: 'upload' } },
+        jobs: [JobName.SMART_SEARCH, JobName.FACE_DETECTION],
+        stub: [assetStub.livePhotoStillAsset],
       },
       {
         item: { name: JobName.GENERATE_THUMBNAILS, data: { id: 'asset-1', source: 'upload' } },
         jobs: [JobName.SMART_SEARCH, JobName.FACE_DETECTION, JobName.VIDEO_CONVERSION],
-      },
-      {
-        item: { name: JobName.GENERATE_THUMBNAILS, data: { id: 'asset-live-image', source: 'upload' } },
-        jobs: [JobName.SMART_SEARCH, JobName.FACE_DETECTION, JobName.VIDEO_CONVERSION],
+        stub: [assetStub.video],
       },
       {
         item: { name: JobName.SMART_SEARCH, data: { id: 'asset-1' } },
@@ -281,14 +289,10 @@ describe(JobService.name, () => {
       },
     ];
 
-    for (const { item, jobs } of tests) {
+    for (const { item, jobs, stub } of tests) {
       it(`should queue ${jobs.length} jobs when a ${item.name} job finishes successfully`, async () => {
-        if (item.name === JobName.GENERATE_THUMBNAILS && item.data.source === 'upload') {
-          if (item.data.id === 'asset-live-image') {
-            mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([assetStub.livePhotoStillAsset as any]);
-          } else {
-            mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([assetStub.livePhotoMotionAsset as any]);
-          }
+        if (stub) {
+          mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue(stub);
         }
 
         mocks.job.run.mockResolvedValue(JobStatus.SUCCESS);

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -297,8 +297,6 @@ export class JobService extends BaseService {
 
         if (asset.type === AssetType.VIDEO) {
           jobs.push({ name: JobName.VIDEO_CONVERSION, data: item.data });
-        } else if (asset.livePhotoVideoId) {
-          jobs.push({ name: JobName.VIDEO_CONVERSION, data: { id: asset.livePhotoVideoId } });
         }
 
         await this.jobRepository.queueAll(jobs);

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -598,6 +598,10 @@ describe(MetadataService.name, () => {
         livePhotoVideoId: fileStub.livePhotoMotion.uuid,
       });
       expect(mocks.asset.update).toHaveBeenCalledTimes(3);
+      expect(mocks.job.queue).toHaveBeenCalledExactlyOnceWith({
+        name: JobName.VIDEO_CONVERSION,
+        data: { id: assetStub.livePhotoMotionAsset.id },
+      });
     });
 
     it('should extract the EmbeddedVideo tag from Samsung JPEG motion photos', async () => {
@@ -652,6 +656,10 @@ describe(MetadataService.name, () => {
         livePhotoVideoId: fileStub.livePhotoMotion.uuid,
       });
       expect(mocks.asset.update).toHaveBeenCalledTimes(3);
+      expect(mocks.job.queue).toHaveBeenCalledExactlyOnceWith({
+        name: JobName.VIDEO_CONVERSION,
+        data: { id: assetStub.livePhotoMotionAsset.id },
+      });
     });
 
     it('should extract the motion photo video from the XMP directory entry ', async () => {
@@ -706,6 +714,10 @@ describe(MetadataService.name, () => {
         livePhotoVideoId: fileStub.livePhotoMotion.uuid,
       });
       expect(mocks.asset.update).toHaveBeenCalledTimes(3);
+      expect(mocks.job.queue).toHaveBeenCalledExactlyOnceWith({
+        name: JobName.VIDEO_CONVERSION,
+        data: { id: assetStub.livePhotoMotionAsset.id },
+      });
     });
 
     it('should delete old motion photo video assets if they do not match what is extracted', async () => {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -576,6 +576,7 @@ export class MetadataService extends BaseService {
         this.logger.log(`Wrote motion photo video to ${motionAsset.originalPath}`);
 
         await this.handleMetadataExtraction({ id: motionAsset.id });
+        await this.jobRepository.queue({ name: JobName.VIDEO_CONVERSION, data: { id: motionAsset.id } });
       }
 
       this.logger.debug(`Finished motion photo video extraction for asset ${asset.id}: ${asset.originalPath}`);


### PR DESCRIPTION
## Description

Extracted Android motion videos are no longer transcoded. This PR queues them for transcoding after metadata extraction. Notably, they get no-oped in storage template migration, thumbnail generation and ML jobs, so transcoding is the only relevant job here. Also removes the explicit queuing of motion photos for transcoding in the job service as it's redundant (it will either cause a repeat transcode, or it won't transcode if a motion asset was created after running metadata extraction manually).

## How Has This Been Tested?

Tested by uploading the motion photo test assets and confirming they were all processed successfully, including transcoding.