### PR TITLE
fix(mobile): prevent upload intent replacement in splash screen and reset upload button when minimize app

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -72,7 +72,9 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
       return;
     }
 
-    context.replaceRoute(const TabControllerRoute());
+    if (context.router.current.name != ShareIntentRoute.name) {
+      context.replaceRoute(const TabControllerRoute());
+    }
 
     final hasPermission =
         await ref.read(galleryPermissionNotifier.notifier).hasPermission;

--- a/mobile/lib/pages/share_intent/share_intent.page.dart
+++ b/mobile/lib/pages/share_intent/share_intent.page.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/upload/share_intent_attachment.model.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/providers/asset_viewer/share_intent_upload.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 
 @RoutePage()
@@ -20,6 +21,11 @@ class ShareIntentPage extends HookConsumerWidget {
     final currentEndpoint = getServerUrl() ?? '--';
     final candidates = ref.watch(shareIntentUploadProvider);
     final isUploaded = useState(false);
+    useOnAppLifecycleStateChange((previous, current) {
+      if (current == AppLifecycleState.resumed) {
+        isUploaded.value = false;
+      }
+    });
 
     void removeAttachment(ShareIntentAttachment attachment) {
       ref.read(shareIntentUploadProvider.notifier).removeAttachment(attachment);
@@ -65,6 +71,14 @@ class ShareIntentPage extends HookConsumerWidget {
               ),
             ),
           ],
+        ),
+        leading: IconButton(
+          onPressed: () {
+            context.navigateTo(
+              const TabControllerRoute(),
+            );
+          },
+          icon: const Icon(Icons.arrow_back),
         ),
       ),
       body: ListView.builder(


### PR DESCRIPTION
## Description

-- Issue 1 
When the app is closed and we want to share a picture to immich (via share intent) the app open, it shows the share intent but then navigate directly to the timeline. 

This is not happening when the app is already open. 

Issue were because in the Splashscreen logic code we were navigating always to the Timelime; I've added a check to not push the timeline route if we are on the share intent.

**There is a kind of new logic here, now, when we go back from a share intent it will always go to the timeline as before if the app was open, it would go back which could have been on a picture for example**

-- Issue 2
When we upload a file via the share intent, minimize the app and upload another file, the upload button was disabled

The issue was caused because the share intent window is not rebuilt, I've added a lifecycle check to reset the upload button state on resume. 


Fixes #18771

## How Has This Been Tested?

- Close the app
- Share a picture to Immich
- Page should be present; and can upload
- On back, it should go to timeline

- Close the app
- Share a picture to immich
- Upload and minimize the app
- Select an new picture to upload
- Upload button is blue (in a uploading state possible)
- Click and the picture should be uploaded

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
