### PR TITLE
fix(web): Stack assets in asset-viewer cut off on the left

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -548,9 +548,9 @@
     {@const stackedAssets = stack.assets}
     <div
       id="stack-slideshow"
-      class="flex place-item-center place-content-center absolute bottom-0 w-full col-span-4 col-start-1 overflow-x-auto overflow-y-hidden horizontal-scrollbar"
+      class="absolute bottom-0 w-full col-span-4 col-start-1  "
     >
-      <div class="relative flex flex-row no-wrap">
+      <div class="relative flex flex-row no-wrap overflow-x-auto overflow-y-hidden horizontal-scrollbar">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div
             class={['inline-block px-1 relative transition-all pb-2']}

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -546,10 +546,7 @@
 
   {#if stack && withStacked}
     {@const stackedAssets = stack.assets}
-    <div
-      id="stack-slideshow"
-      class="absolute bottom-0 w-full col-span-4 col-start-1  "
-    >
+    <div id="stack-slideshow" class="absolute bottom-0 w-full col-span-4 col-start-1">
       <div class="relative flex flex-row no-wrap overflow-x-auto overflow-y-hidden horizontal-scrollbar">
         {#each stackedAssets as stackedAsset (stackedAsset.id)}
           <div


### PR DESCRIPTION
## Description

Fixes scrolling issue with stack assets in the asset-viewer where some assets (when lots in a stack/scrolling needed) would get cut off on the left.

Fixes an issue introduced in #19088

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
