### PR TITLE
fix: ios widget webp support

### DIFF
--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -24,27 +24,11 @@ struct ImageEntry: TimelineEntry {
 struct ImmichWidgetView: View {
   var entry: ImageEntry
 
-  func getErrorText(_ error: WidgetError?) -> String {
-    switch error {
-    case .noLogin:
-      return "Login to Immich"
-
-    case .fetchFailed:
-      return "Unable to connect to your Immich instance"
-
-    case .albumNotFound:
-      return "Album not found"
-
-    default:
-      return "An unknown error occured"
-    }
-  }
-
   var body: some View {
     if entry.image == nil {
       VStack {
         Image("LaunchImage")
-        Text(getErrorText(entry.error))
+        Text(entry.error?.errorDescription ?? "")
           .minimumScaleFactor(0.25)
           .multilineTextAlignment(.center)
           .foregroundStyle(.secondary)


### PR DESCRIPTION
## Description

Widgets originally did not support WebP for the preview format. This support has been added as well as a more efficient image resizing API.

Fixes #19442 

## How Has This Been Tested?

Tested on iOS 18.5 with 4k WebP as the preview thumbnail format.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
