### PR TITLE
chore(mobile): add default cast user pref to openapi patching

### DIFF
--- a/mobile/lib/utils/openapi_patching.dart
+++ b/mobile/lib/utils/openapi_patching.dart
@@ -11,6 +11,7 @@ dynamic upgradeDto(dynamic value, String targetType) {
         addDefault(value, 'people', PeopleResponse().toJson());
         addDefault(value, 'tags', TagsResponse().toJson());
         addDefault(value, 'sharedLinks', SharedLinksResponse().toJson());
+        addDefault(value, 'cast', CastResponse().toJson());
       }
       break;
     case 'ServerConfigDto':


### PR DESCRIPTION
## Description

Adds default user preference for Google Cast on mobile

## How Has This Been Tested?

We currently don't use this on mobile since there is no casting support (currently).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
