### PR TITLE
feat(web): when creating an album share link, enable password by default

### DIFF
--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -31,6 +31,7 @@
   let shouldChangeExpirationTime = $state(false);
   let enablePassword = $state(false);
 
+  const valid = $derived(!enablePassword || (enablePassword && password.length > 0));
   const expirationOptions: [number, Intl.RelativeTimeFormatUnit][] = [
     [30, 'minutes'],
     [1, 'hour'],
@@ -56,6 +57,13 @@
   $effect(() => {
     if (!showMetadata) {
       allowDownload = false;
+    }
+  });
+
+  enablePassword = true;
+  $effect(() => {
+    if (!enablePassword) {
+      password = '';
     }
   });
 
@@ -184,6 +192,7 @@
             label={$t('password')}
             bind:value={password}
             disabled={!enablePassword}
+            required={enablePassword}
           />
         </div>
 
@@ -227,9 +236,9 @@
 
   <ModalFooter>
     {#if editingLink}
-      <Button fullWidth onclick={handleEditLink}>{$t('confirm')}</Button>
+      <Button fullWidth onclick={handleEditLink} disabled={!valid}>{$t('confirm')}</Button>
     {:else}
-      <Button fullWidth onclick={handleCreateSharedLink}>{$t('create_link')}</Button>
+      <Button fullWidth onclick={handleCreateSharedLink} disabled={!valid}>{$t('create_link')}</Button>
     {/if}
   </ModalFooter>
 </Modal>


### PR DESCRIPTION
## Description

This change slightly changes the behaviour of the password field in the share link creation modal:
- It enables the password toggle by default
- It makes the field required (the button will be disabled if not valid)
- When the toggle is switched, the field is emptied

**Motivation**

I feel this change could improve user security by nudging them towards creating passwords for the shared albums. I have seen in some real world examples that when album links are shared, they leak. They could leak through a whole host of systems or reasons but when they do, they get scraped by all sorts of bots, good and bad bots. This seemed to me like a simple solution to nudge users to more safety. 

## How Has This Been Tested?
This has been tested locally.

## API Changes
n/a

## Checklist:

- [X] I have performed a self-review of my own code
- [na] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [na] I have confirmed that any new dependencies are strictly necessary.
- [na] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [na] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [na] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
