### PR TITLE
fix(web): IconButton size in user restore

### DIFF
--- a/web/src/routes/admin/user-management/+page.svelte
+++ b/web/src/routes/admin/user-management/+page.svelte
@@ -161,7 +161,7 @@
                   {#if immichUser.deletedAt && immichUser.status === UserStatus.Deleted}
                     <IconButton
                       shape="round"
-                      size="small"
+                      size="medium"
                       icon={mdiDeleteRestore}
                       title={$t('admin.user_restore_scheduled_removal', {
                         values: { date: getDeleteDate(immichUser.deletedAt) },


### PR DESCRIPTION
This bug is introduced in PR #18138 10 hours ago.
![image](https://github.com/user-attachments/assets/47261a1c-aff3-425d-81ef-bdfe64fd1960)