### PR TITLE
fix(mobile): download notification not localized

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -88,25 +88,6 @@ Future<void> initApp() async {
   };
 
   initializeTimeZones();
-
-  FileDownloader().configureNotification(
-    running: TaskNotification(
-      'downloading_media'.tr(),
-      'file: {filename}',
-    ),
-    complete: TaskNotification(
-      'download_finished'.tr(),
-      'file: {filename}',
-    ),
-    progressBar: true,
-  );
-
-  await FileDownloader().trackTasksInGroup(
-    downloadGroupLivePhoto,
-    markDownloadedComplete: false,
-  );
-
-  await FileDownloader().trackTasks();
 }
 
 class ImmichApp extends ConsumerStatefulWidget {
@@ -146,6 +127,27 @@ class ImmichAppState extends ConsumerState<ImmichApp>
 
   Future<void> initApp() async {
     WidgetsBinding.instance.addObserver(this);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      FileDownloader().configureNotification(
+        running: TaskNotification(
+          'downloading_media'.tr(),
+          'file: {filename}',
+        ),
+        complete: TaskNotification(
+          'download_finished'.tr(),
+          'file: {filename}',
+        ),
+        progressBar: true,
+      );
+
+      await FileDownloader().trackTasksInGroup(
+        downloadGroupLivePhoto,
+        markDownloadedComplete: false,
+      );
+
+      await FileDownloader().trackTasks();
+    });
 
     // Draw the app from edge to edge
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);


### PR DESCRIPTION
## Description
After switching to Weblate for mobile app translations, the file download notifications broke and were showing downloading_media and finished_downloading instead of the localized string, as the context wasn't available before building it so `.tr()` would not do anything. 

This PR fixes this issue, and now the notifications are properly translated.

## How Has This Been Tested?

- [x] Download a file, the notification while downloading will be translated
- [x] Once it is done downloading, the "done message" will also be translated

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
 
<img src="https://github.com/user-attachments/assets/ae7f36ac-4f4e-4eca-a951-c963ec279892" height=400 />

</details>

### Note
There is still a little issue where if you switch the language while in the app, the notification localization will not change until next app launch.