### PR TITLE
fix: storage template onboarding save

### DIFF
--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -5,7 +5,7 @@
   import { featureFlags } from '$lib/stores/server-config.store';
   import { user } from '$lib/stores/user.store';
   import { getConfig, type SystemConfigDto } from '@immich/sdk';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
 
   let config: SystemConfigDto | undefined = $state();
   let adminSettingsComponent = $state<ReturnType<typeof AdminSettings>>();
@@ -14,9 +14,9 @@
     config = await getConfig();
   });
 
-  export const save = async () => {
+  onDestroy(async () => {
     await adminSettingsComponent?.handleSave({ storageTemplate: config?.storageTemplate });
-  };
+  });
 </script>
 
 <div class="flex flex-col">

--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -14,9 +14,7 @@
     config = await getConfig();
   });
 
-  onDestroy(async () => {
-    await adminSettingsComponent?.handleSave({ storageTemplate: config?.storageTemplate });
-  });
+  onDestroy(() => adminSettingsComponent?.handleSave({ storageTemplate: config?.storageTemplate }));
 </script>
 
 <div class="flex flex-col">


### PR DESCRIPTION
## Description

Fixes #19395. Tested on fresh install and storage template is saved.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
