### PR TITLE
fix: `empty_trash` translation in Japanese

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -824,7 +824,7 @@
   "email": "メールアドレス",
   "email_notifications": "Eメール通知",
   "empty_folder": "このフォルダーは空です",
-  "empty_trash": "コミ箱を空にする",
+  "empty_trash": "ゴミ箱を空にする",
   "empty_trash_confirmation": "本当にゴミ箱を空にしますか? これにより、ゴミ箱内のすべてのアセットが Immich から永久に削除されます。\nこの操作を元に戻すことはできません!",
   "enable": "有効化",
   "enable_biometric_auth_description": "生体認証を有効化するために、PINコードを入力してください",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixed miss translation for Japanese.
  - `コミ箱` (lost little dashes) -> `ゴミ箱`

![Screenshot 2025-06-01 at 2 43 28](https://github.com/user-attachments/assets/55c6eeaa-8cd6-4f9a-818c-dcd9f7058e75)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
