### PR TITLE
chore: more flexible modal manager types

### DIFF
--- a/web/src/lib/components/admin-page/settings/auth/auth-settings.svelte
+++ b/web/src/lib/components/admin-page/settings/auth/auth-settings.svelte
@@ -36,7 +36,7 @@
   const handleSave = async (skipConfirm: boolean) => {
     const allMethodsDisabled = !config.oauth.enabled && !config.passwordLogin.enabled;
     if (allMethodsDisabled && !skipConfirm) {
-      const isConfirmed = await modalManager.show(AuthDisableLoginConfirmModal, {});
+      const isConfirmed = await modalManager.show(AuthDisableLoginConfirmModal);
       if (!isConfirmed) {
         return;
       }

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -104,7 +104,7 @@
     if (document.fullscreenElement) {
       await document.exitFullscreen();
     }
-    await modalManager.show(SlideshowSettingsModal, {});
+    await modalManager.show(SlideshowSettingsModal);
   };
 </script>
 

--- a/web/src/lib/components/photos-page/actions/change-description-action.svelte
+++ b/web/src/lib/components/photos-page/actions/change-description-action.svelte
@@ -18,7 +18,7 @@
   const { clearSelect, getOwnedAssets } = getAssetControlContext();
 
   const handleUpdateDescription = async () => {
-    const description = await modalManager.show(AssetUpdateDecriptionConfirmModal, {});
+    const description = await modalManager.show(AssetUpdateDecriptionConfirmModal);
     if (description) {
       const ids = getSelectedAssets(getOwnedAssets(), $user);
 

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -703,7 +703,7 @@
     }
 
     isShortcutModalOpen = true;
-    await modalManager.show(ShortcutsModal, {});
+    await modalManager.show(ShortcutsModal);
     isShortcutModalOpen = false;
   };
 

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -5,11 +5,10 @@
   import Thumbnail from '$lib/components/assets/thumbnail/thumbnail.svelte';
   import { AppRoute, AssetAction } from '$lib/constants';
   import { modalManager } from '$lib/managers/modal-manager.svelte';
+  import type { TimelineAsset, Viewport } from '$lib/managers/timeline-manager/types';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import type { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
-  import type { Viewport } from '$lib/managers/timeline-manager/types';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { handlePromiseError } from '$lib/utils';

--- a/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
+++ b/web/src/lib/components/shared-components/navigation-bar/account-info-panel.svelte
@@ -51,7 +51,7 @@
           shape="round"
           onclick={async () => {
             onClose();
-            await modalManager.show(AvatarEditModal, {});
+            await modalManager.show(AvatarEditModal);
           }}
         />
       </div>

--- a/web/src/lib/components/shared-components/side-bar/purchase-info.svelte
+++ b/web/src/lib/components/shared-components/side-bar/purchase-info.svelte
@@ -27,7 +27,7 @@
   const { isPurchased } = purchaseStore;
 
   const openPurchaseModal = async () => {
-    await modalManager.show(PurchaseModal, {});
+    await modalManager.show(PurchaseModal);
     showMessage = false;
   };
 

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -200,7 +200,7 @@
           icon={mdiInformationOutline}
           aria-label={$t('deduplication_info')}
           size="small"
-          onclick={() => modalManager.show(DuplicatesInformationModal, {})}
+          onclick={() => modalManager.show(DuplicatesInformationModal)}
         />
       </div>
 

--- a/web/src/routes/admin/library-management/+page.svelte
+++ b/web/src/routes/admin/library-management/+page.svelte
@@ -207,7 +207,7 @@
   };
 
   const onCreateNewLibraryClicked = async () => {
-    const result = await modalManager.show(LibraryUserPickerModal, {});
+    const result = await modalManager.show(LibraryUserPickerModal);
     if (result) {
       await handleCreate(result);
     }

--- a/web/src/routes/admin/users/+page.svelte
+++ b/web/src/routes/admin/users/+page.svelte
@@ -58,7 +58,7 @@
   };
 
   const handleCreate = async () => {
-    await modalManager.show(UserCreateModal, {});
+    await modalManager.show(UserCreateModal);
     await refresh();
   };
 


### PR DESCRIPTION
If a modal does not expect any props (besides `onClose` of course) the second argument is now optional (passing `undefined` or `{}` is still valid too)