### PR TITLE
feat(server): separate thumbs dirs for thumbnails and people

### DIFF
--- a/docs/docs/guides/custom-locations.md
+++ b/docs/docs/guides/custom-locations.md
@@ -15,6 +15,8 @@ In our `.env` file, we will define the paths we want to use. Note that you don't
 - UPLOAD_LOCATION=./library
 + UPLOAD_LOCATION=/custom/path/immich/immich_files
 + THUMB_LOCATION=/custom/path/immich/thumbs
++ THUMB_SMALL_LOCATION=/custom/path/immich/small-thumbnails
++ THUMB_PEOPLE_LOCATION=/custom/path/immich/people-thumbnails
 + ENCODED_VIDEO_LOCATION=/custom/path/immich/encoded-video
 + PROFILE_LOCATION=/custom/path/immich/profile
 + BACKUP_LOCATION=/custom/path/immich/backups
@@ -29,6 +31,8 @@ services:
       volumes:
       - ${UPLOAD_LOCATION}:/usr/src/app/upload
 +     - ${THUMB_LOCATION}:/usr/src/app/upload/thumbs
++     - ${THUMB_SMALL_LOCATION}:/usr/src/app/upload/thumbs/thumbnails
++     - ${THUMB_PEOPLE_LOCATION}:/usr/src/app/upload/thumbs/people
 +     - ${ENCODED_VIDEO_LOCATION}:/usr/src/app/upload/encoded-video
 +     - ${PROFILE_LOCATION}:/usr/src/app/upload/profile
 +     - ${BACKUP_LOCATION}:/usr/src/app/upload/backups
@@ -46,7 +50,8 @@ docker compose up -d
 Because of the underlying properties of docker bind mounts, it is not recommended to mount the `upload/` and `library/` folders as separate bind mounts if they are on the same device.
 For this reason, we mount the HDD or the network storage (NAS) to `/usr/src/app/upload` and then mount the folders we want to access under that folder.
 
-The `thumbs/` folder contains both the small thumbnails displayed in the timeline and the larger previews shown when clicking into an image. These cannot be separated.
+Normally, the `thumbs/` folder contains all thumbnails such as the small thumbnails displayed in the timeline and the larger previews shown when clicking into an image.
+You can also specify the location of the `thumbs/thumbnails` and `thumbs/people` folders. For example, you could put these folders on a small SSD for snappy loading while the other assets (like the larger previews) can be on a bigger HDD.
 
 The storage metrics of the Immich server will track available storage at `UPLOAD_LOCATION`, so the administrator must set up some sort of monitoring to ensure the storage does not run out of space. The `profile/` folder is much smaller, usually less than 1 MB.
 :::

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -91,7 +91,11 @@ export class StorageCore {
   }
 
   static getImagePath(asset: ThumbnailPathEntity, type: GeneratedImageType, format: 'jpeg' | 'webp') {
-    return StorageCore.getNestedPath(StorageFolder.THUMBNAILS, asset.ownerId, `${asset.id}-${type}.${format}`);
+    let thumbFolder = StorageFolder.THUMBNAILS;
+    if (type == AssetPathType.THUMBNAIL) { // Subdir for thumbnails, separate from previews etc.
+      thumbFolder = StorageFolder.THUMBNAILS_THUMBNAILS;
+    }
+    return StorageCore.getNestedPath(thumbFolder, asset.ownerId, `${asset.id}-${type}.${format}`);
   }
 
   static getEncodedVideoPath(asset: ThumbnailPathEntity) {

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -92,7 +92,8 @@ export class StorageCore {
 
   static getImagePath(asset: ThumbnailPathEntity, type: GeneratedImageType, format: 'jpeg' | 'webp') {
     let thumbFolder = StorageFolder.THUMBNAILS;
-    if (type == AssetPathType.THUMBNAIL) { // Subdir for thumbnails, separate from previews etc.
+    // Subdir for thumbnails, separate from previews etc.
+    if (type == AssetPathType.THUMBNAIL) {
       thumbFolder = StorageFolder.THUMBNAILS_THUMBNAILS;
     }
     return StorageCore.getNestedPath(thumbFolder, asset.ownerId, `${asset.id}-${type}.${format}`);

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -87,7 +87,7 @@ export class StorageCore {
   }
 
   static getPersonThumbnailPath(person: ThumbnailPathEntity) {
-    return StorageCore.getNestedPath(StorageFolder.THUMBNAILS, person.ownerId, `${person.id}.jpeg`);
+    return StorageCore.getNestedPath(StorageFolder.THUMBNAILS_PEOPLE, person.ownerId, `${person.id}.jpeg`);
   }
 
   static getImagePath(asset: ThumbnailPathEntity, type: GeneratedImageType, format: 'jpeg' | 'webp') {

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -195,6 +195,7 @@ export enum StorageFolder {
   PROFILE = 'profile',
   THUMBNAILS = 'thumbs',
   THUMBNAILS_THUMBNAILS = 'thumbs/thumbnails',
+  THUMBNAILS_PEOPLE = 'thumbs/people',
   BACKUPS = 'backups',
 }
 

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -194,6 +194,7 @@ export enum StorageFolder {
   UPLOAD = 'upload',
   PROFILE = 'profile',
   THUMBNAILS = 'thumbs',
+  THUMBNAILS_THUMBNAILS = 'thumbs/thumbnails',
   BACKUPS = 'backups',
 }
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -216,7 +216,7 @@ describe(MediaService.name, () => {
         entityId: assetStub.image.id,
         pathType: AssetPathType.THUMBNAIL,
         oldPath: '/uploads/user-id/webp/path.ext',
-        newPath: 'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+        newPath: 'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
       });
       expect(mocks.move.create).toHaveBeenCalledTimes(3);
     });
@@ -295,7 +295,7 @@ describe(MediaService.name, () => {
 
       await sut.handleGenerateThumbnails({ id: assetStub.image.id });
 
-      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/user-id/as/se');
+      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/thumbnails/user-id/as/se');
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(assetStub.image.originalPath, {
@@ -327,7 +327,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           raw: rawInfo,
         },
-        'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+        'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
       );
 
       expect(mocks.media.generateThumbhash).toHaveBeenCalledOnce();
@@ -346,7 +346,7 @@ describe(MediaService.name, () => {
         {
           assetId: 'asset-id',
           type: AssetFileType.THUMBNAIL,
-          path: 'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+          path: 'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
         },
       ]);
       expect(mocks.asset.update).toHaveBeenCalledWith({ id: 'asset-id', thumbhash: thumbhashBuffer });
@@ -382,7 +382,7 @@ describe(MediaService.name, () => {
         {
           assetId: 'asset-id',
           type: AssetFileType.THUMBNAIL,
-          path: 'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+          path: 'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
         },
       ]);
     });
@@ -417,7 +417,7 @@ describe(MediaService.name, () => {
         {
           assetId: 'asset-id',
           type: AssetFileType.THUMBNAIL,
-          path: 'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+          path: 'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
         },
       ]);
     });
@@ -486,7 +486,7 @@ describe(MediaService.name, () => {
       const thumbhashBuffer = Buffer.from('a thumbhash', 'utf8');
       mocks.media.generateThumbhash.mockResolvedValue(thumbhashBuffer);
       const previewPath = `upload/thumbs/user-id/as/se/asset-id-preview.${format}`;
-      const thumbnailPath = `upload/thumbs/user-id/as/se/asset-id-thumbnail.webp`;
+      const thumbnailPath = `upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp`;
 
       await sut.handleGenerateThumbnails({ id: assetStub.image.id });
 
@@ -531,7 +531,7 @@ describe(MediaService.name, () => {
       const thumbhashBuffer = Buffer.from('a thumbhash', 'utf8');
       mocks.media.generateThumbhash.mockResolvedValue(thumbhashBuffer);
       const previewPath = `upload/thumbs/user-id/as/se/asset-id-preview.jpeg`;
-      const thumbnailPath = `upload/thumbs/user-id/as/se/asset-id-thumbnail.${format}`;
+      const thumbnailPath = `upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.${format}`;
 
       await sut.handleGenerateThumbnails({ id: assetStub.image.id });
 
@@ -663,7 +663,7 @@ describe(MediaService.name, () => {
       expect(mocks.media.generateThumbnail).toHaveBeenCalledWith(
         rawBuffer,
         expect.objectContaining({ processInvalidImages: false }),
-        'upload/thumbs/user-id/as/se/asset-id-thumbnail.webp',
+        'upload/thumbs/thumbnails/user-id/as/se/asset-id-thumbnail.webp',
       );
 
       expect(mocks.media.generateThumbhash).toHaveBeenCalledOnce();
@@ -911,7 +911,7 @@ describe(MediaService.name, () => {
       );
 
       expect(mocks.person.getDataForThumbnailGenerationJob).toHaveBeenCalledWith(personStub.primaryPerson.id);
-      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/admin_id/pe/rs');
+      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/people/admin_id/pe/rs');
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(personThumbnailStub.newThumbnailMiddle.originalPath, {
         colorspace: Colorspace.P3,
         orientation: undefined,
@@ -933,11 +933,11 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
       expect(mocks.person.update).toHaveBeenCalledWith({
         id: 'person-1',
-        thumbnailPath: 'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        thumbnailPath: 'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       });
     });
 
@@ -953,7 +953,7 @@ describe(MediaService.name, () => {
       );
 
       expect(mocks.person.getDataForThumbnailGenerationJob).toHaveBeenCalledWith(personStub.primaryPerson.id);
-      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/admin_id/pe/rs');
+      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/people/admin_id/pe/rs');
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(personThumbnailStub.newThumbnailMiddle.previewPath, {
         colorspace: Colorspace.P3,
         orientation: undefined,
@@ -975,11 +975,11 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
       expect(mocks.person.update).toHaveBeenCalledWith({
         id: 'person-1',
-        thumbnailPath: 'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        thumbnailPath: 'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       });
     });
 
@@ -1015,7 +1015,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
     });
 
@@ -1052,7 +1052,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
     });
 
@@ -1089,7 +1089,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
     });
 
@@ -1126,7 +1126,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
     });
 
@@ -1168,7 +1168,7 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           size: 250,
         },
-        'upload/thumbs/admin_id/pe/rs/person-1.jpeg',
+        'upload/thumbs/people/admin_id/pe/rs/person-1.jpeg',
       );
     });
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -263,6 +263,7 @@ export class MediaService extends BaseService {
     const previewPath = StorageCore.getImagePath(asset, AssetPathType.PREVIEW, image.preview.format);
     const thumbnailPath = StorageCore.getImagePath(asset, AssetPathType.THUMBNAIL, image.thumbnail.format);
     this.storageCore.ensureFolders(previewPath);
+    this.storageCore.ensureFolders(thumbnailPath);
 
     // Handle embedded preview extraction for RAW files
     const extractEmbedded = image.extractEmbedded && mimeTypes.isRaw(asset.originalFileName);
@@ -410,6 +411,7 @@ export class MediaService extends BaseService {
     const previewPath = StorageCore.getImagePath(asset, AssetPathType.PREVIEW, image.preview.format);
     const thumbnailPath = StorageCore.getImagePath(asset, AssetPathType.THUMBNAIL, image.thumbnail.format);
     this.storageCore.ensureFolders(previewPath);
+    this.storageCore.ensureFolders(thumbnailPath);
 
     const { format, audioStreams, videoStreams } = await this.mediaRepository.probe(asset.originalPath);
     const mainVideoStream = this.getMainStream(videoStreams);

--- a/server/src/services/storage.service.spec.ts
+++ b/server/src/services/storage.service.spec.ts
@@ -29,6 +29,8 @@ describe(StorageService.name, () => {
           library: true,
           profile: true,
           thumbs: true,
+          'thumbs/thumbnails': true,
+          'thumbs/people': true,
           upload: true,
         },
       });
@@ -36,12 +38,16 @@ describe(StorageService.name, () => {
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/library');
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/profile');
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs');
+      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/thumbnails');
+      expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/thumbs/people');
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/upload');
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith('upload/backups');
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/encoded-video/.immich', expect.any(Buffer));
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/library/.immich', expect.any(Buffer));
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/profile/.immich', expect.any(Buffer));
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/thumbs/.immich', expect.any(Buffer));
+      expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/thumbs/thumbnails/.immich', expect.any(Buffer));
+      expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/thumbs/people/.immich', expect.any(Buffer));
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/upload/.immich', expect.any(Buffer));
       expect(mocks.storage.createFile).toHaveBeenCalledWith('upload/backups/.immich', expect.any(Buffer));
     });
@@ -54,6 +60,8 @@ describe(StorageService.name, () => {
           library: false,
           profile: true,
           thumbs: true,
+          'thumbs/thumbnails': true,
+          'thumbs/people': true,
           upload: true,
         },
       });
@@ -67,6 +75,8 @@ describe(StorageService.name, () => {
           library: true,
           profile: true,
           thumbs: true,
+          'thumbs/thumbnails': true,
+          'thumbs/people': true,
           upload: true,
         },
       });


### PR DESCRIPTION
## Description

Separates the thumbnails and people into subdirectories so you can mount them on an SSD while mounting the regular directory containing previews and fullsizes on an HDD.

Implements #17366

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] `make dev` instance

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![Screenshot_20250526_071845](https://github.com/user-attachments/assets/50133b4f-1e7b-4058-92c7-6bc136430b1b)
![Screenshot_20250526_071851](https://github.com/user-attachments/assets/942aafcd-f68f-4246-a2e1-ce4f8ff1e3c0)
![Screenshot_20250526_071902](https://github.com/user-attachments/assets/f24e2551-3531-43f3-9f83-09b7dabd66fd)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
