### PR TITLE
fix(mobile): reduce stutter/jank on search pages

### DIFF
--- a/mobile/lib/pages/albums/albums.page.dart
+++ b/mobile/lib/pages/albums/albums.page.dart
@@ -269,6 +269,7 @@ class AlbumsPage extends HookConsumerWidget {
           ],
         ),
       ),
+      resizeToAvoidBottomInset: false,
     );
   }
 }

--- a/mobile/lib/pages/common/tab_controller.page.dart
+++ b/mobile/lib/pages/common/tab_controller.page.dart
@@ -167,6 +167,7 @@ class TabControllerPage extends HookConsumerWidget {
           onPopInvokedWithResult: (didPop, _) =>
               !didPop ? tabsRouter.setActiveIndex(0) : null,
           child: Scaffold(
+            resizeToAvoidBottomInset: false,
             body: isScreenLandscape
                 ? Row(
                     children: [

--- a/mobile/lib/pages/search/search.page.dart
+++ b/mobile/lib/pages/search/search.page.dart
@@ -523,7 +523,7 @@ class SearchPage extends HookConsumerWidget {
     }
 
     return Scaffold(
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         automaticallyImplyLeading: true,
         actions: [


### PR DESCRIPTION
## Description

On the search pages (like ml search and album search), opening the keyboard shows as a very slow and stuttery animation (Xiaomi 14T pro, Android emulator it looks janky) after performing a search.

The flutter performance profiler shows significant times in rebuild every time the keyboard opens:

![Screenshot 2025-05-18 232133](https://github.com/user-attachments/assets/f3fce49b-e95d-4d69-86d5-32262f28bdb5)

It seems like there are some widgets being rebuilt, as also the navigation bar on the bottom briefly changes its size when hiding the keyboard.



<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've set `resizeToAvoidBottomInset` to the affected components which should avoid resizing (and therefore probably rebuilding (?) some of the assets. That helps espeically when there are many search results.

Flutter performance profiler shows no more significant jank when opening the keyboard (Android emulator).

![Screenshot 2025-05-18 232755](https://github.com/user-attachments/assets/06c941d5-219a-4015-a6a4-38ab661e18fa)

Can also confirm that the animation is now smooth on my physical phone.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Open search page, layout should look as before (also when opening the keyboard). Animation should be smoother.
- [ ] Open album page, layout should look as before (also when opening the keyboard). Animation should be smoother.

<h2>Screenshots (if appropriate)</h2>

<!-- Images go below this line. -->

Quick comparison on my phone.


https://streamable.com/4akogh
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
