### PR TITLE
fix(web): move support & feedback button to user modal

### DIFF
--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -101,13 +101,8 @@
   </div>
 
   <div class="mb-4 flex flex-col">
-    <button
-      type="button"
-      class="flex w-full place-content-center place-items-center gap-2 py-3 font-medium text-gray-500 hover:bg-immich-primary/10 dark:text-gray-300"
-      onclick={onLogout}
-    >
-      <Icon path={mdiLogout} size={24} />
-      {$t('sign_out')}</button
+    <Button class="m-2 mx-4" onclick={onLogout} leadingIcon={mdiLogout} variant="ghost" color="secondary"
+      >{$t('sign_out')}</Button
     >
 
     <button

--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -112,7 +112,7 @@
 
     <button
       type="button"
-      class="flex w-full place-content-center place-items-center pt-1 underline text-xs text-immich-primary dark:text-immich-dark-primary bg-transparent border-0 cursor-pointer"
+      class="text-center pt-1 underline text-xs text-immich-primary dark:text-immich-dark-primary"
       onclick={async () => {
         onClose();
         if (info) {

--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -111,7 +111,7 @@
 
     <button
       type="button"
-      class="text-center mt-2 underline text-xs text-immich-primary dark:text-immich-dark-primary"
+      class="text-center mt-4 underline text-xs text-immich-primary dark:text-immich-dark-primary"
       onclick={async () => {
         onClose();
         if (info) {

--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -39,7 +39,7 @@
   use:focusTrap
 >
   <div
-    class="mx-4 mt-4 flex flex-col items-center justify-center gap-4 rounded-3xl bg-white p-4 dark:bg-immich-dark-primary/10"
+    class="mx-4 mt-4 flex flex-col items-center justify-center gap-4 rounded-t-3xl bg-white p-4 dark:bg-immich-dark-primary/10"
   >
     <div class="relative">
       <UserAvatar user={$user} size="xl" />
@@ -101,13 +101,17 @@
   </div>
 
   <div class="mb-4 flex flex-col">
-    <Button class="m-2 mx-4" onclick={onLogout} leadingIcon={mdiLogout} variant="ghost" color="secondary"
-      >{$t('sign_out')}</Button
+    <Button
+      class="m-1 mx-4 rounded-none rounded-b-3xl bg-white p-3 dark:bg-immich-dark-primary/10"
+      onclick={onLogout}
+      leadingIcon={mdiLogout}
+      variant="ghost"
+      color="secondary">{$t('sign_out')}</Button
     >
 
     <button
       type="button"
-      class="text-center pt-1 underline text-xs text-immich-primary dark:text-immich-dark-primary"
+      class="text-center mt-2 underline text-xs text-immich-primary dark:text-immich-dark-primary"
       onclick={async () => {
         onClose();
         if (info) {

--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -6,9 +6,13 @@
   import { AppRoute } from '$lib/constants';
   import { modalManager } from '$lib/managers/modal-manager.svelte';
   import AvatarEditModal from '$lib/modals/AvatarEditModal.svelte';
+  import HelpAndFeedbackModal from '$lib/modals/HelpAndFeedbackModal.svelte';
   import { user } from '$lib/stores/user.store';
+  import { userInteraction } from '$lib/stores/user.svelte';
+  import { getAboutInfo, type ServerAboutResponseDto } from '@immich/sdk';
   import { Button } from '@immich/ui';
   import { mdiCog, mdiLogout, mdiPencil, mdiWrench } from '@mdi/js';
+  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
   import UserAvatar from '../user-avatar.svelte';
@@ -19,6 +23,12 @@
   }
 
   let { onLogout, onClose = () => {} }: Props = $props();
+
+  let info: ServerAboutResponseDto | undefined = $state();
+
+  onMount(async () => {
+    info = userInteraction.aboutInfo ?? (await getAboutInfo());
+  });
 </script>
 
 <div
@@ -99,5 +109,18 @@
       <Icon path={mdiLogout} size={24} />
       {$t('sign_out')}</button
     >
+
+    <button
+      type="button"
+      class="flex w-full place-content-center place-items-center pt-1 underline text-xs text-immich-primary dark:text-immich-dark-primary bg-transparent border-0 cursor-pointer"
+      onclick={async () => {
+        onClose();
+        if (info) {
+          await modalManager.show(HelpAndFeedbackModal, { info });
+        }
+      }}
+    >
+      {$t('support_and_feedback')}
+    </button>
   </div>
 </div>

--- a/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/navigation-bar.svelte
@@ -12,18 +12,13 @@
   import SearchBar from '$lib/components/shared-components/search-bar/search-bar.svelte';
   import { AppRoute } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
-  import { modalManager } from '$lib/managers/modal-manager.svelte';
-  import HelpAndFeedbackModal from '$lib/modals/HelpAndFeedbackModal.svelte';
   import { mobileDevice } from '$lib/stores/mobile-device.svelte';
   import { notificationManager } from '$lib/stores/notification-manager.svelte';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { user } from '$lib/stores/user.store';
-  import { userInteraction } from '$lib/stores/user.svelte';
-  import { getAboutInfo, type ServerAboutResponseDto } from '@immich/sdk';
   import { Button, IconButton } from '@immich/ui';
-  import { mdiBellBadge, mdiBellOutline, mdiHelpCircleOutline, mdiMagnify, mdiMenu, mdiTrayArrowUp } from '@mdi/js';
-  import { onMount } from 'svelte';
+  import { mdiBellBadge, mdiBellOutline, mdiMagnify, mdiMenu, mdiTrayArrowUp } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import ThemeButton from '../theme-button.svelte';
   import UserAvatar from '../user-avatar.svelte';
@@ -42,12 +37,6 @@
   let shouldShowNotificationPanel = $state(false);
   let innerWidth: number = $state(0);
   const hasUnreadNotifications = $derived(notificationManager.notifications.length > 0);
-
-  let info: ServerAboutResponseDto | undefined = $state();
-
-  onMount(async () => {
-    info = userInteraction.aboutInfo ?? (await getAboutInfo());
-  });
 </script>
 
 <svelte:window bind:innerWidth />
@@ -129,18 +118,6 @@
         {/if}
 
         <ThemeButton padding="2" />
-
-        <div>
-          <IconButton
-            shape="round"
-            color="secondary"
-            variant="ghost"
-            size="medium"
-            icon={mdiHelpCircleOutline}
-            onclick={() => info && modalManager.show(HelpAndFeedbackModal, { info })}
-            aria-label={$t('support_and_feedback')}
-          />
-        </div>
 
         <div
           use:clickOutside={{


### PR DESCRIPTION
## Description

Fixes #18597.

![Screenshot 2025-05-26 at 11 57 25 AM](https://github.com/user-attachments/assets/ab0540af-2f64-4103-8d26-d5895d676108)

## How Has This Been Tested?

Tested on Chrome and Safari

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
