### PR TITLE
fix(web): absolute path match in external library

### DIFF
--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -22,12 +22,12 @@ export class ViewRepository {
       .where('localDateTime', 'is not', null)
       .execute();
 
-    return results.map((row) => row.directoryPath.replaceAll(/^\/|\/$/g, ''));
+    return results.map((row) => row.directoryPath.replaceAll(/\/$/g, ''));
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.STRING] })
   async getAssetsByOriginalPath(userId: string, partialPath: string) {
-    const normalizedPath = partialPath.replaceAll(/^\/|\/$/g, '');
+    const normalizedPath = partialPath.replaceAll(/\/$/g, '');
 
     return this.db
       .selectFrom('assets')


### PR DESCRIPTION
Fixes #19549.
Previous implement do not consider absolute path in the external library.
Now, do not match the slash at the beginning of the file path for external library.