### PR TITLE
fix(server): unset prewarm dim parameter

### DIFF
--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -119,8 +119,6 @@ export class DatabaseRepository {
     await sql`CREATE EXTENSION IF NOT EXISTS ${sql.raw(extension)} CASCADE`.execute(this.db);
     if (extension === DatabaseExtension.VECTORCHORD) {
       const dbName = sql.id(await this.getDatabaseName());
-      await sql`ALTER DATABASE ${dbName} SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536'`.execute(this.db);
-      await sql`SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536'`.execute(this.db);
       await sql`ALTER DATABASE ${dbName} SET vchordrq.probes = 1`.execute(this.db);
       await sql`SET vchordrq.probes = 1`.execute(this.db);
     }

--- a/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
+++ b/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
@@ -1,0 +1,15 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  const { rows } = await sql<{ db: string }>`SELECT current_database() as db;`.execute(db);
+  const databaseName = rows[0].db;
+  await sql.raw(`ALTER DATABASE "${databaseName}" RESET vchordrq.prewarm_dim;`).execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  const { rows } = await sql<{ db: string }>`SELECT current_database() as db;`.execute(db);
+  const databaseName = rows[0].db;
+  await sql
+    .raw(`ALTER DATABASE "${databaseName}" SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536';`)
+    .execute(db);
+}


### PR DESCRIPTION
## Description

The setting was deprecated in 0.4.0. It is not necessary in 0.3.0 either (only an optimization), so it's simpler to remove it for all versions.

Fixes #19254

*Has not been tested*, but I'm relatively confident in the change