### PR TITLE
fix: send correct includeArchived parameter to API when showing markers in map

### DIFF
--- a/mobile/lib/providers/map/map_marker.provider.dart
+++ b/mobile/lib/providers/map/map_marker.provider.dart
@@ -12,8 +12,8 @@ Future<List<MapMarker>> mapMarkers(Ref ref) async {
   final mapState = ref.read(mapStateNotifierProvider);
   DateTime? fileCreatedAfter;
   bool? isFavorite;
-  bool? isIncludeArchived;
-  bool? isWithPartners;
+  bool isIncludeArchived = mapState.includeArchived;
+  bool isWithPartners = mapState.withPartners;
 
   if (mapState.relativeTime != 0) {
     fileCreatedAfter =
@@ -22,14 +22,6 @@ Future<List<MapMarker>> mapMarkers(Ref ref) async {
 
   if (mapState.showFavoriteOnly) {
     isFavorite = true;
-  }
-
-  if (mapState.includeArchived) {
-    isIncludeArchived = true;
-  }
-
-  if (mapState.withPartners) {
-    isWithPartners = true;
   }
 
   final markers = await service.getMapMarkers(

--- a/mobile/lib/providers/map/map_marker.provider.dart
+++ b/mobile/lib/providers/map/map_marker.provider.dart
@@ -24,8 +24,8 @@ Future<List<MapMarker>> mapMarkers(Ref ref) async {
     isFavorite = true;
   }
 
-  if (!mapState.includeArchived) {
-    isIncludeArchived = false;
+  if (mapState.includeArchived) {
+    isIncludeArchived = true;
   }
 
   if (mapState.withPartners) {

--- a/mobile/lib/providers/map/map_marker.provider.g.dart
+++ b/mobile/lib/providers/map/map_marker.provider.g.dart
@@ -6,7 +6,7 @@ part of 'map_marker.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$mapMarkersHash() => r'f33ac4baa3251b3f06423aece89673315966f885';
+String _$mapMarkersHash() => r'a0c129fcddbf1b9bce4aafcd2e47a858ab6ef1c9';
 
 /// See also [mapMarkers].
 @ProviderFor(mapMarkers)

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -189,7 +189,7 @@
 
     return await getMapMarkers(
       {
-        isArchived: includeArchived && undefined,
+        isArchived: includeArchived || undefined,
         isFavorite: onlyFavorites || undefined,
         fileCreatedAfter: fileCreatedAfter || undefined,
         fileCreatedBefore,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # 19640. On both web and mobile, the parameter `includeArchived` was never being set to `true` when calling the `/map/markers` API, regardless of user settings.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Have at least one archived photo with location data. Then:

- [x] On web, go to Map, open map settings, and toggle "Include archived". Archived photo(s) now appear.
- [x] On mobile, go to Library -> Places and click on the map. Open map settings and toggle "Include Archived". Archived photo(s) now appear.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

### Web

Archived image:

<img width="1001" height="962" alt="image" src="https://github.com/user-attachments/assets/020fd36d-613e-4e77-9c1d-0f53238a9868" />

Map without include archived:

<img width="1460" height="896" alt="image" src="https://github.com/user-attachments/assets/ba18a725-3ac0-4d29-aa6e-baa0ec3416f8" />

Map with include archived:

<img width="1460" height="896" alt="image" src="https://github.com/user-attachments/assets/f599a099-27c2-42c9-b60f-8727440bb951" />

### Mobile

Archived image:

<img width="647" height="501" alt="image" src="https://github.com/user-attachments/assets/916f2cae-0136-4b84-9fc0-321c80c45898" />

Map without include archived:

<img width="637" height="880" alt="image" src="https://github.com/user-attachments/assets/759f23a5-fdbf-455d-b6ff-db97aa6791a2" />

Map with include archived:

<img width="637" height="880" alt="image" src="https://github.com/user-attachments/assets/bff96afc-408d-4d77-a75f-2510100e57dd" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
