### PR TITLE
feat(widgets): iOS widget improvements

### DIFF
--- a/mobile/ios/WidgetExtension/ImageWidgetView.swift
+++ b/mobile/ios/WidgetExtension/ImageWidgetView.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 import WidgetKit
 
+extension Image {
+  @ViewBuilder
+  func tintedWidgetImageModifier() -> some View {
+    if #available(iOS 18.0, *) {
+      self
+        .widgetAccentedRenderingMode(.accentedDesaturated)
+    } else {
+      self
+    }
+  }
+}
+
 struct ImmichWidgetView: View {
   var entry: ImageEntry
 
@@ -8,6 +20,7 @@ struct ImmichWidgetView: View {
     if entry.image == nil {
       VStack {
         Image("LaunchImage")
+          .tintedWidgetImageModifier()
         Text(entry.metadata.error?.errorDescription ?? "")
           .minimumScaleFactor(0.25)
           .multilineTextAlignment(.center)
@@ -19,7 +32,9 @@ struct ImmichWidgetView: View {
         Color.clear.overlay(
           Image(uiImage: entry.image!)
             .resizable()
+            .tintedWidgetImageModifier()
             .scaledToFill()
+
         )
         VStack {
           Spacer()

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -2,14 +2,20 @@ import Foundation
 import SwiftUI
 import WidgetKit
 
+let IMMICH_SHARE_GROUP = "group.app.immich.share"
+
 enum WidgetError: Error, Codable {
   case noLogin
   case fetchFailed
-  case unknown
   case albumNotFound
+  case noAssetsAvailable
+}
+
+enum FetchError: Error {
   case unableToResize
   case invalidImage
   case invalidURL
+  case fetchFailed
 }
 
 extension WidgetError: LocalizedError {
@@ -24,14 +30,8 @@ extension WidgetError: LocalizedError {
     case .albumNotFound:
       return "Album not found"
 
-    case .invalidURL:
-      return "An invalid URL was used"
-
-    case .invalidImage:
-      return "An invalid image was received"
-
-    default:
-      return "An unknown error occured"
+    case .noAssetsAvailable:
+      return "No assets available"
     }
   }
 }
@@ -52,10 +52,11 @@ struct Asset: Codable {
   }
 }
 
-struct SearchFilters: Codable {
-  var type: AssetType = .image
-  let size: Int
+struct SearchFilter: Codable {
+  var type = AssetType.image
+  var size = 1
   var albumIds: [String] = []
+  var isFavorite = false
 }
 
 struct MemoryResult: Codable {
@@ -70,12 +71,35 @@ struct MemoryResult: Codable {
   let data: MemoryData
 }
 
-struct Album: Codable {
+struct Album: Codable, Equatable {
   let id: String
   let albumName: String
-}
 
-let IMMICH_SHARE_GROUP = "group.app.immich.share"
+  static let NONE = Album(id: "NONE", albumName: "None")
+  static let FAVORITES = Album(id: "FAVORITES", albumName: "Favorites")
+
+  var filter: SearchFilter {
+    switch self {
+    case Album.NONE:
+      return SearchFilter()
+    case Album.FAVORITES:
+      return SearchFilter(isFavorite: true)
+
+    // regular album
+    default:
+      return SearchFilter(albumIds: [id])
+    }
+  }
+
+  var isVirtual: Bool {
+    switch self {
+    case Album.NONE, Album.FAVORITES:
+      return true
+    default:
+      return false
+    }
+  }
+}
 
 // MARK: API
 
@@ -132,7 +156,8 @@ class ImmichAPI {
     return components?.url
   }
 
-  func fetchSearchResults(with filters: SearchFilters) async throws
+  func fetchSearchResults(with filters: SearchFilter = Album.NONE.filter)
+    async throws
     -> [Asset]
   {
     // get URL
@@ -178,7 +203,7 @@ class ImmichAPI {
     return try JSONDecoder().decode([MemoryResult].self, from: data)
   }
 
-  func fetchImage(asset: Asset) async throws(WidgetError) -> UIImage {
+  func fetchImage(asset: Asset) async throws(FetchError) -> UIImage {
     let thumbnailParams = [URLQueryItem(name: "size", value: "preview")]
     let assetEndpoint = "/assets/" + asset.id + "/thumbnail"
 
@@ -199,7 +224,7 @@ class ImmichAPI {
 
     let decodeOptions: [NSString: Any] = [
       kCGImageSourceCreateThumbnailFromImageAlways: true,
-      kCGImageSourceThumbnailMaxPixelSize: 400,
+      kCGImageSourceThumbnailMaxPixelSize: 512,
       kCGImageSourceCreateThumbnailWithTransform: true,
     ]
 

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -56,7 +56,7 @@ struct SearchFilter: Codable {
   var type = AssetType.image
   var size = 1
   var albumIds: [String] = []
-  var isFavorite = false
+  var isFavorite: Bool? = nil
 }
 
 struct MemoryResult: Codable {

--- a/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
@@ -8,20 +8,21 @@ extension Album: @unchecked Sendable, AppEntity, Identifiable {
 
   struct AlbumQuery: EntityQuery {
     func entities(for identifiers: [Album.ID]) async throws -> [Album] {
-      // use cached albums to search
-      var albums = (try? await AlbumCache.shared.getAlbums()) ?? []
-      albums.insert(NO_ALBUM, at: 0)
-
-      return albums.filter {
+      return await suggestedEntities().filter {
         identifiers.contains($0.id)
       }
     }
 
-    func suggestedEntities() async throws -> [Album] {
-      var albums = (try? await AlbumCache.shared.getAlbums(refresh: true)) ?? []
-      albums.insert(NO_ALBUM, at: 0)
+    func suggestedEntities() async -> [Album] {
+      let albums = (try? await AlbumCache.shared.getAlbums()) ?? []
 
-      return albums
+      let options =
+        [
+          NONE,
+          FAVORITES,
+        ] + albums
+
+      return options
     }
   }
 
@@ -34,8 +35,6 @@ extension Album: @unchecked Sendable, AppEntity, Identifiable {
     DisplayRepresentation(title: "\(albumName)")
   }
 }
-
-let NO_ALBUM = Album(id: "NONE", albumName: "None")
 
 struct RandomConfigurationAppIntent: WidgetConfigurationIntent {
   static var title: LocalizedStringResource { "Select Album" }
@@ -64,25 +63,24 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
     -> ImageEntry
   {
     let cacheKey = "random_none_\(context.family.rawValue)"
-    
+
     guard let api = try? await ImmichAPI() else {
-      return ImageEntry.handleCacheFallback(for: cacheKey, error: .noLogin).entries.first!
+      return ImageEntry.handleError(for: cacheKey, error: .noLogin).entries
+        .first!
     }
 
     guard
       let randomImage = try? await api.fetchSearchResults(
-        with: SearchFilters(size: 1)
+        with: Album.NONE.filter
       ).first,
-      var entry = try? await ImageEntry.build(
+      let entry = try? await ImageEntry.build(
         api: api,
         asset: randomImage,
         dateOffset: 0
       )
     else {
-      return ImageEntry.handleCacheFallback(for: cacheKey).entries.first!
+      return ImageEntry.handleError(for: cacheKey).entries.first!
     }
-
-    entry.resize()
 
     return entry
   }
@@ -97,26 +95,24 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
     let now = Date()
 
     // nil if album is NONE or nil
-    let albumId =
-      configuration.album?.id != "NONE" ? configuration.album?.id : nil
-    let albumName: String? =
-      albumId != nil ? configuration.album?.albumName : nil
+    let album = configuration.album ?? Album.NONE
+    let albumName = album.isVirtual ? nil : album.albumName
 
-    let cacheKey = "random_\(albumId ?? "none")_\(context.family.rawValue)"
+    let cacheKey = "random_\(album.id)_\(context.family.rawValue)"
 
     // If we don't have a server config, return an entry with an error
     guard let api = try? await ImmichAPI() else {
-      return ImageEntry.handleCacheFallback(for: cacheKey, error: .noLogin)
+      return ImageEntry.handleError(for: cacheKey, error: .noLogin)
     }
 
-    if albumId != nil {
+    if !album.isVirtual {
       // make sure the album exists on server, otherwise show error
       guard let albums = try? await api.fetchAlbums() else {
-        return ImageEntry.handleCacheFallback(for: cacheKey)
+        return ImageEntry.handleError(for: cacheKey)
       }
 
-      if !albums.contains(where: { $0.id == albumId }) {
-        return ImageEntry.handleCacheFallback(
+      if !albums.contains(where: { $0.id == album.id }) {
+        return ImageEntry.handleError(
           for: cacheKey,
           error: .albumNotFound
         )
@@ -124,25 +120,25 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
     }
 
     // build entries
-    entries.append(
-      contentsOf: (try? await generateRandomEntries(
+    // this must be a do/catch since we need to
+    // distinguish between a network fail and an empty search
+    do {
+      let search = try await generateRandomEntries(
         api: api,
         now: now,
         count: 12,
-        albumId: albumId,
+        filter: album.filter,
         subtitle: configuration.showAlbumName ? albumName : nil
-      ))
-        ?? []
-    )
+      )
 
-    // Load or save a cached asset for when network conditions are bad
-    if entries.count == 0 {
-      return ImageEntry.handleCacheFallback(for: cacheKey)
-    }
+      // Load or save a cached asset for when network conditions are bad
+      if search.count == 0 {
+        return ImageEntry.handleError(for: cacheKey, error: .noAssetsAvailable)
+      }
 
-    // Resize all images to something that can be stored by iOS
-    for i in entries.indices {
-      entries[i].resize()
+      entries.append(contentsOf: search)
+    } catch {
+      return ImageEntry.handleError(for: cacheKey)
     }
 
     // cache the last image

--- a/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
+++ b/mobile/ios/WidgetExtension/widgets/RandomWidget.swift
@@ -105,20 +105,6 @@ struct ImmichRandomProvider: AppIntentTimelineProvider {
       return ImageEntry.handleError(for: cacheKey, error: .noLogin)
     }
 
-    if !album.isVirtual {
-      // make sure the album exists on server, otherwise show error
-      guard let albums = try? await api.fetchAlbums() else {
-        return ImageEntry.handleError(for: cacheKey)
-      }
-
-      if !albums.contains(where: { $0.id == album.id }) {
-        return ImageEntry.handleError(
-          for: cacheKey,
-          error: .albumNotFound
-        )
-      }
-    }
-
     // build entries
     // this must be a do/catch since we need to
     // distinguish between a network fail and an empty search


### PR DESCRIPTION
## Description

New Features:
- Random widget can now select from your favorites

Fixes:
- Better error handling descriptions (error below is for when favorites, library, or album is empty)

<img width="167" height="186" alt="image" src="https://github.com/user-attachments/assets/fe2ed7a6-0527-41b2-8d6a-7f79123f42ae" />

- Image was not showing when using tinted homescreen, now models similar behavior to native iOS photos app
<img width="341" height="369" alt="image" src="https://github.com/user-attachments/assets/9c7b1cf2-667a-4957-8aca-f7d35e9108fc" />

- Some logic refactoring to clean up codebase


## How Has This Been Tested?

iOS Simulator on both memory and random widget and edge cases including no server connection, empty albums, and album deleted

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
