### PR TITLE
fix: use single bulkTagAssets call instead of loop

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -21,6 +21,7 @@ import { navigate } from '$lib/utils/navigation';
 import {
   addAssetsToAlbum as addAssets,
   AssetVisibility,
+  bulkTagAssets,
   createStack,
   deleteAssets,
   deleteStacks,
@@ -28,7 +29,6 @@ import {
   getBaseUrl,
   getDownloadInfo,
   getStack,
-  tagAssets as tagAllAssets,
   untagAssets,
   updateAsset,
   updateAssets,
@@ -83,9 +83,7 @@ export const tagAssets = async ({
   tagIds: string[];
   showNotification?: boolean;
 }) => {
-  for (const tagId of tagIds) {
-    await tagAllAssets({ id: tagId, bulkIdsDto: { ids: assetIds } });
-  }
+  await bulkTagAssets({ tagBulkAssetsDto: { tagIds, assetIds } });
 
   if (showNotification) {
     const $t = await getFormatter();


### PR DESCRIPTION
When adding many tags to an asset from the web, some of them are not applied properly. The root cause to that is #16747, but this change should at least make it less prone to triggering that issue.