### PR TITLE
fix(mobile): deeplinking to asset view while viewer is already open

### DIFF
--- a/mobile/lib/routing/gallery_guard.dart
+++ b/mobile/lib/routing/gallery_guard.dart
@@ -1,7 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:immich_mobile/routing/router.dart';
 
-/// Guards against duplicate navigation to this route
+/// Handles duplicate navigation to this route (primarily for deep linking)
 class GalleryGuard extends AutoRouteGuard {
   const GalleryGuard();
   @override

--- a/mobile/lib/routing/gallery_guard.dart
+++ b/mobile/lib/routing/gallery_guard.dart
@@ -1,0 +1,30 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:immich_mobile/routing/router.dart';
+
+/// Guards against duplicate navigation to this route
+class GalleryGuard extends AutoRouteGuard {
+  const GalleryGuard();
+  @override
+  void onNavigation(NavigationResolver resolver, StackRouter router) async {
+    final newRouteName = resolver.route.name;
+    final currentTopRouteName =
+        router.stack.isNotEmpty ? router.stack.last.name : null;
+
+    if (currentTopRouteName == newRouteName) {
+      // Replace instead of pushing duplicate
+      final args = resolver.route.args as GalleryViewerRouteArgs;
+
+      router.replace(
+        GalleryViewerRoute(
+          renderList: args.renderList,
+          initialIndex: args.initialIndex,
+          heroOffset: args.heroOffset,
+          showStack: args.showStack,
+        ),
+      );
+      resolver.next(true);
+    } else {
+      resolver.next(true);
+    }
+  }
+}

--- a/mobile/lib/routing/gallery_guard.dart
+++ b/mobile/lib/routing/gallery_guard.dart
@@ -22,9 +22,10 @@ class GalleryGuard extends AutoRouteGuard {
           showStack: args.showStack,
         ),
       );
-      resolver.next(true);
-    } else {
-      resolver.next(true);
+      // Prevent further navigation since we replaced the route
+      resolver.next(false);
+      return;
     }
+    resolver.next(true);
   }
 }

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -78,6 +78,7 @@ import 'package:immich_mobile/routing/auth_guard.dart';
 import 'package:immich_mobile/routing/backup_permission_guard.dart';
 import 'package:immich_mobile/routing/custom_transition_builders.dart';
 import 'package:immich_mobile/routing/duplicate_guard.dart';
+import 'package:immich_mobile/routing/gallery_guard.dart';
 import 'package:immich_mobile/routing/locked_guard.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/local_auth.service.dart';
@@ -102,6 +103,7 @@ class AppRouter extends RootStackRouter {
   late final DuplicateGuard _duplicateGuard;
   late final BackupPermissionGuard _backupPermissionGuard;
   late final LockedGuard _lockedGuard;
+  late final GalleryGuard _galleryGuard;
 
   AppRouter(
     ApiService apiService,
@@ -114,6 +116,7 @@ class AppRouter extends RootStackRouter {
     _lockedGuard =
         LockedGuard(apiService, secureStorageService, localAuthService);
     _backupPermissionGuard = BackupPermissionGuard(galleryPermissionNotifier);
+    _galleryGuard = const GalleryGuard();
   }
 
   @override
@@ -183,7 +186,7 @@ class AppRouter extends RootStackRouter {
     ),
     CustomRoute(
       page: GalleryViewerRoute.page,
-      guards: [_authGuard, _duplicateGuard],
+      guards: [_authGuard, _galleryGuard],
       transitionsBuilder: CustomTransitionsBuilders.zoomedPage,
     ),
     AutoRoute(

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -106,7 +106,6 @@ class DeepLinkService {
 
   Future<PageRouteInfo?> _buildAssetDeepLink(String assetId) async {
     final asset = await _assetService.getAssetByRemoteId(assetId);
-
     if (asset == null) {
       return null;
     }


### PR DESCRIPTION
## Description

There was an issue where deeplinking to an asset when the asset viewer was already open would result in the deep link being "ignored" (it would process but the duplicate guard would cancel it).


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
