### PR TITLE
chore: add google cast feature switch to user admin pane

### DIFF
--- a/web/src/routes/admin/users/[id]/+page.svelte
+++ b/web/src/routes/admin/users/[id]/+page.svelte
@@ -316,6 +316,9 @@
                 <Field readOnly label={$t('tags')}>
                   <Switch checked={userPreferences.tags.enabled} color="primary" />
                 </Field>
+                <Field readOnly label={$t('gcast_enabled')}>
+                  <Switch checked={userPreferences.cast.gCastEnabled} color="primary" />
+                </Field>
               </Stack>
             </div>
           </CardBody>


### PR DESCRIPTION
## Description

Adds a "Google Cast" switch to the user view in the admin pane. This shows the user's current Google Cast setting.

![image](https://github.com/user-attachments/assets/f8e884b1-7b48-4d72-bbde-da54f2e98f2b)

## How Has This Been Tested?

Tested with server admin and regular user.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
