### PR TITLE
fix(mobile): photo_manager ignore filters

### DIFF
--- a/mobile/lib/repositories/album_media.repository.dart
+++ b/mobile/lib/repositories/album_media.repository.dart
@@ -17,6 +17,30 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
   bool get useCustomFilter =>
       Store.get(StoreKey.photoManagerCustomFilter, false);
 
+  FilterOptionGroup? _getAlbumFilter({
+    DateTimeCond? updateTimeCond,
+    bool? containsPathModified,
+    List<OrderOption>? orderBy,
+  }) =>
+      useCustomFilter
+          ? FilterOptionGroup(
+              imageOption: const FilterOption(
+                needTitle: true,
+                sizeConstraint: SizeConstraint(ignoreSize: true),
+              ),
+              videoOption: const FilterOption(
+                needTitle: true,
+                sizeConstraint: SizeConstraint(ignoreSize: true),
+                durationConstraint: DurationConstraint(allowNullable: true),
+              ),
+              containsPathModified: containsPathModified ?? false,
+              createTimeCond: DateTimeCond.def().copyWith(ignore: true),
+              updateTimeCond:
+                  updateTimeCond ?? DateTimeCond.def().copyWith(ignore: true),
+              orders: orderBy ?? [],
+            )
+          : null;
+
   @override
   Future<List<Album>> getAll() async {
     final filter = useCustomFilter
@@ -30,7 +54,8 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
 
   @override
   Future<List<String>> getAssetIds(String albumId) async {
-    final album = await AssetPathEntity.fromId(albumId);
+    final album =
+        await AssetPathEntity.fromId(albumId, filterOption: _getAlbumFilter());
     final List<AssetEntity> assets =
         await album.getAssetListRange(start: 0, end: 0x7fffffffffffffff);
     return assets.map((e) => e.id).toList();
@@ -38,7 +63,8 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
 
   @override
   Future<int> getAssetCount(String albumId) async {
-    final album = await AssetPathEntity.fromId(albumId);
+    final album =
+        await AssetPathEntity.fromId(albumId, filterOption: _getAlbumFilter());
     return album.assetCountAsync;
   }
 
@@ -53,17 +79,14 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
   }) async {
     final onDevice = await AssetPathEntity.fromId(
       albumId,
-      filterOption: FilterOptionGroup(
-        imageOption: const FilterOption(needTitle: true),
-        videoOption: const FilterOption(needTitle: true),
-        containsPathModified: true,
+      filterOption: _getAlbumFilter(
         updateTimeCond: modifiedFrom == null && modifiedUntil == null
             ? null
             : DateTimeCond(
                 min: modifiedFrom ?? DateTime.utc(-271820),
                 max: modifiedUntil ?? DateTime.utc(275760),
               ),
-        orders: orderByModificationDate
+        orderBy: orderByModificationDate
             ? [const OrderOption(type: OrderOptionType.updateDate)]
             : [],
       ),
@@ -80,7 +103,10 @@ class AlbumMediaRepository implements IAlbumMediaRepository {
     DateTime? modifiedFrom,
     DateTime? modifiedUntil,
   }) async {
-    final assetPathEntity = await AssetPathEntity.fromId(id);
+    final assetPathEntity = await AssetPathEntity.fromId(
+      id,
+      filterOption: _getAlbumFilter(containsPathModified: true),
+    );
     return _toAlbum(assetPathEntity);
   }
 


### PR DESCRIPTION
## Description

- Albums and assets are not properly detected due to the default filters used by `photo_manager`. We already ignore those filters for the getAll local albums call. This extends it to the other methods as well.
 
Note: Since I cannot reproduce this locally, I only ensured that the media files are still being detected with the custom filter setting turned on