### PR TITLE
point to help desk channel instead of contributing in troubleshooting.md

### DIFF
--- a/docs/docs/developer/troubleshooting.md
+++ b/docs/docs/developer/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting
 
 :::tip
-A great option to get assistance with troubleshooting is to join our [Discord](https://discord.immich.app) server, where we have a dedicated channel for `#contributing`.
+A great option to get assistance with troubleshooting is to join our [Discord](https://discord.immich.app) server, where we have a dedicated channel for `#help-desk-support`.
 :::
 
 ## Known Issues


### PR DESCRIPTION
## Description

Not sure why the channel linked is for contributing instead.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] This has not been tested.
- [ ] 
<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

I'm going to ignore this checklist since it talks about code and not docs contributions.