### PR TITLE
fix(mobile): distinguish backup settings title from 'backup_controller_page_backup' translation entry

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -511,6 +511,7 @@
   "back_close_deselect": "Back, close, or deselect",
   "background_location_permission": "Background location permission",
   "background_location_permission_content": "In order to switch networks when running in the background, Immich must *always* have precise location access so the app can read the Wi-Fi network's name",
+  "backup": "Backup",
   "backup_album_selection_page_albums_device": "Albums on device ({count})",
   "backup_album_selection_page_albums_tap": "Tap to include, double tap to exclude",
   "backup_album_selection_page_assets_scatter": "Assets can scatter across multiple albums. Thus, albums can be included or excluded during the backup process.",

--- a/mobile/lib/pages/common/settings.page.dart
+++ b/mobile/lib/pages/common/settings.page.dart
@@ -34,7 +34,7 @@ enum SettingSection {
     "asset_viewer_settings_subtitle",
   ),
   backup(
-    'backup_controller_page_backup',
+    'backup',
     Icons.cloud_upload_outlined,
     "backup_setting_subtitle",
   ),


### PR DESCRIPTION
## Description

Different translation in some languages like in French ('Sauvegarde' for title, otherwise 'Sauvegardé').

## How Has This Been Tested?

N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
