### PR TITLE
feat: ios widget alternate server URL support

### DIFF
--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -102,7 +102,13 @@ class ImmichAPI {
   }
 
   private static func validateServer(at endpointURL: URL) async -> URL? {
-    let baseURL = URL(string: endpointURL.scheme! + "://" + endpointURL.host!)!
+    // build a URL that is only scheme, host, and port
+    var components = URLComponents()
+    components.scheme = endpointURL.scheme
+    components.host = endpointURL.host
+    components.port = endpointURL.port
+
+    guard let baseURL = components.url else { return nil }
     
     var pingURL = baseURL
     pingURL.appendPathComponent(".well-known")

--- a/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/MemoryWidget.swift
@@ -20,8 +20,11 @@ struct ImmichMemoryProvider: TimelineProvider {
     completion: @escaping @Sendable (ImageEntry) -> Void
   ) {
     Task {
-      guard let api = try? await ImmichAPI() else {
-        completion(ImageEntry(date: Date(), image: nil, error: .noLogin))
+      var api: ImmichAPI
+      do {
+        api = try await ImmichAPI()
+      } catch let error as WidgetError {
+        completion(ImageEntry(date: Date(), image: nil, error: error))
         return
       }
 
@@ -79,9 +82,13 @@ struct ImmichMemoryProvider: TimelineProvider {
     Task {
       var entries: [ImageEntry] = []
       let now = Date()
-
-      guard let api = try? await ImmichAPI() else {
-        entries.append(ImageEntry(date: now, image: nil, error: .noLogin))
+      
+      
+      var api: ImmichAPI
+      do {
+        api = try await ImmichAPI()
+      } catch let error as WidgetError {
+        entries.append(ImageEntry(date: now, image: nil, error: error))
         completion(Timeline(entries: entries, policy: .atEnd))
         return
       }

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -118,10 +118,8 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }) async {
     await _apiService.setAccessToken(accessToken);
 
-    await _widgetService.writeCredentials(
-      Store.get(StoreKey.serverEndpoint),
-      accessToken,
-    );
+    await _widgetService.writeSessionKey(accessToken);
+    await _widgetService.writeServerList();
 
     // Get the deviceid from the store if it exists, otherwise generate a new one
     String deviceId =
@@ -190,6 +188,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> saveLocalEndpoint(String url) async {
     await Store.put(StoreKey.localEndpoint, url);
+    await _widgetService.writeServerList();
   }
 
   String? getSavedWifiName() {

--- a/mobile/lib/services/widget.service.dart
+++ b/mobile/lib/services/widget.service.dart
@@ -47,7 +47,7 @@ class WidgetService {
     final String? localEndpoint = Store.tryGet(StoreKey.localEndpoint);
     final String? serverUrl = Store.tryGet(StoreKey.serverUrl);
 
-    final List<dynamic> serverUrlList = endpointList.map((e) => e.url).toList();
+    final List<String> serverUrlList = endpointList.map((e) => e.url).toList();
 
     if (localEndpoint != null) {
       serverUrlList.insert(0, localEndpoint);
@@ -57,7 +57,10 @@ class WidgetService {
       serverUrlList.insert(0, serverUrl);
     }
 
-    return serverUrlList.cast<String>();
+    // remove duplicates
+    final Set<String> uniqueServerUrls = serverUrlList.toSet();
+
+    return uniqueServerUrls.toList();
   }
 
   Future<void> clearCredentials() async {

--- a/mobile/lib/services/widget.service.dart
+++ b/mobile/lib/services/widget.service.dart
@@ -4,45 +4,44 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
-import 'package:immich_mobile/models/auth/auxilary_endpoint.model.dart';
+import 'package:immich_mobile/repositories/auth.repository.dart';
 import 'package:immich_mobile/repositories/widget.repository.dart';
 
 final widgetServiceProvider = Provider((ref) {
   return WidgetService(
     ref.watch(widgetRepositoryProvider),
+    ref.watch(authRepositoryProvider),
   );
 });
 
 class WidgetService {
-  final WidgetRepository _repository;
+  final WidgetRepository _widgetRepository;
+  final AuthRepository _authRepository;
 
-  WidgetService(this._repository);
+  WidgetService(this._widgetRepository, this._authRepository);
 
   Future<void> writeSessionKey(
     String sessionKey,
   ) async {
-    await _repository.setAppGroupId(appShareGroupId);
-    await _repository.saveData(kWidgetAuthToken, sessionKey);
+    await _widgetRepository.setAppGroupId(appShareGroupId);
+    await _widgetRepository.saveData(kWidgetAuthToken, sessionKey);
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);
   }
 
   Future<void> writeServerList() async {
-    await _repository.setAppGroupId(appShareGroupId);
+    await _widgetRepository.setAppGroupId(appShareGroupId);
 
     // create json string from serverURLS
     final serverURLSString = jsonEncode(_buildServerList());
 
-    await _repository.saveData(kWidgetServerEndpoint, serverURLSString);
+    await _widgetRepository.saveData(kWidgetServerEndpoint, serverURLSString);
     Future.delayed(const Duration(seconds: 3), refreshWidgets);
   }
 
   List<String> _buildServerList() {
-    final List<dynamic> jsonList =
-        jsonDecode(Store.tryGet(StoreKey.externalEndpointList) ?? "[]");
-    final endpointList =
-        jsonList.map((e) => AuxilaryEndpoint.fromJson(e)).toList();
+    final endpointList = _authRepository.getExternalEndpointList();
 
     final String? localEndpoint = Store.tryGet(StoreKey.localEndpoint);
     final String? serverUrl = Store.tryGet(StoreKey.serverUrl);
@@ -53,20 +52,17 @@ class WidgetService {
       serverUrlList.insert(0, localEndpoint);
     }
 
-    if (serverUrl != null && serverUrl != localEndpoint) {
+    if (serverUrl != null) {
       serverUrlList.insert(0, serverUrl);
     }
 
-    // remove duplicates
-    final Set<String> uniqueServerUrls = serverUrlList.toSet();
-
-    return uniqueServerUrls.toList();
+    return serverUrlList.toSet().toList();
   }
 
   Future<void> clearCredentials() async {
-    await _repository.setAppGroupId(appShareGroupId);
-    await _repository.saveData(kWidgetServerEndpoint, "");
-    await _repository.saveData(kWidgetAuthToken, "");
+    await _widgetRepository.setAppGroupId(appShareGroupId);
+    await _widgetRepository.saveData(kWidgetServerEndpoint, "");
+    await _widgetRepository.saveData(kWidgetAuthToken, "");
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);
@@ -74,7 +70,7 @@ class WidgetService {
 
   Future<void> refreshWidgets() async {
     for (final name in kWidgetNames) {
-      await _repository.refresh(name);
+      await _widgetRepository.refresh(name);
     }
   }
 }

--- a/mobile/lib/widgets/settings/networking_settings/external_network_preference.dart
+++ b/mobile/lib/widgets/settings/networking_settings/external_network_preference.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/auth/auxilary_endpoint.model.dart';
+import 'package:immich_mobile/services/widget.service.dart';
 import 'package:immich_mobile/widgets/settings/networking_settings/endpoint_input.dart';
 
 class ExternalNetworkPreference extends HookConsumerWidget {
@@ -35,6 +36,8 @@ class ExternalNetworkPreference extends HookConsumerWidget {
         StoreKey.externalEndpointList,
         jsonString,
       );
+
+      ref.read(widgetServiceProvider).writeServerList();
     }
 
     updateValidationStatus(String url, int index, AuxCheckStatus status) {


### PR DESCRIPTION
## Description

iOS widget now has support for using the local and remote server endpoints for connection.

## How Has This Been Tested?

Tested on iOS 18.5 Simulator with 2 domains added to the external network list

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
