### PR TITLE
chore: adjust setting subtitle to less clumsy expression

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -359,7 +359,7 @@
   "advanced_settings_enable_alternate_media_filter_subtitle": "Verwende diese Option, um Medien während der Synchronisierung nach anderen Kriterien zu filtern. Versuchen dies nur, wenn Probleme mit der Erkennung aller Alben durch die App auftreten.",
   "advanced_settings_enable_alternate_media_filter_title": "[EXPERIMENTELL] Benutze alternativen Filter für Synchronisierung der Gerätealben",
   "advanced_settings_log_level_title": "Log-Level: {level}",
-  "advanced_settings_prefer_remote_subtitle": "Einige Geräte sind sehr langsam beim Laden von lokalen Miniaturbildern. Aktivieren Sie diese Einstellung, um stattdessen die Server-Bilder zu laden.",
+  "advanced_settings_prefer_remote_subtitle": "Einige Geräte sind sehr langsam beim Laden von Miniaturbildern direkt aus dem Gerät. Aktivieren Sie diese Einstellung, um stattdessen die Server-Bilder zu laden.",
   "advanced_settings_prefer_remote_title": "Server-Bilder bevorzugen",
   "advanced_settings_proxy_headers_subtitle": "Definiere einen Proxy-Header, den Immich bei jeder Netzwerkanfrage mitschicken soll",
   "advanced_settings_proxy_headers_title": "Proxy-Headers",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -359,7 +359,7 @@
   "advanced_settings_enable_alternate_media_filter_subtitle": "Verwende diese Option, um Medien während der Synchronisierung nach anderen Kriterien zu filtern. Versuchen dies nur, wenn Probleme mit der Erkennung aller Alben durch die App auftreten.",
   "advanced_settings_enable_alternate_media_filter_title": "[EXPERIMENTELL] Benutze alternativen Filter für Synchronisierung der Gerätealben",
   "advanced_settings_log_level_title": "Log-Level: {level}",
-  "advanced_settings_prefer_remote_subtitle": "Einige Geräte sind sehr langsam beim Laden von Miniaturbildern direkt aus dem Gerät. Aktivieren Sie diese Einstellung, um stattdessen die Server-Bilder zu laden.",
+  "advanced_settings_prefer_remote_subtitle": "Einige Geräte sind sehr langsam beim Laden von lokalen Miniaturbildern. Aktivieren Sie diese Einstellung, um stattdessen die Server-Bilder zu laden.",
   "advanced_settings_prefer_remote_title": "Server-Bilder bevorzugen",
   "advanced_settings_proxy_headers_subtitle": "Definiere einen Proxy-Header, den Immich bei jeder Netzwerkanfrage mitschicken soll",
   "advanced_settings_proxy_headers_title": "Proxy-Headers",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -376,7 +376,7 @@
   "advanced_settings_enable_alternate_media_filter_subtitle": "Use this option to filter media during sync based on alternate criteria. Only try this if you have issues with the app detecting all albums.",
   "advanced_settings_enable_alternate_media_filter_title": "[EXPERIMENTAL] Use alternate device album sync filter",
   "advanced_settings_log_level_title": "Log level: {level}",
-  "advanced_settings_prefer_remote_subtitle": "Some devices are painfully slow to load thumbnails from assets on the device. Activate this setting to load remote images instead.",
+  "advanced_settings_prefer_remote_subtitle": "Some devices are painfully slow to load thumbnails from local assets. Activate this setting to load remote images instead.",
   "advanced_settings_prefer_remote_title": "Prefer remote images",
   "advanced_settings_proxy_headers_subtitle": "Define proxy headers Immich should send with each network request",
   "advanced_settings_proxy_headers_title": "Proxy Headers",


### PR DESCRIPTION
## Description

On the mobile app, the subtitle to the **Prefer remote images** toggle in advanced settings reads a bit clumsy.
I have adjusted the subtitle in both the English and German translations, but cannot verify other languages.
There is no open issue relating to this change.

## How Has This Been Tested?

Not been tested. It's just a simple change.
**If deemed unnecessary, feel free to reject!**

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
