### PR TITLE
fix(web): handle nullable assets duration

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,7 +16,7 @@ name: immich-dev
 services:
   immich-server:
     container_name: immich_server
-    command: ['/usr/src/app/bin/immich-dev']
+    command: [ '/usr/src/app/bin/immich-dev' ]
     image: immich-server-dev:latest
     # extends:
     #   file: hwaccel.transcoding.yml
@@ -31,6 +31,7 @@ services:
       - ../open-api:/usr/src/open-api
       - ${UPLOAD_LOCATION}/photos:/usr/src/app/upload
       - ${UPLOAD_LOCATION}/photos/upload:/usr/src/app/upload/upload
+      - ${EXTERNAL_LIBRARY}:/data/external-library
       - /usr/src/app/node_modules
       - /etc/localtime:/etc/localtime:ro
     env_file:
@@ -70,7 +71,7 @@ services:
     # user: 0:0
     build:
       context: ../web
-    command: ['/usr/src/app/bin/immich-web']
+    command: [ '/usr/src/app/bin/immich-web' ]
     env_file:
       - .env
     ports:
@@ -134,7 +135,6 @@ services:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
-
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -339,7 +339,7 @@
             url={getAssetPlaybackUrl({ id: asset.id, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}
             curve={selected}
-            durationInSeconds={asset.duration ? timeToSeconds(asset.duration) : 0)}
+            durationInSeconds={asset.duration ? timeToSeconds(asset.duration) : 0}
             playbackOnIconHover={!$playVideoThumbnailOnHover}
           />
         </div>

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -339,7 +339,7 @@
             url={getAssetPlaybackUrl({ id: asset.id, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}
             curve={selected}
-            durationInSeconds={timeToSeconds(asset.duration!)}
+            durationInSeconds={timeToSeconds(asset.duration ?? '00:00:00')}
             playbackOnIconHover={!$playVideoThumbnailOnHover}
           />
         </div>

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -339,7 +339,7 @@
             url={getAssetPlaybackUrl({ id: asset.id, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}
             curve={selected}
-            durationInSeconds={timeToSeconds(asset.duration ?? '00:00:00')}
+            durationInSeconds={asset.duration ? timeToSeconds(asset.duration) : 0)}
             playbackOnIconHover={!$playVideoThumbnailOnHover}
           />
         </div>


### PR DESCRIPTION
Asset duration can be null if a video is invalid, which can lead to the whole bucket not rendering on the web