### PR TITLE
fix(mobile): people collection page layout broken in landscape

### DIFF
--- a/mobile/lib/pages/library/people/people_collection.page.dart
+++ b/mobile/lib/pages/library/people/people_collection.page.dart
@@ -60,80 +60,84 @@ class PeopleCollectionPage extends HookConsumerWidget {
               ),
             ],
           ),
-          body: people.when(
-            data: (people) {
-              if (search.value != null) {
-                people = people.where((person) {
-                  return person.name
-                      .toLowerCase()
-                      .contains(search.value!.toLowerCase());
-                }).toList();
-              }
-              return GridView.builder(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: isTablet ? 6 : 3,
-                  childAspectRatio: 0.85,
-                  mainAxisSpacing: isPortrait && isTablet ? 36 : 0,
-                ),
-                padding: const EdgeInsets.symmetric(vertical: 32),
-                itemCount: people.length,
-                itemBuilder: (context, index) {
-                  final person = people[index];
+          body: SafeArea(
+            child: people.when(
+              data: (people) {
+                if (search.value != null) {
+                  people = people.where((person) {
+                    return person.name
+                        .toLowerCase()
+                        .contains(search.value!.toLowerCase());
+                  }).toList();
+                }
+                return GridView.builder(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: isTablet ? 6 : 3,
+                    childAspectRatio: 0.85,
+                    mainAxisSpacing: isPortrait && isTablet ? 36 : 0,
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 32),
+                  itemCount: people.length,
+                  itemBuilder: (context, index) {
+                    final person = people[index];
 
-                  return Column(
-                    children: [
-                      GestureDetector(
-                        onTap: () {
-                          context.pushRoute(
-                            PersonResultRoute(
-                              personId: person.id,
-                              personName: person.name,
-                            ),
-                          );
-                        },
-                        child: Material(
-                          shape: const CircleBorder(side: BorderSide.none),
-                          elevation: 3,
-                          child: CircleAvatar(
-                            maxRadius: isTablet ? 120 / 2 : 96 / 2,
-                            backgroundImage: NetworkImage(
-                              getFaceThumbnailUrl(person.id),
-                              headers: headers,
+                    return Column(
+                      children: [
+                        GestureDetector(
+                          onTap: () {
+                            context.pushRoute(
+                              PersonResultRoute(
+                                personId: person.id,
+                                personName: person.name,
+                              ),
+                            );
+                          },
+                          child: Material(
+                            shape: const CircleBorder(side: BorderSide.none),
+                            elevation: 3,
+                            child: CircleAvatar(
+                              maxRadius: isTablet ? 120 / 2 : 96 / 2,
+                              backgroundImage: NetworkImage(
+                                getFaceThumbnailUrl(person.id),
+                                headers: headers,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 12),
-                      GestureDetector(
-                        onTap: () => showNameEditModel(person.id, person.name),
-                        child: person.name.isEmpty
-                            ? Text(
-                                'add_a_name'.tr(),
-                                style: context.textTheme.titleSmall?.copyWith(
-                                  fontWeight: FontWeight.w500,
-                                  color: context.colorScheme.primary,
-                                ),
-                              )
-                            : Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 16.0,
-                                ),
-                                child: Text(
-                                  person.name,
-                                  overflow: TextOverflow.ellipsis,
+                        const SizedBox(height: 12),
+                        GestureDetector(
+                          onTap: () =>
+                              showNameEditModel(person.id, person.name),
+                          child: person.name.isEmpty
+                              ? Text(
+                                  'add_a_name'.tr(),
                                   style: context.textTheme.titleSmall?.copyWith(
                                     fontWeight: FontWeight.w500,
+                                    color: context.colorScheme.primary,
+                                  ),
+                                )
+                              : Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 16.0,
+                                  ),
+                                  child: Text(
+                                    person.name,
+                                    overflow: TextOverflow.ellipsis,
+                                    style:
+                                        context.textTheme.titleSmall?.copyWith(
+                                      fontWeight: FontWeight.w500,
+                                    ),
                                   ),
                                 ),
-                              ),
-                      ),
-                    ],
-                  );
-                },
-              );
-            },
-            error: (error, stack) => const Text("error"),
-            loading: () => const Center(child: CircularProgressIndicator()),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
+              error: (error, stack) => const Text("error"),
+              loading: () => const Center(child: CircularProgressIndicator()),
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Description

When viewing the People collection page with something like an iPhone with a "physical islands" the people circle avatar could go behind it. See screenshot (one image worth one thousand words sometimes :))


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/88706e42-5bc4-44a2-a26e-47883b9637fb)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
