### PR TITLE
Devcontainer changes to run make cmds

### DIFF
--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -8,7 +8,8 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
         qemu-user-static \
         libc6:amd64 \
         libstdc++6:amd64 \
-        libgcc1:amd64
+        libgcc1:amd64 \
+        default-jre
 fi
 
 # Install DCM

--- a/server/src/bin/sync-sql.ts
+++ b/server/src/bin/sync-sql.ts
@@ -72,7 +72,7 @@ class SqlGenerator {
     await rm(this.options.targetDir, { force: true, recursive: true });
     await mkdir(this.options.targetDir);
 
-    process.env.DB_HOSTNAME = 'localhost';
+    process.env.DB_HOSTNAME = process.env.DB_HOSTNAME || 'localhost';
     const { database, cls, otel } = new ConfigRepository().getEnv();
 
     const moduleFixture = await Test.createTestingModule({


### PR DESCRIPTION
## Description

- install default-jre package in devcontainer to run `make open-api`
- change sync-sql.ts to be able to manually set DB_HOSTNAME to connect to immich_postgres container from devcontainer

## How Has This Been Tested?

- [x] run `make sql`
- [x] run `make open-api`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
