### PR TITLE
chore: Use a contrasted color for text avatar

### DIFF
--- a/mobile/lib/widgets/common/user_circle_avatar.dart
+++ b/mobile/lib/widgets/common/user_circle_avatar.dart
@@ -5,9 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
-import 'package:immich_mobile/domain/models/user_metadata.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
-import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/widgets/common/transparent_image.dart';
 
@@ -26,7 +24,7 @@ class UserCircleAvatar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    bool isDarkTheme = context.themeData.brightness == Brightness.dark;
+    final userAvatarColor = user.avatarColor.toColor();
     final profileImageUrl =
         '${Store.get(StoreKey.serverEndpoint)}/users/${user.id}/profile-image?d=${Random().nextInt(1024)}';
 
@@ -34,14 +32,14 @@ class UserCircleAvatar extends ConsumerWidget {
       style: TextStyle(
         fontWeight: FontWeight.bold,
         fontSize: 12,
-        color: isDarkTheme && user.avatarColor == AvatarColor.primary
+        color: userAvatarColor.computeLuminance() > 0.5
             ? Colors.black
             : Colors.white,
       ),
       child: Text(user.name[0].toUpperCase()),
     );
     return CircleAvatar(
-      backgroundColor: user.avatarColor.toColor(),
+      backgroundColor: userAvatarColor,
       radius: radius,
       child: user.profileImagePath == null
           ? textIcon


### PR DESCRIPTION
## Description

Choose a contrasted color for text avatar depending by the chosen avatar color. This improves the legibility and makes the mobile app coherent to the web version

## Screenshots (if appropriate)

| Before | After |
|--------|-------|
| ![Screenshot From 2025-07-05 21-51-41](https://github.com/user-attachments/assets/0be70397-d70e-4e51-83a4-752eb4007bd9)  | ![Screenshot From 2025-07-05 21-51-46](https://github.com/user-attachments/assets/e07deb88-a1bf-4536-9e2c-a1d138b372af)  |



