### PR TITLE
feat: open asset from activities and disable focusing activity text field

### DIFF
--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -33,6 +33,7 @@ enum TimelineOrigin {
   map,
   search,
   deepLink,
+  activity,
 }
 
 class TimelineFactory {

--- a/mobile/lib/presentation/pages/drift_activities.page.dart
+++ b/mobile/lib/presentation/pages/drift_activities.page.dart
@@ -3,14 +3,12 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart' hide Store;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/like_activity_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/album/drift_activity_text_field.dart';
 import 'package:immich_mobile/providers/activity.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/activities/activity_tile.dart';
@@ -23,11 +21,10 @@ class DriftActivitiesPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final album = ref.watch(currentRemoteAlbumProvider)!;
-    final asset = ref.watch(currentAssetNotifier) as RemoteAsset?;
     final user = ref.watch(currentUserProvider);
 
-    final activityNotifier = ref.read(albumActivityProvider(album.id, asset?.id).notifier);
-    final activities = ref.watch(albumActivityProvider(album.id, asset?.id));
+    final activityNotifier = ref.read(albumActivityProvider(album.id, null).notifier);
+    final activities = ref.watch(albumActivityProvider(album.id, null));
     final listViewScrollController = useScrollController();
 
     void scrollToBottom() {
@@ -45,14 +42,14 @@ class DriftActivitiesPage extends HookConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: asset == null ? Text(album.name) : null,
-        actions: [const LikeActivityActionButton(menuItem: true)],
+        title: Text(album.name),
+        actions: [const LikeActivityActionButton(menuItem: true, isAlbumLike: true)],
         actionsPadding: const EdgeInsets.only(right: 8),
       ),
       body: activities.widgetWhen(
         onData: (data) {
           final liked = data.firstWhereOrNull(
-            (a) => a.type == ActivityType.like && a.user.id == user?.id && a.assetId == asset?.id,
+            (a) => a.type == ActivityType.like && a.user.id == user?.id && a.assetId == null,
           );
 
           return SafeArea(

--- a/mobile/lib/presentation/widgets/action_buttons/like_activity_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/like_activity_action_button.widget.dart
@@ -12,9 +12,10 @@ import 'package:immich_mobile/providers/infrastructure/current_album.provider.da
 import 'package:immich_mobile/providers/user.provider.dart';
 
 class LikeActivityActionButton extends ConsumerWidget {
-  const LikeActivityActionButton({super.key, this.menuItem = false});
+  const LikeActivityActionButton({super.key, this.menuItem = false, this.isAlbumLike = false});
 
   final bool menuItem;
+  final bool isAlbumLike;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -22,7 +23,10 @@ class LikeActivityActionButton extends ConsumerWidget {
     final asset = ref.watch(currentAssetNotifier) as RemoteAsset?;
     final user = ref.watch(currentUserProvider);
 
-    final activities = ref.watch(albumActivityProvider(album?.id ?? "", asset?.id));
+    // we need to ignore the current asset when liking an album
+    final target = isAlbumLike ? null : asset?.id;
+
+    final activities = ref.watch(albumActivityProvider(album?.id ?? "", target));
 
     onTap(Activity? liked) async {
       if (user == null) {
@@ -30,12 +34,12 @@ class LikeActivityActionButton extends ConsumerWidget {
       }
 
       if (liked != null) {
-        await ref.read(albumActivityProvider(album?.id ?? "", asset?.id).notifier).removeActivity(liked.id);
+        await ref.read(albumActivityProvider(album?.id ?? "", target).notifier).removeActivity(liked.id);
       } else {
-        await ref.read(albumActivityProvider(album?.id ?? "", asset?.id).notifier).addLike();
+        await ref.read(albumActivityProvider(album?.id ?? "", target).notifier).addLike();
       }
 
-      ref.invalidate(albumActivityProvider(album?.id ?? "", asset?.id));
+      ref.invalidate(albumActivityProvider(album?.id ?? "", target));
     }
 
     return activities.when(

--- a/mobile/lib/widgets/activities/activity_text_field.dart
+++ b/mobile/lib/widgets/activities/activity_text_field.dart
@@ -13,24 +13,23 @@ class ActivityTextField extends HookConsumerWidget {
   final String? likeId;
   final Function(String) onSubmit;
 
-  const ActivityTextField({
-    required this.onSubmit,
-    this.isEnabled = true,
-    this.likeId,
-    super.key,
-  });
+  const ActivityTextField({required this.onSubmit, this.isEnabled = true, this.likeId, super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final album = ref.watch(currentAlbumProvider)!;
     final asset = ref.watch(currentAssetProvider);
-    final activityNotifier = ref.read(
-      albumActivityProvider(album.remoteId!, asset?.remoteId).notifier,
-    );
+    final activityNotifier = ref.read(albumActivityProvider(album.remoteId!, asset?.remoteId).notifier);
     final user = ref.watch(currentUserProvider);
     final inputController = useTextEditingController();
     final inputFocusNode = useFocusNode();
     final liked = likeId != null;
+
+    // Show keyboard immediately on activities open
+    useEffect(() {
+      inputFocusNode.requestFocus();
+      return null;
+    }, []);
 
     // Pass text to callback and reset controller
     void onEditingComplete() {
@@ -69,21 +68,13 @@ class ActivityTextField extends HookConsumerWidget {
           suffixIcon: Padding(
             padding: const EdgeInsets.only(right: 10),
             child: IconButton(
-              icon: Icon(
-                liked ? Icons.favorite_rounded : Icons.favorite_border_rounded,
-              ),
+              icon: Icon(liked ? Icons.favorite_rounded : Icons.favorite_border_rounded),
               onPressed: liked ? removeLike : addLike,
             ),
           ),
           suffixIconColor: liked ? Colors.red[700] : null,
-          hintText: !isEnabled
-              ? 'shared_album_activities_input_disable'.tr()
-              : 'say_something'.tr(),
-          hintStyle: TextStyle(
-            fontWeight: FontWeight.normal,
-            fontSize: 14,
-            color: Colors.grey[600],
-          ),
+          hintText: !isEnabled ? 'shared_album_activities_input_disable'.tr() : 'say_something'.tr(),
+          hintStyle: TextStyle(fontWeight: FontWeight.normal, fontSize: 14, color: Colors.grey[600]),
         ),
         onEditingComplete: onEditingComplete,
         onTapOutside: (_) => inputFocusNode.unfocus(),

--- a/mobile/lib/widgets/activities/activity_text_field.dart
+++ b/mobile/lib/widgets/activities/activity_text_field.dart
@@ -13,23 +13,24 @@ class ActivityTextField extends HookConsumerWidget {
   final String? likeId;
   final Function(String) onSubmit;
 
-  const ActivityTextField({required this.onSubmit, this.isEnabled = true, this.likeId, super.key});
+  const ActivityTextField({
+    required this.onSubmit,
+    this.isEnabled = true,
+    this.likeId,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final album = ref.watch(currentAlbumProvider)!;
     final asset = ref.watch(currentAssetProvider);
-    final activityNotifier = ref.read(albumActivityProvider(album.remoteId!, asset?.remoteId).notifier);
+    final activityNotifier = ref.read(
+      albumActivityProvider(album.remoteId!, asset?.remoteId).notifier,
+    );
     final user = ref.watch(currentUserProvider);
     final inputController = useTextEditingController();
     final inputFocusNode = useFocusNode();
     final liked = likeId != null;
-
-    // Show keyboard immediately on activities open
-    useEffect(() {
-      inputFocusNode.requestFocus();
-      return null;
-    }, []);
 
     // Pass text to callback and reset controller
     void onEditingComplete() {
@@ -68,13 +69,21 @@ class ActivityTextField extends HookConsumerWidget {
           suffixIcon: Padding(
             padding: const EdgeInsets.only(right: 10),
             child: IconButton(
-              icon: Icon(liked ? Icons.favorite_rounded : Icons.favorite_border_rounded),
+              icon: Icon(
+                liked ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+              ),
               onPressed: liked ? removeLike : addLike,
             ),
           ),
           suffixIconColor: liked ? Colors.red[700] : null,
-          hintText: !isEnabled ? 'shared_album_activities_input_disable'.tr() : 'say_something'.tr(),
-          hintStyle: TextStyle(fontWeight: FontWeight.normal, fontSize: 14, color: Colors.grey[600]),
+          hintText: !isEnabled
+              ? 'shared_album_activities_input_disable'.tr()
+              : 'say_something'.tr(),
+          hintStyle: TextStyle(
+            fontWeight: FontWeight.normal,
+            fontSize: 14,
+            color: Colors.grey[600],
+          ),
         ),
         onEditingComplete: onEditingComplete,
         onTapOutside: (_) => inputFocusNode.unfocus(),

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -1,15 +1,10 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
-import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
-import 'package:immich_mobile/providers/asset_viewer/show_controls.provider.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
-import 'package:immich_mobile/repositories/asset.repository.dart';
-import 'package:immich_mobile/routing/router.dart';
-import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
+import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
 
 class ActivityTile extends HookConsumerWidget {
@@ -20,36 +15,6 @@ class ActivityTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    Future<void> onTap() async {
-      if (activity.assetId == null) {
-        return;
-      }
-
-      final asset = await ref
-          .read(assetRepositoryProvider)
-          .getByRemoteId(activity.assetId!);
-      if (asset == null) {
-        return;
-      }
-
-      final renderList = await RenderList.fromAssets([
-        asset,
-      ], GroupAssetsBy.none);
-      final assetNotifier = ref.read(currentAssetProvider.notifier);
-      assetNotifier.set(asset);
-      if (asset.isVideo) {
-        ref.read(showControlsProvider.notifier).show = false;
-      }
-      await context.pushRoute(
-        GalleryViewerRoute(
-          initialIndex: 0,
-          heroOffset: 0,
-          renderList: renderList,
-        ),
-      );
-      assetNotifier.set(null);
-    }
-
     final asset = ref.watch(currentAssetProvider);
     final isLike = activity.type == ActivityType.like;
     // Asset thumbnail is displayed when we are accessing activities from the album page
@@ -73,15 +38,8 @@ class ActivityTile extends HookConsumerWidget {
         leftAlign: isBottomSheet ? false : (isLike || showAssetThumbnail),
       ),
       // No subtitle for like, so center title
-      titleAlignment: !isLike
-          ? ListTileTitleAlignment.top
-          : ListTileTitleAlignment.center,
-      trailing: showAssetThumbnail
-          ? GestureDetector(
-              onTap: onTap,
-              child: _ActivityAssetThumbnail(activity.assetId!),
-            )
-          : null,
+      titleAlignment: !isLike ? ListTileTitleAlignment.top : ListTileTitleAlignment.center,
+      trailing: showAssetThumbnail ? _ActivityAssetThumbnail(activity.assetId!) : null,
       subtitle: !isLike ? Text(activity.comment!) : null,
     );
   }
@@ -92,23 +50,15 @@ class _ActivityTitle extends StatelessWidget {
   final String createdAt;
   final bool leftAlign;
 
-  const _ActivityTitle({
-    required this.userName,
-    required this.createdAt,
-    required this.leftAlign,
-  });
+  const _ActivityTitle({required this.userName, required this.createdAt, required this.leftAlign});
 
   @override
   Widget build(BuildContext context) {
     final textColor = context.isDarkTheme ? Colors.white : Colors.black;
-    final textStyle = context.textTheme.bodyMedium?.copyWith(
-      color: textColor.withValues(alpha: 0.6),
-    );
+    final textStyle = context.textTheme.bodyMedium?.copyWith(color: textColor.withValues(alpha: 0.6));
 
     return Row(
-      mainAxisAlignment: leftAlign
-          ? MainAxisAlignment.start
-          : MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: leftAlign ? MainAxisAlignment.start : MainAxisAlignment.spaceBetween,
       mainAxisSize: leftAlign ? MainAxisSize.min : MainAxisSize.max,
       children: [
         Text(userName, style: textStyle, overflow: TextOverflow.ellipsis),

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.pag
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
@@ -21,11 +22,17 @@ class ActivityTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asset = ref.watch(currentAssetProvider);
     final isLike = activity.type == ActivityType.like;
     // Asset thumbnail is displayed when we are accessing activities from the album page
     // currentAssetProvider will not be set until we open the gallery viewer
-    final showAssetThumbnail = asset == null && activity.assetId != null && !isBottomSheet;
+    bool showAssetThumbnail = false;
+    if (Store.isBetaTimelineEnabled) {
+      final asset = ref.watch(currentAssetNotifier);
+      showAssetThumbnail = asset == null && activity.assetId != null;
+    } else {
+      final asset = ref.watch(currentAssetProvider);
+      showAssetThumbnail = asset == null && activity.assetId != null;
+    }
 
     return ListTile(
       minVerticalPadding: 15,

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -1,10 +1,16 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
-import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
 
 class ActivityTile extends HookConsumerWidget {
@@ -76,24 +82,40 @@ class _ActivityTitle extends StatelessWidget {
   }
 }
 
-class _ActivityAssetThumbnail extends StatelessWidget {
+class _ActivityAssetThumbnail extends ConsumerWidget {
   final String assetId;
 
   const _ActivityAssetThumbnail(this.assetId);
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 40,
-      height: 30,
-      decoration: BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(4)),
-        image: DecorationImage(
-          image: ImmichRemoteThumbnailProvider(assetId: assetId),
-          fit: BoxFit.cover,
+  Widget build(BuildContext context, WidgetRef ref) {
+    Future<void> onAssetTapped() async {
+      final asset = await ref.read(assetServiceProvider).getRemoteAsset(assetId);
+      if (asset == null) {
+        return;
+      }
+
+      // TODO: remove this check when old timeline is removed
+      if (Store.isBetaTimelineEnabled) {
+        AssetViewer.setAsset(ref, asset);
+        final timelineService = ref.read(timelineFactoryProvider).fromAssets([asset]);
+        context.pushRoute(AssetViewerRoute(initialIndex: 0, timelineService: timelineService));
+      }
+    }
+
+    return GestureDetector(
+      onTap: onAssetTapped,
+      child: Container(
+        width: 40,
+        height: 30,
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(4)),
+          image: DecorationImage(
+            image: ImmichRemoteThumbnailProvider(assetId: assetId),
+            fit: BoxFit.cover,
+          ),
         ),
       ),
-      child: const SizedBox.shrink(),
     );
   }
 }

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
@@ -105,7 +106,7 @@ class _ActivityAssetThumbnail extends ConsumerWidget {
       // TODO: remove this check when old timeline is removed
       if (Store.isBetaTimelineEnabled) {
         AssetViewer.setAsset(ref, asset);
-        final timelineService = ref.read(timelineFactoryProvider).fromAssets([asset]);
+        final timelineService = ref.read(timelineFactoryProvider).fromAssets([asset], TimelineOrigin.activity);
         context.pushRoute(AssetViewerRoute(initialIndex: 0, timelineService: timelineService));
       }
     }

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -7,10 +7,8 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
-import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
@@ -24,16 +22,6 @@ class ActivityTile extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isLike = activity.type == ActivityType.like;
-    // Asset thumbnail is displayed when we are accessing activities from the album page
-    // currentAssetProvider will not be set until we open the gallery viewer
-    bool showAssetThumbnail = false;
-    if (Store.isBetaTimelineEnabled) {
-      final asset = ref.watch(currentAssetNotifier);
-      showAssetThumbnail = asset == null && activity.assetId != null;
-    } else {
-      final asset = ref.watch(currentAssetProvider);
-      showAssetThumbnail = asset == null && activity.assetId != null;
-    }
 
     return ListTile(
       minVerticalPadding: 15,
@@ -49,11 +37,11 @@ class ActivityTile extends HookConsumerWidget {
       title: _ActivityTitle(
         userName: activity.user.name,
         createdAt: activity.createdAt.timeAgo(),
-        leftAlign: isBottomSheet ? false : (isLike || showAssetThumbnail),
+        leftAlign: isBottomSheet ? false : (isLike || !isBottomSheet),
       ),
       // No subtitle for like, so center title
       titleAlignment: !isLike ? ListTileTitleAlignment.top : ListTileTitleAlignment.center,
-      trailing: showAssetThumbnail ? _ActivityAssetThumbnail(activity.assetId!) : null,
+      trailing: !isBottomSheet && activity.assetId != null ? _ActivityAssetThumbnail(activity.assetId!) : null,
       subtitle: !isLike ? Text(activity.comment!) : null,
     );
   }

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -1,10 +1,15 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
-import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/show_controls.provider.dart';
+import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
+import 'package:immich_mobile/repositories/asset.repository.dart';
+import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/widgets/asset_grid/asset_grid_data_structure.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
 
 class ActivityTile extends HookConsumerWidget {
@@ -15,6 +20,36 @@ class ActivityTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    Future<void> onTap() async {
+      if (activity.assetId == null) {
+        return;
+      }
+
+      final asset = await ref
+          .read(assetRepositoryProvider)
+          .getByRemoteId(activity.assetId!);
+      if (asset == null) {
+        return;
+      }
+
+      final renderList = await RenderList.fromAssets([
+        asset,
+      ], GroupAssetsBy.none);
+      final assetNotifier = ref.read(currentAssetProvider.notifier);
+      assetNotifier.set(asset);
+      if (asset.isVideo) {
+        ref.read(showControlsProvider.notifier).show = false;
+      }
+      await context.pushRoute(
+        GalleryViewerRoute(
+          initialIndex: 0,
+          heroOffset: 0,
+          renderList: renderList,
+        ),
+      );
+      assetNotifier.set(null);
+    }
+
     final asset = ref.watch(currentAssetProvider);
     final isLike = activity.type == ActivityType.like;
     // Asset thumbnail is displayed when we are accessing activities from the album page
@@ -38,8 +73,15 @@ class ActivityTile extends HookConsumerWidget {
         leftAlign: isBottomSheet ? false : (isLike || showAssetThumbnail),
       ),
       // No subtitle for like, so center title
-      titleAlignment: !isLike ? ListTileTitleAlignment.top : ListTileTitleAlignment.center,
-      trailing: showAssetThumbnail ? _ActivityAssetThumbnail(activity.assetId!) : null,
+      titleAlignment: !isLike
+          ? ListTileTitleAlignment.top
+          : ListTileTitleAlignment.center,
+      trailing: showAssetThumbnail
+          ? GestureDetector(
+              onTap: onTap,
+              child: _ActivityAssetThumbnail(activity.assetId!),
+            )
+          : null,
       subtitle: !isLike ? Text(activity.comment!) : null,
     );
   }
@@ -50,15 +92,23 @@ class _ActivityTitle extends StatelessWidget {
   final String createdAt;
   final bool leftAlign;
 
-  const _ActivityTitle({required this.userName, required this.createdAt, required this.leftAlign});
+  const _ActivityTitle({
+    required this.userName,
+    required this.createdAt,
+    required this.leftAlign,
+  });
 
   @override
   Widget build(BuildContext context) {
     final textColor = context.isDarkTheme ? Colors.white : Colors.black;
-    final textStyle = context.textTheme.bodyMedium?.copyWith(color: textColor.withValues(alpha: 0.6));
+    final textStyle = context.textTheme.bodyMedium?.copyWith(
+      color: textColor.withValues(alpha: 0.6),
+    );
 
     return Row(
-      mainAxisAlignment: leftAlign ? MainAxisAlignment.start : MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: leftAlign
+          ? MainAxisAlignment.start
+          : MainAxisAlignment.spaceBetween,
       mainAxisSize: leftAlign ? MainAxisSize.min : MainAxisSize.max,
       children: [
         Text(userName, style: textStyle, overflow: TextOverflow.ellipsis),

--- a/mobile/test/modules/activity/dismissible_activity_test.dart
+++ b/mobile/test/modules/activity/dismissible_activity_test.dart
@@ -3,11 +3,14 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
+import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/activities/activity_tile.dart';
 import 'package:immich_mobile/widgets/activities/dismissible_activity.dart';
-import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
+import 'package:isar/isar.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../fixtures/user.stub.dart';
@@ -20,8 +23,14 @@ final activity = Activity(id: '1', createdAt: DateTime(100), type: ActivityType.
 void main() {
   late MockCurrentAssetProvider assetProvider;
   late List<Override> overrides;
+  late Isar db;
 
-  setUpAll(() => TestUtils.init());
+  setUpAll(() async {
+    TestUtils.init();
+    db = await TestUtils.initIsar();
+
+    await StoreService.init(storeRepository: IsarStoreRepository(db));
+  });
 
   setUp(() {
     assetProvider = MockCurrentAssetProvider();


### PR DESCRIPTION
## Description

This PR adds the ability to open assets directly from the activity page when they are mentioned in activities (likes or comments). Previously, users could only view activities but couldn't easily navigate to the actual asset being referenced. They could only manually locate the asset in album view.

Additionally, it disables autofocus on textfield and keyboard appearance on entering the activities page. Decision was made because of two things. First, IMO, it hurts UX - leaving a comment is not the most popular action for user then opening activities view and none of the apps do this. Second, it triggers keyboard after updating activities view on entering asset viewer. 

## How Has This Been Tested?


- [x] Tapping on activity tiles with associated assets (photos and videos) opens corresponding asset
- [x] Tapping on activity tiles without associated assets (when comment added for the album itself) doesn't do anything
- [x] Asset thumbnails display correctly in activity tiles when activity page is accessed from album page
- [x] Comments and likes are shown only for current asset when activity page is accessed from asset viewer
- [x] TextField is not in focus and keyboard does not appear when activity page is accessed from album view and asset viewer.

<details><summary><h2>Video summary</h2></summary>

https://github.com/user-attachments/assets/4cd05d63-aa98-4a5a-916e-9d66cd8d48e4

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
