### PR TITLE
chore: allow overriding dark mode to light mode with the .light class

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -69,8 +69,7 @@
 }
 
 @layer base {
-  :root,
-  .light {
+  :root {
     /* light */
     --immich-primary: 66 80 175;
     --immich-bg: 255 255 255;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -34,7 +34,7 @@
   grid-template-columns: repeat(auto-fill, minmax(min(calc(var(--spacing) * --value(number)), 100%), 1fr));
 }
 
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark (&:where(.dark, .dark *):not(.light));
 
 @theme inline {
   --color-immich-primary: rgb(var(--immich-primary));
@@ -69,7 +69,8 @@
 }
 
 @layer base {
-  :root {
+  :root,
+  .light {
     /* light */
     --immich-primary: 66 80 175;
     --immich-bg: 255 255 255;


### PR DESCRIPTION
## Description

Brings changes from https://github.com/immich-app/ui/pull/184

Allows us to force light mode for a block of HTML

## How Has This Been Tested?

See https://github.com/immich-app/ui/pull/184 preview on the Button component page.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
