### PR TITLE
fix(web): timeline timezone

### DIFF
--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -108,7 +108,6 @@ export function formatMonthGroupTitle(_date: DateTime): string {
     {
       month: 'short',
       year: 'numeric',
-      timeZone: 'UTC',
     },
     { locale: get(locale) },
   );


### PR DESCRIPTION
Fixes #19380.
This issue happens on the timezone UTC+1 ~ UTC+12.
For example, in UTC+8, incorrect conversion in timezone causes `timeBucket` in `2025-06-01 00:00:00` to `2025-05-31 16:00:00`. This is why there is one month‘s difference.
![屏幕截图 2025-06-22 131107](https://github.com/user-attachments/assets/39aae6ab-70e5-4799-9ded-47de4363d86b)
