### PR TITLE
fix(server): vacuum after deleting people

### DIFF
--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -13,12 +13,6 @@ set
   "personId" = $1
 where
   "asset_faces"."sourceType" = $2
-VACUUM
-ANALYZE asset_faces,
-face_search,
-person
-REINDEX TABLE asset_faces
-REINDEX TABLE person
 
 -- PersonRepository.delete
 delete from "person"
@@ -29,12 +23,6 @@ where
 delete from "asset_faces"
 where
   "asset_faces"."sourceType" = $1
-VACUUM
-ANALYZE asset_faces,
-face_search,
-person
-REINDEX TABLE asset_faces
-REINDEX TABLE person
 
 -- PersonRepository.getAllWithoutFaces
 select

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -105,8 +105,6 @@ export class PersonRepository {
       .set({ personId: null })
       .where('asset_faces.sourceType', '=', sourceType)
       .execute();
-
-    await this.vacuum({ reindexVectors: false });
   }
 
   @GenerateSql({ params: [DummyValue.UUID] })
@@ -121,8 +119,6 @@ export class PersonRepository {
   @GenerateSql({ params: [{ sourceType: SourceType.EXIF }] })
   async deleteFaces({ sourceType }: DeleteFacesOptions): Promise<void> {
     await this.db.deleteFrom('asset_faces').where('asset_faces.sourceType', '=', sourceType).execute();
-
-    await this.vacuum({ reindexVectors: sourceType === SourceType.MACHINE_LEARNING });
   }
 
   getAllFaces(options: GetAllFacesOptions = {}) {
@@ -519,7 +515,7 @@ export class PersonRepository {
     await this.db.updateTable('asset_faces').set({ deletedAt: new Date() }).where('asset_faces.id', '=', id).execute();
   }
 
-  private async vacuum({ reindexVectors }: { reindexVectors: boolean }): Promise<void> {
+  async vacuum({ reindexVectors }: { reindexVectors: boolean }): Promise<void> {
     await sql`VACUUM ANALYZE asset_faces, face_search, person`.execute(this.db);
     await sql`REINDEX TABLE asset_faces`.execute(this.db);
     await sql`REINDEX TABLE person`.execute(this.db);

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -259,6 +259,7 @@ export class PersonService extends BaseService {
     if (force) {
       await this.personRepository.deleteFaces({ sourceType: SourceType.MACHINE_LEARNING });
       await this.handlePersonCleanup();
+      await this.personRepository.vacuum({ reindexVectors: true });
     }
 
     let jobs: JobItem[] = [];
@@ -409,6 +410,7 @@ export class PersonService extends BaseService {
     if (force) {
       await this.personRepository.unassignFaces({ sourceType: SourceType.MACHINE_LEARNING });
       await this.handlePersonCleanup();
+      await this.personRepository.vacuum({ reindexVectors: false });
     } else if (waiting) {
       this.logger.debug(
         `Skipping facial recognition queueing because ${waiting} job${waiting > 1 ? 's are' : ' is'} already queued`,

--- a/server/test/repositories/person.repository.mock.ts
+++ b/server/test/repositories/person.repository.mock.ts
@@ -33,5 +33,6 @@ export const newPersonRepositoryMock = (): Mocked<RepositoryInterface<PersonRepo
     createAssetFace: vitest.fn(),
     deleteAssetFace: vitest.fn(),
     softDeleteAssetFaces: vitest.fn(),
+    vacuum: vitest.fn(),
   };
 };


### PR DESCRIPTION
## Description

The DB gets vacuumed after resetting facial recognition, but it vacuums *before* people get deleted. This results in a massive slowdown as the planner changes how it structures the face search query.