### PR TITLE
fix: update assets when `duplicateId` is provided as `null`

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -431,6 +431,21 @@ describe(AssetService.name, () => {
         { name: JobName.SIDECAR_WRITE, data: { id: 'asset-1', dateTimeOriginal, latitude: 30, longitude: 50 } },
       ]);
     });
+
+    it('should update Assets table if duplicateId is provided as null', async () => {
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+
+      await sut.updateAll(authStub.admin, {
+        ids: ['asset-1'],
+        latitude: 0,
+        longitude: 0,
+        isArchived: undefined,
+        isFavorite: undefined,
+        duplicateId: null,
+        rating: undefined,
+      });
+      expect(mocks.asset.updateAll).toHaveBeenCalled();
+    });
   });
 
   describe('deleteAll', () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -115,10 +115,10 @@ export class AssetService extends BaseService {
     }
 
     if (
-      options.isArchived != undefined ||
-      options.isFavorite != undefined ||
-      options.duplicateId != undefined ||
-      options.rating != undefined
+      options.isArchived !== undefined ||
+      options.isFavorite !== undefined ||
+      options.duplicateId !== undefined ||
+      options.rating !== undefined
     ) {
       await this.assetRepository.updateAll(ids, options);
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
`duplicateId` in `updateAll` is set to `null` to clear the duplicate status of an image. https://github.com/immich-app/immich/commit/d12b1c907d68a9f9e6e4d459f6367c05f5872f03 introduced a check against `undefined` to reduce unnecessary DB updates. Unfortunately, this check is being done with the `!=` operator which treats `undefined` and `null` as the same. Switching to the `!==` operator resolves the issue as it correctly differentiates between the two values.

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #16413

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- multiple people manually tested this change and commented on the issue.
- added a new test in `server/src/services/asset.service.spec.ts`

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
