### PR TITLE
Properly sql escape database name.

### DIFF
--- a/server/src/migrations/1707000751533-AddVectorsToSearchPath.ts
+++ b/server/src/migrations/1707000751533-AddVectorsToSearchPath.ts
@@ -1,14 +1,15 @@
+import { sql } from 'kysely';
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddVectorsToSearchPath1707000751533 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     const res = await queryRunner.query(`SELECT current_database() as db`);
-    const databaseName = res[0]['db'];
+    const databaseName = sql.raw(res[0]['db']);
     await queryRunner.query(`ALTER DATABASE "${databaseName}" SET search_path TO "$user", public, vectors`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const databaseName = await queryRunner.query(`SELECT current_database()`);
+    const databaseName = sql.raw(await queryRunner.query(`SELECT current_database()`));
     await queryRunner.query(`ALTER DATABASE "${databaseName}" SET search_path TO "$user", public`);
   }
 }

--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -118,7 +118,7 @@ export class DatabaseRepository {
     this.logger.log(`Creating ${EXTENSION_NAMES[extension]} extension`);
     await sql`CREATE EXTENSION IF NOT EXISTS ${sql.raw(extension)} CASCADE`.execute(this.db);
     if (extension === DatabaseExtension.VECTORCHORD) {
-      const dbName = sql.table(await this.getDatabaseName());
+      const dbName = sql.raw(sql.table(await this.getDatabaseName()));
       await sql`ALTER DATABASE ${dbName} SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536'`.execute(this.db);
       await sql`SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536'`.execute(this.db);
       await sql`ALTER DATABASE ${dbName} SET vchordrq.probes = 1`.execute(this.db);

--- a/server/src/schema/migrations/1746636476623-DropExtraIndexes.ts
+++ b/server/src/schema/migrations/1746636476623-DropExtraIndexes.ts
@@ -2,7 +2,7 @@ import { Kysely, sql } from 'kysely';
 
 export async function up(db: Kysely<any>): Promise<void> {
   const { rows } = await sql<{ db: string }>`SELECT current_database() as db`.execute(db);
-  const databaseName = rows[0].db;
+  const databaseName = sql.raw(rows[0].db);
   await sql.raw(`ALTER DATABASE "${databaseName}" SET search_path TO "$user", public, vectors`).execute(db);
   const naturalearth_pkey = await sql<{ constraint_name: string }>`SELECT constraint_name
                          FROM information_schema.table_constraints
@@ -24,6 +24,6 @@ export async function up(db: Kysely<any>): Promise<void> {
 
 export async function down(db: Kysely<any>): Promise<void> {
   const { rows } = await sql<{ db: string }>`SELECT current_database() as db`.execute(db);
-  const databaseName = rows[0].db;
+  const databaseName = sql.raw(rows[0].db);
   await sql.raw(`ALTER DATABASE "${databaseName}" RESET "search_path"`).execute(db);
 }

--- a/server/src/sql-tools/to-sql/transformers/parameter.transformer.ts
+++ b/server/src/sql-tools/to-sql/transformers/parameter.transformer.ts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely';
 import { SqlTransformer } from 'src/sql-tools/to-sql/transformers/types';
 import { DatabaseParameter, SchemaDiff } from 'src/sql-tools/types';
 
@@ -18,16 +19,16 @@ export const transformParameters: SqlTransformer = (item: SchemaDiff) => {
 };
 
 const asParameterSet = (parameter: DatabaseParameter): string => {
-  let sql = '';
+  let sql_str = '';
   if (parameter.scope === 'database') {
-    sql += `ALTER DATABASE "${parameter.databaseName}" `;
+    sql_str += `ALTER DATABASE "${sql.raw(parameter.databaseName)}" `;
   }
 
-  sql += `SET ${parameter.name} TO ${parameter.value}`;
+  sql_str += `SET ${parameter.name} TO ${parameter.value}`;
 
-  return sql;
+  return sql_str;
 };
 
 const asParameterReset = (databaseName: string, parameterName: string): string => {
-  return `ALTER DATABASE "${databaseName}" RESET "${parameterName}"`;
+  return `ALTER DATABASE "${sql.raw(databaseName)}" RESET "${parameterName}"`;
 };


### PR DESCRIPTION
## Description

Database names can contain special characters such as `-` or ```2Izuz2a_X)F}~8H<86*R~L_r`sx<<Yf.``` which can break sql statements.
It is important to properly escape them.

During the `v1.133.0` update I encountered an issue with an sql statement.

Fixes:

```
❯ docker compose logs --tail 400 --follow immich-server
Initializing Immich v1.133.0
Detected CPU Cores: 72
Starting api worker
Starting microservices worker
[Nest] 7  - 05/22/2025, 1:20:12 PM     LOG [Microservices:EventRepository] Initialized websocket server
[Nest] 7  - 05/22/2025, 1:20:12 PM     LOG [Microservices:DatabaseRepository] Creating VectorChord extension
Query failed : {
  durationMs: 2.101156999999148,
  error: PostgresError: syntax error at or near "."
      at ErrorResponse (/usr/src/app/node_modules/postgres/cjs/src/connection.js:790:26)
      at handle (/usr/src/app/node_modules/postgres/cjs/src/connection.js:476:6)
      at Socket.data (/usr/src/app/node_modules/postgres/cjs/src/connection.js:315:9)
      at Socket.emit (node:events:518:28)
      at addChunk (node:internal/streams/readable:561:12)
      at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
      at Readable.push (node:internal/streams/readable:392:5)
      at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
    severity_local: 'ERROR',
    severity: 'ERROR',
    code: '42601',
    position: '49',
    file: 'scan.l',
    line: '1176',
    routine: 'scanner_yyerror'
  },
[Nest] 7  - 05/22/2025, 1:20:12 PM   FATAL [Microservices:DatabaseService] Failed to activate VectorChord extension.
    Please ensure the Postgres instance has VectorChord installed.

    If the Postgres instance already has VectorChord installed, Immich may not have the necessary permissions to activate it.
    In this case, please run 'CREATE EXTENSION IF NOT EXISTS vchord CASCADE' manually as a superuser.
    See https://immich.app/docs/guides/database-queries for how to query the database.
  sql: 'ALTER DATABASE "2Izuz2a_X)F}~8H<86*R~L_r`sx<<Yf"."" SET vchordrq.prewarm_dim = \'512,640,768,1024,1152,1536\'',
  params: []
}
PostgresError: syntax error at or near "."
    at ErrorResponse (/usr/src/app/node_modules/postgres/cjs/src/connection.js:790:26)
    at handle (/usr/src/app/node_modules/postgres/cjs/src/connection.js:476:6)
    at Socket.data (/usr/src/app/node_modules/postgres/cjs/src/connection.js:315:9)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
  severity_local: 'ERROR',
  severity: 'ERROR',
  code: '42601',
  position: '49',
  file: 'scan.l',
  line: '1176',
  routine: 'scanner_yyerror'
}
microservices worker error: PostgresError: syntax error at or near ".", stack: PostgresError: syntax error at or near "."
    at ErrorResponse (/usr/src/app/node_modules/postgres/cjs/src/connection.js:790:26)
    at handle (/usr/src/app/node_modules/postgres/cjs/src/connection.js:476:6)
    at Socket.data (/usr/src/app/node_modules/postgres/cjs/src/connection.js:315:9)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
microservices worker exited with code 1
Killing api process
Initializing Immich v1.133.0
Detected CPU Cores: 72
Starting api worker
Starting microservices worker
Rest is looking good
```

## How Has This Been Tested?

- Faith

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [?] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
