### PR TITLE
feat(web): Focus on combo box input when opening add tag modal

### DIFF
--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -46,6 +46,7 @@
      */
     defaultFirstOption?: boolean;
     onSelect?: (option: ComboBoxOption | undefined) => void;
+    forceFocus?: boolean;
   }
 
   let {
@@ -57,6 +58,7 @@
     allowCreate = false,
     defaultFirstOption = false,
     onSelect = () => {},
+    forceFocus = false,
   }: Props = $props();
 
   /**
@@ -114,6 +116,12 @@
       window.visualViewport?.removeEventListener('scroll', onPositionChange);
     };
   });
+
+  const forceFocusInput = (el: HTMLDivElement) => {
+    if (forceFocus) {
+      el.focus();
+    }
+  };
 
   const activate = () => {
     isActive = true;
@@ -284,6 +292,7 @@
       role="combobox"
       type="text"
       value={searchQuery}
+      use:forceFocusInput
       use:shortcuts={[
         {
           shortcut: { key: 'ArrowUp' },

--- a/web/src/lib/modals/AssetTagModal.svelte
+++ b/web/src/lib/modals/AssetTagModal.svelte
@@ -66,6 +66,7 @@
           defaultFirstOption
           options={allTags.map((tag) => ({ id: tag.id, label: tag.value, value: tag.id }))}
           placeholder={$t('search_tags')}
+          forceFocus
         />
       </div>
     </form>


### PR DESCRIPTION
## Description

Sets focus to the add tag ComboBox when opening the modal. Updates ComboBox so this can be enabled on any box with the forceFocus prop.

## How Has This Been Tested?

Clicking Add Tag (asset details or menu) opens the modal and focuses on the ComboBox input. Only happens for tag modal.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
