### PR TITLE
chore(mobile): translate toast messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1230,6 +1230,8 @@
   "month": "Month",
   "monthly_title_text_date_format": "MMMM y",
   "more": "More",
+  "moved_to_archive": "Moved {count, plural, one {# asset} other {# assets}} to archive",
+  "moved_to_library": "Moved {count, plural, one {# asset} other {# assets}} to library",
   "moved_to_trash": "Moved to trash",
   "multiselect_grid_edit_date_time_err_read_only": "Cannot edit date of read only asset(s), skipping",
   "multiselect_grid_edit_gps_err_read_only": "Cannot edit location of read only asset(s), skipping",

--- a/mobile/lib/utils/selection_handlers.dart
+++ b/mobile/lib/utils/selection_handlers.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/asset.provider.dart';
 import 'package:immich_mobile/services/asset.service.dart';
 import 'package:immich_mobile/services/share.service.dart';
+import 'package:immich_mobile/utils/translation.dart';
 import 'package:immich_mobile/widgets/common/date_time_picker.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/location_picker.dart';
@@ -57,12 +58,13 @@ Future<void> handleArchiveAssets(
         .read(assetProvider.notifier)
         .toggleArchive(selection, shouldArchive);
 
-    final assetOrAssets = selection.length > 1 ? 'assets' : 'asset';
-    final archiveOrLibrary = shouldArchive ? 'archive' : 'library';
+    final message = shouldArchive
+        ? t('moved_to_archive', {'count': selection.length})
+        : t('moved_to_library', {'count': selection.length});
     if (context.mounted) {
       ImmichToast.show(
         context: context,
-        msg: 'Moved ${selection.length} $assetOrAssets to $archiveOrLibrary',
+        msg: message,
         gravity: toastGravity,
       );
     }

--- a/mobile/lib/utils/translation.dart
+++ b/mobile/lib/utils/translation.dart
@@ -1,0 +1,14 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:intl/message_format.dart';
+
+String t(String key, [Map<String, Object>? args]) {
+  try {
+    String message = key.tr();
+    if (args != null) {
+      return MessageFormat(message).format(args);
+    }
+    return message;
+  } catch (e) {
+    return key;
+  }
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Translating the toast messages that appear when archiving or unarchiving photos.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Archive 1 photo
- Archive multiple photos
- Unarchive 1 photo
- Unarchive multiple photos

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code