### PR TITLE
chore: no test coverage in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Run small tests & coverage
-        run: npm run test:cov
+        run: npm test
         if: ${{ !cancelled() }}
 
   cli-unit-tests:
@@ -146,7 +146,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Run unit tests & coverage
-        run: npm run test:cov
+        run: npm run test
         if: ${{ !cancelled() }}
 
   cli-unit-tests-win:
@@ -184,7 +184,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Run unit tests & coverage
-        run: npm run test:cov
+        run: npm run test
         if: ${{ !cancelled() }}
 
   web-lint:
@@ -262,7 +262,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Run unit tests & coverage
-        run: npm run test:cov
+        run: npm run test
         if: ${{ !cancelled() }}
 
   i18n-tests:


### PR DESCRIPTION
Skip tracking and generating coverage reports for unit tests in CI, since we aren't currently using them for anything.