### PR TITLE
fix(mobile): Fix a typo in SyncStreamService Logging

### DIFF
--- a/mobile/lib/domain/services/sync_stream.service.dart
+++ b/mobile/lib/domain/services/sync_stream.service.dart
@@ -25,7 +25,7 @@ class SyncStreamService {
   bool get isCancelled => _cancelChecker?.call() ?? false;
 
   Future<void> sync() {
-    _logger.info("Remote sync request for userr");
+    _logger.info("Remote sync request for user");
     DLog.log("Remote sync request for user");
     // Start the sync stream and handle events
     return _syncApiRepository.streamChanges(_handleEvents);


### PR DESCRIPTION
## Description

Fix a typo in SyncStreamService Logging.
Changed "userr" to "user".