### PR TITLE
fix: documentation - synology install docker link

### DIFF
--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -29,7 +29,7 @@ Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/la
 
 ## Step 2 - Populate the .env file with custom values
 
-Follow [Step 2 in Docker Compose](../docker-compose#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
+Follow [Step 2 in Docker Compose](/docs/install/docker-compose#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
 
 ## Step 3 - Create a new project in Container Manager
 

--- a/docs/docs/install/synology.md
+++ b/docs/docs/install/synology.md
@@ -29,7 +29,7 @@ Download [`docker-compose.yml`](https://github.com/immich-app/immich/releases/la
 
 ## Step 2 - Populate the .env file with custom values
 
-Follow [Step 2 in Docker Compose](./docker-compose#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
+Follow [Step 2 in Docker Compose](../docker-compose#step-2---populate-the-env-file-with-custom-values) for instructions on customizing the `.env` file, and then return back to this guide to continue.
 
 ## Step 3 - Create a new project in Container Manager
 


### PR DESCRIPTION
## Description
Updated the docker link from synology install docs page.

Change is required because existing relative link points to a 404 page. See step 2 - https://immich.app/docs/install/synology/

The link does works as-is locally as `/synology` page does not have a trailing slash when run with `docusaurus`. On `immich.app`, the web server might be re-writing `/synology` the page, with a trailing slash, and treating it as a directory i.e. `/synology/`.

For consistency, I'm following the full path convention used in other links.

Fixes # (issue)

No issue filed.

## How Has This Been Tested?

Tested locally. Screen recording show current behavior on immich.app and the updated local

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/1ab0e676-332f-42b6-9e75-a3c4daa89332


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
