### PR TITLE
fix(android): use user-installed trusted CAs for HTTPS by specifying networkSecurityConfig

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
 
   <application android:label="Immich" android:name=".ImmichApp" android:usesCleartextTraffic="true"
     android:icon="@mipmap/ic_launcher" android:requestLegacyExternalStorage="true"
-    android:largeHeap="true" android:enableOnBackInvokedCallback="false">
+    android:largeHeap="true" android:enableOnBackInvokedCallback="false"
+    android:networkSecurityConfig="@xml/network_security_config">
 
     <service
       android:name="androidx.work.impl.foreground.SystemForegroundService"

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <!-- Trust system CA certificates -->
+            <certificates src="system" />
+            <!-- Trust user-added CA certificates -->
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
## Description

- Adds network_security_config.xml to allow trusting both system and user CA certificates for Android HTTPS connections.
- Updates AndroidManifest.xml to reference the new network security config.
- Resolves issue where user-installed CAs in Android's trusted store were not honored.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Create your own CA, generate a certificate for your Immich server FQDN and install it in your Reverse Proxy. Add your custom CA to your phone Trusted CA store.
Open Chrome and visit your Immich instance : Chrome accepts the website without a problem.

Now do the same with Immich app and it will fail to connect, logs saying the CA is not trusted. Turning on 'allow self signed certificates' does fix the issue but is not secure.

This patch allows user's installed CA to be trusted by Immich application.


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
