### PR TITLE
fix(mobile): notification, dialog that don't translate properly

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -89,18 +89,6 @@ Future<void> initApp() async {
 
   initializeTimeZones();
 
-  FileDownloader().configureNotification(
-    running: TaskNotification(
-      'downloading_media'.tr(),
-      'file: {filename}',
-    ),
-    complete: TaskNotification(
-      'download_finished'.tr(),
-      'file: {filename}',
-    ),
-    progressBar: true,
-  );
-
   await FileDownloader().trackTasksInGroup(
     downloadGroupLivePhoto,
     markDownloadedComplete: false,
@@ -167,10 +155,27 @@ class ImmichAppState extends ConsumerState<ImmichApp>
     await ref.read(localNotificationService).setup();
   }
 
+  void _configureFileDownloaderNotifications() {
+    FileDownloader().configureNotification(
+      running: TaskNotification(
+        'downloading_media'.tr(),
+        '${'file_name'.tr()}: {filename}',
+      ),
+      complete: TaskNotification(
+        'download_finished'.tr(),
+        '${'file_name'.tr()}: {filename}',
+      ),
+      progressBar: true,
+    );
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     Intl.defaultLocale = context.locale.toLanguageTag();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _configureFileDownloaderNotifications();
+    });
   }
 
   @override

--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/providers/asset.provider.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/backup/manual_upload.provider.dart';
+import 'package:immich_mobile/providers/locale_provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -23,7 +24,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    context.locale;
+    ref.watch(localeProvider);
     BackUpState backupState = ref.watch(backupProvider);
     final theme = context.themeData;
     bool isHorizontal = !context.isMobile;

--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -23,6 +23,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    context.locale;
     BackUpState backupState = ref.watch(backupProvider);
     final theme = context.themeData;
     bool isHorizontal = !context.isMobile;

--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/models/server_info/server_info.model.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:immich_mobile/providers/locale_provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -16,7 +17,7 @@ class AppBarServerInfo extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    context.locale;
+    ref.watch(localeProvider);
     ServerInfo serverInfoState = ref.watch(serverInfoProvider);
 
     final appInfo = useState({});

--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
@@ -16,6 +16,7 @@ class AppBarServerInfo extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    context.locale;
     ServerInfo serverInfoState = ref.watch(serverInfoProvider);
 
     final appInfo = useState({});


### PR DESCRIPTION
## Description

This update addresses two localization problems:

Download Notifications: Translated strings were not being applied, resulting in notifications always showing English text even when a different language was selected.

Dialogs: The dialogs did not update to reflect the new language when the user changed the language settings.

These changes ensure that both download notifications and dialogs now use the current locale and display the correct translations.

## How Has This Been Tested?

Enable download notifications and test by downloading an image to verify that the notification appears in the selected language.


<summary><h2>Screenshots (if appropriate)</h2></summary>

| Before Edit | After Edit |
| ----------- | ---------- |
| <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/89862334/449713169-aeaf479a-deca-42a6-9245-7b5bbfc2c5e5.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20250601%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250601T072122Z&X-Amz-Expires=300&X-Amz-Signature=3d7cfe225c18d5a74a00f9d69a6172fe4c0368a7da1b6cbbb352b371a4be36b2&X-Amz-SignedHeaders=host" alt="Before Edit" width="400"/> | <img src="https://github.com/user-attachments/assets/d6937451-9f92-470c-b486-b340e43a5b4e" alt="After Edit" width="400"/> |


<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
