### PR TITLE
feat(cli): add ability to replace external library images from upload

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -47,6 +47,8 @@ program
   .addOption(new Option('-i, --ignore <pattern>', 'Pattern to ignore').env('IMMICH_IGNORE_PATHS'))
   .addOption(new Option('-h, --skip-hash', "Don't hash files before upload").env('IMMICH_SKIP_HASH').default(false))
   .addOption(new Option('-H, --include-hidden', 'Include hidden folders').env('IMMICH_INCLUDE_HIDDEN').default(false))
+  .addOption(new Option('-R, --replace-assets', 'Replace with upload').env('IMMICH_REPLACE_ASSETS').default(false))
+  .addOption(new Option('-P, --replace-path <prefixes>', 'Replace local path prefix').env('IMMICH_REPLACE_PATH'))
   .addOption(
     new Option('-a, --album', 'Automatically create albums based on folder name')
       .env('IMMICH_AUTO_CREATE_ALBUM')


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
I have added two flags to the CLI `upload` subcommand: `--replace-path` and `--replace-assets`. (I don't particularly love those flag names, but I couldn't think of better ones)

`--replace-path` adds an extra duplicates check for external libraries using the [`getAssetsByOriginalPath`](https://immich.app/docs/api/get-assets-by-original-path) api. It expects two absolute paths (prefixes), local and server. It groups up files by their `dirname`, replaces the local prefix with the server prefix, and searches for filename matches.

`--replace-assets` adds an optional step in the upload process to upload the duplicates as replacements for the matched asset id using the [`replaceAsset`](https://immich.app/docs/api/replace-asset) api.

<!--- Why is this change required? What problem does it solve? -->

While these two flags are seemingly unrelated features, my goal with this change was to "import" the photos from my external library such that they become managed by immich and I can consolidate my photo storage. If this should rather be two separate pull requests, I'd be glad to split them up and resubmit the changes.

<!--- If it fixes an open issue, please link to the issue here. -->

I have briefly searched for similar issue/feature request, but I couldn't find any and did not spend too much time on it.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I have a folder at `/mnt/media/pictures` with a series of folders where each folder is an album of photos:

```
2011.02.07 - Aquarium
2012.05.18 - Ainsworth
2013.08.23 - Yellowstone
2014.05.17 - New Denver
2015.03.14 - Leavenworth
...
```

Then I mounted that folder as `/data/import/pictures` on my immich docker container and added it as an external library.

Then in a host shell (outside of docker)

```
find /mnt/media/pictures -type d | while read -r album; do node dist/index.js upload -a -c 5 --recursive --replace-path /mnt/media:/data/import --replace-assets "$album"; done
```

This goes through each album folder and replaces each external library asset with an uploaded asset (managed by immich).

The folder I tested has around 15k photos over ~100 albums.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="901" height="597" alt="image" src="https://github.com/user-attachments/assets/bc63ca26-2e48-4c29-bb16-affdbe54b1f7" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

There are a couple more changes I would add to make this better (ex. only replacing external library assets instead of all duplicates), but this was sufficient for my purposes and I wasn't sure if this would be accepted so I didn't put more work than necessary. If there's any additional work that should be done to get this merged, I'd be happy to do it.