### PR TITLE
fix(mobile): reset current asset if we try to go on a activity list page

### DIFF
--- a/mobile/lib/pages/album/album_viewer.dart
+++ b/mobile/lib/pages/album/album_viewer.dart
@@ -14,6 +14,7 @@ import 'package:immich_mobile/pages/album/album_shared_user_icons.dart';
 import 'package:immich_mobile/pages/album/album_title.dart';
 import 'package:immich_mobile/providers/album/album.provider.dart';
 import 'package:immich_mobile/providers/album/current_album.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/timeline.provider.dart';
 import 'package:immich_mobile/utils/immich_loading_overlay.dart';
 import 'package:immich_mobile/providers/multiselect.provider.dart';
@@ -93,6 +94,7 @@ class AlbumViewer extends HookConsumerWidget {
 
     onActivitiesPressed() {
       if (album.remoteId != null) {
+        ref.read(currentAssetProvider.notifier).set(null);
         context.pushRoute(
           const ActivitiesRoute(),
         );


### PR DESCRIPTION
## Description
When you navigate to an asset and then try to open the "Album" comment; it will shows you the comment of the asset and not the comments of the album.

To fix the issue, I had to set to null the currentAsset when we navigate to the general activity screen so it can perform a request without a specific asset (they use the same page under the hood). 

Fixes #16134

## How Has This Been Tested?

- Go on an Album that is shared and have comments
- Navigate to the general activity section, see all the comments of the album
- Navigate to an asset
- See all the comment for that particular asset
- Come back to the general activity section and see all the comments of the album again

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="877" alt="image" src="https://github.com/user-attachments/assets/abc8cd95-fa3e-401b-ab99-43ffb9372fe1" />

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
