### PR TITLE
chore: remove checkbox requirement from dupe search question

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/feature-request.yaml
+++ b/.github/DISCUSSION_TEMPLATE/feature-request.yaml
@@ -14,7 +14,6 @@ body:
       label: I have searched the existing feature requests, both open and closed, to make sure this is not a duplicate request.
       options:
         - label: 'Yes'
-          required: true
 
   - type: textarea
     id: feature

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,7 +6,6 @@ body:
       label: I have searched the existing issues, both open and closed, to make sure this is not a duplicate report.
       options:
         - label: 'Yes'
-          required: true
 
   - type: markdown
     attributes:


### PR DESCRIPTION
People are still expected to check it (and any threads without it can be closed with prejudice), but maybe this will reduce the amount of people checking it blindly just to get past the form validation.