### PR TITLE
fix: disable map fly animation when switching between assets

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -74,6 +74,8 @@
     showSimpleControls = true,
   }: Props = $props();
 
+  const initialCenter = center;
+
   let map: maplibregl.Map | undefined = $state();
   let marker: maplibregl.Marker | null = null;
   let abortController: AbortController;
@@ -247,6 +249,10 @@
       },
     });
   });
+
+  $effect(() => {
+    map?.jumpTo({ center, zoom });
+  });
 </script>
 
 <!--  We handle style loading ourselves so we set style blank here -->
@@ -254,8 +260,8 @@
   {hash}
   style=""
   class="h-full {rounded ? 'rounded-2xl' : 'rounded-none'}"
-  {center}
   {zoom}
+  center={initialCenter}
   attributionControl={false}
   diffStyleUpdates={true}
   onload={(event) => {


### PR DESCRIPTION
This caused a huge amount of requests to the tile server if the assets were far apart, so we will just disable map animation entirely.
