### PR TITLE
feat: start oauth with `autoLaunch=1`

### DIFF
--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -93,6 +93,7 @@ The `.well-known/openid-configuration` part of the url is optional and will be a
 ## Auto Launch
 
 When Auto Launch is enabled, the login page will automatically redirect the user to the OAuth authorization url, to login with OAuth. To access the login screen again, use the browser's back button, or navigate directly to `/auth/login?autoLaunch=0`.
+Auto Launch can also be enabled on a per-request basis by navigating to `/auth/login?authLaunch=1`, this can be useful in situations where Immich is called from e.g. Nextcloud using the _External sites_ app and the _oidc_ app so as to enable users to directly interact with a logged-in instance of Immich.
 
 ## Mobile Redirect URI
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -269,17 +269,13 @@ export const oauth = {
   isAutoLaunchDisabled: (location: Location) => {
     const values = ['autoLaunch=0', 'password=1', 'password=true'];
     for (const value of values) {
-      if (location.search.includes(value)) {
-        return true;
-      }
+      if (location.search.includes(value)) return true;
     }
     return false;
   },
   isAutoLaunchEnabled: (location: Location) => {
     const value = 'autoLaunch=1';
-    if (location.search.includes(value)) {
-      return true;
-    }
+    if (location.search.includes(value)) return true;
     return false;
   },
   authorize: async (location: Location) => {

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -275,7 +275,7 @@ export const oauth = {
   },
   isAutoLaunchEnabled: (location: Location) => {
     const value = 'autoLaunch=1';
-    return (location.search.includes(value));
+    return location.search.includes(value);
   },
   authorize: async (location: Location) => {
     const $t = get(t);

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -269,7 +269,9 @@ export const oauth = {
   isAutoLaunchDisabled: (location: Location) => {
     const values = ['autoLaunch=0', 'password=1', 'password=true'];
     for (const value of values) {
-      if (location.search.includes(value)) return true;
+      if (location.search.includes(value)) {
+        return true;
+      }
     }
     return false;
   },

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -275,8 +275,7 @@ export const oauth = {
   },
   isAutoLaunchEnabled: (location: Location) => {
     const value = 'autoLaunch=1';
-    if (location.search.includes(value)) return true;
-    return false;
+    return (location.search.includes(value));
   },
   authorize: async (location: Location) => {
     const $t = get(t);

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -275,6 +275,13 @@ export const oauth = {
     }
     return false;
   },
+  isAutoLaunchEnabled: (location: Location) => {
+    const value = 'autoLaunch=1';
+    if (location.search.includes(value)) {
+      return true;
+    }
+    return false;
+  },
   authorize: async (location: Location) => {
     const $t = get(t);
     try {

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -53,7 +53,10 @@
     }
 
     try {
-      if (($featureFlags.oauthAutoLaunch && !oauth.isAutoLaunchDisabled(globalThis.location)) || oauth.isAutoLaunchEnabled(globalThis.location)) {
+      if (
+        ($featureFlags.oauthAutoLaunch && !oauth.isAutoLaunchDisabled(globalThis.location)) ||
+        oauth.isAutoLaunchEnabled(globalThis.location)
+      ) {
         await goto(`${AppRoute.AUTH_LOGIN}?autoLaunch=0`, { replaceState: true });
         await oauth.authorize(globalThis.location);
         return;

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -53,7 +53,7 @@
     }
 
     try {
-      if ($featureFlags.oauthAutoLaunch && !oauth.isAutoLaunchDisabled(globalThis.location)) {
+      if (($featureFlags.oauthAutoLaunch && !oauth.isAutoLaunchDisabled(globalThis.location)) || oauth.isAutoLaunchEnabled(globalThis.location)) {
         await goto(`${AppRoute.AUTH_LOGIN}?autoLaunch=0`, { replaceState: true });
         await oauth.authorize(globalThis.location);
         return;


### PR DESCRIPTION
By launching Immich with `/auth/login?autoLaunch=1` an OpenID Connect login attempt is directly initated on installations where OAuth Auto Launch is not enabled. The intended use for this parameter is to enable Immich to be launched from e.g. Nextcloud using the _External sites_ app and the _oids_ OpenID Connect provider app so as to enable the user to directly interact with Immich without the need to press the `Login with ...` button.

## Description

This PR implements the feature suggested in https://github.com/immich-app/immich/discussions/18751:

It wwould be useful for Immich to have a way to directly access the OAuth login workflow through a URL or parameter (e.g. `autoLaunch=1`, i.e. the opposite of the action mentioned in https://immich.app/docs/administration/oauth#auto-launch).

Here's the use case I'm looking at:

 - Immich is linked into a Nextcloud instance through the 'External sites' app
 - Nextcloud acts as an OpenID Connect server using the OIDC app
 - Immich is configured to use this Nextcloud instance as OAuth provider
 - The web server is configured to allow embedding Immich from the Nextcloud domain
 - When the user activates the configured Immich instance by clicking on the icon in the Nextcloud header the Immich instance directly activates the OAuth login flow without having to press the 'Login with [Nextcloud instance name]' button
 - The user can directly interact with the logged-in Immich instance.

For an example of such a workflow have a look at what e.g. Peertube does when accessed through `https://peertube.example.org/plugins/auth-openid-connect/0.1.3/auth/openid-connect` - it does not show the login page but directly activates the OAuth login workflow, landing the user inside a logged-in instance.

This feature request aims to achieve the opposite of what `featureFlags.oauthAutoLaunch` enables in that it explicitly calls for `autoLaunch` on an instance which does not have this feature enabled instead of always using it with the option to disable it through the use of the `autoLaunch=0` parameter. Adding an option to use `autoLaunch=1` for the requested feature is probably the most clean way to do it, in `./src/routes/auth/login/+page.svelte` (add a check for `oauth.isAutoLaunchEnabled`) and `./src/lib/utils.ts` (add a test for `isAutoLaunchEnabled`)

## How Has This Been Tested?

Tested using in-place edited JS files in the FF inspector for lack of a complete Immich build infrastructure. 

## API Changes

`/auth/login?autoLaunch=1` - initiates OpenID Connect login process without the need for user interaction on systems which do not have OAuth Auto Launch enabled.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have followed naming conventions/patterns in the surrounding code
