### PR TITLE
chore: remove unused mocks

### DIFF
--- a/server/src/services/duplicate.service.spec.ts
+++ b/server/src/services/duplicate.service.spec.ts
@@ -151,11 +151,11 @@ describe(SearchService.name, () => {
         },
       });
       const id = assetStub.livePhotoMotionAsset.id;
-      mocks.asset.getById.mockResolvedValue(assetStub.livePhotoMotionAsset);
 
       const result = await sut.handleSearchDuplicates({ id });
 
       expect(result).toBe(JobStatus.SKIPPED);
+      expect(mocks.assetJob.getForSearchDuplicatesJob).not.toHaveBeenCalled();
     });
 
     it('should skip if duplicate detection is disabled', async () => {
@@ -168,11 +168,11 @@ describe(SearchService.name, () => {
         },
       });
       const id = assetStub.livePhotoMotionAsset.id;
-      mocks.asset.getById.mockResolvedValue(assetStub.livePhotoMotionAsset);
 
       const result = await sut.handleSearchDuplicates({ id });
 
       expect(result).toBe(JobStatus.SKIPPED);
+      expect(mocks.assetJob.getForSearchDuplicatesJob).not.toHaveBeenCalled();
     });
 
     it('should fail if asset is not found', async () => {

--- a/server/src/services/library.service.spec.ts
+++ b/server/src/services/library.service.spec.ts
@@ -1113,8 +1113,6 @@ describe(LibraryService.name, () => {
       mocks.library.get.mockResolvedValue(library);
       mocks.library.streamAssetIds.mockReturnValue(makeStream([assetStub.image1]));
 
-      mocks.asset.getById.mockResolvedValue(assetStub.image1);
-
       await expect(sut.handleDeleteLibrary({ id: library.id })).resolves.toBe(JobStatus.SUCCESS);
     });
   });

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -268,7 +268,7 @@ describe(NotificationService.name, () => {
       mocks.album.getById.mockResolvedValue(albumStub.empty);
 
       await expect(sut.handleAlbumInvite({ id: '', recipientId: '' })).resolves.toBe(JobStatus.SKIPPED);
-      expect(mocks.asset.getById).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
     });
 
     it('should skip if the recipient has email notifications disabled', async () => {


### PR DESCRIPTION
A few tests were passing, but still using/reference old methods that the implementation no longer uses.