### PR TITLE
feat: allow to change server installation folder

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,5 +1,6 @@
 import { Duration } from 'luxon';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { SemVer } from 'semver';
 import { DatabaseExtension, ExifOrientation, VectorIndex } from 'src/enum';
 
@@ -40,8 +41,13 @@ export const VECTORCHORD_LIST_SLACK_FACTOR = 1.2;
 export const SALT_ROUNDS = 10;
 
 export const IWorker = 'IWorker';
-
-const { version } = JSON.parse(readFileSync('./package.json', 'utf8'));
+// This is where server is install to, should always be absolute.
+export const SERVER_HOME = process.env.SERVER_HOME || '.';
+// This is what APP_MEDIA_LOCATION is resolved against. (Only matters if APP_MEDIA_LOCATION is relative).
+// Defaults to SERVER_HOME.
+export const BASE_FOLDER = process.env.BASE_FOLDER || SERVER_HOME;
+const packageFile = 'TESTING' in globalThis ? resolve('./package.json') : resolve(SERVER_HOME, './package.json');
+const { version } = JSON.parse(readFileSync(packageFile, 'utf8'));
 export const serverVersion = new SemVer(version);
 
 export const AUDIT_LOG_MAX_DURATION = Duration.fromObject({ days: 100 });

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
-import { APP_MEDIA_LOCATION } from 'src/constants';
+import { APP_MEDIA_LOCATION, BASE_FOLDER } from 'src/constants';
 import { StorageAsset } from 'src/database';
 import { AssetFileType, AssetPathType, ImageFormat, PathType, PersonPathType, StorageFolder } from 'src/enum';
 import { AssetRepository } from 'src/repositories/asset.repository';
@@ -83,7 +83,11 @@ export class StorageCore {
   }
 
   static getBaseFolder(folder: StorageFolder) {
-    return join(APP_MEDIA_LOCATION, folder);
+    if ('TESTING' in globalThis) {
+      // this is a special case for testing, since it expects the spys to be called with relative paths
+      return join(APP_MEDIA_LOCATION, folder);
+    }
+    return resolve(BASE_FOLDER, join(APP_MEDIA_LOCATION, folder));
   }
 
   static getPersonThumbnailPath(person: ThumbnailPathEntity) {

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,7 +1,9 @@
 import { CommandFactory } from 'nest-commander';
 import { ChildProcess, fork } from 'node:child_process';
+import { resolve } from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { ImmichAdminModule } from 'src/app.module';
+import { SERVER_HOME } from 'src/constants';
 import { ImmichWorker, LogLevel } from 'src/enum';
 import { ConfigRepository } from 'src/repositories/config.repository';
 
@@ -35,12 +37,12 @@ function bootstrapWorker(name: ImmichWorker) {
 
   let worker: Worker | ChildProcess;
   if (name === ImmichWorker.API) {
-    worker = fork(`./dist/workers/${name}.js`, [], {
+    worker = fork(resolve(SERVER_HOME, `./dist/workers/${name}.js`), [], {
       execArgv: process.execArgv.map((arg) => (arg.startsWith('--inspect') ? '--inspect=0.0.0.0:9231' : arg)),
     });
     apiProcess = worker;
   } else {
-    worker = new Worker(`./dist/workers/${name}.js`);
+    worker = new Worker(resolve(SERVER_HOME, `./dist/workers/${name}.js`));
   }
 
   worker.on('error', (error) => onError(name, error));

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { join, resolve } from 'node:path';
+import { BASE_FOLDER } from 'src/constants';
 import { StorageCore } from 'src/cores/storage.core';
 import { OnEvent, OnJob } from 'src/decorators';
 import { DatabaseLock, JobName, JobStatus, QueueName, StorageFolder, SystemMetadataKey } from 'src/enum';
@@ -87,7 +88,7 @@ export class StorageService extends BaseService {
     try {
       await this.storageRepository.readFile(internalPath);
     } catch (error) {
-      const fullyQualifiedPath = resolve(process.cwd(), internalPath);
+      const fullyQualifiedPath = resolve(BASE_FOLDER, internalPath);
       this.logger.error(`Failed to read ${fullyQualifiedPath} (${internalPath}): ${error}`);
       throw new ImmichStartupError(`Failed to read: "${externalPath} (${fullyQualifiedPath}) - ${docsMessage}"`);
     }

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -3,6 +3,7 @@ import { NextFunction, Response } from 'express';
 import { access, constants } from 'node:fs/promises';
 import { basename, extname, isAbsolute } from 'node:path';
 import { promisify } from 'node:util';
+import { BASE_FOLDER } from 'src/constants';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { ImmichReadStream } from 'src/repositories/storage.repository';
@@ -65,7 +66,7 @@ export const sendFile = async (
     // configure options for serving
     const options: SendFileOptions = { dotfiles: 'allow' };
     if (!isAbsolute(file.path)) {
-      options.root = process.cwd();
+      options.root = BASE_FOLDER;
     }
 
     await access(file.path, constants.R_OK);

--- a/server/start.sh
+++ b/server/start.sh
@@ -5,13 +5,15 @@ echo "Initializing Immich $IMMICH_SOURCE_REF"
 lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
 export LD_PRELOAD="$lib_path"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
+export SERVER_HOME=/usr/src/app
+export BASE_FOLDER=/usr/src/app
 
 read_file_and_export() {
-	if [ -n "${!1}" ]; then
-		content="$(cat "${!1}")"
-		export "$2"="${content}"
-		unset "$1"
-	fi
+  if [ -n "${!1}" ]; then
+    content="$(cat "${!1}")"
+    export "$2"="${content}"
+    unset "$1"
+  fi
 }
 read_file_and_export "DB_URL_FILE" "DB_URL"
 read_file_and_export "DB_HOSTNAME_FILE" "DB_HOSTNAME"
@@ -26,4 +28,4 @@ if [ "$CPU_CORES" -gt 4 ]; then
   export UV_THREADPOOL_SIZE=$CPU_CORES
 fi
 
-exec node /usr/src/app/dist/main "$@"
+exec node "${SERVER_HOME}/dist/main" "$@"

--- a/server/test/vitest-setup.ts
+++ b/server/test/vitest-setup.ts
@@ -1,0 +1,1 @@
+(globalThis as any).TESTING = true;

--- a/server/test/vitest.config.mjs
+++ b/server/test/vitest.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
     root: './',
     globals: true,
     include: ['src/**/*.spec.ts'],
+    setupFiles: ['./test/vitest-setup.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/cores/**', 'src/services/**', 'src/utils/**', 'src/sql-tools/**'],


### PR DESCRIPTION
## Description

Two new environment variables that let us change the install directory of server, without changing the upload directory. This will allow us to change the layout of the server image, without breaking compatibility with the location users are bind-mounting their data files. 


`SERVER_HOME`  which is the install directory of immich, defaults to `/usr/src/app` which is used by all images right now. Previously this was cwd() which was set to `/usr/src/app` in all images. 
`BASE_FOLDER` which what `APP_MEDIA_LOCATION` is resolved against, and only matters if `APP_MEDIA_LOCATION` is relative. `APP_MEDIA_LOCATION` by default is relative, and its set to `./upload`. `BASE_FOLDER` value is default to value of SERVER_HOME. 

The combined effect is that if your using ALL the defaults: 
```
SERVER_HOME=/usr/src/app
BASE_FOLDER=/usr/src/app
APP_MEDIA_LOCATION=/usr/src/app/upload
```
And the immich folders, like thumbnails/upload/encoded-videos, etc are found under /usr/src/app/upload

If someone had previously set APP_MEDIA_LOCATION to an absolute folder, BASE_FOLDER isn't used, and that folder will be used directly, so there is no change. 

If someone had previously set APP_MEDIA_LOCATION to a different relative folder, it would have been resolved against `cwd()`. Since BASE_FOLDER is the same as the earlier `cwd()` - this will work as before. 

 
