### PR TITLE
feat: improvements of thumbnail animations

### DIFF
--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/constants/constants.dart';
-import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/duration_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/widgets/common/immich_thumbnail.dart';
@@ -47,21 +47,11 @@ class ThumbnailImage extends StatelessWidget {
 
     return Stack(
       children: [
+        Container(color: canDeselect ? assetContainerColor : Colors.grey),
         AnimatedContainer(
           duration: const Duration(milliseconds: 300),
           curve: Curves.decelerate,
-          decoration: BoxDecoration(
-            border: multiselectEnabled && isSelected
-                ? canDeselect
-                      ? Border.all(color: assetContainerColor, width: 8)
-                      : const Border(
-                          top: BorderSide(color: Colors.grey, width: 8),
-                          right: BorderSide(color: Colors.grey, width: 8),
-                          bottom: BorderSide(color: Colors.grey, width: 8),
-                          left: BorderSide(color: Colors.grey, width: 8),
-                        )
-                : const Border(),
-          ),
+          padding: EdgeInsets.all(multiselectEnabled && isSelected ? 8 : 0),
           child: Stack(
             children: [
               _ImageIcon(
@@ -80,13 +70,30 @@ class ThumbnailImage extends StatelessWidget {
             ],
           ),
         ),
-        if (multiselectEnabled)
-          isSelected
-              ? const Padding(
-                  padding: EdgeInsets.all(3.0),
-                  child: Align(alignment: Alignment.topLeft, child: _SelectedIcon()),
-                )
-              : const Icon(Icons.circle_outlined, color: Colors.white),
+        TweenAnimationBuilder<double>(
+          tween: Tween<double>(begin: 0.0, end: multiselectEnabled ? 1.0 : 0.0),
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.decelerate,
+          builder: (context, value, child) {
+            final double outlineCircleScale = 0.6 + (0.4 * value);
+            return Padding(
+              padding: EdgeInsets.all(isSelected ? value * 3.0 : 3.0),
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: Opacity(
+                  opacity: isSelected ? 1 : value,
+                  child: Transform.scale(
+                    scale: isSelected ? value : outlineCircleScale,
+                    alignment: isSelected ? Alignment.topLeft : Alignment.center,
+                    child: isSelected
+                        ? const _SelectedIcon()
+                        : Icon(Icons.circle_outlined, color: Colors.white.withValues(alpha: 0.8)),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
       ],
     );
   }
@@ -247,13 +254,14 @@ class _ImageIcon extends StatelessWidget {
       ),
     );
 
-    if (!multiselectEnabled || !isSelected) {
-      return image;
-    }
-
-    return DecoratedBox(
-      decoration: canDeselect ? BoxDecoration(color: assetContainerColor) : const BoxDecoration(color: Colors.grey),
-      child: ClipRRect(borderRadius: const BorderRadius.all(Radius.circular(15.0)), child: image),
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0.0, end: (multiselectEnabled && isSelected) ? 15.0 : 0.0),
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.decelerate,
+      builder: (context, value, child) {
+        return ClipRRect(borderRadius: BorderRadius.all(Radius.circular(value)), child: child);
+      },
+      child: image,
     );
   }
 }

--- a/mobile/lib/widgets/asset_grid/thumbnail_image.dart
+++ b/mobile/lib/widgets/asset_grid/thumbnail_image.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/constants/constants.dart';
-import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/extensions/duration_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/widgets/common/immich_thumbnail.dart';
@@ -47,11 +47,21 @@ class ThumbnailImage extends StatelessWidget {
 
     return Stack(
       children: [
-        Container(color: canDeselect ? assetContainerColor : Colors.grey),
         AnimatedContainer(
           duration: const Duration(milliseconds: 300),
           curve: Curves.decelerate,
-          padding: EdgeInsets.all(multiselectEnabled && isSelected ? 8 : 0),
+          decoration: BoxDecoration(
+            border: multiselectEnabled && isSelected
+                ? canDeselect
+                      ? Border.all(color: assetContainerColor, width: 8)
+                      : const Border(
+                          top: BorderSide(color: Colors.grey, width: 8),
+                          right: BorderSide(color: Colors.grey, width: 8),
+                          bottom: BorderSide(color: Colors.grey, width: 8),
+                          left: BorderSide(color: Colors.grey, width: 8),
+                        )
+                : const Border(),
+          ),
           child: Stack(
             children: [
               _ImageIcon(
@@ -70,30 +80,13 @@ class ThumbnailImage extends StatelessWidget {
             ],
           ),
         ),
-        TweenAnimationBuilder<double>(
-          tween: Tween<double>(begin: 0.0, end: multiselectEnabled ? 1.0 : 0.0),
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.decelerate,
-          builder: (context, value, child) {
-            final double outlineCircleScale = 0.6 + (0.4 * value);
-            return Padding(
-              padding: EdgeInsets.all(isSelected ? value * 3.0 : 3.0),
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: Opacity(
-                  opacity: isSelected ? 1 : value,
-                  child: Transform.scale(
-                    scale: isSelected ? value : outlineCircleScale,
-                    alignment: isSelected ? Alignment.topLeft : Alignment.center,
-                    child: isSelected
-                        ? const _SelectedIcon()
-                        : Icon(Icons.circle_outlined, color: Colors.white.withValues(alpha: 0.8)),
-                  ),
-                ),
-              ),
-            );
-          },
-        ),
+        if (multiselectEnabled)
+          isSelected
+              ? const Padding(
+                  padding: EdgeInsets.all(3.0),
+                  child: Align(alignment: Alignment.topLeft, child: _SelectedIcon()),
+                )
+              : const Icon(Icons.circle_outlined, color: Colors.white),
       ],
     );
   }
@@ -254,14 +247,13 @@ class _ImageIcon extends StatelessWidget {
       ),
     );
 
-    return TweenAnimationBuilder<double>(
-      tween: Tween<double>(begin: 0.0, end: (multiselectEnabled && isSelected) ? 15.0 : 0.0),
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.decelerate,
-      builder: (context, value, child) {
-        return ClipRRect(borderRadius: BorderRadius.all(Radius.circular(value)), child: child);
-      },
-      child: image,
+    if (!multiselectEnabled || !isSelected) {
+      return image;
+    }
+
+    return DecoratedBox(
+      decoration: canDeselect ? BoxDecoration(color: assetContainerColor) : const BoxDecoration(color: Colors.grey),
+      child: ClipRRect(borderRadius: const BorderRadius.all(Radius.circular(15.0)), child: image),
     );
   }
 }


### PR DESCRIPTION
## Description
I was bothered by the selection animations in the mobile app, and with this PR I am trying to make them more elegant, smoother, and more like That-App-That-Must-Not-Be-Named.

### Before
https://github.com/user-attachments/assets/5b32a681-ecc2-416c-8aa4-782ae4aedfa3

### After
https://github.com/user-attachments/assets/4b261a32-5435-46a2-aa69-e642ae33c543

### Changes
1. The rounded corners of the thumbnail image are now faded in smoothly from 0 to 100% instead of jumping directly to 100%.
2. I made the selection icon (not checked) transparent. 
3. The selection icons (both checked and unchecked) are now animated when displayed
4. The 1-pixel-wide border between the thumbnail image and the outer offset has been removed. (see following image)
<img width="772" height="667" alt="image" src="https://github.com/user-attachments/assets/d6df0927-9a03-4dbc-8033-3396d958cfd3" />

## How Has This Been Tested?
- [x] Tested on Samsung Smartphone and Google Pixel Emulator

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
