### PR TITLE
fix(docs): library and folders minor adjustments

### DIFF
--- a/docs/docs/features/folder-view.md
+++ b/docs/docs/features/folder-view.md
@@ -2,7 +2,7 @@
 
 Folder view provides an additional view besides the timeline that is similar to a file explorer. It allows you to navigate through the folders and files in the library. This feature is handy for a highly curated and customized external library or a nicely configured storage template.
 
-You can enable this feature under [`Account Settings > Features > Folder View`](https://my.immich.app/user-settings?isOpen=feature+folders)
+You can enable this feature under [`Account Settings > Features > Folders`](https://my.immich.app/user-settings?isOpen=feature+folders)
 
 ## Enable folder view
 

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -112,7 +112,7 @@ _Remember to run `docker compose up -d` to register the changes. Make sure you c
 
 These actions must be performed by the Immich administrator.
 
-- Click on your avatar on the upper right corner
+- Click on your avatar in the upper right corner
 - Click on Administration -> External Libraries
 - Click on Create an external library…
 - Select which user owns the library, this can not be changed later

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -161,8 +161,6 @@ Folder view provides an additional view besides the timeline that is similar to 
 
 You can enable this feature under [`Account Settings > Features > Folder View`](https://my.immich.app/user-settings?isOpen=feature+folders)
 
-The UI is currently only available for the web; mobile will come in a subsequent release.
-
 <img src={require('./img/folder-view-1.webp').default} width="100%" title='Folder-view' />
 
 ### Set Custom Scan Interval

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -169,7 +169,7 @@ You can enable this feature under [`Account Settings > Features > Folders`](http
 Only an admin can do this.
 :::
 
-You can define a custom interval for the trigger external library rescan under Administration -> Settings -> Library.  
+You can define a custom interval for the trigger external library rescan under Administration -> Settings -> External Library.  
 You can set the scanning interval using the preset or cron format. For more information you can refer to [Crontab Guru](https://crontab.guru/).
 
 <img src={require('./img/library-custom-scan-interval.webp').default} width="75%" title='Set custom scan interval for external library' />

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -56,7 +56,7 @@ Internally, Immich uses the [glob](https://www.npmjs.com/package/glob) package t
 
 ### Automatic watching (EXPERIMENTAL)
 
-This feature - currently hidden in the config file - is considered experimental and for advanced users only. If enabled, it will allow automatic watching of the filesystem which means new assets are automatically imported to Immich without needing to rescan.
+This feature is considered experimental and for advanced users only. If enabled, it will allow automatic watching of the filesystem which means new assets are automatically imported to Immich without needing to rescan.
 
 If your photos are on a network drive, automatic file watching likely won't work. In that case, you will have to rely on a periodic library refresh to pull in your changes.
 

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -159,7 +159,7 @@ Within seconds, the assets from the old-pics and videos folders should show up i
 
 Folder view provides an additional view besides the timeline that is similar to a file explorer. It allows you to navigate through the folders and files in the library. This feature is handy for a highly curated and customized external library or a nicely configured storage template.
 
-You can enable this feature under [`Account Settings > Features > Folder View`](https://my.immich.app/user-settings?isOpen=feature+folders)
+You can enable this feature under [`Account Settings > Features > Folders`](https://my.immich.app/user-settings?isOpen=feature+folders)
 
 <img src={require('./img/folder-view-1.webp').default} width="100%" title='Folder-view' />
 


### PR DESCRIPTION
- Folder view is available both in web and mobile currently
- Folder view is named Folders in Account Settings > Features
- Library is named External Library in Administration > Settings
- Library watching is not hidden in the config file anymore
- Avatar "in" the upper right corner instead of "on"
