### PR TITLE
chore: change stable release estimate on roadmap

### DIFF
--- a/docs/src/pages/roadmap.tsx
+++ b/docs/src/pages/roadmap.tsx
@@ -218,7 +218,7 @@ const roadmap: Item[] = [
     iconColor: 'indianred',
     title: 'Stable release',
     description: 'Immich goes stable',
-    getDateLabel: () => 'Planned for early 2025',
+    getDateLabel: () => 'Planned for 2025',
   },
   {
     done: false,


### PR DESCRIPTION
## Description

*Early* 2025 has passed at this point. Changes the date on the roadmap for immich to go stable to be 2025 to set reasonable expectations.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
