### PR TITLE
fix: use icons instead of toggles for admin user features view

### DIFF
--- a/web/src/lib/components/admin-page/user/feature-setting.svelte
+++ b/web/src/lib/components/admin-page/user/feature-setting.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Icon, Text } from '@immich/ui';
-  import { t } from 'svelte-i18n';
   import { mdiCheck, mdiClose } from '@mdi/js';
 
   interface Props {
@@ -13,9 +12,5 @@
 
 <div class="flex justify-between items-center">
   <Text class="text-sm font-medium">{title}</Text>
-  <Icon
-    icon={state ? mdiCheck : mdiClose}
-    class={state ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-danger'}
-    size="24"
-  />
+  <Icon icon={state ? mdiCheck : mdiClose} class={state ? 'text-primary' : 'text-danger'} size="24" />
 </div>

--- a/web/src/lib/components/admin-page/user/feature-setting.svelte
+++ b/web/src/lib/components/admin-page/user/feature-setting.svelte
@@ -15,7 +15,7 @@
   <Text class="text-sm font-medium">{title}</Text>
   <Icon
     icon={state ? mdiCheck : mdiClose}
-    class={state ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-gray-400 dark:text-gray-600'}
+    class={state ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-danger'}
     size="24"
   />
 </div>

--- a/web/src/lib/components/admin-page/user/feature-setting.svelte
+++ b/web/src/lib/components/admin-page/user/feature-setting.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Icon, Text } from '@immich/ui';
+  import { t } from 'svelte-i18n';
+  import { mdiCheck, mdiClose } from '@mdi/js';
+
+  interface Props {
+    title: string;
+    state: boolean;
+  }
+
+  let { title, state }: Props = $props();
+</script>
+
+<div class="flex justify-between items-center">
+  <Text class="text-sm font-medium">{title}</Text>
+  <Icon
+    icon={state ? mdiCheck : mdiClose}
+    class={state ? 'text-immich-primary dark:text-immich-dark-primary' : 'text-gray-400 dark:text-gray-600'}
+    size="24"
+  />
+</div>

--- a/web/src/routes/admin/users/[id]/+page.svelte
+++ b/web/src/routes/admin/users/[id]/+page.svelte
@@ -39,7 +39,9 @@
     mdiCameraIris,
     mdiChartPie,
     mdiChartPieOutline,
+    mdiCheck,
     mdiCheckCircle,
+    mdiClose,
     mdiDeleteRestore,
     mdiFeatureSearchOutline,
     mdiLockSmart,
@@ -50,6 +52,7 @@
   } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
+  import FeatureSetting from '$lib/components/admin-page/user/feature-setting.svelte';
 
   interface Props {
     data: PageData;
@@ -292,33 +295,15 @@
           <CardBody>
             <div class="px-4 pb-4">
               <Stack gap={3}>
-                <Field readOnly label={$t('email_notifications')}>
-                  <Switch checked={userPreferences.emailNotifications.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('folders')}>
-                  <Switch checked={userPreferences.folders.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('memories')}>
-                  <Switch checked={userPreferences.memories.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('people')}>
-                  <Switch checked={userPreferences.people.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('rating')}>
-                  <Switch checked={userPreferences.ratings.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('shared_links')}>
-                  <Switch checked={userPreferences.sharedLinks.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('show_supporter_badge')}>
-                  <Switch checked={userPreferences.purchase.showSupportBadge} color="primary" />
-                </Field>
-                <Field readOnly label={$t('tags')}>
-                  <Switch checked={userPreferences.tags.enabled} color="primary" />
-                </Field>
-                <Field readOnly label={$t('gcast_enabled')}>
-                  <Switch checked={userPreferences.cast.gCastEnabled} color="primary" />
-                </Field>
+                <FeatureSetting title={$t('email_notifications')} state={userPreferences.emailNotifications.enabled} />
+                <FeatureSetting title={$t('folders')} state={userPreferences.folders.enabled} />
+                <FeatureSetting title={$t('memories')} state={userPreferences.memories.enabled} />
+                <FeatureSetting title={$t('people')} state={userPreferences.people.enabled} />
+                <FeatureSetting title={$t('rating')} state={userPreferences.ratings.enabled} />
+                <FeatureSetting title={$t('shared_links')} state={userPreferences.sharedLinks.enabled} />
+                <FeatureSetting title={$t('show_supporter_badge')} state={userPreferences.purchase.showSupportBadge} />
+                <FeatureSetting title={$t('tags')} state={userPreferences.tags.enabled} />
+                <FeatureSetting title={$t('gcast_enabled')} state={userPreferences.cast.gCastEnabled} />
               </Stack>
             </div>
           </CardBody>

--- a/web/src/routes/admin/users/[id]/+page.svelte
+++ b/web/src/routes/admin/users/[id]/+page.svelte
@@ -25,13 +25,11 @@
     CardTitle,
     Code,
     Container,
-    Field,
     getByteUnitString,
     Heading,
     HStack,
     Icon,
     Stack,
-    Switch,
     Text,
   } from '@immich/ui';
   import {
@@ -39,9 +37,7 @@
     mdiCameraIris,
     mdiChartPie,
     mdiChartPieOutline,
-    mdiCheck,
     mdiCheckCircle,
-    mdiClose,
     mdiDeleteRestore,
     mdiFeatureSearchOutline,
     mdiLockSmart,


### PR DESCRIPTION
## Description

<img width="563" alt="image" src="https://github.com/user-attachments/assets/2ed0d62d-ccf7-4a7c-9465-72a78ebc4170" />


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
