### PR TITLE
fix(server): rename `android-links` api endpoint to `apk-links` 

### DIFF
--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -184,7 +184,7 @@ Class | Method | HTTP request | Description
 *SearchApi* | [**searchSmart**](doc//SearchApi.md#searchsmart) | **POST** /search/smart | 
 *ServerApi* | [**deleteServerLicense**](doc//ServerApi.md#deleteserverlicense) | **DELETE** /server/license | 
 *ServerApi* | [**getAboutInfo**](doc//ServerApi.md#getaboutinfo) | **GET** /server/about | 
-*ServerApi* | [**getAndroidLinks**](doc//ServerApi.md#getandroidlinks) | **GET** /server/android-links | 
+*ServerApi* | [**getApkLinks**](doc//ServerApi.md#getapklinks) | **GET** /server/apk-links | 
 *ServerApi* | [**getServerConfig**](doc//ServerApi.md#getserverconfig) | **GET** /server/config | 
 *ServerApi* | [**getServerFeatures**](doc//ServerApi.md#getserverfeatures) | **GET** /server/features | 
 *ServerApi* | [**getServerLicense**](doc//ServerApi.md#getserverlicense) | **GET** /server/license | 

--- a/mobile/openapi/lib/api/server_api.dart
+++ b/mobile/openapi/lib/api/server_api.dart
@@ -90,10 +90,10 @@ class ServerApi {
     return null;
   }
 
-  /// Performs an HTTP 'GET /server/android-links' operation and returns the [Response].
-  Future<Response> getAndroidLinksWithHttpInfo() async {
+  /// Performs an HTTP 'GET /server/apk-links' operation and returns the [Response].
+  Future<Response> getApkLinksWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final apiPath = r'/server/android-links';
+    final apiPath = r'/server/apk-links';
 
     // ignore: prefer_final_locals
     Object? postBody;
@@ -116,8 +116,8 @@ class ServerApi {
     );
   }
 
-  Future<ServerApkLinksDto?> getAndroidLinks() async {
-    final response = await getAndroidLinksWithHttpInfo();
+  Future<ServerApkLinksDto?> getApkLinks() async {
+    final response = await getApkLinksWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -5275,9 +5275,9 @@
         ]
       }
     },
-    "/server/android-links": {
+    "/server/apk-links": {
       "get": {
-        "operationId": "getAndroidLinks",
+        "operationId": "getApkLinks",
         "parameters": [],
         "responses": {
           "200": {
@@ -5291,17 +5291,6 @@
             "description": ""
           }
         },
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "cookie": []
-          },
-          {
-            "api_key": []
-          }
-        ],
         "tags": [
           "Server"
         ]

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -5291,6 +5291,17 @@
             "description": ""
           }
         },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
         "tags": [
           "Server"
         ]

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2874,11 +2874,11 @@ export function getAboutInfo(opts?: Oazapfts.RequestOpts) {
         ...opts
     }));
 }
-export function getAndroidLinks(opts?: Oazapfts.RequestOpts) {
+export function getApkLinks(opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: ServerApkLinksDto;
-    }>("/server/android-links", {
+    }>("/server/apk-links", {
         ...opts
     }));
 }

--- a/server/src/controllers/server.controller.ts
+++ b/server/src/controllers/server.controller.ts
@@ -36,6 +36,7 @@ export class ServerController {
   }
 
   @Get('apk-links')
+  @Authenticated()
   getApkLinks(): ServerApkLinksDto {
     return this.service.getApkLinks();
   }

--- a/server/src/controllers/server.controller.ts
+++ b/server/src/controllers/server.controller.ts
@@ -35,10 +35,9 @@ export class ServerController {
     return this.service.getAboutInfo();
   }
 
-  @Get('android-links')
-  @Authenticated()
-  getAndroidLinks(): ServerApkLinksDto {
-    return this.service.getAndroidLinks();
+  @Get('apk-links')
+  getApkLinks(): ServerApkLinksDto {
+    return this.service.getApkLinks();
   }
 
   @Get('storage')

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -49,7 +49,7 @@ export class ServerService extends BaseService {
     };
   }
 
-  getAndroidLinks(): ServerApkLinksDto {
+  getApkLinks(): ServerApkLinksDto {
     const baseUrl = `https://github.com/immich-app/immich/releases/download/v${serverVersion.toString()}`;
     return {
       arm64v8a: `${baseUrl}/app-arm64-v8a-release.apk`,


### PR DESCRIPTION
## Description

I think we decided apk instead of android, but I didn't update that everywhere (oops). I renamed the endpoint and everything involved in it.
Renames the endpoint from #18700
Replaces #18787

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] `make dev`

## API Changes
The `/api/server/android-links` endpoint is now `/api/server/apk-links`.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have no unrelated changes in the PR.
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
