### PR TITLE
feat: test for non-standard database name

### DIFF
--- a/server/test/medium/globalSetup.ts
+++ b/server/test/medium/globalSetup.ts
@@ -7,12 +7,13 @@ import { getKyselyConfig } from 'src/utils/database';
 import { GenericContainer, Wait } from 'testcontainers';
 
 const globalSetup = async () => {
+  const templateName = 'mich';
   const postgresContainer = await new GenericContainer('ghcr.io/immich-app/postgres:14-vectorchord0.4.3')
     .withExposedPorts(5432)
     .withEnvironment({
       POSTGRES_PASSWORD: 'postgres',
       POSTGRES_USER: 'postgres',
-      POSTGRES_DB: 'immich',
+      POSTGRES_DB: templateName,
     })
     .withCommand([
       'postgres',
@@ -35,7 +36,7 @@ const globalSetup = async () => {
     .start();
 
   const postgresPort = postgresContainer.getMappedPort(5432);
-  const postgresUrl = `postgres://postgres:postgres@localhost:${postgresPort}/immich`;
+  const postgresUrl = `postgres://postgres:postgres@localhost:${postgresPort}/${templateName}`;
 
   process.env.IMMICH_TEST_POSTGRES_URL = postgresUrl;
 

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -373,18 +373,23 @@ function* newPngFactory() {
 
 const pngFactory = newPngFactory();
 
-const withDatabase = (url: string, name: string) => url.replace('/immich', `/${name}`);
+const templateName = 'mich';
+
+const withDatabase = (url: string, name: string) => url.replace(`/${templateName}`, `/${name}`);
 
 export const getKyselyDB = async (suffix?: string): Promise<Kysely<DB>> => {
   const testUrl = process.env.IMMICH_TEST_POSTGRES_URL!;
   const sql = postgres({
-    ...asPostgresConnectionConfig({ connectionType: 'url', url: withDatabase(testUrl, 'postgres') }),
+    ...asPostgresConnectionConfig({
+      connectionType: 'url',
+      url: withDatabase(testUrl, 'postgres'),
+    }),
     max: 1,
   });
 
   const randomSuffix = Math.random().toString(36).slice(2, 7);
   const dbName = `immich_${suffix ?? randomSuffix}`;
-  await sql.unsafe(`CREATE DATABASE ${dbName} WITH TEMPLATE immich OWNER postgres;`);
+  await sql.unsafe(`CREATE DATABASE ${dbName} WITH TEMPLATE ${templateName} OWNER postgres;`);
 
   return new Kysely<DB>(getKyselyConfig({ connectionType: 'url', url: withDatabase(testUrl, dbName) }));
 };


### PR DESCRIPTION
 Run medium tests with a non standard database name to make sure migrations still work correctly.