### PR TITLE
fix: default route permission

### DIFF
--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -459,18 +459,34 @@ describe(AuthService.name, () => {
 
       mocks.apiKey.getKey.mockResolvedValue({ ...authApiKey, user: authUser });
 
-      await expect(
-        sut.authenticate({
-          headers: { 'x-api-key': 'auth_token' },
-          queryParams: {},
-          metadata: { adminRoute: false, sharedLinkRoute: false, uri: 'test', permission: Permission.AssetRead },
-        }),
-      ).rejects.toBeInstanceOf(ForbiddenException);
+      const result = sut.authenticate({
+        headers: { 'x-api-key': 'auth_token' },
+        queryParams: {},
+        metadata: { adminRoute: false, sharedLinkRoute: false, uri: 'test', permission: Permission.AssetRead },
+      });
+
+      await expect(result).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(result).rejects.toThrow('Missing required permission: asset.read');
+    });
+
+    it('should default to requiring the all permission when omitted', async () => {
+      const authUser = factory.authUser();
+      const authApiKey = factory.authApiKey({ permissions: [Permission.AssetRead] });
+
+      mocks.apiKey.getKey.mockResolvedValue({ ...authApiKey, user: authUser });
+
+      const result = sut.authenticate({
+        headers: { 'x-api-key': 'auth_token' },
+        queryParams: {},
+        metadata: { adminRoute: false, sharedLinkRoute: false, uri: 'test' },
+      });
+      await expect(result).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(result).rejects.toThrow('Missing required permission: all');
     });
 
     it('should return an auth dto', async () => {
       const authUser = factory.authUser();
-      const authApiKey = factory.authApiKey({ permissions: [] });
+      const authApiKey = factory.authApiKey({ permissions: [Permission.All] });
 
       mocks.apiKey.getKey.mockResolvedValue({ ...authApiKey, user: authUser });
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -174,7 +174,8 @@ export class AuthService extends BaseService {
 
   async authenticate({ headers, queryParams, metadata }: ValidateRequest): Promise<AuthDto> {
     const authDto = await this.validate({ headers, queryParams });
-    const { adminRoute, sharedLinkRoute, permission, uri } = metadata;
+    const { adminRoute, sharedLinkRoute, uri } = metadata;
+    const requestedPermission = metadata.permission ?? Permission.All;
 
     if (!authDto.user.isAdmin && adminRoute) {
       this.logger.warn(`Denied access to admin only route: ${uri}`);
@@ -186,8 +187,8 @@ export class AuthService extends BaseService {
       throw new ForbiddenException('Forbidden');
     }
 
-    if (authDto.apiKey && permission && !isGranted({ requested: [permission], current: authDto.apiKey.permissions })) {
-      throw new ForbiddenException(`Missing required permission: ${permission}`);
+    if (authDto.apiKey && !isGranted({ requested: [requestedPermission], current: authDto.apiKey.permissions })) {
+      throw new ForbiddenException(`Missing required permission: ${requestedPermission}`);
     }
 
     return authDto;


### PR DESCRIPTION
Routes that don't have a specified permission, previously were accessibly via any API key, even one with specific permissions like `['asset.read']`. They now have an implied `all` permission and will throw forbidden exceptions for any key that is missing `['all']`.