### PR TITLE
fix: change `URL` to `Url` in the Obtainium apk links api endpoint

### DIFF
--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -50,12 +50,12 @@ export class ServerService extends BaseService {
   }
 
   getAndroidLinks(): ServerApkLinksDto {
-    const baseURL = `https://github.com/immich-app/immich/releases/download/v${serverVersion.toString()}`;
+    const baseUrl = `https://github.com/immich-app/immich/releases/download/v${serverVersion.toString()}`;
     return {
-      arm64v8a: `${baseURL}/app-arm64-v8a-release.apk`,
-      armeabiv7a: `${baseURL}/app-armeabi-v7a-release.apk`,
-      universal: `${baseURL}/app-release.apk`,
-      x86_64: `${baseURL}/app-x86_64-release.apk`,
+      arm64v8a: `${baseUrl}/app-arm64-v8a-release.apk`,
+      armeabiv7a: `${baseUrl}/app-armeabi-v7a-release.apk`,
+      universal: `${baseUrl}/app-release.apk`,
+      x86_64: `${baseUrl}/app-x86_64-release.apk`,
     };
   }
 


### PR DESCRIPTION
## Description

Realized I did it wrong in #18700.

## API Changes
Nothing external.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have no unrelated changes in the PR.
- [X] I have followed naming conventions/patterns in the surrounding code
