### PR TITLE
fix(mobile): places search not working in beta version

### DIFF
--- a/mobile/lib/presentation/pages/drift_place.page.dart
+++ b/mobile/lib/presentation/pages/drift_place.page.dart
@@ -22,12 +22,17 @@ class DriftPlacePage extends StatelessWidget {
     final ValueNotifier<String?> search = ValueNotifier(null);
 
     return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          _PlaceSliverAppBar(search: search),
-          _Map(search: search, currentLocation: currentLocation),
-          _PlaceList(search: search),
-        ],
+      body: ValueListenableBuilder(
+        valueListenable: search,
+        builder: (context, searchValue, child) {
+          return CustomScrollView(
+            slivers: [
+              _PlaceSliverAppBar(search: search),
+              _Map(search: search, currentLocation: currentLocation),
+              _PlaceList(search: search),
+            ],
+          );
+        },
       ),
     );
   }
@@ -104,7 +109,9 @@ class _Map extends StatelessWidget {
               ),
             ),
           )
-        : const SizedBox.shrink();
+        : const SliverToBoxAdapter(
+            child: SizedBox.shrink(),
+          );
   }
 }
 


### PR DESCRIPTION
## Description
Fixed the search feature in the Places page of the beta app (`drift_place_page`).

`ValueListenableBuilder` was missing, so the UI wasn't listening to changes to `search`, and the search icon in the app-bar would do nothing.