### PR TITLE
fix(mobile): Showing videos of partner in search page quick links

### DIFF
--- a/mobile/lib/interfaces/timeline.interface.dart
+++ b/mobile/lib/interfaces/timeline.interface.dart
@@ -14,7 +14,7 @@ abstract class ITimelineRepository {
     Album album,
     GroupAssetsBy groupAssetsBy,
   );
-  Stream<RenderList> watchAllVideosTimeline();
+  Stream<RenderList> watchAllVideosTimeline(String userId);
 
   Stream<RenderList> watchHomeTimeline(
     String userId,

--- a/mobile/lib/repositories/timeline.repository.dart
+++ b/mobile/lib/repositories/timeline.repository.dart
@@ -98,8 +98,10 @@ class TimelineRepository extends DatabaseRepository
   }
 
   @override
-  Stream<RenderList> watchAllVideosTimeline() {
+  Stream<RenderList> watchAllVideosTimeline(String userId) {
     final query = db.assets
+        .where()
+        .ownerIdEqualToAnyChecksum(fastHash(userId))
         .filter()
         .isTrashedEqualTo(false)
         .visibilityEqualTo(AssetVisibilityEnum.timeline)

--- a/mobile/lib/services/timeline.service.dart
+++ b/mobile/lib/services/timeline.service.dart
@@ -75,7 +75,9 @@ class TimelineService {
   }
 
   Stream<RenderList> watchAllVideosTimeline() {
-    return _timelineRepository.watchAllVideosTimeline();
+    final user = _userService.getMyUser();
+
+    return _timelineRepository.watchAllVideosTimeline(user.id);
   }
 
   Future<RenderList> getTimelineFromAssets(


### PR DESCRIPTION
## Description

Fix issue #18628

I've modified the timeline interface to accept a user Id then modify the timeline repository to check on the user id. 
I took the user id in the service which pass down to the repository. 

I copy the same behavior than for Favorite but adapted for videos

```dart
@override
  Stream<RenderList> watchFavoriteTimeline(String userId) {
    final query = db.assets
        .where()
        .ownerIdEqualToAnyChecksum(fastHash(userId))
        .filter()
        .isFavoriteEqualTo(true)
        .not()
        .visibilityEqualTo(AssetVisibilityEnum.locked)
        .isTrashedEqualTo(false)
        .sortByFileCreatedAtDesc();

    return _watchRenderList(query, GroupAssetsBy.none);
  }
  ```


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create an account with one video
- Create another account with one video
- Make them partners
- Check if the videos of partner 2 in the quick links  (NO)
- Check if videos of the owner is in the quick links (YES)

<details><summary><h2>Screenshots / Videos</h2></summary>

Here is a video of the working state of the PR

https://github.com/user-attachments/assets/d68c8787-b232-41db-a293-49fbe1570873

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
