### PR TITLE
fix: path in external library docs

### DIFF
--- a/docs/docs/guides/external-library.md
+++ b/docs/docs/guides/external-library.md
@@ -41,7 +41,7 @@ In the Immich web UI:
 - Click Add path
   <img src={require('./img/add-path-button.webp').default} width="50%" title="Add Path button" />
 
-- Enter **/usr/src/app/external** as the path and click Add
+- Enter **/home/user/photos1** as the path and click Add
   <img src={require('./img/add-path-field.webp').default} width="50%" title="Add Path field" />
 
 - Save the new path


### PR DESCRIPTION
Update the path used in the doc.

## Description

The path used in the doc did not match the paths added to the docker-compose which creates confusion.



## How Has This Been Tested?

Used the doc to add an external library to my server.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
