### PR TITLE
chore: add missing api properties on sync enums

### DIFF
--- a/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/infrastructure/entities/remote_asset.entity.drift.
 import 'package:immich_mobile/infrastructure/entities/user.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:logging/logging.dart';
+import 'package:openapi/api.dart' as api show AssetVisibility;
 import 'package:openapi/api.dart' hide AssetVisibility;
 
 class DriftSyncStreamRepository extends DriftDatabaseRepository
@@ -231,22 +232,22 @@ class DriftSyncStreamRepository extends DriftDatabaseRepository
       });
 }
 
-extension on SyncAssetV1TypeEnum {
+extension on AssetTypeEnum {
   AssetType toAssetType() => switch (this) {
-        SyncAssetV1TypeEnum.IMAGE => AssetType.image,
-        SyncAssetV1TypeEnum.VIDEO => AssetType.video,
-        SyncAssetV1TypeEnum.AUDIO => AssetType.audio,
-        SyncAssetV1TypeEnum.OTHER => AssetType.other,
-        _ => throw Exception('Unknown SyncAssetV1TypeEnum value: $this'),
+        AssetTypeEnum.IMAGE => AssetType.image,
+        AssetTypeEnum.VIDEO => AssetType.video,
+        AssetTypeEnum.AUDIO => AssetType.audio,
+        AssetTypeEnum.OTHER => AssetType.other,
+        _ => throw Exception('Unknown AssetType value: $this'),
       };
 }
 
-extension on SyncAssetV1VisibilityEnum {
+extension on api.AssetVisibility {
   AssetVisibility toAssetVisibility() => switch (this) {
-        SyncAssetV1VisibilityEnum.timeline => AssetVisibility.timeline,
-        SyncAssetV1VisibilityEnum.hidden => AssetVisibility.hidden,
-        SyncAssetV1VisibilityEnum.archive => AssetVisibility.archive,
-        SyncAssetV1VisibilityEnum.locked => AssetVisibility.locked,
-        _ => throw Exception('Unknown SyncAssetV1VisibilityEnum value: $this'),
+        api.AssetVisibility.timeline => AssetVisibility.timeline,
+        api.AssetVisibility.hidden => AssetVisibility.hidden,
+        api.AssetVisibility.archive => AssetVisibility.archive,
+        api.AssetVisibility.locked => AssetVisibility.locked,
+        _ => throw Exception('Unknown AssetVisibility value: $this'),
       };
 }

--- a/mobile/openapi/lib/model/sync_album_user_v1.dart
+++ b/mobile/openapi/lib/model/sync_album_user_v1.dart
@@ -20,7 +20,7 @@ class SyncAlbumUserV1 {
 
   String albumId;
 
-  SyncAlbumUserV1RoleEnum role;
+  AlbumUserRole role;
 
   String userId;
 
@@ -58,7 +58,7 @@ class SyncAlbumUserV1 {
 
       return SyncAlbumUserV1(
         albumId: mapValueOfType<String>(json, r'albumId')!,
-        role: SyncAlbumUserV1RoleEnum.fromJson(json[r'role'])!,
+        role: AlbumUserRole.fromJson(json[r'role'])!,
         userId: mapValueOfType<String>(json, r'userId')!,
       );
     }
@@ -112,78 +112,4 @@ class SyncAlbumUserV1 {
     'userId',
   };
 }
-
-
-class SyncAlbumUserV1RoleEnum {
-  /// Instantiate a new enum with the provided [value].
-  const SyncAlbumUserV1RoleEnum._(this.value);
-
-  /// The underlying value of this enum member.
-  final String value;
-
-  @override
-  String toString() => value;
-
-  String toJson() => value;
-
-  static const editor = SyncAlbumUserV1RoleEnum._(r'editor');
-  static const viewer = SyncAlbumUserV1RoleEnum._(r'viewer');
-
-  /// List of all possible values in this [enum][SyncAlbumUserV1RoleEnum].
-  static const values = <SyncAlbumUserV1RoleEnum>[
-    editor,
-    viewer,
-  ];
-
-  static SyncAlbumUserV1RoleEnum? fromJson(dynamic value) => SyncAlbumUserV1RoleEnumTypeTransformer().decode(value);
-
-  static List<SyncAlbumUserV1RoleEnum> listFromJson(dynamic json, {bool growable = false,}) {
-    final result = <SyncAlbumUserV1RoleEnum>[];
-    if (json is List && json.isNotEmpty) {
-      for (final row in json) {
-        final value = SyncAlbumUserV1RoleEnum.fromJson(row);
-        if (value != null) {
-          result.add(value);
-        }
-      }
-    }
-    return result.toList(growable: growable);
-  }
-}
-
-/// Transformation class that can [encode] an instance of [SyncAlbumUserV1RoleEnum] to String,
-/// and [decode] dynamic data back to [SyncAlbumUserV1RoleEnum].
-class SyncAlbumUserV1RoleEnumTypeTransformer {
-  factory SyncAlbumUserV1RoleEnumTypeTransformer() => _instance ??= const SyncAlbumUserV1RoleEnumTypeTransformer._();
-
-  const SyncAlbumUserV1RoleEnumTypeTransformer._();
-
-  String encode(SyncAlbumUserV1RoleEnum data) => data.value;
-
-  /// Decodes a [dynamic value][data] to a SyncAlbumUserV1RoleEnum.
-  ///
-  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
-  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
-  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
-  ///
-  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
-  /// and users are still using an old app with the old code.
-  SyncAlbumUserV1RoleEnum? decode(dynamic data, {bool allowNull = true}) {
-    if (data != null) {
-      switch (data) {
-        case r'editor': return SyncAlbumUserV1RoleEnum.editor;
-        case r'viewer': return SyncAlbumUserV1RoleEnum.viewer;
-        default:
-          if (!allowNull) {
-            throw ArgumentError('Unknown enum value to decode: $data');
-          }
-      }
-    }
-    return null;
-  }
-
-  /// Singleton [SyncAlbumUserV1RoleEnumTypeTransformer] instance.
-  static SyncAlbumUserV1RoleEnumTypeTransformer? _instance;
-}
-
 

--- a/mobile/openapi/lib/model/sync_asset_v1.dart
+++ b/mobile/openapi/lib/model/sync_asset_v1.dart
@@ -47,9 +47,9 @@ class SyncAssetV1 {
 
   String? thumbhash;
 
-  SyncAssetV1TypeEnum type;
+  AssetTypeEnum type;
 
-  SyncAssetV1VisibilityEnum visibility;
+  AssetVisibility visibility;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SyncAssetV1 &&
@@ -141,8 +141,8 @@ class SyncAssetV1 {
         originalFileName: mapValueOfType<String>(json, r'originalFileName')!,
         ownerId: mapValueOfType<String>(json, r'ownerId')!,
         thumbhash: mapValueOfType<String>(json, r'thumbhash'),
-        type: SyncAssetV1TypeEnum.fromJson(json[r'type'])!,
-        visibility: SyncAssetV1VisibilityEnum.fromJson(json[r'visibility'])!,
+        type: AssetTypeEnum.fromJson(json[r'type'])!,
+        visibility: AssetVisibility.fromJson(json[r'visibility'])!,
       );
     }
     return null;
@@ -204,164 +204,4 @@ class SyncAssetV1 {
     'visibility',
   };
 }
-
-
-class SyncAssetV1TypeEnum {
-  /// Instantiate a new enum with the provided [value].
-  const SyncAssetV1TypeEnum._(this.value);
-
-  /// The underlying value of this enum member.
-  final String value;
-
-  @override
-  String toString() => value;
-
-  String toJson() => value;
-
-  static const IMAGE = SyncAssetV1TypeEnum._(r'IMAGE');
-  static const VIDEO = SyncAssetV1TypeEnum._(r'VIDEO');
-  static const AUDIO = SyncAssetV1TypeEnum._(r'AUDIO');
-  static const OTHER = SyncAssetV1TypeEnum._(r'OTHER');
-
-  /// List of all possible values in this [enum][SyncAssetV1TypeEnum].
-  static const values = <SyncAssetV1TypeEnum>[
-    IMAGE,
-    VIDEO,
-    AUDIO,
-    OTHER,
-  ];
-
-  static SyncAssetV1TypeEnum? fromJson(dynamic value) => SyncAssetV1TypeEnumTypeTransformer().decode(value);
-
-  static List<SyncAssetV1TypeEnum> listFromJson(dynamic json, {bool growable = false,}) {
-    final result = <SyncAssetV1TypeEnum>[];
-    if (json is List && json.isNotEmpty) {
-      for (final row in json) {
-        final value = SyncAssetV1TypeEnum.fromJson(row);
-        if (value != null) {
-          result.add(value);
-        }
-      }
-    }
-    return result.toList(growable: growable);
-  }
-}
-
-/// Transformation class that can [encode] an instance of [SyncAssetV1TypeEnum] to String,
-/// and [decode] dynamic data back to [SyncAssetV1TypeEnum].
-class SyncAssetV1TypeEnumTypeTransformer {
-  factory SyncAssetV1TypeEnumTypeTransformer() => _instance ??= const SyncAssetV1TypeEnumTypeTransformer._();
-
-  const SyncAssetV1TypeEnumTypeTransformer._();
-
-  String encode(SyncAssetV1TypeEnum data) => data.value;
-
-  /// Decodes a [dynamic value][data] to a SyncAssetV1TypeEnum.
-  ///
-  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
-  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
-  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
-  ///
-  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
-  /// and users are still using an old app with the old code.
-  SyncAssetV1TypeEnum? decode(dynamic data, {bool allowNull = true}) {
-    if (data != null) {
-      switch (data) {
-        case r'IMAGE': return SyncAssetV1TypeEnum.IMAGE;
-        case r'VIDEO': return SyncAssetV1TypeEnum.VIDEO;
-        case r'AUDIO': return SyncAssetV1TypeEnum.AUDIO;
-        case r'OTHER': return SyncAssetV1TypeEnum.OTHER;
-        default:
-          if (!allowNull) {
-            throw ArgumentError('Unknown enum value to decode: $data');
-          }
-      }
-    }
-    return null;
-  }
-
-  /// Singleton [SyncAssetV1TypeEnumTypeTransformer] instance.
-  static SyncAssetV1TypeEnumTypeTransformer? _instance;
-}
-
-
-
-class SyncAssetV1VisibilityEnum {
-  /// Instantiate a new enum with the provided [value].
-  const SyncAssetV1VisibilityEnum._(this.value);
-
-  /// The underlying value of this enum member.
-  final String value;
-
-  @override
-  String toString() => value;
-
-  String toJson() => value;
-
-  static const archive = SyncAssetV1VisibilityEnum._(r'archive');
-  static const timeline = SyncAssetV1VisibilityEnum._(r'timeline');
-  static const hidden = SyncAssetV1VisibilityEnum._(r'hidden');
-  static const locked = SyncAssetV1VisibilityEnum._(r'locked');
-
-  /// List of all possible values in this [enum][SyncAssetV1VisibilityEnum].
-  static const values = <SyncAssetV1VisibilityEnum>[
-    archive,
-    timeline,
-    hidden,
-    locked,
-  ];
-
-  static SyncAssetV1VisibilityEnum? fromJson(dynamic value) => SyncAssetV1VisibilityEnumTypeTransformer().decode(value);
-
-  static List<SyncAssetV1VisibilityEnum> listFromJson(dynamic json, {bool growable = false,}) {
-    final result = <SyncAssetV1VisibilityEnum>[];
-    if (json is List && json.isNotEmpty) {
-      for (final row in json) {
-        final value = SyncAssetV1VisibilityEnum.fromJson(row);
-        if (value != null) {
-          result.add(value);
-        }
-      }
-    }
-    return result.toList(growable: growable);
-  }
-}
-
-/// Transformation class that can [encode] an instance of [SyncAssetV1VisibilityEnum] to String,
-/// and [decode] dynamic data back to [SyncAssetV1VisibilityEnum].
-class SyncAssetV1VisibilityEnumTypeTransformer {
-  factory SyncAssetV1VisibilityEnumTypeTransformer() => _instance ??= const SyncAssetV1VisibilityEnumTypeTransformer._();
-
-  const SyncAssetV1VisibilityEnumTypeTransformer._();
-
-  String encode(SyncAssetV1VisibilityEnum data) => data.value;
-
-  /// Decodes a [dynamic value][data] to a SyncAssetV1VisibilityEnum.
-  ///
-  /// If [allowNull] is true and the [dynamic value][data] cannot be decoded successfully,
-  /// then null is returned. However, if [allowNull] is false and the [dynamic value][data]
-  /// cannot be decoded successfully, then an [UnimplementedError] is thrown.
-  ///
-  /// The [allowNull] is very handy when an API changes and a new enum value is added or removed,
-  /// and users are still using an old app with the old code.
-  SyncAssetV1VisibilityEnum? decode(dynamic data, {bool allowNull = true}) {
-    if (data != null) {
-      switch (data) {
-        case r'archive': return SyncAssetV1VisibilityEnum.archive;
-        case r'timeline': return SyncAssetV1VisibilityEnum.timeline;
-        case r'hidden': return SyncAssetV1VisibilityEnum.hidden;
-        case r'locked': return SyncAssetV1VisibilityEnum.locked;
-        default:
-          if (!allowNull) {
-            throw ArgumentError('Unknown enum value to decode: $data');
-          }
-      }
-    }
-    return null;
-  }
-
-  /// Singleton [SyncAssetV1VisibilityEnumTypeTransformer] instance.
-  static SyncAssetV1VisibilityEnumTypeTransformer? _instance;
-}
-
 

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -12988,11 +12988,11 @@
             "type": "string"
           },
           "role": {
-            "enum": [
-              "editor",
-              "viewer"
-            ],
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AlbumUserRole"
+              }
+            ]
           },
           "userId": {
             "type": "string"
@@ -13241,22 +13241,18 @@
             "type": "string"
           },
           "type": {
-            "enum": [
-              "IMAGE",
-              "VIDEO",
-              "AUDIO",
-              "OTHER"
-            ],
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AssetTypeEnum"
+              }
+            ]
           },
           "visibility": {
-            "enum": [
-              "archive",
-              "timeline",
-              "hidden",
-              "locked"
-            ],
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AssetVisibility"
+              }
+            ]
           }
         },
         "required": [

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -65,9 +65,11 @@ export class SyncAssetV1 {
   fileCreatedAt!: Date | null;
   fileModifiedAt!: Date | null;
   localDateTime!: Date | null;
+  @ApiProperty({ enumName: 'AssetTypeEnum', enum: AssetType })
   type!: AssetType;
   deletedAt!: Date | null;
   isFavorite!: boolean;
+  @ApiProperty({ enumName: 'AssetVisibility', enum: AssetVisibility })
   visibility!: AssetVisibility;
 }
 
@@ -125,6 +127,7 @@ export class SyncAlbumUserDeleteV1 {
 export class SyncAlbumUserV1 {
   albumId!: string;
   userId!: string;
+  @ApiProperty({ enumName: 'AlbumUserRole', enum: AlbumUserRole })
   role!: AlbumUserRole;
 }
 


### PR DESCRIPTION
## Description

- Adds few missing `ApiProperty` annotations on enums used in the sync stream DTOs
- The double import of the openapi library in the mobile codebase is because:
	- The first import hides all enums with name collisions and imports the remaining DTOs
	- The second import only imports the enums with collisions, but assigns a namespace to them so you can still refer to them

Updated by @wuzihao051119: see discussion here. #18876