### PR TITLE
fix: add quiet zone to QR code

### DIFF
--- a/web/src/lib/components/shared-components/qrcode.svelte
+++ b/web/src/lib/components/shared-components/qrcode.svelte
@@ -10,7 +10,7 @@
 
   const { value, width, alt = $t('alt_text_qr_code') }: Props = $props();
 
-  let promise = $derived(QRCode.toDataURL(value, { margin: 0, width }));
+  let promise = $derived(QRCode.toDataURL(value, { margin: 4, width }));
 </script>
 
 <div style="width: {width}px; height: {width}px">


### PR DESCRIPTION
This is needed for the QR code to be readable by many QR readers. It is also a requirement for it to be a valid QR code.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
