### PR TITLE
fix: remainder backup count

### DIFF
--- a/mobile/lib/infrastructure/repositories/backup.repository.dart
+++ b/mobile/lib/infrastructure/repositories/backup.repository.dart
@@ -63,13 +63,14 @@ class DriftBackupRepository extends DriftDatabaseRepository {
         ),
         leftOuterJoin(
           _db.remoteAssetEntity,
-          _db.localAssetEntity.checksum.equalsExp(_db.remoteAssetEntity.checksum),
+          _db.localAssetEntity.checksum.equalsExp(_db.remoteAssetEntity.checksum) &
+              _db.remoteAssetEntity.ownerId.equals(userId),
           useColumns: false,
         ),
       ])
       ..where(
         _db.localAlbumEntity.backupSelection.equalsValue(BackupSelection.selected) &
-            (_db.remoteAssetEntity.id.isNull() | _db.remoteAssetEntity.ownerId.equals(userId).not()) &
+            _db.remoteAssetEntity.id.isNull() &
             _db.localAlbumAssetEntity.assetId.isNotInQuery(_getExcludedSubquery()),
       );
 


### PR DESCRIPTION
Fixes the issue where the query was finding assets that were either not backed up or backed up by someone else, which included assets that are from partners users

Fixes #20195