### PR TITLE
fix: add missing `await`s when changing client certificate

### DIFF
--- a/mobile/lib/entities/store.entity.dart
+++ b/mobile/lib/entities/store.entity.dart
@@ -13,11 +13,11 @@ class SSLClientCertStoreVal {
 
   const SSLClientCertStoreVal(this.data, this.password);
 
-  void save() {
+  Future<void> save() async {
     final b64Str = base64Encode(data);
-    Store.put(StoreKey.sslClientCertData, b64Str);
+    await Store.put(StoreKey.sslClientCertData, b64Str);
     if (password != null) {
-      Store.put(StoreKey.sslClientPasswd, password!);
+      await Store.put(StoreKey.sslClientPasswd, password!);
     }
   }
 
@@ -31,8 +31,8 @@ class SSLClientCertStoreVal {
     return SSLClientCertStoreVal(certData, passwd);
   }
 
-  static void delete() {
-    Store.delete(StoreKey.sslClientCertData);
-    Store.delete(StoreKey.sslClientPasswd);
+  static Future<void> delete() async {
+    await Store.delete(StoreKey.sslClientCertData);
+    await Store.delete(StoreKey.sslClientPasswd);
   }
 }

--- a/mobile/lib/widgets/settings/ssl_client_cert_settings.dart
+++ b/mobile/lib/widgets/settings/ssl_client_cert_settings.dart
@@ -61,7 +61,7 @@ class _SslClientCertSettingsState extends State<SslClientCertSettings> {
                 width: 15,
               ),
               ElevatedButton(
-                onPressed: widget.isLoggedIn || !isCertExist ? null : () => removeCert(context),
+                onPressed: widget.isLoggedIn || !isCertExist ? null : () async => await removeCert(context),
                 child: Text("remove".tr()),
               ),
             ],
@@ -86,7 +86,11 @@ class _SslClientCertSettingsState extends State<SslClientCertSettings> {
     );
   }
 
-  void storeCert(BuildContext context, Uint8List data, String? password) {
+  Future<void> storeCert(
+    BuildContext context,
+    Uint8List data,
+    String? password,
+  ) async {
     if (password != null && password.isEmpty) {
       password = null;
     }
@@ -100,7 +104,7 @@ class _SslClientCertSettingsState extends State<SslClientCertSettings> {
       showMessage(context, "client_cert_invalid_msg".tr());
       return;
     }
-    cert.save();
+    await cert.save();
     HttpSSLOptions.apply();
     setState(
       () => isCertExist = true,
@@ -124,7 +128,7 @@ class _SslClientCertSettingsState extends State<SslClientCertSettings> {
         ),
         actions: [
           TextButton(
-            onPressed: () => {ctx.pop(), storeCert(context, data, password.text)},
+            onPressed: () async => {ctx.pop(), await storeCert(context, data, password.text)},
             child: Text("client_cert_dialog_msg_confirm".tr()),
           ),
         ],
@@ -147,8 +151,8 @@ class _SslClientCertSettingsState extends State<SslClientCertSettings> {
     }
   }
 
-  void removeCert(BuildContext context) {
-    SSLClientCertStoreVal.delete();
+  Future<void> removeCert(BuildContext context) async {
+    await SSLClientCertStoreVal.delete();
     HttpSSLOptions.apply();
     setState(
       () => isCertExist = false,


### PR DESCRIPTION
I ran into this while testing out
<https://github.com/immich-app/immich/pull/19830>. When I add, change, or remove a client certificate under Immich's advanced settings, the change wouldn't take effect until some mysterious point in the future. For example:

1. Add a client certificate. It doesn't get used.
2. Remove certificate. *Now* the client certificate from step 1) is used.
3. Restart application. Now no client certificate is used.

This all boils down to some missing `await`s. The user would change the cert, and we'd start asynchronously saving it to the store, and while the save is still happening, [`HttpSSLOptions` pulls the "old" value out of `SSLClientCertStoreVal`](https://github.com/immich-app/immich/blob/v1.136.0/mobile/lib/utils/http_ssl_options.dart#L30).

With the appropriate `await`s, this behaves much more sanely.