### PR TITLE
fix(server): tighten asset visibility

### DIFF
--- a/server/src/queries/activity.repository.sql
+++ b/server/src/queries/activity.repository.sql
@@ -73,3 +73,4 @@ where
   and "activity"."albumId" = $2
   and "activity"."isLiked" = $3
   and "assets"."deletedAt" is null
+  and "assets"."visibility" != 'locked'

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -80,6 +80,7 @@ select
         where
           "albums_assets_assets"."albumsId" = "albums"."id"
           and "assets"."deletedAt" is null
+          and "assets"."visibility" in ('archive', 'timeline')
         order by
           "assets"."fileCreatedAt" desc
       ) as "asset"
@@ -178,7 +179,8 @@ from
   "assets"
   inner join "albums_assets_assets" as "album_assets" on "album_assets"."assetsId" = "assets"."id"
 where
-  "album_assets"."albumsId" in ($1)
+  "assets"."visibility" in ('archive', 'timeline')
+  and "album_assets"."albumsId" in ($1)
   and "assets"."deletedAt" is null
 group by
   "album_assets"."albumsId"

--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -186,8 +186,8 @@ from
   inner join "smart_search" on "assets"."id" = "smart_search"."assetId"
   inner join "asset_job_status" as "job_status" on "job_status"."assetId" = "assets"."id"
 where
-  "assets"."visibility" != $1
-  and "assets"."deletedAt" is null
+  "assets"."deletedAt" is null
+  and "assets"."visibility" in ('archive', 'timeline')
   and "job_status"."duplicatesDetectedAt" is null
 
 -- AssetJobRepository.streamForEncodeClip
@@ -349,7 +349,7 @@ from
       "assets" as "stacked"
     where
       "stacked"."deletedAt" is not null
-      and "stacked"."visibility" != $1
+      and "stacked"."visibility" = $1
       and "stacked"."stackId" = "asset_stack"."id"
     group by
       "asset_stack"."id"

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -130,7 +130,6 @@ select
 from
   "assets"
   left join "exif" on "assets"."id" = "exif"."assetId"
-  left join "asset_stack" on "asset_stack"."id" = "assets"."stackId"
 where
   "assets"."id" = any ($1::uuid[])
 

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -159,7 +159,6 @@ where
   "ownerId" = $1::uuid
   and "deviceId" = $2
   and "deletedAt" is null
-  and "assets"."visibility" in ('archive', 'timeline')
 
 -- AssetRepository.getLivePhotoCount
 select

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -158,6 +158,7 @@ from
 where
   "ownerId" = $1::uuid
   and "deviceId" = $2
+  and "visibility" != $3
   and "deletedAt" is null
 
 -- AssetRepository.getLivePhotoCount

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -189,13 +189,13 @@ where
 
 -- PersonRepository.getNumberOfPeople
 select
-  coalesce(count(*), $1) as "total",
+  coalesce(count(*), 0) as "total",
   coalesce(
     count(*) filter (
       where
-        "isHidden" = $2
+        "isHidden" = $1
     ),
-    $3
+    0
   ) as "hidden"
 from
   "person"
@@ -217,7 +217,7 @@ where
           and "assets"."deletedAt" is null
       )
   )
-  and "person"."ownerId" = $4
+  and "person"."ownerId" = $2
 
 -- PersonRepository.refreshFaces
 with

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -102,23 +102,23 @@ with
       "assets"
       inner join "smart_search" on "assets"."id" = "smart_search"."assetId"
     where
-      "assets"."ownerId" = any ($2::uuid[])
+      "assets"."visibility" in ('archive', 'timeline')
+      and "assets"."ownerId" = any ($2::uuid[])
       and "assets"."deletedAt" is null
-      and "assets"."visibility" != $3
-      and "assets"."type" = $4
-      and "assets"."id" != $5::uuid
+      and "assets"."type" = $3
+      and "assets"."id" != $4::uuid
       and "assets"."stackId" is null
     order by
       "distance"
     limit
-      $6
+      $5
   )
 select
   *
 from
   "cte"
 where
-  "cte"."distance" <= $7
+  "cte"."distance" <= $6
 commit
 
 -- SearchRepository.searchFaces

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -241,7 +241,7 @@ from
   inner join "assets" on "assets"."id" = "exif"."assetId"
 where
   "ownerId" = any ($1::uuid[])
-  and "visibility" != $2
+  and "visibility" = $2
   and "deletedAt" is null
   and "state" is not null
 
@@ -253,7 +253,7 @@ from
   inner join "assets" on "assets"."id" = "exif"."assetId"
 where
   "ownerId" = any ($1::uuid[])
-  and "visibility" != $2
+  and "visibility" = $2
   and "deletedAt" is null
   and "city" is not null
 
@@ -265,7 +265,7 @@ from
   inner join "assets" on "assets"."id" = "exif"."assetId"
 where
   "ownerId" = any ($1::uuid[])
-  and "visibility" != $2
+  and "visibility" = $2
   and "deletedAt" is null
   and "make" is not null
 
@@ -277,6 +277,6 @@ from
   inner join "assets" on "assets"."id" = "exif"."assetId"
 where
   "ownerId" = any ($1::uuid[])
-  and "visibility" != $2
+  and "visibility" = $2
   and "deletedAt" is null
   and "model" is not null

--- a/server/src/queries/stack.repository.sql
+++ b/server/src/queries/stack.repository.sql
@@ -52,6 +52,7 @@ select
         where
           "assets"."deletedAt" is null
           and "assets"."stackId" = "asset_stack"."id"
+          and "assets"."visibility" in ('archive', 'timeline')
       ) as agg
   ) as "assets"
 from
@@ -135,6 +136,7 @@ select
         where
           "assets"."deletedAt" is null
           and "assets"."stackId" = "asset_stack"."id"
+          and "assets"."visibility" in ('archive', 'timeline')
       ) as agg
   ) as "assets"
 from

--- a/server/src/queries/user.repository.sql
+++ b/server/src/queries/user.repository.sql
@@ -293,11 +293,17 @@ select
   "users"."quotaSizeInBytes",
   count(*) filter (
     where
-      "assets"."type" = 'IMAGE'
+      (
+        "assets"."type" = 'IMAGE'
+        and "assets"."visibility" != 'hidden'
+      )
   ) as "photos",
   count(*) filter (
     where
-      "assets"."type" = 'VIDEO'
+      (
+        "assets"."type" = 'VIDEO'
+        and "assets"."visibility" != 'hidden'
+      )
   ) as "videos",
   coalesce(
     sum("exif"."fileSizeInByte") filter (
@@ -330,7 +336,6 @@ from
   "users"
   left join "assets" on "assets"."ownerId" = "users"."id"
   and "assets"."deletedAt" is null
-  and "assets"."visibility" != 'hidden'
   left join "exif" on "exif"."assetId" = "assets"."id"
 group by
   "users"."id"

--- a/server/src/queries/user.repository.sql
+++ b/server/src/queries/user.repository.sql
@@ -293,17 +293,11 @@ select
   "users"."quotaSizeInBytes" as "quotaSizeInBytes",
   count(*) filter (
     where
-      (
-        "assets"."type" = 'IMAGE'
-        and "assets"."visibility" != 'hidden'
-      )
+      "assets"."type" = 'IMAGE'
   ) as "photos",
   count(*) filter (
     where
-      (
-        "assets"."type" = 'VIDEO'
-        and "assets"."visibility" != 'hidden'
-      )
+      "assets"."type" = 'VIDEO'
   ) as "videos",
   coalesce(
     sum("exif"."fileSizeInByte") filter (
@@ -335,9 +329,9 @@ select
 from
   "users"
   left join "assets" on "assets"."ownerId" = "users"."id"
+  and "assets"."deletedAt" is null
+  and "assets"."visibility" in ('timeline', 'archive')
   left join "exif" on "exif"."assetId" = "assets"."id"
-where
-  "assets"."deletedAt" is null
 group by
   "users"."id"
 order by
@@ -363,6 +357,7 @@ set
       left join "exif" on "exif"."assetId" = "assets"."id"
     where
       "assets"."libraryId" is null
+      and "assets"."visibility" in ('timeline', 'archive')
       and "assets"."ownerId" = "users"."id"
   ),
   "updatedAt" = $1

--- a/server/src/queries/user.repository.sql
+++ b/server/src/queries/user.repository.sql
@@ -290,7 +290,7 @@ order by
 select
   "users"."id" as "userId",
   "users"."name" as "userName",
-  "users"."quotaSizeInBytes" as "quotaSizeInBytes",
+  "users"."quotaSizeInBytes",
   count(*) filter (
     where
       "assets"."type" = 'IMAGE'
@@ -330,7 +330,7 @@ from
   "users"
   left join "assets" on "assets"."ownerId" = "users"."id"
   and "assets"."deletedAt" is null
-  and "assets"."visibility" in ('timeline', 'archive')
+  and "assets"."visibility" != 'hidden'
   left join "exif" on "exif"."assetId" = "assets"."id"
 group by
   "users"."id"
@@ -357,7 +357,6 @@ set
       left join "exif" on "exif"."assetId" = "assets"."id"
     where
       "assets"."libraryId" is null
-      and "assets"."visibility" in ('timeline', 'archive')
       and "assets"."ownerId" = "users"."id"
   ),
   "updatedAt" = $1

--- a/server/src/repositories/activity.repository.ts
+++ b/server/src/repositories/activity.repository.ts
@@ -5,6 +5,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { Activity, DB } from 'src/db';
 import { DummyValue, GenerateSql } from 'src/decorators';
+import { AssetVisibility } from 'src/enum';
 import { asUuid } from 'src/utils/database';
 
 export interface ActivitySearch {
@@ -76,6 +77,7 @@ export class ActivityRepository {
       .where('activity.albumId', '=', albumId)
       .where('activity.isLiked', '=', false)
       .where('assets.deletedAt', 'is', null)
+      .where('assets.visibility', '!=', sql.lit(AssetVisibility.LOCKED))
       .executeTakeFirstOrThrow();
 
     return count;

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -6,6 +6,7 @@ import { columns, Exif } from 'src/database';
 import { Albums, DB } from 'src/db';
 import { Chunked, ChunkedArray, ChunkedSet, DummyValue, GenerateSql } from 'src/decorators';
 import { AlbumUserCreateDto } from 'src/dtos/album.dto';
+import { withDefaultVisibility } from 'src/utils/database';
 
 export interface AlbumAssetCount {
   albumId: string;
@@ -58,6 +59,7 @@ const withAssets = (eb: ExpressionBuilder<DB, 'albums'>) => {
         .innerJoin('albums_assets_assets', 'albums_assets_assets.assetsId', 'assets.id')
         .whereRef('albums_assets_assets.albumsId', '=', 'albums.id')
         .where('assets.deletedAt', 'is', null)
+        .$call(withDefaultVisibility)
         .orderBy('assets.fileCreatedAt', 'desc')
         .as('asset'),
     )
@@ -121,6 +123,7 @@ export class AlbumRepository {
     return (
       this.db
         .selectFrom('assets')
+        .$call(withDefaultVisibility)
         .innerJoin('albums_assets_assets as album_assets', 'album_assets.assetsId', 'assets.id')
         .select('album_assets.albumsId as albumId')
         .select((eb) => eb.fn.min(sql<Date>`("assets"."localDateTime" AT TIME ZONE 'UTC'::text)::date`).as('startDate'))

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -11,6 +11,7 @@ import {
   anyUuid,
   asUuid,
   toJson,
+  withDefaultVisibility,
   withExif,
   withExifInner,
   withFaces,
@@ -140,9 +141,9 @@ export class AssetJobRepository {
     return this.db
       .selectFrom('assets')
       .select(['assets.id'])
-      .where('assets.visibility', '!=', AssetVisibility.HIDDEN)
       .where('assets.deletedAt', 'is', null)
       .innerJoin('smart_search', 'assets.id', 'smart_search.assetId')
+      .$call(withDefaultVisibility)
       .$if(!force, (qb) =>
         qb
           .innerJoin('asset_job_status as job_status', 'job_status.assetId', 'assets.id')
@@ -226,7 +227,7 @@ export class AssetJobRepository {
             .select(['asset_stack.id', 'asset_stack.primaryAssetId'])
             .select((eb) => eb.fn<Asset[]>('array_agg', [eb.table('stacked')]).as('assets'))
             .where('stacked.deletedAt', 'is not', null)
-            .where('stacked.visibility', '!=', AssetVisibility.ARCHIVE)
+            .where('stacked.visibility', '=', AssetVisibility.TIMELINE)
             .whereRef('stacked.stackId', '=', 'asset_stack.id')
             .groupBy('asset_stack.id')
             .as('stacked_assets'),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -348,7 +348,6 @@ export class AssetRepository {
       .where('ownerId', '=', asUuid(ownerId))
       .where('deviceId', '=', deviceId)
       .where('deletedAt', 'is', null)
-      .$call(withDefaultVisibility)
       .execute();
 
     return items.map((asset) => asset.deviceAssetId);

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -347,8 +347,8 @@ export class AssetRepository {
       .select(['deviceAssetId'])
       .where('ownerId', '=', asUuid(ownerId))
       .where('deviceId', '=', deviceId)
-      .where('visibility', '!=', AssetVisibility.HIDDEN)
       .where('deletedAt', 'is', null)
+      .$call(withDefaultVisibility)
       .execute();
 
     return items.map((asset) => asset.deviceAssetId);
@@ -523,8 +523,8 @@ export class AssetRepository {
       .selectFrom('assets')
       .selectAll('assets')
       .$call(withExif)
+      .$call(withDefaultVisibility)
       .where('ownerId', '=', anyUuid(userIds))
-      .where('visibility', '!=', AssetVisibility.HIDDEN)
       .where('deletedAt', 'is', null)
       .orderBy((eb) => eb.fn('random'))
       .limit(take)
@@ -709,6 +709,7 @@ export class AssetRepository {
         .with('duplicates', (qb) =>
           qb
             .selectFrom('assets')
+            .$call(withDefaultVisibility)
             .leftJoinLateral(
               (qb) =>
                 qb
@@ -727,7 +728,6 @@ export class AssetRepository {
             .where('assets.duplicateId', 'is not', null)
             .$narrowType<{ duplicateId: NotNull }>()
             .where('assets.deletedAt', 'is', null)
-            .where('assets.visibility', '!=', AssetVisibility.HIDDEN)
             .where('assets.stackId', 'is', null)
             .groupBy('assets.duplicateId'),
         )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -634,8 +634,6 @@ export class AssetRepository {
           )
           .$if(!!options.personId, (qb) => hasPeople(qb, [options.personId!]))
           .$if(!!options.userIds, (qb) => qb.where('assets.ownerId', '=', anyUuid(options.userIds!)))
-          .$if(options.visibility == undefined, withDefaultVisibility)
-          .$if(!!options.visibility, (qb) => qb.where('assets.visibility', '=', options.visibility!))
           .$if(options.isFavorite !== undefined, (qb) => qb.where('assets.isFavorite', '=', options.isFavorite!))
           .$if(!!options.withStacked, (qb) =>
             qb
@@ -656,7 +654,7 @@ export class AssetRepository {
                     .select(sql`array[stacked."stackId"::text, count('stacked')::text]`.as('stack'))
                     .whereRef('stacked.stackId', '=', 'assets.stackId')
                     .where('stacked.deletedAt', 'is', null)
-                    .where('stacked.visibility', '!=', AssetVisibility.ARCHIVE)
+                    .where('stacked.visibility', '=', AssetVisibility.TIMELINE)
                     .groupBy('stacked.stackId')
                     .as('stacked_assets'),
                 (join) => join.onTrue(),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -300,7 +300,6 @@ export class AssetRepository {
       .select(withFacesAndPeople)
       .select(withTags)
       .$call(withExif)
-      .leftJoin('asset_stack', 'asset_stack.id', 'assets.stackId')
       .where('assets.id', '=', anyUuid(ids))
       .execute();
   }

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -347,6 +347,7 @@ export class AssetRepository {
       .select(['deviceAssetId'])
       .where('ownerId', '=', asUuid(ownerId))
       .where('deviceId', '=', deviceId)
+      .where('visibility', '!=', AssetVisibility.HIDDEN)
       .where('deletedAt', 'is', null)
       .execute();
 

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -38,11 +38,6 @@ export interface PersonStatistics {
   assets: number;
 }
 
-export interface PeopleStatistics {
-  total: number;
-  hidden: number;
-}
-
 export interface DeleteFacesOptions {
   sourceType: SourceType;
 }
@@ -151,7 +146,7 @@ export class PersonRepository {
       .innerJoin('assets', (join) =>
         join
           .onRef('asset_faces.assetId', '=', 'assets.id')
-          .on('assets.visibility', '!=', AssetVisibility.ARCHIVE)
+          .on('assets.visibility', '=', sql.lit(AssetVisibility.TIMELINE))
           .on('assets.deletedAt', 'is', null),
       )
       .where('person.ownerId', '=', userId)
@@ -341,7 +336,7 @@ export class PersonRepository {
         join
           .onRef('assets.id', '=', 'asset_faces.assetId')
           .on('asset_faces.personId', '=', personId)
-          .on('assets.visibility', '!=', AssetVisibility.ARCHIVE)
+          .on('assets.visibility', '=', sql.lit(AssetVisibility.TIMELINE))
           .on('assets.deletedAt', 'is', null),
       )
       .select((eb) => eb.fn.count(eb.fn('distinct', ['assets.id'])).as('count'))
@@ -354,35 +349,31 @@ export class PersonRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID] })
-  async getNumberOfPeople(userId: string): Promise<PeopleStatistics> {
-    const items = await this.db
+  getNumberOfPeople(userId: string) {
+    const zero = sql.val(0);
+    return this.db
       .selectFrom('person')
-      .innerJoin('asset_faces', 'asset_faces.personId', 'person.id')
+      .where((eb) =>
+        eb.exists((eb) =>
+          eb
+            .selectFrom('asset_faces')
+            .whereRef('asset_faces.personId', '=', 'person.id')
+            .where('asset_faces.deletedAt', 'is', null)
+            .where((eb) =>
+              eb.exists((eb) =>
+                eb
+                  .selectFrom('assets')
+                  .whereRef('assets.id', '=', 'asset_faces.assetId')
+                  .where('assets.visibility', '=', sql.lit(AssetVisibility.TIMELINE))
+                  .where('assets.deletedAt', 'is', null),
+              ),
+            ),
+        ),
+      )
       .where('person.ownerId', '=', userId)
-      .where('asset_faces.deletedAt', 'is', null)
-      .innerJoin('assets', (join) =>
-        join
-          .onRef('assets.id', '=', 'asset_faces.assetId')
-          .on('assets.deletedAt', 'is', null)
-          .on('assets.visibility', '!=', AssetVisibility.ARCHIVE),
-      )
-      .select((eb) => eb.fn.count(eb.fn('distinct', ['person.id'])).as('total'))
-      .select((eb) =>
-        eb.fn
-          .count(eb.fn('distinct', ['person.id']))
-          .filterWhere('person.isHidden', '=', true)
-          .as('hidden'),
-      )
-      .executeTakeFirst();
-
-    if (items == undefined) {
-      return { total: 0, hidden: 0 };
-    }
-
-    return {
-      total: Number(items.total),
-      hidden: Number(items.hidden),
-    };
+      .select((eb) => eb.fn.coalesce(eb.fn.countAll<number>(), zero).as('total'))
+      .select((eb) => eb.fn.coalesce(eb.fn.countAll<number>().filterWhere('isHidden', '=', true), zero).as('hidden'))
+      .executeTakeFirstOrThrow();
   }
 
   create(person: Insertable<Person>) {

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -350,7 +350,7 @@ export class PersonRepository {
 
   @GenerateSql({ params: [DummyValue.UUID] })
   getNumberOfPeople(userId: string) {
-    const zero = sql.val(0);
+    const zero = sql.lit(0);
     return this.db
       .selectFrom('person')
       .where((eb) =>

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -7,7 +7,7 @@ import { DummyValue, GenerateSql } from 'src/decorators';
 import { MapAsset } from 'src/dtos/asset-response.dto';
 import { AssetStatus, AssetType, AssetVisibility, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
-import { anyUuid, asUuid, searchAssetBuilder } from 'src/utils/database';
+import { anyUuid, asUuid, searchAssetBuilder, withDefaultVisibility } from 'src/utils/database';
 import { paginationHelper } from 'src/utils/pagination';
 import { isValidInteger } from 'src/validation';
 
@@ -268,6 +268,7 @@ export class SearchRepository {
         .with('cte', (qb) =>
           qb
             .selectFrom('assets')
+            .$call(withDefaultVisibility)
             .select([
               'assets.id as assetId',
               'assets.duplicateId',
@@ -276,7 +277,6 @@ export class SearchRepository {
             .innerJoin('smart_search', 'assets.id', 'smart_search.assetId')
             .where('assets.ownerId', '=', anyUuid(userIds))
             .where('assets.deletedAt', 'is', null)
-            .where('assets.visibility', '!=', AssetVisibility.HIDDEN)
             .where('assets.type', '=', type)
             .where('assets.id', '!=', asUuid(assetId))
             .where('assets.stackId', 'is', null)

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -472,7 +472,7 @@ export class SearchRepository {
       .distinctOn(field)
       .innerJoin('assets', 'assets.id', 'exif.assetId')
       .where('ownerId', '=', anyUuid(userIds))
-      .where('visibility', '!=', AssetVisibility.HIDDEN)
+      .where('visibility', '=', AssetVisibility.TIMELINE)
       .where('deletedAt', 'is', null)
       .where(field, 'is not', null);
   }

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -5,7 +5,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { AssetStack, DB } from 'src/db';
 import { DummyValue, GenerateSql } from 'src/decorators';
-import { asUuid } from 'src/utils/database';
+import { asUuid, withDefaultVisibility } from 'src/utils/database';
 
 export interface StackSearch {
   ownerId: string;
@@ -34,7 +34,8 @@ const withAssets = (eb: ExpressionBuilder<DB, 'asset_stack'>, withTags = false) 
       )
       .select((eb) => eb.fn.toJson('exifInfo').as('exifInfo'))
       .where('assets.deletedAt', 'is', null)
-      .whereRef('assets.stackId', '=', 'asset_stack.id'),
+      .whereRef('assets.stackId', '=', 'asset_stack.id')
+      .$call(withDefaultVisibility),
   ).as('assets');
 };
 

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -214,10 +214,10 @@ export class UserRepository {
         join
           .onRef('assets.ownerId', '=', 'users.id')
           .on('assets.deletedAt', 'is', null)
-          .on('assets.visibility', 'in', [sql.lit(AssetVisibility.TIMELINE), sql.lit(AssetVisibility.ARCHIVE)]),
+          .on('assets.visibility', '!=', sql.lit(AssetVisibility.HIDDEN)),
       )
       .leftJoin('exif', 'exif.assetId', 'assets.id')
-      .select(['users.id as userId', 'users.name as userName', 'users.quotaSizeInBytes as quotaSizeInBytes'])
+      .select(['users.id as userId', 'users.name as userName', 'users.quotaSizeInBytes'])
       .select((eb) => [
         eb.fn
           .countAll<number>()
@@ -277,7 +277,6 @@ export class UserRepository {
             .leftJoin('exif', 'exif.assetId', 'assets.id')
             .select((eb) => eb.fn.coalesce(eb.fn.sum<number>('exif.fileSizeInByte'), eb.lit(0)).as('usage'))
             .where('assets.libraryId', 'is', null)
-            .where('assets.visibility', 'in', [sql.lit(AssetVisibility.TIMELINE), sql.lit(AssetVisibility.ARCHIVE)])
             .where('assets.ownerId', '=', eb.ref('users.id')),
         updatedAt: new Date(),
       })

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -221,16 +221,11 @@ export class UserRepository {
       .select((eb) => [
         eb.fn
           .countAll<number>()
-          .filterWhere((eb) =>
-            eb.and([
-              eb('assets.type', '=', sql.lit(AssetType.IMAGE)),
-              eb('assets.visibility', 'in', [sql.lit(AssetVisibility.TIMELINE), sql.lit(AssetVisibility.ARCHIVE)]),
-            ]),
-          )
+          .filterWhere((eb) => eb('assets.type', '=', sql.lit(AssetType.IMAGE)))
           .as('photos'),
         eb.fn
           .countAll<number>()
-          .filterWhere((eb) => eb.and([eb('assets.type', '=', sql.lit(AssetType.VIDEO))]))
+          .filterWhere((eb) => eb('assets.type', '=', sql.lit(AssetType.VIDEO)))
           .as('videos'),
         eb.fn
           .coalesce(eb.fn.sum<number>('exif.fileSizeInByte').filterWhere('assets.libraryId', 'is', null), eb.lit(0))

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -17,13 +17,14 @@ import { AuthDto } from 'src/dtos/auth.dto';
 import { AssetStatus, AssetVisibility, JobName, JobStatus, Permission, QueueName } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
 import { ISidecarWriteJob, JobItem, JobOf } from 'src/types';
+import { requireElevatedPermission } from 'src/utils/access';
 import { getAssetFiles, getMyPartnerIds, onAfterUnlink, onBeforeLink, onBeforeUnlink } from 'src/utils/asset.util';
 
 @Injectable()
 export class AssetService extends BaseService {
   async getStatistics(auth: AuthDto, dto: AssetStatsDto) {
-    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
-      throw new BadRequestException('Locked assets require elevated permissions');
+    if (dto.visibility === AssetVisibility.LOCKED) {
+      requireElevatedPermission(auth);
     }
 
     const stats = await this.assetRepository.getStatistics(auth.user.id, dto);

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -22,6 +22,10 @@ import { getAssetFiles, getMyPartnerIds, onAfterUnlink, onBeforeLink, onBeforeUn
 @Injectable()
 export class AssetService extends BaseService {
   async getStatistics(auth: AuthDto, dto: AssetStatsDto) {
+    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
+      throw new BadRequestException('Locked assets require elevated permissions');
+    }
+
     const stats = await this.assetRepository.getStatistics(auth.user.id, dto);
     return mapStats(stats);
   }

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -14,7 +14,7 @@ import {
   SearchSuggestionType,
   SmartSearchDto,
 } from 'src/dtos/search.dto';
-import { AssetOrder } from 'src/enum';
+import { AssetOrder, AssetVisibility } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
 import { getMyPartnerIds } from 'src/utils/asset.util';
 import { isSmartSearchEnabled } from 'src/utils/misc';
@@ -40,9 +40,11 @@ export class SearchService extends BaseService {
   }
 
   async searchMetadata(auth: AuthDto, dto: MetadataSearchDto): Promise<SearchResponseDto> {
-    let checksum: Buffer | undefined;
-    const userIds = await this.getUserIdsToSearch(auth);
+    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
+      throw new BadRequestException('Locked assets require elevated permissions');
+    }
 
+    let checksum: Buffer | undefined;
     if (dto.checksum) {
       const encoding = dto.checksum.length === 28 ? 'base64' : 'hex';
       checksum = Buffer.from(dto.checksum, encoding);
@@ -50,6 +52,7 @@ export class SearchService extends BaseService {
 
     const page = dto.page ?? 1;
     const size = dto.size || 250;
+    const userIds = await this.getUserIdsToSearch(auth);
     const { hasNextPage, items } = await this.searchRepository.searchMetadata(
       { page, size },
       {
@@ -64,12 +67,20 @@ export class SearchService extends BaseService {
   }
 
   async searchRandom(auth: AuthDto, dto: RandomSearchDto): Promise<AssetResponseDto[]> {
+    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
+      throw new BadRequestException('Locked assets require elevated permissions');
+    }
+
     const userIds = await this.getUserIdsToSearch(auth);
     const items = await this.searchRepository.searchRandom(dto.size || 250, { ...dto, userIds });
     return items.map((item) => mapAsset(item, { auth }));
   }
 
   async searchSmart(auth: AuthDto, dto: SmartSearchDto): Promise<SearchResponseDto> {
+    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
+      throw new BadRequestException('Locked assets require elevated permissions');
+    }
+
     const { machineLearning } = await this.getConfig({ withCache: false });
     if (!isSmartSearchEnabled(machineLearning)) {
       throw new BadRequestException('Smart search is not enabled');

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -16,6 +16,7 @@ import {
 } from 'src/dtos/search.dto';
 import { AssetOrder, AssetVisibility } from 'src/enum';
 import { BaseService } from 'src/services/base.service';
+import { requireElevatedPermission } from 'src/utils/access';
 import { getMyPartnerIds } from 'src/utils/asset.util';
 import { isSmartSearchEnabled } from 'src/utils/misc';
 
@@ -40,8 +41,8 @@ export class SearchService extends BaseService {
   }
 
   async searchMetadata(auth: AuthDto, dto: MetadataSearchDto): Promise<SearchResponseDto> {
-    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
-      throw new BadRequestException('Locked assets require elevated permissions');
+    if (dto.visibility === AssetVisibility.LOCKED) {
+      requireElevatedPermission(auth);
     }
 
     let checksum: Buffer | undefined;
@@ -67,8 +68,8 @@ export class SearchService extends BaseService {
   }
 
   async searchRandom(auth: AuthDto, dto: RandomSearchDto): Promise<AssetResponseDto[]> {
-    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
-      throw new BadRequestException('Locked assets require elevated permissions');
+    if (dto.visibility === AssetVisibility.LOCKED) {
+      requireElevatedPermission(auth);
     }
 
     const userIds = await this.getUserIdsToSearch(auth);
@@ -77,8 +78,8 @@ export class SearchService extends BaseService {
   }
 
   async searchSmart(auth: AuthDto, dto: SmartSearchDto): Promise<SearchResponseDto> {
-    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
-      throw new BadRequestException('Locked assets require elevated permissions');
+    if (dto.visibility === AssetVisibility.LOCKED) {
+      requireElevatedPermission(auth);
     }
 
     const { machineLearning } = await this.getConfig({ withCache: false });

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -4,6 +4,7 @@ import { TimeBucketAssetDto, TimeBucketDto, TimeBucketsResponseDto } from 'src/d
 import { AssetVisibility, Permission } from 'src/enum';
 import { TimeBucketOptions } from 'src/repositories/asset.repository';
 import { BaseService } from 'src/services/base.service';
+import { requireElevatedPermission } from 'src/utils/access';
 import { getMyPartnerIds } from 'src/utils/asset.util';
 
 @Injectable()
@@ -44,8 +45,8 @@ export class TimelineService extends BaseService {
   }
 
   private async timeBucketChecks(auth: AuthDto, dto: TimeBucketDto) {
-    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
-      throw new BadRequestException('Locked assets require elevated permissions');
+    if (dto.visibility === AssetVisibility.LOCKED) {
+      requireElevatedPermission(auth);
     }
 
     if (dto.albumId) {

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -44,6 +44,10 @@ export class TimelineService extends BaseService {
   }
 
   private async timeBucketChecks(auth: AuthDto, dto: TimeBucketDto) {
+    if (dto.visibility === AssetVisibility.LOCKED && !auth.session?.hasElevatedPermission) {
+      throw new BadRequestException('Locked assets require elevated permissions');
+    }
+
     if (dto.albumId) {
       await this.requireAccess({ auth, permission: Permission.ALBUM_READ, ids: [dto.albumId] });
     } else {

--- a/server/src/utils/access.ts
+++ b/server/src/utils/access.ts
@@ -304,3 +304,9 @@ const checkOtherAccess = async (access: AccessRepository, request: OtherAccessRe
     }
   }
 };
+
+export const requireElevatedPermission = (auth: AuthDto) => {
+  if (!auth.session?.hasElevatedPermission) {
+    throw new UnauthorizedException('Elevated permission is required');
+  }
+};

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -156,12 +156,7 @@ export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
 // TODO come up with a better query that only selects the fields we need
 
 export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'assets', O>) {
-  return qb.where((qb) =>
-    qb.or([
-      qb('assets.visibility', '=', AssetVisibility.TIMELINE),
-      qb('assets.visibility', '=', AssetVisibility.ARCHIVE),
-    ]),
-  );
+  return qb.where('assets.visibility', 'in', [sql.lit(AssetVisibility.ARCHIVE), sql.lit(AssetVisibility.TIMELINE)]);
 }
 
 export function withExif<O>(qb: SelectQueryBuilder<DB, 'assets', O>) {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -153,12 +153,12 @@ export function toJson<DB, TB extends keyof DB & string, T extends TB | Expressi
 }
 
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
-// TODO come up with a better query that only selects the fields we need
 
 export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'assets', O>) {
   return qb.where('assets.visibility', 'in', [sql.lit(AssetVisibility.ARCHIVE), sql.lit(AssetVisibility.TIMELINE)]);
 }
 
+// TODO come up with a better query that only selects the fields we need
 export function withExif<O>(qb: SelectQueryBuilder<DB, 'assets', O>) {
   return qb
     .leftJoin('exif', 'assets.id', 'exif.assetId')


### PR DESCRIPTION
## Description

This PR adds a number of filters and checks to avoid including locked asset metadata in the API. I also changed the visibility filters from `or` syntax to `in`. With 2 elements, they perform about the same and `in` is cleaner. Adding more elements would make `in` faster at that point as well.