### PR TITLE
revert: fix(web): wrap long names with textarea

### DIFF
--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -370,15 +370,16 @@
             onToggleFavorite={() => handleToggleFavorite(person)}
           />
 
-          <textarea
-            class="bg-white dark:bg-immich-dark-gray border-gray-100 placeholder-gray-400 text-center dark:border-gray-900 w-full rounded-2xl mt-2 p-2 text-sm text-immich-primary dark:text-immich-dark-primary resize-none field-sizing-content"
+          <input
+            type="text"
+            class=" bg-white dark:bg-immich-dark-gray border-gray-100 placeholder-gray-400 text-center dark:border-gray-900 w-full rounded-2xl mt-2 py-2 text-sm text-immich-primary dark:text-immich-dark-primary"
             value={person.name}
             placeholder={$t('add_a_name')}
             use:shortcut={{ shortcut: { key: 'Enter' }, onShortcut: (e) => e.currentTarget.blur() }}
             onfocusin={() => onNameChangeInputFocus(person)}
             onfocusout={() => onNameChangeSubmit(newName, person)}
             oninput={(event) => onNameChangeInputUpdate(event)}
-          ></textarea>
+          />
         </div>
       {/snippet}
     </PeopleInfiniteScroll>


### PR DESCRIPTION
Reverts immich-app/immich#19301

This doesn't work with firefox due to them not supporting `field-sizing-content` on textarea.