### PR TITLE
fix: various typos (grouped in to separate commits)

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -72,7 +72,7 @@ In rare cases, the library watcher can hang, preventing Immich from starting up.
 
 ### Nightly job
 
-There is an automatic scan job that is scheduled to run once a day. This job also cleans up any libraries stuck in deletion. It is possible to trigger the cleanup by clicking "Scan all libraries" in the library managment page.
+There is an automatic scan job that is scheduled to run once a day. This job also cleans up any libraries stuck in deletion. It is possible to trigger the cleanup by clicking "Scan all libraries" in the library management page.
 
 ## Usage
 

--- a/docs/docs/features/searching.md
+++ b/docs/docs/features/searching.md
@@ -92,7 +92,7 @@ Memory and execution time estimates were obtained without acceleration on a 7800
 
 **Execution Time (ms)**: After warming up the model with one pass, the mean execution time of 100 passes with the same input.
 
-**Memory (MiB)**: The peak RSS usage of the process afer performing the above timing benchmark. Does not include image decoding, concurrent processing, the web server, etc., which are relatively constant factors.
+**Memory (MiB)**: The peak RSS usage of the process after performing the above timing benchmark. Does not include image decoding, concurrent processing, the web server, etc., which are relatively constant factors.
 
 **Recall (%)**: Evaluated on Crossmodal-3600, the average of the recall@1, recall@5 and recall@10 results for zeroshot image retrieval. Chinese (Simplified), English, French, German, Italian, Japanese, Korean, Polish, Russian, Spanish and Turkish are additionally tested on XTD-10. Chinese (Simplified) and English are additionally tested on Flickr30k. The recall metrics are the average across all tested datasets.
 

--- a/machine-learning/immich_ml/sessions/rknn/rknnpool.py
+++ b/machine-learning/immich_ml/sessions/rknn/rknnpool.py
@@ -53,7 +53,7 @@ def init_rknn(model_path: str) -> "RKNNLite":
         ret = rknn_lite.init_runtime()  # Please do not set this parameter on other platforms.
 
     if ret != 0:
-        raise RuntimeError("Failed to inititalize RKNN runtime environment")
+        raise RuntimeError("Failed to initialize RKNN runtime environment")
 
     return rknn_lite
 

--- a/server/src/schema/tables/shared-link.table.ts
+++ b/server/src/schema/tables/shared-link.table.ts
@@ -16,7 +16,7 @@ export class SharedLinkTable {
   userId!: string;
 
   @Column({ type: 'bytea', indexName: 'IDX_sharedlink_key' })
-  key!: Buffer; // use to access the inidividual asset
+  key!: Buffer; // use to access the individual asset
 
   @Column()
   type!: SharedLinkType;

--- a/web/src/lib/components/assets/thumbnail/__test__/thumbnail.spec.ts
+++ b/web/src/lib/components/assets/thumbnail/__test__/thumbnail.spec.ts
@@ -41,7 +41,7 @@ describe('Thumbnail component', () => {
     expect(container).not.toBeNull();
     expect(container!.getAttribute('tabindex')).toBe('0');
 
-    // Guarding against inserting extra tabbable elments in future in <Thumbnail/>
+    // Guarding against inserting extra tabbable elements in future in <Thumbnail/>
     const tabbables = getTabbable(container!);
     expect(tabbables.length).toBe(0);
   });

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -123,7 +123,7 @@
           await progressBarController.set(1);
         } catch (error) {
           // this may happen if browser blocks auto-play of the video on first page load. This can either be a setting
-          // or just defaut in certain browsers on page load without any DOM interaction by user.
+          // or just default in certain browsers on page load without any DOM interaction by user.
           console.error(`handleAction[${callingContext}] videoPlayer play problem: ${error}`);
           paused = true;
           await progressBarController.set(0);

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -299,7 +299,7 @@
           // allowing next to be at least 1 may cause percent to go negative, so ensure positive percentage
           scrubBucketPercent = Math.max(0, top / (bucketHeight * maxScrollPercent));
 
-          // compensate for lost precision/rouding errors advance to the next bucket, if present
+          // compensate for lost precision/rounding errors advance to the next bucket, if present
           if (scrubBucketPercent > 0.9999 && i + 1 < bucketsLength - 1) {
             scrubBucket = assetStore.buckets[i + 1];
             scrubBucketPercent = 0;

--- a/web/src/lib/utils/cancellable-task.ts
+++ b/web/src/lib/utils/cancellable-task.ts
@@ -69,7 +69,7 @@ export class CancellableTask {
     } catch (error) {
       // eslint-disable-next-line  @typescript-eslint/no-explicit-any
       if ((error as any).name === 'AbortError') {
-        // abort error is not treated as an error, but as a cancelation.
+        // abort error is not treated as an error, but as a cancellation.
         return 'CANCELED';
       }
       this.#transitionToErrored(error);


### PR DESCRIPTION
## Description

Fixes user-facing and non-user-facing typos

Found via `codespell -q 3 -S "./i18n,./docs/package-lock.json,./readme_i18n,./mobile/assets/i18n" -L afterall,nd,renderd`

## How Has This Been Tested?

Hasn't been tested

## API Changes

n/a

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services`)
