### PR TITLE
chore: update docker permissions (dev)

### DIFF
--- a/.devcontainer/server/container-start.sh
+++ b/.devcontainer/server/container-start.sh
@@ -3,9 +3,6 @@
 # shellcheck disable=SC1091
 source /immich-devcontainer/container-common.sh
 
-log "Setting up Immich dev container..."
-fix_permissions
-
 log "Installing npm dependencies (node_modules)..."
 install_dependencies
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -22,6 +22,9 @@ services:
     #   file: hwaccel.transcoding.yml
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     build:
+      args:
+        - SERVER_USER=${SERVER_USER:-0}
+        - SERVER_GROUP=${SERVER_GROUP:-0}
       context: ../
       dockerfile: server/Dockerfile
       target: dev
@@ -35,7 +38,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
-    user: ${SERVER_UID:-0}:${SERVER_GID:-0}
     environment:
       IMMICH_REPOSITORY: immich-app/immich
       IMMICH_REPOSITORY_URL: https://github.com/immich-app/immich
@@ -67,9 +69,12 @@ services:
   immich-web:
     container_name: immich_web
     image: immich-web-dev:latest
-    # user: 0:0 needed for rootless docker setup, see https://github.com/moby/moby/issues/45919
-    user: ${WEB_UID:-1000}:${WEB_GID:-1000}
+    # Needed for rootless docker setup, see https://github.com/moby/moby/issues/45919
+    # user: 0:0
     build:
+      args:
+        - WEB_USER=${WEB_USER:-1000}
+        - WEB_GROUP=${WEB_GROUP:-1000}
       context: ../
       dockerfile: web/Dockerfile
     command: ['immich-web']

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -35,6 +35,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
+    user: ${SERVER_UID:-0}:${SERVER_GID:-0}
     environment:
       IMMICH_REPOSITORY: immich-app/immich
       IMMICH_REPOSITORY_URL: https://github.com/immich-app/immich
@@ -66,8 +67,8 @@ services:
   immich-web:
     container_name: immich_web
     image: immich-web-dev:latest
-    # Needed for rootless docker setup, see https://github.com/moby/moby/issues/45919
-    # user: 0:0
+    # user: 0:0 needed for rootless docker setup, see https://github.com/moby/moby/issues/45919
+    user: ${WEB_UID:-1000}:${WEB_GID:-1000}
     build:
       context: ../
       dockerfile: web/Dockerfile

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,12 @@ FROM ghcr.io/immich-app/base-server-dev:202507162011@sha256:85d4230c2208646bd6c5
 WORKDIR /usr/src/app
 COPY ./server/package* ./server/
 WORKDIR /usr/src/app/server
-RUN npm ci && \
+RUN  echo "umask 000" | tee /etc/profile /etc/bash.bashrc >/dev/null && \
+  umask 000 && \
+  chmod o+wx /usr/src/app && \
+  chmod o+wx /usr/src/app/server && \
+  mkdir -p /usr/src/app/upload && \
+  npm ci && \
   # exiftool-vendored.pl, sharp-linux-x64 and sharp-linux-arm64 are the only ones we need
   # they're marked as optional dependencies, so we need to copy them manually after pruning
   rm -rf node_modules/@img/sharp-libvips* && \
@@ -26,17 +31,14 @@ RUN apt-get update && \
 RUN usermod -aG sudo node
 RUN echo "node ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /workspaces/immich
-RUN chown node -R /workspaces
-COPY --chown=node:node --chmod=777 ../.devcontainer/server/*.sh /immich-devcontainer/
+COPY --chmod=777 ../.devcontainer/server/*.sh /immich-devcontainer/
 
-USER node
-COPY --chown=node:node .. /tmp/create-dep-cache/
+COPY .. /tmp/create-dep-cache/
 WORKDIR /tmp/create-dep-cache
 RUN make ci-all && rm -rf /tmp/create-dep-cache
 
-
 FROM dev-container-server AS dev-container-mobile
-USER root
+
 # Enable multiarch for arm64 if necessary
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
   dpkg --add-architecture amd64 && \
@@ -62,7 +64,6 @@ RUN mkdir -p ${FLUTTER_HOME} \
   && rm flutter.tar.xz \
   && chown -R node ${FLUTTER_HOME}
 
-USER node
 RUN sudo apt-get update \
   && wget -qO- https://dcm.dev/pgp-key.public | sudo gpg --dearmor -o /usr/share/keyrings/dcm.gpg \
   && echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,14 +1,17 @@
 # dev build
 FROM ghcr.io/immich-app/base-server-dev:202507162011@sha256:85d4230c2208646bd6c528db41b2213d780b11b7a311397ca6a2aaba7cf697c8 AS dev
 
+ARG SERVER_USER=0
+ARG SERVER_GROUP=${SERVER_USER}
+
+RUN chown -R ${SERVER_USER}:${SERVER_GROUP} /usr/src/app
+USER ${SERVER_USER}:${SERVER_GROUP}
+
 WORKDIR /usr/src/app
-COPY ./server/package* ./server/
+COPY --chown=${SERVER_USER}:${SERVER_GROUP} ./server/package* ./server/
 WORKDIR /usr/src/app/server
-RUN  echo "umask 000" | tee /etc/profile /etc/bash.bashrc >/dev/null && \
-  umask 000 && \
-  chmod o+wx /usr/src/app && \
-  chmod o+wx /usr/src/app/server && \
-  mkdir -p /usr/src/app/upload && \
+
+RUN mkdir -p /usr/src/app/upload && \
   npm ci && \
   # exiftool-vendored.pl, sharp-linux-x64 and sharp-linux-arm64 are the only ones we need
   # they're marked as optional dependencies, so we need to copy them manually after pruning
@@ -22,23 +25,27 @@ ENTRYPOINT ["tini", "--", "/bin/bash", "-c"]
 
 FROM dev AS dev-container-server
 
-RUN rm -rf /usr/src/app
-RUN apt-get update && \
-  apt-get install sudo inetutils-ping openjdk-11-jre-headless \
+USER 0:0
+RUN rm -rf /usr/src/app && \
+  apt-get update && \
+  apt-get install inetutils-ping openjdk-11-jre-headless \
   vim nano \
   -y --no-install-recommends --fix-missing
 
-RUN usermod -aG sudo node
-RUN echo "node ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-RUN mkdir -p /workspaces/immich
-COPY --chmod=777 ../.devcontainer/server/*.sh /immich-devcontainer/
+RUN mkdir -p /workspaces/immich/server/node_modules && \
+  mkdir -p /workspaces/immich/web/node_modules && \
+  mkdir -p /workspaces/immich/open-api/typescript-sdk/node_modules && \
+  chown -R ${SERVER_USER}:${SERVER_GROUP} /workspaces/immich
 
-COPY .. /tmp/create-dep-cache/
+USER $SERVER_USER:$SERVER_GROUP
+COPY --chmod=555 --chown=${SERVER_USER}:${SERVER_GROUP} ../.devcontainer/server/*.sh /immich-devcontainer/
+
+COPY --chown=${SERVER_USER}:${SERVER_GROUP} .. /tmp/create-dep-cache/
 WORKDIR /tmp/create-dep-cache
 RUN make ci-all && rm -rf /tmp/create-dep-cache
 
 FROM dev-container-server AS dev-container-mobile
-
+USER 0:0
 # Enable multiarch for arm64 if necessary
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
   dpkg --add-architecture amd64 && \
@@ -62,20 +69,20 @@ RUN mkdir -p ${FLUTTER_HOME} \
   && curl -C - --output flutter.tar.xz https://storage.googleapis.com/flutter_infra_release/releases/${FLUTTER_CHANNEL}/linux/flutter_linux_${FLUTTER_VERSION}-${FLUTTER_CHANNEL}.tar.xz \
   && tar -xf flutter.tar.xz --strip-components=1 -C ${FLUTTER_HOME} \
   && rm flutter.tar.xz \
-  && chown -R node ${FLUTTER_HOME}
+  && chown -R ${SERVER_USER}:${SERVER_GROUP} ${FLUTTER_HOME}
 
-RUN sudo apt-get update \
-  && wget -qO- https://dcm.dev/pgp-key.public | sudo gpg --dearmor -o /usr/share/keyrings/dcm.gpg \
-  && echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list \
-  && sudo apt-get update \
-  && sudo apt-get install dcm -y
+RUN apt-get update \
+  && wget -qO- https://dcm.dev/pgp-key.public | gpg --dearmor -o /usr/share/keyrings/dcm.gpg \
+  && echo 'deb [signed-by=/usr/share/keyrings/dcm.gpg arch=amd64] https://dcm.dev/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list \
+  && apt-get update \
+  && apt-get install dcm -y
 
-COPY --chmod=777 ../.devcontainer/mobile/container-mobile-post-create.sh /immich-devcontainer/container-mobile-post-create.sh
-
+USER $SERVER_USER:$SERVER_GROUP
 RUN dart --disable-analytics
 
 FROM dev AS prod
 
+USER 0:0
 COPY server .
 RUN npm run build
 RUN npm prune --omit=dev --omit=optional
@@ -85,6 +92,7 @@ COPY --from=dev /usr/src/app/server/node_modules/exiftool-vendored.pl ./node_mod
 # web build
 FROM node:22.16.0-alpine3.20@sha256:2289fb1fba0f4633b08ec47b94a89c7e20b829fc5679f9b7b298eaa2f1ed8b7e AS web
 
+USER 0:0
 WORKDIR /usr/src/app
 COPY ./web ./web/
 COPY ./i18n ./i18n/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,14 +1,15 @@
 FROM node:22.16.0-alpine3.20@sha256:2289fb1fba0f4633b08ec47b94a89c7e20b829fc5679f9b7b298eaa2f1ed8b7e
 
-RUN apk add --no-cache tini bash
+WORKDIR /usr/src/app/web
+COPY ./web/package* ./
 
-USER node
-WORKDIR /usr/src/app
-
-COPY --chown=node:node ./web/package* ./web/
+RUN apk add --no-cache tini bash && \
+  echo "umask 000" | tee /etc/profile /etc/bash.bashrc >/dev/null && \
+  chmod o+wx /usr/src/app && \
+  chmod o+wx /usr/src/app/web
 
 WORKDIR /usr/src/app/web
-RUN npm ci
+RUN umask 000 && npm ci
 
 ENV CHOKIDAR_USEPOLLING=true \
   PATH="${PATH}:/usr/src/app/web/bin"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,15 +1,16 @@
 FROM node:22.16.0-alpine3.20@sha256:2289fb1fba0f4633b08ec47b94a89c7e20b829fc5679f9b7b298eaa2f1ed8b7e
 
-WORKDIR /usr/src/app/web
-COPY ./web/package* ./
+ARG WEB_USER=1000
+ARG WEB_GROUP=1000
 
-RUN apk add --no-cache tini bash && \
-  echo "umask 000" | tee /etc/profile /etc/bash.bashrc >/dev/null && \
-  chmod o+wx /usr/src/app && \
-  chmod o+wx /usr/src/app/web
+RUN apk add --no-cache tini bash
+
+USER $WEB_USER:$WEB_GROUP
+WORKDIR /usr/src/app/web
+COPY --chown=${WEB_USER}:${WEB_GROUP} ./web/package* ./
 
 WORKDIR /usr/src/app/web
-RUN umask 000 && npm ci
+RUN npm ci
 
 ENV CHOKIDAR_USEPOLLING=true \
   PATH="${PATH}:/usr/src/app/web/bin"


### PR DESCRIPTION
Instead of switching from root/node in the dockerfile build, leave this completely up to the user.

- Add umask 000 to /etc/profile and /etc/bash.bashrc which will allow the 'other' group to read/write files by default (matching user and group default permissions) 
  - This will allow user node (1000:1000) or root (0:0) (or any other user) to install/manipulate files in the `dev` stage
  - Production stage is unchanged (runs as root) 
- Add o+wx to /usr/src/app, /usr/src/server
- load UID/GID from .env, if present, otherwise, default is 0:0 for dev, and 1000:1000 for web (matching current behavior) 

This will a user to specify a different (any) user for runtime. 

The intension behind this change is 
1) Don't assume what user is running at runtime when building the dev images. 
2) When the docker-compose.dev bind mounts paths into the container, because the container would be running as 0:0, then the `node_modules` or `server/dist` folders that contain deps or compiled code will be owned by 0:0, even tho my host is usually not running as the root user - this is annoying to cleanup, and not as secure as running as a non-root user. 

