### PR TITLE
fix(web): Uniform random distribution during shuffle

### DIFF
--- a/web/src/lib/managers/timeline-manager/day-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/day-group.svelte.ts
@@ -82,11 +82,6 @@ export class DayGroup {
     return this.viewerAssets[0]?.asset;
   }
 
-  getRandomAsset() {
-    const random = Math.floor(Math.random() * this.viewerAssets.length);
-    return this.viewerAssets[random];
-  }
-
   *assetsIterator(options: { startAsset?: TimelineAsset; direction?: Direction } = {}) {
     const isEarlier = (options?.direction ?? 'earlier') === 'earlier';
     let assetIndex = options?.startAsset

--- a/web/src/lib/managers/timeline-manager/month-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/month-group.svelte.ts
@@ -233,15 +233,6 @@ export class MonthGroup {
     addContext.changedDayGroups.add(dayGroup);
   }
 
-  getRandomDayGroup() {
-    const random = Math.floor(Math.random() * this.dayGroups.length);
-    return this.dayGroups[random];
-  }
-
-  getRandomAsset() {
-    return this.getRandomDayGroup()?.getRandomAsset()?.asset;
-  }
-
   get viewId() {
     const { year, month } = this.yearMonth;
     return year + '-' + month;

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.spec.ts
@@ -580,4 +580,60 @@ describe('TimelineManager', () => {
       expect(timelineManager.getMonthGroupByAssetId(assetOne.id)?.yearMonth.month).toEqual(1);
     });
   });
+
+  describe('getRandomAsset', () => {
+    let timelineManager: TimelineManager;
+    const bucketAssets: Record<string, TimelineAsset[]> = {
+      '2024-03-01T00:00:00.000Z': timelineAssetFactory.buildList(1).map((asset) =>
+        deriveLocalDateTimeFromFileCreatedAt({
+          ...asset,
+          fileCreatedAt: fromISODateTimeUTCToObject('2024-03-01T00:00:00.000Z'),
+        }),
+      ),
+      '2024-02-01T00:00:00.000Z': timelineAssetFactory.buildList(10).map((asset, idx) =>
+        deriveLocalDateTimeFromFileCreatedAt({
+          ...asset,
+          // here we make sure that not all assets are on the first day of the month
+          fileCreatedAt: fromISODateTimeUTCToObject(`2024-02-0${idx < 7 ? 1 : 2}T00:00:00.000Z`),
+        }),
+      ),
+      '2024-01-01T00:00:00.000Z': timelineAssetFactory.buildList(3).map((asset) =>
+        deriveLocalDateTimeFromFileCreatedAt({
+          ...asset,
+          fileCreatedAt: fromISODateTimeUTCToObject('2024-01-01T00:00:00.000Z'),
+        }),
+      ),
+    };
+
+    const bucketAssetsResponse: Record<string, TimeBucketAssetResponseDto> = Object.fromEntries(
+      Object.entries(bucketAssets).map(([key, assets]) => [key, toResponseDto(...assets)]),
+    );
+
+    beforeEach(async () => {
+      timelineManager = new TimelineManager();
+      sdkMock.getTimeBuckets.mockResolvedValue([
+        { count: 1, timeBucket: '2024-03-01' },
+        { count: 10, timeBucket: '2024-02-01' },
+        { count: 3, timeBucket: '2024-01-01' },
+      ]);
+
+      sdkMock.getTimeBucket.mockImplementation(({ timeBucket }) => Promise.resolve(bucketAssetsResponse[timeBucket]));
+      await timelineManager.updateViewport({ width: 1588, height: 0 });
+    });
+
+    it('gets all assets once', async () => {
+      const assetCount = timelineManager.assetCount;
+      expect(assetCount).toBe(14);
+      const discoveredAssets: Set<string> = new Set();
+      for (let idx = 0; idx < assetCount; idx++) {
+        const asset = await timelineManager.getRandomAsset(idx);
+        expect(asset).toBeDefined();
+        const id = asset!.id;
+        expect(discoveredAssets.has(id)).toBeFalsy();
+        discoveredAssets.add(id);
+      }
+
+      expect(discoveredAssets.size).toBe(assetCount);
+    });
+  });
 });


### PR DESCRIPTION
## Description

In the slide show settings, the user can select if a slide show should run in forward, reverse, or shuffle order. This PR modifies the shuffle algorithm to improve the randomness, while not changing anything else.

Previously, the algorithm to determine the next photo was to: uniformly at random select a month from all the months with photos in them, then uniformly at random select a day within this month, then a random photo within that day. This has the issue that the algorithm does not result in a uniform distribution over all photos.

Assume that a user has 10 photos in their library, one in January and the other ones in February. Then the January photo will on average be shown on 50% of the slides in the slide show, even though we would only expect that to be 10%.

This PR achieves a uniform distribution by first select a month, weighted by the number of photos in that month, followed by a weighted selection of the day within that month, and then a uniform distribution over the photos within that day.

This change was discussed yesterday in the "contributing" channel on discord.

Note: I set up a quick benchmark [here](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJzSTFLdzM2S0xGS1VkY0NRZU9zMzEiLCJjb2RlIjoibGV0IHN1bSA9IDA7XG5jb25zdCBwcmVmaXggPSBEQVRBLm1hcCh2ID0-IHtzdW0gKz0gdjsgcmV0dXJuIHN1bSAtIHY7fSk7XG5cbmZ1bmN0aW9uIHNlYXJjaChsb3csIGhpLCB2YWwpIHtcbiAgaWYgKGhpIDw9IGxvdyArIDEpIHtyZXR1cm4gbG93O31cblxuICBjb25zdCBtaWQgPSBNYXRoLmZsb29yKChsb3cgKyBoaSkgLyAyKTtcbiAgaWYgKHByZWZpeFttaWRdIDwgdmFsKSB7XG4gICAgcmV0dXJuIHNlYXJjaChtaWQsIGhpLCB2YWwpO1xuICB9IGVsc2Uge1xuICAgIHJldHVybiBzZWFyY2gobG93LCBtaWQsIHZhbCk7XG4gIH1cbn1cblxucmV0dXJuIHNlYXJjaCgwLCBwcmVmaXgubGVuZ3RoLCBNYXRoLnJhbmRvbSgpICogc3VtKTsiLCJuYW1lIjoiYmluYXJ5IHNlYXJjaCIsImRlcGVuZGVuY2llcyI6W119LHsiaWQiOiJlaGdhdmpUb2tldG1OZE1WeGxoMXYiLCJjb2RlIjoibGV0IHN1bSA9IDA7XG5jb25zdCBwcmVmaXggPSBEQVRBLm1hcCh2ID0-IHtzdW0gKz0gdjsgcmV0dXJuIHN1bTt9KTtcbmNvbnN0IHNlYXJjaFZhbHVlID0gc3VtICogTWF0aC5yYW5kb20oKTtcblxuY29uc3QgaWR4ID0gcHJlZml4LmZpbmQodiA9PiB2ID4gc2VhcmNoVmFsdWUpO1xuaWYgKGlkeCA9PT0gdW5kZWZpbmVkKSB7XG4gIHJldHVybiBwcmVmaXgubGVuZ3RoIC0gMTtcbn1cbnJldHVybiBpZHg7XG4iLCJuYW1lIjoic2NhbiIsImRlcGVuZGVuY2llcyI6W119XSwiY29uZmlnIjp7Im5hbWUiOiJCYXNpYyBleGFtcGxlIiwicGFyYWxsZWwiOnRydWUsImdsb2JhbFRlc3RDb25maWciOnsiZGVwZW5kZW5jaWVzIjpbXX0sImRhdGFDb2RlIjoicmV0dXJuIFsuLi5BcnJheSgxMjApLmtleXMoKV0ubWFwKChuKSA9PiBNYXRoLnJhbmRvbSgpKSJ9fQ) to compare the performance of a linear scan vs. binary search to find the matching element in the prefix sum. The runtime complexity is *O(n)* either way due to the assembly of the prefix sum. We could theoretically cache the prefix sum over the asset counts of the months, but since *n* is so small I'd argue that it's not worth it. Overall I prefer the linear scan version due to the shorter and simpler code.

## How Has This Been Tested?

Testing was done manually. Without this change I always start to notice duplicates after a short while in the slide show. This has not been the case with this change added.

Note that I also added some basic tests for the sampling utility function.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
