### PR TITLE
fix(mobile): do not continue on remote stream parse error

### DIFF
--- a/mobile/lib/infrastructure/repositories/sync_api.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_api.repository.dart
@@ -25,7 +25,6 @@ class SyncApiRepository implements ISyncApiRepository {
     int batchSize = kSyncEventBatchSize,
     http.Client? httpClient,
   }) async {
-    // ignore: avoid-unused-assignment
     final stopwatch = Stopwatch()..start();
     final client = httpClient ?? http.Client();
     final endpoint = "${_api.apiClient.basePath}/sync/stream";
@@ -98,7 +97,7 @@ class SyncApiRepository implements ISyncApiRepository {
         await onData(_parseLines(lines), abort);
       }
     } catch (error, stack) {
-      _logger.severe("error processing stream", error, stack);
+      _logger.severe("Error processing stream", error, stack);
       return Future.error(error, stack);
     } finally {
       client.close();
@@ -112,21 +111,17 @@ class SyncApiRepository implements ISyncApiRepository {
     final List<SyncEvent> data = [];
 
     for (final line in lines) {
-      try {
-        final jsonData = jsonDecode(line);
-        final type = SyncEntityType.fromJson(jsonData['type'])!;
-        final dataJson = jsonData['data'];
-        final ack = jsonData['ack'];
-        final converter = _kResponseMap[type];
-        if (converter == null) {
-          _logger.warning("[_parseSyncResponse] Unknown type $type");
-          continue;
-        }
-
-        data.add(SyncEvent(type: type, data: converter(dataJson), ack: ack));
-      } catch (error, stack) {
-        _logger.severe("[_parseSyncResponse] Error parsing json", error, stack);
+      final jsonData = jsonDecode(line);
+      final type = SyncEntityType.fromJson(jsonData['type'])!;
+      final dataJson = jsonData['data'];
+      final ack = jsonData['ack'];
+      final converter = _kResponseMap[type];
+      if (converter == null) {
+        _logger.warning("Unknown type $type");
+        continue;
       }
+
+      data.add(SyncEvent(type: type, data: converter(dataJson), ack: ack));
     }
 
     return data;


### PR DESCRIPTION
### Description

- The current handling continues to process the stream even if there is a failure during the parsing of the lines into events. We do not want this but want to abort the stream on the first error.
