### PR TITLE
fix(mobile): t function localization

### DIFF
--- a/mobile/lib/utils/translation.dart
+++ b/mobile/lib/utils/translation.dart
@@ -5,7 +5,8 @@ String t(String key, [Map<String, Object>? args]) {
   try {
     String message = key.tr();
     if (args != null) {
-      return MessageFormat(message, locale: Intl.defaultLocale!).format(args);
+      return MessageFormat(message, locale: Intl.defaultLocale ?? 'en')
+          .format(args);
     }
     return message;
   } catch (e) {

--- a/mobile/lib/utils/translation.dart
+++ b/mobile/lib/utils/translation.dart
@@ -5,7 +5,7 @@ String t(String key, [Map<String, Object>? args]) {
   try {
     String message = key.tr();
     if (args != null) {
-      return MessageFormat(message).format(args);
+      return MessageFormat(message, locale: Intl.defaultLocale!).format(args);
     }
     return message;
   } catch (e) {


### PR DESCRIPTION
- fixed `t` function to use current language (not always `en` as before)
~- uses weblate `items_count` for items translation instead of obsolete `album_thumbnail_card_item` and `album_thumbnail_card_items`~