### PR TITLE
feat(web): add gray background for images with transparency

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.spec.ts
+++ b/web/src/lib/components/asset-viewer/photo-viewer.spec.ts
@@ -1,7 +1,7 @@
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import PhotoViewer from '$lib/components/asset-viewer/photo-viewer.svelte';
 import * as utils from '$lib/utils';
-import { AssetMediaSize } from '@immich/sdk';
+import {AssetMediaSize, AssetTypeEnum} from '@immich/sdk';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 import { render } from '@testing-library/svelte';
@@ -64,20 +64,23 @@ describe('PhotoViewer component', () => {
     vi.resetAllMocks();
   });
 
-  it('loads the thumbnail', () => {
+  it('loads the thumbnail and original', () => {
     const asset = assetFactory.build({ originalPath: 'image.jpg', originalMimeType: 'image/jpeg' });
     render(PhotoViewer, { asset });
 
+    expect(getAssetOriginalUrlSpy).toBeCalledWith({
+      id: asset.id,
+      cacheKey: asset.thumbhash,
+    });
     expect(getAssetThumbnailUrlSpy).toBeCalledWith({
       id: asset.id,
       size: AssetMediaSize.Preview,
       cacheKey: asset.thumbhash,
     });
-    expect(getAssetOriginalUrlSpy).not.toBeCalled();
   });
 
   it('loads the original image for gifs', () => {
-    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif' });
+    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif', type: AssetTypeEnum.Image });
     render(PhotoViewer, { asset });
 
     expect(getAssetThumbnailUrlSpy).not.toBeCalled();
@@ -85,7 +88,7 @@ describe('PhotoViewer component', () => {
   });
 
   it('loads original for shared link when download permission is true and showMetadata permission is true', () => {
-    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif' });
+    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif', type: AssetTypeEnum.Image });
     const sharedLink = sharedLinkFactory.build({ allowDownload: true, showMetadata: true, assets: [asset] });
     render(PhotoViewer, { asset, sharedLink });
 
@@ -94,7 +97,7 @@ describe('PhotoViewer component', () => {
   });
 
   it('not loads original image when shared link download permission is false', () => {
-    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif' });
+    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif', type: AssetTypeEnum.Image });
     const sharedLink = sharedLinkFactory.build({ allowDownload: false, assets: [asset] });
     render(PhotoViewer, { asset, sharedLink });
 
@@ -108,7 +111,7 @@ describe('PhotoViewer component', () => {
   });
 
   it('not loads original image when shared link showMetadata permission is false', () => {
-    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif' });
+    const asset = assetFactory.build({ originalPath: 'image.gif', originalMimeType: 'image/gif', type: AssetTypeEnum.Image });
     const sharedLink = sharedLinkFactory.build({ showMetadata: false, assets: [asset] });
     render(PhotoViewer, { asset, sharedLink });
 

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -179,11 +179,12 @@
     assetFileUrl = imageLoaderUrl;
     originalImageLoaded = targetImageSize === AssetMediaSize.Fullsize || targetImageSize === 'original';
 
-    if (asset.type !== AssetTypeEnum.Image) {
+    if (!isWebCompatibleImage(asset)) {
       return;
     }
 
-    const fullsizeUrl: string = getAssetUrl(asset.id, AssetMediaSize.Fullsize, asset.thumbhash);
+    const imageSize = asset.originalMimeType === 'image/gif' ? targetImageSize : 'original';
+    const fullsizeUrl: string = getAssetUrl(asset.id, imageSize, asset.thumbhash);
     imageHasTransparency(fullsizeUrl)
       .then((result) => {
         transparentBackgroundRequired = result;

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -269,7 +269,7 @@
         bind:this={$photoViewerImgElement}
         src={assetFileUrl}
         alt={$getAltText(toTimelineAsset(asset))}
-        class="h-full w-full {transparentBackgroundRequired ? 'checkerboard' : ''} {$slideshowState ===
+        class="h-full w-full {transparentBackgroundRequired ? 'bg-gray-300' : ''} {$slideshowState ===
         SlideshowState.None
           ? 'object-contain'
           : slideshowLookCssMapping[$slideshowLook]}"
@@ -299,18 +299,5 @@
   #spinner {
     visibility: hidden;
     animation: 0s linear 0.4s forwards delayedVisibility;
-  }
-
-  .checkerboard {
-    background-color: #ccc;
-    background-image:
-      linear-gradient(45deg, #999 25%, transparent 25%), linear-gradient(-45deg, #999 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #999 75%), linear-gradient(-45deg, transparent 75%, #999 75%);
-    background-size: 20px 20px;
-    background-position:
-      0 0,
-      0 10px,
-      10px -10px,
-      -10px 0px;
   }
 </style>

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -593,3 +593,31 @@ export const copyImageToClipboard = async (source: HTMLImageElement | string) =>
   const blob = source instanceof HTMLImageElement ? await imgToBlob(source) : await urlToBlob(source);
   await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
 };
+
+export const imageHasTransparency = async (assetFileUrl: string): Promise<boolean> => {
+  const source: Blob = await urlToBlob(assetFileUrl);
+  const bitmap: ImageBitmap = await createImageBitmap(source);
+
+  const canvas: HTMLCanvasElement = document.createElement('canvas');
+  const context: CanvasRenderingContext2D | null = canvas.getContext('2d');
+
+  if (!context) {
+    return false;
+  }
+
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+
+  context.drawImage(bitmap, 0, 0);
+
+  const imageData: ImageData = context.getImageData(0, 0, canvas.width, canvas.height);
+  const pixelData: Uint8ClampedArray = imageData.data;
+
+  for (let i: number = 3; i < pixelData.length; i += 4) {
+    if (pixelData[i] < 255) {
+      return true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Description

This change adds a gray background to the `photo-viewer` component if it detects an image that has transparency. It fixes an issue that can occur that makes images with both transparency and black pixels invisible. It also makes these types of images look more inline with what is visible on the `asset-viewer` (as seen in screenshots below).

Fixes #17757

## How Has This Been Tested?

Uploaded a semi-transparent image to my Immich instance, allowed all processing of thumbnails to be done, and then viewed the image int he web photo viewer.

Also tested via going through several hundred other images in my Immich instance, of different file types, sizes, etc

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
## Before
<img width="1380" alt="before" src="https://github.com/user-attachments/assets/02c42067-e0be-4683-9fd9-9614522e2fa5" />

## After
<img width="1496" alt="after" src="https://github.com/user-attachments/assets/052c6088-ec0f-46f9-9051-5ef93aa7437e" />

## Timeline view
<img width="265" alt="timeline view" src="https://github.com/user-attachments/assets/fff06713-e50a-4e32-859d-64bc109ee63a" />


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)