### PR TITLE
feat: view the user's app version on the User Management page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -446,6 +446,7 @@
   "app_bar_signout_dialog_ok": "Yes",
   "app_bar_signout_dialog_title": "Sign out",
   "app_settings": "App Settings",
+  "app_version": "App version",
   "appears_in": "Appears in",
   "archive": "Archive",
   "archive_action_prompt": "{count} added to Archive",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -15957,6 +15957,11 @@
       },
       "UserAdminResponseDto": {
         "properties": {
+          "appVersion": {
+            "description": "Latest app version from mobile app User-Agent header",
+            "nullable": true,
+            "type": "string"
+          },
           "avatarColor": {
             "allOf": [
               {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -88,6 +88,7 @@ export type UserLicense = {
     licenseKey: string;
 };
 export type UserAdminResponseDto = {
+    appVersion?: string | null;
     avatarColor: UserAvatarColor;
     createdAt: string;
     deletedAt: string | null;

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -28,11 +28,13 @@ export class AuthController {
 
   @Post('login')
   async login(
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
     @Body() loginCredential: LoginCredentialDto,
     @GetLoginDetails() loginDetails: LoginDetails,
   ): Promise<LoginResponseDto> {
-    const body = await this.service.login(loginCredential, loginDetails);
+    const userAgent = req.headers['user-agent'] as string | undefined;
+    const body = await this.service.login(loginCredential, loginDetails, userAgent);
     return respondWithCookie(res, body, {
       isSecure: loginDetails.isSecure,
       values: [

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -23,6 +23,7 @@ export type AuthUser = {
   email: string;
   quotaUsageInBytes: number;
   quotaSizeInBytes: number | null;
+  appVersion?: string | null;
 };
 
 export type AlbumUser = {

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -166,9 +166,13 @@ export class UserAdminResponseDto extends UserResponseDto {
   @ValidateEnum({ enum: UserStatus, name: 'UserStatus' })
   status!: string;
   license!: UserLicense | null;
+  @ApiProperty({ type: 'string', required: false, description: 'Latest app version from mobile app User-Agent header' })
+  appVersion?: string | null;
 }
 
-export function mapUserAdmin(entity: UserAdmin): UserAdminResponseDto {
+type UserAdminWithAppVersion = UserAdmin & { appVersion?: string | null };
+
+export function mapUserAdmin(entity: UserAdminWithAppVersion): UserAdminResponseDto {
   const metadata = entity.metadata || [];
   const license = metadata.find(
     (item): item is UserMetadataItem<UserMetadataKey.License> => item.key === UserMetadataKey.License,
@@ -186,5 +190,6 @@ export function mapUserAdmin(entity: UserAdmin): UserAdminResponseDto {
     quotaUsageInBytes: entity.quotaUsageInBytes,
     status: entity.status,
     license: license ? { ...license, activatedAt: new Date(license?.activatedAt) } : null,
+    appVersion: (entity as any).appVersion ?? null,
   };
 }

--- a/server/src/migrations/20250725-add-app-version-to-user.ts
+++ b/server/src/migrations/20250725-add-app-version-to-user.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAppVersionToUser20250725 implements MigrationInterface {
+  name = 'AddAppVersionToUser20250725';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD COLUMN "appVersion" character varying NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "appVersion"`);
+  }
+}

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -53,7 +53,7 @@ export class UserRepository {
 
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .select(withMetadata)
       .where('user.id', '=', userId)
       .$if(!options.withDeleted, (eb) => eb.where('user.deletedAt', 'is', null))
@@ -72,7 +72,7 @@ export class UserRepository {
   getAdmin() {
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .select(withMetadata)
       .where('user.isAdmin', '=', true)
       .where('user.deletedAt', 'is', null)
@@ -125,7 +125,7 @@ export class UserRepository {
   getByEmail(email: string, options?: { withPassword?: boolean }) {
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .select(withMetadata)
       .$if(!!options?.withPassword, (eb) => eb.select('password'))
       .where('email', '=', email)
@@ -137,7 +137,7 @@ export class UserRepository {
   getByStorageLabel(storageLabel: string) {
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .where('user.storageLabel', '=', storageLabel)
       .where('user.deletedAt', 'is', null)
       .executeTakeFirst();
@@ -147,7 +147,7 @@ export class UserRepository {
   getByOAuthId(oauthId: string) {
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .select(withMetadata)
       .where('user.oauthId', '=', oauthId)
       .where('user.deletedAt', 'is', null)
@@ -166,7 +166,7 @@ export class UserRepository {
   getList({ id, withDeleted }: UserListFilter = {}) {
     return this.db
       .selectFrom('user')
-      .select(columns.userAdmin)
+      .select([...columns.userAdmin, 'user.appVersion'])
       .select(withMetadata)
       .$if(!withDeleted, (eb) => eb.where('user.deletedAt', 'is', null))
       .$if(!!id, (eb) => eb.where('user.id', '=', id!))
@@ -178,7 +178,7 @@ export class UserRepository {
     return this.db
       .insertInto('user')
       .values(dto)
-      .returning(columns.userAdmin)
+      .returning([...columns.userAdmin, 'user.appVersion'])
       .returning(withMetadata)
       .executeTakeFirstOrThrow();
   }
@@ -189,7 +189,7 @@ export class UserRepository {
       .set(dto)
       .where('user.id', '=', asUuid(id))
       .where('user.deletedAt', 'is', null)
-      .returning(columns.userAdmin)
+      .returning([...columns.userAdmin, 'user.appVersion'])
       .returning(withMetadata)
       .executeTakeFirstOrThrow();
   }
@@ -199,7 +199,7 @@ export class UserRepository {
       .updateTable('user')
       .set({ status: UserStatus.Active, deletedAt: null })
       .where('user.id', '=', asUuid(id))
-      .returning(columns.userAdmin)
+      .returning([...columns.userAdmin, 'user.appVersion'])
       .returning(withMetadata)
       .executeTakeFirstOrThrow();
   }

--- a/server/src/schema/migrations/1753448439844-AddAppVersionToUser20250725.ts
+++ b/server/src/schema/migrations/1753448439844-AddAppVersionToUser20250725.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ADD "appVersion" character varying;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" DROP COLUMN "appVersion";`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -37,6 +37,9 @@ export class UserTable {
   @Column({ nullable: true })
   pinCode!: string | null;
 
+  @Column({ nullable: true, default: null })
+  appVersion!: string | null;
+
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -61,7 +61,9 @@ export class AuthService extends BaseService {
       throw new UnauthorizedException('Password login has been disabled');
     }
 
-    let user = await this.userRepository.getByEmail(dto.email, { withPassword: true }) as (UserAdmin & { password?: string | null; appVersion?: string | null }) | undefined;
+    let user = (await this.userRepository.getByEmail(dto.email, { withPassword: true })) as
+      | (UserAdmin & { password?: string | null; appVersion?: string | null })
+      | undefined;
     if (user && user.password) {
       const isAuthenticated = this.validateSecret(dto.password, user.password);
       if (!isAuthenticated) {

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -90,6 +90,7 @@ export const controllerSetup = async (controller: ClassConstructor<unknown>, pro
       { provide: APP_GUARD, useClass: AuthGuard },
       { provide: LoggingRepository, useValue: LoggingRepository.create() },
       { provide: AuthService, useValue: { authenticate: vi.fn() } },
+      { provide: UserRepository, useValue: { update: vi.fn() } },
       ...providers,
     ],
   })

--- a/web/src/routes/admin/users/+page.svelte
+++ b/web/src/routes/admin/users/+page.svelte
@@ -96,6 +96,7 @@
             >
             <th class="hidden sm:block w-3/12 text-center text-sm font-medium">{$t('name')}</th>
             <th class="hidden xl:block w-3/12 2xl:w-2/12 text-center text-sm font-medium">{$t('has_quota')}</th>
+            <th class="hidden md:block w-2/12 text-center text-sm font-medium">{$t('app_version')}</th>
             <th class="w-4/12 lg:w-3/12 xl:w-2/12 text-center text-sm font-medium">{$t('action')}</th>
           </tr>
         </thead>
@@ -119,6 +120,9 @@
                       <Icon path={mdiInfinity} size="16" />
                     {/if}
                   </div>
+                </td>
+                <td class="hidden md:block w-2/12 text-ellipsis break-all px-2 text-sm">
+                  {immichUser.appVersion ?? '-'}
                 </td>
                 <td
                   class="flex flex-row flex-wrap justify-center gap-x-2 gap-y-1 w-4/12 lg:w-3/12 xl:w-2/12 text-ellipsis break-all text-sm"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds information for the system administrator about which version each user is currently using. This is updated every time the user accesses one of the Android or iPhone mobile applications only by information coming from the User-Agent header.

This change also adds a **new database column** called appVersion to store the information for each user.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I tried accessing the app for Android and the app for iPhone and saw that the version is updated on the User Management page even if a version update is made to the app and even if the user accesses it.
To ensure that the latest version is always displayed for each user, it updates the App version every time a request is sent to the server by the user from one of the mobile applications.

I tried accessing from the browser and making sure that it does not affect the App version on the User Management page
Although it is not possible to access with port 2283 as we access from the app (I am not sure if this makes any difference at all?), I was able to connect with port 3000 as we access on the computer and verify that the App version did not change as expected.

Full disclosure: I'm not good with typescript but immich was an inspiration for me to start learning TS so I hope what's here is good enough.
Yes I had to use ML to solve some problems along the way and work with regex and kysely so I hope it's not too bad.
I tried to do all the testing to make sure it would be good enough :)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="892" height="302" alt="image" src="https://github.com/user-attachments/assets/c612da02-de2f-42c9-bab8-cae0a61fdfbc" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code (I hope so.)
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
