### PR TITLE
fix(web): add tag button not using translation

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
@@ -70,7 +70,9 @@
         title="Add tag"
         onclick={handleAddTag}
       >
-        <span class="text-sm px-1 flex place-items-center place-content-center gap-1"><Icon path={mdiPlus} />{$t('add')}</span>
+        <span class="text-sm px-1 flex place-items-center place-content-center gap-1"
+          ><Icon path={mdiPlus} />{$t('add')}</span
+        >
       </button>
     </section>
   </section>

--- a/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-tags.svelte
@@ -70,7 +70,7 @@
         title="Add tag"
         onclick={handleAddTag}
       >
-        <span class="text-sm px-1 flex place-items-center place-content-center gap-1"><Icon path={mdiPlus} />Add</span>
+        <span class="text-sm px-1 flex place-items-center place-content-center gap-1"><Icon path={mdiPlus} />{$t('add')}</span>
       </button>
     </section>
   </section>


### PR DESCRIPTION
## Description

Make the add tag button use translations instead of hardcoded "Add"

Fixes n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
