### PR TITLE
feat(cli): upload hash caching

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -13,3 +13,5 @@ oclif.manifest.json
 /coverage/
 .reverse-geocoding-dump/
 upload/
+local-build.sh
+*.code-workspace

--- a/cli/package.json
+++ b/cli/package.json
@@ -21,6 +21,7 @@
     "@types/micromatch": "^4.0.9",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^22.18.8",
+    "@types/picomatch": "^4.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "byte-size": "^9.0.0",
     "cli-progress": "^3.12.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,6 @@
     "@types/byte-size": "^8.1.0",
     "@types/cli-progress": "^3.11.0",
     "@types/lodash-es": "^4.17.12",
-    "@types/micromatch": "^4.0.9",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^22.18.8",
     "@types/picomatch": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@eslint/js": "^9.8.0",
     "@immich/sdk": "file:../open-api/typescript-sdk",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/byte-size": "^8.1.0",
     "@types/cli-progress": "^3.11.0",
     "@types/lodash-es": "^4.17.12",
@@ -63,11 +64,12 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "better-sqlite3": "^12.4.1",
     "chokidar": "^4.0.3",
     "fast-glob": "^3.3.2",
     "fastq": "^1.17.1",
     "lodash-es": "^4.17.21",
-    "micromatch": "^4.0.8"
+    "picomatch": "^4.0.3"
   },
   "volta": {
     "node": "22.20.0"

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -167,13 +167,17 @@ const scan = async (pathsToCrawl: string[], options: UploadOptionsDto) => {
   });
 
   // Calculate total size
-  let totalSize = 0;
   try {
-    for (const file of files) {
-      const stats = await stat(file);
-      totalSize += stats.size;
-    }
-    console.log(`Found ${files.length} assets (${byteSize(totalSize)})`);
+    const results = await Promise.allSettled(
+      files.map((file) =>
+        stat(file).then(
+          (stats) => stats.size,
+          () => 0,
+        ),
+      ),
+    );
+
+    const totalSize = results.reduce((sum, result) => (result.status === 'fulfilled' ? sum + result.value : sum), 0);
   } catch (error) {
     console.warn('Failed to calculate total size', error);
   }

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -124,7 +124,7 @@ const processedAlbumNames = new Set<string>();
 export const upload = async (paths: string[], baseOptions: BaseOptions, options: UploadOptionsDto) => {
   // Clear the album names cache at the start of each upload command
   processedAlbumNames.clear();
-  
+
   // Initialize hash cache
   const hashCache = new FileHashCache(baseOptions.configDirectory);
   await hashCache.load();
@@ -208,14 +208,14 @@ export const checkForDuplicates = async (
 
   if (progress) {
     multiBar = new MultiBar(
-      { 
+      {
         format: '{message} | {bar} | {percentage}% | ETA: {eta_formatted} | {value}/{total}',
         formatValue: (v: number, options, type) => {
           // Don't format percentage
           if (type === 'percentage') return v.toString();
           return byteSize(v).toString();
         },
-        etaBuffer: 100,  // Increase samples for ETA calculation
+        etaBuffer: 100, // Increase samples for ETA calculation
       },
       Presets.shades_classic,
     );
@@ -231,11 +231,11 @@ export const checkForDuplicates = async (
     console.log(`Received ${files.length} files (${byteSize(totalSize)}), hashing...`);
   }
 
-  const hashProgressBar = multiBar?.create(totalSize, 0, { 
-    message: 'Hashing files          '
+  const hashProgressBar = multiBar?.create(totalSize, 0, {
+    message: 'Hashing files          ',
   });
-  const checkProgressBar = multiBar?.create(totalSize, 0, { 
-    message: 'Checking for duplicates'
+  const checkProgressBar = multiBar?.create(totalSize, 0, {
+    message: 'Checking for duplicates',
   });
 
   const newFiles: string[] = [];
@@ -294,7 +294,7 @@ export const checkForDuplicates = async (
         if (!stats) {
           throw new Error(`Stats not found for ${filepath}`);
         }
-        
+
         const dto = { id: filepath, checksum: await hashCache.getHash(filepath, stats) };
 
         results.push(dto);
@@ -589,46 +589,15 @@ const updateAlbums = async (assets: Asset[], options: UploadOptionsDto) => {
   }
 };
 
-const processAlbumName = (name: string, options: UploadOptionsDto): string => {
-  // Only process if formatAlbumNames is enabled
-  if (!options.formatAlbumNames) {
-    return name;
-  }
-
-  const originalName = name;
-  let processedName = name;
-
-  // Remove leading non-alphabetic characters (including numbers but preserving accented letters)
-  processedName = processedName.replace(/^[^\p{Letter}]+/u, '');
-
-  // Replace underscores and dashes with spaces, then handle multiple spaces
-  processedName = processedName
-    .replace(/[_\-]/g, ' ')     // Convert underscores and dashes to spaces
-    .replace(/\s+/g, ' ')       // Replace multiple spaces with single space
-    .trim();                    // Remove leading/trailing spaces
-
-  // Capitalize first letter
-  processedName = processedName.charAt(0).toUpperCase() + processedName.slice(1);
-
-  // Only show message once per unique original name
-  if (originalName !== processedName && !processedAlbumNames.has(originalName)) {
-    processedAlbumNames.add(originalName);
-    console.log(`Album name changed: "${originalName}" → "${processedName}"`);
-  }
-
-  return processedName;
-};
-
 // `filepath` valid format:
 // - Windows: `D:\\test\\Filename.txt` or `D:/test/Filename.txt`
 // - Unix: `/test/Filename.txt`
 export const getAlbumName = (filepath: string, options: UploadOptionsDto) => {
   if (options.albumName) {
-    return options.albumName;  // Don't process custom album names
+    return options.albumName;
   }
-  
-  const dirName = path.basename(path.dirname(filepath));
-  return processAlbumName(dirName, options);
+
+  return path.basename(path.dirname(filepath));
 };
 
 // `

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -590,9 +590,6 @@ const updateAlbums = async (assets: Asset[], options: UploadOptionsDto) => {
 
   if (newAlbums.size > 0) {
     console.log(`Created ${newAlbums.size} new album${s(newAlbums.size)}`);
-    for (const albumName of newAlbums) {
-      console.log(`- ${albumName}`);
-    }
   }
   console.log(`Successfully updated ${assets.length} asset${s(assets.length)}`);
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -82,10 +82,6 @@ program
       .implies({ progress: false }),
   )
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
-  .action((paths, options) => {
-    // Merge program options with command options
-    const mergedOptions = { ...program.opts(), ...options };
-    upload(paths, program.opts(), mergedOptions);
-  });
+  .action((paths, options) => upload(paths, program.opts(), options));
 
 program.parse(process.argv);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -45,7 +45,7 @@ program
   .usage('[paths...] [options]')
   .addOption(new Option('-r, --recursive', 'Recursive').env('IMMICH_RECURSIVE').default(false))
   .addOption(new Option('-i, --ignore <pattern>', 'Pattern to ignore').env('IMMICH_IGNORE_PATHS'))
-  .addOption(new Option('-s, --skip-hash', "Don't hash files before upload").env('IMMICH_SKIP_HASH').default(false))
+  .addOption(new Option('-h, --skip-hash', "Don't hash files before upload").env('IMMICH_SKIP_HASH').default(false))
   .addOption(new Option('-H, --include-hidden', 'Include hidden folders').env('IMMICH_INCLUDE_HIDDEN').default(false))
   .addOption(
     new Option('-a, --album', 'Automatically create albums based on folder name')
@@ -53,12 +53,9 @@ program
       .default(false),
   )
   .addOption(
-    new Option('-A, --album-name <n>', 'Add all assets to specified album').env('IMMICH_ALBUM_NAME').conflicts('album'),
-  )
-  .addOption(
-    new Option('-f, --format-album-names', 'Format album names (remove leading numbers, clean up spaces and dashes)')
-      .env('IMMICH_FORMAT_ALBUM_NAMES')
-      .default(false),
+    new Option('-A, --album-name <name>', 'Add all assets to specified album')
+      .env('IMMICH_ALBUM_NAME')
+      .conflicts('album'),
   )
   .addOption(
     new Option('-n, --dry-run', "Don't perform any actions, just show what will be done")

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,7 +8,6 @@ import { serverInfo } from 'src/commands/server-info';
 import { version } from '../package.json';
 
 const defaultConfigDirectory = path.join(os.homedir(), '.config/immich/');
-const defaultConcurrency = Math.max(1, os.cpus().length - 1);
 
 const program = new Command()
   .name('immich')
@@ -54,9 +53,7 @@ program
       .default(false),
   )
   .addOption(
-    new Option('-A, --album-name <n>', 'Add all assets to specified album')
-      .env('IMMICH_ALBUM_NAME')
-      .conflicts('album')
+    new Option('-A, --album-name <n>', 'Add all assets to specified album').env('IMMICH_ALBUM_NAME').conflicts('album'),
   )
   .addOption(
     new Option('-f, --format-album-names', 'Format album names (remove leading numbers, clean up spaces and dashes)')
@@ -72,7 +69,7 @@ program
   .addOption(
     new Option('-c, --concurrency <number>', 'Number of assets to upload at the same time')
       .env('IMMICH_UPLOAD_CONCURRENCY')
-      .default(defaultConcurrency),
+      .default(4),
   )
   .addOption(
     new Option('-j, --json-output', 'Output detailed information in json format')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -56,7 +56,7 @@ program
   .addOption(
     new Option('-A, --album-name <n>', 'Add all assets to specified album')
       .env('IMMICH_ALBUM_NAME')
-      .conflicts('album'),
+      .conflicts('album')
   )
   .addOption(
     new Option('-f, --format-album-names', 'Format album names (remove leading numbers, clean up spaces and dashes)')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -88,6 +88,10 @@ program
       .implies({ progress: false }),
   )
   .argument('[paths...]', 'One or more paths to assets to be uploaded')
-  .action((paths, options) => upload(paths, program.opts(), options));
+  .action((paths, options) => {
+    // Merge program options with command options
+    const mergedOptions = { ...program.opts(), ...options };
+    upload(paths, program.opts(), mergedOptions);
+  });
 
 program.parse(process.argv);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,6 +8,7 @@ import { serverInfo } from 'src/commands/server-info';
 import { version } from '../package.json';
 
 const defaultConfigDirectory = path.join(os.homedir(), '.config/immich/');
+const defaultConcurrency = Math.max(1, os.cpus().length - 1);
 
 const program = new Command()
   .name('immich')
@@ -45,7 +46,7 @@ program
   .usage('[paths...] [options]')
   .addOption(new Option('-r, --recursive', 'Recursive').env('IMMICH_RECURSIVE').default(false))
   .addOption(new Option('-i, --ignore <pattern>', 'Pattern to ignore').env('IMMICH_IGNORE_PATHS'))
-  .addOption(new Option('-h, --skip-hash', "Don't hash files before upload").env('IMMICH_SKIP_HASH').default(false))
+  .addOption(new Option('-s, --skip-hash', "Don't hash files before upload").env('IMMICH_SKIP_HASH').default(false))
   .addOption(new Option('-H, --include-hidden', 'Include hidden folders').env('IMMICH_INCLUDE_HIDDEN').default(false))
   .addOption(
     new Option('-a, --album', 'Automatically create albums based on folder name')
@@ -53,9 +54,14 @@ program
       .default(false),
   )
   .addOption(
-    new Option('-A, --album-name <name>', 'Add all assets to specified album')
+    new Option('-A, --album-name <n>', 'Add all assets to specified album')
       .env('IMMICH_ALBUM_NAME')
       .conflicts('album'),
+  )
+  .addOption(
+    new Option('-f, --format-album-names', 'Format album names (remove leading numbers, clean up spaces and dashes)')
+      .env('IMMICH_FORMAT_ALBUM_NAMES')
+      .default(false),
   )
   .addOption(
     new Option('-n, --dry-run', "Don't perform any actions, just show what will be done")
@@ -66,7 +72,7 @@ program
   .addOption(
     new Option('-c, --concurrency <number>', 'Number of assets to upload at the same time')
       .env('IMMICH_UPLOAD_CONCURRENCY')
-      .default(4),
+      .default(defaultConcurrency),
   )
   .addOption(
     new Option('-j, --json-output', 'Output detailed information in json format')

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -256,7 +256,7 @@ export class FileHashCache {
   async load() {
     if (existsSync(this.cacheFile)) {
       try {
-        const content = await readFile(this.cacheFile, 'utf-8');
+        const content = await readFile(this.cacheFile, 'utf8');
         this.cache = JSON.parse(content);
       } catch (error) {
         console.warn('Failed to load hash cache:', error);
@@ -272,7 +272,7 @@ export class FileHashCache {
         await writeFile(this.cacheFile, JSON.stringify(this.cache));
         this.isDirty = false;
       } catch (error) {
-        console.warn('Failed to save hash cache');
+        console.warn('Failed to save hash cache', error);
       }
     }
   }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -297,8 +297,8 @@ export class FileHashCache {
         const migrate = migrations[i];
         db.exec('BEGIN');
         migrate(db);
-        db.exec('COMMIT');
         insertVersion.run(i + 1);
+        db.exec('COMMIT');
       }
     }
     return db;

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       output: {
         dir: 'dist',
       },
+      external: ['better-sqlite3'],
     },
     ssr: true,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
-      '@types/micromatch':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@types/mock-fs':
         specifier: ^4.13.1
         version: 4.13.4
@@ -4401,9 +4398,6 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
-  '@types/braces@3.0.5':
-    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
-
   '@types/byte-size@8.1.2':
     resolution: {integrity: sha512-jGyVzYu6avI8yuqQCNTZd65tzI8HZrLjKX9sdMqZrGWVlNChu0rf6p368oVEDCYJe5BMx2Ov04tD1wqtgTwGSA==}
 
@@ -4582,9 +4576,6 @@ packages:
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
-
-  '@types/micromatch@4.0.9':
-    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -16123,8 +16114,6 @@ snapshots:
     dependencies:
       '@types/node': 22.18.10
 
-  '@types/braces@3.0.5': {}
-
   '@types/byte-size@8.1.2': {}
 
   '@types/chai@5.2.2':
@@ -16340,10 +16329,6 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/methods@1.1.4': {}
-
-  '@types/micromatch@4.0.9':
-    dependencies:
-      '@types/braces': 3.0.5
 
   '@types/mime@1.3.5': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 9.37.0
       '@immich/sdk':
         specifier: file:../open-api/typescript-sdk
-        version: file:open-api/typescript-sdk
+        version: link:../open-api/typescript-sdk
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -73,7 +73,7 @@ importers:
         version: 4.0.2
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       byte-size:
         specifier: ^9.0.0
         version: 9.0.1
@@ -121,10 +121,10 @@ importers:
         version: 5.1.4(typescript@5.9.3)(vite@7.1.9(@types/node@22.18.10)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
       vitest-fetch-mock:
         specifier: ^0.4.0
-        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
+        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       yaml:
         specifier: ^2.3.1
         version: 2.8.1
@@ -2731,9 +2731,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@immich/sdk@file:open-api/typescript-sdk':
-    resolution: {directory: open-api/typescript-sdk, type: directory}
 
   '@immich/ui@0.34.2':
     resolution: {integrity: sha512-tWjEV1prSZ9VLes69Ha9jnnZj6tbv/9+PdQjsK+5zK7sQok/l7kyzAobj5z4XRD11XtGk/cAqi/ZOlqRWvZilA==}
@@ -14221,10 +14218,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@immich/sdk@file:open-api/typescript-sdk':
-    dependencies:
-      '@oazapfts/runtime': 1.0.4
-
   '@immich/ui@0.34.2(@internationalized/date@3.8.2)(svelte@5.39.11)':
     dependencies:
       '@mdi/js': 7.4.47
@@ -16609,25 +16602,6 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.3
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.19
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:
@@ -24188,9 +24162,9 @@ snapshots:
     optionalDependencies:
       vite: 7.1.9(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
 
-  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)):
+  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)):
     dependencies:
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
 
   cli:
     dependencies:
+      better-sqlite3:
+        specifier: ^12.4.1
+        version: 12.4.1
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -37,16 +40,19 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      micromatch:
-        specifier: ^4.0.8
-        version: 4.0.8
+      picomatch:
+        specifier: ^4.0.3
+        version: 4.0.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.37.0
       '@immich/sdk':
         specifier: file:../open-api/typescript-sdk
-        version: link:../open-api/typescript-sdk
+        version: file:open-api/typescript-sdk
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/byte-size':
         specifier: ^8.1.0
         version: 8.1.2
@@ -65,9 +71,12 @@ importers:
       '@types/node':
         specifier: ^22.18.8
         version: 22.18.10
+      '@types/picomatch':
+        specifier: ^4.0.0
+        version: 4.0.2
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       byte-size:
         specifier: ^9.0.0
         version: 9.0.1
@@ -115,10 +124,10 @@ importers:
         version: 5.1.4(typescript@5.9.3)(vite@7.1.9(@types/node@22.18.10)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
       vitest-fetch-mock:
         specifier: ^0.4.0
-        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
+        version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       yaml:
         specifier: ^2.3.1
         version: 2.8.1
@@ -2726,6 +2735,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@immich/sdk@file:open-api/typescript-sdk':
+    resolution: {directory: open-api/typescript-sdk, type: directory}
+
   '@immich/ui@0.34.2':
     resolution: {integrity: sha512-tWjEV1prSZ9VLes69Ha9jnnZj6tbv/9+PdQjsK+5zK7sQok/l7kyzAobj5z4XRD11XtGk/cAqi/ZOlqRWvZilA==}
     peerDependencies:
@@ -4380,6 +4392,9 @@ packages:
   '@types/bcrypt@6.0.0':
     resolution: {integrity: sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -5227,12 +5242,19 @@ packages:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
     engines: {node: '>= 18'}
 
+  better-sqlite3@12.4.1:
+    resolution: {integrity: sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bits-ui@2.9.8:
     resolution: {integrity: sha512-oVAqdhLSuGIgEiT0yu3ShSI7AxncCxX26Gv6Lul94BuKHV2uzHoKfIodtnMQSq+udJ54svuCIRqA58whsv7vaA==}
@@ -6558,6 +6580,10 @@ packages:
   exiftool-vendored@28.8.0:
     resolution: {integrity: sha512-R7tirJLr9fWuH9JS/KFFLB+O7jNGKuPXGxREc6YybYangEudGb+X8ERsYXk9AifMiAWh/2agNfbgkbcQcF+MxA==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
@@ -6672,6 +6698,9 @@ packages:
   file-type@21.0.0:
     resolution: {integrity: sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==}
     engines: {node: '>=20'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -6869,6 +6898,9 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -8397,6 +8429,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -8455,6 +8490,10 @@ packages:
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+
+  node-abi@3.78.0:
+    resolution: {integrity: sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==}
+    engines: {node: '>=10'}
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -9389,6 +9428,11 @@ packages:
   potpack@2.1.0:
     resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -10083,6 +10127,9 @@ packages:
   simple-get@3.1.1:
     resolution: {integrity: sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==}
 
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-icons@15.16.1:
     resolution: {integrity: sha512-UpT6dslPDUfl+9xAjxHAh4ralefkrAqBe8o4cN+HtBOa2HjYZnEAiQsUkAdkaMfW05rU/rc/MWaKxF/cpUllCg==}
     engines: {node: '>=0.12.18'}
@@ -10733,6 +10780,9 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -14180,6 +14230,10 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
+  '@immich/sdk@file:open-api/typescript-sdk':
+    dependencies:
+      '@oazapfts/runtime': 1.0.4
+
   '@immich/ui@0.34.2(@internationalized/date@3.8.2)(svelte@5.39.11)':
     dependencies:
       '@mdi/js': 7.4.47
@@ -16056,6 +16110,10 @@ snapshots:
     dependencies:
       '@types/node': 22.18.10
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.18.10
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -16566,6 +16624,25 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.19
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))':
     dependencies:
@@ -17084,9 +17161,18 @@ snapshots:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
 
+  better-sqlite3@12.4.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   bits-ui@2.9.8(@internationalized/date@3.8.2)(svelte@5.39.11):
     dependencies:
@@ -18624,6 +18710,8 @@ snapshots:
     optionalDependencies:
       exiftool-vendored.exe: 13.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.2.1: {}
 
   exponential-backoff@3.1.2: {}
@@ -18799,6 +18887,8 @@ snapshots:
       uint8array-extras: 1.4.1
     transitivePeerDependencies:
       - supports-color
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -19011,6 +19101,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
+
+  github-from-package@0.0.0: {}
 
   github-slugger@1.5.0: {}
 
@@ -20995,6 +21087,8 @@ snapshots:
 
   nanoid@5.1.5: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   nearley@2.20.1:
@@ -21056,6 +21150,10 @@ snapshots:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.8.1
+
+  node-abi@3.78.0:
+    dependencies:
+      semver: 7.7.3
 
   node-abort-controller@3.1.1: {}
 
@@ -22021,6 +22119,21 @@ snapshots:
 
   potpack@2.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.78.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -22922,8 +23035,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@3.1.1:
     dependencies:
@@ -22931,6 +23043,12 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
     optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-icons@15.16.1: {}
 
@@ -23686,6 +23804,10 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
@@ -24081,9 +24203,9 @@ snapshots:
     optionalDependencies:
       vite: 7.1.9(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
 
-  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)):
+  vitest-fetch-mock@0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)):
     dependencies:
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.18.10)(happy-dom@20.0.2)(jiti@2.6.1)(jsdom@26.1.0(canvas@2.11.2(encoding@0.1.13)))(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
   - server
   - web
   - .github
+
+dedupePeerDependents: false
+
 ignoredBuiltDependencies:
   - '@nestjs/core'
   - '@scarf/scarf'
@@ -22,37 +25,44 @@ ignoredBuiltDependencies:
   - protobufjs
   - ssh2
   - utimes
+
+injectWorkspacePackages: true
+
 onlyBuiltDependencies:
-  - sharp
   - '@tailwindcss/oxide'
+  - better-sqlite3
+  - sharp
+
 overrides:
   canvas: 2.11.2
   sharp: ^0.34.4
+
 packageExtensions:
-  nestjs-kysely:
+  '@immich/ui':
     dependencies:
-      tslib: '*'
-  nestjs-otel:
-    dependencies:
-      tslib: '*'
+      tailwindcss: '>=4.1'
   '@photo-sphere-viewer/equirectangular-video-adapter':
     dependencies:
       three: '*'
   '@photo-sphere-viewer/video-plugin':
     dependencies:
       three: '*'
+  nestjs-kysely:
+    dependencies:
+      tslib: '*'
+  nestjs-otel:
+    dependencies:
+      tslib: '*'
   sharp:
     dependencies:
       node-addon-api: '*'
       node-gyp: '*'
-  '@immich/ui':
-    dependencies:
-      tailwindcss: '>=4.1'
   tailwind-variants:
     dependencies:
       tailwindcss: '>=4.1'
-dedupePeerDependents: false
+
 preferWorkspacePackages: true
-injectWorkspacePackages: true
+
 shamefullyHoist: false
+
 verifyDepsBeforeRun: install


### PR DESCRIPTION
## Description
This PR adds hash caching :
  - Avoids rehashing all the files if you want to try different configs or check if everything has been uploaded in your whole library
  - Enables doing large uploads over multiple runs without loosing all progress
  - Stored in `~/.config/immich/hash-cache.json`

## How Has This Been Tested?

Tested on a dummy file structure and on a real >1TB library upload.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
