### PR TITLE
fix(server): default current users to an onboarded state migration

### DIFF
--- a/server/src/schema/migrations/1749067526135-UserOnboardingDefault.ts
+++ b/server/src/schema/migrations/1749067526135-UserOnboardingDefault.ts
@@ -1,0 +1,12 @@
+import { Kysely, sql } from 'kysely';
+import { UserMetadataKey } from 'src/enum';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`INSERT INTO user_metadata SELECT id, ${UserMetadataKey.ONBOARDING}, '{"isOnboarded": true}' FROM users
+    ON CONFLICT ("userId", key) DO UPDATE SET value = EXCLUDED.value
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DELETE FROM user_metadata WHERE key = ${UserMetadataKey.ONBOARDING}`.execute(db);
+}

--- a/server/src/schema/migrations/1749067526135-UserOnboardingDefault.ts
+++ b/server/src/schema/migrations/1749067526135-UserOnboardingDefault.ts
@@ -3,7 +3,7 @@ import { UserMetadataKey } from 'src/enum';
 
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`INSERT INTO user_metadata SELECT id, ${UserMetadataKey.ONBOARDING}, '{"isOnboarded": true}' FROM users
-    ON CONFLICT ("userId", key) DO UPDATE SET value = EXCLUDED.value
+    ON CONFLICT ("userId", key) DO NOTHING
   `.execute(db);
 }
 


### PR DESCRIPTION
## Description

With #18782, a new key was added to the user metadata that contained if they had completed onboarding or not. We want current users to default to an onboarded state since they are already using Immich.

## How Has This Been Tested?

This was tested with @mertalev and the migration succeeded.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
