### PR TITLE
fix(server): use actual total in search pagination

### DIFF
--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -50,7 +50,7 @@ export class SearchService extends BaseService {
 
     const page = dto.page ?? 1;
     const size = dto.size || 250;
-    const { hasNextPage, items } = await this.searchRepository.searchMetadata(
+    const { hasNextPage, items, total } = await this.searchRepository.searchMetadata(
       { page, size },
       {
         ...dto,
@@ -60,7 +60,7 @@ export class SearchService extends BaseService {
       },
     );
 
-    return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null, { auth });
+    return this.mapResponse(items, total ?? items.length, hasNextPage ? (page + 1).toString() : null, { auth });
   }
 
   async searchRandom(auth: AuthDto, dto: RandomSearchDto): Promise<AssetResponseDto[]> {
@@ -82,12 +82,12 @@ export class SearchService extends BaseService {
     });
     const page = dto.page ?? 1;
     const size = dto.size || 100;
-    const { hasNextPage, items } = await this.searchRepository.searchSmart(
+    const { hasNextPage, items, total } = await this.searchRepository.searchSmart(
       { page, size },
       { ...dto, userIds, embedding },
     );
 
-    return this.mapResponse(items, hasNextPage ? (page + 1).toString() : null, { auth });
+    return this.mapResponse(items, total ?? items.length, hasNextPage ? (page + 1).toString() : null, { auth });
   }
 
   async getAssetsByCity(auth: AuthDto): Promise<AssetResponseDto[]> {
@@ -137,11 +137,16 @@ export class SearchService extends BaseService {
     return [auth.user.id, ...partnerIds];
   }
 
-  private mapResponse(assets: MapAsset[], nextPage: string | null, options: AssetMapOptions): SearchResponseDto {
+  private mapResponse(
+    assets: MapAsset[],
+    total: number,
+    nextPage: string | null,
+    options: AssetMapOptions,
+  ): SearchResponseDto {
     return {
       albums: { total: 0, count: 0, items: [], facets: [] },
       assets: {
-        total: assets.length,
+        total,
         count: assets.length,
         items: assets.map((asset) => mapAsset(asset, options)),
         facets: [],

--- a/server/src/utils/pagination.ts
+++ b/server/src/utils/pagination.ts
@@ -6,11 +6,16 @@ export interface PaginationOptions {
 export interface PaginationResult<T> {
   items: T[];
   hasNextPage: boolean;
+  total?: number;
 }
 
-export function paginationHelper<Entity extends object>(items: Entity[], take: number): PaginationResult<Entity> {
+export function paginationHelper<Entity extends object>(
+  items: Entity[],
+  take: number,
+  total?: number,
+): PaginationResult<Entity> {
   const hasNextPage = items.length > take;
   items.splice(take);
 
-  return { items, hasNextPage };
+  return { items, hasNextPage, total };
 }


### PR DESCRIPTION
## Description

Previously, the response of `/api/search/metadata` included both `total` and `count` fields which were simply duplicates of one another and reflected the number of items in the current results page only, with nothing to indicate the total number of matched results.
This PR changes the `total` to actually reflect the total number of results that can be obtained after requesting all the pages.

## How Has This Been Tested?

Tested manually by running Immich locally, adding some images to the library, and running some requests to `/api/search/metadata`. For example, a request with `{ "page": 1, "size": 4 }` returns:
```json
{
	"albums": {
		"total": 0,
		"count": 0,
		"items": [],
		"facets": []
	},
	"assets": {
		"total": 17,
		"count": 4,
		"items": [
			/* ... */
		],
		"facets": [],
		"nextPage": "2"
	}
}
```


## API Changes
The `total` field in `/api/search/metadata` and `/api/search/smart` results is no longer equivalent to `count`.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
