### PR TITLE
server: Specify the hostname of the Postgres and Redis containers

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -20,3 +20,7 @@ DB_PASSWORD=postgres
 ###################################################################################
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
+DB_HOSTNAME=postgres
+
+# Redis
+REDIS_HOSTNAME=redis

--- a/docker/example.env
+++ b/docker/example.env
@@ -20,7 +20,7 @@ DB_PASSWORD=postgres
 ###################################################################################
 DB_USERNAME=postgres
 DB_DATABASE_NAME=immich
-DB_HOSTNAME=postgres
+DB_HOSTNAME=database
 
 # Redis
 REDIS_HOSTNAME=redis


### PR DESCRIPTION
## Description

I have deployed Immich for the first time on my home server, along with many other Docker containers. I wanted to name the Postgres container for Immich as immich-postgres (instead of database, as shown in the example).
This seems reasonable to me and is probably a common need for many users.