### PR TITLE
fix: Fix marking items as "not a duplicate".

### DIFF
--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -117,7 +117,7 @@ export class AssetService extends BaseService {
     if (
       options.isArchived != undefined ||
       options.isFavorite != undefined ||
-      options.duplicateId != undefined ||
+      options.duplicateId !== undefined ||
       options.rating != undefined
     ) {
       await this.assetRepository.updateAll(ids, options);


### PR DESCRIPTION
The problem arose because `null == undefined` in JS. The other caparisons in this block should probably use `!==` as well (and `===` should be the general default because it is more predictable) but they are technically fine because no valid values will `== undefined`. So I have left them for now.

I am not sure if this is the best fix, but it does appear to solve the problem.

All credit goes to https://github.com/zzzorgo. I just converted it into a patch.

Fixes: https://github.com/immich-app/immich/issues/16413

## Description

## How Has This Been Tested?

- [ ] Mark a candidate duplicate as not a duplicate. Then reload and see if it reappears.

## API Changes

The `/api/assets` endpoint will now clear the `duplicateId` field if the request body contains `duplicateId: null`.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
