### PR TITLE
fix: flappy e2e test

### DIFF
--- a/e2e/src/api/specs/oauth.e2e-spec.ts
+++ b/e2e/src/api/specs/oauth.e2e-spec.ts
@@ -142,7 +142,7 @@ describe(`/oauth`, () => {
     it(`should throw an error if the state mismatches`, async () => {
       const callbackParams = await loginWithOAuth('oauth-auto-register');
       const { state } = await loginWithOAuth('oauth-auto-register');
-      const { status, body } = await request(app)
+      const { status } = await request(app)
         .post('/oauth/callback')
         .send({ ...callbackParams, state });
       expect(status).toBeGreaterThanOrEqual(400);

--- a/e2e/src/web/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/web/specs/shared-link.e2e-spec.ts
@@ -55,7 +55,6 @@ test.describe('Shared Links', () => {
     await page.goto(`/share/${sharedLink.key}`);
     await page.getByRole('heading', { name: 'Test Album' }).waitFor();
     await page.getByRole('button', { name: 'Download' }).click();
-    await page.getByText('DOWNLOADING', { exact: true }).waitFor();
     await page.waitForEvent('download');
   });
 


### PR DESCRIPTION
## Description

This test flaps, the fix is to not wait for the text (the download might be done faster than it can take to show dialog) - plus, the next line waits for the download event anyways, so we know download actually happened. 
