### PR TITLE
fix(mobile): group settings not respected without restart

### DIFF
--- a/mobile/lib/services/app_settings.service.dart
+++ b/mobile/lib/services/app_settings.service.dart
@@ -104,7 +104,7 @@ class AppSettingsService {
     return Store.get(setting.storeKey, setting.defaultValue);
   }
 
-  void setSetting<T>(AppSettingsEnum<T> setting, T value) {
-    Store.put(setting.storeKey, value);
+  Future<void> setSetting<T>(AppSettingsEnum<T> setting, T value) {
+    return Store.put(setting.storeKey, value);
   }
 }

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -1,12 +1,14 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
+import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 import 'package:immich_mobile/widgets/settings/settings_sub_title.dart';
-import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
 
 class GroupSettings extends HookConsumerWidget {
   const GroupSettings({
@@ -18,14 +20,18 @@ class GroupSettings extends HookConsumerWidget {
     final groupByIndex = useAppSettingsState(AppSettingsEnum.groupAssetsBy);
     final groupBy = GroupAssetsBy.values[groupByIndex.value];
 
+    Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
+      await ref.watch(appSettingsServiceProvider).setSetting(
+            AppSettingsEnum.groupAssetsBy,
+            groupBy.index,
+          );
+      ref.invalidate(appSettingsServiceProvider);
+    }
+
     void changeGroupValue(GroupAssetsBy? value) {
       if (value != null) {
         groupByIndex.value = value.index;
-        ref.watch(appSettingsServiceProvider).setSetting(
-              AppSettingsEnum.groupAssetsBy,
-              value.index,
-            );
-        ref.invalidate(appSettingsServiceProvider);
+        unawaited(updateAppSettings(groupBy));
       }
     }
 

--- a/mobile/test/modules/album/album_sort_by_options_provider_test.dart
+++ b/mobile/test/modules/album/album_sort_by_options_provider_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/album.entity.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
-import 'package:immich_mobile/entities/album.entity.dart';
-import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:isar/isar.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -225,6 +225,18 @@ void main() {
           appSettingsServiceProvider.overrideWith((ref) => settingsMock),
         ],
       );
+      when(
+        () => settingsMock.setSetting<bool>(
+          AppSettingsEnum.selectedAlbumSortReverse,
+          any(),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => settingsMock.setSetting<int>(
+          AppSettingsEnum.selectedAlbumSortOrder,
+          any(),
+        ),
+      ).thenAnswer((_) async => {});
     });
 
     test('Returns the default sort mode when none set', () {
@@ -298,6 +310,8 @@ void main() {
     late AppSettingsService settingsMock;
     late ProviderContainer container;
 
+    registerFallbackValue(AppSettingsEnum.selectedAlbumSortReverse);
+
     setUp(() async {
       settingsMock = MockAppSettingsService();
       container = TestUtils.createContainer(
@@ -305,6 +319,18 @@ void main() {
           appSettingsServiceProvider.overrideWith((ref) => settingsMock),
         ],
       );
+      when(
+        () => settingsMock.setSetting<bool>(
+          AppSettingsEnum.selectedAlbumSortReverse,
+          any(),
+        ),
+      ).thenAnswer((_) async => {});
+      when(
+        () => settingsMock.setSetting<int>(
+          AppSettingsEnum.selectedAlbumSortOrder,
+          any(),
+        ),
+      ).thenAnswer((_) async => {});
     });
 
     test('Returns the default sort order when none set - false', () {


### PR DESCRIPTION
### Description

- The App Store uses asynchronous operation for storing / updating a value. However, the other parts of the app assumes the operation to be synchronous leading to subtle issues occurring due to the operations running in out of order. This PR addresses one such case where on random occasions, the grid group settings change is not updated in the store before the timeline is refreshed, resulting in the timeline buckets still being grouped by the old setting.

Possibly fixes #18798

## How Has This Been Tested?

The issue is hard to almost impossible to reproduce on an emulator. I could reproduce this few times on a physical device, but it is not consistent enough to confirm the fix works