### PR TITLE
fix(mobile): use immutable cache keys for local images

### DIFF
--- a/mobile/lib/providers/image/immich_local_image_provider.dart
+++ b/mobile/lib/providers/image/immich_local_image_provider.dart
@@ -106,12 +106,11 @@ class ImmichLocalImageProvider extends ImageProvider<ImmichLocalImageProvider> {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is ImmichLocalImageProvider) {
-      return asset == other.asset;
+      return asset.id == other.asset.id && asset.localId == other.asset.localId;
     }
-
     return false;
   }
 
   @override
-  int get hashCode => asset.hashCode;
+  int get hashCode => Object.hash(asset.id, asset.localId);
 }

--- a/mobile/lib/providers/image/immich_local_thumbnail_provider.dart
+++ b/mobile/lib/providers/image/immich_local_thumbnail_provider.dart
@@ -82,11 +82,13 @@ class ImmichLocalThumbnailProvider
 
   @override
   bool operator ==(Object other) {
-    if (other is! ImmichLocalThumbnailProvider) return false;
     if (identical(this, other)) return true;
-    return asset == other.asset;
+    if (other is ImmichLocalThumbnailProvider) {
+      return asset.id == other.asset.id && asset.localId == other.asset.localId;
+    }
+    return false;
   }
 
   @override
-  int get hashCode => asset.hashCode;
+  int get hashCode => Object.hash(asset.id, asset.localId);
 }


### PR DESCRIPTION
## Description

**Second take**
I actually check asset.id and asset.localId as it seems id is empty or not unique for Assets created from AssetEntity in the backup album selection view. Now the thumbnails are different for each asset there too.

It get rids of this exception which happens when deleting photos and swiping around the gallery. The key is the whole asset, which is mutable and changes and breaks the hashmap access in flutter internals. The remote asset variants already used the assetId as the key rather than the whole object.

```
Exception: Null check operator used on a null value
Library: image resource service
Context: Instance of 'ErrorDescription' |
#0      ImageCache._checkCacheSize (package:flutter/src/painting/image_cache.dart:511)
#1      ImageCache._touch (package:flutter/src/painting/image_cache.dart:288)
#2      ImageCache.putIfAbsent.listener (package:flutter/src/painting/image_cache.dart:423)
#3      ImageStreamCompleter.setImage (package:flutter/src/painting/image_stream.dart:747)
#4      MultiFrameImageStreamCompleter._emitFrame (package:flutter/src/painting/image_stream.dart:1097)
#5      MultiImageStreamCompleter._decodeNextFrameAndSchedule (package:cached_network_image/src/image_provider/multi_image_stream_completer.dart:154)
```

I believe it fixes the most annoying issue that I have with Immich apart for large library performance.
Fixes #10545

## How Has This Been Tested?
I reproduced the issue from the ticket. After I updated the code, I didn't manage to reproduce anymore.
I also tested the thumbnails in album to backup selection view.

## Checklist:

- [V] I have performed a self-review of my own code
- [V] I have made corresponding changes to the documentation if applicable
- [V] I have no unrelated changes in the PR.
- [V] I have confirmed that any new dependencies are strictly necessary.
- [V] I have written tests for new code (if applicable)
- [V] I have followed naming conventions/patterns in the surrounding code
- [V] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [V] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
