### PR TITLE
fix: pinch zoom in mobile app

### DIFF
--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -120,7 +120,6 @@ class PhotoViewCoreState extends State<PhotoViewCore>
         TickerProviderStateMixin,
         PhotoViewControllerDelegate,
         HitCornersDetector {
-  Offset? _normalizedPosition;
   double? _scaleBefore;
   double? _rotationBefore;
 
@@ -153,7 +152,6 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   void onScaleStart(ScaleStartDetails details) {
     _rotationBefore = controller.rotation;
     _scaleBefore = scale;
-    _normalizedPosition = details.focalPoint - controller.position;
     _scaleAnimationController.stop();
     _positionAnimationController.stop();
     _rotationAnimationController.stop();

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -161,15 +161,16 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   void onScaleUpdate(ScaleUpdateDetails details) {
     final double newScale = _scaleBefore! * details.scale;
-    final Offset delta = details.focalPoint - _normalizedPosition!;
+    final double scaleDelta = newScale / scale;
+    final Offset newPosition = controller.position + details.focalPointDelta;
 
     updateScaleStateFromNewScale(newScale);
 
     updateMultiple(
       scale: newScale,
       position: widget.enablePanAlways
-          ? delta
-          : clampPosition(position: delta, scale: details.scale),
+          ? newPosition
+          : clampPosition(position: newPosition * scaleDelta),
       rotation:
           widget.enableRotation ? _rotationBefore! + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -159,8 +159,9 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   void onScaleUpdate(ScaleUpdateDetails details) {
     final centeredFocalPoint = Offset(
-        details.focalPoint.dx - scaleBoundaries.outerSize.width / 2,
-        details.focalPoint.dy - scaleBoundaries.outerSize.height / 2);
+      details.focalPoint.dx - scaleBoundaries.outerSize.width / 2,
+      details.focalPoint.dy - scaleBoundaries.outerSize.height / 2,
+    );
     final double newScale = _scaleBefore! * details.scale;
     final double scaleDelta = newScale / scale;
     final Offset newPosition =

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -160,9 +160,13 @@ class PhotoViewCoreState extends State<PhotoViewCore>
   }
 
   void onScaleUpdate(ScaleUpdateDetails details) {
+    final centeredFocalPoint = Offset(
+        details.focalPoint.dx - scaleBoundaries.outerSize.width/2,
+        details.focalPoint.dy - scaleBoundaries.outerSize.height/2
+    );
     final double newScale = _scaleBefore! * details.scale;
     final double scaleDelta = newScale / scale;
-    final Offset newPosition = controller.position + details.focalPointDelta;
+    final Offset newPosition = (controller.position + details.focalPointDelta) * scaleDelta - centeredFocalPoint * (scaleDelta - 1);
 
     updateScaleStateFromNewScale(newScale);
 
@@ -170,7 +174,7 @@ class PhotoViewCoreState extends State<PhotoViewCore>
       scale: newScale,
       position: widget.enablePanAlways
           ? newPosition
-          : clampPosition(position: newPosition * scaleDelta),
+          : clampPosition(position: newPosition),
       rotation:
           widget.enableRotation ? _rotationBefore! + details.rotation : null,
       rotationFocusPoint: widget.enableRotation ? details.focalPoint : null,

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_core.dart
@@ -159,12 +159,13 @@ class PhotoViewCoreState extends State<PhotoViewCore>
 
   void onScaleUpdate(ScaleUpdateDetails details) {
     final centeredFocalPoint = Offset(
-        details.focalPoint.dx - scaleBoundaries.outerSize.width/2,
-        details.focalPoint.dy - scaleBoundaries.outerSize.height/2
-    );
+        details.focalPoint.dx - scaleBoundaries.outerSize.width / 2,
+        details.focalPoint.dy - scaleBoundaries.outerSize.height / 2);
     final double newScale = _scaleBefore! * details.scale;
     final double scaleDelta = newScale / scale;
-    final Offset newPosition = (controller.position + details.focalPointDelta) * scaleDelta - centeredFocalPoint * (scaleDelta - 1);
+    final Offset newPosition =
+        (controller.position + details.focalPointDelta) * scaleDelta -
+            centeredFocalPoint * (scaleDelta - 1);
 
     updateScaleStateFromNewScale(newScale);
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Unfortunately I think I broke more things than I fixed in #18569, sorry for not testing it enough.

Fixes #18730 "always zooms towards the image center". Now zooms to the `focalPoint`.

I am not sure if or where `widget.enablePanAlways` is `true` or what it should do in that case, but I believe it should only disable the clamping.

`details.focalPoint` is relative to top left of the screen, but `this.position` is relative to the center, which is why I calculate `centeredFocalPoint`. I didn't find any function that would provide this functionality. The closest one was `scaleBoundaries.outerSize.center(origin)` but that one _adds_ half of the size instead of subtracting it.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] see screen recording

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

Screen recording after the changes:

https://github.com/user-attachments/assets/7060e661-5301-4862-a9ec-98011e2e8d9e


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
