### PR TITLE
fix(mobile): double swipe

### DIFF
--- a/mobile/lib/pages/common/gallery_viewer.page.dart
+++ b/mobile/lib/pages/common/gallery_viewer.page.dart
@@ -223,7 +223,8 @@ class GalleryViewerPage extends HookConsumerWidget {
         heroAttributes: _getHeroAttributes(asset),
         filterQuality: FilterQuality.high,
         tightMode: true,
-        minScale: PhotoViewComputedScale.contained,
+        initialScale: PhotoViewComputedScale.contained * 0.99,
+        minScale: PhotoViewComputedScale.contained * 0.99,
         errorBuilder: (context, error, stackTrace) => ImmichImage(
           asset,
           fit: BoxFit.contain,
@@ -238,9 +239,9 @@ class GalleryViewerPage extends HookConsumerWidget {
         onDragUpdate: (_, details, __) => handleSwipeUpDown(details),
         heroAttributes: _getHeroAttributes(asset),
         filterQuality: FilterQuality.high,
-        initialScale: 1.0,
+        initialScale: PhotoViewComputedScale.contained * 0.99,
         maxScale: 1.0,
-        minScale: 1.0,
+        minScale: PhotoViewComputedScale.contained * 0.99,
         basePosition: Alignment.center,
         child: SizedBox(
           width: context.width,

--- a/mobile/lib/widgets/photo_view/src/core/photo_view_hit_corners.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_hit_corners.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/widgets.dart';
-
 import 'package:immich_mobile/widgets/photo_view/src/controller/photo_view_controller_delegate.dart'
     show PhotoViewControllerDelegate;
 
@@ -7,7 +6,7 @@ mixin HitCornersDetector on PhotoViewControllerDelegate {
   HitCorners _hitCornersX() {
     final double childWidth = scaleBoundaries.childSize.width * scale;
     final double screenWidth = scaleBoundaries.outerSize.width;
-    if (screenWidth >= childWidth) {
+    if (screenWidth - childWidth > -0.001) {
       return const HitCorners(true, true);
     }
     final x = -position.dx;
@@ -18,7 +17,7 @@ mixin HitCornersDetector on PhotoViewControllerDelegate {
   HitCorners _hitCornersY() {
     final double childHeight = scaleBoundaries.childSize.height * scale;
     final double screenHeight = scaleBoundaries.outerSize.height;
-    if (screenHeight >= childHeight) {
+    if (screenHeight - childHeight > -0.001) {
       return const HitCorners(true, true);
     }
     final y = -position.dy;


### PR DESCRIPTION
### Description

- Fixes gestures not intercepted by `photo_view` due to floating point arithmetic
- Changes are sourced from the workarounds proposed in the `photo_view` repo:
[photo_view#383]( https://github.com/bluefireteam/photo_view/issues/383#issuecomment-863419892)
[photo_view#220](https://github.com/bluefireteam/photo_view/issues/220#issuecomment-955153058)