### PR TITLE
fix: devcontainer in codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,7 +55,7 @@
   "userEnvProbe": "loginInteractiveShell",
   "remoteEnv": {
     // The location where your uploaded files are stored
-    "UPLOAD_LOCATION": "${localEnv:UPLOAD_LOCATION:upload-devcontainer-volume}",
+    "UPLOAD_LOCATION": "${localEnv:UPLOAD_LOCATION:./library}",
     //  Connection secret for postgres. You should change it to a random password
     //  Please use only the characters `A-Za-z0-9`, without special characters or spaces
     "DB_PASSWORD": "${localEnv:DB_PASSWORD:postgres}",

--- a/.devcontainer/server/container-common.sh
+++ b/.devcontainer/server/container-common.sh
@@ -51,14 +51,27 @@ fix_permissions() {
 
     run_cmd sudo find "${IMMICH_WORKSPACE}/server/upload" -not -path "${IMMICH_WORKSPACE}/server/upload/postgres/*" -not -path "${IMMICH_WORKSPACE}/server/upload/postgres" -exec chown node {} +
 
-    run_cmd sudo chown node -R "${IMMICH_WORKSPACE}/.vscode" \
+    # Change ownership for directories that exist
+    for dir in "${IMMICH_WORKSPACE}/.vscode" \
         "${IMMICH_WORKSPACE}/cli/node_modules" \
         "${IMMICH_WORKSPACE}/e2e/node_modules" \
         "${IMMICH_WORKSPACE}/open-api/typescript-sdk/node_modules" \
         "${IMMICH_WORKSPACE}/server/node_modules" \
         "${IMMICH_WORKSPACE}/server/dist" \
         "${IMMICH_WORKSPACE}/web/node_modules" \
-        "${IMMICH_WORKSPACE}/web/dist"
+        "${IMMICH_WORKSPACE}/web/dist"; do
+        if [ -d "$dir" ]; then
+            run_cmd sudo chown node -R "$dir"
+        fi
+    done
+
+    # Set ownership for docker/Library (node) but postgres subdirectory (999:999)
+    if [ -d "${IMMICH_WORKSPACE}/docker/Library" ]; then
+        run_cmd sudo chown node "${IMMICH_WORKSPACE}/docker/Library"
+        if [ -d "${IMMICH_WORKSPACE}/docker/Library/postgres" ]; then
+            run_cmd sudo chown -R 999:999 "${IMMICH_WORKSPACE}/docker/Library/postgres"
+        fi
+    fi
 
     log ""
 }

--- a/.devcontainer/server/container-common.sh
+++ b/.devcontainer/server/container-common.sh
@@ -65,14 +65,6 @@ fix_permissions() {
         fi
     done
 
-    # Set ownership for docker/Library (node) but postgres subdirectory (999:999)
-    if [ -d "${IMMICH_WORKSPACE}/docker/Library" ]; then
-        run_cmd sudo chown node "${IMMICH_WORKSPACE}/docker/Library"
-        if [ -d "${IMMICH_WORKSPACE}/docker/Library/postgres" ]; then
-            run_cmd sudo chown -R 999:999 "${IMMICH_WORKSPACE}/docker/Library/postgres"
-        fi
-    fi
-
     log ""
 }
 

--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -12,8 +12,8 @@ services:
       - open_api_node_modules:/workspaces/immich/open-api/typescript-sdk/node_modules
       - server_node_modules:/workspaces/immich/server/node_modules
       - web_node_modules:/workspaces/immich/web/node_modules
-      - ${UPLOAD_LOCATION-./Library}/photos:/workspaces/immich/server/upload
-      - ${UPLOAD_LOCATION-./Library}/photos/upload:/workspaces/immich/server/upload/upload
+      - ${IMMICH_UPLOAD_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/photos}${UPLOAD_LOCATION:-upload-devcontainer-volume}}:/workspaces/immich/server/upload
+      - ${IMMICH_UPLOAD_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/photos/upload}${UPLOAD_LOCATION:-upload-devcontainer-volume}}:/workspaces/immich/server/upload/upload
       - /etc/localtime:/etc/localtime:ro
 
   immich-web:
@@ -31,7 +31,7 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
       POSTGRES_HOST_AUTH_METHOD: md5
     volumes:
-      - ${UPLOAD_LOCATION-./Library}/postgres:/var/lib/postgresql/data
+      - ${IMMICH_POSTGRES_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/postgres}${UPLOAD_LOCATION:-postgres-devcontainer-volume}}:/var/lib/postgresql/data
 
   redis:
     env_file: !reset []
@@ -44,3 +44,4 @@ volumes:
   server_node_modules:
   web_node_modules:
   upload-devcontainer-volume:
+  postgres-devcontainer-volume:

--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -12,8 +12,8 @@ services:
       - open_api_node_modules:/workspaces/immich/open-api/typescript-sdk/node_modules
       - server_node_modules:/workspaces/immich/server/node_modules
       - web_node_modules:/workspaces/immich/web/node_modules
-      - ${IMMICH_UPLOAD_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/photos}${UPLOAD_LOCATION:-upload-devcontainer-volume}}:/workspaces/immich/server/upload
-      - ${IMMICH_UPLOAD_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/photos/upload}${UPLOAD_LOCATION:-upload-devcontainer-volume}}:/workspaces/immich/server/upload/upload
+      - ${UPLOAD_LOCATION:-upload1-devcontainer-volume}${UPLOAD_LOCATION:+/photos}:/workspaces/immich/server/upload
+      - ${UPLOAD_LOCATION:-upload2-devcontainer-volume}${UPLOAD_LOCATION:+/photos/upload}:/workspaces/immich/server/upload/upload
       - /etc/localtime:/etc/localtime:ro
 
   immich-web:
@@ -30,8 +30,8 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME-immich}
       POSTGRES_INITDB_ARGS: '--data-checksums'
       POSTGRES_HOST_AUTH_METHOD: md5
-    volumes:
-      - ${IMMICH_POSTGRES_VOLUME-${UPLOAD_LOCATION:+${UPLOAD_LOCATION}/postgres}${UPLOAD_LOCATION:-postgres-devcontainer-volume}}:/var/lib/postgresql/data
+    volumes: 
+      - ${UPLOAD_LOCATION:-postgres-devcontainer-volume}${UPLOAD_LOCATION:+/postgres}:/var/lib/postgresql/data
 
   redis:
     env_file: !reset []
@@ -43,5 +43,6 @@ volumes:
   open_api_node_modules:
   server_node_modules:
   web_node_modules:
-  upload-devcontainer-volume:
+  upload1-devcontainer-volume:
+  upload2-devcontainer-volume:
   postgres-devcontainer-volume:

--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -29,6 +29,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME-postgres}
       POSTGRES_DB: ${DB_DATABASE_NAME-immich}
       POSTGRES_INITDB_ARGS: '--data-checksums'
+      POSTGRES_HOST_AUTH_METHOD: md5
     volumes:
       - ${UPLOAD_LOCATION-./Library}/postgres:/var/lib/postgresql/data
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 docker/upload
 docker/library
-docker/Library
 uploads
 coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 docker/upload
 docker/library
+docker/Library
 uploads
 coverage
 


### PR DESCRIPTION
Ran into some problems with devcontainers on codespaces and using bind mounts. 

This tweak will use bind-mounts when the variable UPLOAD_LOCATION is specified, but will fallback to volume mounts when unspecified (like when running on a cloud-initialized codespaces container). 

It took some doing, but with some fancy variable interpolation, was able to use a single volume definition that could either be a bind-mount or a volume mount, depending on if the UPLOAD_LOCATION variable was defined or not. 