### PR TITLE
feat: Add DB_SSL_MODE environment variable for Postgres sslmode

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -80,6 +80,7 @@ Information on the current workers can be found [here](/docs/administration/jobs
 | `DB_USERNAME`                       | Database user                                                            |  `postgres`  | server, database<sup>\*1</sup> |
 | `DB_PASSWORD`                       | Database password                                                        |  `postgres`  | server, database<sup>\*1</sup> |
 | `DB_DATABASE_NAME`                  | Database name                                                            |   `immich`   | server, database<sup>\*1</sup> |
+| `DB_SSL_MODE`                       | Database SSL mode                                                        |              | server                         |
 | `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`pgvector`, `pgvecto.rs`])            | `pgvecto.rs` | server                         |
 | `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`]) |   `false`    | server                         |
 

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -1,6 +1,6 @@
 import { Transform, Type } from 'class-transformer';
 import { IsEnum, IsInt, IsString } from 'class-validator';
-import { ImmichEnvironment, LogLevel } from 'src/enum';
+import { DatabaseSslMode, ImmichEnvironment, LogLevel } from 'src/enum';
 import { IsIPRange, Optional, ValidateBoolean } from 'src/validation';
 
 export class EnvDto {
@@ -142,9 +142,9 @@ export class EnvDto {
   @ValidateBoolean({ optional: true })
   DB_SKIP_MIGRATIONS?: boolean;
 
-  @IsEnum(['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'])
+  @IsEnum(DatabaseSslMode)
   @Optional()
-  DB_SSL_MODE?: 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
+  DB_SSL_MODE?: DatabaseSslMode;
 
   @IsString()
   @Optional()

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -142,6 +142,10 @@ export class EnvDto {
   @ValidateBoolean({ optional: true })
   DB_SKIP_MIGRATIONS?: boolean;
 
+  @IsEnum(['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'])
+  @Optional()
+  DB_SSL_MODE?: 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
+
   @IsString()
   @Optional()
   DB_URL?: string;

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -610,3 +610,11 @@ export enum OAuthTokenEndpointAuthMethod {
   CLIENT_SECRET_POST = 'client_secret_post',
   CLIENT_SECRET_BASIC = 'client_secret_basic',
 }
+
+export enum DatabaseSslMode {
+  Disable = 'disable',
+  Allow = 'allow',
+  Prefer = 'prefer',
+  Require = 'require',
+  VerifyFull = 'verify-full',
+}

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -93,6 +93,17 @@ describe('getEnv', () => {
       });
     });
 
+    it('should validate DB_SSL_MODE', () => {
+      process.env.DB_SSL_MODE = 'invalid';
+      expect(() => getEnv()).toThrowError('Invalid environment variables: DB_SSL_MODE');
+    });
+
+    it('should accept a valid DB_SSL_MODE', () => {
+      process.env.DB_SSL_MODE = 'prefer';
+      const { database } = getEnv();
+      expect(database.config).toMatchObject(expect.objectContaining({ ssl: 'prefer' }));
+    });
+
     it('should allow skipping migrations', () => {
       process.env.DB_SKIP_MIGRATIONS = 'true';
       const { database } = getEnv();

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -23,6 +23,7 @@ const resetEnv = () => {
     'DB_USERNAME',
     'DB_PASSWORD',
     'DB_DATABASE_NAME',
+    'DB_SSL_MODE',
     'DB_SKIP_MIGRATIONS',
     'DB_VECTOR_EXTENSION',
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -193,6 +193,7 @@ const getEnv = (): EnvData => {
         username: dto.DB_USERNAME || 'postgres',
         password: dto.DB_PASSWORD || 'postgres',
         database: dto.DB_DATABASE_NAME || 'immich',
+        ssl: dto.DB_SSL_MODE || undefined,
       };
 
   return {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -373,6 +373,8 @@ export type DatabaseConnectionURL = {
   url: string;
 };
 
+type SSL = 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
+
 export type DatabaseConnectionParts = {
   connectionType: 'parts';
   host: string;
@@ -380,6 +382,7 @@ export type DatabaseConnectionParts = {
   username: string;
   password: string;
   database: string;
+  ssl?: SSL;
 };
 
 export type DatabaseConnectionParams = DatabaseConnectionURL | DatabaseConnectionParts;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -2,6 +2,7 @@ import { SystemConfig } from 'src/config';
 import {
   AssetType,
   DatabaseExtension,
+  DatabaseSslMode,
   ExifOrientation,
   ImageFormat,
   JobName,
@@ -373,8 +374,6 @@ export type DatabaseConnectionURL = {
   url: string;
 };
 
-type SSL = 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full';
-
 export type DatabaseConnectionParts = {
   connectionType: 'parts';
   host: string;
@@ -382,7 +381,7 @@ export type DatabaseConnectionParts = {
   username: string;
   password: string;
   database: string;
-  ssl?: SSL;
+  ssl?: DatabaseSslMode;
 };
 
 export type DatabaseConnectionParams = DatabaseConnectionURL | DatabaseConnectionParts;

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -17,7 +17,7 @@ import { parse } from 'pg-connection-string';
 import postgres, { Notice } from 'postgres';
 import { columns, Exif, Person } from 'src/database';
 import { DB } from 'src/db';
-import { AssetFileType, DatabaseExtension } from 'src/enum';
+import { AssetFileType, DatabaseExtension, DatabaseSslMode } from 'src/enum';
 import { TimeBucketSize } from 'src/repositories/asset.repository';
 import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
 import { DatabaseConnectionParams, VectorExtension } from 'src/types';
@@ -35,7 +35,7 @@ export const asPostgresConnectionConfig = (params: DatabaseConnectionParams) => 
       username: params.username,
       password: params.password,
       database: params.database,
-      ssl: params.ssl,
+      ssl: params.ssl === DatabaseSslMode.Disable ? false : params.ssl,
     };
   }
 

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -35,7 +35,7 @@ export const asPostgresConnectionConfig = (params: DatabaseConnectionParams) => 
       username: params.username,
       password: params.password,
       database: params.database,
-      ssl: undefined,
+      ssl: params.ssl,
     };
   }
 


### PR DESCRIPTION
## Description

Adds a `DB_SSL_MODE` environment variable to the server, which is plumbed into the postgres connection config as the value of the `sslmode` parameter: https://www.postgresql.org/docs/current/libpq-ssl.html

Previously, it was only possible to change this parameter by providing a full Postgres DSN (with the `?sslmode` param) to `DB_URL`. This is not ideal for any environments where the database username and/or password might be provided to the container from some kind of secret store, but the SSL mode still needs to be configured.

e.g., The Kubernetes environment I am trying to deploy Immich into creates a Kubernetes Secret `immich-db-user` with keys `username` and `password` for my managed Postgres database. I would like to configure my Immich `Deployment` to use these secret values for the `DB_USERNAME` and `DB_PASSWORD` variables (using `env[*].valueFrom.secretKeyRef`). I would still like to set the `sslmode` parameter for the connection without having to find some way to deploy _another_ secret that reformats the username and password from the managed secret into something that could be used for `DB_URL`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
