### PR TITLE
chore: graceful(not) disposal(be gong) Isar

### DIFF
--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -63,7 +63,17 @@ Cancelable<T?> runInIsolateGentle<T>({
       try {
         await LogService.I.flushBuffer();
         await ref.read(driftProvider).close();
-        await ref.read(isarProvider).close();
+
+        // Close Isar safely
+        try {
+          final isar = ref.read(isarProvider);
+          if (isar.isOpen) {
+            await isar.close();
+          }
+        } catch (e) {
+          debugPrint("Error closing Isar: $e");
+        }
+
         ref.dispose();
       } catch (error) {
         debugPrint("Error closing resources in isolate: $error");


### PR DESCRIPTION
Handle the case below which crashes development build

```
flutter: Error closing resources in isolate: IsarError: Isar instance has already been closed
```

