### PR TITLE
chore: add security.txt

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -72,4 +72,5 @@ jobs:
         with:
           name: docs-build-output
           path: docs/build/
+          include-hidden-files: true
           retention-days: 1

--- a/docs/static/.well-known/security.txt
+++ b/docs/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Policy: https://github.com/immich-app/immich/blob/main/SECURITY.md
+Contact: mailto:security@immich.app
+Preferred-Languages: en
+Expires: 2026-05-01T23:59:00.000Z
+Canonical: https://immich.app/.well-known/security.txt

--- a/web/static/.well-known/security.txt
+++ b/web/static/.well-known/security.txt
@@ -1,0 +1,7 @@
+# This site is running an Immich instance.
+# Immich-related security problems should be reported to the Immich security team.
+# Security problems related to this instance should be reported to its administration.
+Policy: https://github.com/immich-app/immich/blob/main/SECURITY.md
+Contact: mailto:security@immich.app
+Preferred-Languages: en
+Expires: 2026-05-01T23:59:00.000Z


### PR DESCRIPTION
## Description

Serves a text file at `/.well-known/security.txt` per https://securitytxt.org spec, at both immich.app and on instances, to make it easier for security researchers encountering an issue with Immich in the wild to know who to contact and how.

Resolves #14607

## How Has This Been Tested?

- [x] I ran a local instance with these changes, and both of the `/.well-known/security.txt` endpoints returned the expected data.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] ~~I have written tests for new code (not applicable)~~
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
