### PR TITLE
feat(mobile): ios widget deeplink to asset in app

### DIFF
--- a/mobile/ios/WidgetExtension/EntryGenerators.swift
+++ b/mobile/ios/WidgetExtension/EntryGenerators.swift
@@ -3,7 +3,7 @@ import WidgetKit
 
 func buildEntry(
   api: ImmichAPI,
-  asset: SearchResult,
+  asset: Asset,
   dateOffset: Int,
   subtitle: String? = nil
 )
@@ -15,7 +15,8 @@ func buildEntry(
     to: Date.now
   )!
   let image = try await api.fetchImage(asset: asset)
-  return ImageEntry(date: entryDate, image: image, subtitle: subtitle)
+
+  return ImageEntry(date: entryDate, image: image, subtitle: subtitle, deeplink: asset.deeplink)
 }
 
 func generateRandomEntries(

--- a/mobile/ios/WidgetExtension/EntryGenerators.swift
+++ b/mobile/ios/WidgetExtension/EntryGenerators.swift
@@ -16,7 +16,7 @@ func buildEntry(
   )!
   let image = try await api.fetchImage(asset: asset)
 
-  return ImageEntry(date: entryDate, image: image, subtitle: subtitle, deeplink: asset.deeplink)
+  return ImageEntry(date: entryDate, image: image, subtitle: subtitle, deepLink: asset.deepLink)
 }
 
 func generateRandomEntries(

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -6,6 +6,7 @@ struct ImageEntry: TimelineEntry {
   var image: UIImage?
   var subtitle: String? = nil
   var error: WidgetError? = nil
+  var deeplink: URL? = nil
 
   // Resizes the stored image to a maximum width of 450 pixels
   mutating func resize() {
@@ -54,6 +55,7 @@ struct ImmichWidgetView: View {
         }
         .padding(16)
       }
+      .widgetURL(entry.deeplink)
     }
   }
 }

--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -6,7 +6,7 @@ struct ImageEntry: TimelineEntry {
   var image: UIImage?
   var subtitle: String? = nil
   var error: WidgetError? = nil
-  var deeplink: URL? = nil
+  var deepLink: URL? = nil
 
   // Resizes the stored image to a maximum width of 450 pixels
   mutating func resize() {
@@ -55,7 +55,7 @@ struct ImmichWidgetView: View {
         }
         .padding(16)
       }
-      .widgetURL(entry.deeplink)
+      .widgetURL(entry.deepLink)
     }
   }
 }

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -43,9 +43,13 @@ enum AssetType: String, Codable {
   case other = "OTHER"
 }
 
-struct SearchResult: Codable {
+struct Asset: Codable {
   let id: String
   let type: AssetType
+  
+  var deepLink: URL? {
+    return URL(string: "immich://asset?id=\(id)")
+  }
 }
 
 struct SearchFilters: Codable {
@@ -56,7 +60,7 @@ struct SearchFilters: Codable {
 
 struct MemoryResult: Codable {
   let id: String
-  var assets: [SearchResult]
+  var assets: [Asset]
   let type: String
 
   struct MemoryData: Codable {
@@ -127,7 +131,7 @@ class ImmichAPI {
   }
 
   func fetchSearchResults(with filters: SearchFilters) async throws
-    -> [SearchResult]
+    -> [Asset]
   {
     // get URL
     guard
@@ -147,7 +151,7 @@ class ImmichAPI {
     let (data, _) = try await URLSession.shared.data(for: request)
 
     // decode data
-    return try JSONDecoder().decode([SearchResult].self, from: data)
+    return try JSONDecoder().decode([Asset].self, from: data)
   }
 
   func fetchMemory(for date: Date) async throws -> [MemoryResult] {
@@ -172,7 +176,7 @@ class ImmichAPI {
     return try JSONDecoder().decode([MemoryResult].self, from: data)
   }
 
-  func fetchImage(asset: SearchResult) async throws(WidgetError) -> UIImage {
+  func fetchImage(asset: Asset) async throws(WidgetError) -> UIImage {
     let thumbnailParams = [URLQueryItem(name: "size", value: "preview")]
     let assetEndpoint = "/assets/" + asset.id + "/thumbnail"
 


### PR DESCRIPTION
## Description

When tapping on a widget, the widget deeplinks to the asset viewer inside of the app.

## How Has This Been Tested?

iOS 18.5 Simulator and iOS 18.5 physical device works

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
