### PR TITLE
refactor(web): tree data structure for folder and tag views

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -19,6 +19,7 @@
   import { handleError } from '$lib/utils/handle-error';
   import { getMetadataSearchQuery } from '$lib/utils/metadata-search';
   import { fromISODateTime, fromISODateTimeUTC } from '$lib/utils/timeline-util';
+  import { getParentPath } from '$lib/utils/tree-utils';
   import {
     AssetMediaSize,
     getAssetInfo,
@@ -137,7 +138,7 @@
   const getAssetFolderHref = (asset: AssetResponseDto) => {
     const folderUrl = new URL(AppRoute.FOLDERS, globalThis.location.href);
     // Remove the last part of the path to get the parent path
-    const assetParentPath = asset.originalPath.split('/').slice(0, -1).join('/');
+    const assetParentPath = getParentPath(asset.originalPath);
     folderUrl.searchParams.set(QueryParameter.PATH, assetParentPath);
     return folderUrl.href;
   };

--- a/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
+++ b/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
@@ -51,8 +51,7 @@
           aria-current={isRoot ? 'page' : undefined}
         />
       </li>
-      <!-- eslint-disable-next-line svelte/require-each-key -->
-      {#each parents as parent}
+      {#each parents as parent (parent)}
         <li
           class="flex gap-2 items-center font-mono text-sm text-nowrap text-immich-primary dark:text-immich-dark-primary"
         >

--- a/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
+++ b/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
@@ -51,6 +51,7 @@
           aria-current={isRoot ? 'page' : undefined}
         />
       </li>
+      <!-- eslint-disable-next-line svelte/require-each-key -->
       {#each parents as parent}
         <li
           class="flex gap-2 items-center font-mono text-sm text-nowrap text-immich-primary dark:text-immich-dark-primary"

--- a/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
+++ b/web/src/lib/components/shared-components/tree/breadcrumbs.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
+  import { TreeNode } from '$lib/utils/tree-utils';
   import { IconButton } from '@immich/ui';
   import { mdiArrowUpLeft, mdiChevronRight } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   interface Props {
-    pathSegments?: string[];
+    node: TreeNode;
     getLink: (path: string) => string;
     title: string;
     icon: string;
   }
 
-  let { pathSegments = [], getLink, title, icon }: Props = $props();
+  const { node, getLink, title, icon }: Props = $props();
 
-  let isRoot = $derived(pathSegments.length === 0);
+  const rootLink = getLink('');
+  const isRoot = $derived(node.parent === null);
+  const parentLink = $derived(getLink(node.parent ? node.parent.path : ''));
+  const parents = $derived(node.parents);
 </script>
 
 <nav class="flex items-center py-2">
-  {#if !isRoot}
+  {#if parentLink}
     <div>
       <IconButton
         shape="round"
@@ -25,9 +29,8 @@
         variant="ghost"
         icon={mdiArrowUpLeft}
         aria-label={$t('to_parent')}
-        href={getLink(pathSegments.slice(0, -1).join('/'))}
+        href={parentLink}
         class="me-2"
-        onclick={() => {}}
       />
     </div>
   {/if}
@@ -42,31 +45,29 @@
           color="secondary"
           variant="ghost"
           {icon}
-          href={getLink('')}
+          href={rootLink}
           aria-label={title}
           size="medium"
           aria-current={isRoot ? 'page' : undefined}
-          onclick={() => {}}
         />
       </li>
-      {#each pathSegments as segment, index (index)}
-        {@const isLastSegment = index === pathSegments.length - 1}
+      {#each parents as parent}
         <li
           class="flex gap-2 items-center font-mono text-sm text-nowrap text-immich-primary dark:text-immich-dark-primary"
         >
           <Icon path={mdiChevronRight} class="text-gray-500 dark:text-gray-300" size={16} ariaHidden />
-          {#if isLastSegment}
-            <p class="cursor-default whitespace-pre-wrap">{segment}</p>
-          {:else}
-            <a
-              class="underline hover:font-semibold whitespace-pre-wrap"
-              href={getLink(pathSegments.slice(0, index + 1).join('/'))}
-            >
-              {segment}
-            </a>
-          {/if}
+          <a class="underline hover:font-semibold whitespace-pre-wrap" href={getLink(parent.path)}>
+            {parent.value}
+          </a>
         </li>
       {/each}
+
+      <li
+        class="flex gap-2 items-center font-mono text-sm text-nowrap text-immich-primary dark:text-immich-dark-primary"
+      >
+        <Icon path={mdiChevronRight} class="text-gray-500 dark:text-gray-300" size={16} ariaHidden />
+        <p class="cursor-default whitespace-pre-wrap">{node.value}</p>
+      </li>
     </ol>
   </div>
 </nav>

--- a/web/src/lib/components/shared-components/tree/tree-item-thumbnails.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-item-thumbnails.svelte
@@ -15,6 +15,7 @@
   <div
     class="w-full grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 2xl:grid-cols-8 gap-2 bg-gray-50 dark:bg-immich-dark-gray/50 rounded-2xl border border-gray-100 dark:border-gray-900"
   >
+    <!-- eslint-disable-next-line svelte/require-each-key -->
     {#each items as item}
       <button
         class="flex flex-col place-items-center gap-2 py-2 px-4 hover:bg-immich-primary/10 dark:hover:bg-immich-primary/40 rounded-xl"

--- a/web/src/lib/components/shared-components/tree/tree-item-thumbnails.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-item-thumbnails.svelte
@@ -1,29 +1,30 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
+  import type { TreeNode } from '$lib/utils/tree-utils';
 
   interface Props {
-    items?: string[];
+    items: TreeNode[];
     icon: string;
     onClick: (path: string) => void;
   }
 
-  let { items = [], icon, onClick }: Props = $props();
+  let { items, icon, onClick }: Props = $props();
 </script>
 
 {#if items.length > 0}
   <div
     class="w-full grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 2xl:grid-cols-8 gap-2 bg-gray-50 dark:bg-immich-dark-gray/50 rounded-2xl border border-gray-100 dark:border-gray-900"
   >
-    {#each items as item (item)}
+    {#each items as item}
       <button
         class="flex flex-col place-items-center gap-2 py-2 px-4 hover:bg-immich-primary/10 dark:hover:bg-immich-primary/40 rounded-xl"
-        onclick={() => onClick(item)}
-        title={item}
+        onclick={() => onClick(item.value)}
+        title={item.value}
         type="button"
       >
         <Icon path={icon} class="text-immich-primary dark:text-immich-dark-primary" size={64} />
         <p class="text-sm dark:text-gray-200 text-nowrap text-ellipsis overflow-clip w-full whitespace-pre-wrap">
-          {item}
+          {item.value}
         </p>
       </button>
     {/each}

--- a/web/src/lib/components/shared-components/tree/tree-items.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-items.svelte
@@ -3,20 +3,19 @@
   import { type TreeNode } from '$lib/utils/tree-utils';
 
   interface Props {
-    node: TreeNode;
+    tree: TreeNode;
     active: string;
     icons: { default: string; active: string };
     getLink: (path: string) => string;
-    getColor?: (path: string) => string | undefined;
   }
 
-  let { node, active, icons, getLink, getColor }: Props = $props();
+  let { tree, active, icons, getLink }: Props = $props();
 </script>
 
 <ul class="list-none ms-2">
-  {#each node.children as childNode (getColor ? childNode.path + getColor(childNode.path) : childNode.path)}
+  {#each tree.children as node (node.color ? node.path + node.color : node.path)}
     <li>
-      <Tree node={childNode} {icons} {active} {getLink} {getColor} />
+      <Tree {node} {icons} {active} {getLink} />
     </li>
   {/each}
 </ul>

--- a/web/src/lib/components/shared-components/tree/tree-items.svelte
+++ b/web/src/lib/components/shared-components/tree/tree-items.svelte
@@ -1,28 +1,22 @@
 <script lang="ts">
   import Tree from '$lib/components/shared-components/tree/tree.svelte';
-  import { normalizeTreePath, type RecursiveObject } from '$lib/utils/tree-utils';
+  import { type TreeNode } from '$lib/utils/tree-utils';
 
   interface Props {
-    items: RecursiveObject;
-    parent?: string;
-    active?: string;
+    node: TreeNode;
+    active: string;
     icons: { default: string; active: string };
     getLink: (path: string) => string;
     getColor?: (path: string) => string | undefined;
   }
 
-  let { items, parent = '', active = '', icons, getLink, getColor = () => undefined }: Props = $props();
+  let { node, active, icons, getLink, getColor }: Props = $props();
 </script>
 
 <ul class="list-none ms-2">
-  <!-- eslint-disable-next-line svelte/require-each-key -->
-  {#each Object.entries(items).sort() as [path, tree]}
-    {@const value = normalizeTreePath(`${parent}/${path}`)}
-    {@const key = value + getColor(value)}
-    {#key key}
-      <li>
-        <Tree {parent} value={path} {tree} {icons} {active} {getLink} {getColor} />
-      </li>
-    {/key}
+  {#each node.children as childNode (getColor ? childNode.path + getColor(childNode.path) : childNode.path)}
+    <li>
+      <Tree node={childNode} {icons} {active} {getLink} {getColor} />
+    </li>
   {/each}
 </ul>

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -9,14 +9,12 @@
     active: string;
     icons: { default: string; active: string };
     getLink: (path: string) => string;
-    getColor?: (path: string) => string | undefined;
   }
 
-  let { node, active, icons, getLink, getColor }: Props = $props();
+  let { node, active, icons, getLink }: Props = $props();
 
   const isTarget = $derived(active === node.path);
   const isActive = $derived(active === node.path || active.startsWith(`${node.path}/`) || (node.value === '/' && active.startsWith('/')));
-  const color = $derived(getColor?.(node.path));
   let isOpen = $derived(isActive);
 
   const onclick = (event: MouseEvent) => {
@@ -40,7 +38,7 @@
     <Icon
       path={isActive ? icons.active : icons.default}
       class={isActive ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-gray-400'}
-      {color}
+      color={node.color}
       size={20}
     />
   </div>
@@ -48,5 +46,5 @@
 </a>
 
 {#if isOpen}
-  <TreeItems {node} {icons} {active} {getLink} {getColor} />
+  <TreeItems tree={node} {icons} {active} {getLink} />
 {/if}

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -14,9 +14,7 @@
   let { node, active, icons, getLink }: Props = $props();
 
   const isTarget = $derived(active === node.path);
-  const isActive = $derived(
-    active === node.path || active.startsWith(`${node.path}/`) || (node.value === '/' && active.startsWith('/')),
-  );
+  const isActive = $derived(active === node.path || active.startsWith(node.value === '/' ? '/' : `${node.path}/`));
   let isOpen = $derived(isActive);
 
   const onclick = (event: MouseEvent) => {

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -1,25 +1,22 @@
 <script lang="ts">
   import Icon from '$lib/components/elements/icon.svelte';
   import TreeItems from '$lib/components/shared-components/tree/tree-items.svelte';
-  import { normalizeTreePath, type RecursiveObject } from '$lib/utils/tree-utils';
+  import { TreeNode } from '$lib/utils/tree-utils';
   import { mdiChevronDown, mdiChevronRight } from '@mdi/js';
 
   interface Props {
-    tree: RecursiveObject;
-    parent: string;
-    value: string;
-    active?: string;
+    node: TreeNode;
+    active: string;
     icons: { default: string; active: string };
     getLink: (path: string) => string;
-    getColor: (path: string) => string | undefined;
+    getColor?: (path: string) => string | undefined;
   }
 
-  let { tree, parent, value, active = '', icons, getLink, getColor }: Props = $props();
+  let { node, active, icons, getLink, getColor }: Props = $props();
 
-  const path = $derived(normalizeTreePath(`${parent}/${value}`));
-  const isActive = $derived(active === path || active.startsWith(`${path}/`));
-  const isTarget = $derived(active === path);
-  const color = $derived(getColor(path));
+  const isTarget = $derived(active === node.path);
+  const isActive = $derived(active === node.path || active.startsWith(`${node.path}/`) || (node.value === '/' && active.startsWith('/')));
+  const color = $derived(getColor?.(node.path));
   let isOpen = $derived(isActive);
 
   const onclick = (event: MouseEvent) => {
@@ -29,15 +26,17 @@
 </script>
 
 <a
-  href={getLink(path)}
-  title={value}
+  href={getLink(node.path)}
+  title={node.value}
   class={`flex grow place-items-center ps-2 py-1 text-sm rounded-lg hover:bg-slate-200 dark:hover:bg-slate-800 hover:font-semibold ${isTarget ? 'bg-slate-100 dark:bg-slate-700 font-semibold text-immich-primary dark:text-immich-dark-primary' : 'dark:text-gray-200'}`}
   data-sveltekit-keepfocus
 >
-  <button type="button" {onclick} class={Object.values(tree).length === 0 ? 'invisible' : ''}>
-    <Icon path={isOpen ? mdiChevronDown : mdiChevronRight} class="text-gray-400" size={20} />
-  </button>
-  <div>
+  {#if node.size > 0}
+    <button type="button" {onclick}>
+      <Icon path={isOpen ? mdiChevronDown : mdiChevronRight} class="text-gray-400" size={20} />
+    </button>
+  {/if}
+  <div class={node.size === 0 ? 'ml-[1.5em] ' : ''}>
     <Icon
       path={isActive ? icons.active : icons.default}
       class={isActive ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-gray-400'}
@@ -45,9 +44,9 @@
       size={20}
     />
   </div>
-  <span class="text-nowrap overflow-hidden text-ellipsis font-mono ps-1 pt-1 whitespace-pre-wrap">{value}</span>
+  <span class="text-nowrap overflow-hidden text-ellipsis font-mono ps-1 pt-1 whitespace-pre-wrap">{node.value}</span>
 </a>
 
 {#if isOpen}
-  <TreeItems parent={path} items={tree} {icons} {active} {getLink} {getColor} />
+  <TreeItems {node} {icons} {active} {getLink} {getColor} />
 {/if}

--- a/web/src/lib/components/shared-components/tree/tree.svelte
+++ b/web/src/lib/components/shared-components/tree/tree.svelte
@@ -14,7 +14,9 @@
   let { node, active, icons, getLink }: Props = $props();
 
   const isTarget = $derived(active === node.path);
-  const isActive = $derived(active === node.path || active.startsWith(`${node.path}/`) || (node.value === '/' && active.startsWith('/')));
+  const isActive = $derived(
+    active === node.path || active.startsWith(`${node.path}/`) || (node.value === '/' && active.startsWith('/')),
+  );
   let isOpen = $derived(isActive);
 
   const onclick = (event: MouseEvent) => {

--- a/web/src/lib/stores/folders.svelte.ts
+++ b/web/src/lib/stores/folders.svelte.ts
@@ -28,8 +28,9 @@ class FoldersStore {
     }
     this.initialized = true;
 
-    const uniquePaths = await getUniqueOriginalPaths();
-    return (this.folders = TreeNode.fromPaths(uniquePaths));
+    this.folders = TreeNode.fromPaths(await getUniqueOriginalPaths());
+    this.folders.collapseTree();
+    return this.folders;
   }
 
   bustAssetCache() {

--- a/web/src/lib/stores/folders.svelte.ts
+++ b/web/src/lib/stores/folders.svelte.ts
@@ -14,7 +14,7 @@ type AssetCache = {
 };
 
 class FoldersStore {
-  folders = $state.raw<TreeNode>();
+  folders = $state.raw<TreeNode | null>(null);
   private initialized = false;
   private assets = $state<AssetCache>({});
 
@@ -29,7 +29,7 @@ class FoldersStore {
     this.initialized = true;
 
     this.folders = TreeNode.fromPaths(await getUniqueOriginalPaths());
-    this.folders.collapseTree();
+    this.folders.collapse();
     return this.folders;
   }
 
@@ -48,7 +48,7 @@ class FoldersStore {
   clearCache() {
     this.initialized = false;
     this.assets = {};
-    this.folders = undefined;
+    this.folders = null;
   }
 }
 

--- a/web/src/lib/utils/navigation.ts
+++ b/web/src/lib/utils/navigation.ts
@@ -23,7 +23,7 @@ export const isAssetViewerRoute = (target?: NavigationTarget | null) =>
   !!(target?.route.id?.endsWith('/[[assetId=id]]') && 'assetId' in (target?.params || {}));
 
 export function getAssetInfoFromParam({ assetId, key }: { assetId?: string; key?: string }) {
-  return assetId && getAssetInfo({ id: assetId, key });
+  return assetId ? getAssetInfo({ id: assetId, key }) : undefined;
 }
 
 function currentUrlWithoutAsset() {

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -1,21 +1,110 @@
-export interface RecursiveObject {
-  [key: string]: RecursiveObject;
+export class TreeNode extends Map<string, TreeNode> {
+  readonly value: string;
+  readonly path: string;
+  readonly parent: TreeNode | null;
+  readonly hasLeaf: boolean;
+  #parents: TreeNode[] | null;
+  #children: TreeNode[] | null;
+
+  private constructor(value: string, path: string, parent: TreeNode | null) {
+    super();
+    this.value = value;
+    this.parent = parent;
+    this.path = path;
+    this.hasLeaf = false;
+    this.#parents = null;
+    this.#children = null;
+  }
+
+  static fromPaths(paths: string[]) {
+    const root = new TreeNode('', '', null);
+    for (const path of paths) {
+      let current = root;
+      for (const part of getPathParts(path)) {
+        if (!current.has(part)) {
+          const child = new TreeNode(part, joinPaths([current.path, part]), current);
+          current.set(part, child);
+        }
+        current = current.get(part)!;
+      }
+      (current.hasLeaf as boolean) = true; // allow reading but not modifying properties externally
+    }
+    return root;
+  }
+
+  lowestCommonNode() {
+    let curNode: TreeNode = this;
+    while (curNode.size === 1) {
+      const nextNode = curNode.values().next().value!;
+      curNode = nextNode;
+    }
+    return curNode;
+  }
+
+  closestRelativeNode(path: string): TreeNode {
+    const parts = getPathParts(normalizeTreePath(path));
+    let current: TreeNode = this;
+    for (const part of parts) {
+      if (!current || !current.has(part)) {
+        break;
+      }
+      current = current.get(part)!;
+    }
+    return current;
+  }
+
+  get parents(): TreeNode[] {
+    if (this.#parents) {
+      return this.#parents;
+    }
+    const parents: TreeNode[] = [];
+    let current: TreeNode | null = this.parent;
+    while (current !== null && current.parent !== null) {
+      parents.push(current);
+      current = current.parent;
+    }
+    return (this.#parents = parents.reverse());
+  }
+
+  get children(): TreeNode[] {
+    return (this.#children ??= this.values().toArray());
+  }
 }
 
-export const normalizeTreePath = (path: string) => path.replace(/^\//, '').replace(/\/$/, '');
+export const normalizeTreePath = (path: string) =>
+  path.length > 1 && path[path.length - 1] === '/' ? path.slice(0, -1) : path;
 
-export function buildTree(paths: string[]) {
-  const root: RecursiveObject = {};
+export function getPathParts(path: string) {
+  const parts = path.split('/');
+  if (path[0] === '/') {
+    parts[0] = '/';
+  }
 
-  for (const path of paths) {
-    const parts = path.split('/');
-    let current = root;
-    for (const part of parts) {
-      if (!current[part]) {
-        current[part] = {};
-      }
-      current = current[part];
+  if (path[path.length - 1] === '/') {
+    parts.pop();
+  }
+
+  return parts;
+}
+
+export function joinPaths(inputPaths: string[]) {
+  const paths = new Array(inputPaths.length);
+  for (let i = 0; i < inputPaths.length; i++) {
+    const path = inputPaths[i];
+    if (path === '/') {
+      paths[i] = '';
+    } else if (path.length > 0) {
+      paths[i] = path;
     }
   }
-  return root;
+  return paths.join('/');
+}
+
+export function getParentPath(path: string) {
+  const normalized = normalizeTreePath(path);
+  const last = normalized.lastIndexOf('/');
+  if (last > 0) {
+    return normalized.slice(0, last);
+  }
+  return last === 0 ? '/' : normalized;
 }

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -100,7 +100,7 @@ export class TreeNode extends Map<string, TreeNode> {
   }
 
   get children(): TreeNode[] {
-    return (this._children ??= this.values().toArray());
+    return (this._children ??= Array.from(this.values()));
   }
 }
 

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-this-alias */
+/* eslint-disable unicorn/no-this-assignment */
+/* eslint-disable unicorn/prefer-at */
 import type { TagResponseDto } from '@immich/sdk';
 
 export class TreeNode extends Map<string, TreeNode> {

--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -58,14 +58,12 @@ export class TreeNode extends Map<string, TreeNode> {
   }
 
   collapse() {
-    if (this.size === 1 && !this.hasAssets) {
+    if (this.size === 1 && !this.hasAssets && this.parent !== null) {
       const child = this.values().next().value!;
       child.value = joinPaths(this.value, child.value);
       child.parent = this.parent;
-      if (this.parent !== null) {
-        this.parent.delete(this.value);
-        this.parent.set(child.value, child);
-      }
+      this.parent.delete(this.value);
+      this.parent.set(child.value, child);
     }
 
     for (const child of this.values()) {

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -43,7 +43,7 @@
 
   const assetInteraction = new AssetInteraction();
 
-  const handleNavigateToFolder = (folderName: string) => navigateToView(joinPaths([data.tree.path, folderName]));
+  const handleNavigateToFolder = (folderName: string) => navigateToView(joinPaths(data.tree.path, folderName));
 
   function getLinkForPath(path: string) {
     const url = new URL(AppRoute.FOLDERS, globalThis.location.href);

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { afterNavigate, goto, invalidateAll } from '$app/navigation';
-  import { page } from '$app/stores';
   import SkipLink from '$lib/components/elements/buttons/skip-link.svelte';
   import UserPageLayout, { headerId } from '$lib/components/layouts/user-page-layout.svelte';
   import AddToAlbum from '$lib/components/photos-page/actions/add-to-album.svelte';
@@ -28,10 +27,9 @@
   import { preferences } from '$lib/stores/user.store';
   import { cancelMultiselect } from '$lib/utils/asset-utils';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
-  import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+  import { joinPaths } from '$lib/utils/tree-utils';
   import { IconButton } from '@immich/ui';
   import { mdiDotsVertical, mdiFolder, mdiFolderHome, mdiFolderOutline, mdiPlus, mdiSelectAll } from '@mdi/js';
-  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
 
@@ -43,51 +41,40 @@
 
   const viewport: Viewport = $state({ width: 0, height: 0 });
 
-  let pathSegments = $derived(data.path ? data.path.split('/') : []);
-  let tree = $derived(buildTree(foldersStore.uniquePaths));
-  let currentPath = $derived($page.url.searchParams.get(QueryParameter.PATH) || '');
-  let currentTreeItems = $derived(currentPath ? data.currentFolders : Object.keys(tree).sort());
-
   const assetInteraction = new AssetInteraction();
 
-  onMount(async function initializeFolders() {
-    await foldersStore.fetchUniquePaths();
-  });
+  const handleNavigateToFolder = (folderName: string) => navigateToView(joinPaths([data.tree.path, folderName]));
 
-  const handleNavigateToFolder = async function handleNavigateToFolder(folderName: string) {
-    await navigateToView(normalizeTreePath(`${data.path || ''}/${folderName}`));
-  };
-
-  const getLinkForPath = function getLinkForPath(path: string) {
+  function getLinkForPath(path: string) {
     const url = new URL(AppRoute.FOLDERS, globalThis.location.href);
-    if (path) {
-      url.searchParams.set(QueryParameter.PATH, path);
-    }
+    url.searchParams.set(QueryParameter.PATH, path);
     return url.href;
-  };
+  }
 
   afterNavigate(function clearAssetSelection() {
     // Clear the asset selection when we navigate (like going to another folder)
     cancelMultiselect(assetInteraction);
   });
 
-  const navigateToView = function navigateToView(path: string) {
-    return goto(getLinkForPath(path));
-  };
+  function navigateToView(path: string) {
+    return goto(getLinkForPath(path), { keepFocus: true, noScroll: true });
+  }
 
-  const triggerAssetUpdate = async function updateAssets() {
+  async function triggerAssetUpdate() {
     cancelMultiselect(assetInteraction);
-    await foldersStore.refreshAssetsByPath(data.path);
+    if (data.tree.path) {
+      await foldersStore.refreshAssetsByPath(data.tree.path);
+    }
     await invalidateAll();
-  };
+  }
 
-  const handleSelectAllAssets = function handleSelectAllAssets() {
+  function handleSelectAllAssets() {
     if (!data.pathAssets) {
       return;
     }
 
     assetInteraction.selectAssets(data.pathAssets.map((asset) => toTimelineAsset(asset)));
-  };
+  }
 </script>
 
 <UserPageLayout title={data.meta.title}>
@@ -99,8 +86,8 @@
         <div class="h-full">
           <TreeItems
             icons={{ default: mdiFolderOutline, active: mdiFolder }}
-            items={tree}
-            active={currentPath}
+            node={foldersStore.folders!}
+            active={data.tree.path}
             getLink={getLinkForPath}
           />
         </div>
@@ -108,10 +95,10 @@
     </Sidebar>
   {/snippet}
 
-  <Breadcrumbs {pathSegments} icon={mdiFolderHome} title={$t('folders')} getLink={getLinkForPath} />
+  <Breadcrumbs node={data.tree} icon={mdiFolderHome} title={$t('folders')} getLink={getLinkForPath} />
 
   <section class="mt-2 h-[calc(100%-(--spacing(20)))] overflow-auto immich-scrollbar">
-    <TreeItemThumbnails items={currentTreeItems} icon={mdiFolder} onClick={handleNavigateToFolder} />
+    <TreeItemThumbnails items={data.tree.children} icon={mdiFolder} onClick={handleNavigateToFolder} />
 
     <!-- Assets -->
     {#if data.pathAssets && data.pathAssets.length > 0}

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -86,7 +86,7 @@
         <div class="h-full">
           <TreeItems
             icons={{ default: mdiFolderOutline, active: mdiFolder }}
-            node={foldersStore.folders!}
+            tree={foldersStore.folders!}
             active={data.tree.path}
             getLink={getLinkForPath}
           />

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -7,8 +7,9 @@ import type { PageLoad } from './$types';
 
 export const load = (async ({ params, url }) => {
   await authenticate(url);
-  let [tree, asset, $t] = await Promise.all([foldersStore.fetchTree(), getAssetInfoFromParam(params), getFormatter()]);
+  const [, asset, $t] = await Promise.all([foldersStore.fetchTree(), getAssetInfoFromParam(params), getFormatter()]);
 
+  let tree = foldersStore.folders!;
   const path = url.searchParams.get(QueryParameter.PATH);
   if (path) {
     tree = tree.traverse(path);

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -11,7 +11,7 @@ export const load = (async ({ params, url }) => {
 
   const path = url.searchParams.get(QueryParameter.PATH);
   if (path) {
-    tree = tree.closestRelativeNode(path);
+    tree = tree.traverse(path);
   } else if (path === null) {
     // If no path is provided, we've just navigated to the folders page.
     // We should bust the asset cache of the folder store, to make sure we don't show stale data
@@ -19,7 +19,7 @@ export const load = (async ({ params, url }) => {
   }
 
   // only fetch assets if the folder has assets
-  const pathAssets = tree.hasLeaf ? await foldersStore.fetchAssetsByPath(tree.path) : null;
+  const pathAssets = tree.hasAssets ? await foldersStore.fetchAssetsByPath(tree.path) : null;
 
   return {
     asset,

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -15,9 +15,7 @@ export const load = (async ({ params, url }) => {
   } else if (path === null) {
     // If no path is provided, we've just navigated to the folders page.
     // We should bust the asset cache of the folder store, to make sure we don't show stale data
-    // and default to the lowest common folder
     foldersStore.bustAssetCache();
-    tree = tree.lowestCommonNode();
   }
 
   // only fetch assets if the folder has assets

--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -3,38 +3,29 @@ import { foldersStore } from '$lib/stores/folders.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ params, url }) => {
   await authenticate(url);
-  const asset = await getAssetInfoFromParam(params);
-  const $t = await getFormatter();
-
-  await foldersStore.fetchUniquePaths();
-
-  let pathAssets = null;
+  let [tree, asset, $t] = await Promise.all([foldersStore.fetchTree(), getAssetInfoFromParam(params), getFormatter()]);
 
   const path = url.searchParams.get(QueryParameter.PATH);
   if (path) {
-    await foldersStore.fetchAssetsByPath(path);
-    pathAssets = foldersStore.assets[path] || null;
-  } else {
-    // If no path is provided, we we're at the root level
+    tree = tree.closestRelativeNode(path);
+  } else if (path === null) {
+    // If no path is provided, we've just navigated to the folders page.
     // We should bust the asset cache of the folder store, to make sure we don't show stale data
+    // and default to the lowest common folder
     foldersStore.bustAssetCache();
+    tree = tree.lowestCommonNode();
   }
 
-  let tree = buildTree(foldersStore.uniquePaths);
-  const parts = normalizeTreePath(path || '').split('/');
-  for (const part of parts) {
-    tree = tree?.[part];
-  }
+  // only fetch assets if the folder has assets
+  const pathAssets = tree.hasLeaf ? await foldersStore.fetchAssetsByPath(tree.path) : null;
 
   return {
     asset,
-    path,
-    currentFolders: Object.keys(tree || {}).sort(),
+    tree,
     pathAssets,
     meta: {
       title: $t('folders'),

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -130,12 +130,7 @@
       <section>
         <div class="text-xs ps-4 mb-2 dark:text-white">{$t('explorer').toUpperCase()}</div>
         <div class="h-full">
-          <TreeItems
-            icons={{ default: mdiTag, active: mdiTag }}
-            tree={tree}
-            active={tag.path}
-            {getLink}
-          />
+          <TreeItems icons={{ default: mdiTag, active: mdiTag }} {tree} active={tag.path} {getLink} />
         </div>
       </section>
     </Sidebar>

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -45,7 +45,7 @@
   const tagId = $derived(tag?.id);
 
   const handleNavigation = async (tag: string) => {
-    await navigateToView(joinPaths([data.tree.path, tag]));
+    await navigateToView(joinPaths(data.tree.path, tag));
   };
 
   const getLink = (path: string) => {

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -1,7 +1,7 @@
+import { QueryParameter } from '$lib/constants';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { TreeNode } from '$lib/utils/tree-utils';
 import { getAllTags } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
@@ -11,12 +11,11 @@ export const load = (async ({ params, url }) => {
   const $t = await getFormatter();
 
   const tags = await getAllTags();
-  const tree = TreeNode.fromPaths(tags.map((tag) => tag.value));
 
   return {
+    path: url.searchParams.get(QueryParameter.PATH) ?? '',
     tags,
     asset,
-    tree,
     meta: {
       title: $t('tags'),
     },

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -1,8 +1,7 @@
-import { QueryParameter } from '$lib/constants';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
-import { buildTree, normalizeTreePath } from '$lib/utils/tree-utils';
+import { TreeNode } from '$lib/utils/tree-utils';
 import { getAllTags } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
@@ -11,20 +10,13 @@ export const load = (async ({ params, url }) => {
   const asset = await getAssetInfoFromParam(params);
   const $t = await getFormatter();
 
-  const path = url.searchParams.get(QueryParameter.PATH);
   const tags = await getAllTags();
-  const tree = buildTree(tags.map((tag) => tag.value));
-  let currentTree = tree;
-  const parts = normalizeTreePath(path || '').split('/');
-  for (const part of parts) {
-    currentTree = currentTree?.[part];
-  }
+  const tree = TreeNode.fromPaths(tags.map((tag) => tag.value));
 
   return {
     tags,
     asset,
-    path,
-    children: Object.keys(currentTree || {}),
+    tree,
     meta: {
       title: $t('tags'),
     },


### PR DESCRIPTION
# Description

* Encapsulates tree building and traversal with `TreeNode`s, using this as the primary building block for passing data to tree components
  * Nodes extend from Map, which is *dramatically* faster to iterate on compared to object keys, gives us a `size` property and allows lazy iteration of either child names (keys) or child nodes (values)
* Handles absolute vs relative paths (leading `/` is respected)
* In the folder view, only fetches assets for paths that contain assets
* In the folder view, collapses path sections that are shared across all subtrees to avoid unnecessary clicks
* In the folder view, only bust the asset cache when initially navigating to the page and not whenever you go to the root

This makes the folder view significantly snappier, especially when dealing with many folders. After these changes, profiling shows that almost all time at this point is spent in Svelte or in style rendering. Virtualizing the sidebar is left for future work.

Notably, these changes are needed for server-side optimizations to properly index folders, which will bring another major improvement to responsiveness and make folders and files sorted numerically instead of lexicographically.

## How Has This Been Tested?

Tested both folder and tag views. For the tag view, I confirmed that clicking a tag will display assets with that tag or any child tags (current behavior). For the folder view, I confirmed that path traversal with collapsed sections worked as expected.