### PR TITLE
fix: startup log level

### DIFF
--- a/server/src/services/system-config.service.ts
+++ b/server/src/services/system-config.service.ts
@@ -27,7 +27,7 @@ export class SystemConfigService extends BaseService {
     return mapConfig(defaults);
   }
 
-  @OnEvent({ name: 'config.init' })
+  @OnEvent({ name: 'config.init', priority: -100 })
   onConfigInit({ newConfig: { logging } }: ArgOf<'config.init'>) {
     const { logLevel: envLevel } = this.configRepository.getEnv();
     const configLevel = logging.enabled ? logging.level : false;


### PR DESCRIPTION
Fixes some scenarios where log level isn't respected/applied on startup.

Of all the `config.init` handlers, make sure the one that sets the log level runs first. There still may be some cases where handlers responding to `app.bootstrap` log. I think we'll have to fix this in the future by enabling the logs to be buffered and then written/flushed once the logger is initialized.