### PR TITLE
fix(web): improve asset name readability in dark mode

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -501,7 +501,7 @@
           />
           {#if showAssetName && !isTimelineAsset(currentAsset)}
             <div
-              class="absolute text-center p-1 text-xs font-mono font-semibold w-full bottom-0 bg-linear-to-t bg-slate-50/75 overflow-clip text-ellipsis whitespace-pre-wrap"
+              class="absolute text-center p-1 text-xs font-mono font-semibold w-full bottom-0 bg-linear-to-t bg-slate-50/75 dark:bg-slate-800/75 overflow-clip text-ellipsis whitespace-pre-wrap"
             >
               {currentAsset.originalFileName}
             </div>


### PR DESCRIPTION
## Description

Poor contrast when trying to read asset name in folders when dark theme is turned on

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Text background changes colour when dark theme is toggled in the navigation bar (see screenshots)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

__Before__

![image](https://github.com/user-attachments/assets/ee0e58d6-5521-4345-afb8-9aac88a748df)

__After__

![image](https://github.com/user-attachments/assets/ca37b4c6-886a-4451-82a7-475ed533160c)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
