### PR TITLE
chore: remove usage of deprecated Kysely method

### DIFF
--- a/server/src/repositories/audit.repository.ts
+++ b/server/src/repositories/audit.repository.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@nestjs/common';
-import { Kysely } from 'kysely';
-import { InjectKysely } from 'nestjs-kysely';
-import { DB } from 'src/db';
-import { DummyValue, GenerateSql } from 'src/decorators';
-import { DatabaseAction, EntityType } from 'src/enum';
+import { Injectable } from '@nestjs/common'
+import { Kysely } from 'kysely'
+import { InjectKysely } from 'nestjs-kysely'
+import { DB } from 'src/db'
+import { DummyValue, GenerateSql } from 'src/decorators'
+import { DatabaseAction, EntityType } from 'src/enum'
 
 export interface AuditSearch {
   action?: DatabaseAction;
@@ -29,7 +29,9 @@ export class AuditRepository {
       .$if(!!options.entityType, (qb) => qb.where('audit.entityType', '=', options.entityType!))
       .where('audit.ownerId', 'in', options.userIds)
       .distinctOn(['audit.entityId', 'audit.entityType'])
-      .orderBy(['audit.entityId desc', 'audit.entityType desc', 'audit.createdAt desc'])
+      .orderBy('audit.entityId', 'desc')
+      .orderBy('audit.entityType', 'desc')
+      .orderBy('audit.createdAt', 'desc')
       .select('audit.entityId')
       .execute();
 

--- a/server/src/repositories/audit.repository.ts
+++ b/server/src/repositories/audit.repository.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@nestjs/common'
-import { Kysely } from 'kysely'
-import { InjectKysely } from 'nestjs-kysely'
-import { DB } from 'src/db'
-import { DummyValue, GenerateSql } from 'src/decorators'
-import { DatabaseAction, EntityType } from 'src/enum'
+import { Injectable } from '@nestjs/common';
+import { Kysely } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { DB } from 'src/db';
+import { DummyValue, GenerateSql } from 'src/decorators';
+import { DatabaseAction, EntityType } from 'src/enum';
 
 export interface AuditSearch {
   action?: DatabaseAction;

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@nestjs/common'
-import { Insertable, Kysely, SelectQueryBuilder, sql } from 'kysely'
-import { InjectKysely } from 'nestjs-kysely'
-import { columns } from 'src/database'
-import { DB, SessionSyncCheckpoints } from 'src/db'
-import { DummyValue, GenerateSql } from 'src/decorators'
-import { SyncEntityType } from 'src/enum'
-import { SyncAck } from 'src/types'
+import { Injectable } from '@nestjs/common';
+import { Insertable, Kysely, SelectQueryBuilder, sql } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { columns } from 'src/database';
+import { DB, SessionSyncCheckpoints } from 'src/db';
+import { DummyValue, GenerateSql } from 'src/decorators';
+import { SyncEntityType } from 'src/enum';
+import { SyncAck } from 'src/types';
 
 type auditTables = 'users_audit' | 'partners_audit' | 'assets_audit';
 type upsertTables = 'users' | 'partners' | 'assets' | 'exif';

--- a/server/src/repositories/sync.repository.ts
+++ b/server/src/repositories/sync.repository.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@nestjs/common';
-import { Insertable, Kysely, SelectQueryBuilder, sql } from 'kysely';
-import { InjectKysely } from 'nestjs-kysely';
-import { columns } from 'src/database';
-import { DB, SessionSyncCheckpoints } from 'src/db';
-import { DummyValue, GenerateSql } from 'src/decorators';
-import { SyncEntityType } from 'src/enum';
-import { SyncAck } from 'src/types';
+import { Injectable } from '@nestjs/common'
+import { Insertable, Kysely, SelectQueryBuilder, sql } from 'kysely'
+import { InjectKysely } from 'nestjs-kysely'
+import { columns } from 'src/database'
+import { DB, SessionSyncCheckpoints } from 'src/db'
+import { DummyValue, GenerateSql } from 'src/decorators'
+import { SyncEntityType } from 'src/enum'
+import { SyncAck } from 'src/types'
 
 type auditTables = 'users_audit' | 'partners_audit' | 'assets_audit';
 type upsertTables = 'users' | 'partners' | 'assets' | 'exif';
@@ -159,7 +159,7 @@ export class SyncRepository {
     return builder
       .where('deletedAt', '<', sql.raw<Date>("now() - interval '1 millisecond'"))
       .$if(!!ack, (qb) => qb.where('id', '>', ack!.updateId))
-      .orderBy(['id asc']) as SelectQueryBuilder<DB, T, D>;
+      .orderBy('id', 'asc') as SelectQueryBuilder<DB, T, D>;
   }
 
   private upsertTableFilters<T extends keyof Pick<DB, upsertTables>, D>(
@@ -170,6 +170,6 @@ export class SyncRepository {
     return builder
       .where('updatedAt', '<', sql.raw<Date>("now() - interval '1 millisecond'"))
       .$if(!!ack, (qb) => qb.where('updateId', '>', ack!.updateId))
-      .orderBy(['updateId asc']) as SelectQueryBuilder<DB, T, D>;
+      .orderBy('updateId', 'asc') as SelectQueryBuilder<DB, T, D>;
   }
 }


### PR DESCRIPTION
## Description

This is just a minor future proof update, to replace the usage of deprecated orderBy(array) method.

## How Has This Been Tested?

It hasn't

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
