### PR TITLE
refactor(mobile): timeline queries

### DIFF
--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -58,11 +58,11 @@ class TimelineFactory {
         ),
       );
 
-  TimelineService remoteAssets(List<String> timelineUsers) => TimelineService(
+  TimelineService remoteAssets(String ownerId) => TimelineService(
         assetSource: (offset, count) => _timelineRepository
-            .getRemoteBucketAssets(timelineUsers, offset: offset, count: count),
+            .getRemoteBucketAssets(ownerId, offset: offset, count: count),
         bucketSource: () => _timelineRepository.watchRemoteBucket(
-          timelineUsers,
+          ownerId,
           groupBy: GroupAssetsBy.month,
         ),
       );

--- a/mobile/lib/infrastructure/repositories/remote_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/remote_album.repository.dart
@@ -26,11 +26,13 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
       leftOuterJoin(
         _db.userEntity,
         _db.userEntity.id.equalsExp(_db.remoteAlbumEntity.ownerId),
+        useColumns: false,
       ),
     ]);
     query
       ..where(_db.remoteAssetEntity.deletedAt.isNull())
       ..addColumns([assetCount])
+      ..addColumns([_db.userEntity.name])
       ..groupBy([_db.remoteAlbumEntity.id]);
 
     if (sortBy.isNotEmpty) {
@@ -49,7 +51,7 @@ class DriftRemoteAlbumRepository extends DriftDatabaseRepository {
         .map(
           (row) => row.readTable(_db.remoteAlbumEntity).toDto(
                 assetCount: row.read(assetCount) ?? 0,
-                ownerName: row.readTable(_db.userEntity).name,
+                ownerName: row.read(_db.userEntity.name)!,
               ),
         )
         .get();

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -124,6 +124,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
         innerJoin(
           _db.localAlbumAssetEntity,
           _db.localAlbumAssetEntity.assetId.equalsExp(_db.localAssetEntity.id),
+          useColumns: false,
         ),
       ])
       ..where(_db.localAlbumAssetEntity.albumId.equals(albumId))
@@ -147,6 +148,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
         innerJoin(
           _db.localAlbumAssetEntity,
           _db.localAlbumAssetEntity.assetId.equalsExp(_db.localAssetEntity.id),
+          useColumns: false,
         ),
       ],
     )
@@ -179,6 +181,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
           _db.remoteAlbumAssetEntity,
           _db.remoteAlbumAssetEntity.assetId
               .equalsExp(_db.remoteAssetEntity.id),
+          useColumns: false,
         ),
       ])
       ..where(
@@ -206,6 +209,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
           _db.remoteAlbumAssetEntity,
           _db.remoteAlbumAssetEntity.assetId
               .equalsExp(_db.remoteAssetEntity.id),
+          useColumns: false,
         ),
       ],
     )
@@ -221,7 +225,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
   }
 
   Stream<List<Bucket>> watchRemoteBucket(
-    List<String> userIds, {
+    String ownerId, {
     GroupAssetsBy groupBy = GroupAssetsBy.day,
   }) {
     if (groupBy == GroupAssetsBy.none) {
@@ -230,7 +234,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
             where: (row) =>
                 row.deletedAt.isNull() &
                 row.visibility.equalsValue(AssetVisibility.timeline) &
-                row.ownerId.isIn(userIds),
+                row.ownerId.equals(ownerId),
           )
           .map(_generateBuckets)
           .watchSingle();
@@ -245,7 +249,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
         _db.remoteAssetEntity.deletedAt.isNull() &
             _db.remoteAssetEntity.visibility
                 .equalsValue(AssetVisibility.timeline) &
-            _db.remoteAssetEntity.ownerId.isIn(userIds),
+            _db.remoteAssetEntity.ownerId.equals(ownerId),
       )
       ..groupBy([dateExp])
       ..orderBy([OrderingTerm.desc(dateExp)]);
@@ -258,7 +262,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
   }
 
   Future<List<BaseAsset>> getRemoteBucketAssets(
-    List<String> userIds, {
+    String ownerId, {
     required int offset,
     required int count,
   }) {
@@ -267,7 +271,7 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
         (row) =>
             row.deletedAt.isNull() &
             row.visibility.equalsValue(AssetVisibility.timeline) &
-            row.ownerId.isIn(userIds),
+            row.ownerId.equals(ownerId),
       )
       ..orderBy([(row) => OrderingTerm.desc(row.createdAt)])
       ..limit(count, offset: offset);

--- a/mobile/lib/presentation/pages/dev/drift_recently_taken.page.dart
+++ b/mobile/lib/presentation/pages/dev/drift_recently_taken.page.dart
@@ -23,7 +23,7 @@ class DriftRecentlyTakenPage extends StatelessWidget {
             }
 
             final timelineService =
-                ref.watch(timelineFactoryProvider).remoteAssets([user.id]);
+                ref.watch(timelineFactoryProvider).remoteAssets(user.id);
             ref.onDispose(timelineService.dispose);
             return timelineService;
           },

--- a/mobile/lib/presentation/pages/drift_asset_selection_timeline.page.dart
+++ b/mobile/lib/presentation/pages/drift_asset_selection_timeline.page.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
 class DriftAssetSelectionTimelinePage extends ConsumerWidget {
@@ -29,10 +30,15 @@ class DriftAssetSelectionTimelinePage extends ConsumerWidget {
         ),
         timelineServiceProvider.overrideWith(
           (ref) {
-            final timelineUsers =
-                ref.watch(timelineUsersProvider).valueOrNull ?? [];
+            final user = ref.watch(currentUserProvider);
+            if (user == null) {
+              throw Exception(
+                'User must be logged in to access recently taken',
+              );
+            }
+
             final timelineService =
-                ref.watch(timelineFactoryProvider).remoteAssets(timelineUsers);
+                ref.watch(timelineFactoryProvider).remoteAssets(user.id);
             ref.onDispose(timelineService.dispose);
             return timelineService;
           },


### PR DESCRIPTION
### Description

- The remote albums query is updated to take a single user ID as input rather than a list of users. It is currently used in the asset selection page where it displays all remote assets including partner assets. However, it should only display the assets owned by the current user. The other pages that might use this query are the partner details page and the recently take page. They do not need a list of user Ids to filter on as well
- The `getAll` method in the remote album repository is updated to ignore user entity columns in the query. Instead, the only column used, i.e, user name is added manually.
- Other queries in timeline repo are updated to ignore columns from joins