### PR TITLE
feat(server): sort images in duplicate groups by date

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -296,7 +296,11 @@ with
   "duplicates" as (
     select
       "assets"."duplicateId",
-      jsonb_agg("asset") as "assets"
+      json_agg(
+        "asset"
+        order by
+          "assets"."localDateTime" asc
+      ) as "assets"
     from
       "assets"
       left join lateral (
@@ -323,7 +327,7 @@ with
     from
       "duplicates"
     where
-      jsonb_array_length("assets") = $3
+      json_array_length("assets") = $3
   ),
   "removed_unique" as (
     update "assets"

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -649,10 +649,7 @@ export class AssetRepository {
             )
             .select('assets.duplicateId')
             .select((eb) =>
-              eb
-                .fn('jsonb_agg', [eb.table('asset')])
-                .$castTo<MapAsset[]>()
-                .as('assets'),
+              eb.fn.jsonAgg('asset').orderBy('assets.localDateTime', 'asc').$castTo<MapAsset[]>().as('assets'),
             )
             .where('assets.ownerId', '=', asUuid(userId))
             .where('assets.duplicateId', 'is not', null)
@@ -666,7 +663,7 @@ export class AssetRepository {
           qb
             .selectFrom('duplicates')
             .select('duplicateId')
-            .where((eb) => eb(eb.fn('jsonb_array_length', ['assets']), '=', 1)),
+            .where((eb) => eb(eb.fn('json_array_length', ['assets']), '=', 1)),
         )
         .with('removed_unique', (qb) =>
           qb
@@ -677,7 +674,7 @@ export class AssetRepository {
         )
         .selectFrom('duplicates')
         .selectAll()
-        // TODO: compare with filtering by jsonb_array_length > 1
+        // TODO: compare with filtering by json_array_length > 1
         .where(({ not, exists }) =>
           not(exists((eb) => eb.selectFrom('unique').whereRef('unique.duplicateId', '=', 'duplicates.duplicateId'))),
         )


### PR DESCRIPTION
## Description

Sort images in duplicate groups by date for easier duplicates selection.

This restores behaviour introduced in 562fec6e2bc293ff977730ce809a7ee182eb3eef and lost in 2e12c46980b45072beb0f4ba125f821053b13851.

Full rationale for this change here: https://github.com/immich-app/immich/pull/12094 .

## How Has This Been Tested?

- [x] Applied a variation of this commit on top of v.131.2 (what I'm running on production atm), de-duplicated a few pictures, checking if they were ordered by date
- [x] Checked that the nix package for v.132.3 (closest available to main) builds with this commit added 

I did not try with the development environment or run tests, I suppose the CI would do that anyways (if not I'll go ahead and do the docker thing).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

See https://github.com/immich-app/immich/pull/12094#issuecomment-2315994046 . Doesn't seem that the UI changed.

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## On replacing `jsonb` with `json`

The change is basically adding `ORDER BY` into the `jsonb_agg` function of the SQL query to get the duplicates (here: https://github.com/GeoffreyFrogeye/immich/blob/8a9eb3a0c97750bd9cd73e8a62addc31b56cd7c2/server/src/queries/asset.repository.sql#L299 ... btw no idea where this file is used but it's been useful). It doesn't seem that kysely's `ExpressionBuilder.fn` allows to do that as-is. However, [they do allow using `orderBy`](https://github.com/kysely-org/kysely/issues/780) on their `ExpressionBuilder.fn.jsonAgg` but  that produces a `json_agg` function, instead of a `jsonb_agg`. [They don't seem to be keen on implementing `jsonb_agg`](https://github.com/kysely-org/kysely/issues/395),  because it is actually slower? It doesn't seem to make a difference in our case, but still wanted to explain why I did this, in case you were wondering.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable): **this might be applicable however there doesn't seem to be any existing one for `getDuplicates` and creating a new one is above my skills – this was already nearing my limits, only pushed through because I really wanted to sort my duplicates comfortably**
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) **not sure I get this, de-duplicating assets sounds immich specific and yet... anyways, not me that put that here**
