### PR TITLE
chore(docs): add instruction for trusting self-signed certificates with Immich and an OAuth server

### DIFF
--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -60,7 +60,7 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Trust Self Signed Certificates with Immich - OAuth Setup',
-    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication."
+    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.",
     url: 'https://github.com/immich-app/immich/discussions/18614',
   },
 ];

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -60,7 +60,7 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Trust Self Signed Certificates with Immich - OAuth Setup',
-    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.',
+    description: 'Set up Certificate Authority trust with Immich, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.',
     url: 'https://github.com/immich-app/immich/discussions/18614',
   },
 ];

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -60,7 +60,7 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Trust Self Signed Certificates with Immich - OAuth Setup',
-    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.",
+    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.',
     url: 'https://github.com/immich-app/immich/discussions/18614',
   },
 ];

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -58,6 +58,11 @@ const guides: CommunityGuidesProps[] = [
     description: 'Access Immich with an end-to-end encrypted connection.',
     url: 'https://meshnet.nordvpn.com/how-to/remote-files-media-access/immich-remote-access',
   },
+  {
+    title: 'Trust Self Signed Certificates with Immich - OAuth Setup',
+    description: 'Set up Certificate Authority trust with Immitch, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication."
+    url: 'https://github.com/immich-app/immich/discussions/18614',
+  },
 ];
 
 function CommunityGuide({ title, description, url }: CommunityGuidesProps): JSX.Element {

--- a/docs/src/components/community-guides.tsx
+++ b/docs/src/components/community-guides.tsx
@@ -60,7 +60,8 @@ const guides: CommunityGuidesProps[] = [
   },
   {
     title: 'Trust Self Signed Certificates with Immich - OAuth Setup',
-    description: 'Set up Certificate Authority trust with Immich, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.',
+    description:
+      'Set up Certificate Authority trust with Immich, and your private OAuth2/OpenID service, while using a private CA for HTTPS commication.',
     url: 'https://github.com/immich-app/immich/discussions/18614',
   },
 ];


### PR DESCRIPTION
## Description
Added an additional guide to setting up a private CA trust with a local OAuth server.

## How Has This Been Tested?

1. Deploy an Authentik server (such as [with Docker Compose](https://docs.goauthentik.io/docs/install-config/install/docker-compose)).
3. [Set up an NGINX server as a reverse proxy for Authentik](https://docs.goauthentik.io/docs/install-config/reverse-proxy), using a self-signed HTTPS certificate.
4. [Establish OAuth Authentication with Immich](https://immich.app/docs/administration/oauth) with your local Authentik server. Use HTTPS through the reverse proxy NGINX.

More information in the discussion #18614

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
