### PR TITLE
fix(mobile): hide video thumbnail when video is ready

### DIFF
--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -397,7 +397,8 @@ class NativeVideoViewerPage extends HookConsumerWidget {
       children: [
         // This remains under the video to avoid flickering
         // For motion videos, this is the image portion of the asset
-        if (!isVideoReady.value) Center(key: ValueKey(asset.id), child: image),
+        if (!isVideoReady.value || asset.isMotionPhoto)
+          Center(key: ValueKey(asset.id), child: image),
         if (aspectRatio.value != null && !isCasting)
           Visibility.maintain(
             key: ValueKey(asset),

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -63,6 +63,8 @@ class NativeVideoViewerPage extends HookConsumerWidget {
 
     final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
 
+    final isVideoReady = useState(false);
+
     Future<VideoSource?> createSource() async {
       if (!context.mounted) {
         return null;
@@ -196,6 +198,8 @@ class NativeVideoViewerPage extends HookConsumerWidget {
       final videoPlayback =
           VideoPlaybackValue.fromNativeController(videoController);
       ref.read(videoPlaybackValueProvider.notifier).value = videoPlayback;
+
+      isVideoReady.value = true;
 
       try {
         await videoController.play();
@@ -393,8 +397,7 @@ class NativeVideoViewerPage extends HookConsumerWidget {
       children: [
         // This remains under the video to avoid flickering
         // For motion videos, this is the image portion of the asset
-        if (controller.value == null)
-          Center(key: ValueKey(asset.id), child: image),
+        if (!isVideoReady.value) Center(key: ValueKey(asset.id), child: image),
         if (aspectRatio.value != null && !isCasting)
           Visibility.maintain(
             key: ValueKey(asset),

--- a/mobile/lib/pages/common/native_video_viewer.page.dart
+++ b/mobile/lib/pages/common/native_video_viewer.page.dart
@@ -393,7 +393,8 @@ class NativeVideoViewerPage extends HookConsumerWidget {
       children: [
         // This remains under the video to avoid flickering
         // For motion videos, this is the image portion of the asset
-        Center(key: ValueKey(asset.id), child: image),
+        if (controller.value == null)
+          Center(key: ValueKey(asset.id), child: image),
         if (aspectRatio.value != null && !isCasting)
           Visibility.maintain(
             key: ValueKey(asset),


### PR DESCRIPTION
Fixes #18701

## Description

This PR changes `NativeVideoViewerPage` to check if the video is ready to play and hides the video thumbnail to avoid misalignment (1 pixel wide static line on the bottom and right side of the frame.) 

Fixes #18701