### PR TITLE
feat(web): update icons

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/set-visibility-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/set-visibility-action.svelte
@@ -25,6 +25,7 @@
       prompt: isLocked ? $t('remove_from_locked_folder_confirmation') : $t('move_to_locked_folder_confirmation'),
       confirmText: $t('move'),
       confirmColor: isLocked ? 'danger' : 'primary',
+      icon: isLocked ? mdiLockOpenVariantOutline : mdiLockOutline,
     });
 
     if (!isConfirmed) {

--- a/web/src/lib/components/photos-page/actions/set-visibility-action.svelte
+++ b/web/src/lib/components/photos-page/actions/set-visibility-action.svelte
@@ -26,6 +26,7 @@
       prompt: unlock ? $t('remove_from_locked_folder_confirmation') : $t('move_to_locked_folder_confirmation'),
       confirmText: $t('move'),
       confirmColor: unlock ? 'danger' : 'primary',
+      icon: unlock ? mdiLockOpenVariantOutline : mdiLockOutline,
     });
 
     if (!isConfirmed) {

--- a/web/src/lib/components/photos-page/delete-asset-dialog.svelte
+++ b/web/src/lib/components/photos-page/delete-asset-dialog.svelte
@@ -3,6 +3,7 @@
   import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { Checkbox, Label } from '@immich/ui';
+  import { mdiDeleteForeverOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -26,6 +27,7 @@
 <ConfirmModal
   title={$t('permanently_delete_assets_count', { values: { count: size } })}
   confirmText={$t('delete')}
+  icon={mdiDeleteForeverOutline}
   onClose={(confirmed) => (confirmed ? handleConfirm() : onCancel())}
 >
   {#snippet promptSnippet()}

--- a/web/src/lib/components/shared-components/change-date.svelte
+++ b/web/src/lib/components/shared-components/change-date.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
+  import { mdiCalendarEditOutline } from '@mdi/js';
   import { DateTime, Duration } from 'luxon';
   import { t } from 'svelte-i18n';
   import DateInput from '../elements/date-input.svelte';
@@ -178,6 +179,7 @@
 <ConfirmModal
   confirmColor="primary"
   {title}
+  icon={mdiCalendarEditOutline}
   prompt="Please select a new date:"
   disabled={!date.isValid}
   onClose={(confirmed) => (confirmed ? handleConfirm() : onCancel())}

--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -11,6 +11,7 @@
   import { delay } from '$lib/utils/asset-utils';
   import { handleError } from '$lib/utils/handle-error';
   import { searchPlaces, type AssetResponseDto, type PlacesResponseDto } from '@immich/sdk';
+  import { mdiMapMarkerMultipleOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store';
   interface Point {
@@ -113,6 +114,7 @@
 <ConfirmModal
   confirmColor="primary"
   title={$t('change_location')}
+  icon={mdiMapMarkerMultipleOutline}
   size="medium"
   onClose={(confirmed) => (confirmed ? handleConfirm() : onCancel())}
 >

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -124,7 +124,12 @@
     </SettingAccordion>
   {/if}
 
-  <SettingAccordion icon={mdiFormTextboxPassword} key="password" title={$t('password')} subtitle={$t('change_your_password')}>
+  <SettingAccordion
+    icon={mdiFormTextboxPassword}
+    key="password"
+    title={$t('password')}
+    subtitle={$t('change_your_password')}
+  >
     <ChangePasswordSettings />
   </SettingAccordion>
 

--- a/web/src/lib/components/user-settings-page/user-settings-list.svelte
+++ b/web/src/lib/components/user-settings-page/user-settings-list.svelte
@@ -22,7 +22,7 @@
     mdiFeatureSearchOutline,
     mdiKeyOutline,
     mdiLockSmart,
-    mdiOnepassword,
+    mdiFormTextboxPassword,
     mdiServerOutline,
     mdiTwoFactorAuthentication,
   } from '@mdi/js';
@@ -124,7 +124,7 @@
     </SettingAccordion>
   {/if}
 
-  <SettingAccordion icon={mdiOnepassword} key="password" title={$t('password')} subtitle={$t('change_your_password')}>
+  <SettingAccordion icon={mdiFormTextboxPassword} key="password" title={$t('password')} subtitle={$t('change_your_password')}>
     <ChangePasswordSettings />
   </SettingAccordion>
 

--- a/web/src/lib/modals/AssetUpdateDecriptionConfirmModal.svelte
+++ b/web/src/lib/modals/AssetUpdateDecriptionConfirmModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ConfirmModal from '$lib/modals/ConfirmModal.svelte';
   import { Input } from '@immich/ui';
+  import { mdiText } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -15,6 +16,7 @@
 <ConfirmModal
   confirmColor="primary"
   title={$t('edit_description')}
+  icon={mdiText}
   prompt={$t('edit_description_prompt')}
   onClose={(confirmed) => (confirmed ? onClose(description) : onClose())}
 >

--- a/web/src/lib/modals/ConfirmModal.svelte
+++ b/web/src/lib/modals/ConfirmModal.svelte
@@ -10,6 +10,7 @@
     confirmColor?: Color;
     disabled?: boolean;
     size?: 'small' | 'medium';
+    icon?: string;
     onClose: (confirmed: boolean) => void;
     promptSnippet?: Snippet;
   }
@@ -21,6 +22,7 @@
     confirmColor = 'danger',
     disabled = false,
     size = 'small',
+    icon = undefined,
     onClose,
     promptSnippet,
   }: Props = $props();
@@ -30,7 +32,7 @@
   };
 </script>
 
-<Modal {title} onClose={() => onClose(false)} {size}>
+<Modal {title} {icon} onClose={() => onClose(false)} {size}>
   <ModalBody>
     {#if promptSnippet}{@render promptSnippet()}{:else}
       <p>{prompt}</p>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've added some icons to many of the modals found in the web interface, instead of just having the default Immich logo. I don't think all the modals have icons, this is just a start.

I also changed the password icon in the user settings from `mdiOnepassword` to `mdiFormTextboxPassword`, as it's probably not appropriate to be using the 1Password logo.

## Screenshots

### Change location modal (same changes for other modals):

**Before**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/78b4594a-e355-4a95-8235-5a131b5b826f" />


**After**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cd759586-0250-445a-9e48-dd50a1865ca7" />


### Password Settings

**Before**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f3dc9b1e-d03a-47e4-96bc-b7d5cdbe6396" />


**After**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/681d7a85-1483-48a2-a84c-d632914aef11" />

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Running the web instance on my machine connected to a remote backend

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
