### PR TITLE
fix(mobile): Set the currentAsset to the asset clicked when opening an asset from folders

### DIFF
--- a/mobile/lib/pages/library/folder/folder.page.dart
+++ b/mobile/lib/pages/library/folder/folder.page.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/models/folder/recursive_folder.model.dart';
 import 'package:immich_mobile/models/folder/root_folder.model.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
+import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/folder.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/bytes_units.dart';
@@ -219,12 +220,15 @@ class FolderContent extends HookConsumerWidget {
                       list.allAssets!.isNotEmpty)
                     ...list.allAssets!.map(
                       (asset) => LargeLeadingTile(
-                        onTap: () => context.pushRoute(
-                          GalleryViewerRoute(
-                            renderList: list,
-                            initialIndex: list.allAssets!.indexOf(asset),
-                          ),
-                        ),
+                        onTap: () {
+                          ref.read(currentAssetProvider.notifier).set(asset);
+                          context.pushRoute(
+                            GalleryViewerRoute(
+                              renderList: list,
+                              initialIndex: list.allAssets!.indexOf(asset),
+                            ),
+                          );
+                        },
                         leading: ClipRRect(
                           borderRadius: const BorderRadius.all(
                             Radius.circular(15),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Before navigating to the GalleryViewerRoute I'm setting the currentAsset; 
<!--- Why is this change required? What problem does it solve? -->
The GalleryViewPage use the current asset to show controls and many other features; if not set it won't shows controls; if sets from previous image opening; it will have the wrong asset because it keeps in memory the old asset. 
<!--- If it fixes an open issue, please link to the issue here. --> 
Fixes #17691  - it might fix #18067 also

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I've done the scenario from issue multiple times with pictures and videos. 
(scenario: 
- Open the app
- Click on any photo of the timeline
- Press the return button of the smartphone (to get back to the timeline)
- Go to the library tab, scroll down to the folder button and click it
- Open any photo from the folder view (I kept pressing the first entry recursively in the folder view, until it became an asset and not a directory)
- Press the share button
)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [O] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

I'm not very familiar with Dart test; could you tell me if some need to be written for this issue?