### PR TITLE
fix(web): modal race condition

### DIFF
--- a/web/src/lib/managers/modal-manager.svelte.ts
+++ b/web/src/lib/managers/modal-manager.svelte.ts
@@ -27,7 +27,9 @@ class ModalManager {
     const deferred = new Promise<StripValueIfOptional<K>>((resolve) => {
       onClose = async (...args: [StripValueIfOptional<K>]) => {
         await unmount(modal);
-        resolve(args?.[0]);
+        setTimeout(() => {
+          resolve(args?.[0]);
+        }, 0);
       };
 
       modal = mount(Component, {


### PR DESCRIPTION
**Replaced by https://github.com/immich-app/ui/pull/196.**

Fixes #18615.
Add `setTimeout(func, 0)` to enforce to execute `func` in the next event loop to prevent from race condition.
![image](https://github.com/user-attachments/assets/15fa0592-7818-48b1-ad0d-e3e7bc2f55a3)
