### PR TITLE
fix: android app link support

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -104,20 +104,18 @@
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
 
+          <data android:scheme="https" />
+
           <data
-              android:scheme="https"
               android:host="my.immich.app"
               android:path="/" />
           <data
-              android:scheme="https"
               android:host="my.immich.app"
               android:pathPrefix="/albums/" />
           <data
-              android:scheme="https"
               android:host="my.immich.app"
               android:pathPrefix="/memories/" />
           <data
-              android:scheme="https"
               android:host="my.immich.app"
               android:pathPrefix="/photos/" />
       </intent-filter>

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -90,11 +90,36 @@
         <data android:mimeType="video/*" />
       </intent-filter>
 
+      <!-- immich:// URL scheme handling -->
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="immich" />
+      </intent-filter>
+
+      <!-- my.immich.app deep link -->
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+
+          <data
+              android:scheme="https"
+              android:host="my.immich.app"
+              android:path="/" />
+          <data
+              android:scheme="https"
+              android:host="my.immich.app"
+              android:pathPrefix="/albums/" />
+          <data
+              android:scheme="https"
+              android:host="my.immich.app"
+              android:pathPrefix="/memories/" />
+          <data
+              android:scheme="https"
+              android:host="my.immich.app"
+              android:pathPrefix="/photos/" />
       </intent-filter>
     </activity>
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -99,7 +99,7 @@
       </intent-filter>
 
       <!-- my.immich.app deep link -->
-      <intent-filter>
+      <intent-filter android:autoVerify="true">
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
## Description

Add missing intent filters to `AndroidManifest.xml` .

## How Has This Been Tested?

It appears that we need to verify domains in Play Console before it will let us test the feature. The well-known files are in place and should work once released.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
