### PR TITLE
fix: album list CSS margins

### DIFF
--- a/web/src/lib/components/album-page/albums-table.svelte
+++ b/web/src/lib/components/album-page/albums-table.svelte
@@ -45,7 +45,7 @@
       {@const isCollapsed = isAlbumGroupCollapsed($albumViewSettings, albumGroup.id)}
       {@const iconRotation = isCollapsed ? 'rotate-0' : 'rotate-90'}
       <tbody
-        class="block w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg"
+        class="block w-full overflow-y-auto rounded-md border dark:border-immich-dark-gray dark:text-immich-dark-fg mt-4"
       >
         <tr
           class="flex w-full place-items-center p-2 md:ps-5 md:pe-5 md:pt-3 md:pb-3"


### PR DESCRIPTION
## Description

Minor UI fix to the Album List view making it unclear which section albums belong to due to the albums "sticking" to the wrong year - see screenshots.

I'm no UX designer, I'm sure there are alternative options, but I figured having it balanced would be best for now. :) 

## How Has This Been Tested?

- [x] Manually checking the frontend; this is a purely visual change

<details><summary><h2>Screenshots</h2></summary>

Before; the albums seem to be attached to the next year
<img width="744" alt="Screenshot 2025-06-19 at 08 35 40" src="https://github.com/user-attachments/assets/d31b739b-3f49-47a0-a5f1-c8449ecd1db1" />

After; added a gap between the year dividers to ensure that they aren't stuck to the albums.
<img width="755" alt="Screenshot 2025-06-19 at 08 36 50" src="https://github.com/user-attachments/assets/2bb7f9e5-575d-44f8-b97c-8b77418b7e46" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
