### PR TITLE
fix: translations from background service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -504,6 +504,11 @@ jobs:
         with:
           channel: 'stable'
           flutter-version-file: ./mobile/pubspec.yaml
+
+      - name: Generate translation file
+        run: make translation
+        working-directory: ./mobile
+
       - name: Run tests
         working-directory: ./mobile
         run: flutter test -j 1

--- a/mobile/lib/services/localization.service.dart
+++ b/mobile/lib/services/localization.service.dart
@@ -1,10 +1,10 @@
 // ignore_for_file: implementation_imports
 
-import 'package:flutter/foundation.dart';
-import 'package:easy_localization/src/asset_loader.dart';
 import 'package:easy_localization/src/easy_localization_controller.dart';
 import 'package:easy_localization/src/localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/constants/locales.dart';
+import 'package:immich_mobile/generated/codegen_loader.g.dart';
 
 /// Workaround to manually load translations in another Isolate
 Future<bool> loadTranslations() async {
@@ -14,7 +14,7 @@ Future<bool> loadTranslations() async {
     supportedLocales: locales.values.toList(),
     useFallbackTranslations: true,
     saveLocale: true,
-    assetLoader: const RootBundleAssetLoader(),
+    assetLoader: const CodegenLoader(),
     path: translationsPath,
     useOnlyLangCode: false,
     onLoadError: (e) => debugPrint(e.toString()),


### PR DESCRIPTION
## Description

- The background service was using the older asset loader resulting in keys not getting translated when notifications are shown from the background.