### PR TITLE
feat: adds option to search only for untagged assets

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1884,6 +1884,7 @@
   "unselect_all_in": "Unselect all in {group}",
   "unstack": "Un-stack",
   "unstacked_assets_count": "Un-stacked {count, plural, one {# asset} other {# assets}}",
+  "untagged": "Untagged",
   "up_next": "Up next",
   "updated_at": "Updated",
   "updated_password": "Updated password",

--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -29,7 +29,6 @@ class MetadataSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
-    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -169,14 +168,6 @@ class MetadataSearchDto {
   ///
   bool? isOffline;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? isUntagged;
-
   String? lensModel;
 
   String? libraryId;
@@ -250,7 +241,7 @@ class MetadataSearchDto {
 
   String? state;
 
-  List<String> tagIds;
+  List<String>? tagIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -374,7 +365,6 @@ class MetadataSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
-    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -422,7 +412,6 @@ class MetadataSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
-    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -436,7 +425,7 @@ class MetadataSearchDto {
     (rating == null ? 0 : rating!.hashCode) +
     (size == null ? 0 : size!.hashCode) +
     (state == null ? 0 : state!.hashCode) +
-    (tagIds.hashCode) +
+    (tagIds == null ? 0 : tagIds!.hashCode) +
     (takenAfter == null ? 0 : takenAfter!.hashCode) +
     (takenBefore == null ? 0 : takenBefore!.hashCode) +
     (thumbnailPath == null ? 0 : thumbnailPath!.hashCode) +
@@ -452,7 +441,7 @@ class MetadataSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -532,11 +521,6 @@ class MetadataSearchDto {
     } else {
     //  json[r'isOffline'] = null;
     }
-    if (this.isUntagged != null) {
-      json[r'isUntagged'] = this.isUntagged;
-    } else {
-    //  json[r'isUntagged'] = null;
-    }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
     } else {
@@ -594,7 +578,11 @@ class MetadataSearchDto {
     } else {
     //  json[r'state'] = null;
     }
+    if (this.tagIds != null) {
       json[r'tagIds'] = this.tagIds;
+    } else {
+    //  json[r'tagIds'] = null;
+    }
     if (this.takenAfter != null) {
       json[r'takenAfter'] = this.takenAfter!.toUtc().toIso8601String();
     } else {
@@ -690,7 +678,6 @@ class MetadataSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
-        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/mobile/openapi/lib/model/metadata_search_dto.dart
+++ b/mobile/openapi/lib/model/metadata_search_dto.dart
@@ -29,6 +29,7 @@ class MetadataSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
+    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -167,6 +168,14 @@ class MetadataSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isOffline;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isUntagged;
 
   String? lensModel;
 
@@ -365,6 +374,7 @@ class MetadataSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
+    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -412,6 +422,7 @@ class MetadataSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
+    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -441,7 +452,7 @@ class MetadataSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'MetadataSearchDto[albumIds=$albumIds, checksum=$checksum, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceAssetId=$deviceAssetId, deviceId=$deviceId, encodedVideoPath=$encodedVideoPath, id=$id, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, order=$order, originalFileName=$originalFileName, originalPath=$originalPath, page=$page, personIds=$personIds, previewPath=$previewPath, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, thumbnailPath=$thumbnailPath, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -520,6 +531,11 @@ class MetadataSearchDto {
       json[r'isOffline'] = this.isOffline;
     } else {
     //  json[r'isOffline'] = null;
+    }
+    if (this.isUntagged != null) {
+      json[r'isUntagged'] = this.isUntagged;
+    } else {
+    //  json[r'isUntagged'] = null;
     }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
@@ -674,6 +690,7 @@ class MetadataSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
+        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/mobile/openapi/lib/model/random_search_dto.dart
+++ b/mobile/openapi/lib/model/random_search_dto.dart
@@ -24,6 +24,7 @@ class RandomSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
+    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -116,6 +117,14 @@ class RandomSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isOffline;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isUntagged;
 
   String? lensModel;
 
@@ -266,6 +275,7 @@ class RandomSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
+    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -302,6 +312,7 @@ class RandomSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
+    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -325,7 +336,7 @@ class RandomSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'RandomSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'RandomSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -379,6 +390,11 @@ class RandomSearchDto {
       json[r'isOffline'] = this.isOffline;
     } else {
     //  json[r'isOffline'] = null;
+    }
+    if (this.isUntagged != null) {
+      json[r'isUntagged'] = this.isUntagged;
+    } else {
+    //  json[r'isUntagged'] = null;
     }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
@@ -502,6 +518,7 @@ class RandomSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
+        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/mobile/openapi/lib/model/random_search_dto.dart
+++ b/mobile/openapi/lib/model/random_search_dto.dart
@@ -24,7 +24,6 @@ class RandomSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
-    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -118,14 +117,6 @@ class RandomSearchDto {
   ///
   bool? isOffline;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? isUntagged;
-
   String? lensModel;
 
   String? libraryId;
@@ -164,7 +155,7 @@ class RandomSearchDto {
 
   String? state;
 
-  List<String> tagIds;
+  List<String>? tagIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -275,7 +266,6 @@ class RandomSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
-    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -312,7 +302,6 @@ class RandomSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
-    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -321,7 +310,7 @@ class RandomSearchDto {
     (rating == null ? 0 : rating!.hashCode) +
     (size == null ? 0 : size!.hashCode) +
     (state == null ? 0 : state!.hashCode) +
-    (tagIds.hashCode) +
+    (tagIds == null ? 0 : tagIds!.hashCode) +
     (takenAfter == null ? 0 : takenAfter!.hashCode) +
     (takenBefore == null ? 0 : takenBefore!.hashCode) +
     (trashedAfter == null ? 0 : trashedAfter!.hashCode) +
@@ -336,7 +325,7 @@ class RandomSearchDto {
     (withStacked == null ? 0 : withStacked!.hashCode);
 
   @override
-  String toString() => 'RandomSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
+  String toString() => 'RandomSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif, withPeople=$withPeople, withStacked=$withStacked]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -391,11 +380,6 @@ class RandomSearchDto {
     } else {
     //  json[r'isOffline'] = null;
     }
-    if (this.isUntagged != null) {
-      json[r'isUntagged'] = this.isUntagged;
-    } else {
-    //  json[r'isUntagged'] = null;
-    }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
     } else {
@@ -432,7 +416,11 @@ class RandomSearchDto {
     } else {
     //  json[r'state'] = null;
     }
+    if (this.tagIds != null) {
       json[r'tagIds'] = this.tagIds;
+    } else {
+    //  json[r'tagIds'] = null;
+    }
     if (this.takenAfter != null) {
       json[r'takenAfter'] = this.takenAfter!.toUtc().toIso8601String();
     } else {
@@ -518,7 +506,6 @@ class RandomSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
-        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/mobile/openapi/lib/model/smart_search_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_dto.dart
@@ -24,6 +24,7 @@ class SmartSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
+    this.isUntagged,
     this.language,
     this.lensModel,
     this.libraryId,
@@ -117,6 +118,14 @@ class SmartSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isOffline;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isUntagged;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -270,6 +279,7 @@ class SmartSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
+    other.isUntagged == isUntagged &&
     other.language == language &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -307,6 +317,7 @@ class SmartSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
+    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (language == null ? 0 : language!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -331,7 +342,7 @@ class SmartSearchDto {
     (withExif == null ? 0 : withExif!.hashCode);
 
   @override
-  String toString() => 'SmartSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
+  String toString() => 'SmartSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -385,6 +396,11 @@ class SmartSearchDto {
       json[r'isOffline'] = this.isOffline;
     } else {
     //  json[r'isOffline'] = null;
+    }
+    if (this.isUntagged != null) {
+      json[r'isUntagged'] = this.isUntagged;
+    } else {
+    //  json[r'isUntagged'] = null;
     }
     if (this.language != null) {
       json[r'language'] = this.language;
@@ -509,6 +525,7 @@ class SmartSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
+        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         language: mapValueOfType<String>(json, r'language'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/smart_search_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_dto.dart
@@ -24,7 +24,6 @@ class SmartSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
-    this.isUntagged,
     this.language,
     this.lensModel,
     this.libraryId,
@@ -125,14 +124,6 @@ class SmartSearchDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
-  bool? isUntagged;
-
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
   String? language;
 
   String? lensModel;
@@ -184,7 +175,7 @@ class SmartSearchDto {
 
   String? state;
 
-  List<String> tagIds;
+  List<String>? tagIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -279,7 +270,6 @@ class SmartSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
-    other.isUntagged == isUntagged &&
     other.language == language &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
@@ -317,7 +307,6 @@ class SmartSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
-    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (language == null ? 0 : language!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
@@ -329,7 +318,7 @@ class SmartSearchDto {
     (rating == null ? 0 : rating!.hashCode) +
     (size == null ? 0 : size!.hashCode) +
     (state == null ? 0 : state!.hashCode) +
-    (tagIds.hashCode) +
+    (tagIds == null ? 0 : tagIds!.hashCode) +
     (takenAfter == null ? 0 : takenAfter!.hashCode) +
     (takenBefore == null ? 0 : takenBefore!.hashCode) +
     (trashedAfter == null ? 0 : trashedAfter!.hashCode) +
@@ -342,7 +331,7 @@ class SmartSearchDto {
     (withExif == null ? 0 : withExif!.hashCode);
 
   @override
-  String toString() => 'SmartSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
+  String toString() => 'SmartSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, language=$language, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, page=$page, personIds=$personIds, query=$query, rating=$rating, size=$size, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility, withDeleted=$withDeleted, withExif=$withExif]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -397,11 +386,6 @@ class SmartSearchDto {
     } else {
     //  json[r'isOffline'] = null;
     }
-    if (this.isUntagged != null) {
-      json[r'isUntagged'] = this.isUntagged;
-    } else {
-    //  json[r'isUntagged'] = null;
-    }
     if (this.language != null) {
       json[r'language'] = this.language;
     } else {
@@ -449,7 +433,11 @@ class SmartSearchDto {
     } else {
     //  json[r'state'] = null;
     }
+    if (this.tagIds != null) {
       json[r'tagIds'] = this.tagIds;
+    } else {
+    //  json[r'tagIds'] = null;
+    }
     if (this.takenAfter != null) {
       json[r'takenAfter'] = this.takenAfter!.toUtc().toIso8601String();
     } else {
@@ -525,7 +513,6 @@ class SmartSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
-        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         language: mapValueOfType<String>(json, r'language'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),

--- a/mobile/openapi/lib/model/statistics_search_dto.dart
+++ b/mobile/openapi/lib/model/statistics_search_dto.dart
@@ -25,6 +25,7 @@ class StatisticsSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
+    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -120,6 +121,14 @@ class StatisticsSearchDto {
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
   bool? isOffline;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? isUntagged;
 
   String? lensModel;
 
@@ -229,6 +238,7 @@ class StatisticsSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
+    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -261,6 +271,7 @@ class StatisticsSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
+    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -279,7 +290,7 @@ class StatisticsSearchDto {
     (visibility == null ? 0 : visibility!.hashCode);
 
   @override
-  String toString() => 'StatisticsSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility]';
+  String toString() => 'StatisticsSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -338,6 +349,11 @@ class StatisticsSearchDto {
       json[r'isOffline'] = this.isOffline;
     } else {
     //  json[r'isOffline'] = null;
+    }
+    if (this.isUntagged != null) {
+      json[r'isUntagged'] = this.isUntagged;
+    } else {
+    //  json[r'isUntagged'] = null;
     }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
@@ -437,6 +453,7 @@ class StatisticsSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
+        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/mobile/openapi/lib/model/statistics_search_dto.dart
+++ b/mobile/openapi/lib/model/statistics_search_dto.dart
@@ -25,7 +25,6 @@ class StatisticsSearchDto {
     this.isMotion,
     this.isNotInAlbum,
     this.isOffline,
-    this.isUntagged,
     this.lensModel,
     this.libraryId,
     this.make,
@@ -122,14 +121,6 @@ class StatisticsSearchDto {
   ///
   bool? isOffline;
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? isUntagged;
-
   String? lensModel;
 
   String? libraryId;
@@ -158,7 +149,7 @@ class StatisticsSearchDto {
 
   String? state;
 
-  List<String> tagIds;
+  List<String>? tagIds;
 
   ///
   /// Please note: This property should have been non-nullable! Since the specification file
@@ -238,7 +229,6 @@ class StatisticsSearchDto {
     other.isMotion == isMotion &&
     other.isNotInAlbum == isNotInAlbum &&
     other.isOffline == isOffline &&
-    other.isUntagged == isUntagged &&
     other.lensModel == lensModel &&
     other.libraryId == libraryId &&
     other.make == make &&
@@ -271,7 +261,6 @@ class StatisticsSearchDto {
     (isMotion == null ? 0 : isMotion!.hashCode) +
     (isNotInAlbum == null ? 0 : isNotInAlbum!.hashCode) +
     (isOffline == null ? 0 : isOffline!.hashCode) +
-    (isUntagged == null ? 0 : isUntagged!.hashCode) +
     (lensModel == null ? 0 : lensModel!.hashCode) +
     (libraryId == null ? 0 : libraryId!.hashCode) +
     (make == null ? 0 : make!.hashCode) +
@@ -279,7 +268,7 @@ class StatisticsSearchDto {
     (personIds.hashCode) +
     (rating == null ? 0 : rating!.hashCode) +
     (state == null ? 0 : state!.hashCode) +
-    (tagIds.hashCode) +
+    (tagIds == null ? 0 : tagIds!.hashCode) +
     (takenAfter == null ? 0 : takenAfter!.hashCode) +
     (takenBefore == null ? 0 : takenBefore!.hashCode) +
     (trashedAfter == null ? 0 : trashedAfter!.hashCode) +
@@ -290,7 +279,7 @@ class StatisticsSearchDto {
     (visibility == null ? 0 : visibility!.hashCode);
 
   @override
-  String toString() => 'StatisticsSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, isUntagged=$isUntagged, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility]';
+  String toString() => 'StatisticsSearchDto[albumIds=$albumIds, city=$city, country=$country, createdAfter=$createdAfter, createdBefore=$createdBefore, description=$description, deviceId=$deviceId, isEncoded=$isEncoded, isFavorite=$isFavorite, isMotion=$isMotion, isNotInAlbum=$isNotInAlbum, isOffline=$isOffline, lensModel=$lensModel, libraryId=$libraryId, make=$make, model=$model, personIds=$personIds, rating=$rating, state=$state, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, trashedAfter=$trashedAfter, trashedBefore=$trashedBefore, type=$type, updatedAfter=$updatedAfter, updatedBefore=$updatedBefore, visibility=$visibility]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -350,11 +339,6 @@ class StatisticsSearchDto {
     } else {
     //  json[r'isOffline'] = null;
     }
-    if (this.isUntagged != null) {
-      json[r'isUntagged'] = this.isUntagged;
-    } else {
-    //  json[r'isUntagged'] = null;
-    }
     if (this.lensModel != null) {
       json[r'lensModel'] = this.lensModel;
     } else {
@@ -386,7 +370,11 @@ class StatisticsSearchDto {
     } else {
     //  json[r'state'] = null;
     }
+    if (this.tagIds != null) {
       json[r'tagIds'] = this.tagIds;
+    } else {
+    //  json[r'tagIds'] = null;
+    }
     if (this.takenAfter != null) {
       json[r'takenAfter'] = this.takenAfter!.toUtc().toIso8601String();
     } else {
@@ -453,7 +441,6 @@ class StatisticsSearchDto {
         isMotion: mapValueOfType<bool>(json, r'isMotion'),
         isNotInAlbum: mapValueOfType<bool>(json, r'isNotInAlbum'),
         isOffline: mapValueOfType<bool>(json, r'isOffline'),
-        isUntagged: mapValueOfType<bool>(json, r'isUntagged'),
         lensModel: mapValueOfType<String>(json, r'lensModel'),
         libraryId: mapValueOfType<String>(json, r'libraryId'),
         make: mapValueOfType<String>(json, r'make'),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11140,6 +11140,9 @@
           "isOffline": {
             "type": "boolean"
           },
+          "isUntagged": {
+            "type": "boolean"
+          },
           "lensModel": {
             "nullable": true,
             "type": "string"
@@ -12048,6 +12051,9 @@
             "type": "boolean"
           },
           "isOffline": {
+            "type": "boolean"
+          },
+          "isUntagged": {
             "type": "boolean"
           },
           "lensModel": {
@@ -13105,6 +13111,9 @@
           "isOffline": {
             "type": "boolean"
           },
+          "isUntagged": {
+            "type": "boolean"
+          },
           "language": {
             "type": "string"
           },
@@ -13309,6 +13318,9 @@
             "type": "boolean"
           },
           "isOffline": {
+            "type": "boolean"
+          },
+          "isUntagged": {
             "type": "boolean"
           },
           "lensModel": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11140,9 +11140,6 @@
           "isOffline": {
             "type": "boolean"
           },
-          "isUntagged": {
-            "type": "boolean"
-          },
           "lensModel": {
             "nullable": true,
             "type": "string"
@@ -11206,6 +11203,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "nullable": true,
             "type": "array"
           },
           "takenAfter": {
@@ -12053,9 +12051,6 @@
           "isOffline": {
             "type": "boolean"
           },
-          "isUntagged": {
-            "type": "boolean"
-          },
           "lensModel": {
             "nullable": true,
             "type": "string"
@@ -12098,6 +12093,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "nullable": true,
             "type": "array"
           },
           "takenAfter": {
@@ -13111,9 +13107,6 @@
           "isOffline": {
             "type": "boolean"
           },
-          "isUntagged": {
-            "type": "boolean"
-          },
           "language": {
             "type": "string"
           },
@@ -13166,6 +13159,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "nullable": true,
             "type": "array"
           },
           "takenAfter": {
@@ -13320,9 +13314,6 @@
           "isOffline": {
             "type": "boolean"
           },
-          "isUntagged": {
-            "type": "boolean"
-          },
           "lensModel": {
             "nullable": true,
             "type": "string"
@@ -13360,6 +13351,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "nullable": true,
             "type": "array"
           },
           "takenAfter": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -876,6 +876,7 @@ export type MetadataSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
+    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;
@@ -948,6 +949,7 @@ export type RandomSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
+    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;
@@ -982,6 +984,7 @@ export type SmartSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
+    isUntagged?: boolean;
     language?: string;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -1018,6 +1021,7 @@ export type StatisticsSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
+    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -876,7 +876,6 @@ export type MetadataSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
-    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;
@@ -890,7 +889,7 @@ export type MetadataSearchDto = {
     rating?: number;
     size?: number;
     state?: string | null;
-    tagIds?: string[];
+    tagIds?: string[] | null;
     takenAfter?: string;
     takenBefore?: string;
     thumbnailPath?: string;
@@ -949,7 +948,6 @@ export type RandomSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
-    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;
@@ -958,7 +956,7 @@ export type RandomSearchDto = {
     rating?: number;
     size?: number;
     state?: string | null;
-    tagIds?: string[];
+    tagIds?: string[] | null;
     takenAfter?: string;
     takenBefore?: string;
     trashedAfter?: string;
@@ -984,7 +982,6 @@ export type SmartSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
-    isUntagged?: boolean;
     language?: string;
     lensModel?: string | null;
     libraryId?: string | null;
@@ -996,7 +993,7 @@ export type SmartSearchDto = {
     rating?: number;
     size?: number;
     state?: string | null;
-    tagIds?: string[];
+    tagIds?: string[] | null;
     takenAfter?: string;
     takenBefore?: string;
     trashedAfter?: string;
@@ -1021,7 +1018,6 @@ export type StatisticsSearchDto = {
     isMotion?: boolean;
     isNotInAlbum?: boolean;
     isOffline?: boolean;
-    isUntagged?: boolean;
     lensModel?: string | null;
     libraryId?: string | null;
     make?: string;
@@ -1029,7 +1025,7 @@ export type StatisticsSearchDto = {
     personIds?: string[];
     rating?: number;
     state?: string | null;
-    tagIds?: string[];
+    tagIds?: string[] | null;
     takenAfter?: string;
     takenBefore?: string;
     trashedAfter?: string;

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -87,6 +87,9 @@ class BaseSearchDto {
   lensModel?: string | null;
 
   @ValidateBoolean({ optional: true })
+  isUntagged?: boolean;
+
+  @ValidateBoolean({ optional: true })
   isNotInAlbum?: boolean;
 
   @ValidateUUID({ each: true, optional: true })

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -87,16 +87,13 @@ class BaseSearchDto {
   lensModel?: string | null;
 
   @ValidateBoolean({ optional: true })
-  isUntagged?: boolean;
-
-  @ValidateBoolean({ optional: true })
   isNotInAlbum?: boolean;
 
   @ValidateUUID({ each: true, optional: true })
   personIds?: string[];
 
   @ValidateUUID({ each: true, optional: true })
-  tagIds?: string[];
+  tagIds?: string[] | null;
 
   @ValidateUUID({ each: true, optional: true })
   albumIds?: string[];

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -92,7 +92,7 @@ class BaseSearchDto {
   @ValidateUUID({ each: true, optional: true })
   personIds?: string[];
 
-  @ValidateUUID({ each: true, optional: true })
+  @ValidateUUID({ each: true, optional: true, nullable: true })
   tagIds?: string[] | null;
 
   @ValidateUUID({ each: true, optional: true })

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -32,6 +32,7 @@ export interface SearchStatusOptions {
   isMotion?: boolean;
   isOffline?: boolean;
   isNotInAlbum?: boolean;
+  isUntagged?: boolean;
   type?: AssetType;
   status?: AssetStatus;
   withArchived?: boolean;

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -32,7 +32,6 @@ export interface SearchStatusOptions {
   isMotion?: boolean;
   isOffline?: boolean;
   isNotInAlbum?: boolean;
-  isUntagged?: boolean;
   type?: AssetType;
   status?: AssetStatus;
   withArchived?: boolean;
@@ -90,7 +89,7 @@ export interface SearchPeopleOptions {
 }
 
 export interface SearchTagOptions {
-  tagIds?: string[];
+  tagIds?: string[] | null;
 }
 
 export interface SearchAlbumOptions {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -382,6 +382,9 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(options.isMotion !== undefined, (qb) =>
       qb.where('assets.livePhotoVideoId', options.isMotion ? 'is not' : 'is', null),
     )
+    .$if(!!options.isUntagged && (!options.tagIds || options.tagIds.length === 0), (qb) =>
+      qb.where((eb) => eb.not(eb.exists((eb) => eb.selectFrom('tag_asset').whereRef('assetsId', '=', 'assets.id')))),
+    )
     .$if(!!options.isNotInAlbum && (!options.albumIds || options.albumIds.length === 0), (qb) =>
       qb.where((eb) =>
         eb.not(eb.exists((eb) => eb.selectFrom('albums_assets_assets').whereRef('assetsId', '=', 'assets.id'))),

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -307,6 +307,9 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .where('assets.visibility', '=', visibility)
     .$if(!!options.albumIds && options.albumIds.length > 0, (qb) => inAlbums(qb, options.albumIds!))
     .$if(!!options.tagIds && options.tagIds.length > 0, (qb) => hasTags(qb, options.tagIds!))
+    .$if(options.tagIds === null, (qb) =>
+      qb.where((eb) => eb.not(eb.exists((eb) => eb.selectFrom('tag_asset').whereRef('assetsId', '=', 'assets.id')))),
+    )
     .$if(!!options.personIds && options.personIds.length > 0, (qb) => hasPeople(qb, options.personIds!))
     .$if(!!options.createdBefore, (qb) => qb.where('assets.createdAt', '<=', options.createdBefore!))
     .$if(!!options.createdAfter, (qb) => qb.where('assets.createdAt', '>=', options.createdAfter!))
@@ -381,9 +384,6 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     )
     .$if(options.isMotion !== undefined, (qb) =>
       qb.where('assets.livePhotoVideoId', options.isMotion ? 'is not' : 'is', null),
-    )
-    .$if(!!options.isUntagged && (!options.tagIds || options.tagIds.length === 0), (qb) =>
-      qb.where((eb) => eb.not(eb.exists((eb) => eb.selectFrom('tag_asset').whereRef('assetsId', '=', 'assets.id')))),
     )
     .$if(!!options.isNotInAlbum && (!options.albumIds || options.albumIds.length === 0), (qb) =>
       qb.where((eb) =>

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -33,6 +33,7 @@
 
   interface Props {
     label: string;
+    disabled: boolean;
     hideLabel?: boolean;
     options?: ComboBoxOption[];
     selectedOption?: ComboBoxOption | undefined;
@@ -52,6 +53,7 @@
   let {
     label,
     hideLabel = false,
+    disabled = false,
     options = [],
     selectedOption = $bindable(),
     placeholder = '',
@@ -275,6 +277,7 @@
 
     <input
       {placeholder}
+      {disabled}
       aria-activedescendant={selectedIndex || selectedIndex === 0 ? `${listboxId}-${selectedIndex}` : ''}
       aria-autocomplete="list"
       aria-controls={listboxId}

--- a/web/src/lib/components/shared-components/combobox.svelte
+++ b/web/src/lib/components/shared-components/combobox.svelte
@@ -33,7 +33,7 @@
 
   interface Props {
     label: string;
-    disabled: boolean;
+    disabled?: boolean;
     hideLabel?: boolean;
     options?: ComboBoxOption[];
     selectedOption?: ComboBoxOption | undefined;

--- a/web/src/lib/components/shared-components/search-bar/search-display-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-display-section.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   export interface SearchDisplayFilters {
     isNotInAlbum: boolean;
+    isUntagged: boolean;
     isArchive: boolean;
     isFavorite: boolean;
   }
@@ -22,6 +23,10 @@
   <fieldset>
     <legend class="immich-form-label">{$t('display_options').toUpperCase()}</legend>
     <div class="flex flex-wrap gap-x-5 gap-y-2 mt-1">
+      <div class="flex items-center gap-2">
+        <Checkbox id="untagged-checkbox" size="tiny" bind:checked={filters.isUntagged} />
+        <Label label={$t('untagged')} for="untagged-checkbox" />
+      </div>
       <div class="flex items-center gap-2">
         <Checkbox id="not-in-album-checkbox" size="tiny" bind:checked={filters.isNotInAlbum} />
         <Label label={$t('not_in_any_album')} for="not-in-album-checkbox" />

--- a/web/src/lib/components/shared-components/search-bar/search-display-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-display-section.svelte
@@ -1,7 +1,6 @@
 <script lang="ts" module>
   export interface SearchDisplayFilters {
     isNotInAlbum: boolean;
-    isUntagged: boolean;
     isArchive: boolean;
     isFavorite: boolean;
   }
@@ -23,10 +22,6 @@
   <fieldset>
     <legend class="immich-form-label">{$t('display_options').toUpperCase()}</legend>
     <div class="flex flex-wrap gap-x-5 gap-y-2 mt-1">
-      <div class="flex items-center gap-2">
-        <Checkbox id="untagged-checkbox" size="tiny" bind:checked={filters.isUntagged} />
-        <Label label={$t('untagged')} for="untagged-checkbox" />
-      </div>
       <div class="flex items-center gap-2">
         <Checkbox id="not-in-album-checkbox" size="tiny" bind:checked={filters.isNotInAlbum} />
         <Label label={$t('not_in_any_album')} for="not-in-album-checkbox" />

--- a/web/src/lib/components/shared-components/search-bar/search-tags-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-tags-section.svelte
@@ -3,13 +3,14 @@
   import Combobox, { type ComboBoxOption } from '$lib/components/shared-components/combobox.svelte';
   import { preferences } from '$lib/stores/user.store';
   import { getAllTags, type TagResponseDto } from '@immich/sdk';
+  import { Checkbox, Label } from '@immich/ui';
   import { mdiClose } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import { SvelteSet } from 'svelte/reactivity';
 
   interface Props {
-    selectedTags: SvelteSet<string>;
+    selectedTags: SvelteSet<string> | null;
   }
 
   let { selectedTags = $bindable() }: Props = $props();
@@ -23,7 +24,7 @@
   });
 
   const handleSelect = (option?: ComboBoxOption) => {
-    if (!option || !option.id) {
+    if (!option || !option.id || selectedTags === null) {
       return;
     }
 
@@ -32,6 +33,10 @@
   };
 
   const handleRemove = (tag: string) => {
+    if (selectedTags === null) {
+      return;
+    }
+
     selectedTags.delete(tag);
   };
 </script>
@@ -41,6 +46,7 @@
     <form autocomplete="off" id="create-tag-form">
       <div class="my-4 flex flex-col gap-2">
         <Combobox
+          disabled={selectedTags === null}
           onSelect={handleSelect}
           label={$t('tags').toUpperCase()}
           defaultFirstOption
@@ -49,10 +55,21 @@
           placeholder={$t('search_tags')}
         />
       </div>
+      <div class="flex items-center gap-2">
+        <Checkbox
+          id="untagged-checkbox"
+          size="tiny"
+          checked={selectedTags === null}
+          onCheckedChange={(checked) => {
+            selectedTags = checked ? null : new SvelteSet();
+          }}
+        />
+        <Label label={$t('untagged')} for="untagged-checkbox" />
+      </div>
     </form>
 
     <section class="flex flex-wrap pt-2 gap-1">
-      {#each selectedTags as tagId (tagId)}
+      {#each selectedTags ?? [] as tagId (tagId)}
         {@const tag = tagMap[tagId]}
         {#if tag}
           <div class="flex group transition-all">

--- a/web/src/lib/modals/SearchFilterModal.svelte
+++ b/web/src/lib/modals/SearchFilterModal.svelte
@@ -8,7 +8,7 @@
     query: string;
     queryType: 'smart' | 'metadata' | 'description';
     personIds: SvelteSet<string>;
-    tagIds: SvelteSet<string>;
+    tagIds: SvelteSet<string> | null;
     location: SearchLocationFilter;
     camera: SearchCameraFilter;
     date: SearchDateFilter;
@@ -68,7 +68,12 @@
     query: 'query' in searchQuery ? searchQuery.query : searchQuery.originalFileName || '',
     queryType: defaultQueryType(),
     personIds: new SvelteSet('personIds' in searchQuery ? searchQuery.personIds : []),
-    tagIds: new SvelteSet('tagIds' in searchQuery ? searchQuery.tagIds : []),
+    tagIds:
+      'tagIds' in searchQuery
+        ? searchQuery.tagIds === null
+          ? null
+          : new SvelteSet(searchQuery.tagIds)
+        : new SvelteSet(),
     location: {
       country: withNullAsUndefined(searchQuery.country),
       state: withNullAsUndefined(searchQuery.state),
@@ -86,7 +91,6 @@
       isArchive: searchQuery.visibility === AssetVisibility.Archive,
       isFavorite: searchQuery.isFavorite ?? false,
       isNotInAlbum: 'isNotInAlbum' in searchQuery ? (searchQuery.isNotInAlbum ?? false) : false,
-      isUntagged: 'isUntagged' in searchQuery ? (searchQuery.isUntagged ?? false) : false,
     },
     mediaType:
       searchQuery.type === AssetTypeEnum.Image
@@ -110,7 +114,6 @@
         isArchive: false,
         isFavorite: false,
         isNotInAlbum: false,
-        isUntagged: false,
       },
       mediaType: MediaType.All,
       rating: undefined,
@@ -141,9 +144,8 @@
       visibility: filter.display.isArchive ? AssetVisibility.Archive : undefined,
       isFavorite: filter.display.isFavorite || undefined,
       isNotInAlbum: filter.display.isNotInAlbum || undefined,
-      isUntagged: filter.display.isUntagged || undefined,
       personIds: filter.personIds.size > 0 ? [...filter.personIds] : undefined,
-      tagIds: filter.tagIds.size > 0 ? [...filter.tagIds] : undefined,
+      tagIds: filter.tagIds === null ? null : filter.tagIds.size > 0 ? [...filter.tagIds] : undefined,
       type,
       rating: filter.rating,
     };

--- a/web/src/lib/modals/SearchFilterModal.svelte
+++ b/web/src/lib/modals/SearchFilterModal.svelte
@@ -86,6 +86,7 @@
       isArchive: searchQuery.visibility === AssetVisibility.Archive,
       isFavorite: searchQuery.isFavorite ?? false,
       isNotInAlbum: 'isNotInAlbum' in searchQuery ? (searchQuery.isNotInAlbum ?? false) : false,
+      isUntagged: 'isUntagged' in searchQuery ? (searchQuery.isUntagged ?? false) : false,
     },
     mediaType:
       searchQuery.type === AssetTypeEnum.Image
@@ -109,6 +110,7 @@
         isArchive: false,
         isFavorite: false,
         isNotInAlbum: false,
+        isUntagged: false,
       },
       mediaType: MediaType.All,
       rating: undefined,
@@ -139,6 +141,7 @@
       visibility: filter.display.isArchive ? AssetVisibility.Archive : undefined,
       isFavorite: filter.display.isFavorite || undefined,
       isNotInAlbum: filter.display.isNotInAlbum || undefined,
+      isUntagged: filter.display.isUntagged || undefined,
       personIds: filter.personIds.size > 0 ? [...filter.personIds] : undefined,
       tagIds: filter.tagIds.size > 0 ? [...filter.tagIds] : undefined,
       type,

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -201,6 +201,7 @@
       visibility: $t('in_archive'),
       isFavorite: $t('favorite'),
       isNotInAlbum: $t('not_in_any_album'),
+      isUntagged: $t('untagged'),
       type: $t('media_type'),
       query: $t('context'),
       city: $t('city'),

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -201,7 +201,6 @@
       visibility: $t('in_archive'),
       isFavorite: $t('favorite'),
       isNotInAlbum: $t('not_in_any_album'),
-      isUntagged: $t('untagged'),
       type: $t('media_type'),
       query: $t('context'),
       city: $t('city'),
@@ -234,7 +233,10 @@
     return personNames.join(', ');
   }
 
-  async function getTagNames(tagIds: string[]) {
+  async function getTagNames(tagIds: string[] | null) {
+    if (tagIds === null) {
+      return $t('untagged');
+    }
     const tagNames = await Promise.all(
       tagIds.map(async (tagId) => {
         const tag = await getTagById({ id: tagId });
@@ -344,7 +346,7 @@
               {#await getPersonName(value) then personName}
                 {personName}
               {/await}
-            {:else if searchKey === 'tagIds' && Array.isArray(value)}
+            {:else if searchKey === 'tagIds' && (Array.isArray(value) || value === null)}
               {#await getTagNames(value) then tagNames}
                 {tagNames}
               {/await}


### PR DESCRIPTION
## Description

The possibility to search for untagged assets makes organisation easier. This feature allows the user to start tagging their assets exhaustively. Personnally, tagging features are the only thing I'm waiting before switching to Immich entirely!

## How Has This Been Tested?

This adds very little change to the codebase, and similar search parameters, like "Not in any album" aren't tested, so it doesn't look like a necessity here.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

![image](https://github.com/user-attachments/assets/f8d520ac-91a4-424a-9f0f-bfd237a49d14)

</details>


## API Changes
- Added a `isUntagged: bool` parameter to search-related DTOs.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
