### PR TITLE
fix(web): Make date-time formatting follow locale

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -544,7 +544,7 @@
 
             <div class="absolute left-8 top-4 text-sm font-medium text-white">
               <p>
-                {fromLocalDateTime(current.memory.assets[0].localDateTime).toLocaleString(DateTime.DATE_FULL)}
+                {fromLocalDateTime(current.memory.assets[0].localDateTime).toLocaleString(DateTime.DATE_FULL, {locale: $locale})}
               </p>
               <p>
                 {current.asset.exifInfo?.city || ''}

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -544,7 +544,9 @@
 
             <div class="absolute left-8 top-4 text-sm font-medium text-white">
               <p>
-                {fromLocalDateTime(current.memory.assets[0].localDateTime).toLocaleString(DateTime.DATE_FULL, {locale: $locale})}
+                {fromLocalDateTime(current.memory.assets[0].localDateTime).toLocaleString(DateTime.DATE_FULL, {
+                  locale: $locale,
+                })}
               </p>
               <p>
                 {current.asset.exifInfo?.city || ''}

--- a/web/src/lib/components/shared-components/server-about-modal.svelte
+++ b/web/src/lib/components/shared-components/server-about-modal.svelte
@@ -178,16 +178,19 @@
               <span
                 class="immich-form-label pb-2 text-xs"
                 id="version-history"
-                title={createdAt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS, {locale: $locale})}
+                title={createdAt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS, { locale: $locale })}
               >
                 {$t('version_history_item', {
                   values: {
                     version: item.version,
-                    date: createdAt.toLocaleString({
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    }, {locale: $locale}),
+                    date: createdAt.toLocaleString(
+                      {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      },
+                      { locale: $locale },
+                    ),
                   },
                 })}
               </span>

--- a/web/src/lib/components/shared-components/server-about-modal.svelte
+++ b/web/src/lib/components/shared-components/server-about-modal.svelte
@@ -6,6 +6,7 @@
   import { t } from 'svelte-i18n';
   import { mdiAlert } from '@mdi/js';
   import Icon from '$lib/components/elements/icon.svelte';
+  import { locale } from '$lib/stores/preferences.store';
 
   interface Props {
     onClose: () => void;
@@ -177,7 +178,7 @@
               <span
                 class="immich-form-label pb-2 text-xs"
                 id="version-history"
-                title={createdAt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS)}
+                title={createdAt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS, {locale: $locale})}
               >
                 {$t('version_history_item', {
                   values: {
@@ -186,7 +187,7 @@
                       month: 'short',
                       day: 'numeric',
                       year: 'numeric',
-                    }),
+                    }, {locale: $locale}),
                   },
                 })}
               </span>

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -64,7 +64,9 @@
         <span>{DateTime.fromISO(device.updatedAt, { locale: $locale }).toRelativeCalendar(options)}</span>
         <span class="text-xs text-gray-500 dark:text-gray-400"> - </span>
         <span class="text-xs text-gray-500 dark:text-gray-400">
-          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED, {locale: $locale})}
+          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED, {
+            locale: $locale,
+          })}
         </span>
       </div>
     </div>

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -64,7 +64,7 @@
         <span>{DateTime.fromISO(device.updatedAt, { locale: $locale }).toRelativeCalendar(options)}</span>
         <span class="text-xs text-gray-500 dark:text-gray-400"> - </span>
         <span class="text-xs text-gray-500 dark:text-gray-400">
-          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED)}
+          {DateTime.fromISO(device.updatedAt, { locale: $locale }).toLocaleString(DateTime.DATETIME_MED, {locale: $locale})}
         </span>
       </div>
     </div>

--- a/web/src/lib/utils/byte-units.ts
+++ b/web/src/lib/utils/byte-units.ts
@@ -34,6 +34,7 @@ export function getBytesWithUnit(bytes: number, maxPrecision = 1): [number, Byte
  * * de: `1,5 KiB`
  *
  * @param bytes number of bytes
+ * @param locale locale to use, default is `navigator.language`
  * @param maxPrecision maximum number of decimal places, default is `1`
  * @returns localized bytes with unit as string
  */

--- a/web/src/lib/utils/thumbnail-util.ts
+++ b/web/src/lib/utils/thumbnail-util.ts
@@ -1,7 +1,8 @@
 import { AssetTypeEnum, type AssetResponseDto } from '@immich/sdk';
 import { t } from 'svelte-i18n';
-import { derived } from 'svelte/store';
+import { derived, get } from 'svelte/store';
 import { fromLocalDateTime } from './timeline-util';
+import { locale } from '$lib/stores/preferences.store';
 
 /**
  * Calculate thumbnail size based on number of assets and viewport width
@@ -43,7 +44,7 @@ export const getAltText = derived(t, ($t) => {
       return asset.exifInfo.description;
     }
 
-    const date = fromLocalDateTime(asset.localDateTime).toLocaleString({ dateStyle: 'long' });
+    const date = fromLocalDateTime(asset.localDateTime).toLocaleString({ dateStyle: 'long' }, {locale: get(locale)});
     const hasPlace = !!asset.exifInfo?.city && !!asset.exifInfo?.country;
     const names = asset.people?.filter((p) => p.name).map((p) => p.name) ?? [];
     const peopleCount = names.length;

--- a/web/src/lib/utils/thumbnail-util.ts
+++ b/web/src/lib/utils/thumbnail-util.ts
@@ -1,8 +1,8 @@
+import { locale } from '$lib/stores/preferences.store';
 import { AssetTypeEnum, type AssetResponseDto } from '@immich/sdk';
 import { t } from 'svelte-i18n';
 import { derived, get } from 'svelte/store';
 import { fromLocalDateTime } from './timeline-util';
-import { locale } from '$lib/stores/preferences.store';
 
 /**
  * Calculate thumbnail size based on number of assets and viewport width
@@ -44,7 +44,7 @@ export const getAltText = derived(t, ($t) => {
       return asset.exifInfo.description;
     }
 
-    const date = fromLocalDateTime(asset.localDateTime).toLocaleString({ dateStyle: 'long' }, {locale: get(locale)});
+    const date = fromLocalDateTime(asset.localDateTime).toLocaleString({ dateStyle: 'long' }, { locale: get(locale) });
     const hasPlace = !!asset.exifInfo?.city && !!asset.exifInfo?.country;
     const names = asset.people?.filter((p) => p.name).map((p) => p.name) ?? [];
     const peopleCount = names.length;

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -87,7 +87,7 @@ export function formatGroupTitle(_date: DateTime): string {
 
   // Last week
   if (date >= today.minus({ days: 6 }) && date < today) {
-    return date.toLocaleString({ weekday: 'long' });
+    return date.toLocaleString({ weekday: 'long' }, {locale: get(locale)});
   }
 
   // This year
@@ -96,11 +96,12 @@ export function formatGroupTitle(_date: DateTime): string {
       weekday: 'short',
       month: 'short',
       day: 'numeric',
-    });
+    }, {locale: get(locale)});
   }
 
   return getDateLocaleString(date);
 }
+
 export const getDateLocaleString = (date: DateTime, opts?: LocaleOptions): string =>
   date.toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY, opts);
 

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -1,72 +1,19 @@
-import type { AssetBucket } from '$lib/stores/assets-store.svelte';
 import { locale } from '$lib/stores/preferences.store';
-import { type CommonJustifiedLayout } from '$lib/utils/layout-utils';
-
-import type { AssetResponseDto } from '@immich/sdk';
 import { memoize } from 'lodash-es';
 import { DateTime, type LocaleOptions } from 'luxon';
 import { get } from 'svelte/store';
 
-export type DateGroup = {
-  bucket: AssetBucket;
-  index: number;
-  row: number;
-  col: number;
-  date: DateTime;
-  groupTitle: string;
-  assets: AssetResponseDto[];
-  assetsIntersecting: boolean[];
-  height: number;
-  intersecting: boolean;
-  geometry: CommonJustifiedLayout;
-};
 export type ScrubberListener = (
   bucketDate: string | undefined,
   overallScrollPercent: number,
   bucketScrollPercent: number,
 ) => void | Promise<void>;
-export type ScrollTargetListener = ({
-  bucket,
-  dateGroup,
-  asset,
-  offset,
-}: {
-  bucket: AssetBucket;
-  dateGroup: DateGroup;
-  asset: AssetResponseDto;
-  offset: number;
-}) => void;
 
 export const fromLocalDateTime = (localDateTime: string) =>
   DateTime.fromISO(localDateTime, { zone: 'UTC', locale: get(locale) });
 
 export const fromDateTimeOriginal = (dateTimeOriginal: string, timeZone: string) =>
   DateTime.fromISO(dateTimeOriginal, { zone: timeZone });
-
-export type LayoutBox = {
-  aspectRatio: number;
-  top: number;
-  width: number;
-  height: number;
-  left: number;
-  forcedAspectRatio?: boolean;
-};
-
-export function findTotalOffset(element: HTMLElement, stop: HTMLElement) {
-  let offset = 0;
-  while (element.offsetParent && element !== stop) {
-    offset += element.offsetTop;
-    element = element.offsetParent as HTMLElement;
-  }
-  return offset;
-}
-
-export const groupDateFormat: Intl.DateTimeFormatOptions = {
-  weekday: 'short',
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-};
 
 export function formatGroupTitle(_date: DateTime): string {
   if (!_date.isValid) {

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -15,7 +15,7 @@ export const fromLocalDateTime = (localDateTime: string) =>
 export const fromDateTimeOriginal = (dateTimeOriginal: string, timeZone: string) =>
   DateTime.fromISO(dateTimeOriginal, { zone: timeZone });
 
-function formatGroupTitle(_date: DateTime): string {
+export function formatGroupTitle(_date: DateTime): string {
   if (!_date.isValid) {
     return _date.toString();
   }

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -15,7 +15,7 @@ export const fromLocalDateTime = (localDateTime: string) =>
 export const fromDateTimeOriginal = (dateTimeOriginal: string, timeZone: string) =>
   DateTime.fromISO(dateTimeOriginal, { zone: timeZone });
 
-export function formatGroupTitle(_date: DateTime): string {
+function formatGroupTitle(_date: DateTime): string {
   if (!_date.isValid) {
     return _date.toString();
   }
@@ -46,7 +46,7 @@ export function formatGroupTitle(_date: DateTime): string {
     }, {locale: get(locale)});
   }
 
-  return getDateLocaleString(date);
+  return getDateLocaleString(date, {locale: get(locale)});
 }
 
 export const getDateLocaleString = (date: DateTime, opts?: LocaleOptions): string =>

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -34,19 +34,22 @@ export function formatGroupTitle(_date: DateTime): string {
 
   // Last week
   if (date >= today.minus({ days: 6 }) && date < today) {
-    return date.toLocaleString({ weekday: 'long' }, {locale: get(locale)});
+    return date.toLocaleString({ weekday: 'long' }, { locale: get(locale) });
   }
 
   // This year
   if (today.hasSame(date, 'year')) {
-    return date.toLocaleString({
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-    }, {locale: get(locale)});
+    return date.toLocaleString(
+      {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      },
+      { locale: get(locale) },
+    );
   }
 
-  return getDateLocaleString(date, {locale: get(locale)});
+  return getDateLocaleString(date, { locale: get(locale) });
 }
 
 export const getDateLocaleString = (date: DateTime, opts?: LocaleOptions): string =>


### PR DESCRIPTION
## Description

Some date and time formatting calls were missing references to the configured locale.

Fixes #17897

I also took the liberty of removing dead code in one file. It seems like it was just forgotten to be removed after some change in the past?

## How Has This Been Tested?

- [x] Manual test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/cb559c00-a712-4e3b-aaf3-7bddb301de2c)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
