### PR TITLE
fix(web): load day group in asset viewer

### DIFF
--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -30,7 +30,12 @@
   import { deleteAssets, updateStackedAssetInTimeline, updateUnstackedAssetInTimeline } from '$lib/utils/actions';
   import { archiveAssets, cancelMultiselect, selectAllAssets, stackAssets } from '$lib/utils/asset-utils';
   import { navigate } from '$lib/utils/navigation';
-  import { toTimelineAsset, type ScrubberListener, type TimelinePlainYearMonth } from '$lib/utils/timeline-util';
+  import {
+    getTimes,
+    toTimelineAsset,
+    type ScrubberListener,
+    type TimelinePlainYearMonth,
+  } from '$lib/utils/timeline-util';
   import { AssetVisibility, getAssetInfo, type AlbumResponseDto, type PersonResponseDto } from '@immich/sdk';
   import { DateTime } from 'luxon';
   import { onMount, type Snippet } from 'svelte';
@@ -766,6 +771,13 @@
   $effect(() => {
     if (shiftKeyIsDown && lastAssetMouseEvent) {
       void selectAssetCandidates(lastAssetMouseEvent);
+    }
+  });
+
+  $effect(() => {
+    if ($showAssetViewer) {
+      const { localDateTime } = getTimes($viewingAsset.fileCreatedAt, DateTime.local().offset / 60);
+      timelineManager.loadMonthGroup({ year: localDateTime.year, month: localDateTime.month });
     }
   });
 </script>

--- a/web/src/lib/components/photos-page/asset-grid.svelte
+++ b/web/src/lib/components/photos-page/asset-grid.svelte
@@ -777,7 +777,7 @@
   $effect(() => {
     if ($showAssetViewer) {
       const { localDateTime } = getTimes($viewingAsset.fileCreatedAt, DateTime.local().offset / 60);
-      timelineManager.loadMonthGroup({ year: localDateTime.year, month: localDateTime.month });
+      void timelineManager.loadMonthGroup({ year: localDateTime.year, month: localDateTime.month });
     }
   });
 </script>


### PR DESCRIPTION
Fixes #19396.
It is not related to person page. If you access `/photos/{id}` directly instead of by navigation, `dayGroup` will not be loaded.