### PR TITLE
docs: Add config example for Authelia

### DIFF
--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -64,7 +64,7 @@ Once you have a new OAuth client application configured, Immich can be configure
 | Storage Label Claim                                  | string  | preferred_username   | Claim mapping for the user's storage label**¹**                                     |
 | Role Claim                                           | string  | immich_role          | Claim mapping for the user's role. (should return "user" or "admin")**¹**           |
 | Storage Quota Claim                                  | string  | immich_quota         | Claim mapping for the user's storage**¹**                                           |
-| Default Storage Quota (GiB)                          | number  | 0                    | Default quota for user without storage quota claim (Enter 0 for unlimited quota)    |
+| Default Storage Quota (GiB)                          | number  | 0                    | Default quota for user without storage quota claim (empty for unlimited quota)      |
 | Button Text                                          | string  | Login with OAuth     | Text for the OAuth button on the web                                                |
 | Auto Register                                        | boolean | true                 | When true, will automatically register a user the first time they sign in           |
 | [Auto Launch](#auto-launch)                          | boolean | false                | When true, will skip the login page and automatically start the OAuth login process |
@@ -107,6 +107,89 @@ Immich has a route (`/api/oauth/mobile-redirect`) that is already configured to 
 ## Example Configuration
 
 <details>
+<summary>Authelia Example</summary>
+
+### Authelia Example
+
+Here's an example of OAuth configured for Authelia:
+
+This assumes there exist an attribute `immichquota` in the user schema, which is used to set the user's storage quota in Immich.
+The configuration concerning the quota is optional.
+
+```yaml
+authentication_backend:
+  ldap:
+    # The LDAP server configuration goes here.
+    # See: https://www.authelia.com/c/ldap
+    attributes:
+      extra:
+        immichquota: # The attribute name from LDAP
+          name: 'immich_quota'
+          multi_valued: false
+          value_type: 'integer'
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    claims_policies:
+      immich_policy:
+        custom_claims:
+          immich_quota:
+            attribute: 'immich_quota'
+    scopes:
+      immich_scope:
+        claims:
+          - 'immich_quota'
+
+    clients:
+      - client_id: 'immich'
+        client_name: 'Immich'
+        # https://www.authelia.com/integration/openid-connect/frequently-asked-questions/#how-do-i-generate-a-client-identifier-or-client-secret
+        client_secret: $pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'
+        public: false
+        require_pkce: false
+        redirect_uris:
+          - 'https://example.immich.app/auth/login'
+          - 'https://example.immich.app/user-settings'
+          - 'app.immich:///oauth-callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'immich_scope'
+        claims_policy: 'immich_policy'
+        response_types:
+          - 'code'
+        grant_types:
+          - 'authorization_code'
+        id_token_signed_response_alg: 'RS256'
+        userinfo_signed_response_alg: 'RS256'
+        token_endpoint_auth_method: 'client_secret_post'
+```
+
+Configuration of OAuth in Immich System Settings
+
+| Setting                            | Value                                                               |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| Issuer URL                         | `https://example.immich.app/.well-known/openid-configuration`       |
+| Client ID                          | immich                                                              |
+| Client Secret                      | 0v89FXkQOWO\***\*\*\*\*\***\*\*\***\*\*\*\*\***mprbvXD549HH6s1iw... |
+| Token Endpoint Auth Method         | client_secret_post                                                  |
+| Scope                              | openid email profile immich_scope                                   |
+| ID Token Signed Response Algorithm | RS256                                                               |
+| Userinfo Signed Response Algorithm | RS256                                                               |
+| Storage Label Claim                | uid                                                                 |
+| Storage Quota Claim                | immich_quota                                                        |
+| Default Storage Quota (GiB)        | 0 (empty for unlimited quota)                                       |
+| Button Text                        | Sign in with Authelia (optional)                                    |
+| Auto Register                      | Enabled (optional)                                                  |
+| Auto Launch                        | Enabled (optional)                                                  |
+| Mobile Redirect URI Override       | Disable                                                             |
+| Mobile Redirect URI                |                                                                     |
+
+</details>
+
+<details>
 <summary>Authentik Example</summary>
 
 ### Authentik Example
@@ -128,7 +211,7 @@ Configuration of OAuth in Immich System Settings
 | Signing Algorithm            | RS256                                                                              |
 | Storage Label Claim          | preferred_username                                                                 |
 | Storage Quota Claim          | immich_quota                                                                       |
-| Default Storage Quota (GiB)  | 0 (0 for unlimited quota)                                                          |
+| Default Storage Quota (GiB)  | 0 (empty for unlimited quota)                                                      |
 | Button Text                  | Sign in with Authentik (optional)                                                  |
 | Auto Register                | Enabled (optional)                                                                 |
 | Auto Launch                  | Enabled (optional)                                                                 |
@@ -159,7 +242,7 @@ Configuration of OAuth in Immich System Settings
 | Signing Algorithm            | RS256                                                                        |
 | Storage Label Claim          | preferred_username                                                           |
 | Storage Quota Claim          | immich_quota                                                                 |
-| Default Storage Quota (GiB)  | 0 (0 for unlimited quota)                                                    |
+| Default Storage Quota (GiB)  | 0 (empty for unlimited quota)                                                |
 | Button Text                  | Sign in with Google (optional)                                               |
 | Auto Register                | Enabled (optional)                                                           |
 | Auto Launch                  | Enabled                                                                      |


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The configuration provided by [Authelia](https://www.authelia.com/integration/openid-connect/immich/#authelia) works, but lacks information about quota.

Secondly, zero is not used as "unlimited" quota sentinel value anymore.

`immich_role` configuration is omitted as I don't use it in my setup. Something similar to the configuration for the quota would be needed. This would also make further assumptions about the LDAP setup.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested on my own setup

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
