### PR TITLE
refactor: database connection parsing

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -44,7 +44,7 @@ const imports = [
   BullModule.registerQueue(...bull.queues),
   ClsModule.forRoot(cls.config),
   OpenTelemetryModule.forRoot(otel),
-  KyselyModule.forRoot(getKyselyConfig(database.config.kysely)),
+  KyselyModule.forRoot(getKyselyConfig(database.config)),
 ];
 
 class BaseModule implements OnModuleInit, OnModuleDestroy {

--- a/server/src/bin/migrations.ts
+++ b/server/src/bin/migrations.ts
@@ -10,7 +10,7 @@ import { DatabaseRepository } from 'src/repositories/database.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import 'src/schema';
 import { schemaDiff, schemaFromCode, schemaFromDatabase } from 'src/sql-tools';
-import { getKyselyConfig } from 'src/utils/database';
+import { asPostgresConnectionConfig, getKyselyConfig } from 'src/utils/database';
 
 const main = async () => {
   const command = process.argv[2];
@@ -56,7 +56,7 @@ const main = async () => {
 const getDatabaseClient = () => {
   const configRepository = new ConfigRepository();
   const { database } = configRepository.getEnv();
-  return new Kysely<any>(getKyselyConfig(database.config.kysely));
+  return new Kysely<any>(getKyselyConfig(database.config));
 };
 
 const runQuery = async (query: string) => {
@@ -105,7 +105,7 @@ const create = (path: string, up: string[], down: string[]) => {
 const compare = async () => {
   const configRepository = new ConfigRepository();
   const { database } = configRepository.getEnv();
-  const db = postgres(database.config.kysely);
+  const db = postgres(asPostgresConnectionConfig(database.config));
 
   const source = schemaFromCode();
   const target = await schemaFromDatabase(db, {});

--- a/server/src/bin/sync-sql.ts
+++ b/server/src/bin/sync-sql.ts
@@ -78,7 +78,7 @@ class SqlGenerator {
     const moduleFixture = await Test.createTestingModule({
       imports: [
         KyselyModule.forRoot({
-          ...getKyselyConfig(database.config.kysely),
+          ...getKyselyConfig(database.config),
           log: (event) => {
             if (event.level === 'query') {
               this.sqlLogger.logQuery(event.query.sql);

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -80,21 +80,12 @@ describe('getEnv', () => {
       const { database } = getEnv();
       expect(database).toEqual({
         config: {
-          kysely: expect.objectContaining({
-            host: 'database',
-            port: 5432,
-            database: 'immich',
-            username: 'postgres',
-            password: 'postgres',
-          }),
-          typeorm: expect.objectContaining({
-            type: 'postgres',
-            host: 'database',
-            port: 5432,
-            database: 'immich',
-            username: 'postgres',
-            password: 'postgres',
-          }),
+          connectionType: 'parts',
+          host: 'database',
+          port: 5432,
+          database: 'immich',
+          username: 'postgres',
+          password: 'postgres',
         },
         skipMigrations: false,
         vectorExtension: 'vectors',
@@ -110,88 +101,9 @@ describe('getEnv', () => {
     it('should use DB_URL', () => {
       process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich';
       const { database } = getEnv();
-      expect(database.config.kysely).toMatchObject({
-        host: 'database1',
-        password: 'postgres2',
-        user: 'postgres1',
-        port: 54_320,
-        database: 'immich',
-      });
-    });
-
-    it('should handle sslmode=require', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=require';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: {} });
-    });
-
-    it('should handle sslmode=prefer', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=prefer';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: {} });
-    });
-
-    it('should handle sslmode=verify-ca', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-ca';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: {} });
-    });
-
-    it('should handle sslmode=verify-full', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-full';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: {} });
-    });
-
-    it('should handle sslmode=no-verify', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=no-verify';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: { rejectUnauthorized: false } });
-    });
-
-    it('should handle ssl=true', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?ssl=true';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({ ssl: true });
-    });
-
-    it('should reject invalid ssl', () => {
-      process.env.DB_URL = 'postgres://postgres1:postgres2@database1:54320/immich?ssl=invalid';
-
-      expect(() => getEnv()).toThrowError('Invalid ssl option: invalid');
-    });
-
-    it('should handle socket: URLs', () => {
-      process.env.DB_URL = 'socket:/run/postgresql?db=database1';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({
-        host: '/run/postgresql',
-        database: 'database1',
-      });
-    });
-
-    it('should handle sockets in postgres: URLs', () => {
-      process.env.DB_URL = 'postgres:///database2?host=/path/to/socket';
-
-      const { database } = getEnv();
-
-      expect(database.config.kysely).toMatchObject({
-        host: '/path/to/socket',
-        database: 'database2',
+      expect(database.config).toMatchObject({
+        connectionType: 'url',
+        url: 'postgres://postgres1:postgres2@database1:54320/immich',
       });
     });
   });

--- a/server/src/services/backup.service.ts
+++ b/server/src/services/backup.service.ts
@@ -70,7 +70,7 @@ export class BackupService extends BaseService {
   async handleBackupDatabase(): Promise<JobStatus> {
     this.logger.debug(`Database Backup Started`);
     const { database } = this.configRepository.getEnv();
-    const config = database.config.typeorm;
+    const config = database.config;
 
     const isUrlConnection = config.connectionType === 'url';
 

--- a/server/src/services/database.service.spec.ts
+++ b/server/src/services/database.service.spec.ts
@@ -53,22 +53,12 @@ describe(DatabaseService.name, () => {
           mockEnvData({
             database: {
               config: {
-                kysely: {
-                  host: 'database',
-                  port: 5432,
-                  user: 'postgres',
-                  password: 'postgres',
-                  database: 'immich',
-                },
-                typeorm: {
-                  connectionType: 'parts',
-                  type: 'postgres',
-                  host: 'database',
-                  port: 5432,
-                  username: 'postgres',
-                  password: 'postgres',
-                  database: 'immich',
-                },
+                connectionType: 'parts',
+                host: 'database',
+                port: 5432,
+                username: 'postgres',
+                password: 'postgres',
+                database: 'immich',
               },
               skipMigrations: false,
               vectorExtension: extension,
@@ -292,22 +282,12 @@ describe(DatabaseService.name, () => {
         mockEnvData({
           database: {
             config: {
-              kysely: {
-                host: 'database',
-                port: 5432,
-                user: 'postgres',
-                password: 'postgres',
-                database: 'immich',
-              },
-              typeorm: {
-                connectionType: 'parts',
-                type: 'postgres',
-                host: 'database',
-                port: 5432,
-                username: 'postgres',
-                password: 'postgres',
-                database: 'immich',
-              },
+              connectionType: 'parts',
+              host: 'database',
+              port: 5432,
+              username: 'postgres',
+              password: 'postgres',
+              database: 'immich',
             },
             skipMigrations: true,
             vectorExtension: DatabaseExtension.VECTORS,
@@ -325,22 +305,12 @@ describe(DatabaseService.name, () => {
         mockEnvData({
           database: {
             config: {
-              kysely: {
-                host: 'database',
-                port: 5432,
-                user: 'postgres',
-                password: 'postgres',
-                database: 'immich',
-              },
-              typeorm: {
-                connectionType: 'parts',
-                type: 'postgres',
-                host: 'database',
-                port: 5432,
-                username: 'postgres',
-                password: 'postgres',
-                database: 'immich',
-              },
+              connectionType: 'parts',
+              host: 'database',
+              port: 5432,
+              username: 'postgres',
+              password: 'postgres',
+              database: 'immich',
             },
             skipMigrations: true,
             vectorExtension: DatabaseExtension.VECTOR,

--- a/server/src/utils/database.spec.ts
+++ b/server/src/utils/database.spec.ts
@@ -1,0 +1,83 @@
+import { asPostgresConnectionConfig } from 'src/utils/database';
+
+describe('database  utils', () => {
+  describe('asPostgresConnectionConfig', () => {
+    it('should handle sslmode=require', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=require',
+        }),
+      ).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=prefer', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=prefer',
+        }),
+      ).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=verify-ca', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-ca',
+        }),
+      ).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=verify-full', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=verify-full',
+        }),
+      ).toMatchObject({ ssl: {} });
+    });
+
+    it('should handle sslmode=no-verify', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?sslmode=no-verify',
+        }),
+      ).toMatchObject({ ssl: { rejectUnauthorized: false } });
+    });
+
+    it('should handle ssl=true', () => {
+      expect(
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?ssl=true',
+        }),
+      ).toMatchObject({ ssl: true });
+    });
+
+    it('should reject invalid ssl', () => {
+      expect(() =>
+        asPostgresConnectionConfig({
+          connectionType: 'url',
+          url: 'postgres://postgres1:postgres2@database1:54320/immich?ssl=invalid',
+        }),
+      ).toThrowError('Invalid ssl option');
+    });
+
+    it('should handle socket: URLs', () => {
+      expect(
+        asPostgresConnectionConfig({ connectionType: 'url', url: 'socket:/run/postgresql?db=database1' }),
+      ).toMatchObject({ host: '/run/postgresql', database: 'database1' });
+    });
+
+    it('should handle sockets in postgres: URLs', () => {
+      expect(
+        asPostgresConnectionConfig({ connectionType: 'url', url: 'postgres:///database2?host=/path/to/socket' }),
+      ).toMatchObject({
+        host: '/path/to/socket',
+        database: 'database2',
+      });
+    });
+  });
+});

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -13,33 +13,57 @@ import {
 } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
+import { parse } from 'pg-connection-string';
 import postgres, { Notice } from 'postgres';
 import { columns, Exif, Person } from 'src/database';
 import { DB } from 'src/db';
 import { AssetFileType } from 'src/enum';
 import { TimeBucketSize } from 'src/repositories/asset.repository';
 import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
+import { DatabaseConnectionParams } from 'src/types';
 
 type Ssl = 'require' | 'allow' | 'prefer' | 'verify-full' | boolean | object;
 
-export type PostgresConnectionConfig = {
-  host?: string;
-  password?: string;
-  user?: string;
-  port?: number;
-  database?: string;
-  max?: number;
-  client_encoding?: string;
-  ssl?: Ssl;
-  application_name?: string;
-  fallback_application_name?: string;
-  options?: string;
-};
-
-export const isValidSsl = (ssl?: string | boolean | object): ssl is Ssl =>
+const isValidSsl = (ssl?: string | boolean | object): ssl is Ssl =>
   typeof ssl !== 'string' || ssl === 'require' || ssl === 'allow' || ssl === 'prefer' || ssl === 'verify-full';
 
-export const getKyselyConfig = (options: PostgresConnectionConfig): KyselyConfig => {
+export const asPostgresConnectionConfig = (params: DatabaseConnectionParams) => {
+  if (params.connectionType === 'parts') {
+    return {
+      host: params.host,
+      port: params.port,
+      username: params.username,
+      password: params.password,
+      database: params.database,
+      ssl: undefined,
+    };
+  }
+
+  const { host, port, user, password, database, ...rest } = parse(params.url);
+  let ssl: Ssl | undefined;
+  if (rest.ssl) {
+    if (!isValidSsl(rest.ssl)) {
+      throw new Error(`Invalid ssl option: ${rest.ssl}`);
+    }
+    ssl = rest.ssl;
+  }
+
+  return {
+    host: host ?? undefined,
+    port: port ? Number(port) : undefined,
+    username: user,
+    password,
+    database: database ?? undefined,
+    ssl,
+  };
+};
+
+export const getKyselyConfig = (
+  params: DatabaseConnectionParams,
+  options: Partial<postgres.Options<Record<string, postgres.PostgresType>>> = {},
+): KyselyConfig => {
+  const config = asPostgresConnectionConfig(params);
+
   return {
     dialect: new PostgresJSDialect({
       postgres: postgres({
@@ -66,6 +90,12 @@ export const getKyselyConfig = (options: PostgresConnectionConfig): KyselyConfig
         connection: {
           TimeZone: 'UTC',
         },
+        host: config.host,
+        port: config.port,
+        username: config.username,
+        password: config.password,
+        database: config.database,
+        ssl: config.ssl,
         ...options,
       }),
     }),

--- a/server/test/medium/globalSetup.ts
+++ b/server/test/medium/globalSetup.ts
@@ -1,5 +1,4 @@
 import { Kysely } from 'kysely';
-import { parse } from 'pg-connection-string';
 import { DB } from 'src/db';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
@@ -37,19 +36,10 @@ const globalSetup = async () => {
 
   const postgresPort = postgresContainer.getMappedPort(5432);
   const postgresUrl = `postgres://postgres:postgres@localhost:${postgresPort}/immich`;
-  const parsed = parse(postgresUrl);
 
   process.env.IMMICH_TEST_POSTGRES_URL = postgresUrl;
 
-  const db = new Kysely<DB>(
-    getKyselyConfig({
-      ...parsed,
-      ssl: false,
-      host: parsed.host ?? undefined,
-      port: parsed.port ? Number(parsed.port) : undefined,
-      database: parsed.database ?? undefined,
-    }),
-  );
+  const db = new Kysely<DB>(getKyselyConfig({ connectionType: 'url', url: postgresUrl }));
 
   const configRepository = new ConfigRepository();
   const logger = new LoggingRepository(undefined, configRepository);

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -21,19 +21,12 @@ const envData: EnvData = {
 
   database: {
     config: {
-      kysely: { database: 'immich', host: 'database', port: 5432 },
-      typeorm: {
-        connectionType: 'parts',
-        database: 'immich',
-        type: 'postgres',
-        host: 'database',
-        port: 5432,
-        username: 'postgres',
-        password: 'postgres',
-        name: 'immich',
-        synchronize: false,
-        migrationsRun: true,
-      },
+      connectionType: 'parts',
+      database: 'immich',
+      host: 'database',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
     },
 
     skipMigrations: false,


### PR DESCRIPTION
The config repo now just returns a connection object of type `parts` or `url`.  For `new DataSource(...)` we can pass the url directly to it. For `postgres(...)` we pre-parse the url using `pg-connection-string`, and then pass the parsed options. This simplifies the configuration objects we need, and prevent things (like the backup service) from using typeorm-based configuration.