### PR TITLE
fix(web): map broken after redirect from details

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <script lang="ts">
+  import { afterNavigate } from '$app/navigation';
   import Icon from '$lib/components/elements/icon.svelte';
   import { Theme } from '$lib/constants';
   import { modalManager } from '$lib/managers/modal-manager.svelte';
@@ -212,6 +213,17 @@
       }
     }
   };
+
+  afterNavigate(() => {
+    if (map) {
+      map.resize();
+
+      if (window.location.hash) {
+        const hashChangeEvent = new HashChangeEvent('hashchange');
+        window.dispatchEvent(hashChangeEvent);
+      }
+    }
+  });
 
   onMount(async () => {
     if (!mapMarkers) {

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -218,9 +218,9 @@
     if (map) {
       map.resize();
 
-      if (window.location.hash) {
+      if (globalThis.location.hash) {
         const hashChangeEvent = new HashChangeEvent('hashchange');
-        window.dispatchEvent(hashChangeEvent);
+        globalThis.dispatchEvent(hashChangeEvent);
       }
     }
   });


### PR DESCRIPTION
## Description
Fixes the issue where the map would be small and broken after redirecting from the "goto map" in the details pane.

Fixes #17750

Before:
<img width="600" alt="Screenshot 2025-06-22 at 10 26 36" src="https://github.com/user-attachments/assets/85915e23-c28b-4bd5-b6f5-acd91c51dd55" />

After:
<img width="600" alt="Screenshot 2025-06-22 at 10 27 11" src="https://github.com/user-attachments/assets/b4ee71e0-26d2-4625-92fb-76c3b06bc942" />
