### PR TITLE
feat: use sqlite timeline user provider

### DIFF
--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -15,6 +15,21 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
 
   const DriftTimelineRepository(super._db) : _db = _db;
 
+  Stream<List<String>> watchTimelineUserIds(String userId) {
+    final query = _db.partnerEntity.selectOnly()
+      ..addColumns([_db.partnerEntity.sharedById])
+      ..where(
+        _db.partnerEntity.inTimeline.equals(true) &
+            _db.partnerEntity.sharedWithId.equals(userId),
+      );
+
+    return query
+        .map((row) => row.read(_db.partnerEntity.sharedById)!)
+        .watch()
+        // Add current user ID to the list
+        .map((users) => users..add(userId));
+  }
+
   List<Bucket> _generateBuckets(int count) {
     final numBuckets = (count / kTimelineNoneSegmentSize).floor();
     final buckets = List.generate(

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
-import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
 class MainTimelinePage extends StatelessWidget {
@@ -17,9 +16,10 @@ class MainTimelinePage extends StatelessWidget {
       overrides: [
         timelineServiceProvider.overrideWith(
           (ref) {
-            final timelineService = ref
-                .watch(timelineFactoryProvider)
-                .main(ref.watch(timelineUsersIdsProvider));
+            final timelineUsers =
+                ref.watch(timelineUsersProvider).valueOrNull ?? [];
+            final timelineService =
+                ref.watch(timelineFactoryProvider).main(timelineUsers);
             ref.onDispose(() => unawaited(timelineService.dispose()));
             return timelineService;
           },

--- a/mobile/lib/providers/infrastructure/timeline.provider.dart
+++ b/mobile/lib/providers/infrastructure/timeline.provider.dart
@@ -4,6 +4,7 @@ import 'package:immich_mobile/infrastructure/repositories/timeline.repository.da
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 
 final timelineRepositoryProvider = Provider<DriftTimelineRepository>(
   (ref) => DriftTimelineRepository(ref.watch(driftProvider)),
@@ -24,4 +25,17 @@ final timelineFactoryProvider = Provider<TimelineFactory>(
     timelineRepository: ref.watch(timelineRepositoryProvider),
     settingsService: ref.watch(settingsProvider),
   ),
+);
+
+final timelineUsersProvider = StreamProvider<List<String>>(
+  (ref) {
+    final currentUserId = ref.watch(currentUserProvider.select((u) => u?.id));
+    if (currentUserId == null) {
+      return Stream.value([]);
+    }
+
+    return ref
+        .watch(timelineRepositoryProvider)
+        .watchTimelineUserIds(currentUserId);
+  },
 );


### PR DESCRIPTION
## Description

- Replaces the timeline user provider backed by Isar to a new one backed by Sqlite. The `currentUserProvider` used by the timeline provider is still using a store that is backed by Isar. This is because it is tightly coupled to the other parts of the app. It will eventually be migrated to one fully backed by Sqlite as well
