### PR TITLE
fix(web): asset-viewer error when selecting a stacked asset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "immich",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "immich",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -569,6 +569,7 @@
               asset={toTimelineAsset(stackedAsset)}
               onClick={() => {
                 asset = stackedAsset;
+                previewStackedAsset = undefined;
               }}
               onMouseEvent={({ isMouseOver }) => handleStackedAssetMouseEvent(isMouseOver, stackedAsset)}
               readonly


### PR DESCRIPTION
## Description

Fixes error where previewStackedAsset is not correctly set when clicking one of the stacked assets at the bottom of the asset view. Fix sets previewStackedAsset to undefined to avoid the error.

Fixes: unknown, could not find existing issue.

## How Has This Been Tested?

Opening a stack and clicking one of the other assets. Previously, photo viewer would then go blank on stackedAsset mouse-over, or click. Now, the photo viewer continues to display updates as expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
