### PR TITLE
feat(deployment): add shm_size for PG

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -134,7 +134,7 @@ services:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
-    shm_size: 768mb
+    shm_size: 128mb
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -134,6 +134,7 @@ services:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    shm_size: 768mb
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -75,6 +75,7 @@ services:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    shm_size: 768mb
     restart: always
 
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -75,7 +75,7 @@ services:
       - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
-    shm_size: 768mb
+    shm_size: 128mb
     restart: always
 
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,6 +67,7 @@ services:
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    shm_size: 768mb
     restart: always
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
-    shm_size: 768mb
+    shm_size: 128mb
     restart: always
 
 volumes:

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -458,7 +458,7 @@ A result of `on` means that checksums are enabled.
 <summary>Check if checksums are enabled</summary>
 
 ```bash
-docker exec -it immich_postgres psql --dbname=postgres --username=<DB_USERNAME> --command="show data_checksums"
+docker exec -it immich_postgres psql --dbname=postgres --username=postgres --command="show data_checksums"
  data_checksums
 ----------------
  on
@@ -473,7 +473,7 @@ If checksums are enabled, you can check the status of the database with the foll
 <summary>Check for database corruption</summary>
 
 ```bash
-docker exec -it immich_postgres psql --dbname=postgres --username=<DB_USERNAME> --command="SELECT datname, checksum_failures, checksum_last_failure FROM pg_stat_database WHERE datname IS NOT NULL"
+docker exec -it immich_postgres psql --dbname=postgres --username=postgres --command="SELECT datname, checksum_failures, checksum_last_failure FROM pg_stat_database WHERE datname IS NOT NULL"
   datname  | checksum_failures | checksum_last_failure
 -----------+-------------------+-----------------------
  postgres  |                 0 |


### PR DESCRIPTION
I did some digging and it seems that setting `shm_size` is often needed for PG in Docker. We should consider setting `shm_size: 768mb` to our docker-compose now that we specify a shared_buffers of 512MB

https://www.instaclustr.com/blog/postgresql-docker-and-shared-memory/

https://hub.docker.com/_/postgres

https://stackoverflow.com/questions/56839975/docker-shm-size-dev-shm-resizing-shared-memory

(also removes some unnecessary DB_USERNAME from the FAQ) 