### PR TITLE
fix: album share modal navigation

### DIFF
--- a/web/src/lib/modals/AlbumShareModal.svelte
+++ b/web/src/lib/modals/AlbumShareModal.svelte
@@ -171,7 +171,7 @@
         {#if sharedLinks.length > 0}
           <div class="flex justify-between items-center">
             <Text>{$t('shared_links')}</Text>
-            <Link href={AppRoute.SHARED_LINKS} class="text-sm">{$t('view_all')}</Link>
+            <Link href={AppRoute.SHARED_LINKS} onclick={() => onClose()} class="text-sm">{$t('view_all')}</Link>
           </div>
 
           <Stack gap={4}>


### PR DESCRIPTION
Forgot to close the modal when navigating away from the page.
Closes #19241 