### PR TITLE
fix: timeline service uninitialised across routes

### DIFF
--- a/mobile/lib/pages/common/tab_shell.page.dart
+++ b/mobile/lib/pages/common/tab_shell.page.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/asset_viewer/scroll_notifier.provider.dart';
-import 'package:immich_mobile/providers/multiselect.provider.dart';
-import 'package:immich_mobile/providers/search/search_input_focus.provider.dart';
-import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/providers/search/search_input_focus.provider.dart';
 import 'package:immich_mobile/providers/tab.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 
 @RoutePage()
 class TabShellPage extends ConsumerWidget {
@@ -138,7 +138,8 @@ class TabShellPage extends ConsumerWidget {
       );
     }
 
-    final multiselectEnabled = ref.watch(multiselectProvider);
+    final multiselectEnabled =
+        ref.watch(multiSelectProvider.select((s) => s.isEnabled));
     return AutoTabsRouter(
       routes: [
         const MainTimelineRoute(),

--- a/mobile/lib/presentation/pages/dev/local_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/local_timeline.page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -20,7 +18,7 @@ class LocalTimelinePage extends StatelessWidget {
           (ref) {
             final timelineService =
                 ref.watch(timelineFactoryProvider).localAlbum(albumId: albumId);
-            ref.onDispose(() => unawaited(timelineService.dispose()));
+            ref.onDispose(timelineService.dispose);
             return timelineService;
           },
         ),

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -1,10 +1,7 @@
-import 'dart:async';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
-import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 
 @RoutePage()
 class MainTimelinePage extends ConsumerWidget {
@@ -12,23 +9,6 @@ class MainTimelinePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ProviderScope(
-      key: ref.watch(timelineUsersProvider).value != null
-          ? ValueKey(ref.watch(timelineUsersProvider).value)
-          : const ValueKey("main-timeline"),
-      overrides: [
-        timelineServiceProvider.overrideWith(
-          (ref) {
-            final timelineUsers =
-                ref.watch(timelineUsersProvider).valueOrNull ?? [];
-            final timelineService =
-                ref.watch(timelineFactoryProvider).main(timelineUsers);
-            ref.onDispose(() => unawaited(timelineService.dispose()));
-            return timelineService;
-          },
-        ),
-      ],
-      child: const Timeline(),
-    );
+    return const Timeline();
   }
 }

--- a/mobile/lib/presentation/pages/dev/remote_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/remote_timeline.page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,7 +19,7 @@ class RemoteTimelinePage extends StatelessWidget {
             final timelineService = ref
                 .watch(timelineFactoryProvider)
                 .remoteAlbum(albumId: albumId);
-            ref.onDispose(() => unawaited(timelineService.dispose()));
+            ref.onDispose(timelineService.dispose);
             return timelineService;
           },
         ),

--- a/mobile/lib/presentation/widgets/bottom_app_bar/home_bottom_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_app_bar/home_bottom_app_bar.widget.dart
@@ -30,8 +30,7 @@ class HomeBottomAppBar extends ConsumerWidget {
 
     return BaseBottomSheet(
       initialChildSize: 0.25,
-      minChildSize: 0.22,
-      expand: false,
+      shouldCloseOnMinExtent: false,
       actions: [
         if (multiselect.isEnabled) const ShareActionButton(),
         if (multiselect.hasRemote) ...[

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -1,19 +1,17 @@
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
-import 'package:immich_mobile/providers/multiselect.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/action.service.dart';
+import 'package:immich_mobile/services/timeline.service.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 final actionProvider = NotifierProvider<ActionNotifier, void>(
   ActionNotifier.new,
   dependencies: [
-    actionServiceProvider,
+    multiSelectProvider,
     timelineServiceProvider,
-    multiselectProvider,
   ],
 );
 
@@ -31,7 +29,7 @@ class ActionResult {
 
 class ActionNotifier extends Notifier<void> {
   final Logger _logger = Logger('ActionNotifier');
-  late final ActionService _service;
+  late ActionService _service;
 
   ActionNotifier() : super();
 

--- a/mobile/lib/providers/infrastructure/timeline.provider.dart
+++ b/mobile/lib/providers/infrastructure/timeline.provider.dart
@@ -15,9 +15,17 @@ final timelineArgsProvider = Provider.autoDispose<TimelineArgs>(
       throw UnimplementedError('Will be overridden through a ProviderScope.'),
 );
 
-final timelineServiceProvider = Provider.autoDispose<TimelineService>(
-  (ref) =>
-      throw UnimplementedError('Will be overridden through a ProviderScope.'),
+final timelineServiceProvider = Provider<TimelineService>(
+  (ref) {
+    final timelineUsers = ref.watch(timelineUsersProvider).valueOrNull ?? [];
+    final timelineService =
+        ref.watch(timelineFactoryProvider).main(timelineUsers);
+    ref.onDispose(timelineService.dispose);
+    return timelineService;
+  },
+  // Empty dependencies to inform the framework that this provider
+  // might be used in a ProviderScope
+  dependencies: [],
 );
 
 final timelineFactoryProvider = Provider<TimelineFactory>(

--- a/mobile/lib/providers/timeline/multiselect.provider.dart
+++ b/mobile/lib/providers/timeline/multiselect.provider.dart
@@ -47,12 +47,10 @@ class MultiSelectState {
 }
 
 class MultiSelectNotifier extends Notifier<MultiSelectState> {
-  late final TimelineService _timelineService;
+  TimelineService get _timelineService => ref.read(timelineServiceProvider);
 
   @override
   MultiSelectState build() {
-    _timelineService = ref.read(timelineServiceProvider);
-
     return const MultiSelectState(selectedAssets: {});
   }
 
@@ -145,5 +143,5 @@ final bucketSelectionProvider = Provider.family<bool, List<BaseAsset>>(
     // Check if all assets in the bucket are selected
     return bucketAssets.every((asset) => selectedAssets.contains(asset));
   },
-  dependencies: [multiSelectProvider],
+  dependencies: [multiSelectProvider, timelineServiceProvider],
 );


### PR DESCRIPTION
## Description

Using a `ProviderScope` to override the `timelineService` for a particular sub-tree works for most cases except when we need access to the overridden service in other sub-trees like from the parent / across routes. It is addressed by making the service always initialised with the main timeline segments.

Whenever a new route with a timeline is pushed, we've to now update the global service provider to use the buckets for the new route. The new route will revert the provider to the main timeline segments before being disposed
