### PR TITLE
fix: oauth

### DIFF
--- a/server/src/repositories/oauth.repository.ts
+++ b/server/src/repositories/oauth.repository.ts
@@ -40,8 +40,8 @@ export class OAuthRepository {
       redirect_uri: redirectUrl,
       scope: config.scope,
       state,
-      code_challenge: codeChallenge,
-      code_challenge_method: 'S256',
+      code_challenge: client.serverMetadata().supportsPKCE() ? codeChallenge : '',
+      code_challenge_method: client.serverMetadata().supportsPKCE() ? 'S256' : '',
     }).toString();
     return { url, state, codeVerifier };
   }


### PR DESCRIPTION
# Problem

Entra supports (and encourages) PKCE. It'll use PKCE iff `code_challenge` and `code_challenge_method` are provided during the authorization [1]. *However*, Entra does not have `code_challenge_methods_supported: ["S256"]` in its .well known openid configuration. 
Thus, `client.serverMetadata().supportsPKCE()`, which checks that field, returns false, assuming the provider does not support PKCE. We used to only check that when getting the profile (https://github.com/immich-app/immich/blob/main/server/src/repositories/oauth.repository.ts#L62) and considered that sufficient. Under the assumption that the OIDC provider wouldn't start a PKCE flow if it's not mentioned in the well known config, this holds. 
With Entra however we're now in a PKCE flow, but don't send the code verifier. That caused Entra to yell that the `code_verifier` is not valid. 




The solution is to never even offer a code challenge, if the provider does not explicitly state it supports that. In the case of Entra this isn't ideal, because PKCE *is* the preferred and more secure solution, but I honestly don't care if they're too incompetent to serve a correct openid-configuration.

Fixes #17958


[1] https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code