### PR TITLE
refactor(server): sync service

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -13425,6 +13425,7 @@
         "properties": {
           "acks": {
             "items": {
+              "maxLength": 1000,
               "type": "string"
             },
             "type": "array"

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsInt, IsPositive, IsString } from 'class-validator';
+import { IsEnum, IsInt, IsPositive, IsString, MaxLength } from 'class-validator';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { AlbumUserRole, AssetOrder, AssetType, AssetVisibility, SyncEntityType, SyncRequestType } from 'src/enum';
 import { Optional, ValidateDate, ValidateUUID } from 'src/validation';
@@ -217,6 +217,7 @@ export class SyncAckDto {
 }
 
 export class SyncAckSetDto {
+  @MaxLength(1000)
   @IsString({ each: true })
   acks!: string[];
 }

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -96,10 +96,7 @@ export class SyncService extends BaseService {
         throw new BadRequestException(`Invalid ack type: ${type}`);
       }
 
-      if (checkpoints[type]) {
-        throw new BadRequestException('Only one ack per type is allowed');
-      }
-
+      // TODO pick the latest ack for each type, instead of using the last one
       checkpoints[type] = { sessionId, type, ack };
     }
 


### PR DESCRIPTION
- Add a max-length restriction to acks
- Allow multiple acks of the same type (currently uses the last one of each type)