### PR TITLE
fix(web): exit slideshow when exiting fullscreen.

### DIFF
--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -108,6 +108,30 @@
     }
     await modalManager.show(SlideshowSettingsModal);
   };
+
+  onMount(() => {
+    function exitFullscreenHandler() {
+      const doc = document as Document & {
+        webkitIsFullScreen?: boolean;
+      };
+
+      if (
+        // eslint-disable-next-line tscompat/tscompat
+        !document.fullscreenElement &&
+        !doc.webkitIsFullScreen
+      ) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('fullscreenchange', exitFullscreenHandler);
+    document.addEventListener('webkitfullscreenchange', exitFullscreenHandler);
+
+    return () => {
+      document.removeEventListener('fullscreenchange', exitFullscreenHandler);
+      document.removeEventListener('webkitfullscreenchange', exitFullscreenHandler);
+    };
+  });
 </script>
 
 <svelte:document


### PR DESCRIPTION
Browsers do not send a keyboard event when exiting fullscreen, so if the user exits fullscreen with the escape key, the slideshow remains open, requiring another escape key press to close it. Fix this by listening for the fullscreenchange event and closing the slideshow when exiting fullscreen. This is the same behavior as app-which-should-not-be-named.

## How Has This Been Tested?

Tested manually in Chrome.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
