### PR TITLE
docs: document `DB_STORAGE_TYPE` environment variable

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -89,7 +89,7 @@ Information on the current workers can be found [here](/docs/administration/jobs
 
 \*2: If not provided, the appropriate extension to use is auto-detected at startup by introspecting the database. When multiple extensions are installed, the order of preference is VectorChord, pgvecto.rs, pgvector.
 
-\*3: Uses either [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) which mainly controls Postgres its `effective_io_concurrency` setting to allow for concurrenct IO on SSDs and sequential IO on HDDs
+\*3: Uses either [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) which mainly controls the Postgres `effective_io_concurrency` setting to allow for concurrenct IO on SSDs and sequential IO on HDDs. 
 
 :::info
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -72,24 +72,24 @@ Information on the current workers can be found [here](/docs/administration/jobs
 
 ## Database
 
-| Variable                            | Description                                                                               |  Default   | Containers                     |
-| :---------------------------------- | :---------------------------------------------------------------------------------------- | :--------: | :----------------------------- |
-| `DB_URL`                            | Database URL                                                                              |            | server                         |
-| `DB_HOSTNAME`                       | Database host                                                                             | `database` | server                         |
-| `DB_PORT`                           | Database port                                                                             |   `5432`   | server                         |
-| `DB_USERNAME`                       | Database user                                                                             | `postgres` | server, database<sup>\*1</sup> |
-| `DB_PASSWORD`                       | Database password                                                                         | `postgres` | server, database<sup>\*1</sup> |
-| `DB_DATABASE_NAME`                  | Database name                                                                             |  `immich`  | server, database<sup>\*1</sup> |
-| `DB_SSL_MODE`                       | Database SSL mode                                                                         |            | server                         |
-| `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`])              |            | server                         |
-| `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])                  |  `false`   | server                         |
-| `DB_STORAGE_TYPE`                   | Configure for high IO for SSDs or no concurrent IO on HDDs ([`SSD`, `HDD`])<sup>\*3</sup> |  `SSD`     | server                         |
+| Variable                            | Description                                                                            |  Default   | Containers                     |
+| :---------------------------------- | :------------------------------------------------------------------------------------- | :--------: | :----------------------------- |
+| `DB_URL`                            | Database URL                                                                           |            | server                         |
+| `DB_HOSTNAME`                       | Database host                                                                          | `database` | server                         |
+| `DB_PORT`                           | Database port                                                                          |   `5432`   | server                         |
+| `DB_USERNAME`                       | Database user                                                                          | `postgres` | server, database<sup>\*1</sup> |
+| `DB_PASSWORD`                       | Database password                                                                      | `postgres` | server, database<sup>\*1</sup> |
+| `DB_DATABASE_NAME`                  | Database name                                                                          |  `immich`  | server, database<sup>\*1</sup> |
+| `DB_SSL_MODE`                       | Database SSL mode                                                                      |            | server                         |
+| `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`])           |            | server                         |
+| `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])               |  `false`   | server                         |
+| `DB_STORAGE_TYPE`                   | Optimize concurrent IO on SSDs or sequential IO on HDDs ([`SSD`, `HDD`])<sup>\*3</sup> |  `SSD`     | server                         |
 
 \*1: The values of `DB_USERNAME`, `DB_PASSWORD`, and `DB_DATABASE_NAME` are passed to the Postgres container as the variables `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` in `docker-compose.yml`.
 
 \*2: If not provided, the appropriate extension to use is auto-detected at startup by introspecting the database. When multiple extensions are installed, the order of preference is VectorChord, pgvecto.rs, pgvector.
 
-\*3: Configures using [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) primarily controls Postgres `effective_io_concurrency` setting to allow for high concurrenct IO.
+\*3: Uses either [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) which mainly controls Postgres its `effective_io_concurrency` setting to allow for concurrenct IO on SSDs and sequential IO on HDDs
 
 :::info
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -72,22 +72,24 @@ Information on the current workers can be found [here](/docs/administration/jobs
 
 ## Database
 
-| Variable                            | Description                                                                  |  Default   | Containers                     |
-| :---------------------------------- | :--------------------------------------------------------------------------- | :--------: | :----------------------------- |
-| `DB_URL`                            | Database URL                                                                 |            | server                         |
-| `DB_HOSTNAME`                       | Database host                                                                | `database` | server                         |
-| `DB_PORT`                           | Database port                                                                |   `5432`   | server                         |
-| `DB_USERNAME`                       | Database user                                                                | `postgres` | server, database<sup>\*1</sup> |
-| `DB_PASSWORD`                       | Database password                                                            | `postgres` | server, database<sup>\*1</sup> |
-| `DB_DATABASE_NAME`                  | Database name                                                                |  `immich`  | server, database<sup>\*1</sup> |
-| `DB_SSL_MODE`                       | Database SSL mode                                                            |            | server                         |
-| `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`]) |            | server                         |
-| `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])     |  `false`   | server                         |
-| `DB_STORAGE_TYPE`                   | By default assumes `SSD` but can be set to `HDD`                             |  `SSD`     | server                         |
+| Variable                            | Description                                                                               |  Default   | Containers                     |
+| :---------------------------------- | :---------------------------------------------------------------------------------------- | :--------: | :----------------------------- |
+| `DB_URL`                            | Database URL                                                                              |            | server                         |
+| `DB_HOSTNAME`                       | Database host                                                                             | `database` | server                         |
+| `DB_PORT`                           | Database port                                                                             |   `5432`   | server                         |
+| `DB_USERNAME`                       | Database user                                                                             | `postgres` | server, database<sup>\*1</sup> |
+| `DB_PASSWORD`                       | Database password                                                                         | `postgres` | server, database<sup>\*1</sup> |
+| `DB_DATABASE_NAME`                  | Database name                                                                             |  `immich`  | server, database<sup>\*1</sup> |
+| `DB_SSL_MODE`                       | Database SSL mode                                                                         |            | server                         |
+| `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`])              |            | server                         |
+| `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])                  |  `false`   | server                         |
+| `DB_STORAGE_TYPE`                   | Configure for high IO for SSDs or no concurrent IO on HDDs ([`SSD`, `HDD`])<sup>\*3</sup> |  `SSD`     | server                         |
 
 \*1: The values of `DB_USERNAME`, `DB_PASSWORD`, and `DB_DATABASE_NAME` are passed to the Postgres container as the variables `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` in `docker-compose.yml`.
 
 \*2: If not provided, the appropriate extension to use is auto-detected at startup by introspecting the database. When multiple extensions are installed, the order of preference is VectorChord, pgvecto.rs, pgvector.
+
+\*3: Configures using [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) primarily controls Postgres `effective_io_concurrency` setting to allow for high concurrenct IO.
 
 :::info
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -83,6 +83,7 @@ Information on the current workers can be found [here](/docs/administration/jobs
 | `DB_SSL_MODE`                       | Database SSL mode                                                            |            | server                         |
 | `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`]) |            | server                         |
 | `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])     |  `false`   | server                         |
+| `DB_STORAGE_TYPE`                   | By default assumes `SSD` but can be set to `HDD`                             |  `SSD`     | server                         |
 
 \*1: The values of `DB_USERNAME`, `DB_PASSWORD`, and `DB_DATABASE_NAME` are passed to the Postgres container as the variables `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` in `docker-compose.yml`.
 

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -83,13 +83,13 @@ Information on the current workers can be found [here](/docs/administration/jobs
 | `DB_SSL_MODE`                       | Database SSL mode                                                                      |            | server                         |
 | `DB_VECTOR_EXTENSION`<sup>\*2</sup> | Database vector extension (one of [`vectorchord`, `pgvector`, `pgvecto.rs`])           |            | server                         |
 | `DB_SKIP_MIGRATIONS`                | Whether to skip running migrations on startup (one of [`true`, `false`])               |  `false`   | server                         |
-| `DB_STORAGE_TYPE`                   | Optimize concurrent IO on SSDs or sequential IO on HDDs ([`SSD`, `HDD`])<sup>\*3</sup> |  `SSD`     | server                         |
+| `DB_STORAGE_TYPE`                   | Optimize concurrent IO on SSDs or sequential IO on HDDs ([`SSD`, `HDD`])<sup>\*3</sup> |   `SSD`    | server                         |
 
 \*1: The values of `DB_USERNAME`, `DB_PASSWORD`, and `DB_DATABASE_NAME` are passed to the Postgres container as the variables `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` in `docker-compose.yml`.
 
 \*2: If not provided, the appropriate extension to use is auto-detected at startup by introspecting the database. When multiple extensions are installed, the order of preference is VectorChord, pgvecto.rs, pgvector.
 
-\*3: Uses either [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) which mainly controls the Postgres `effective_io_concurrency` setting to allow for concurrenct IO on SSDs and sequential IO on HDDs. 
+\*3: Uses either [`postgresql.ssd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.ssd.conf) or [`postgresql.hdd.conf`](https://github.com/immich-app/base-images/blob/main/postgres/postgresql.hdd.conf) which mainly controls the Postgres `effective_io_concurrency` setting to allow for concurrenct IO on SSDs and sequential IO on HDDs.
 
 :::info
 


### PR DESCRIPTION
## Description

Document `DB_STORAGE_TYPE`, I was pointed to this setting on Discord:

https://github.com/immich-app/immich/blob/main/docker/docker-compose.yml#L65-L66`

## How Has This Been Tested?

1. Added envvar to docker compose
2. Started it
3. Observed `mmich_postgres            | Using HDD storage` in the logs indicating the envvar was found and used.

## Checklist:

NA, no code change, only docs update.
