### PR TITLE
feat: add session creation endpoint

### DIFF
--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -194,6 +194,7 @@ Class | Method | HTTP request | Description
 *ServerApi* | [**getVersionHistory**](doc//ServerApi.md#getversionhistory) | **GET** /server/version-history | 
 *ServerApi* | [**pingServer**](doc//ServerApi.md#pingserver) | **GET** /server/ping | 
 *ServerApi* | [**setServerLicense**](doc//ServerApi.md#setserverlicense) | **PUT** /server/license | 
+*SessionsApi* | [**createSession**](doc//SessionsApi.md#createsession) | **POST** /sessions | 
 *SessionsApi* | [**deleteAllSessions**](doc//SessionsApi.md#deleteallsessions) | **DELETE** /sessions | 
 *SessionsApi* | [**deleteSession**](doc//SessionsApi.md#deletesession) | **DELETE** /sessions/{id} | 
 *SessionsApi* | [**getSessions**](doc//SessionsApi.md#getsessions) | **GET** /sessions | 
@@ -420,6 +421,8 @@ Class | Method | HTTP request | Description
  - [ServerThemeDto](doc//ServerThemeDto.md)
  - [ServerVersionHistoryResponseDto](doc//ServerVersionHistoryResponseDto.md)
  - [ServerVersionResponseDto](doc//ServerVersionResponseDto.md)
+ - [SessionCreateDto](doc//SessionCreateDto.md)
+ - [SessionCreateResponseDto](doc//SessionCreateResponseDto.md)
  - [SessionResponseDto](doc//SessionResponseDto.md)
  - [SharedLinkCreateDto](doc//SharedLinkCreateDto.md)
  - [SharedLinkEditDto](doc//SharedLinkEditDto.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -218,6 +218,8 @@ part 'model/server_storage_response_dto.dart';
 part 'model/server_theme_dto.dart';
 part 'model/server_version_history_response_dto.dart';
 part 'model/server_version_response_dto.dart';
+part 'model/session_create_dto.dart';
+part 'model/session_create_response_dto.dart';
 part 'model/session_response_dto.dart';
 part 'model/shared_link_create_dto.dart';
 part 'model/shared_link_edit_dto.dart';

--- a/mobile/openapi/lib/api/sessions_api.dart
+++ b/mobile/openapi/lib/api/sessions_api.dart
@@ -16,6 +16,53 @@ class SessionsApi {
 
   final ApiClient apiClient;
 
+  /// Performs an HTTP 'POST /sessions' operation and returns the [Response].
+  /// Parameters:
+  ///
+  /// * [SessionCreateDto] sessionCreateDto (required):
+  Future<Response> createSessionWithHttpInfo(SessionCreateDto sessionCreateDto,) async {
+    // ignore: prefer_const_declarations
+    final apiPath = r'/sessions';
+
+    // ignore: prefer_final_locals
+    Object? postBody = sessionCreateDto;
+
+    final queryParams = <QueryParam>[];
+    final headerParams = <String, String>{};
+    final formParams = <String, String>{};
+
+    const contentTypes = <String>['application/json'];
+
+
+    return apiClient.invokeAPI(
+      apiPath,
+      'POST',
+      queryParams,
+      postBody,
+      headerParams,
+      formParams,
+      contentTypes.isEmpty ? null : contentTypes.first,
+    );
+  }
+
+  /// Parameters:
+  ///
+  /// * [SessionCreateDto] sessionCreateDto (required):
+  Future<SessionCreateResponseDto?> createSession(SessionCreateDto sessionCreateDto,) async {
+    final response = await createSessionWithHttpInfo(sessionCreateDto,);
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    }
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'SessionCreateResponseDto',) as SessionCreateResponseDto;
+    
+    }
+    return null;
+  }
+
   /// Performs an HTTP 'DELETE /sessions' operation and returns the [Response].
   Future<Response> deleteAllSessionsWithHttpInfo() async {
     // ignore: prefer_const_declarations

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -492,6 +492,10 @@ class ApiClient {
           return ServerVersionHistoryResponseDto.fromJson(value);
         case 'ServerVersionResponseDto':
           return ServerVersionResponseDto.fromJson(value);
+        case 'SessionCreateDto':
+          return SessionCreateDto.fromJson(value);
+        case 'SessionCreateResponseDto':
+          return SessionCreateResponseDto.fromJson(value);
         case 'SessionResponseDto':
           return SessionResponseDto.fromJson(value);
         case 'SharedLinkCreateDto':

--- a/mobile/openapi/lib/model/permission.dart
+++ b/mobile/openapi/lib/model/permission.dart
@@ -81,6 +81,7 @@ class Permission {
   static const personPeriodStatistics = Permission._(r'person.statistics');
   static const personPeriodMerge = Permission._(r'person.merge');
   static const personPeriodReassign = Permission._(r'person.reassign');
+  static const sessionPeriodCreate = Permission._(r'session.create');
   static const sessionPeriodRead = Permission._(r'session.read');
   static const sessionPeriodUpdate = Permission._(r'session.update');
   static const sessionPeriodDelete = Permission._(r'session.delete');
@@ -166,6 +167,7 @@ class Permission {
     personPeriodStatistics,
     personPeriodMerge,
     personPeriodReassign,
+    sessionPeriodCreate,
     sessionPeriodRead,
     sessionPeriodUpdate,
     sessionPeriodDelete,
@@ -286,6 +288,7 @@ class PermissionTypeTransformer {
         case r'person.statistics': return Permission.personPeriodStatistics;
         case r'person.merge': return Permission.personPeriodMerge;
         case r'person.reassign': return Permission.personPeriodReassign;
+        case r'session.create': return Permission.sessionPeriodCreate;
         case r'session.read': return Permission.sessionPeriodRead;
         case r'session.update': return Permission.sessionPeriodUpdate;
         case r'session.delete': return Permission.sessionPeriodDelete;

--- a/mobile/openapi/lib/model/session_create_dto.dart
+++ b/mobile/openapi/lib/model/session_create_dto.dart
@@ -1,0 +1,145 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class SessionCreateDto {
+  /// Returns a new [SessionCreateDto] instance.
+  SessionCreateDto({
+    this.deviceOS,
+    this.deviceType,
+    this.duration,
+  });
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? deviceOS;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  String? deviceType;
+
+  /// session duration, in seconds
+  ///
+  /// Minimum value: 1
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  num? duration;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is SessionCreateDto &&
+    other.deviceOS == deviceOS &&
+    other.deviceType == deviceType &&
+    other.duration == duration;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (deviceOS == null ? 0 : deviceOS!.hashCode) +
+    (deviceType == null ? 0 : deviceType!.hashCode) +
+    (duration == null ? 0 : duration!.hashCode);
+
+  @override
+  String toString() => 'SessionCreateDto[deviceOS=$deviceOS, deviceType=$deviceType, duration=$duration]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+    if (this.deviceOS != null) {
+      json[r'deviceOS'] = this.deviceOS;
+    } else {
+    //  json[r'deviceOS'] = null;
+    }
+    if (this.deviceType != null) {
+      json[r'deviceType'] = this.deviceType;
+    } else {
+    //  json[r'deviceType'] = null;
+    }
+    if (this.duration != null) {
+      json[r'duration'] = this.duration;
+    } else {
+    //  json[r'duration'] = null;
+    }
+    return json;
+  }
+
+  /// Returns a new [SessionCreateDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static SessionCreateDto? fromJson(dynamic value) {
+    upgradeDto(value, "SessionCreateDto");
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return SessionCreateDto(
+        deviceOS: mapValueOfType<String>(json, r'deviceOS'),
+        deviceType: mapValueOfType<String>(json, r'deviceType'),
+        duration: num.parse('${json[r'duration']}'),
+      );
+    }
+    return null;
+  }
+
+  static List<SessionCreateDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <SessionCreateDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = SessionCreateDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, SessionCreateDto> mapFromJson(dynamic json) {
+    final map = <String, SessionCreateDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = SessionCreateDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of SessionCreateDto-objects as value to a dart map
+  static Map<String, List<SessionCreateDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<SessionCreateDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = SessionCreateDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+  };
+}
+

--- a/mobile/openapi/lib/model/session_create_response_dto.dart
+++ b/mobile/openapi/lib/model/session_create_response_dto.dart
@@ -1,0 +1,147 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class SessionCreateResponseDto {
+  /// Returns a new [SessionCreateResponseDto] instance.
+  SessionCreateResponseDto({
+    required this.createdAt,
+    required this.current,
+    required this.deviceOS,
+    required this.deviceType,
+    required this.id,
+    required this.token,
+    required this.updatedAt,
+  });
+
+  String createdAt;
+
+  bool current;
+
+  String deviceOS;
+
+  String deviceType;
+
+  String id;
+
+  String token;
+
+  String updatedAt;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is SessionCreateResponseDto &&
+    other.createdAt == createdAt &&
+    other.current == current &&
+    other.deviceOS == deviceOS &&
+    other.deviceType == deviceType &&
+    other.id == id &&
+    other.token == token &&
+    other.updatedAt == updatedAt;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (createdAt.hashCode) +
+    (current.hashCode) +
+    (deviceOS.hashCode) +
+    (deviceType.hashCode) +
+    (id.hashCode) +
+    (token.hashCode) +
+    (updatedAt.hashCode);
+
+  @override
+  String toString() => 'SessionCreateResponseDto[createdAt=$createdAt, current=$current, deviceOS=$deviceOS, deviceType=$deviceType, id=$id, token=$token, updatedAt=$updatedAt]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'createdAt'] = this.createdAt;
+      json[r'current'] = this.current;
+      json[r'deviceOS'] = this.deviceOS;
+      json[r'deviceType'] = this.deviceType;
+      json[r'id'] = this.id;
+      json[r'token'] = this.token;
+      json[r'updatedAt'] = this.updatedAt;
+    return json;
+  }
+
+  /// Returns a new [SessionCreateResponseDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static SessionCreateResponseDto? fromJson(dynamic value) {
+    upgradeDto(value, "SessionCreateResponseDto");
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return SessionCreateResponseDto(
+        createdAt: mapValueOfType<String>(json, r'createdAt')!,
+        current: mapValueOfType<bool>(json, r'current')!,
+        deviceOS: mapValueOfType<String>(json, r'deviceOS')!,
+        deviceType: mapValueOfType<String>(json, r'deviceType')!,
+        id: mapValueOfType<String>(json, r'id')!,
+        token: mapValueOfType<String>(json, r'token')!,
+        updatedAt: mapValueOfType<String>(json, r'updatedAt')!,
+      );
+    }
+    return null;
+  }
+
+  static List<SessionCreateResponseDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <SessionCreateResponseDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = SessionCreateResponseDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, SessionCreateResponseDto> mapFromJson(dynamic json) {
+    final map = <String, SessionCreateResponseDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = SessionCreateResponseDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of SessionCreateResponseDto-objects as value to a dart map
+  static Map<String, List<SessionCreateResponseDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<SessionCreateResponseDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = SessionCreateResponseDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'createdAt',
+    'current',
+    'deviceOS',
+    'deviceType',
+    'id',
+    'token',
+    'updatedAt',
+  };
+}
+

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -5618,6 +5618,46 @@
         "tags": [
           "Sessions"
         ]
+      },
+      "post": {
+        "operationId": "createSession",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionCreateDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionCreateResponseDto"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Sessions"
+        ]
       }
     },
     "/sessions/{id}": {
@@ -11052,6 +11092,7 @@
           "person.statistics",
           "person.merge",
           "person.reassign",
+          "session.create",
           "session.read",
           "session.update",
           "session.delete",
@@ -12035,6 +12076,57 @@
           "major",
           "minor",
           "patch"
+        ],
+        "type": "object"
+      },
+      "SessionCreateDto": {
+        "properties": {
+          "deviceOS": {
+            "type": "string"
+          },
+          "deviceType": {
+            "type": "string"
+          },
+          "duration": {
+            "description": "session duration, in seconds",
+            "minimum": 1,
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "SessionCreateResponseDto": {
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "current": {
+            "type": "boolean"
+          },
+          "deviceOS": {
+            "type": "string"
+          },
+          "deviceType": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "createdAt",
+          "current",
+          "deviceOS",
+          "deviceType",
+          "id",
+          "token",
+          "updatedAt"
         ],
         "type": "object"
       },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1078,6 +1078,21 @@ export type SessionResponseDto = {
     id: string;
     updatedAt: string;
 };
+export type SessionCreateDto = {
+    deviceOS?: string;
+    deviceType?: string;
+    /** session duration, in seconds */
+    duration?: number;
+};
+export type SessionCreateResponseDto = {
+    createdAt: string;
+    current: boolean;
+    deviceOS: string;
+    deviceType: string;
+    id: string;
+    token: string;
+    updatedAt: string;
+};
 export type SharedLinkResponseDto = {
     album?: AlbumResponseDto;
     allowDownload: boolean;
@@ -2917,6 +2932,18 @@ export function getSessions(opts?: Oazapfts.RequestOpts) {
         ...opts
     }));
 }
+export function createSession({ sessionCreateDto }: {
+    sessionCreateDto: SessionCreateDto;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 201;
+        data: SessionCreateResponseDto;
+    }>("/sessions", oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: sessionCreateDto
+    })));
+}
 export function deleteSession({ id }: {
     id: string;
 }, opts?: Oazapfts.RequestOpts) {
@@ -3678,6 +3705,7 @@ export enum Permission {
     PersonStatistics = "person.statistics",
     PersonMerge = "person.merge",
     PersonReassign = "person.reassign",
+    SessionCreate = "session.create",
     SessionRead = "session.read",
     SessionUpdate = "session.update",
     SessionDelete = "session.delete",

--- a/server/src/controllers/session.controller.ts
+++ b/server/src/controllers/session.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Delete, Get, HttpCode, HttpStatus, Param } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { SessionResponseDto } from 'src/dtos/session.dto';
+import { SessionCreateDto, SessionCreateResponseDto, SessionResponseDto } from 'src/dtos/session.dto';
 import { Permission } from 'src/enum';
 import { Auth, Authenticated } from 'src/middleware/auth.guard';
 import { SessionService } from 'src/services/session.service';
@@ -11,6 +11,12 @@ import { UUIDParamDto } from 'src/validation';
 @Controller('sessions')
 export class SessionController {
   constructor(private service: SessionService) {}
+
+  @Post()
+  @Authenticated({ permission: Permission.SESSION_CREATE })
+  createSession(@Auth() auth: AuthDto, @Body() dto: SessionCreateDto): Promise<SessionCreateResponseDto> {
+    return this.service.create(auth, dto);
+  }
 
   @Get()
   @Authenticated({ permission: Permission.SESSION_READ })

--- a/server/src/db.d.ts
+++ b/server/src/db.d.ts
@@ -343,6 +343,8 @@ export interface Sessions {
   deviceOS: Generated<string>;
   deviceType: Generated<string>;
   id: Generated<string>;
+  parentId: string | null;
+  expiredAt: Date | null;
   token: string;
   updatedAt: Generated<Timestamp>;
   updateId: Generated<string>;

--- a/server/src/dtos/session.dto.ts
+++ b/server/src/dtos/session.dto.ts
@@ -1,4 +1,24 @@
+import { IsInt, IsPositive, IsString } from 'class-validator';
 import { Session } from 'src/database';
+import { Optional } from 'src/validation';
+
+export class SessionCreateDto {
+  /**
+   * session duration, in seconds
+   */
+  @IsInt()
+  @IsPositive()
+  @Optional()
+  duration?: number;
+
+  @IsString()
+  @Optional()
+  deviceType?: string;
+
+  @IsString()
+  @Optional()
+  deviceOS?: string;
+}
 
 export class SessionResponseDto {
   id!: string;
@@ -7,6 +27,10 @@ export class SessionResponseDto {
   current!: boolean;
   deviceType!: string;
   deviceOS!: string;
+}
+
+export class SessionCreateResponseDto extends SessionResponseDto {
+  token!: string;
 }
 
 export const mapSession = (entity: Session, currentId?: string): SessionResponseDto => ({

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -144,6 +144,7 @@ export enum Permission {
   PERSON_MERGE = 'person.merge',
   PERSON_REASSIGN = 'person.reassign',
 
+  SESSION_CREATE = 'session.create',
   SESSION_READ = 'session.read',
   SESSION_UPDATE = 'session.update',
   SESSION_DELETE = 'session.delete',

--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -36,6 +36,10 @@ from
   "sessions"
 where
   "sessions"."token" = $1
+  and (
+    "sessions"."expiredAt" is null
+    or "sessions"."expiredAt" > $2
+  )
 
 -- SessionRepository.getByUserId
 select

--- a/server/src/repositories/crypto.repository.ts
+++ b/server/src/repositories/crypto.repository.ts
@@ -54,7 +54,7 @@ export class CryptoRepository {
     });
   }
 
-  newPassword(bytes: number) {
+  randomBytesAsText(bytes: number) {
     return randomBytes(bytes).toString('base64').replaceAll(/\W/g, '');
   }
 }

--- a/server/src/schema/migrations/1747329504572-AddNewSessionColumns.ts
+++ b/server/src/schema/migrations/1747329504572-AddNewSessionColumns.ts
@@ -1,0 +1,15 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "sessions" ADD "expiredAt" timestamp with time zone;`.execute(db);
+  await sql`ALTER TABLE "sessions" ADD "parentId" uuid;`.execute(db);
+  await sql`ALTER TABLE "sessions" ADD CONSTRAINT "FK_afbbabbd7daf5b91de4dca84de8" FOREIGN KEY ("parentId") REFERENCES "sessions" ("id") ON UPDATE CASCADE ON DELETE CASCADE;`.execute(db);
+  await sql`CREATE INDEX "IDX_afbbabbd7daf5b91de4dca84de" ON "sessions" ("parentId")`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX "IDX_afbbabbd7daf5b91de4dca84de";`.execute(db);
+  await sql`ALTER TABLE "sessions" DROP CONSTRAINT "FK_afbbabbd7daf5b91de4dca84de8";`.execute(db);
+  await sql`ALTER TABLE "sessions" DROP COLUMN "expiredAt";`.execute(db);
+  await sql`ALTER TABLE "sessions" DROP COLUMN "parentId";`.execute(db);
+}

--- a/server/src/schema/tables/session.table.ts
+++ b/server/src/schema/tables/session.table.ts
@@ -25,8 +25,14 @@ export class SessionTable {
   @UpdateDateColumn()
   updatedAt!: Date;
 
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  expiredAt!: Date | null;
+
   @ForeignKeyColumn(() => UserTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE' })
   userId!: string;
+
+  @ForeignKeyColumn(() => SessionTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE', nullable: true })
+  parentId!: string | null;
 
   @Column({ default: '' })
   deviceType!: string;

--- a/server/src/services/api-key.service.spec.ts
+++ b/server/src/services/api-key.service.spec.ts
@@ -18,7 +18,7 @@ describe(ApiKeyService.name, () => {
       const apiKey = factory.apiKey({ userId: auth.user.id, permissions: [Permission.ALL] });
       const key = 'super-secret';
 
-      mocks.crypto.newPassword.mockReturnValue(key);
+      mocks.crypto.randomBytesAsText.mockReturnValue(key);
       mocks.apiKey.create.mockResolvedValue(apiKey);
 
       await sut.create(auth, { name: apiKey.name, permissions: apiKey.permissions });
@@ -29,7 +29,7 @@ describe(ApiKeyService.name, () => {
         permissions: apiKey.permissions,
         userId: apiKey.userId,
       });
-      expect(mocks.crypto.newPassword).toHaveBeenCalled();
+      expect(mocks.crypto.randomBytesAsText).toHaveBeenCalled();
       expect(mocks.crypto.hashSha256).toHaveBeenCalled();
     });
 
@@ -38,7 +38,7 @@ describe(ApiKeyService.name, () => {
       const apiKey = factory.apiKey({ userId: auth.user.id });
       const key = 'super-secret';
 
-      mocks.crypto.newPassword.mockReturnValue(key);
+      mocks.crypto.randomBytesAsText.mockReturnValue(key);
       mocks.apiKey.create.mockResolvedValue(apiKey);
 
       await sut.create(auth, { permissions: [Permission.ALL] });
@@ -49,7 +49,7 @@ describe(ApiKeyService.name, () => {
         permissions: [Permission.ALL],
         userId: auth.user.id,
       });
-      expect(mocks.crypto.newPassword).toHaveBeenCalled();
+      expect(mocks.crypto.randomBytesAsText).toHaveBeenCalled();
       expect(mocks.crypto.hashSha256).toHaveBeenCalled();
     });
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -492,17 +492,17 @@ export class AuthService extends BaseService {
   }
 
   private async createLoginResponse(user: UserAdmin, loginDetails: LoginDetails) {
-    const key = this.cryptoRepository.newPassword(32);
-    const token = this.cryptoRepository.hashSha256(key);
+    const token = this.cryptoRepository.randomBytesAsText(32);
+    const tokenHashed = this.cryptoRepository.hashSha256(token);
 
     await this.sessionRepository.create({
-      token,
+      token: tokenHashed,
       deviceOS: loginDetails.deviceOS,
       deviceType: loginDetails.deviceType,
       userId: user.id,
     });
 
-    return mapLoginResponse(user, key);
+    return mapLoginResponse(user, token);
   }
 
   private getClaim<T>(profile: OAuthProfile, options: ClaimOptions<T>): T {

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -17,7 +17,7 @@ export class CliService extends BaseService {
     }
 
     const providedPassword = await ask(mapUserAdmin(admin));
-    const password = providedPassword || this.cryptoRepository.newPassword(24);
+    const password = providedPassword || this.cryptoRepository.randomBytesAsText(24);
     const hashedPassword = await this.cryptoRepository.hashBcrypt(password, SALT_ROUNDS);
 
     await this.userRepository.update(admin.id, { password: hashedPassword });

--- a/server/src/services/session.service.spec.ts
+++ b/server/src/services/session.service.spec.ts
@@ -17,30 +17,9 @@ describe('SessionService', () => {
   });
 
   describe('handleCleanup', () => {
-    it('should return skipped if nothing is to be deleted', async () => {
-      mocks.session.search.mockResolvedValue([]);
-      await expect(sut.handleCleanup()).resolves.toEqual(JobStatus.SKIPPED);
-      expect(mocks.session.search).toHaveBeenCalled();
-    });
-
-    it('should delete sessions', async () => {
-      mocks.session.search.mockResolvedValue([
-        {
-          createdAt: new Date('1970-01-01T00:00:00.00Z'),
-          updatedAt: new Date('1970-01-02T00:00:00.00Z'),
-          deviceOS: '',
-          deviceType: '',
-          id: '123',
-          token: '420',
-          userId: '42',
-          updateId: 'uuid-v7',
-          pinExpiresAt: null,
-        },
-      ]);
-      mocks.session.delete.mockResolvedValue();
-
+    it('should clean sessions', async () => {
+      mocks.session.cleanup.mockResolvedValue([]);
       await expect(sut.handleCleanup()).resolves.toEqual(JobStatus.SUCCESS);
-      expect(mocks.session.delete).toHaveBeenCalledWith('123');
     });
   });
 

--- a/server/src/services/session.service.ts
+++ b/server/src/services/session.service.ts
@@ -1,8 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { OnJob } from 'src/decorators';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { SessionResponseDto, mapSession } from 'src/dtos/session.dto';
+import { SessionCreateDto, SessionCreateResponseDto, SessionResponseDto, mapSession } from 'src/dtos/session.dto';
 import { JobName, JobStatus, Permission, QueueName } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
 
@@ -10,22 +10,33 @@ import { BaseService } from 'src/services/base.service';
 export class SessionService extends BaseService {
   @OnJob({ name: JobName.CLEAN_OLD_SESSION_TOKENS, queue: QueueName.BACKGROUND_TASK })
   async handleCleanup(): Promise<JobStatus> {
-    const sessions = await this.sessionRepository.search({
-      updatedBefore: DateTime.now().minus({ days: 90 }).toJSDate(),
-    });
-
-    if (sessions.length === 0) {
-      return JobStatus.SKIPPED;
-    }
-
+    const sessions = await this.sessionRepository.cleanup();
     for (const session of sessions) {
-      await this.sessionRepository.delete(session.id);
       this.logger.verbose(`Deleted expired session token: ${session.deviceOS}/${session.deviceType}`);
     }
 
     this.logger.log(`Deleted ${sessions.length} expired session tokens`);
 
     return JobStatus.SUCCESS;
+  }
+
+  async create(auth: AuthDto, dto: SessionCreateDto): Promise<SessionCreateResponseDto> {
+    if (!auth.session) {
+      throw new BadRequestException('This endpoint can only be used with a session token');
+    }
+
+    const token = this.cryptoRepository.randomBytesAsText(32);
+    const tokenHashed = this.cryptoRepository.hashSha256(token);
+    const session = await this.sessionRepository.create({
+      parentId: auth.session.id,
+      userId: auth.user.id,
+      expiredAt: dto.duration ? DateTime.now().plus({ seconds: dto.duration }).toJSDate() : null,
+      deviceType: dto.deviceType,
+      deviceOS: dto.deviceOS,
+      token: tokenHashed,
+    });
+
+    return { ...mapSession(session), token };
   }
 
   async getAll(auth: AuthDto): Promise<SessionResponseDto[]> {

--- a/server/test/repositories/crypto.repository.mock.ts
+++ b/server/test/repositories/crypto.repository.mock.ts
@@ -12,6 +12,6 @@ export const newCryptoRepositoryMock = (): Mocked<RepositoryInterface<CryptoRepo
     verifySha256: vitest.fn().mockImplementation(() => true),
     hashSha1: vitest.fn().mockImplementation((input) => Buffer.from(`${input.toString()} (hashed)`)),
     hashFile: vitest.fn().mockImplementation((input) => `${input} (file-hashed)`),
-    newPassword: vitest.fn().mockReturnValue(Buffer.from('random-bytes').toString('base64')),
+    randomBytesAsText: vitest.fn().mockReturnValue(Buffer.from('random-bytes').toString('base64')),
   };
 };

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -126,6 +126,8 @@ const sessionFactory = (session: Partial<Session> = {}) => ({
   deviceOS: 'android',
   deviceType: 'mobile',
   token: 'abc123',
+  parentId: null,
+  expiredAt: null,
   userId: newUuid(),
   pinExpiresAt: newDate(),
   ...session,

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -7,6 +7,7 @@
     mdiAndroid,
     mdiApple,
     mdiAppleSafari,
+    mdiCast,
     mdiGoogleChrome,
     mdiHelp,
     mdiLinux,
@@ -46,6 +47,8 @@
       <Icon path={mdiUbuntu} size="40" />
     {:else if device.deviceOS === 'Chrome OS' || device.deviceType === 'Chrome' || device.deviceType === 'Chromium' || device.deviceType === 'Mobile Chrome'}
       <Icon path={mdiGoogleChrome} size="40" />
+    {:else if device.deviceOS === 'Google Cast'}
+      <Icon path={mdiCast} size="40" />
     {:else}
       <Icon path={mdiHelp} size="40" />
     {/if}


### PR DESCRIPTION
## Description

This adds a session creation endpoint to the API. Allows frontend to create sessions owned by the Authed user. This will be expanded to add scoping and expiry in the future.

## How Has This Been Tested?

Pair programmed with @jrasm91 

## API Changes

Created `POST /sessions`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
