### PR TITLE
feat(mobile): enable Croatian (hr) translations

### DIFF
--- a/mobile/lib/constants/locales.dart
+++ b/mobile/lib/constants/locales.dart
@@ -11,6 +11,7 @@ const Map<String, Locale> locales = {
       Locale.fromSubtags(languageCode: 'zh', scriptCode: 'SIMPLIFIED'),
   'Chinese Traditional (zh_TW)':
       Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
+  'Croatian (hr)': Locale('hr'),
   'Czech (cs)': Locale('cs'),
   'Danish (da)': Locale('da'),
   'Dutch (nl)': Locale('nl'),


### PR DESCRIPTION
## Description

Enabled Croatian (hr) translations in the mobile app by adding 'Croatian (hr)' to the supported locales list and ensuring the list is sorted alphabetically.

This change allows users to select Croatian as their app language.

I was unable to test this change locally due to environment limitations (no Flutter + Waydroid or iOS setup). Please verify functionality during review, if needed.

Sorry for not being able to test.

## How Has This Been Tested?

- [ ] Manually selected Croatian in the app language settings and verified UI translations appear in Croatian.
- [ ] Confirmed the app builds and runs without errors.

**Note:** I could not test locally. Please test as part of the review process if needed.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- No screenshots available; unable to run the app locally. -->

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable  (n/a?)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable) (n/a?)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (assumed since no complicated changes were made)
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`) (assumed since no complicated changes were made)