### PR TITLE
fix: bump vchord default to 0.4.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -644,7 +644,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: ghcr.io/immich-app/postgres:14-vectorchord0.4.1
+        image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.2-pgvectors0.2.0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -63,7 +63,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.2-pgvectors0.2.0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.2-pgvectors0.2.0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}

--- a/server/test/medium/globalSetup.ts
+++ b/server/test/medium/globalSetup.ts
@@ -7,7 +7,7 @@ import { getKyselyConfig } from 'src/utils/database';
 import { GenericContainer, Wait } from 'testcontainers';
 
 const globalSetup = async () => {
-  const postgresContainer = await new GenericContainer('ghcr.io/immich-app/postgres:14-vectorchord0.4.1')
+  const postgresContainer = await new GenericContainer('ghcr.io/immich-app/postgres:14-vectorchord0.4.3')
     .withExposedPorts(5432)
     .withEnvironment({
       POSTGRES_PASSWORD: 'postgres',


### PR DESCRIPTION
## Description

0.4.0-0.4.2 does not work on certain aarch64 environments like Raspberry Pi and Asahi Linux. 0.4.3 fixes this and should be the default as a result. There is no need to upgrade unless affected by this issue.

Depends on [this](https://github.com/immich-app/base-images/pull/241) PR being merged first

Fixes #19038