### PR TITLE
refactor(mobile): share action button in new timeline

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1691,6 +1691,7 @@
   "settings_saved": "Settings saved",
   "setup_pin_code": "Setup a PIN code",
   "share": "Share",
+  "share_action_prompt": "Shared {count} assets",
   "share_add_photos": "Add photos",
   "share_assets_selected": "{count} selected",
   "share_dialog_preparing": "Preparing...",

--- a/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
@@ -1,12 +1,49 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class ShareActionButton extends ConsumerWidget {
-  const ShareActionButton({super.key});
+  final ActionSource source;
+
+  const ShareActionButton({super.key, required this.source});
+
+  void _onTap(BuildContext context, WidgetRef ref) async {
+    if (!context.mounted) {
+      return;
+    }
+
+    final result = await ref.read(actionProvider.notifier).shareAssets(source);
+    ref.read(multiSelectProvider.notifier).reset();
+
+    if (!context.mounted) {
+      return;
+    }
+
+    if (!result.success) {
+      ImmichToast.show(
+        context: context,
+        msg: 'scaffold_body_error_occurred'.t(context: context),
+        gravity: ToastGravity.BOTTOM,
+        toastType: ToastType.error,
+      );
+    } else if (result.count > 0) {
+      ImmichToast.show(
+        context: context,
+        msg: 'share_action_prompt'
+            .t(context: context, args: {'count': result.count.toString()}),
+        gravity: ToastGravity.BOTTOM,
+        toastType: ToastType.success,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -14,6 +51,7 @@ class ShareActionButton extends ConsumerWidget {
       iconData:
           Platform.isAndroid ? Icons.share_rounded : Icons.ios_share_rounded,
       label: 'share'.t(context: context),
+      onPressed: () => _onTap(context, ref),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -38,7 +38,7 @@ class ViewerBottomBar extends ConsumerWidget {
     }
 
     final actions = <Widget>[
-      const ShareActionButton(),
+      const ShareActionButton(source: ActionSource.viewer),
       const _EditActionButton(),
       if (asset.hasRemote && isOwner)
         const ArchiveActionButton(source: ActionSource.viewer),

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
@@ -45,7 +45,7 @@ class AssetDetailBottomSheet extends ConsumerWidget {
     );
 
     final actions = <Widget>[
-      const ShareActionButton(),
+      const ShareActionButton(source: ActionSource.viewer),
       if (asset.hasRemote) ...[
         const ShareLinkActionButton(source: ActionSource.viewer),
         const ArchiveActionButton(source: ActionSource.viewer),

--- a/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
@@ -33,7 +33,7 @@ class ArchiveBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        const ShareActionButton(),
+        const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
           const UnArchiveActionButton(source: ActionSource.timeline),

--- a/mobile/lib/presentation/widgets/bottom_sheet/favorite_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/favorite_bottom_sheet.widget.dart
@@ -33,7 +33,7 @@ class FavoriteBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        const ShareActionButton(),
+        const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
           const UnFavoriteActionButton(source: ActionSource.timeline),

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -33,7 +33,7 @@ class GeneralBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        const ShareActionButton(),
+        const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
           const ArchiveActionButton(source: ActionSource.timeline),

--- a/mobile/lib/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart
@@ -16,7 +16,7 @@ class LocalAlbumBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        ShareActionButton(),
+        ShareActionButton(source: ActionSource.timeline),
         DeleteLocalActionButton(source: ActionSource.timeline),
         UploadActionButton(),
       ],

--- a/mobile/lib/presentation/widgets/bottom_sheet/locked_folder_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/locked_folder_bottom_sheet.widget.dart
@@ -17,7 +17,7 @@ class LockedFolderBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        ShareActionButton(),
+        ShareActionButton(source: ActionSource.timeline),
         DownloadActionButton(),
         DeletePermanentActionButton(source: ActionSource.timeline),
         RemoveFromLockFolderActionButton(source: ActionSource.timeline),

--- a/mobile/lib/presentation/widgets/bottom_sheet/partner_detail_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/partner_detail_bottom_sheet.widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
@@ -14,7 +15,7 @@ class PartnerDetailBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        ShareActionButton(),
+        ShareActionButton(source: ActionSource.timeline),
         DownloadActionButton(),
       ],
     );

--- a/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
@@ -36,7 +36,7 @@ class RemoteAlbumBottomSheet extends ConsumerWidget {
       maxChildSize: 0.4,
       shouldCloseOnMinExtent: false,
       actions: [
-        const ShareActionButton(),
+        const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
           const ArchiveActionButton(source: ActionSource.timeline),

--- a/mobile/lib/repositories/asset_api.repository.dart
+++ b/mobile/lib/repositories/asset_api.repository.dart
@@ -1,4 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
@@ -81,6 +82,10 @@ class AssetApiRepository extends ApiRepository {
         longitude: location.longitude,
       ),
     );
+  }
+
+  Future<Response> downloadAsset(String id) {
+    return _api.downloadAssetWithHttpInfo(id);
   }
 
   _mapVisibility(AssetVisibilityEnum visibility) => switch (visibility) {

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -1,27 +1,41 @@
+import 'dart:io';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/entities/asset.entity.dart' as asset_entity;
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/repositories/asset_api.repository.dart';
 import 'package:immich_mobile/utils/hash.dart';
-import 'package:photo_manager/photo_manager.dart' hide AssetType;
+import 'package:logging/logging.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:photo_manager/photo_manager.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/extensions/response_extensions.dart';
+import 'package:share_plus/share_plus.dart';
 
 final assetMediaRepositoryProvider =
-    Provider((ref) => const AssetMediaRepository());
+    Provider(
+  (ref) => AssetMediaRepository(ref.watch(assetApiRepositoryProvider)),
+);
 
 class AssetMediaRepository {
-  const AssetMediaRepository();
+  final AssetApiRepository _assetApiRepository;
+  static final Logger _log = Logger("AssetMediaRepository");
+
+  const AssetMediaRepository(this._assetApiRepository);
+  
   Future<List<String>> deleteAll(List<String> ids) =>
       PhotoManager.editor.deleteWithIds(ids);
 
-  Future<Asset?> get(String id) async {
+  Future<asset_entity.Asset?> get(String id) async {
     final entity = await AssetEntity.fromId(id);
     return toAsset(entity);
   }
 
-  static Asset? toAsset(AssetEntity? local) {
+  static asset_entity.Asset? toAsset(AssetEntity? local) {
     if (local == null) return null;
-    final Asset asset = Asset(
+    final asset_entity.Asset asset = asset_entity.Asset(
       checksum: "",
       localId: local.id,
       ownerId: fastHash(Store.get(StoreKey.currentUser).id),
@@ -29,7 +43,7 @@ class AssetMediaRepository {
       fileModifiedAt: local.modifiedDateTime,
       updatedAt: local.modifiedDateTime,
       durationInSeconds: local.duration,
-      type: AssetType.values[local.typeInt],
+      type: asset_entity.AssetType.values[local.typeInt],
       fileName: local.title!,
       width: local.width,
       height: local.height,
@@ -56,5 +70,58 @@ class AssetMediaRepository {
     // titleAsync gets the correct original filename for some assets on iOS
     // otherwise using the `entity.title` would return a random GUID
     return await entity.titleAsync;
+  }
+
+  // TODO: make this more efficient
+  Future<int> shareAssets(List<BaseAsset> assets) async {
+    final downloadedXFiles = <XFile>[];
+
+    for (var asset in assets) {
+      final localId = (asset is LocalAsset)
+          ? asset.id
+          : asset is RemoteAsset
+              ? asset.localId
+              : null;
+      if (localId != null) {
+        File? f =
+            await AssetEntity(id: localId, width: 1, height: 1, typeInt: 0)
+                .originFile;
+        downloadedXFiles.add(XFile(f!.path));
+      } else if (asset is RemoteAsset) {
+        final tempDir = await getTemporaryDirectory();
+        final name = asset.name;
+        final tempFile = await File('${tempDir.path}/$name').create();
+        final res = await _assetApiRepository.downloadAsset(asset.id);
+
+        if (res.statusCode != 200) {
+          _log.severe("Download for $name failed", res.toLoggerString());
+          continue;
+        }
+
+        await tempFile.writeAsBytes(res.bodyBytes);
+        downloadedXFiles.add(XFile(tempFile.path));
+      } else {
+        _log.warning("Asset type not supported for sharing: $asset");
+        continue;
+      }
+    }
+
+    if (downloadedXFiles.isEmpty) {
+      _log.warning("No asset can be retrieved for share");
+      return 0;
+    }
+
+    final result = await Share.shareXFiles(downloadedXFiles);
+
+    for (var file in downloadedXFiles) {
+      try {
+        await File(file.path).delete();
+      } catch (e) {
+        _log.warning("Failed to delete temporary file: ${file.path}", e);
+      }
+    }
+    return result.status == ShareResultStatus.success
+        ? downloadedXFiles.length
+        : 0;
   }
 }

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -14,8 +14,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:share_plus/share_plus.dart';
 
-final assetMediaRepositoryProvider =
-    Provider(
+final assetMediaRepositoryProvider = Provider(
   (ref) => AssetMediaRepository(ref.watch(assetApiRepositoryProvider)),
 );
 
@@ -24,7 +23,7 @@ class AssetMediaRepository {
   static final Logger _log = Logger("AssetMediaRepository");
 
   const AssetMediaRepository(this._assetApiRepository);
-  
+
   Future<List<String>> deleteAll(List<String> ids) =>
       PhotoManager.editor.deleteWithIds(ids);
 

--- a/mobile/lib/services/action.service.dart
+++ b/mobile/lib/services/action.service.dart
@@ -1,10 +1,7 @@
-import 'dart:io';
-
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_album.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_asset.repository.dart';
@@ -15,12 +12,8 @@ import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/repositories/drift_album_api_repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/location_picker.dart';
-import 'package:logging/logging.dart';
 import 'package:maplibre_gl/maplibre_gl.dart' as maplibre;
-import 'package:path_provider/path_provider.dart';
-import 'package:photo_manager/photo_manager.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:share_plus/share_plus.dart';
 
 final actionServiceProvider = Provider<ActionService>(
   (ref) => ActionService(
@@ -40,8 +33,6 @@ class ActionService {
   final DriftAlbumApiRepository _albumApiRepository;
   final DriftRemoteAlbumRepository _remoteAlbumRepository;
   final AssetMediaRepository _assetMediaRepository;
-
-  static final Logger _log = Logger("ActionService");
 
   const ActionService(
     this._assetApiRepository,
@@ -175,56 +166,7 @@ class ActionService {
     return removedCount;
   }
 
-  // TODO: make this more efficient
-  Future<int> shareAssets(List<BaseAsset> assets) async {
-    final downloadedXFiles = <XFile>[];
-
-    for (var asset in assets) {
-      final localId = (asset is LocalAsset)
-          ? asset.id
-          : asset is RemoteAsset
-              ? asset.localId
-              : null;
-      if (localId != null) {
-        File? f =
-            await AssetEntity(id: localId, width: 1, height: 1, typeInt: 0)
-                .originFile;
-        downloadedXFiles.add(XFile(f!.path));
-      } else if (asset is RemoteAsset) {
-        final tempDir = await getTemporaryDirectory();
-        final name = asset.name;
-        final tempFile = await File('${tempDir.path}/$name').create();
-        final res = await _assetApiRepository.downloadAsset(asset.id);
-
-        if (res.statusCode != 200) {
-          _log.severe("Download for $name failed", res.toLoggerString());
-          continue;
-        }
-
-        await tempFile.writeAsBytes(res.bodyBytes);
-        downloadedXFiles.add(XFile(tempFile.path));
-      } else {
-        _log.warning("Asset type not supported for sharing: $asset");
-        continue;
-      }
-    }
-
-    if (downloadedXFiles.isEmpty) {
-      _log.warning("No asset can be retrieved for share");
-      return 0;
-    }
-
-    final result = await Share.shareXFiles(downloadedXFiles);
-
-    for (var file in downloadedXFiles) {
-      try {
-        await File(file.path).delete();
-      } catch (e) {
-        _log.warning("Failed to delete temporary file: ${file.path}", e);
-      }
-    }
-    return result.status == ShareResultStatus.success
-        ? downloadedXFiles.length
-        : 0;
+  Future<int> shareAssets(List<BaseAsset> assets) {
+    return _assetMediaRepository.shareAssets(assets);
   }
 }


### PR DESCRIPTION
## Description

This PR implements the share button in the new timeline. The sharing implementation is not great, but improving it is left for future work.

#19961 should be merged first

## How Has This Been Tested?

Tested by pressing the share button in the main timeline, seeing the native share prompt, then seeing a success toast with the share being performed as expected. Dismissing the share button does not emit a toast and just resets the multiselect.