### PR TITLE
fix(web): no rounded map on /map page

### DIFF
--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -72,7 +72,7 @@
 {#if $featureFlags.loaded && $featureFlags.map}
   <UserPageLayout title={data.meta.title}>
     <div class="isolate h-full w-full">
-      <Map hash onSelect={onViewAssets} rounded />
+      <Map hash onSelect={onViewAssets} />
     </div>
   </UserPageLayout>
   <Portal target="body">


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/2437d9f0-2f3b-4327-9af7-80a6d52a1e6e)

After

![image](https://github.com/user-attachments/assets/61fd368c-94d4-40fe-aa96-9cdd5c648561)
