### PR TITLE
fix(web): datetime in storage template example

### DIFF
--- a/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
+++ b/web/src/lib/components/admin-page/settings/storage-template/supported-datetime-panel.svelte
@@ -23,7 +23,7 @@
 <div class="mt-2 rounded-lg bg-gray-200 p-4 text-xs dark:bg-gray-700 dark:text-immich-dark-fg">
   <div class="mb-2 text-gray-600 dark:text-immich-dark-fg">
     <p>{$t('admin.storage_template_date_time_description')}</p>
-    <p>{$t('admin.storage_template_date_time_sample', { values: { date: '2022-02-03T04:56:05.250' } })}</p>
+    <p>{$t('admin.storage_template_date_time_sample', { values: { date: '2022-09-04T20:03:05.250' } })}</p>
   </div>
   <div class="flex gap-[40px]">
     <div>


### PR DESCRIPTION
## Description

Fixes incorrect example in the storage template options
Fixes #18772

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/ad4d3979-eef9-4ec1-ba5a-225f65e53b5c)


</details>
