### PR TITLE
feat(server): lru cache for query embeddings

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -48,6 +48,7 @@
         "kysely-postgres-js": "^2.0.0",
         "lodash": "^4.17.21",
         "luxon": "^3.4.2",
+        "mnemonist": "^0.40.3",
         "nest-commander": "^3.16.0",
         "nestjs-cls": "^5.0.0",
         "nestjs-kysely": "^1.1.0",
@@ -472,6 +473,13 @@
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
       }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -3173,6 +3181,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@npmcli/fs": {
       "version": "4.0.0",
@@ -6859,6 +6874,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/archiver-utils/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/archiver-utils/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -7483,6 +7504,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "9.0.5",
@@ -11837,10 +11865,13 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/luxon": {
       "version": "3.6.1",
@@ -12303,6 +12334,15 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
+      "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.4"
+      }
     },
     "node_modules/mock-fs": {
       "version": "5.5.0",
@@ -13061,6 +13101,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -13490,15 +13536,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/path-source": {
@@ -16043,6 +16080,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/sucrase/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/sucrase/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -16595,6 +16639,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "9.0.5",
@@ -17195,6 +17246,12 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/typeorm/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/typeorm/node_modules/minimatch": {
       "version": "9.0.5",

--- a/server/package.json
+++ b/server/package.json
@@ -74,6 +74,7 @@
     "kysely-postgres-js": "^2.0.0",
     "lodash": "^4.17.21",
     "luxon": "^3.4.2",
+    "mnemonist": "^0.40.3",
     "nest-commander": "^3.16.0",
     "nestjs-cls": "^5.0.0",
     "nestjs-kysely": "^1.1.0",

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import LRUMap from 'mnemonist/lru-map';
+import LRUMap from 'node_modules/mnemonist/lru-cache';
 import { AssetMapOptions, AssetResponseDto, MapAsset, mapAsset } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { mapPerson, PersonResponseDto } from 'src/dtos/person.dto';

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import LRUMap from 'node_modules/mnemonist/lru-cache';
+import LRUMap from 'node_modules/mnemonist/lru-map';
 import { AssetMapOptions, AssetResponseDto, MapAsset, mapAsset } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { mapPerson, PersonResponseDto } from 'src/dtos/person.dto';

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import LRUMap from 'node_modules/mnemonist/lru-map';
+import { LRUMap } from 'mnemonist';
 import { AssetMapOptions, AssetResponseDto, MapAsset, mapAsset } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { mapPerson, PersonResponseDto } from 'src/dtos/person.dto';


### PR DESCRIPTION
## Description

This is an easy win for search performance. An embedding is currently generated for any given request, including later pages of the same search query. It's much better to cache the latest embeddings to avoid repeated work.

## How Has This Been Tested?

Searching and scrolling search results works as normal, with the only difference that it's much faster after the first time the text has been searched.