### PR TITLE
fix: invalid android manifest

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -171,7 +171,6 @@
     <activity android:name=".widget.configure.RandomConfigure"
       android:exported="true"
       android:theme="@style/Theme.Material3.DayNight.NoActionBar">
-      >
 
       <intent-filter>
         <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE"/>


### PR DESCRIPTION
An extra `>` was added when #19310 merged