### PR TITLE
feat(server): search, album filters

### DIFF
--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -22,13 +22,13 @@ class MetadataSearchDto {
     this.deviceAssetId,
     this.deviceId,
     this.encodedVideoPath,
+    this.excludeAlbumIds = const [],
     this.id,
+    this.includeAlbumIds = const [],
     this.isEncoded,
     this.isFavorite,
-    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
-    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.lensModel,
     this.libraryId,
@@ -119,6 +119,9 @@ class MetadataSearchDto {
   ///
   String? encodedVideoPath;
 
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> excludeAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -126,6 +129,9 @@ class MetadataSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   String? id;
+
+  /// List of album IDs the assets must belong to (any of)
+  List<String> includeAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -143,9 +149,6 @@ class MetadataSearchDto {
   ///
   bool? isFavorite;
 
-  /// List of album IDs the assets must belong to (any of)
-  List<String> isInAlbumIds;
-
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -161,9 +164,6 @@ class MetadataSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
-
-  /// List of album IDs the assets must not belong to (none of)
-  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -363,13 +363,13 @@ class MetadataSearchDto {
     other.deviceAssetId == deviceAssetId &&
     other.deviceId == deviceId &&
     other.encodedVideoPath == encodedVideoPath &&
+    _deepEquality.equals(other.excludeAlbumIds, excludeAlbumIds) &&
     other.id == id &&
+    _deepEquality.equals(other.includeAlbumIds, includeAlbumIds) &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
-    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
-    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -411,13 +411,13 @@ class MetadataSearchDto {
     (deviceAssetId == null ? 0 : deviceAssetId!.hashCode) +
     (deviceId == null ? 0 : deviceId!.hashCode) +
     (encodedVideoPath == null ? 0 : encodedVideoPath!.hashCode) +
+    (excludeAlbumIds.hashCode) +
     (id == null ? 0 : id!.hashCode) +
+    (includeAlbumIds.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
-    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
-    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -448,7 +448,7 @@ class MetadataSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'MetadataSearchDto[checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'MetadataSearchDto[checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, excludeAlbumIds=$excludeAlbumIds, id=$id, includeAlbumIds=$includeAlbumIds, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -497,11 +497,13 @@ class MetadataSearchDto {
     } else {
     //  json[r'encodedVideoPath'] = null;
     }
+      json[r'excludeAlbumIds'] = this.excludeAlbumIds;
     if (this.id != null) {
       json[r'id'] = this.id;
     } else {
     //  json[r'id'] = null;
     }
+      json[r'includeAlbumIds'] = this.includeAlbumIds;
     if (this.isEncoded != null) {
       json[r'isEncoded'] = this.isEncoded;
     } else {
@@ -512,7 +514,6 @@ class MetadataSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
-      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -523,7 +524,6 @@ class MetadataSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
-      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -673,17 +673,17 @@ class MetadataSearchDto {
         deviceAssetId: mapValueOfType<String>(json, r'deviceAssetId'),
         deviceId: mapValueOfType<String>(json, r'deviceId'),
         encodedVideoPath: mapValueOfType<String>(json, r'encodedVideoPath'),
+        excludeAlbumIds: json[r'excludeAlbumIds'] is Iterable
+            ? (json[r'excludeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         id: mapValueOfType<String>(json, r'id'),
+        includeAlbumIds: json[r'includeAlbumIds'] is Iterable
+            ? (json[r'includeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
-        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
-            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
-        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
-            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -25,8 +25,10 @@ class MetadataSearchDto {
     this.id,
     this.isEncoded,
     this.isFavorite,
+    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
+    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.lensModel,
     this.libraryId,
@@ -141,6 +143,9 @@ class MetadataSearchDto {
   ///
   bool? isFavorite;
 
+  /// List of album IDs the assets must belong to (any of)
+  List<String> isInAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -156,6 +161,9 @@ class MetadataSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
+
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -358,8 +366,10 @@ class MetadataSearchDto {
     other.id == id &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
+    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
+    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -404,8 +414,10 @@ class MetadataSearchDto {
     (id == null ? 0 : id!.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
+    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -436,7 +448,7 @@ class MetadataSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'MetadataSearchDto[checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'MetadataSearchDto[checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -500,6 +512,7 @@ class MetadataSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
+      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -510,6 +523,7 @@ class MetadataSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
+      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -662,8 +676,14 @@ class MetadataSearchDto {
         id: mapValueOfType<String>(json, r'id'),
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
+            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
+        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
+            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/random_search_dto.dart
+++ b/mobile/openapi/lib/model/random_search_dto.dart
@@ -20,8 +20,10 @@ class RandomSearchDto {
     this.deviceId,
     this.isEncoded,
     this.isFavorite,
+    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
+    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.lensModel,
     this.libraryId,
@@ -90,6 +92,9 @@ class RandomSearchDto {
   ///
   bool? isFavorite;
 
+  /// List of album IDs the assets must belong to (any of)
+  List<String> isInAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -105,6 +110,9 @@ class RandomSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
+
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -259,8 +267,10 @@ class RandomSearchDto {
     other.deviceId == deviceId &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
+    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
+    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -294,8 +304,10 @@ class RandomSearchDto {
     (deviceId == null ? 0 : deviceId!.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
+    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -320,7 +332,7 @@ class RandomSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'RandomSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'RandomSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -359,6 +371,7 @@ class RandomSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
+      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -369,6 +382,7 @@ class RandomSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
+      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -490,8 +504,14 @@ class RandomSearchDto {
         deviceId: mapValueOfType<String>(json, r'deviceId'),
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
+            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
+        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
+            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/random_search_dto.dart
+++ b/mobile/openapi/lib/model/random_search_dto.dart
@@ -18,12 +18,12 @@ class RandomSearchDto {
     this.createdAfter,
     this.createdBefore,
     this.deviceId,
+    this.excludeAlbumIds = const [],
+    this.includeAlbumIds = const [],
     this.isEncoded,
     this.isFavorite,
-    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
-    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.lensModel,
     this.libraryId,
@@ -76,6 +76,12 @@ class RandomSearchDto {
   ///
   String? deviceId;
 
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> excludeAlbumIds;
+
+  /// List of album IDs the assets must belong to (any of)
+  List<String> includeAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -92,9 +98,6 @@ class RandomSearchDto {
   ///
   bool? isFavorite;
 
-  /// List of album IDs the assets must belong to (any of)
-  List<String> isInAlbumIds;
-
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -110,9 +113,6 @@ class RandomSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
-
-  /// List of album IDs the assets must not belong to (none of)
-  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -265,12 +265,12 @@ class RandomSearchDto {
     other.createdAfter == createdAfter &&
     other.createdBefore == createdBefore &&
     other.deviceId == deviceId &&
+    _deepEquality.equals(other.excludeAlbumIds, excludeAlbumIds) &&
+    _deepEquality.equals(other.includeAlbumIds, includeAlbumIds) &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
-    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
-    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -302,12 +302,12 @@ class RandomSearchDto {
     (createdAfter == null ? 0 : createdAfter!.hashCode) +
     (createdBefore == null ? 0 : createdBefore!.hashCode) +
     (deviceId == null ? 0 : deviceId!.hashCode) +
+    (excludeAlbumIds.hashCode) +
+    (includeAlbumIds.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
-    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
-    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -332,7 +332,7 @@ class RandomSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'RandomSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'RandomSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, excludeAlbumIds=$excludeAlbumIds, includeAlbumIds=$includeAlbumIds, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -361,6 +361,8 @@ class RandomSearchDto {
     } else {
     //  json[r'deviceId'] = null;
     }
+      json[r'excludeAlbumIds'] = this.excludeAlbumIds;
+      json[r'includeAlbumIds'] = this.includeAlbumIds;
     if (this.isEncoded != null) {
       json[r'isEncoded'] = this.isEncoded;
     } else {
@@ -371,7 +373,6 @@ class RandomSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
-      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -382,7 +383,6 @@ class RandomSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
-      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -502,16 +502,16 @@ class RandomSearchDto {
         createdAfter: mapDateTime(json, r'createdAfter', r''),
         createdBefore: mapDateTime(json, r'createdBefore', r''),
         deviceId: mapValueOfType<String>(json, r'deviceId'),
+        excludeAlbumIds: json[r'excludeAlbumIds'] is Iterable
+            ? (json[r'excludeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
+        includeAlbumIds: json[r'includeAlbumIds'] is Iterable
+            ? (json[r'includeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
-        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
-            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
-        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
-            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/smart_search_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_dto.dart
@@ -20,8 +20,10 @@ class SmartSearchDto {
     this.deviceId,
     this.isEncoded,
     this.isFavorite,
+    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
+    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.language,
     this.lensModel,
@@ -91,6 +93,9 @@ class SmartSearchDto {
   ///
   bool? isFavorite;
 
+  /// List of album IDs the assets must belong to (any of)
+  List<String> isInAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -106,6 +111,9 @@ class SmartSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
+
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -263,8 +271,10 @@ class SmartSearchDto {
     other.deviceId == deviceId &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
+    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
+    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.language == language &&
     other.lensModel == lensModel &&
@@ -299,8 +309,10 @@ class SmartSearchDto {
     (deviceId == null ? 0 : deviceId!.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
+    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
+    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (language == null ? 0 : language!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
@@ -326,7 +338,7 @@ class SmartSearchDto {
     (withExif == null ? 0 : withExif!.hashCode);
 
   @override
-  String toString() => 'SmartSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
+  String toString() => 'SmartSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -365,6 +377,7 @@ class SmartSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
+      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -375,6 +388,7 @@ class SmartSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
+      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -497,8 +511,14 @@ class SmartSearchDto {
         deviceId: mapValueOfType<String>(json, r'deviceId'),
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
+        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
+            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
+        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
+            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         language: mapValueOfType<String>(json, r'language'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),

--- a/mobile/openapi/lib/model/smart_search_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_dto.dart
@@ -18,12 +18,12 @@ class SmartSearchDto {
     this.createdAfter,
     this.createdBefore,
     this.deviceId,
+    this.excludeAlbumIds = const [],
+    this.includeAlbumIds = const [],
     this.isEncoded,
     this.isFavorite,
-    this.isInAlbumIds = const [],
     this.isMotion,
     this.isNotInAlbum,
-    this.isNotInAlbumIds = const [],
     this.isOffline,
     this.language,
     this.lensModel,
@@ -77,6 +77,12 @@ class SmartSearchDto {
   ///
   String? deviceId;
 
+  /// List of album IDs the assets must not belong to (none of)
+  List<String> excludeAlbumIds;
+
+  /// List of album IDs the assets must belong to (any of)
+  List<String> includeAlbumIds;
+
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -93,9 +99,6 @@ class SmartSearchDto {
   ///
   bool? isFavorite;
 
-  /// List of album IDs the assets must belong to (any of)
-  List<String> isInAlbumIds;
-
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
   /// does not include a default value (using the "default:" property), however, the generated
@@ -111,9 +114,6 @@ class SmartSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isNotInAlbum;
-
-  /// List of album IDs the assets must not belong to (none of)
-  List<String> isNotInAlbumIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -269,12 +269,12 @@ class SmartSearchDto {
     other.createdAfter == createdAfter &&
     other.createdBefore == createdBefore &&
     other.deviceId == deviceId &&
+    _deepEquality.equals(other.excludeAlbumIds, excludeAlbumIds) &&
+    _deepEquality.equals(other.includeAlbumIds, includeAlbumIds) &&
     other.isEncoded == isEncoded &&
     other.isFavorite == isFavorite &&
-    _deepEquality.equals(other.isInAlbumIds, isInAlbumIds) &&
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
-    _deepEquality.equals(other.isNotInAlbumIds, isNotInAlbumIds) &&
     other.isOffline == isOffline &&
     other.language == language &&
     other.lensModel == lensModel &&
@@ -307,12 +307,12 @@ class SmartSearchDto {
     (createdAfter == null ? 0 : createdAfter!.hashCode) +
     (createdBefore == null ? 0 : createdBefore!.hashCode) +
     (deviceId == null ? 0 : deviceId!.hashCode) +
+    (excludeAlbumIds.hashCode) +
+    (includeAlbumIds.hashCode) +
     (isEncoded == null ? 0 : isEncoded!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
-    (isInAlbumIds.hashCode) +
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
-    (isNotInAlbumIds.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
     (language == null ? 0 : language!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
@@ -338,7 +338,7 @@ class SmartSearchDto {
     (withExif == null ? 0 : withExif!.hashCode);
 
   @override
-  String toString() => 'SmartSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isInAlbumIds=$isInAlbumIds, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isNotInAlbumIds=$isNotInAlbumIds, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
+  String toString() => 'SmartSearchDto[city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, excludeAlbumIds=$excludeAlbumIds, includeAlbumIds=$includeAlbumIds, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -367,6 +367,8 @@ class SmartSearchDto {
     } else {
     //  json[r'deviceId'] = null;
     }
+      json[r'excludeAlbumIds'] = this.excludeAlbumIds;
+      json[r'includeAlbumIds'] = this.includeAlbumIds;
     if (this.isEncoded != null) {
       json[r'isEncoded'] = this.isEncoded;
     } else {
@@ -377,7 +379,6 @@ class SmartSearchDto {
     } else {
     //  json[r'isFavorite'] = null;
     }
-      json[r'isInAlbumIds'] = this.isInAlbumIds;
     if (this.isMotion != null) {
       json[r'isMotion'] = this.isMotion;
     } else {
@@ -388,7 +389,6 @@ class SmartSearchDto {
     } else {
     //  json[r'isNotInAlbum'] = null;
     }
-      json[r'isNotInAlbumIds'] = this.isNotInAlbumIds;
     if (this.isOffline != null) {
       json[r'isOffline'] = this.isOffline;
     } else {
@@ -509,16 +509,16 @@ class SmartSearchDto {
         createdAfter: mapDateTime(json, r'createdAfter', r''),
         createdBefore: mapDateTime(json, r'createdBefore', r''),
         deviceId: mapValueOfType<String>(json, r'deviceId'),
+        excludeAlbumIds: json[r'excludeAlbumIds'] is Iterable
+            ? (json[r'excludeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
+        includeAlbumIds: json[r'includeAlbumIds'] is Iterable
+            ? (json[r'includeAlbumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const [],
         isEncoded: mapValueOfType<bool>(json, r'isEncoded'),
         isFavorite: mapValueOfType<bool>(json, r'isFavorite'),
-        isInAlbumIds: json[r'isInAlbumIds'] is Iterable
-            ? (json[r'isInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
-        isNotInAlbumIds: json[r'isNotInAlbumIds'] is Iterable
-            ? (json[r'isNotInAlbumIds'] as Iterable).cast<String>().toList(growable: false)
-            : const [],
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
         language: mapValueOfType<String>(json, r'language'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10602,11 +10602,27 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "isInAlbumIds": {
+            "description": "List of album IDs the assets must belong to (any of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
+          },
+          "isNotInAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
           },
           "isOffline": {
             "type": "boolean"
@@ -11483,11 +11499,27 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "isInAlbumIds": {
+            "description": "List of album IDs the assets must belong to (any of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
+          },
+          "isNotInAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
           },
           "isOffline": {
             "type": "boolean"
@@ -12497,11 +12529,27 @@
           "isFavorite": {
             "type": "boolean"
           },
+          "isInAlbumIds": {
+            "description": "List of album IDs the assets must belong to (any of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
+          },
+          "isNotInAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
           },
           "isOffline": {
             "type": "boolean"

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -10592,17 +10592,19 @@
           "encodedVideoPath": {
             "type": "string"
           },
+          "excludeAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "id": {
             "format": "uuid",
             "type": "string"
           },
-          "isEncoded": {
-            "type": "boolean"
-          },
-          "isFavorite": {
-            "type": "boolean"
-          },
-          "isInAlbumIds": {
+          "includeAlbumIds": {
             "description": "List of album IDs the assets must belong to (any of)",
             "items": {
               "format": "uuid",
@@ -10610,19 +10612,17 @@
             },
             "type": "array"
           },
+          "isEncoded": {
+            "type": "boolean"
+          },
+          "isFavorite": {
+            "type": "boolean"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
-          },
-          "isNotInAlbumIds": {
-            "description": "List of album IDs the assets must not belong to (none of)",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
           },
           "isOffline": {
             "type": "boolean"
@@ -11493,13 +11493,15 @@
           "deviceId": {
             "type": "string"
           },
-          "isEncoded": {
-            "type": "boolean"
+          "excludeAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
           },
-          "isFavorite": {
-            "type": "boolean"
-          },
-          "isInAlbumIds": {
+          "includeAlbumIds": {
             "description": "List of album IDs the assets must belong to (any of)",
             "items": {
               "format": "uuid",
@@ -11507,19 +11509,17 @@
             },
             "type": "array"
           },
+          "isEncoded": {
+            "type": "boolean"
+          },
+          "isFavorite": {
+            "type": "boolean"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
-          },
-          "isNotInAlbumIds": {
-            "description": "List of album IDs the assets must not belong to (none of)",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
           },
           "isOffline": {
             "type": "boolean"
@@ -12523,13 +12523,15 @@
           "deviceId": {
             "type": "string"
           },
-          "isEncoded": {
-            "type": "boolean"
+          "excludeAlbumIds": {
+            "description": "List of album IDs the assets must not belong to (none of)",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
           },
-          "isFavorite": {
-            "type": "boolean"
-          },
-          "isInAlbumIds": {
+          "includeAlbumIds": {
             "description": "List of album IDs the assets must belong to (any of)",
             "items": {
               "format": "uuid",
@@ -12537,19 +12539,17 @@
             },
             "type": "array"
           },
+          "isEncoded": {
+            "type": "boolean"
+          },
+          "isFavorite": {
+            "type": "boolean"
+          },
           "isMotion": {
             "type": "boolean"
           },
           "isNotInAlbum": {
             "type": "boolean"
-          },
-          "isNotInAlbumIds": {
-            "description": "List of album IDs the assets must not belong to (none of)",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
           },
           "isOffline": {
             "type": "boolean"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -842,8 +842,12 @@ export type MetadataSearchDto = {
     id?: string;
     isEncoded?: boolean;
     isFavorite?: boolean;
+    /** List of album IDs the assets must belong to (any of) */
+    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
+    /** List of album IDs the assets must not belong to (none of) */
+    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -913,8 +917,12 @@ export type RandomSearchDto = {
     deviceId?: string;
     isEncoded?: boolean;
     isFavorite?: boolean;
+    /** List of album IDs the assets must belong to (any of) */
+    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
+    /** List of album IDs the assets must not belong to (none of) */
+    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -946,8 +954,12 @@ export type SmartSearchDto = {
     deviceId?: string;
     isEncoded?: boolean;
     isFavorite?: boolean;
+    /** List of album IDs the assets must belong to (any of) */
+    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
+    /** List of album IDs the assets must not belong to (none of) */
+    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     language?: string;
     lensModel?: string | null;

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -839,15 +839,15 @@ export type MetadataSearchDto = {
     deviceAssetId?: string;
     deviceId?: string;
     encodedVideoPath?: string;
+    /** List of album IDs the assets must not belong to (none of) */
+    excludeAlbumIds?: string[];
     id?: string;
+    /** List of album IDs the assets must belong to (any of) */
+    includeAlbumIds?: string[];
     isEncoded?: boolean;
     isFavorite?: boolean;
-    /** List of album IDs the assets must belong to (any of) */
-    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
-    /** List of album IDs the assets must not belong to (none of) */
-    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -915,14 +915,14 @@ export type RandomSearchDto = {
     createdAfter?: string;
     createdBefore?: string;
     deviceId?: string;
+    /** List of album IDs the assets must not belong to (none of) */
+    excludeAlbumIds?: string[];
+    /** List of album IDs the assets must belong to (any of) */
+    includeAlbumIds?: string[];
     isEncoded?: boolean;
     isFavorite?: boolean;
-    /** List of album IDs the assets must belong to (any of) */
-    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
-    /** List of album IDs the assets must not belong to (none of) */
-    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -952,14 +952,14 @@ export type SmartSearchDto = {
     createdAfter?: string;
     createdBefore?: string;
     deviceId?: string;
+    /** List of album IDs the assets must not belong to (none of) */
+    excludeAlbumIds?: string[];
+    /** List of album IDs the assets must belong to (any of) */
+    includeAlbumIds?: string[];
     isEncoded?: boolean;
     isFavorite?: boolean;
-    /** List of album IDs the assets must belong to (any of) */
-    isInAlbumIds?: string[];
     isMotion?: boolean;
     isNotInAlbum?: boolean;
-    /** List of album IDs the assets must not belong to (none of) */
-    isNotInAlbumIds?: string[];
     isOffline?: boolean;
     language?: string;
     lensModel?: string | null;

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -102,6 +102,18 @@ class BaseSearchDto {
   @ValidateBoolean({ optional: true })
   isNotInAlbum?: boolean;
 
+  /**
+   * List of album IDs the assets must belong to (any of)
+   */
+  @ValidateUUID({ each: true, optional: true })
+  isInAlbumIds?: string[];
+
+  /**
+   * List of album IDs the assets must not belong to (none of)
+   */
+  @ValidateUUID({ each: true, optional: true })
+  isNotInAlbumIds?: string[];
+
   @ValidateUUID({ each: true, optional: true })
   personIds?: string[];
 

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -106,13 +106,13 @@ class BaseSearchDto {
    * List of album IDs the assets must belong to (any of)
    */
   @ValidateUUID({ each: true, optional: true })
-  isInAlbumIds?: string[];
+  includeAlbumIds?: string[];
 
   /**
    * List of album IDs the assets must not belong to (none of)
    */
   @ValidateUUID({ each: true, optional: true })
-  isNotInAlbumIds?: string[];
+  excludeAlbumIds?: string[];
 
   @ValidateUUID({ each: true, optional: true })
   personIds?: string[];

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -83,6 +83,11 @@ export interface SearchEmbeddingOptions {
   userIds: string[];
 }
 
+export interface SearchAlbumOptions {
+  isInAlbumIds?: string[];
+  isNotInAlbumIds?: string[];
+}
+
 export interface SearchPeopleOptions {
   personIds?: string[];
 }
@@ -108,6 +113,7 @@ type BaseAssetSearchOptions = SearchDateOptions &
   SearchStatusOptions &
   SearchUserIdOptions &
   SearchPeopleOptions &
+  SearchAlbumOptions &
   SearchTagOptions;
 
 export type AssetSearchOptions = BaseAssetSearchOptions & SearchRelationOptions;

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -84,8 +84,8 @@ export interface SearchEmbeddingOptions {
 }
 
 export interface SearchAlbumOptions {
-  isInAlbumIds?: string[];
-  isNotInAlbumIds?: string[];
+  includeAlbumIds?: string[];
+  excludeAlbumIds?: string[];
 }
 
 export interface SearchPeopleOptions {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -379,6 +379,28 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
         eb.not(eb.exists((eb) => eb.selectFrom('albums_assets_assets').whereRef('assetsId', '=', 'assets.id'))),
       ),
     )
+    .$if(!!options.isInAlbumIds, (qb) =>
+      qb.where((eb) =>
+        eb.exists((eb) =>
+          eb
+            .selectFrom('albums_assets_assets')
+            .whereRef('albums_assets_assets.assetsId', '=', 'assets.id')
+            .where('albums_assets_assets.albumsId', '=', anyUuid(options.isInAlbumIds!)),
+        ),
+      ),
+    )
+    .$if(!!options.isNotInAlbumIds, (qb) =>
+      qb.where((eb) =>
+        eb.not(
+          eb.exists((eb) =>
+            eb
+              .selectFrom('albums_assets_assets')
+              .whereRef('albums_assets_assets.assetsId', '=', 'assets.id')
+              .where('albums_assets_assets.albumsId', '=', anyUuid(options.isNotInAlbumIds!)),
+          ),
+        ),
+      ),
+    )
     .$if(!!options.withExif, withExifInner)
     .$if(!!(options.withFaces || options.withPeople || options.personIds), (qb) => qb.select(withFacesAndPeople))
     .$if(!options.withDeleted, (qb) => qb.where('assets.deletedAt', 'is', null));

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -379,24 +379,24 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
         eb.not(eb.exists((eb) => eb.selectFrom('albums_assets_assets').whereRef('assetsId', '=', 'assets.id'))),
       ),
     )
-    .$if(!!options.isInAlbumIds, (qb) =>
+    .$if(!!options.includeAlbumIds, (qb) =>
       qb.where((eb) =>
         eb.exists((eb) =>
           eb
             .selectFrom('albums_assets_assets')
             .whereRef('albums_assets_assets.assetsId', '=', 'assets.id')
-            .where('albums_assets_assets.albumsId', '=', anyUuid(options.isInAlbumIds!)),
+            .where('albums_assets_assets.albumsId', '=', anyUuid(options.includeAlbumIds!)),
         ),
       ),
     )
-    .$if(!!options.isNotInAlbumIds, (qb) =>
+    .$if(!!options.excludeAlbumIds, (qb) =>
       qb.where((eb) =>
         eb.not(
           eb.exists((eb) =>
             eb
               .selectFrom('albums_assets_assets')
               .whereRef('albums_assets_assets.assetsId', '=', 'assets.id')
-              .where('albums_assets_assets.albumsId', '=', anyUuid(options.isNotInAlbumIds!)),
+              .where('albums_assets_assets.albumsId', '=', anyUuid(options.excludeAlbumIds!)),
           ),
         ),
       ),


### PR DESCRIPTION
## Description

This allows filtering by albums when doing a search i.e. search assets in some albums only or exclude some albums.
This first PR focuses on the server. I plan on doing another PR to add the feature in the search on the web later.
Having this first PR merged would already allow other tools or applications made by the community and using the API to benefit from the feature.

## How Has This Been Tested?

Tested locally inside the dev container

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
