### PR TITLE
fix(server): Storage-templates: Dots getting replaced in album names

### DIFF
--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -357,7 +357,7 @@ export class StorageTemplateService extends BaseService {
       assetId: asset.id,
       assetIdShort: asset.id.slice(-12),
       //just throw into the root if it doesn't belong to an album
-      album: (albumName && sanitize(albumName.replaceAll(/\.+/g, ''))) || '',
+      album: !albumName || albumName.match(/^\.+$/) ? '' : sanitize(albumName),
     };
 
     const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -357,7 +357,7 @@ export class StorageTemplateService extends BaseService {
       assetId: asset.id,
       assetIdShort: asset.id.slice(-12),
       //just throw into the root if it doesn't belong to an album
-      album: !albumName || albumName.match(/^\.+$/) ? '' : sanitize(albumName),
+      album: !albumName || /^\.+$/.test(albumName) ? '' : sanitize(albumName),
     };
 
     const systemTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
## Description

Instead of replacing all dots in an album name with empty strings, it will only replace the whole album name with an empty string when it solely consists out of dots, to prevent saving files in ".." for example. Maybe this is paranoid, but I wanted to be safe.

Fixes [#4917(comment)](https://github.com/immich-app/immich/issues/4917#issuecomment-2635470887)


## How Has This Been Tested?

- [x] Add one photo to an album named "2004.12"
- [x] Add one photo to an album named "."
- [x] Add one photo without an album
- [x] Run storage-template migration

The first photo lands inside an folder called "2004.12", as expected.
The other two land inside the folder root, as expected.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
