### PR TITLE
fix: properly work with languages with multiple scripts

### DIFF
--- a/mobile/lib/constants/locales.dart
+++ b/mobile/lib/constants/locales.dart
@@ -6,8 +6,8 @@ const Map<String, Locale> locales = {
   // Additional locales
   'Arabic (ar)': Locale('ar'),
   'Catalan (ca)': Locale('ca'),
-  'Chinese Simplified (zh_CN)': Locale('zh', 'SIMPLIFIED'),
-  'Chinese Traditional (zh_TW)': Locale('zh', 'Hant'),
+  'Chinese Simplified (zh_CN)': Locale('zh', 'CN'),
+  'Chinese Traditional (zh_TW)': Locale('zh', 'TW'),
   'Czech (cs)': Locale('cs'),
   'Danish (da)': Locale('da'),
   'Dutch (nl)': Locale('nl'),
@@ -31,8 +31,10 @@ const Map<String, Locale> locales = {
   'Portuguese (pt)': Locale('pt'),
   'Romanian (ro)': Locale('ro'),
   'Russian (ru)': Locale('ru'),
-  'Serbian Cyrillic (sr_Cyrl)': Locale('sr', 'Cyrl'),
-  'Serbian Latin (sr_Latn)': Locale('sr', 'Latn'),
+  'Serbian Cyrillic (sr_Cyrl)':
+      Locale.fromSubtags(languageCode: 'sr', scriptCode: 'Cyrl'),
+  'Serbian Latin (sr_Latn)':
+      Locale.fromSubtags(languageCode: 'sr', scriptCode: 'Latn'),
   'Slovak (sk)': Locale('sk'),
   'Slovenian (sl)': Locale('sl'),
   'Spanish (es)': Locale('es'),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The pointers by @zlewe in the Issue have been very helpful. This is literally just the implementation.

Fixes #17965 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
This has been manually tested with the following steps

- Open App
- Choose {zh_TW|zh_CN|sr_Latn|sr_Cyrl}
- Reopen App
- Observe the chosen language to still be selected and applied

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
