### PR TITLE
fix(web): Make QR code colors solid

### DIFF
--- a/web/src/lib/components/shared-components/qrcode.svelte
+++ b/web/src/lib/components/shared-components/qrcode.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { Theme } from '$lib/constants';
-  import { themeManager } from '$lib/managers/theme-manager.svelte';
   import QRCode from 'qrcode';
   import { t } from 'svelte-i18n';
 
@@ -12,13 +10,7 @@
 
   const { value, width, alt = $t('alt_text_qr_code') }: Props = $props();
 
-  let promise = $derived(
-    QRCode.toDataURL(value, {
-      color: { dark: themeManager.value === Theme.DARK ? '#ffffffff' : '#000000ff', light: '#00000000' },
-      margin: 0,
-      width,
-    }),
-  );
+  let promise = $derived(QRCode.toDataURL(value, { margin: 0, width }));
 </script>
 
 <div style="width: {width}px; height: {width}px">


### PR DESCRIPTION
## Description
Updates QR code colors to be solid instead of transparent.

Fixes #18339 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Light mode:
![image](https://github.com/user-attachments/assets/3dc84dee-78dd-4033-a943-deea70155a06)

Dark mode:
![image](https://github.com/user-attachments/assets/016dfdb7-4096-47f8-882a-e443d6027b0a)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
