### PR TITLE
fix(server): do not filter out assets without preview path for person thumbnail generation

### DIFF
--- a/e2e/src/api/specs/asset.e2e-spec.ts
+++ b/e2e/src/api/specs/asset.e2e-spec.ts
@@ -199,10 +199,9 @@ describe('/asset', () => {
       ];
       // should produce same resulting face region coordinates for any orientation
       const expectedFaces = [
-        {
+        expect.objectContaining({
           name: 'Marie Curie',
           birthDate: null,
-          thumbnailPath: '',
           isHidden: false,
           faces: [
             {
@@ -215,11 +214,10 @@ describe('/asset', () => {
               sourceType: 'exif',
             },
           ],
-        },
-        {
+        }),
+        expect.objectContaining({
           name: 'Pierre Curie',
           birthDate: null,
-          thumbnailPath: '',
           isHidden: false,
           faces: [
             {
@@ -232,7 +230,7 @@ describe('/asset', () => {
               sourceType: 'exif',
             },
           ],
-        },
+        }),
       ];
 
       it.each(metadataFaceTests)('should get the asset faces from $filename $description', async ({ filename }) => {

--- a/e2e/src/api/specs/asset.e2e-spec.ts
+++ b/e2e/src/api/specs/asset.e2e-spec.ts
@@ -199,7 +199,7 @@ describe('/asset', () => {
       ];
       // should produce same resulting face region coordinates for any orientation
       const expectedFaces = [
-        expect.objectContaining({
+        {
           name: 'Marie Curie',
           birthDate: null,
           isHidden: false,
@@ -214,8 +214,8 @@ describe('/asset', () => {
               sourceType: 'exif',
             },
           ],
-        }),
-        expect.objectContaining({
+        },
+        {
           name: 'Pierre Curie',
           birthDate: null,
           isHidden: false,
@@ -230,7 +230,7 @@ describe('/asset', () => {
               sourceType: 'exif',
             },
           ],
-        }),
+        },
       ];
 
       it.each(metadataFaceTests)('should get the asset faces from $filename $description', async ({ filename }) => {

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -145,18 +145,24 @@ select
   "asset_faces"."imageHeight" as "oldHeight",
   "assets"."type",
   "assets"."originalPath",
-  "asset_files"."path" as "previewPath",
-  "exif"."orientation" as "exifOrientation"
+  "exif"."orientation" as "exifOrientation",
+  (
+    select
+      "asset_files"."path"
+    from
+      "asset_files"
+    where
+      "asset_files"."assetId" = "assets"."id"
+      and "asset_files"."type" = $1
+  ) as "previewPath"
 from
   "person"
   inner join "asset_faces" on "asset_faces"."id" = "person"."faceAssetId"
   inner join "assets" on "asset_faces"."assetId" = "assets"."id"
   left join "exif" on "exif"."assetId" = "assets"."id"
-  left join "asset_files" on "asset_files"."assetId" = "assets"."id"
 where
-  "person"."id" = $1
+  "person"."id" = $2
   and "asset_faces"."deletedAt" is null
-  and "asset_files"."type" = $2
 
 -- PersonRepository.reassignFace
 update "asset_faces"

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -153,7 +153,7 @@ select
       "asset_files"
     where
       "asset_files"."assetId" = "assets"."id"
-      and "asset_files"."type" = $1
+      and "asset_files"."type" = 'preview'
   ) as "previewPath"
 from
   "person"
@@ -161,7 +161,7 @@ from
   inner join "assets" on "asset_faces"."assetId" = "assets"."id"
   left join "exif" on "exif"."assetId" = "assets"."id"
 where
-  "person"."id" = $2
+  "person"."id" = $1
   and "asset_faces"."deletedAt" is null
 
 -- PersonRepository.reassignFace

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -282,7 +282,7 @@ export class PersonRepository {
           .selectFrom('asset_files')
           .select('asset_files.path')
           .whereRef('asset_files.assetId', '=', 'assets.id')
-          .where('asset_files.type', '=', AssetFileType.PREVIEW)
+          .where('asset_files.type', '=', sql.lit(AssetFileType.PREVIEW))
           .as('previewPath'),
       )
       .where('person.id', '=', id)

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ExpressionBuilder, Insertable, Kysely, NotNull, Selectable, sql, Updateable } from 'kysely';
+import { ExpressionBuilder, Insertable, Kysely, Selectable, sql, Updateable } from 'kysely';
 import { jsonObjectFrom } from 'kysely/helpers/postgres';
 import { InjectKysely } from 'nestjs-kysely';
 import { AssetFaces, DB, FaceSearch, Person } from 'src/db';
@@ -265,7 +265,6 @@ export class PersonRepository {
       .innerJoin('asset_faces', 'asset_faces.id', 'person.faceAssetId')
       .innerJoin('assets', 'asset_faces.assetId', 'assets.id')
       .leftJoin('exif', 'exif.assetId', 'assets.id')
-      .leftJoin('asset_files', 'asset_files.assetId', 'assets.id')
       .select([
         'person.ownerId',
         'asset_faces.boundingBoxX1 as x1',
@@ -276,13 +275,18 @@ export class PersonRepository {
         'asset_faces.imageHeight as oldHeight',
         'assets.type',
         'assets.originalPath',
-        'asset_files.path as previewPath',
         'exif.orientation as exifOrientation',
       ])
+      .select((eb) =>
+        eb
+          .selectFrom('asset_files')
+          .select('asset_files.path')
+          .whereRef('asset_files.assetId', '=', 'assets.id')
+          .where('asset_files.type', '=', AssetFileType.PREVIEW)
+          .as('previewPath'),
+      )
       .where('person.id', '=', id)
       .where('asset_faces.deletedAt', 'is', null)
-      .where('asset_files.type', '=', AssetFileType.PREVIEW)
-      .$narrowType<{ exifImageWidth: NotNull; exifImageHeight: NotNull }>()
       .executeTakeFirst();
   }
 


### PR DESCRIPTION
## Description

The intent of this filter is to only include the preview path and not other paths, not to filter out assets that do not (yet) have a preview path.