### PR TITLE
chore(web): passive events

### DIFF
--- a/web/src/lib/components/asset-viewer/editor/crop-tool/crop-area.svelte
+++ b/web/src/lib/components/asset-viewer/editor/crop-tool/crop-area.svelte
@@ -53,12 +53,10 @@
 
     img.src = getAssetOriginalUrl({ id: asset.id, cacheKey: asset.thumbhash });
 
-    img.addEventListener('load', () => onImageLoad(true));
-    img.addEventListener('error', (error) => {
-      handleError(error, $t('error_loading_image'));
-    });
+    img.addEventListener('load', () => onImageLoad(true), { passive: true });
+    img.addEventListener('error', (error) => handleError(error, $t('error_loading_image')), { passive: true });
 
-    globalThis.addEventListener('mousemove', handleMouseMove);
+    globalThis.addEventListener('mousemove', handleMouseMove, { passive: true });
   });
 
   onDestroy(() => {

--- a/web/src/lib/components/asset-viewer/editor/crop-tool/image-loading.ts
+++ b/web/src/lib/components/asset-viewer/editor/crop-tool/image-loading.ts
@@ -31,8 +31,8 @@ export function onImageLoad(resetSize: boolean = false) {
     cropFrameEl?.classList.add('transition');
     cropSettings.update((crop) => normalizeCropArea(crop, img, scale));
     cropFrameEl?.classList.add('transition');
-    cropFrameEl?.addEventListener('transitionend', () => {
-      cropFrameEl?.classList.remove('transition');
+    cropFrameEl?.addEventListener('transitionend', () => cropFrameEl?.classList.remove('transition'), {
+      passive: true,
     });
   }
   cropImageScale.set(scale);

--- a/web/src/lib/components/asset-viewer/editor/crop-tool/mouse-handlers.ts
+++ b/web/src/lib/components/asset-viewer/editor/crop-tool/mouse-handlers.ts
@@ -58,7 +58,7 @@ export function handleMouseDown(e: MouseEvent) {
   }
 
   document.body.style.userSelect = 'none';
-  globalThis.addEventListener('mouseup', handleMouseUp);
+  globalThis.addEventListener('mouseup', handleMouseUp, { passive: true });
 }
 
 export function handleMouseMove(e: MouseEvent) {

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -4,8 +4,8 @@
   import FaceEditor from '$lib/components/asset-viewer/face-editor/face-editor.svelte';
   import BrokenAsset from '$lib/components/assets/broken-asset.svelte';
   import { castManager } from '$lib/managers/cast-manager.svelte';
-  import { photoViewerImgElement } from '$lib/stores/assets-store.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
+  import { photoViewerImgElement } from '$lib/stores/assets-store.svelte';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { alwaysLoadOriginalFile } from '$lib/stores/preferences.store';
@@ -192,8 +192,8 @@
     if (loader?.complete) {
       onload();
     }
-    loader?.addEventListener('load', onload);
-    loader?.addEventListener('error', onerror);
+    loader?.addEventListener('load', onload, { passive: true });
+    loader?.addEventListener('error', onerror, { passive: true });
     return () => {
       loader?.removeEventListener('load', onload);
       loader?.removeEventListener('error', onerror);

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -105,9 +105,9 @@
     }
     observer.observe(input);
     const scrollableAncestor = input?.closest('.overflow-y-auto, .overflow-y-scroll');
-    scrollableAncestor?.addEventListener('scroll', onPositionChange);
-    window.visualViewport?.addEventListener('resize', onPositionChange);
-    window.visualViewport?.addEventListener('scroll', onPositionChange);
+    scrollableAncestor?.addEventListener('scroll', onPositionChange, { passive: true });
+    window.visualViewport?.addEventListener('resize', onPositionChange, { passive: true });
+    window.visualViewport?.addEventListener('scroll', onPositionChange, { passive: true });
 
     return () => {
       observer.disconnect();

--- a/web/src/lib/components/shared-components/control-app-bar.svelte
+++ b/web/src/lib/components/shared-components/control-app-bar.svelte
@@ -53,7 +53,7 @@
 
   onMount(() => {
     if (browser) {
-      document.addEventListener('scroll', onScroll);
+      document.addEventListener('scroll', onScroll, { passive: true });
     }
   });
 

--- a/web/src/lib/components/shared-components/scrubber/scrubber.svelte
+++ b/web/src/lib/components/shared-components/scrubber/scrubber.svelte
@@ -367,8 +367,8 @@
     document.addEventListener('touchstart', onTouchStart, { capture: true, passive: true });
     document.addEventListener('touchend', onTouchEnd, { capture: true, passive: true });
     return () => {
-      document.addEventListener('touchstart', onTouchStart, true);
-      document.addEventListener('touchend', onTouchEnd, true);
+      document.removeEventListener('touchstart', onTouchStart, true);
+      document.removeEventListener('touchend', onTouchEnd, true);
     };
   });
 

--- a/web/src/lib/components/shared-components/scrubber/scrubber.svelte
+++ b/web/src/lib/components/shared-components/scrubber/scrubber.svelte
@@ -357,15 +357,15 @@
   };
   /* eslint-enable tscompat/tscompat */
   onMount(() => {
-    document.addEventListener('touchmove', onTouchMove, true);
+    document.addEventListener('touchmove', onTouchMove, { capture: true, passive: true });
     return () => {
-      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchmove', onTouchMove, true);
     };
   });
 
   onMount(() => {
-    document.addEventListener('touchstart', onTouchStart, true);
-    document.addEventListener('touchend', onTouchEnd, true);
+    document.addEventListener('touchstart', onTouchStart, { capture: true, passive: true });
+    document.addEventListener('touchend', onTouchEnd, { capture: true, passive: true });
     return () => {
       document.addEventListener('touchstart', onTouchStart, true);
       document.addEventListener('touchend', onTouchEnd, true);

--- a/web/src/lib/managers/theme-manager.svelte.ts
+++ b/web/src/lib/managers/theme-manager.svelte.ts
@@ -52,11 +52,15 @@ class ThemeManager {
   }
 
   #onAppInit() {
-    globalThis.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-      if (this.theme.system) {
-        this.#update('system');
-      }
-    });
+    globalThis.matchMedia('(prefers-color-scheme: dark)').addEventListener(
+      'change',
+      () => {
+        if (this.theme.system) {
+          this.#update('system');
+        }
+      },
+      { passive: true },
+    );
   }
 
   #update(value: Theme | 'system') {

--- a/web/src/lib/utils/file-uploader.ts
+++ b/web/src/lib/utils/file-uploader.ts
@@ -67,15 +67,19 @@ export const openFileUploadDialog = async (options: FileUploadParam = {}) => {
       fileSelector.type = 'file';
       fileSelector.multiple = multiple;
       fileSelector.accept = extensions.join(',');
-      fileSelector.addEventListener('change', (e: Event) => {
-        const target = e.target as HTMLInputElement;
-        if (!target.files) {
-          return;
-        }
-        const files = Array.from(target.files);
+      fileSelector.addEventListener(
+        'change',
+        (e: Event) => {
+          const target = e.target as HTMLInputElement;
+          if (!target.files) {
+            return;
+          }
+          const files = Array.from(target.files);
 
-        resolve(fileUploadHandler({ files, albumId, replaceAssetId: assetId }));
-      });
+          resolve(fileUploadHandler({ files, albumId, replaceAssetId: assetId }));
+        },
+        { passive: true },
+      );
 
       fileSelector.click();
     } catch (error) {

--- a/web/src/service-worker/index.ts
+++ b/web/src/service-worker/index.ts
@@ -20,7 +20,7 @@ const handleInstall = (event: ExtendableEvent) => {
   event.waitUntil(addFilesToCache());
 };
 
-sw.addEventListener('install', handleInstall);
-sw.addEventListener('activate', handleActivate);
-sw.addEventListener('fetch', handleFetchEvent);
+sw.addEventListener('install', handleInstall, { passive: true });
+sw.addEventListener('activate', handleActivate, { passive: true });
+sw.addEventListener('fetch', handleFetchEvent, { passive: true });
 installBroadcastChannelListener();


### PR DESCRIPTION
## Description

The passive option lets the browser skip checking if `preventDefault` was called, acting as a promise that the listener won't call `preventDefault`. It makes things like scrolling faster because it skips this check. This PR adds this option to the listeners that I could confirm don't call `preventDefault`.

It also adjusts the thumbnail event handlers in particular by optimizing `clearLongPressTimer`. It ends up being called *a lot* and shows up very prominently during profiling.

## How Has This Been Tested?

Selecting or long pressing thumbnails works fine, as does scrubbing. I haven't tested every individual event here, but I very much doubt there would be any issues.