### PR TITLE
fix(web): center memory lane buttons

### DIFF
--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -47,7 +47,10 @@
     {#if canScrollLeft || canScrollRight}
       <div class="sticky start-0 z-1">
         {#if canScrollLeft}
-          <div class="absolute start-4 max-md:top-[75px] top-[108px] -translate-y-1/2" transition:fade={{ duration: 200 }}>
+          <div
+            class="absolute start-4 max-md:top-[75px] top-[108px] -translate-y-1/2"
+            transition:fade={{ duration: 200 }}
+          >
             <button
               type="button"
               class="rounded-full border border-gray-500 bg-gray-100 p-2 text-gray-500 opacity-50 hover:opacity-100"
@@ -60,7 +63,10 @@
           </div>
         {/if}
         {#if canScrollRight}
-          <div class="absolute end-4 max-md:top-[75px] top-[108px] -translate-y-1/2 z-1" transition:fade={{ duration: 200 }}>
+          <div
+            class="absolute end-4 max-md:top-[75px] top-[108px] -translate-y-1/2 z-1"
+            transition:fade={{ duration: 200 }}
+          >
             <button
               type="button"
               class="rounded-full border border-gray-500 bg-gray-100 p-2 text-gray-500 opacity-50 hover:opacity-100"

--- a/web/src/lib/components/photos-page/memory-lane.svelte
+++ b/web/src/lib/components/photos-page/memory-lane.svelte
@@ -47,7 +47,7 @@
     {#if canScrollLeft || canScrollRight}
       <div class="sticky start-0 z-1">
         {#if canScrollLeft}
-          <div class="absolute start-4 top-24" transition:fade={{ duration: 200 }}>
+          <div class="absolute start-4 max-md:top-[75px] top-[108px] -translate-y-1/2" transition:fade={{ duration: 200 }}>
             <button
               type="button"
               class="rounded-full border border-gray-500 bg-gray-100 p-2 text-gray-500 opacity-50 hover:opacity-100"
@@ -60,7 +60,7 @@
           </div>
         {/if}
         {#if canScrollRight}
-          <div class="absolute end-4 top-24 z-1" transition:fade={{ duration: 200 }}>
+          <div class="absolute end-4 max-md:top-[75px] top-[108px] -translate-y-1/2 z-1" transition:fade={{ duration: 200 }}>
             <button
               type="button"
               class="rounded-full border border-gray-500 bg-gray-100 p-2 text-gray-500 opacity-50 hover:opacity-100"
@@ -77,7 +77,7 @@
     <div class="inline-block" use:resizeObserver={({ width }) => (innerWidth = width)}>
       {#each memoryStore.memories as memory (memory.id)}
         <a
-          class="memory-card relative me-2 md:me-4 last:me-0 inline-block aspect-3/4 md:aspect-4/3 max-md:h-[150px] xl:aspect-video h-[215px] rounded-xl"
+          class="memory-card relative me-2 md:me-4 last:me-0 inline-block aspect-3/4 md:aspect-4/3 max-md:h-[150px] xl:aspect-video h-[216px] rounded-xl"
           href="{AppRoute.MEMORY}?{QueryParameter.ID}={memory.assets[0].id}"
         >
           <img


### PR DESCRIPTION
## Description

Centers the memory lane buttons, especially on mobile they were way off center.

I also changed the height by `1px` to make centering more accurate, hope that's okay.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manual test in Firefox and Chrome

<details><summary><h2>Screenshots</h2></summary>

| before | after |
|--------|-------|
|![Screenshot from 2025-05-25 19-50-13](https://github.com/user-attachments/assets/57d236f5-aa48-44a9-b0cd-1b3ab10ed955)|![Screenshot from 2025-05-25 19-50-08](https://github.com/user-attachments/assets/32cbbbb0-c27a-4df5-af78-aed00fbcd65d)|
|![Screenshot from 2025-05-25 19-50-34](https://github.com/user-attachments/assets/414b7d99-d0a9-47a8-b74e-438d27437758)|![Screenshot from 2025-05-25 19-50-42](https://github.com/user-attachments/assets/d2fe7101-6f45-4c4a-bc51-036ec318b408)|

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
