### PR TITLE
refactor: vscode - format/organize on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,45 +1,63 @@
 {
-  "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.tabSize": 2,
-    "editor.formatOnSave": true
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.tabSize": 2,
-    "editor.formatOnSave": true
-  },
   "[css]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.tabSize": 2,
-    "editor.formatOnSave": true
-  },
-  "[svelte]": {
-    "editor.defaultFormatter": "svelte.svelte-vscode",
+    "editor.formatOnSave": true,
     "editor.tabSize": 2
   },
-  "svelte.enable-ts-plugin": true,
-  "eslint.validate": [
-    "javascript",
-    "svelte"
-  ],
-  "typescript.preferences.importModuleSpecifier": "non-relative",
   "[dart]": {
+    "editor.defaultFormatter": "Dart-Code.dart-code",
     "editor.formatOnSave": true,
     "editor.selectionHighlight": false,
     "editor.suggest.snippetsPreventQuickSuggestions": false,
     "editor.suggestSelection": "first",
     "editor.tabCompletion": "onlySnippets",
-    "editor.wordBasedSuggestions": "off",
-    "editor.defaultFormatter": "Dart-Code.dart-code"
+    "editor.wordBasedSuggestions": "off"
   },
-  "cSpell.words": [
-    "immich"
-  ],
+  "[javascript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.removeUnusedImports": "explicit"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[svelte]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.removeUnusedImports": "explicit"
+    },
+    "editor.defaultFormatter": "svelte.svelte-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.removeUnusedImports": "explicit"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "cSpell.words": ["immich"],
+  "editor.formatOnSave": true,
+  "eslint.validate": ["javascript", "svelte"],
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.ts": "${capture}.spec.ts,${capture}.mock.ts",
-    "*.dart": "${capture}.g.dart,${capture}.gr.dart,${capture}.drift.dart"
-  }
+    "*.dart": "${capture}.g.dart,${capture}.gr.dart,${capture}.drift.dart",
+    "*.ts": "${capture}.spec.ts,${capture}.mock.ts"
+  },
+  "svelte.enable-ts-plugin": true,
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
## Description

Format and org imports on save - makes diffs less noisy and reduces probability of unused import error. 
