### PR TITLE
chore: better modal manager types

### DIFF
--- a/web/src/lib/managers/modal-manager.svelte.ts
+++ b/web/src/lib/managers/modal-manager.svelte.ts
@@ -2,11 +2,14 @@ import ConfirmDialog from '$lib/components/shared-components/dialog/confirm-dial
 import { mount, unmount, type Component, type ComponentProps } from 'svelte';
 
 type OnCloseData<T> = T extends { onClose: (data: infer R) => void } ? R : never;
-// TODO make `props` optional if component only has `onClose`
-// type OptionalIfEmpty<T extends object> = keyof T extends never ? undefined : T;
+type OptionalIfEmpty<T extends object> = keyof T extends never ? undefined : T;
 
 class ModalManager {
-  open<T extends object, K = OnCloseData<T>>(Component: Component<T>, props: Omit<T, 'onClose'>) {
+  open<T extends object, K = OnCloseData<T>>(
+    Component: Component<T>,
+    props?: OptionalIfEmpty<Omit<T, 'onClose'>> | Record<string, never>,
+  ): Promise<K>;
+  open<T extends object, K = OnCloseData<T>>(Component: Component<T>, props: OptionalIfEmpty<Omit<T, 'onClose'>>) {
     return new Promise<K>((resolve) => {
       let modal: object = {};
 
@@ -18,7 +21,7 @@ class ModalManager {
       modal = mount(Component, {
         target: document.body,
         props: {
-          ...(props as T),
+          ...((props ?? {}) as T),
           onClose,
         },
       });

--- a/web/src/routes/admin/jobs-status/+page.svelte
+++ b/web/src/routes/admin/jobs-status/+page.svelte
@@ -39,7 +39,7 @@
     <HStack gap={0}>
       <Button
         leadingIcon={mdiPlus}
-        onclick={() => modalManager.open(JobCreateModal, {})}
+        onclick={() => modalManager.open(JobCreateModal)}
         size="small"
         variant="ghost"
         color="secondary"

--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -59,7 +59,7 @@
   };
 
   const handleCreate = async () => {
-    await modalManager.open(UserCreateModal, {});
+    await modalManager.open(UserCreateModal);
     await refresh();
   };
 


### PR DESCRIPTION
The second argument (`props`) is now optional if the passed component (let's call it `Foo`) only exposes `onClose`. In this case, the following three calls are all valid:
- `modalManager.open(Foo)`;
- `modalManager.open(Foo, undefined);`
- `modalManager.open(Foo, {});`

A non-empty object such as in `modalManager.open(Foo, { foo: '42' })` is now invalid.