### PR TITLE
chore: add curl to machine-learning container image

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -136,7 +136,7 @@ FROM prod-${DEVICE} AS prod
 ARG DEVICE
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tini $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
+    apt-get install -y --no-install-recommends tini curl $(if ! [ "$DEVICE" = "openvino" ] && ! [ "$DEVICE" = "rocm" ]; then echo "libmimalloc2.0"; fi) && \
     apt-get autoremove -yqq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

This pull request includes a small update to the `machine-learning/Dockerfile`. The change adds the installation of `curl` to the list of packages installed during the build process. Having curl in the container allows for more advanced health checking setups in bigger/cloud-native environemtns.

## How Has This Been Tested?

- [x] Container has been build locally and run shortly to verify the curl installation

## Checklist:

- [x] I have performed a self-review of my own code
- n/a I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- n/a I have confirmed that any new dependencies are strictly necessary.
- n/a I have written tests for new code (if applicable)
- n/a I have followed naming conventions/patterns in the surrounding code
- n/a All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- n/a All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
