### PR TITLE
chore: tighten vchord version range

### DIFF
--- a/docs/docs/administration/postgres-standalone.md
+++ b/docs/docs/administration/postgres-standalone.md
@@ -15,7 +15,7 @@ You must install VectorChord into your instance of Postgres using their [instruc
 :::note
 Immich is known to work with Postgres versions 14, 15, 16 and 17. Earlier versions are unsupported.
 
-Make sure the installed version of VectorChord is compatible with your version of Immich. The current accepted range for VectorChord is `>= 0.3.0, < 1.0.0`.
+Make sure the installed version of VectorChord is compatible with your version of Immich. The current accepted range for VectorChord is `>= 0.3.0, < 0.4.0`.
 :::
 
 ## Specifying the connection URL

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -4,7 +4,7 @@ import { SemVer } from 'semver';
 import { DatabaseExtension, ExifOrientation, VectorIndex } from 'src/enum';
 
 export const POSTGRES_VERSION_RANGE = '>=14.0.0';
-export const VECTORCHORD_VERSION_RANGE = '>=0.3 <1';
+export const VECTORCHORD_VERSION_RANGE = '>=0.3 <0.4';
 export const VECTORS_VERSION_RANGE = '>=0.2 <0.4';
 export const VECTOR_VERSION_RANGE = '>=0.5 <1';
 


### PR DESCRIPTION
## Description

It was extended to allow minor updates in light of vchord being easier to upgrade and more mature overall. However, based on discussion, it's good to still constrain the version so we can test new releases first, as the extension does not have an officially stable version yet.

Unsure if the `ghcr.io/immich-app/postgres:<PG_MAJOR>` tags should be removed with this change. It's conventional to have these tags, but it would cause more trouble for Immich users who use them if they can't actually update when a new release comes.