### PR TITLE
fix(server): double rotation on HEIF files

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -266,7 +266,9 @@ export class MediaService extends BaseService {
 
     const { info, data, colorspace } = await this.decodeImage(
       extracted ? extracted.buffer : asset.originalPath,
-      asset.exifInfo,
+      // only specify orientation to extracted images which don't have EXIF orientation data
+      // or it can double rotate the image
+      { ...asset.exifInfo, orientation: extracted ? asset.exifInfo.orientation : null },
       convertFullsize ? undefined : image.preview.size,
     );
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -268,7 +268,7 @@ export class MediaService extends BaseService {
       extracted ? extracted.buffer : asset.originalPath,
       // only specify orientation to extracted images which don't have EXIF orientation data
       // or it can double rotate the image
-      { ...asset.exifInfo, orientation: extracted ? asset.exifInfo.orientation : null },
+      extracted ? asset.exifInfo :  { ...asset.exifInfo, orientation: null },
       convertFullsize ? undefined : image.preview.size,
     );
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -268,7 +268,7 @@ export class MediaService extends BaseService {
       extracted ? extracted.buffer : asset.originalPath,
       // only specify orientation to extracted images which don't have EXIF orientation data
       // or it can double rotate the image
-      extracted ? asset.exifInfo :  { ...asset.exifInfo, orientation: null },
+      extracted ? asset.exifInfo : { ...asset.exifInfo, orientation: null },
       convertFullsize ? undefined : image.preview.size,
     );
 


### PR DESCRIPTION
a quick fix to address double rotation on HEIF files, as discussed in https://github.com/immich-app/immich/pull/17861#pullrequestreview-2807300642

tested to work with portrait/landscape ARW/DNG/HEIC/HIF files