### PR TITLE
fix: construct chinese languages from subtags

### DIFF
--- a/mobile/lib/constants/locales.dart
+++ b/mobile/lib/constants/locales.dart
@@ -6,8 +6,10 @@ const Map<String, Locale> locales = {
   // Additional locales
   'Arabic (ar)': Locale('ar'),
   'Catalan (ca)': Locale('ca'),
-  'Chinese Simplified (zh_CN)': Locale('zh', 'CN'),
-  'Chinese Traditional (zh_TW)': Locale('zh', 'TW'),
+  'Chinese Simplified (zh_CN)':
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'SIMPLIFIED'),
+  'Chinese Traditional (zh_TW)':
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
   'Czech (cs)': Locale('cs'),
   'Danish (da)': Locale('da'),
   'Dutch (nl)': Locale('nl'),


### PR DESCRIPTION
## Description

The change proposed in #18167 does correctly handle the saving of the designated language. However, as the i18n files are named the way they are the localization framework cannot access the Chinese languages anymore.

This patch is supposed to be a hotfix addressing the issue (which I brought in due to my insufficient testing) by using the `scriptCode` parameter to load the correct language file.

Furthermore, I want to use the chance to ask the question why the language `zh_SIMPLIFIED` is named the way it is rather than `zh_Hans` - which would be the more standardized way?
Background for this question is the fact that the web client also does some more parsing before using it too.
In my opinion it would make sense to rename this file to match the standard.

## How Has This Been Tested?

- Open App
- Change Language to `zh_SIMPLIFIED | zh_Hant` 
- Observe Language actually changes to the chosen Han script
- Restart App 
- Observe Language sticking

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
