### PR TITLE
fix(server): don't hardcode database name in migration

### DIFF
--- a/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
+++ b/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
@@ -7,8 +7,8 @@ export async function up(qb: Kysely<any>): Promise<void> {
     return;
   }
 
-  await sql`alter database immich reset all;`.execute(qb);
   const { db, guc } = res.rows[0];
+  await sql.raw(`alter database "${db}" reset all;`).execute(qb);
   for (const parameter of guc) {
     const [key, value] = parameter.split('=');
     if (key === 'vchordrq.prewarm_dim') {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/immich-app/immich/issues/19374

## How Has This Been Tested?
No errors on NixOS, where the database name is immich though.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

cc @mertalev 