### PR TITLE
fix(mobile): center loading spinner in people page

### DIFF
--- a/mobile/lib/pages/library/people/people_collection.page.dart
+++ b/mobile/lib/pages/library/people/people_collection.page.dart
@@ -133,7 +133,7 @@ class PeopleCollectionPage extends HookConsumerWidget {
               );
             },
             error: (error, stack) => const Text("error"),
-            loading: () => const CircularProgressIndicator(),
+            loading: () => const Center(child: CircularProgressIndicator()),
           ),
         );
       },


### PR DESCRIPTION
## Description

Fixes #18761

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img src="https://github.com/user-attachments/assets/307067d4-b465-4844-a62f-ab2c94c5b05f" height=400 />


</details>