### PR TITLE
fix: remove safe area from bottom bar

### DIFF
--- a/mobile/lib/pages/common/change_experience.page.dart
+++ b/mobile/lib/pages/common/change_experience.page.dart
@@ -2,10 +2,14 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/album/album.provider.dart';
 import 'package:immich_mobile/providers/asset.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
+import 'package:immich_mobile/providers/backup/backup.provider.dart';
+import 'package:immich_mobile/providers/backup/manual_upload.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
@@ -43,6 +47,17 @@ class _ChangeExperiencePageState extends ConsumerState<ChangeExperiencePage> {
         albumNotifier.dispose();
       }
 
+      // Cancel uploads
+      await Store.put(StoreKey.backgroundBackup, false);
+      ref.read(backupProvider.notifier).configureBackgroundBackup(
+            enabled: false,
+            onBatteryInfo: () {},
+            onError: (_) {},
+          );
+      ref.read(backupProvider.notifier).setAutoBackup(false);
+      ref.read(backupProvider.notifier).cancelBackup();
+      ref.read(manualUploadProvider.notifier).cancelBackup();
+      // Start listening to new websocket events
       ref.read(websocketProvider.notifier).stopListenToOldEvents();
       ref.read(websocketProvider.notifier).startListeningToBetaEvents();
 

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -50,31 +50,30 @@ class ViewerBottomBar extends ConsumerWidget {
           duration: Durations.short4,
           child: isSheetOpen
               ? const SizedBox.shrink()
-              : SafeArea(
-                  child: Theme(
-                    data: context.themeData.copyWith(
-                      iconTheme:
-                          const IconThemeData(size: 22, color: Colors.white),
-                      textTheme: context.themeData.textTheme.copyWith(
-                        labelLarge:
-                            context.themeData.textTheme.labelLarge?.copyWith(
-                          color: Colors.white,
-                        ),
+              : Theme(
+                  data: context.themeData.copyWith(
+                    iconTheme:
+                        const IconThemeData(size: 22, color: Colors.white),
+                    textTheme: context.themeData.textTheme.copyWith(
+                      labelLarge:
+                          context.themeData.textTheme.labelLarge?.copyWith(
+                        color: Colors.white,
                       ),
                     ),
-                    child: Container(
-                      height: asset.isVideo ? 160 : 80,
-                      color: Colors.black.withAlpha(125),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          if (asset.isVideo) const VideoControls(),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: actions,
-                          ),
-                        ],
-                      ),
+                  ),
+                  child: Container(
+                    height: context.padding.bottom + (asset.isVideo ? 160 : 80),
+                    color: Colors.black.withAlpha(125),
+                    padding: EdgeInsets.only(bottom: context.padding.bottom),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        if (asset.isVideo) const VideoControls(),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: actions,
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/video_viewer.widget.dart
@@ -27,6 +27,26 @@ import 'package:logging/logging.dart';
 import 'package:native_video_player/native_video_player.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
+bool _isCurrentAsset(
+  BaseAsset asset,
+  BaseAsset? currentAsset,
+) {
+  if (asset is RemoteAsset) {
+    return switch (currentAsset) {
+      RemoteAsset remoteAsset => remoteAsset.id == asset.id,
+      LocalAsset localAsset => localAsset.remoteId == asset.id,
+      _ => false,
+    };
+  } else if (asset is LocalAsset) {
+    return switch (currentAsset) {
+      RemoteAsset remoteAsset => remoteAsset.localId == asset.id,
+      LocalAsset localAsset => localAsset.id == asset.id,
+      _ => false,
+    };
+  }
+  return false;
+}
+
 class NativeVideoViewer extends HookConsumerWidget {
   final BaseAsset asset;
   final bool showControls;
@@ -56,7 +76,7 @@ class NativeVideoViewer extends HookConsumerWidget {
     // If the swipe is completed, `isCurrent` will be true for video B after a delay.
     // If the swipe is canceled, `currentAsset` will not have changed and video A will continue to play.
     final currentAsset = useState(ref.read(currentAssetNotifier));
-    final isCurrent = currentAsset.value == asset;
+    final isCurrent = _isCurrentAsset(asset, currentAsset.value);
 
     // Used to show the placeholder during hero animations for remote videos to avoid a stutter
     final isVisible = useState(Platform.isIOS && asset.hasLocal);


### PR DESCRIPTION
## Description

- Fixes video not playing from search results
- Fixes bottom bar padding inside the asset viewer
- Stops foreground & background when migrating to the new timeline