### PR TITLE
chore: remove share link success prompt

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/share_link_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/share_link_action_button.widget.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
-import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class ShareLinkActionButton extends ConsumerWidget {
   final ActionSource source;
@@ -18,25 +15,7 @@ class ShareLinkActionButton extends ConsumerWidget {
       return;
     }
 
-    final result =
-        await ref.read(actionProvider.notifier).shareLink(source, context);
-    ref.read(multiSelectProvider.notifier).reset();
-
-    final successMessage = 'share_link_action_prompt'.t(
-      context: context,
-      args: {'count': result.count.toString()},
-    );
-
-    if (context.mounted) {
-      ImmichToast.show(
-        context: context,
-        msg: result.success
-            ? successMessage
-            : 'scaffold_body_error_occurred'.t(context: context),
-        gravity: ToastGravity.BOTTOM,
-        toastType: result.success ? ToastType.success : ToastType.error,
-      );
-    }
+    await ref.read(actionProvider.notifier).shareLink(source, context);
   }
 
   @override


### PR DESCRIPTION
Share link doesn't need success prompt when navigating back since the form already provides feedback instantly