### PR TITLE
fix(server): filter parameters by database and role

### DIFF
--- a/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
+++ b/server/src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
@@ -2,7 +2,11 @@ import { Kysely, sql } from 'kysely';
 
 export async function up(qb: Kysely<any>): Promise<void> {
   type Conf = { db: string; guc: string[] };
-  const res = await sql<Conf>`select current_database() db, to_json(setconfig) guc from pg_db_role_setting`.execute(qb);
+  const res = await sql<Conf>`
+    select current_database() db, to_json(setconfig) guc
+    from pg_db_role_setting
+    where setdatabase = (select oid from pg_database where datname = current_database())
+      and setrole = 0;`.execute(qb);
   if (res.rows.length === 0) {
     return;
   }


### PR DESCRIPTION
If the Postgres instance has multiple database besides immich and one of them has a database or role wide parameter override set, it is possible for the migration to apply the wrong parameters. Immich happens to work without the right parameters set *unless* Postgres is also using pgvecto.rs, and it's unlikely for the incorrect parameters to be disruptive.  But it's of course not an ideal scenario. This PR filters the query fetching these parameters to avoid this happening.

Fixes #19391