### PR TITLE
fix(mobile): beta search page improvements

### DIFF
--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -652,7 +652,7 @@ class DriftSearchPage extends HookConsumerWidget {
       body: CustomScrollView(
         slivers: [
           SliverPadding(
-            padding: const EdgeInsets.only(top: 12.0),
+            padding: const EdgeInsets.only(top: 12.0, bottom: 4.0),
             sliver: SliverToBoxAdapter(
               child: SizedBox(
                 height: 50,

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -49,6 +49,7 @@ class Timeline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: LayoutBuilder(
         builder: (_, constraints) => ProviderScope(
           overrides: [


### PR DESCRIPTION
## Description

timeline does not get messed up by keyboard anymore, fixed padding on filter chips

Fixes #20169
<img width="1290" height="2796" alt="simulator_screenshot_6062A7B1-754A-42E2-ABF2-FA69DC2E9ABE" src="https://github.com/user-attachments/assets/238ce24c-6941-4f6d-b69d-5fb88a359a42" />

