### PR TITLE
fix: notification text's color

### DIFF
--- a/web/src/lib/components/shared-components/notification/notification-card.svelte
+++ b/web/src/lib/components/shared-components/notification/notification-card.svelte
@@ -100,7 +100,7 @@
     />
   </div>
 
-  <p class="whitespace-pre-wrap ps-[28px] pe-[16px] text-sm text-light" data-testid="message">
+  <p class="whitespace-pre-wrap ps-[28px] pe-[16px] text-sm text-black/80" data-testid="message">
     {#if isComponentNotification(notification)}
       <notification.component.type {...notification.component.props} />
     {:else}


### PR DESCRIPTION
Since the notification background color doesn't change in light/dark mode. Setting the text color as a single color is fine