### PR TITLE
fix(mobile): revert get location on app start

### DIFF
--- a/mobile/lib/pages/library/library.page.dart
+++ b/mobile/lib/pages/library/library.page.dart
@@ -1,7 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
@@ -13,7 +12,6 @@ import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/utils/image_url_builder.dart';
-import 'package:immich_mobile/utils/map_utils.dart';
 import 'package:immich_mobile/widgets/album/album_thumbnail_card.dart';
 import 'package:immich_mobile/widgets/common/immich_app_bar.dart';
 import 'package:immich_mobile/widgets/common/user_avatar.dart';
@@ -357,66 +355,51 @@ class PlacesCollectionCard extends StatelessWidget {
         final widthFactor = isTablet ? 0.25 : 0.5;
         final size = context.width * widthFactor - 20.0;
 
-        return FutureBuilder<(Position?, LocationPermission?)>(
-          future: MapUtils.checkPermAndGetLocation(
-            context: context,
-            silent: true,
+        return GestureDetector(
+          onTap: () => context.pushRoute(
+            PlacesCollectionRoute(
+              currentLocation: null,
+            ),
           ),
-          builder: (context, snapshot) {
-            var position = snapshot.data?.$1;
-            return GestureDetector(
-              onTap: () => context.pushRoute(
-                PlacesCollectionRoute(
-                  currentLocation: position != null
-                      ? LatLng(position.latitude, position.longitude)
-                      : null,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: size,
+                width: size,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: const BorderRadius.all(Radius.circular(20)),
+                    color:
+                        context.colorScheme.secondaryContainer.withAlpha(100),
+                  ),
+                  child: IgnorePointer(
+                    child: MapThumbnail(
+                      zoom: 8,
+                      centre: const LatLng(
+                        21.44950,
+                        -157.91959,
+                      ),
+                      showAttribution: false,
+                      themeMode: context.isDarkTheme
+                          ? ThemeMode.dark
+                          : ThemeMode.light,
+                    ),
+                  ),
                 ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(
-                    height: size,
-                    width: size,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        borderRadius:
-                            const BorderRadius.all(Radius.circular(20)),
-                        color: context.colorScheme.secondaryContainer
-                            .withAlpha(100),
-                      ),
-                      child: IgnorePointer(
-                        child: snapshot.connectionState ==
-                                ConnectionState.waiting
-                            ? const Center(child: CircularProgressIndicator())
-                            : MapThumbnail(
-                                zoom: 8,
-                                centre: LatLng(
-                                  position?.latitude ?? 21.44950,
-                                  position?.longitude ?? -157.91959,
-                                ),
-                                showAttribution: false,
-                                themeMode: context.isDarkTheme
-                                    ? ThemeMode.dark
-                                    : ThemeMode.light,
-                              ),
-                      ),
-                    ),
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  'places'.tr(),
+                  style: context.textTheme.titleSmall?.copyWith(
+                    color: context.colorScheme.onSurface,
+                    fontWeight: FontWeight.w500,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text(
-                      'places'.tr(),
-                      style: context.textTheme.titleSmall?.copyWith(
-                        color: context.colorScheme.onSurface,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
-            );
-          },
+            ],
+          ),
         );
       },
     );


### PR DESCRIPTION
## Description
Removes the location request on app launch due to issue Baseflow/flutter-geolocator/issues/1210
Opening with "Improve location accuracy" doesn't prompt the user to enable the location accuracy.

Note: this will prevent the map thumbnails to show user's location and the map will open zoomed-out as it has been in previous versions.

Fixes #17826 
Blocks #17740

## Potential improvements
Maybe we should test [location package](https://pub.dev/packages/location) to replace geolocator. 