### PR TITLE
feat(mobile): Capitalize first letter when add / edit name

### DIFF
--- a/mobile/lib/widgets/search/person_name_edit_form.dart
+++ b/mobile/lib/widgets/search/person_name_edit_form.dart
@@ -35,6 +35,7 @@ class PersonNameEditForm extends HookConsumerWidget {
       content: SingleChildScrollView(
         child: TextFormField(
           controller: controller,
+          textCapitalization: TextCapitalization.words,
           autofocus: true,
           decoration: InputDecoration(
             hintText: 'name'.tr(),


### PR DESCRIPTION
## Description

Small QOL improvement when the keyboard open the first letter will be capitalized. 
( I started to add names for my pictures and had to click the shift cap every time first) 

## How Has This Been Tested?

Edit a name and when the keyboard open the first letter should be a capital.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![image](https://github.com/user-attachments/assets/03dbacb8-8f71-49c2-81db-2b8a538c52c7)


</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
