### PR TITLE
fix(mobile): restore backup selection search bar

### DIFF
--- a/mobile/lib/pages/backup/backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/backup_album_selection.page.dart
@@ -22,7 +22,12 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
     final enableSyncUploadAlbum =
         useAppSettingsState(AppSettingsEnum.syncAlbums);
     final isDarkTheme = context.isDarkTheme;
-    final albums = ref.watch(backupProvider).availableAlbums;
+    final allAlbums = ref.watch(backupProvider).availableAlbums;
+
+    // Albums which are displayed to the user
+    // by filtering out based on search
+    final filteredAlbums = useState(allAlbums);
+    final albums = filteredAlbums.value;
 
     useEffect(
       () {
@@ -146,6 +151,48 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
           ),
         );
       }).toSet();
+    }
+
+    buildSearchBar() {
+      return Padding(
+        padding: const EdgeInsets.only(left: 16.0, right: 16, bottom: 8.0),
+        child: TextFormField(
+          onChanged: (searchValue) {
+            if (searchValue.isEmpty) {
+              filteredAlbums.value = allAlbums;
+            } else {
+              filteredAlbums.value = allAlbums
+                  .where(
+                    (album) => album.name
+                        .toLowerCase()
+                        .contains(searchValue.toLowerCase()),
+                  )
+                  .toList();
+            }
+          },
+          decoration: InputDecoration(
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 8.0,
+              vertical: 8.0,
+            ),
+            hintText: "Search",
+            hintStyle: TextStyle(
+              color: isDarkTheme ? Colors.white : Colors.grey,
+              fontSize: 14.0,
+            ),
+            prefixIcon: const Icon(
+              Icons.search,
+              color: Colors.grey,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(10),
+              borderSide: BorderSide.none,
+            ),
+            filled: true,
+            fillColor: isDarkTheme ? Colors.white30 : Colors.grey[200],
+          ),
+        ),
+      );
     }
 
     handleSyncAlbumToggle(bool isEnable) async {
@@ -279,7 +326,7 @@ class BackupAlbumSelectionPage extends HookConsumerWidget {
                   ),
                 ),
 
-                // buildSearchBar(),
+                buildSearchBar(),
               ],
             ),
           ),


### PR DESCRIPTION
## Description

Fixes #6164, pretty much just reverts https://github.com/immich-app/immich/pull/5655

## How Has This Been Tested?

- Setup new blank instance of immich
- Connect to instance with app
- Navigate to backup selection screen
- Type stuff into search bar to filter albums to select
- Select a few albums
- Click `Start Backup` to ensure the selected albums actually get backed up




<details><summary><h2>Screenshots (if appropriate)</h2></summary>

![Screenshot_20250723-170529](https://github.com/user-attachments/assets/feaaad95-169d-4ae7-a2a9-c1744b277de2)
![Screenshot_20250723-170705](https://github.com/user-attachments/assets/38559cff-d509-4696-8815-a1b3736601fe)
![Screenshot_20250723-170845](https://github.com/user-attachments/assets/e0876c5d-9e97-4ffe-90e2-d1a075a3aad0)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
