### PR TITLE
fix(web): timeline date group width

### DIFF
--- a/web/src/lib/utils/layout-utils.ts
+++ b/web/src/lib/utils/layout-utils.ts
@@ -57,7 +57,7 @@ class Adapter {
     this.result = result;
     this.width = 0;
     for (const box of this.result.boxes) {
-      if (box.top < 100) {
+      if (box.top === 0) {
         this.width = box.left + box.width;
       } else {
         break;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix the calculation for the date group width, so there's never a scenario where photos will be hidden. Only use photos in the first row of the day group to determine its visible width.

On mobile devices, photos in the second row could have a top position of <100px, which was throwing off the calculation of the date group width.

* Fixes #19897 
* Fixes #17632
 
## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Navigate to the shared link in the preview env, using either a mobile phone or the Chrome devtools with the device simulator set to "iPhone SE": <https://pr-19964.preview.internal.immich.cloud/share/XBbGEcsN_3XO6BWTaDY6EpVnoM7IFP8N9gRFceFj0skNYuHJmRe1zVpTS_UIkj2KU8I>
- [x] Check that the main timeline is still showing day groups as expected

<details><summary><h2>Annotated screenshot</h2></summary>

<!-- Images go below this line. -->

<img width="375" height="669" alt="Screenshot 2025-07-16 at 07 10 50" src="https://github.com/user-attachments/assets/a705e289-c591-4123-9c53-72d35a1edd49" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
