### PR TITLE
feat(mobile): Proposition to improve delete

### DIFF
--- a/mobile/lib/widgets/asset_grid/multiselect_grid.dart
+++ b/mobile/lib/widgets/asset_grid/multiselect_grid.dart
@@ -472,6 +472,11 @@ class MultiselectGrid extends HookConsumerWidget {
               onShare: onShareAssets,
               onFavorite: favoriteEnabled ? onFavoriteAssets : null,
               onArchive: archiveEnabled ? onArchiveAsset : null,
+
+              // PROPOSITION
+              // As in the gallery viewer, we should ask for a confirmation before deleting anything
+              // As in google photos, only a "move to trash" button should be necessary
+
               onDelete: deleteEnabled ? onDelete : null,
               onDeleteServer: deleteEnabled ? onDeleteRemote : null,
 

--- a/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
+++ b/mobile/lib/widgets/asset_viewer/bottom_gallery_bar.dart
@@ -105,6 +105,11 @@ class BottomGalleryBar extends ConsumerWidget {
         return isDeleted;
       }
 
+      // PROPOSITION
+      // Before trashing anything; ask for a confirmation (Same as in google photos)
+      // Rename that to "Trash" instead of "Delete"
+      // This galery view bar is also used on "Trashed item" in my opinion it should, why would you want to edit a trashed item; in google photos only two choice - restore or delete
+
       // Asset is trashed
       if (isTrashEnabled && !isFromTrash) {
         final isDeleted = await onDelete(false);


### PR DESCRIPTION
## Description

After seeing an issue about the delete ( #18200 ) I look a bit deeper into the delete into Immich mobile app and it seems that there is some inconsistency a bit everywhere. 

### 1. Multiple select 


#### When image is on the server and locally

<img width="288" alt="image" src="https://github.com/user-attachments/assets/d8c1f38c-4310-4768-95f7-16629d4e0f1b" />

Here we can "Delete", "Move to Trash" and "Delete from Device"

- Delete remove from Server + ask to remove locally
- Move to Trash remove from server only
- Delete from Device ask to remove locally only

#### When image is on the server only

<img width="351" alt="image" src="https://github.com/user-attachments/assets/76f0c605-0718-484e-866b-1ea198033c6e" />

We can only "Move to trash"

## Proposition

- Rename "Delete" to "Move to Trash" and remove all the other options. 
- Modify delete to first ask for a confirmation (Currently it directly delete the picture without confirmation) (same behavior as in google photos image below) 

<img width="290" alt="image" src="https://github.com/user-attachments/assets/ad884ba4-b5a2-46ee-83d2-26f3df2c5c2e" />


### 2. Galery View

The Gallery view has only one option which is Delete; It has the correct behavior that I want to implement in the multi selection.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/04c9970c-cb4e-4589-9a03-765ccbef3d01" />


## Proposition

- Rename "Delete" to "Move to Trash" 
- Ask for a confirmation before any deletion. 

### 3. Trash item - Gallery View 
Opening a picture in the trash open the Gallery View where I think it should open something similar to the multi select of items in the trash (Why would you edit or favorite a picture in the trash ?) (see screnshot on the right) (again same behavior in google photos)

<img width="946" alt="image" src="https://github.com/user-attachments/assets/25cce50c-68f9-42e4-ad70-b610bab10fc7" />

### 4. Trash page, three dots, empty trash
Emptying the trash will remove the assets from Immich Trash but not ask to delete local files while selecting multiples photos from the trash and then selection action Delete will ask for permission to delete too

(found in issue #17979)


It's an open discussion; if you think it's necessary please let me know I'll implement the changes. If I forgot something or didn't think of something let me know too :) 
