### PR TITLE
feat(mobile): save grid size on gesture resize

### DIFF
--- a/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid.dart
@@ -97,6 +97,7 @@ class ImmichAssetGrid extends HookConsumerWidget {
               );
               if (7 - scaleFactor.value.toInt() != perRow.value) {
                 perRow.value = 7 - scaleFactor.value.toInt();
+                settings.setSetting(AppSettingsEnum.tilesPerRow, perRow.value);
               }
             };
           }),


### PR DESCRIPTION
## Description
Remember the grid size when resizing it using gestures. This way, the user doesn't need to find the slider in settings.

## How Has This Been Tested?
- [x] Resize the main photo grid using the zoom in/out gesture
- [x] Restart the app
- [x] The zoom level persists between app sessions