### PR TITLE
fix: ensure buffer loaded before opening asset viewer

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/fixed/segment.model.dart
@@ -159,17 +159,18 @@ class _AssetTileWidget extends ConsumerWidget {
     required this.assetIndex,
   });
 
-  void _handleOnTap(
+  Future _handleOnTap(
     BuildContext ctx,
     WidgetRef ref,
     int assetIndex,
     BaseAsset asset,
-  ) {
+  ) async {
     final multiSelectState = ref.read(multiSelectProvider);
 
     if (multiSelectState.forceEnable || multiSelectState.isEnabled) {
       ref.read(multiSelectProvider.notifier).toggleAssetSelection(asset);
     } else {
+      await ref.read(timelineServiceProvider).loadAssets(assetIndex, 1);
       ctx.pushRoute(
         AssetViewerRoute(
           initialIndex: assetIndex,


### PR DESCRIPTION
## Description

- This change makes sure that the current asset that is requested to be opened in the asset viewer is loaded in the timeline service's buffer before navigating to the viewer route
