### PR TITLE
fix(web): small issues with the memory viewer.

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -3,9 +3,10 @@
   import { zoomImageAction } from '$lib/actions/zoom-image';
   import FaceEditor from '$lib/components/asset-viewer/face-editor/face-editor.svelte';
   import BrokenAsset from '$lib/components/assets/broken-asset.svelte';
+  import { assetViewerFadeDuration } from '$lib/constants';
   import { castManager } from '$lib/managers/cast-manager.svelte';
-  import { photoViewerImgElement } from '$lib/stores/assets-store.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
+  import { photoViewerImgElement } from '$lib/stores/assets-store.svelte';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { alwaysLoadOriginalFile } from '$lib/stores/preferences.store';
@@ -240,7 +241,7 @@
       use:swipe={() => ({})}
       onswipe={onSwipe}
       class="h-full w-full"
-      transition:fade={{ duration: haveFadeTransition ? 150 : 0 }}
+      transition:fade={{ duration: haveFadeTransition ? assetViewerFadeDuration : 0 }}
     >
       {#if $slideshowState !== SlideshowState.None && $slideshowLook === SlideshowLook.BlurredBackground}
         <img

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -260,12 +260,7 @@
     playerInitialized = true;
   };
 
-  afterNavigate(({ from, to, type }) => {
-    if (type === 'enter') {
-      // afterNavigate triggers twice on first page load (once when mounted with 'enter' and then a second time
-      // with the actual 'goto' to URL).
-      return;
-    }
+  afterNavigate(({ from, to }) => {
     memoryStore.initialize().then(
       () => {
         let target = null;

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -23,12 +23,11 @@
     notificationController,
     NotificationType,
   } from '$lib/components/shared-components/notification/notification';
-  import { AppRoute, QueryParameter } from '$lib/constants';
+  import { AppRoute, assetViewerFadeDuration, QueryParameter } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import type { TimelineAsset, Viewport } from '$lib/managers/timeline-manager/types';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
-  import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
-  import type { Viewport } from '$lib/managers/timeline-manager/types';
   import { type MemoryAsset, memoryStore } from '$lib/stores/memory.store.svelte';
   import { locale, videoViewerMuted, videoViewerVolume } from '$lib/stores/preferences.store';
   import { preferences } from '$lib/stores/user.store';
@@ -469,7 +468,7 @@
         >
           <div class="relative h-full w-full rounded-2xl bg-black">
             {#key current.asset.id}
-              <div transition:fade class="h-full w-full">
+              <div transition:fade={{ duration: assetViewerFadeDuration }} class="h-full w-full">
                 {#if current.asset.isVideo}
                   <video
                     bind:this={videoPlayer}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -420,3 +420,5 @@ export enum ToggleVisibility {
   HIDE_UNNANEMD = 'hide-unnamed',
   SHOW_ALL = 'show-all',
 }
+
+export const assetViewerFadeDuration: number = 150; // milliseconds

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -421,4 +421,4 @@ export enum ToggleVisibility {
   SHOW_ALL = 'show-all',
 }
 
-export const assetViewerFadeDuration: number = 150; // milliseconds
+export const assetViewerFadeDuration: number = 150;


### PR DESCRIPTION
## Description

* The old memory viewer had a much higher fade duration when navigating between assets, than the regular asset viewer. Match the transition durations between the asset-viewer and memory-viewer.
* Fix an issue where the the page would be blank if the user refreshed the page while viewing a memory. I was not able to reproduce `afterNavigate` being called twice, so this might have been fixed in a newer version of Svelte at some point. In any case, the `memoryStore` itself has protections against being initialized multiple times already. 

## How Has This Been Tested?

Tested locally in my browser.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
