### PR TITLE
fix: skip locked photos during duplicate scan.

### DIFF
--- a/server/src/services/duplicate.service.ts
+++ b/server/src/services/duplicate.service.ts
@@ -69,6 +69,11 @@ export class DuplicateService extends BaseService {
       return JobStatus.SKIPPED;
     }
 
+    if (asset.visibility === AssetVisibility.LOCKED) {
+      this.logger.debug(`Asset ${id} is locked, skipping`);
+      return JobStatus.SKIPPED;
+    }
+
     if (!asset.embedding) {
       this.logger.debug(`Asset ${id} is missing embedding`);
       return JobStatus.FAILED;


### PR DESCRIPTION
## Description

When attempting to delete duplicates, sometimes and error is encountered:
```
Error Not found or no asset delete access
```
This change uses the logic for skipping hidden files to also skip locked files.

Fixes # (issue)
https://github.com/immich-app/immich/issues/18813

## How Has This Been Tested?

This PR needs to be tested.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
