### PR TITLE
docs: update instructions for external libraries

### DIFF
--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -112,11 +112,14 @@ _Remember to run `docker compose up -d` to register the changes. Make sure you c
 
 These actions must be performed by the Immich administrator.
 
-- Click on Administration -> Libraries
-- Click on Create External Library
+- Click on your avatar on the upper right corner
+- Click on Administration -> External Libraries
+- Click on Create an external library…
 - Select which user owns the library, this can not be changed later
 - Enter `/mnt/media/christmas-trip` then click Add
 - Click on Save
+- Click the drop-down menu on the newly created library
+- Click on Scan
 - Click the drop-down menu on the newly created library
 - Click on Rename Library and rename it to "Christmas Trip"
 


### PR DESCRIPTION
## Description

The first step was missing—it's probably obvious for those already familiar with Immich, but not for a newcomer.

After I added the external library, no photos showed up anywhere and all interfaces indicated that I had no photos

Eventually I found this "Scan" button, and after clicking it photos started to appear. This is a necessary step before photos from the library actually show up anywhere, so point it out explicitly.

(no issue open—I thought it simpler to just update the docs)

## How Has This Been Tested?

n/a, just read the changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding docs
