### PR TITLE
feat(server): log failed healthchecks to server container stderr in verbose mode

### DIFF
--- a/server/bin/immich-healthcheck
+++ b/server/bin/immich-healthcheck
@@ -7,8 +7,8 @@ log_container_verbose() {
 }
 
 if [[ ( $IMMICH_WORKERS_INCLUDE != '' && $IMMICH_WORKERS_INCLUDE != *api* ) || $IMMICH_WORKERS_EXCLUDE == *api* ]]; then
-        echo "API worker excluded, skipping";
-        exit 0;
+  echo "API worker excluded, skipping"
+  exit 0
 fi
 
 IMMICH_HOST="${IMMICH_HOST:-localhost}"
@@ -18,13 +18,13 @@ result=$(curl -fsS -m 2 http://"$IMMICH_HOST":"$IMMICH_PORT"/api/server/ping)
 result_exit=$?
 
 if [ $result_exit != 0 ]; then
-        echo "Fail: exit code is $result_exit";
-        log_container_verbose "Healthcheck failed: exit code $result_exit"
-        exit 1;
+  echo "Fail: exit code is $result_exit"
+  log_container_verbose "Healthcheck failed: exit code $result_exit"
+  exit 1
 fi
 
 if [ "$result" != "{\"res\":\"pong\"}" ]; then
-        echo "Fail: didn't reply with pong";
-        log_container_verbose "Healthcheck failed: didn't reply with pong"
-        exit 1;
+  echo "Fail: didn't reply with pong"
+  log_container_verbose "Healthcheck failed: didn't reply with pong"
+  exit 1
 fi

--- a/server/bin/immich-healthcheck
+++ b/server/bin/immich-healthcheck
@@ -23,7 +23,7 @@ if [ $result_exit != 0 ]; then
   exit 1
 fi
 
-if [ "$result" != "{\"res\":\"pong\"}" ]; then
+if [ "$result" != '{"res":"pong"}' ]; then
   echo "Fail: didn't reply with pong"
   log_container_verbose "Healthcheck failed: didn't reply with pong"
   exit 1

--- a/server/bin/immich-healthcheck
+++ b/server/bin/immich-healthcheck
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+log_container_verbose() {
+  if [[ $IMMICH_LOG_LEVEL == verbose ]]; then
+    echo "$1" > /proc/1/fd/2
+  fi
+}
+
 if [[ ( $IMMICH_WORKERS_INCLUDE != '' && $IMMICH_WORKERS_INCLUDE != *api* ) || $IMMICH_WORKERS_EXCLUDE == *api* ]]; then
         echo "API worker excluded, skipping";
         exit 0;
@@ -13,10 +19,12 @@ result_exit=$?
 
 if [ $result_exit != 0 ]; then
         echo "Fail: exit code is $result_exit";
+        log_container_verbose "Healthcheck failed: exit code $result_exit"
         exit 1;
 fi
 
 if [ "$result" != "{\"res\":\"pong\"}" ]; then
         echo "Fail: didn't reply with pong";
+        log_container_verbose "Healthcheck failed: didn't reply with pong"
         exit 1;
 fi


### PR DESCRIPTION
## Description

Log failed healthchecks to server container stderr when verbose logging is enabled. As suggested in https://github.com/immich-app/immich/issues/18544#issuecomment-2909854135.

This PR adds sending failed health checks to stderr of PID 1, so that they appear in docker logs. (Is there a better way?)
Also some bash formatting included.

The healthcheck logs only appear when IMMICH_LOG_LEVEL is verbose, so hopefully these new logs would not confuse regular users.

## How Has This Been Tested?

Tested with and without `IMMICH_LOG_LEVEL=verbose` env var.

Example log message during server start-up:
```
immich-server    | 2025-05-28T07:42:12.273493172Z Healthcheck failed: exit code 7
```
