### PR TITLE
fix(mobile): After editing people name, back button close the app

### DIFF
--- a/mobile/lib/pages/library/people/people_collection.page.dart
+++ b/mobile/lib/pages/library/people/people_collection.page.dart
@@ -27,6 +27,7 @@ class PeopleCollectionPage extends HookConsumerWidget {
     ) {
       return showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (BuildContext context) {
           return PersonNameEditForm(personId: personId, personName: personName);
         },

--- a/mobile/lib/pages/search/person_result.page.dart
+++ b/mobile/lib/pages/search/person_result.page.dart
@@ -28,6 +28,7 @@ class PersonResultPage extends HookConsumerWidget {
     showEditNameDialog() {
       showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (BuildContext context) {
           return PersonNameEditForm(
             personId: personId,

--- a/mobile/lib/widgets/asset_viewer/detail_panel/people_info.dart
+++ b/mobile/lib/widgets/asset_viewer/detail_panel/people_info.dart
@@ -83,16 +83,15 @@ class PeopleInfo extends ConsumerWidget {
               child: CuratedPeopleRow(
                 padding: padding,
                 content: curatedPeople,
-                onTap: (content, index) async {
-                  await context.pushRoute(
-                    PersonResultRoute(
-                      personId: content.id,
-                      personName: content.label,
-                    ),
-                  );
-
-
-                  peopleProvider.refresh();
+                onTap: (content, index) {
+                  context
+                      .pushRoute(
+                        PersonResultRoute(
+                          personId: content.id,
+                          personName: content.label,
+                        ),
+                      )
+                      .then((_) => peopleProvider.refresh());
                 },
                 onNameTap: (person, index) => {
                   showPersonNameEditModel(person.id, person.label),

--- a/mobile/lib/widgets/asset_viewer/detail_panel/people_info.dart
+++ b/mobile/lib/widgets/asset_viewer/detail_panel/people_info.dart
@@ -31,6 +31,7 @@ class PeopleInfo extends ConsumerWidget {
     ) {
       return showDialog(
         context: context,
+        useRootNavigator: false,
         builder: (BuildContext context) {
           return PersonNameEditForm(personId: personId, personName: personName);
         },
@@ -82,15 +83,16 @@ class PeopleInfo extends ConsumerWidget {
               child: CuratedPeopleRow(
                 padding: padding,
                 content: curatedPeople,
-                onTap: (content, index) {
-                  context
-                      .pushRoute(
-                        PersonResultRoute(
-                          personId: content.id,
-                          personName: content.label,
-                        ),
-                      )
-                      .then((_) => peopleProvider.refresh());
+                onTap: (content, index) async {
+                  await context.pushRoute(
+                    PersonResultRoute(
+                      personId: content.id,
+                      personName: content.label,
+                    ),
+                  );
+
+
+                  peopleProvider.refresh();
                 },
                 onNameTap: (person, index) => {
                   showPersonNameEditModel(person.id, person.label),


### PR DESCRIPTION
A bit similar to Share button on a previous PR, this was the same issue and same fix.

## Description

After editing the name or adding a new name, doing a back with Android back button close the app. 

Fixes I didn't create an issue just go the problem and fix it directly. 

## How Has This Been Tested?

There is three places where you can edit a name
On the peoples page (with everyone)
On the people page itself (click on the name and edit)
On the people page three dots open a submenu 

After editing whatever on those three scenario try the back button


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
