### PR TITLE
feat: add --json-output option to upload command

### DIFF
--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -43,6 +43,7 @@ export interface UploadOptionsDto {
   concurrency: number;
   progress?: boolean;
   watch?: boolean;
+  jsonOutput?: boolean;
 }
 
 class UploadFile extends File {
@@ -65,6 +66,9 @@ class UploadFile extends File {
 const uploadBatch = async (files: string[], options: UploadOptionsDto) => {
   const { newFiles, duplicates } = await checkForDuplicates(files, options);
   const newAssets = await uploadFiles(newFiles, options);
+  if (options.jsonOutput) {
+    console.log(JSON.stringify({ newFiles, duplicates, newAssets }, undefined, 4));
+  }
   await updateAlbums([...newAssets, ...duplicates], options);
   await deleteFiles(newFiles, options);
 };

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -68,6 +68,11 @@ program
       .env('IMMICH_UPLOAD_CONCURRENCY')
       .default(4),
   )
+  .addOption(
+    new Option('-j, --json-output', 'Output detailed information in json format')
+      .env('IMMICH_JSON_OUTPUT')
+      .default(false),
+  )
   .addOption(new Option('--delete', 'Delete local assets after upload').env('IMMICH_DELETE_ASSETS'))
   .addOption(new Option('--no-progress', 'Hide progress bars').env('IMMICH_PROGRESS_BAR').default(true))
   .addOption(

--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -90,19 +90,21 @@ Usage: immich upload [paths...] [options]
 Upload assets
 
 Arguments:
-paths                       One or more paths to assets to be uploaded
+  paths                       One or more paths to assets to be uploaded
 
 Options:
--r, --recursive             Recursive (default: false, env: IMMICH_RECURSIVE)
--i, --ignore [paths...]     Paths to ignore (default: [], env: IMMICH_IGNORE_PATHS)
--h, --skip-hash             Don't hash files before upload (default: false, env: IMMICH_SKIP_HASH)
--H, --include-hidden        Include hidden folders (default: false, env: IMMICH_INCLUDE_HIDDEN)
--a, --album                 Automatically create albums based on folder name (default: false, env: IMMICH_AUTO_CREATE_ALBUM)
--A, --album-name <name>     Add all assets to specified album (env: IMMICH_ALBUM_NAME)
--n, --dry-run               Don't perform any actions, just show what will be done (default: false, env: IMMICH_DRY_RUN)
--c, --concurrency <number>  Number of assets to upload at the same time (default: 4, env: IMMICH_UPLOAD_CONCURRENCY)
---delete                    Delete local assets after upload (env: IMMICH_DELETE_ASSETS)
---help                      display help for command
+  -r, --recursive             Recursive (default: false, env: IMMICH_RECURSIVE)
+  -i, --ignore <pattern>      Pattern to ignore (env: IMMICH_IGNORE_PATHS)
+  -h, --skip-hash             Don't hash files before upload (default: false, env: IMMICH_SKIP_HASH)
+  -H, --include-hidden        Include hidden folders (default: false, env: IMMICH_INCLUDE_HIDDEN)
+  -a, --album                 Automatically create albums based on folder name (default: false, env: IMMICH_AUTO_CREATE_ALBUM)
+  -A, --album-name <name>     Add all assets to specified album (env: IMMICH_ALBUM_NAME)
+  -n, --dry-run               Don't perform any actions, just show what will be done (default: false, env: IMMICH_DRY_RUN)
+  -c, --concurrency <number>  Number of assets to upload at the same time (default: 4, env: IMMICH_UPLOAD_CONCURRENCY)
+  --delete                    Delete local assets after upload (env: IMMICH_DELETE_ASSETS)
+  --no-progress               Hide progress bars (env: IMMICH_PROGRESS_BAR)
+  --watch                     Watch for changes and upload automatically (default: false, env: IMMICH_WATCH_CHANGES)
+  --help                      display help for command
 ```
 
 </details>

--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -101,6 +101,7 @@ Options:
   -A, --album-name <name>     Add all assets to specified album (env: IMMICH_ALBUM_NAME)
   -n, --dry-run               Don't perform any actions, just show what will be done (default: false, env: IMMICH_DRY_RUN)
   -c, --concurrency <number>  Number of assets to upload at the same time (default: 4, env: IMMICH_UPLOAD_CONCURRENCY)
+  -j, --json-output           Output detailed information in json format (default: false, env: IMMICH_JSON_OUTPUT)
   --delete                    Delete local assets after upload (env: IMMICH_DELETE_ASSETS)
   --no-progress               Hide progress bars (env: IMMICH_PROGRESS_BAR)
   --watch                     Watch for changes and upload automatically (default: false, env: IMMICH_WATCH_CHANGES)
@@ -172,6 +173,16 @@ By default, hidden files are skipped. If you want to include hidden files, use t
 
 ```bash
 immich upload --include-hidden --recursive directory/
+```
+
+You can use the `--json-output` option to get a json printed which includes
+three keys: `newFiles`, `duplicates` and `newAssets`. Due to some logging
+output you will need to strip the first three lines of output to get the json.
+For example to get a list of files that would be uploaded for further
+processing:
+
+```bash
+immich upload --dry-run . | tail -n +4 | jq .newFiles[]
 ```
 
 ### Obtain the API Key


### PR DESCRIPTION
## fix(docs): update the cli upload usage

The cli upload usage is missing some options compared to what is the current
output of `immich upload --help`. Update the docs accordingly.

## feat(cli): add --json-output option to upload command

Add an option that allows retrieving per-file information about the
upload process. The output includes the newFiles, duplicates and
newAssets lists, but could accommodate more information later if needed.

One use case this allows for is using --dry-run to get a list of all the
files that would be uploaded, and checking them manually before an
upload. This can be particularly useful when a curated subset of images
have already been uploaded to immich and we want to double check for
some stragglers without uploading everything to immich.

The upload command has a few lines of logging, so to get an actually
parsable json one needs to strip those lines:

```
immich upload --dry-run * | tail -n +4 | jq .newFiles[]
```
## How Has This Been Tested?

Tested locally. Since it's essentially adding a console.log and an option to
print it or not, reproducing it should only need to involve building the CLI
and running `immich upload --dry-run -j .` and `immich upload --dry-run` and
observing the new output or the lack of it.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] ~~I have written tests for new code (if applicable)~~
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~
- [ ] ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~

