### PR TITLE
fix(server): migration failing on pg15+

### DIFF
--- a/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
+++ b/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
@@ -18,4 +18,4 @@ export async function up(qb: Kysely<any>): Promise<void> {
   }
 }
 
-export async function down(db: Kysely<any>): Promise<void> {}
+export async function down(): Promise<void> {}

--- a/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
+++ b/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
@@ -1,15 +1,21 @@
 import { Kysely, sql } from 'kysely';
 
-export async function up(db: Kysely<any>): Promise<void> {
-  const { rows } = await sql<{ db: string }>`SELECT current_database() as db;`.execute(db);
-  const databaseName = rows[0].db;
-  await sql.raw(`ALTER DATABASE "${databaseName}" RESET vchordrq.prewarm_dim;`).execute(db);
+export async function up(qb: Kysely<any>): Promise<void> {
+  type Conf = { db: string; guc: string[] };
+  const res = await sql<Conf>`select current_database() db, to_json(setconfig) guc from pg_db_role_setting`.execute(qb);
+  if (res.rows.length === 0) {
+    return;
+  }
+
+  await sql`alter database immich reset all;`.execute(qb);
+  const { db, guc } = res.rows[0];
+  for (const parameter of guc) {
+    const [key, value] = parameter.split('=');
+    if (key === 'vchordrq.prewarm_dim') {
+      continue;
+    }
+    await sql.raw(`alter database "${db}" set ${key} to ${value};`).execute(qb);
+  }
 }
 
-export async function down(db: Kysely<any>): Promise<void> {
-  const { rows } = await sql<{ db: string }>`SELECT current_database() as db;`.execute(db);
-  const databaseName = rows[0].db;
-  await sql
-    .raw(`ALTER DATABASE "${databaseName}" SET vchordrq.prewarm_dim = '512,640,768,1024,1152,1536';`)
-    .execute(db);
-}
+export async function down(db: Kysely<any>): Promise<void> {}


### PR DESCRIPTION
## Description

`RESET`ing the now-unused parameter of an extension is allowed in 14, but not in 15+ (see [commit](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=88103567c)). One solution to this is to run the following query

```sql
UPDATE pg_db_role_setting SET setconfig = array_remove(setconfig, 'vchordrq.prewarm_dim=512,640,768,1024,1152,1536')
WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname = '<DB_DATABASE_NAME>');
```
However, it will not work for non-superuser environments, and writing to `pg_catalog` directly is not recommended.

Another option is to run `ALTER DATABASE immich RESET ALL;`, which both removes the parameter and works for non-superusers. However, this command has side effects as database-level parameters set elsewhere can be silently removed in this way.

This PR first queries the database-level parameter overrides, then resets all parameters, and finally reapplies all parameters except the removed `prewarm_dim` parameter. This should work for all users.

Fixes #19313

## How Has This Been Tested?

I created a new instance at 1.134.0 using `ghcr.io/immich-app/postgres:15-vectorchord0.3.0-pgvectors0.2.0`, then upgraded to 1.135.0 with `0.4.2` confirming that it worked with warnings, then upgraded to 1.135.1 confirming that it crashloops, then tried with this pr and confirmed it started up successfully. I inspected the `setconfig` array before and after this PR and confirmed that all parameters except for `vchordrq.prewarm_dim` were set exactly as before.