### PR TITLE
fix(docs): remove old patch versions from version switcher

### DIFF
--- a/docs/static/archived-versions.json
+++ b/docs/static/archived-versions.json
@@ -4,44 +4,12 @@
     "url": "https://v1.132.3.archive.immich.app"
   },
   {
-    "label": "v1.132.1",
-    "url": "https://v1.132.1.archive.immich.app"
-  },
-  {
-    "label": "v1.132.0",
-    "url": "https://v1.132.0.archive.immich.app"
-  },
-  {
     "label": "v1.131.3",
     "url": "https://v1.131.3.archive.immich.app"
   },
   {
-    "label": "v1.131.2",
-    "url": "https://v1.131.2.archive.immich.app"
-  },
-  {
-    "label": "v1.131.1",
-    "url": "https://v1.131.1.archive.immich.app"
-  },
-  {
-    "label": "v1.131.0",
-    "url": "https://v1.131.0.archive.immich.app"
-  },
-  {
     "label": "v1.130.3",
     "url": "https://v1.130.3.archive.immich.app"
-  },
-  {
-    "label": "v1.130.2",
-    "url": "https://v1.130.2.archive.immich.app"
-  },
-  {
-    "label": "v1.130.1",
-    "url": "https://v1.130.1.archive.immich.app"
-  },
-  {
-    "label": "v1.130.0",
-    "url": "https://v1.130.0.archive.immich.app"
   },
   {
     "label": "v1.129.0",
@@ -60,44 +28,12 @@
     "url": "https://v1.126.1.archive.immich.app"
   },
   {
-    "label": "v1.126.0",
-    "url": "https://v1.126.0.archive.immich.app"
-  },
-  {
     "label": "v1.125.7",
     "url": "https://v1.125.7.archive.immich.app"
   },
   {
-    "label": "v1.125.6",
-    "url": "https://v1.125.6.archive.immich.app"
-  },
-  {
-    "label": "v1.125.5",
-    "url": "https://v1.125.5.archive.immich.app"
-  },
-  {
-    "label": "v1.125.3",
-    "url": "https://v1.125.3.archive.immich.app"
-  },
-  {
-    "label": "v1.125.2",
-    "url": "https://v1.125.2.archive.immich.app"
-  },
-  {
-    "label": "v1.125.1",
-    "url": "https://v1.125.1.archive.immich.app"
-  },
-  {
     "label": "v1.124.2",
     "url": "https://v1.124.2.archive.immich.app"
-  },
-  {
-    "label": "v1.124.1",
-    "url": "https://v1.124.1.archive.immich.app"
-  },
-  {
-    "label": "v1.124.0",
-    "url": "https://v1.124.0.archive.immich.app"
   },
   {
     "label": "v1.123.0",
@@ -108,18 +44,6 @@
     "url": "https://v1.122.3.archive.immich.app"
   },
   {
-    "label": "v1.122.2",
-    "url": "https://v1.122.2.archive.immich.app"
-  },
-  {
-    "label": "v1.122.1",
-    "url": "https://v1.122.1.archive.immich.app"
-  },
-  {
-    "label": "v1.122.0",
-    "url": "https://v1.122.0.archive.immich.app"
-  },
-  {
     "label": "v1.121.0",
     "url": "https://v1.121.0.archive.immich.app"
   },
@@ -128,32 +52,12 @@
     "url": "https://v1.120.2.archive.immich.app"
   },
   {
-    "label": "v1.120.1",
-    "url": "https://v1.120.1.archive.immich.app"
-  },
-  {
-    "label": "v1.120.0",
-    "url": "https://v1.120.0.archive.immich.app"
-  },
-  {
     "label": "v1.119.1",
     "url": "https://v1.119.1.archive.immich.app"
   },
   {
-    "label": "v1.119.0",
-    "url": "https://v1.119.0.archive.immich.app"
-  },
-  {
     "label": "v1.118.2",
     "url": "https://v1.118.2.archive.immich.app"
-  },
-  {
-    "label": "v1.118.1",
-    "url": "https://v1.118.1.archive.immich.app"
-  },
-  {
-    "label": "v1.118.0",
-    "url": "https://v1.118.0.archive.immich.app"
   },
   {
     "label": "v1.117.0",
@@ -162,14 +66,6 @@
   {
     "label": "v1.116.2",
     "url": "https://v1.116.2.archive.immich.app"
-  },
-  {
-    "label": "v1.116.1",
-    "url": "https://v1.116.1.archive.immich.app"
-  },
-  {
-    "label": "v1.116.0",
-    "url": "https://v1.116.0.archive.immich.app"
   },
   {
     "label": "v1.115.0",
@@ -184,16 +80,8 @@
     "url": "https://v1.113.1.archive.immich.app"
   },
   {
-    "label": "v1.113.0",
-    "url": "https://v1.113.0.archive.immich.app"
-  },
-  {
     "label": "v1.112.1",
     "url": "https://v1.112.1.archive.immich.app"
-  },
-  {
-    "label": "v1.112.0",
-    "url": "https://v1.112.0.archive.immich.app"
   },
   {
     "label": "v1.111.0",
@@ -208,14 +96,6 @@
     "url": "https://v1.109.2.archive.immich.app"
   },
   {
-    "label": "v1.109.1",
-    "url": "https://v1.109.1.archive.immich.app"
-  },
-  {
-    "label": "v1.109.0",
-    "url": "https://v1.109.0.archive.immich.app"
-  },
-  {
     "label": "v1.108.0",
     "url": "https://v1.108.0.archive.immich.app"
   },
@@ -224,36 +104,12 @@
     "url": "https://v1.107.2.archive.immich.app"
   },
   {
-    "label": "v1.107.1",
-    "url": "https://v1.107.1.archive.immich.app"
-  },
-  {
-    "label": "v1.107.0",
-    "url": "https://v1.107.0.archive.immich.app"
-  },
-  {
     "label": "v1.106.4",
     "url": "https://v1.106.4.archive.immich.app"
   },
   {
-    "label": "v1.106.3",
-    "url": "https://v1.106.3.archive.immich.app"
-  },
-  {
-    "label": "v1.106.2",
-    "url": "https://v1.106.2.archive.immich.app"
-  },
-  {
-    "label": "v1.106.1",
-    "url": "https://v1.106.1.archive.immich.app"
-  },
-  {
     "label": "v1.105.1",
     "url": "https://v1.105.1.archive.immich.app"
-  },
-  {
-    "label": "v1.105.0",
-    "url": "https://v1.105.0.archive.immich.app"
   },
   {
     "label": "v1.104.0",
@@ -264,24 +120,8 @@
     "url": "https://v1.103.1.archive.immich.app"
   },
   {
-    "label": "v1.103.0",
-    "url": "https://v1.103.0.archive.immich.app"
-  },
-  {
     "label": "v1.102.3",
     "url": "https://v1.102.3.archive.immich.app"
-  },
-  {
-    "label": "v1.102.2",
-    "url": "https://v1.102.2.archive.immich.app"
-  },
-  {
-    "label": "v1.102.1",
-    "url": "https://v1.102.1.archive.immich.app"
-  },
-  {
-    "label": "v1.102.0",
-    "url": "https://v1.102.0.archive.immich.app"
   },
   {
     "label": "v1.101.0",

--- a/docs/static/archived-versions.json
+++ b/docs/static/archived-versions.json
@@ -4,10 +4,6 @@
     "url": "https://v1.132.3.archive.immich.app"
   },
   {
-    "label": "v1.132.2",
-    "url": "https://v1.132.2.archive.immich.app"
-  },
-  {
     "label": "v1.132.1",
     "url": "https://v1.132.1.archive.immich.app"
   },


### PR DESCRIPTION
## Description

Removes old patch versions and keeps the latest patch of each major version in the docs version switcher.

To be clear, this DOES NOT add any automation to handle this in the future.

The dead link to `v1.132.2` was also removed.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test on dev instance.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
