### PR TITLE
fix(web): add photos to album

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -57,6 +57,7 @@
   import {
     AlbumUserRole,
     AssetOrder,
+    AssetVisibility,
     addAssetsToAlbum,
     addUsersToAlbum,
     deleteAlbum,
@@ -373,6 +374,7 @@
       void assetStore.updateOptions({ albumId, order: albumOrder });
     } else if (viewMode === AlbumPageViewMode.SELECT_ASSETS) {
       void assetStore.updateOptions({
+        visibility: AssetVisibility.Timeline,
         withPartners: true,
         timelineAlbumId: albumId,
       });


### PR DESCRIPTION
`GET /timeline/buckets` not set `AssetVisible.Timeline` cause 400 Bad Request when adding photos to album.
This bug is introduced in PR #17939.
![image](https://github.com/user-attachments/assets/84b1bd82-0a01-4941-b65d-8a67a36c118a)
![image](https://github.com/user-attachments/assets/6ae5e343-3142-4fdc-bc02-78373f277691)