### PR TITLE
feat(mobile): load user certificates for Android

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/HttpSSLOptionsPlugin.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/HttpSSLOptionsPlugin.kt
@@ -78,6 +78,19 @@ class HttpSSLOptionsPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
           result.success(true)
         }
 
+        "getUserCertificates" -> {
+          val userInstalledCaCertificates: List<X509Certificate> = try {
+            val keyStore = KeyStore.getInstance("AndroidCAStore")
+            keyStore.load(null, null)
+            val aliasList = keyStore.aliases().toList().filter { it.startsWith("user") }
+            aliasList.map { keyStore.getCertificate(it) as X509Certificate }
+          } catch (e: Exception) {
+            emptyList()
+          }
+          val mapOfBytes = userInstalledCaCertificates.associate { it.issuerX500Principal.name to it.encoded }
+          result.success(mapOfBytes)
+        }
+
         else -> result.notImplemented()
       }
     } catch (e: Throwable) {


### PR DESCRIPTION
## Description

Hi, I made this PR to load Android User Certificates in the Flutter HTTP Client. This is useful when using your own Root Certificate installed on your phone. The only workaround for now is to enable the Self Signed Certificate option in the App.

The code in this PR was inspired from https://github.com/jfly/flutter_user_certificates_android

## How Has This Been Tested?

I was able to run the App with this patch in the Android Emulator to validate that the Certificate was loaded and properly used.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
