### PR TITLE
fix(server): use preview path for person thumbnails from videos

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -328,15 +328,13 @@ export class MediaService extends BaseService {
 
     const { ownerId, x1, y1, x2, y2, oldWidth, oldHeight, exifOrientation, previewPath, originalPath } = data;
     let inputImage: string | Buffer;
-    if (mimeTypes.isVideo(originalPath)) {
+    if (data.type === AssetType.VIDEO) {
       if (!previewPath) {
         this.logger.error(`Could not generate person thumbnail for video ${id}: missing preview path`);
         return JobStatus.FAILED;
       }
       inputImage = previewPath;
-    }
-
-    if (image.extractEmbedded && mimeTypes.isRaw(originalPath)) {
+    } else if (image.extractEmbedded && mimeTypes.isRaw(originalPath)) {
       const extracted = await this.extractImage(originalPath, image.preview.size);
       inputImage = extracted ? extracted.buffer : originalPath;
     } else {

--- a/server/test/fixtures/person.stub.ts
+++ b/server/test/fixtures/person.stub.ts
@@ -246,4 +246,17 @@ export const personThumbnailStub = {
     exifOrientation: '1',
     previewPath: previewFile.path,
   }),
+  videoThumbnail: Object.freeze({
+    ownerId: userStub.admin.id,
+    x1: 100,
+    y1: 100,
+    x2: 200,
+    y2: 200,
+    oldHeight: 500,
+    oldWidth: 400,
+    type: AssetType.VIDEO,
+    originalPath: '/original/path.mp4',
+    exifOrientation: '1',
+    previewPath: previewFile.path,
+  }),
 };


### PR DESCRIPTION
## Description

The job was incorrectly setting the input path to the original asset for videos.