### PR TITLE
fix: enable photo manager custom filter by default

### DIFF
--- a/mobile/lib/repositories/album_media.repository.dart
+++ b/mobile/lib/repositories/album_media.repository.dart
@@ -14,7 +14,7 @@ class AlbumMediaRepository {
   const AlbumMediaRepository();
 
   bool get useCustomFilter =>
-      Store.get(StoreKey.photoManagerCustomFilter, false);
+      Store.get(StoreKey.photoManagerCustomFilter, true);
 
   FilterOptionGroup? _getAlbumFilter({
     DateTimeCond? updateTimeCond,

--- a/mobile/lib/services/app_settings.service.dart
+++ b/mobile/lib/services/app_settings.service.dart
@@ -88,7 +88,7 @@ enum AppSettingsEnum<T> {
   photoManagerCustomFilter<bool>(
     StoreKey.photoManagerCustomFilter,
     null,
-    false,
+    true,
   ),
   ;
 

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -23,7 +23,7 @@ import 'package:isar/isar.dart';
 // ignore: import_rule_photo_manager
 import 'package:photo_manager/photo_manager.dart';
 
-const int targetVersion = 12;
+const int targetVersion = 13;
 
 Future<void> migrateDatabaseIfNeeded(Isar db) async {
   final int version = Store.get(StoreKey.version, targetVersion);
@@ -56,14 +56,18 @@ Future<void> migrateDatabaseIfNeeded(Isar db) async {
     await drift.close();
   }
 
+  if (version < 13) {
+    await Store.put(StoreKey.photoManagerCustomFilter, true);
+  }
+
+  if (targetVersion >= 12) {
+    await Store.put(StoreKey.version, targetVersion);
+    return;
+  }
+
   final shouldTruncate = version < 8 || version < targetVersion;
 
   if (shouldTruncate) {
-    if (targetVersion == 12) {
-      await Store.put(StoreKey.version, targetVersion);
-      return;
-    }
-
     await _migrateTo(db, targetVersion);
   }
 }


### PR DESCRIPTION
## Description

- Defaults to using custom filters for `photo_manager` operations which fixes the issue of local media not detected due to default filters applied through it