### PR TITLE
feat(mobile): Capitalize month names in asset grid

### DIFF
--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -786,7 +786,7 @@ class _Title extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GroupDividerTitle(
-      text: title,
+      text: toBeginningOfSentenceCase(title, context.locale.languageCode),
       multiselectEnabled: selectionActive,
       onSelect: () => selectAssets(assets),
       onDeselect: () => deselectAssets(assets),

--- a/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
+++ b/mobile/lib/widgets/asset_grid/immich_asset_grid_view.dart
@@ -755,7 +755,7 @@ class _MonthTitle extends StatelessWidget {
       key: Key("month-$title"),
       padding: const EdgeInsets.only(left: 12.0, top: 24.0),
       child: Text(
-        title,
+        toBeginningOfSentenceCase(title, context.locale.languageCode),
         style: const TextStyle(
           fontSize: 26,
           fontWeight: FontWeight.w500,


### PR DESCRIPTION
## Description

Capitalizes month titles in the photos tab in the mobile app

Fixes #17803

## How Has This Been Tested?

- [x] Manual test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/346ec561-b13b-463a-a861-5919a0191f4a)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
