### PR TITLE
feat(mobile): update maplibre to support PMTiles in the mobile app

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -29,6 +29,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
   compileSdkVersion 35
+  ndkVersion = "28.1.13356709"
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_17

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -67,10 +67,10 @@ PODS:
   - local_auth_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
-  - MapLibre (6.5.0)
+  - MapLibre (6.14.0)
   - maplibre_gl (0.0.1):
     - Flutter
-    - MapLibre (= 6.5.0)
+    - MapLibre (= 6.14.0)
   - native_video_player (1.0.0):
     - Flutter
   - network_info_plus (0.0.1):
@@ -260,8 +260,8 @@ SPEC CHECKSUMS:
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   isar_flutter_libs: fdf730ca925d05687f36d7f1d355e482529ed097
   local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
-  MapLibre: 0ebfa9329d313cec8bf0a5ba5a336a1dc903785e
-  maplibre_gl: be7b98f1c3ed75bf77f321eec04df359d0ff6f62
+  MapLibre: 69e572367f4ef6287e18246cfafc39c80cdcabcd
+  maplibre_gl: 753f55d763a81cbdba087d02af02d12206e6f94e
   native_video_player: d12af78a1a4a8cf09775a5177d5b392def6fd23c
   network_info_plus: 6613d9d7cdeb0e6f366ed4dbe4b3c51c52d567a9
   package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1136,26 +1136,26 @@ packages:
     dependency: "direct main"
     description:
       name: maplibre_gl
-      sha256: cd0adf2da87149cab556ac70977783d6dcb3bd73b17a5583cc8366a5aafa46f8
+      sha256: "5c7b1008396b2a321bada7d986ed60f9423406fbc7bd16f7ce91b385dfa054cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.0"
+    version: "0.22.0"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "6db8234705e58c09b6fd5a43747a817ba1e6e91a76deb3ed057a36a994d86f22"
+      sha256: "08ee0a2d0853ea945a0ab619d52c0c714f43144145cd67478fc6880b52f37509"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.0"
+    version: "0.22.0"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: e1cbe04594fdb0d76de7cd448c0048290df8dc69dc37a85d23307dd595779141
+      sha256: "2b13d4b1955a9a54e38a718f2324e56e4983c080fc6de316f6f4b5458baacb58"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.0"
+    version: "0.22.0"
   matcher:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   intl: ^0.19.0
   local_auth: ^2.3.0
   logging: ^1.3.0
-  maplibre_gl: ^0.21.0
+  maplibre_gl: ^0.22.0
   network_info_plus: ^6.1.3
   octo_image: ^2.1.0
   package_info_plus: ^8.3.0


### PR DESCRIPTION
## Description

I prepared a fix a long time ago to support PMTiles in `flutter-maplibre-gl` (https://github.com/maplibre/flutter-maplibre-gl/pull/552) and recently did it again (https://github.com/maplibre/flutter-maplibre-gl/pull/582) and finally it received an 0.22.0 update with those patches.

Web already supports it with this patch: https://github.com/immich-app/immich/pull/16629

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested on Android, works perfectly with my selfhosted PMTiles.
- [ ] Tested on iOS (don't have iOS device, but it should work).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
