### PR TITLE
fix(web): map cluster

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -315,7 +315,7 @@
         features: mapMarkers?.map((marker) => asFeature(marker)) ?? [],
       }}
       id="geojson"
-      cluster={{ radius: 35, maxZoom: 17 }}
+      cluster={{ radius: 35, maxZoom: 18 }}
     >
       <MarkerLayer
         applyToClusters


### PR DESCRIPTION
See discord. Match the zoom level in map and cluster. Now the maximum zoom level is 18 in both.
![image](https://github.com/user-attachments/assets/43f7940d-197b-4e12-8361-5a4e5ab4ecb1)
