### PR TITLE
fix(web): format dates with the locale preference

### DIFF
--- a/web/src/lib/components/user-settings-page/user-api-key-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-api-key-list.svelte
@@ -18,18 +18,13 @@
   import { fade } from 'svelte/transition';
   import { handleError } from '../../utils/handle-error';
   import { notificationController, NotificationType } from '../shared-components/notification/notification';
+  import { dateFormats } from '$lib/constants';
 
   interface Props {
     keys: ApiKeyResponseDto[];
   }
 
   let { keys = $bindable() }: Props = $props();
-
-  const format: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  };
 
   async function refreshKeys() {
     keys = await getApiKeys();
@@ -130,7 +125,7 @@
             >
               <td class="w-1/3 text-ellipsis px-4 text-sm">{key.name}</td>
               <td class="w-1/3 text-ellipsis px-4 text-sm"
-                >{new Date(key.createdAt).toLocaleDateString($locale, format)}
+                >{new Date(key.createdAt).toLocaleDateString($locale, dateFormats.settings)}
               </td>
               <td class="flex flex-row flex-wrap justify-center gap-x-2 gap-y-1 w-1/3">
                 <CircleIconButton

--- a/web/src/lib/components/user-settings-page/user-purchase-settings.svelte
+++ b/web/src/lib/components/user-settings-page/user-purchase-settings.svelte
@@ -4,7 +4,9 @@
   import Icon from '$lib/components/elements/icon.svelte';
   import PurchaseContent from '$lib/components/shared-components/purchasing/purchase-content.svelte';
   import SettingSwitch from '$lib/components/shared-components/settings/setting-switch.svelte';
+  import { dateFormats } from '$lib/constants';
   import { modalManager } from '$lib/managers/modal-manager.svelte';
+  import { locale } from '$lib/stores/preferences.store';
   import { purchaseStore } from '$lib/stores/purchase.store';
   import { preferences, user } from '$lib/stores/user.store';
   import { handleError } from '$lib/utils/handle-error';
@@ -132,7 +134,9 @@
             {#if $user.isAdmin && serverPurchaseInfo?.activatedAt}
               <p class="dark:text-white text-sm mt-1 col-start-2">
                 {$t('purchase_activated_time', {
-                  values: { date: new Date(serverPurchaseInfo.activatedAt) },
+                  values: {
+                    date: new Date(serverPurchaseInfo.activatedAt).toLocaleString($locale, dateFormats.settings),
+                  },
                 })}
               </p>
             {:else}
@@ -161,7 +165,9 @@
             {#if $user.license?.activatedAt}
               <p class="dark:text-white text-sm mt-1 col-start-2">
                 {$t('purchase_activated_time', {
-                  values: { date: new Date($user.license?.activatedAt) },
+                  values: {
+                    date: new Date($user.license?.activatedAt).toLocaleString($locale, dateFormats.settings),
+                  },
                 })}
               </p>
             {/if}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -68,6 +68,11 @@ export const dateFormats = {
     day: 'numeric',
     year: 'numeric',
   },
+  settings: <Intl.DateTimeFormatOptions>{
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  },
 };
 
 export enum QueryParameter {


### PR DESCRIPTION
## Description

Dates in the settings were not formatted according to the locale set by the user.

It seems like the locale formatting is not supported by `svelte-i18n`, so I'm formatting directly in code and removed the ICU message format in the translations.

> [!IMPORTANT]
> The translation PR is required for this PR to work, as the variable changed.
> https://github.com/immich-app/immich/pull/18083

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Local web build, updated the translations locally

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->
![image](https://github.com/user-attachments/assets/a2377c98-2df0-468b-a180-3a1c4f9a4a9f)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
