### PR TITLE
refactor: event names

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -73,11 +73,11 @@ class BaseModule implements OnModuleInit, OnModuleDestroy {
     );
 
     this.eventRepository.setup({ services });
-    await this.eventRepository.emit('app.bootstrap');
+    await this.eventRepository.emit('AppBootstrap');
   }
 
   async onModuleDestroy() {
-    await this.eventRepository.emit('app.shutdown');
+    await this.eventRepository.emit('AppShutdown');
     await teardownTelemetry();
   }
 }

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -35,59 +35,59 @@ type Item<T extends EmitEvent> = {
 
 type EventMap = {
   // app events
-  'app.bootstrap': [];
-  'app.shutdown': [];
+  AppBootstrap: [];
+  AppShutdown: [];
 
-  'config.init': [{ newConfig: SystemConfig }];
+  ConfigInit: [{ newConfig: SystemConfig }];
   // config events
-  'config.update': [
+  ConfigUpdate: [
     {
       newConfig: SystemConfig;
       oldConfig: SystemConfig;
     },
   ];
-  'config.validate': [{ newConfig: SystemConfig; oldConfig: SystemConfig }];
+  ConfigValidate: [{ newConfig: SystemConfig; oldConfig: SystemConfig }];
 
   // album events
-  'album.update': [{ id: string; recipientId: string }];
-  'album.invite': [{ id: string; userId: string }];
+  AlbumUpdate: [{ id: string; recipientId: string }];
+  AlbumInvite: [{ id: string; userId: string }];
 
   // asset events
-  'asset.tag': [{ assetId: string }];
-  'asset.untag': [{ assetId: string }];
-  'asset.hide': [{ assetId: string; userId: string }];
-  'asset.show': [{ assetId: string; userId: string }];
-  'asset.trash': [{ assetId: string; userId: string }];
-  'asset.delete': [{ assetId: string; userId: string }];
-  'asset.metadataExtracted': [{ assetId: string; userId: string; source?: JobSource }];
+  AssetTag: [{ assetId: string }];
+  AssetUntag: [{ assetId: string }];
+  AssetHide: [{ assetId: string; userId: string }];
+  AssetShow: [{ assetId: string; userId: string }];
+  AssetTrash: [{ assetId: string; userId: string }];
+  AssetDelete: [{ assetId: string; userId: string }];
+  AssetMetadataExtracted: [{ assetId: string; userId: string; source?: JobSource }];
 
   // asset bulk events
-  'assets.trash': [{ assetIds: string[]; userId: string }];
-  'assets.delete': [{ assetIds: string[]; userId: string }];
-  'assets.restore': [{ assetIds: string[]; userId: string }];
+  AssetTrashAll: [{ assetIds: string[]; userId: string }];
+  AssetDeleteAll: [{ assetIds: string[]; userId: string }];
+  AssetRestoreAll: [{ assetIds: string[]; userId: string }];
 
-  'job.start': [QueueName, JobItem];
-  'job.failed': [{ job: JobItem; error: Error | any }];
+  JobStart: [QueueName, JobItem];
+  JobFailed: [{ job: JobItem; error: Error | any }];
 
   // session events
-  'session.delete': [{ sessionId: string }];
+  SessionDelete: [{ sessionId: string }];
 
   // stack events
-  'stack.create': [{ stackId: string; userId: string }];
-  'stack.update': [{ stackId: string; userId: string }];
-  'stack.delete': [{ stackId: string; userId: string }];
+  StackCreate: [{ stackId: string; userId: string }];
+  StackUpdate: [{ stackId: string; userId: string }];
+  StackDelete: [{ stackId: string; userId: string }];
 
   // stack bulk events
-  'stacks.delete': [{ stackIds: string[]; userId: string }];
+  StackDeleteAll: [{ stackIds: string[]; userId: string }];
 
   // user events
-  'user.signup': [{ notify: boolean; id: string; tempPassword?: string }];
+  UserSignup: [{ notify: boolean; id: string; tempPassword?: string }];
 
   // websocket events
-  'websocket.connect': [{ userId: string }];
+  WebsocketConnect: [{ userId: string }];
 };
 
-export const serverEvents = ['config.update'] as const;
+export const serverEvents = ['ConfigUpdate'] as const;
 export type ServerEvents = (typeof serverEvents)[number];
 
 export type EmitEvent = keyof EventMap;
@@ -213,7 +213,7 @@ export class EventRepository implements OnGatewayConnection, OnGatewayDisconnect
       if (auth.session) {
         await client.join(auth.session.id);
       }
-      await this.onEvent({ name: 'websocket.connect', args: [{ userId: auth.user.id }], server: false });
+      await this.onEvent({ name: 'WebsocketConnect', args: [{ userId: auth.user.id }], server: false });
     } catch (error: Error | any) {
       this.logger.error(`Websocket connection error: ${error}`, error?.stack);
       client.emit('error', 'unauthorized');

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -89,7 +89,7 @@ export class JobRepository {
       this.logger.debug(`Starting worker for queue: ${queueName}`);
       this.workers[queueName] = new Worker(
         queueName,
-        (job) => this.eventRepository.emit('job.start', queueName, job as JobItem),
+        (job) => this.eventRepository.emit('JobStart', queueName, job as JobItem),
         { ...bull.config, concurrency: 1 },
       );
     }

--- a/server/src/services/album.service.spec.ts
+++ b/server/src/services/album.service.spec.ts
@@ -166,7 +166,7 @@ describe(AlbumService.name, () => {
       expect(mocks.user.get).toHaveBeenCalledWith('user-id', {});
       expect(mocks.user.getMetadata).toHaveBeenCalledWith(authStub.admin.user.id);
       expect(mocks.access.asset.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['123']), false);
-      expect(mocks.event.emit).toHaveBeenCalledWith('album.invite', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
         id: albumStub.empty.id,
         userId: 'user-id',
       });
@@ -209,7 +209,7 @@ describe(AlbumService.name, () => {
       expect(mocks.user.get).toHaveBeenCalledWith('user-id', {});
       expect(mocks.user.getMetadata).toHaveBeenCalledWith(authStub.admin.user.id);
       expect(mocks.access.asset.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['123']), false);
-      expect(mocks.event.emit).toHaveBeenCalledWith('album.invite', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
         id: albumStub.empty.id,
         userId: 'user-id',
       });
@@ -413,7 +413,7 @@ describe(AlbumService.name, () => {
         usersId: authStub.user2.user.id,
         albumsId: albumStub.sharedWithAdmin.id,
       });
-      expect(mocks.event.emit).toHaveBeenCalledWith('album.invite', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumInvite', {
         id: albumStub.sharedWithAdmin.id,
         userId: userStub.user2.id,
       });
@@ -662,7 +662,7 @@ describe(AlbumService.name, () => {
         albumThumbnailAssetId: 'asset-1',
       });
       expect(mocks.album.addAssetIds).toHaveBeenCalledWith('album-123', ['asset-1', 'asset-2', 'asset-3']);
-      expect(mocks.event.emit).toHaveBeenCalledWith('album.update', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AlbumUpdate', {
         id: 'album-123',
         recipientId: 'admin_id',
       });

--- a/server/src/services/album.service.ts
+++ b/server/src/services/album.service.ts
@@ -122,7 +122,7 @@ export class AlbumService extends BaseService {
     );
 
     for (const { userId } of albumUsers) {
-      await this.eventRepository.emit('album.invite', { id: album.id, userId });
+      await this.eventRepository.emit('AlbumInvite', { id: album.id, userId });
     }
 
     return mapAlbumWithAssets(album);
@@ -179,7 +179,7 @@ export class AlbumService extends BaseService {
       );
 
       for (const recipientId of allUsersExceptUs) {
-        await this.eventRepository.emit('album.update', { id, recipientId });
+        await this.eventRepository.emit('AlbumUpdate', { id, recipientId });
       }
     }
 
@@ -225,7 +225,7 @@ export class AlbumService extends BaseService {
       }
 
       await this.albumUserRepository.create({ usersId: userId, albumsId: id, role });
-      await this.eventRepository.emit('album.invite', { id, userId });
+      await this.eventRepository.emit('AlbumInvite', { id, userId });
     }
 
     return this.findOrFail(id, { withAssets: true }).then(mapAlbumWithoutAssets);

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -180,7 +180,7 @@ export class AssetMediaService extends BaseService {
       const copiedPhoto = await this.createCopy(asset);
       // and immediate trash it
       await this.assetRepository.updateAll([copiedPhoto.id], { deletedAt: new Date(), status: AssetStatus.TRASHED });
-      await this.eventRepository.emit('asset.trash', { assetId: copiedPhoto.id, userId: auth.user.id });
+      await this.eventRepository.emit('AssetTrash', { assetId: copiedPhoto.id, userId: auth.user.id });
 
       await this.userRepository.updateUsage(auth.user.id, file.size);
 

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -255,7 +255,7 @@ describe(AssetService.name, () => {
         id: assetStub.livePhotoMotionAsset.id,
         visibility: AssetVisibility.TIMELINE,
       });
-      expect(mocks.event.emit).not.toHaveBeenCalledWith('asset.show', {
+      expect(mocks.event.emit).not.toHaveBeenCalledWith('AssetShow', {
         assetId: assetStub.livePhotoMotionAsset.id,
         userId: userStub.admin.id,
       });
@@ -279,7 +279,7 @@ describe(AssetService.name, () => {
         id: assetStub.livePhotoMotionAsset.id,
         visibility: AssetVisibility.TIMELINE,
       });
-      expect(mocks.event.emit).not.toHaveBeenCalledWith('asset.show', {
+      expect(mocks.event.emit).not.toHaveBeenCalledWith('AssetShow', {
         assetId: assetStub.livePhotoMotionAsset.id,
         userId: userStub.admin.id,
       });
@@ -303,7 +303,7 @@ describe(AssetService.name, () => {
         id: assetStub.livePhotoMotionAsset.id,
         visibility: AssetVisibility.TIMELINE,
       });
-      expect(mocks.event.emit).not.toHaveBeenCalledWith('asset.show', {
+      expect(mocks.event.emit).not.toHaveBeenCalledWith('AssetShow', {
         assetId: assetStub.livePhotoMotionAsset.id,
         userId: userStub.admin.id,
       });
@@ -327,7 +327,7 @@ describe(AssetService.name, () => {
         id: assetStub.livePhotoMotionAsset.id,
         visibility: AssetVisibility.HIDDEN,
       });
-      expect(mocks.event.emit).toHaveBeenCalledWith('asset.hide', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetHide', {
         assetId: assetStub.livePhotoMotionAsset.id,
         userId: userStub.admin.id,
       });
@@ -360,7 +360,7 @@ describe(AssetService.name, () => {
         id: assetStub.livePhotoMotionAsset.id,
         visibility: assetStub.livePhotoStillAsset.visibility,
       });
-      expect(mocks.event.emit).toHaveBeenCalledWith('asset.show', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetShow', {
         assetId: assetStub.livePhotoMotionAsset.id,
         userId: userStub.admin.id,
       });
@@ -484,7 +484,7 @@ describe(AssetService.name, () => {
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: true });
 
-      expect(mocks.event.emit).toHaveBeenCalledWith('assets.delete', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetDeleteAll', {
         assetIds: ['asset1', 'asset2'],
         userId: 'user-id',
       });

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -208,7 +208,7 @@ export class AssetService extends BaseService {
       await this.userRepository.updateUsage(asset.ownerId, -(asset.exifInfo?.fileSizeInByte || 0));
     }
 
-    await this.eventRepository.emit('asset.delete', { assetId: id, userId: asset.ownerId });
+    await this.eventRepository.emit('AssetDelete', { assetId: id, userId: asset.ownerId });
 
     // delete the motion if it is not used by another asset
     if (asset.livePhotoVideoId) {
@@ -241,7 +241,10 @@ export class AssetService extends BaseService {
       deletedAt: new Date(),
       status: force ? AssetStatus.DELETED : AssetStatus.TRASHED,
     });
-    await this.eventRepository.emit(force ? 'assets.delete' : 'assets.trash', { assetIds: ids, userId: auth.user.id });
+    await this.eventRepository.emit(force ? 'AssetDeleteAll' : 'AssetTrashAll', {
+      assetIds: ids,
+      userId: auth.user.id,
+    });
   }
 
   async run(auth: AuthDto, dto: AssetJobsDto) {

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -179,7 +179,7 @@ describe(AuthService.name, () => {
       });
 
       expect(mocks.session.delete).toHaveBeenCalledWith('token123');
-      expect(mocks.event.emit).toHaveBeenCalledWith('session.delete', { sessionId: 'token123' });
+      expect(mocks.event.emit).toHaveBeenCalledWith('SessionDelete', { sessionId: 'token123' });
     });
 
     it('should return the default redirect if auth type is OAUTH but oauth is not enabled', async () => {

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -80,7 +80,7 @@ export class AuthService extends BaseService {
   async logout(auth: AuthDto, authType: AuthType): Promise<LogoutResponseDto> {
     if (auth.session) {
       await this.sessionRepository.delete(auth.session.id);
-      await this.eventRepository.emit('session.delete', { sessionId: auth.session.id });
+      await this.eventRepository.emit('SessionDelete', { sessionId: auth.session.id });
     }
 
     return {

--- a/server/src/services/backup.service.ts
+++ b/server/src/services/backup.service.ts
@@ -14,12 +14,12 @@ import { handlePromiseError } from 'src/utils/misc';
 export class BackupService extends BaseService {
   private backupLock = false;
 
-  @OnEvent({ name: 'config.init', workers: [ImmichWorker.MICROSERVICES] })
+  @OnEvent({ name: 'ConfigInit', workers: [ImmichWorker.MICROSERVICES] })
   async onConfigInit({
     newConfig: {
       backup: { database },
     },
-  }: ArgOf<'config.init'>) {
+  }: ArgOf<'ConfigInit'>) {
     this.backupLock = await this.databaseRepository.tryLock(DatabaseLock.BackupDatabase);
 
     if (this.backupLock) {
@@ -32,8 +32,8 @@ export class BackupService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'config.update', server: true })
-  onConfigUpdate({ newConfig: { backup } }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', server: true })
+  onConfigUpdate({ newConfig: { backup } }: ArgOf<'ConfigUpdate'>) {
     if (!this.backupLock) {
       return;
     }

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -57,7 +57,7 @@ const messages = {
 
 @Injectable()
 export class DatabaseService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap', priority: BootstrapEventPriority.DatabaseService })
+  @OnEvent({ name: 'AppBootstrap', priority: BootstrapEventPriority.DatabaseService })
   async onBootstrap() {
     const version = await this.databaseRepository.getPostgresVersion();
     const current = semver.coerce(version);

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -67,8 +67,8 @@ export class JobService extends BaseService {
   private services: ClassConstructor<unknown>[] = [];
   private nightlyJobsLock = false;
 
-  @OnEvent({ name: 'config.init' })
-  async onConfigInit({ newConfig: config }: ArgOf<'config.init'>) {
+  @OnEvent({ name: 'ConfigInit' })
+  async onConfigInit({ newConfig: config }: ArgOf<'ConfigInit'>) {
     if (this.worker === ImmichWorker.MICROSERVICES) {
       this.updateQueueConcurrency(config);
       return;
@@ -87,8 +87,8 @@ export class JobService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'config.update', server: true })
-  onConfigUpdate({ newConfig: config }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', server: true })
+  onConfigUpdate({ newConfig: config }: ArgOf<'ConfigUpdate'>) {
     if (this.worker === ImmichWorker.MICROSERVICES) {
       this.updateQueueConcurrency(config);
       return;
@@ -101,7 +101,7 @@ export class JobService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'app.bootstrap', priority: BootstrapEventPriority.JobService })
+  @OnEvent({ name: 'AppBootstrap', priority: BootstrapEventPriority.JobService })
   onBootstrap() {
     this.jobRepository.setup(this.services);
     if (this.worker === ImmichWorker.MICROSERVICES) {
@@ -243,8 +243,8 @@ export class JobService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'job.start' })
-  async onJobStart(...[queueName, job]: ArgsOf<'job.start'>) {
+  @OnEvent({ name: 'JobStart' })
+  async onJobStart(...[queueName, job]: ArgsOf<'JobStart'>) {
     const queueMetric = `immich.queues.${snakeCase(queueName)}.active`;
     this.telemetryRepository.jobs.addToGauge(queueMetric, 1);
     try {
@@ -255,7 +255,7 @@ export class JobService extends BaseService {
         await this.onDone(job);
       }
     } catch (error: Error | any) {
-      await this.eventRepository.emit('job.failed', { job, error });
+      await this.eventRepository.emit('JobFailed', { job, error });
     } finally {
       this.telemetryRepository.jobs.addToGauge(queueMetric, -1);
     }

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -32,12 +32,12 @@ export class LibraryService extends BaseService {
   private lock = false;
   private watchers: Record<string, () => Promise<void>> = {};
 
-  @OnEvent({ name: 'config.init', workers: [ImmichWorker.MICROSERVICES] })
+  @OnEvent({ name: 'ConfigInit', workers: [ImmichWorker.MICROSERVICES] })
   async onConfigInit({
     newConfig: {
       library: { watch, scan },
     },
-  }: ArgOf<'config.init'>) {
+  }: ArgOf<'ConfigInit'>) {
     // This ensures that library watching only occurs in one microservice
     this.lock = await this.databaseRepository.tryLock(DatabaseLock.Library);
 
@@ -58,8 +58,8 @@ export class LibraryService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'config.update', server: true })
-  async onConfigUpdate({ newConfig: { library } }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', server: true })
+  async onConfigUpdate({ newConfig: { library } }: ArgOf<'ConfigUpdate'>) {
     if (!this.lock) {
       return;
     }
@@ -155,7 +155,7 @@ export class LibraryService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'app.shutdown' })
+  @OnEvent({ name: 'AppShutdown' })
   async onShutdown() {
     await this.unwatchAll();
   }

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -51,7 +51,7 @@ interface UpsertFileOptions {
 export class MediaService extends BaseService {
   videoInterfaces: VideoInterfaces = { dri: [], mali: false };
 
-  @OnEvent({ name: 'app.bootstrap' })
+  @OnEvent({ name: 'AppBootstrap' })
   async onBootstrap() {
     const [dri, mali] = await Promise.all([this.getDevices(), this.hasMaliOpenCL()]);
     this.videoInterfaces = { dri, mali };

--- a/server/src/services/metadata.service.spec.ts
+++ b/server/src/services/metadata.service.spec.ts
@@ -1368,7 +1368,7 @@ describe(MetadataService.name, () => {
 
       await sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id });
 
-      expect(mocks.event.emit).toHaveBeenCalledWith('asset.hide', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetHide', {
         userId: assetStub.livePhotoMotionAsset.ownerId,
         assetId: assetStub.livePhotoMotionAsset.id,
       });
@@ -1384,7 +1384,7 @@ describe(MetadataService.name, () => {
 
       await sut.handleMetadataExtraction({ id: assetStub.livePhotoStillAsset.id });
 
-      expect(mocks.event.emit).toHaveBeenCalledWith('asset.metadataExtracted', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AssetMetadataExtracted', {
         assetId: assetStub.livePhotoStillAsset.id,
         userId: assetStub.livePhotoStillAsset.ownerId,
       });

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -126,24 +126,24 @@ type Dates = {
 
 @Injectable()
 export class MetadataService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap', workers: [ImmichWorker.MICROSERVICES] })
+  @OnEvent({ name: 'AppBootstrap', workers: [ImmichWorker.MICROSERVICES] })
   async onBootstrap() {
     this.logger.log('Bootstrapping metadata service');
     await this.init();
   }
 
-  @OnEvent({ name: 'app.shutdown' })
+  @OnEvent({ name: 'AppShutdown' })
   async onShutdown() {
     await this.metadataRepository.teardown();
   }
 
-  @OnEvent({ name: 'config.init', workers: [ImmichWorker.MICROSERVICES] })
-  onConfigInit({ newConfig }: ArgOf<'config.init'>) {
+  @OnEvent({ name: 'ConfigInit', workers: [ImmichWorker.MICROSERVICES] })
+  onConfigInit({ newConfig }: ArgOf<'ConfigInit'>) {
     this.metadataRepository.setMaxConcurrency(newConfig.job.metadataExtraction.concurrency);
   }
 
-  @OnEvent({ name: 'config.update', workers: [ImmichWorker.MICROSERVICES], server: true })
-  onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.MICROSERVICES], server: true })
+  onConfigUpdate({ newConfig }: ArgOf<'ConfigUpdate'>) {
     this.metadataRepository.setMaxConcurrency(newConfig.job.metadataExtraction.concurrency);
   }
 
@@ -190,7 +190,7 @@ export class MetadataService extends BaseService {
       this.albumRepository.removeAssetsFromAll([motionAsset.id]),
     ]);
 
-    await this.eventRepository.emit('asset.hide', { assetId: motionAsset.id, userId: motionAsset.ownerId });
+    await this.eventRepository.emit('AssetHide', { assetId: motionAsset.id, userId: motionAsset.ownerId });
   }
 
   @OnJob({ name: JobName.QUEUE_METADATA_EXTRACTION, queue: QueueName.METADATA_EXTRACTION })
@@ -313,7 +313,7 @@ export class MetadataService extends BaseService {
 
     await this.assetRepository.upsertJobStatus({ assetId: asset.id, metadataExtractedAt: new Date() });
 
-    await this.eventRepository.emit('asset.metadataExtracted', {
+    await this.eventRepository.emit('AssetMetadataExtracted', {
       assetId: asset.id,
       userId: asset.ownerId,
       source: data.source,
@@ -351,13 +351,13 @@ export class MetadataService extends BaseService {
     return this.processSidecar(id, false);
   }
 
-  @OnEvent({ name: 'asset.tag' })
-  async handleTagAsset({ assetId }: ArgOf<'asset.tag'>) {
+  @OnEvent({ name: 'AssetTag' })
+  async handleTagAsset({ assetId }: ArgOf<'AssetTag'>) {
     await this.jobRepository.queue({ name: JobName.SIDECAR_WRITE, data: { id: assetId, tags: true } });
   }
 
-  @OnEvent({ name: 'asset.untag' })
-  async handleUntagAsset({ assetId }: ArgOf<'asset.untag'>) {
+  @OnEvent({ name: 'AssetUntag' })
+  async handleUntagAsset({ assetId }: ArgOf<'AssetUntag'>) {
     await this.jobRepository.queue({ name: JobName.SIDECAR_WRITE, data: { id: assetId, tags: true } });
   }
 

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -64,7 +64,7 @@ describe(NotificationService.name, () => {
       const update = { oldConfig: defaults, newConfig: defaults };
       expect(sut.onConfigUpdate(update)).toBeUndefined();
       expect(mocks.event.clientBroadcast).toHaveBeenCalledWith('on_config_update');
-      expect(mocks.event.serverSend).toHaveBeenCalledWith('config.update', update);
+      expect(mocks.event.serverSend).toHaveBeenCalledWith('ConfigUpdate', update);
     });
   });
 

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -77,8 +77,8 @@ export class NotificationService extends BaseService {
     await this.notificationRepository.cleanup();
   }
 
-  @OnEvent({ name: 'job.failed' })
-  async onJobFailed({ job, error }: ArgOf<'job.failed'>) {
+  @OnEvent({ name: 'JobFailed' })
+  async onJobFailed({ job, error }: ArgOf<'JobFailed'>) {
     const admin = await this.userRepository.getAdmin();
     if (!admin) {
       return;
@@ -107,14 +107,14 @@ export class NotificationService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'config.update' })
-  onConfigUpdate({ oldConfig, newConfig }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate' })
+  onConfigUpdate({ oldConfig, newConfig }: ArgOf<'ConfigUpdate'>) {
     this.eventRepository.clientBroadcast('on_config_update');
-    this.eventRepository.serverSend('config.update', { oldConfig, newConfig });
+    this.eventRepository.serverSend('ConfigUpdate', { oldConfig, newConfig });
   }
 
-  @OnEvent({ name: 'config.validate', priority: -100 })
-  async onConfigValidate({ oldConfig, newConfig }: ArgOf<'config.validate'>) {
+  @OnEvent({ name: 'ConfigValidate', priority: -100 })
+  async onConfigValidate({ oldConfig, newConfig }: ArgOf<'ConfigValidate'>) {
     try {
       if (
         newConfig.notifications.smtp.enabled &&
@@ -128,33 +128,33 @@ export class NotificationService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'asset.hide' })
-  onAssetHide({ assetId, userId }: ArgOf<'asset.hide'>) {
+  @OnEvent({ name: 'AssetHide' })
+  onAssetHide({ assetId, userId }: ArgOf<'AssetHide'>) {
     this.eventRepository.clientSend('on_asset_hidden', userId, assetId);
   }
 
-  @OnEvent({ name: 'asset.show' })
-  async onAssetShow({ assetId }: ArgOf<'asset.show'>) {
+  @OnEvent({ name: 'AssetShow' })
+  async onAssetShow({ assetId }: ArgOf<'AssetShow'>) {
     await this.jobRepository.queue({ name: JobName.GENERATE_THUMBNAILS, data: { id: assetId, notify: true } });
   }
 
-  @OnEvent({ name: 'asset.trash' })
-  onAssetTrash({ assetId, userId }: ArgOf<'asset.trash'>) {
+  @OnEvent({ name: 'AssetTrash' })
+  onAssetTrash({ assetId, userId }: ArgOf<'AssetTrash'>) {
     this.eventRepository.clientSend('on_asset_trash', userId, [assetId]);
   }
 
-  @OnEvent({ name: 'asset.delete' })
-  onAssetDelete({ assetId, userId }: ArgOf<'asset.delete'>) {
+  @OnEvent({ name: 'AssetDelete' })
+  onAssetDelete({ assetId, userId }: ArgOf<'AssetDelete'>) {
     this.eventRepository.clientSend('on_asset_delete', userId, assetId);
   }
 
-  @OnEvent({ name: 'assets.trash' })
-  onAssetsTrash({ assetIds, userId }: ArgOf<'assets.trash'>) {
+  @OnEvent({ name: 'AssetTrashAll' })
+  onAssetsTrash({ assetIds, userId }: ArgOf<'AssetTrashAll'>) {
     this.eventRepository.clientSend('on_asset_trash', userId, assetIds);
   }
 
-  @OnEvent({ name: 'asset.metadataExtracted' })
-  async onAssetMetadataExtracted({ assetId, userId, source }: ArgOf<'asset.metadataExtracted'>) {
+  @OnEvent({ name: 'AssetMetadataExtracted' })
+  async onAssetMetadataExtracted({ assetId, userId, source }: ArgOf<'AssetMetadataExtracted'>) {
     if (source !== 'sidecar-write') {
       return;
     }
@@ -165,40 +165,40 @@ export class NotificationService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'assets.restore' })
-  onAssetsRestore({ assetIds, userId }: ArgOf<'assets.restore'>) {
+  @OnEvent({ name: 'AssetRestoreAll' })
+  onAssetsRestore({ assetIds, userId }: ArgOf<'AssetRestoreAll'>) {
     this.eventRepository.clientSend('on_asset_restore', userId, assetIds);
   }
 
-  @OnEvent({ name: 'stack.create' })
-  onStackCreate({ userId }: ArgOf<'stack.create'>) {
+  @OnEvent({ name: 'StackCreate' })
+  onStackCreate({ userId }: ArgOf<'StackCreate'>) {
     this.eventRepository.clientSend('on_asset_stack_update', userId);
   }
 
-  @OnEvent({ name: 'stack.update' })
-  onStackUpdate({ userId }: ArgOf<'stack.update'>) {
+  @OnEvent({ name: 'StackUpdate' })
+  onStackUpdate({ userId }: ArgOf<'StackUpdate'>) {
     this.eventRepository.clientSend('on_asset_stack_update', userId);
   }
 
-  @OnEvent({ name: 'stack.delete' })
-  onStackDelete({ userId }: ArgOf<'stack.delete'>) {
+  @OnEvent({ name: 'StackDelete' })
+  onStackDelete({ userId }: ArgOf<'StackDelete'>) {
     this.eventRepository.clientSend('on_asset_stack_update', userId);
   }
 
-  @OnEvent({ name: 'stacks.delete' })
-  onStacksDelete({ userId }: ArgOf<'stacks.delete'>) {
+  @OnEvent({ name: 'StackDeleteAll' })
+  onStacksDelete({ userId }: ArgOf<'StackDeleteAll'>) {
     this.eventRepository.clientSend('on_asset_stack_update', userId);
   }
 
-  @OnEvent({ name: 'user.signup' })
-  async onUserSignup({ notify, id, tempPassword }: ArgOf<'user.signup'>) {
+  @OnEvent({ name: 'UserSignup' })
+  async onUserSignup({ notify, id, tempPassword }: ArgOf<'UserSignup'>) {
     if (notify) {
       await this.jobRepository.queue({ name: JobName.NOTIFY_SIGNUP, data: { id, tempPassword } });
     }
   }
 
-  @OnEvent({ name: 'album.update' })
-  async onAlbumUpdate({ id, recipientId }: ArgOf<'album.update'>) {
+  @OnEvent({ name: 'AlbumUpdate' })
+  async onAlbumUpdate({ id, recipientId }: ArgOf<'AlbumUpdate'>) {
     await this.jobRepository.removeJob(JobName.NOTIFY_ALBUM_UPDATE, `${id}/${recipientId}`);
     await this.jobRepository.queue({
       name: JobName.NOTIFY_ALBUM_UPDATE,
@@ -206,13 +206,13 @@ export class NotificationService extends BaseService {
     });
   }
 
-  @OnEvent({ name: 'album.invite' })
-  async onAlbumInvite({ id, userId }: ArgOf<'album.invite'>) {
+  @OnEvent({ name: 'AlbumInvite' })
+  async onAlbumInvite({ id, userId }: ArgOf<'AlbumInvite'>) {
     await this.jobRepository.queue({ name: JobName.NOTIFY_ALBUM_INVITE, data: { id, recipientId: userId } });
   }
 
-  @OnEvent({ name: 'session.delete' })
-  onSessionDelete({ sessionId }: ArgOf<'session.delete'>) {
+  @OnEvent({ name: 'SessionDelete' })
+  onSessionDelete({ sessionId }: ArgOf<'SessionDelete'>) {
     // after the response is sent
     setTimeout(() => this.eventRepository.clientSend('on_session_delete', sessionId, sessionId), 500);
   }

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -23,7 +23,7 @@ import { isDuplicateDetectionEnabled, isFacialRecognitionEnabled, isSmartSearchE
 
 @Injectable()
 export class ServerService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap' })
+  @OnEvent({ name: 'AppBootstrap' })
   async onBootstrap(): Promise<void> {
     const featureFlags = await this.getFeatures();
     if (featureFlags.configFile) {

--- a/server/src/services/smart-info.service.ts
+++ b/server/src/services/smart-info.service.ts
@@ -10,18 +10,18 @@ import { getCLIPModelInfo, isSmartSearchEnabled } from 'src/utils/misc';
 
 @Injectable()
 export class SmartInfoService extends BaseService {
-  @OnEvent({ name: 'config.init', workers: [ImmichWorker.MICROSERVICES] })
-  async onConfigInit({ newConfig }: ArgOf<'config.init'>) {
+  @OnEvent({ name: 'ConfigInit', workers: [ImmichWorker.MICROSERVICES] })
+  async onConfigInit({ newConfig }: ArgOf<'ConfigInit'>) {
     await this.init(newConfig);
   }
 
-  @OnEvent({ name: 'config.update', workers: [ImmichWorker.MICROSERVICES], server: true })
-  async onConfigUpdate({ oldConfig, newConfig }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', workers: [ImmichWorker.MICROSERVICES], server: true })
+  async onConfigUpdate({ oldConfig, newConfig }: ArgOf<'ConfigUpdate'>) {
     await this.init(newConfig, oldConfig);
   }
 
-  @OnEvent({ name: 'config.validate' })
-  onConfigValidate({ newConfig }: ArgOf<'config.validate'>) {
+  @OnEvent({ name: 'ConfigValidate' })
+  onConfigValidate({ newConfig }: ArgOf<'ConfigValidate'>) {
     try {
       getCLIPModelInfo(newConfig.machineLearning.clip.modelName);
     } catch {

--- a/server/src/services/stack.service.spec.ts
+++ b/server/src/services/stack.service.spec.ts
@@ -52,7 +52,7 @@ describe(StackService.name, () => {
         ],
       });
 
-      expect(mocks.event.emit).toHaveBeenCalledWith('stack.create', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('StackCreate', {
         stackId: 'stack-id',
         userId: authStub.admin.user.id,
       });
@@ -138,7 +138,7 @@ describe(StackService.name, () => {
         id: 'stack-id',
         primaryAssetId: assetStub.image1.id,
       });
-      expect(mocks.event.emit).toHaveBeenCalledWith('stack.update', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('StackUpdate', {
         stackId: 'stack-id',
         userId: authStub.admin.user.id,
       });
@@ -160,7 +160,7 @@ describe(StackService.name, () => {
       await sut.delete(authStub.admin, 'stack-id');
 
       expect(mocks.stack.delete).toHaveBeenCalledWith('stack-id');
-      expect(mocks.event.emit).toHaveBeenCalledWith('stack.delete', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('StackDelete', {
         stackId: 'stack-id',
         userId: authStub.admin.user.id,
       });
@@ -182,7 +182,7 @@ describe(StackService.name, () => {
       await sut.deleteAll(authStub.admin, { ids: ['stack-id'] });
 
       expect(mocks.stack.deleteAll).toHaveBeenCalledWith(['stack-id']);
-      expect(mocks.event.emit).toHaveBeenCalledWith('stacks.delete', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('StackDeleteAll', {
         stackIds: ['stack-id'],
         userId: authStub.admin.user.id,
       });

--- a/server/src/services/stack.service.ts
+++ b/server/src/services/stack.service.ts
@@ -21,7 +21,7 @@ export class StackService extends BaseService {
 
     const stack = await this.stackRepository.create({ ownerId: auth.user.id }, dto.assetIds);
 
-    await this.eventRepository.emit('stack.create', { stackId: stack.id, userId: auth.user.id });
+    await this.eventRepository.emit('StackCreate', { stackId: stack.id, userId: auth.user.id });
 
     return mapStack(stack, { auth });
   }
@@ -41,7 +41,7 @@ export class StackService extends BaseService {
 
     const updatedStack = await this.stackRepository.update(id, { id, primaryAssetId: dto.primaryAssetId });
 
-    await this.eventRepository.emit('stack.update', { stackId: id, userId: auth.user.id });
+    await this.eventRepository.emit('StackUpdate', { stackId: id, userId: auth.user.id });
 
     return mapStack(updatedStack, { auth });
   }
@@ -49,13 +49,13 @@ export class StackService extends BaseService {
   async delete(auth: AuthDto, id: string): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.STACK_DELETE, ids: [id] });
     await this.stackRepository.delete(id);
-    await this.eventRepository.emit('stack.delete', { stackId: id, userId: auth.user.id });
+    await this.eventRepository.emit('StackDelete', { stackId: id, userId: auth.user.id });
   }
 
   async deleteAll(auth: AuthDto, dto: BulkIdsDto): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.STACK_DELETE, ids: dto.ids });
     await this.stackRepository.deleteAll(dto.ids);
-    await this.eventRepository.emit('stacks.delete', { stackIds: dto.ids, userId: auth.user.id });
+    await this.eventRepository.emit('StackDeleteAll', { stackIds: dto.ids, userId: auth.user.id });
   }
 
   private async findOrFail(id: string) {

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -75,8 +75,8 @@ export class StorageTemplateService extends BaseService {
     return this._template;
   }
 
-  @OnEvent({ name: 'config.init' })
-  onConfigInit({ newConfig }: ArgOf<'config.init'>) {
+  @OnEvent({ name: 'ConfigInit' })
+  onConfigInit({ newConfig }: ArgOf<'ConfigInit'>) {
     const template = newConfig.storageTemplate.template;
     if (!this._template || template !== this.template.raw) {
       this.logger.debug(`Compiling new storage template: ${template}`);
@@ -84,13 +84,13 @@ export class StorageTemplateService extends BaseService {
     }
   }
 
-  @OnEvent({ name: 'config.update', server: true })
-  onConfigUpdate({ newConfig }: ArgOf<'config.update'>) {
+  @OnEvent({ name: 'ConfigUpdate', server: true })
+  onConfigUpdate({ newConfig }: ArgOf<'ConfigUpdate'>) {
     this.onConfigInit({ newConfig });
   }
 
-  @OnEvent({ name: 'config.validate' })
-  onConfigValidate({ newConfig }: ArgOf<'config.validate'>) {
+  @OnEvent({ name: 'ConfigValidate' })
+  onConfigValidate({ newConfig }: ArgOf<'ConfigValidate'>) {
     try {
       const { compiled } = this.compile(newConfig.storageTemplate.template);
       this.render(compiled, {
@@ -116,8 +116,8 @@ export class StorageTemplateService extends BaseService {
     return { ...storageTokens, presetOptions: storagePresets };
   }
 
-  @OnEvent({ name: 'asset.metadataExtracted' })
-  async onAssetMetadataExtracted({ source, assetId }: ArgOf<'asset.metadataExtracted'>) {
+  @OnEvent({ name: 'AssetMetadataExtracted' })
+  async onAssetMetadataExtracted({ source, assetId }: ArgOf<'AssetMetadataExtracted'>) {
     await this.jobRepository.queue({ name: JobName.STORAGE_TEMPLATE_MIGRATION_SINGLE, data: { source, id: assetId } });
   }
 
@@ -182,8 +182,8 @@ export class StorageTemplateService extends BaseService {
     return JobStatus.SUCCESS;
   }
 
-  @OnEvent({ name: 'asset.delete' })
-  async handleMoveHistoryCleanup({ assetId }: ArgOf<'asset.delete'>) {
+  @OnEvent({ name: 'AssetDelete' })
+  async handleMoveHistoryCleanup({ assetId }: ArgOf<'AssetDelete'>) {
     this.logger.debug(`Cleaning up move history for asset ${assetId}`);
     await this.moveRepository.cleanMoveHistorySingle(assetId);
   }

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -11,7 +11,7 @@ const docsMessage = `Please see https://immich.app/docs/administration/system-in
 
 @Injectable()
 export class StorageService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap' })
+  @OnEvent({ name: 'AppBootstrap' })
   async onBootstrap() {
     const envData = this.configRepository.getEnv();
 

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -412,7 +412,7 @@ describe(SystemConfigService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue(partialConfig);
       await expect(sut.updateSystemConfig(updatedConfig)).resolves.toEqual(updatedConfig);
       expect(mocks.event.emit).toHaveBeenCalledWith(
-        'config.update',
+        'ConfigUpdate',
         expect.objectContaining({ oldConfig: expect.any(Object), newConfig: updatedConfig }),
       );
     });

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -90,7 +90,7 @@ export class TagService extends BaseService {
 
     const results = await this.tagRepository.upsertAssetIds(items);
     for (const assetId of new Set(results.map((item) => item.assetsId))) {
-      await this.eventRepository.emit('asset.tag', { assetId });
+      await this.eventRepository.emit('AssetTag', { assetId });
     }
 
     return { count: results.length };
@@ -107,7 +107,7 @@ export class TagService extends BaseService {
 
     for (const { id: assetId, success } of results) {
       if (success) {
-        await this.eventRepository.emit('asset.tag', { assetId });
+        await this.eventRepository.emit('AssetTag', { assetId });
       }
     }
 
@@ -125,7 +125,7 @@ export class TagService extends BaseService {
 
     for (const { id: assetId, success } of results) {
       if (success) {
-        await this.eventRepository.emit('asset.untag', { assetId });
+        await this.eventRepository.emit('AssetUntag', { assetId });
       }
     }
 

--- a/server/src/services/trash.service.ts
+++ b/server/src/services/trash.service.ts
@@ -17,7 +17,7 @@ export class TrashService extends BaseService {
 
     await this.requireAccess({ auth, permission: Permission.ASSET_DELETE, ids });
     await this.trashRepository.restoreAll(ids);
-    await this.eventRepository.emit('assets.restore', { assetIds: ids, userId: auth.user.id });
+    await this.eventRepository.emit('AssetRestoreAll', { assetIds: ids, userId: auth.user.id });
 
     this.logger.log(`Restored ${ids.length} asset(s) from trash`);
 
@@ -40,7 +40,7 @@ export class TrashService extends BaseService {
     return { count };
   }
 
-  @OnEvent({ name: 'assets.delete' })
+  @OnEvent({ name: 'AssetDeleteAll' })
   async onAssetsDelete() {
     await this.jobRepository.queue({ name: JobName.QUEUE_TRASH_EMPTY, data: {} });
   }

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -35,7 +35,7 @@ export class UserAdminService extends BaseService {
 
     const user = await this.createUser(userDto);
 
-    await this.eventRepository.emit('user.signup', {
+    await this.eventRepository.emit('UserSignup', {
       notify: !!notify,
       id: user.id,
       tempPassword: user.shouldChangePassword ? userDto.password : undefined,

--- a/server/src/services/version.service.ts
+++ b/server/src/services/version.service.ts
@@ -20,7 +20,7 @@ const asNotification = ({ checkedAt, releaseVersion }: VersionCheckMetadata): Re
 
 @Injectable()
 export class VersionService extends BaseService {
-  @OnEvent({ name: 'app.bootstrap' })
+  @OnEvent({ name: 'AppBootstrap' })
   async onBootstrap(): Promise<void> {
     await this.handleVersionCheck();
 
@@ -102,8 +102,8 @@ export class VersionService extends BaseService {
     return JobStatus.SUCCESS;
   }
 
-  @OnEvent({ name: 'websocket.connect' })
-  async onWebsocketConnection({ userId }: ArgOf<'websocket.connect'>) {
+  @OnEvent({ name: 'WebsocketConnect' })
+  async onWebsocketConnection({ userId }: ArgOf<'WebsocketConnect'>) {
     this.eventRepository.clientSend('on_server_version', userId, serverVersion);
     const metadata = await this.systemMetadataRepository.get(SystemMetadataKey.VERSION_CHECK_STATE);
     if (metadata) {

--- a/server/src/utils/asset.util.ts
+++ b/server/src/utils/asset.util.ts
@@ -152,7 +152,7 @@ export const onBeforeLink = async (
 
   if (motionAsset && motionAsset.visibility === AssetVisibility.TIMELINE) {
     await assetRepository.update({ id: livePhotoVideoId, visibility: AssetVisibility.HIDDEN });
-    await eventRepository.emit('asset.hide', { assetId: motionAsset.id, userId });
+    await eventRepository.emit('AssetHide', { assetId: motionAsset.id, userId });
   }
 };
 
@@ -177,7 +177,7 @@ export const onAfterUnlink = async (
   { userId, livePhotoVideoId, visibility }: { userId: string; livePhotoVideoId: string; visibility: AssetVisibility },
 ) => {
   await assetRepository.update({ id: livePhotoVideoId, visibility });
-  await eventRepository.emit('asset.show', { assetId: livePhotoVideoId, userId });
+  await eventRepository.emit('AssetShow', { assetId: livePhotoVideoId, userId });
 };
 
 export function mapToUploadFile(file: ImmichFile): UploadFile {


### PR DESCRIPTION
Transition internal event names to match the naming strategy we used for the sync process (minus the version)