### PR TITLE
fix: allow insecure connections in iOS WidgetExtension

### DIFF
--- a/mobile/ios/WidgetExtension/Info.plist
+++ b/mobile/ios/WidgetExtension/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Description

This is a change to the WidgetExtension bundle for the iOS application to allow insecure connections. It mirrors the same values allowed on the main iOS application, that is, it allows any insecure connection.

This fixes cases similar to #19829 where an insecure server connection is attempted and the connection is rejected by the system. Currently if the Immich server is accessed via a local IP (such as 192.169.1.100) there is no issue as iOS won't safeguard the connection with App Transport Security (ATS). But if using a hostname, and in my case, accessing via an insecure Tailscale host (ie http://tailscale.ts.net) the widget connection fails. By changing the App Transport Security setting for the WidgetExtension to match the Application setting, this issue is resolved.

There are other options for ATS, though with servers provided via user input, a more strict allowance may be hard to manage. Since the primary app bundle allows arbitrary loads, I don't see an issue with using that same setting for the widget bundle. If there's ever a change to the app bundle, we'd probably want to keep this mirrored as well.

Potentially Fixes #19829 though in the provided image in that issue, it appears the server is secured, though I am not able to verify.

## How Has This Been Tested?

I compiled and ran the code, and reproduced the issue using my insecure hostname which redirects to my local URL. This loads fine in the app, but fails in the iOS widget. Digging in and running via Xcode I added a [catch to where the error was occurring](https://github.com/immich-app/immich/blob/55fe67dd2045637089d402aeab16643da007496f/mobile/ios/WidgetExtension/ImmichAPI.swift#L153) and received the log indicating the failure:

```
Error Domain=NSURLErrorDomain Code=-1022 "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection." UserInfo={NSLocalizedDescription=The resource could not be loaded because the App Transport Security policy requires the use of a secure connection., NSErrorFailingURLStringKey=http://<SERVER_HOSTI>/api/search/random?sessionKey=<SESSION_KEY>, NSErrorFailingURLKey=http://<SERVER_HOSTI>/api/search/random?sessionKey=<SESSION_KEY>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <46B07288-CF8D-46D8-9FA5-5052271CA038>.<1>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <46B07288-CF8D-46D8-9FA5-5052271CA038>.<1>, NSUnderlyingError=0x600000c20d80 {Error Domain=kCFErrorDomainCFNetwork Code=-1022 "(null)"}}
```

With this clear message, I made the requested change that [mirrors the app bundle](https://github.com/immich-app/immich/blob/55fe67dd2045637089d402aeab16643da007496f/mobile/ios/Runner/Info.plist#L123C4-L127C12) settings for this same configuration.

With the change in place, recompiling and running allows the widgets to refresh and show images as expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
