### PR TITLE
 feat: view the user's app version on the User Management page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -446,6 +446,7 @@
   "app_bar_signout_dialog_ok": "Yes",
   "app_bar_signout_dialog_title": "Sign out",
   "app_settings": "App Settings",
+  "app_version": "App version",
   "appears_in": "Appears in",
   "archive": "Archive",
   "archive_action_prompt": "{count} added to Archive",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -15957,6 +15957,10 @@
       },
       "UserAdminResponseDto": {
         "properties": {
+          "appVersion": {
+            "nullable": true,
+            "type": "string"
+          },
           "avatarColor": {
             "allOf": [
               {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -88,6 +88,7 @@ export type UserLicense = {
     licenseKey: string;
 };
 export type UserAdminResponseDto = {
+    appVersion?: string | null;
     avatarColor: UserAvatarColor;
     createdAt: string;
     deletedAt: string | null;

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -23,6 +23,7 @@ export type AuthUser = {
   email: string;
   quotaUsageInBytes: number;
   quotaSizeInBytes: number | null;
+  appVersion?: string | null;
 };
 
 export type AlbumUser = {
@@ -142,6 +143,7 @@ export type UserAdmin = User & {
   quotaUsageInBytes: number;
   status: UserStatus;
   metadata: UserMetadataItem[];
+  appVersion?: string | null;
 };
 
 export type StorageAsset = {
@@ -306,7 +308,7 @@ export const columns = {
     'asset.type',
   ],
   assetFiles: ['asset_file.id', 'asset_file.path', 'asset_file.type'],
-  authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes'],
+  authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes', 'user.appVersion'],
   authApiKey: ['api_key.id', 'api_key.permissions'],
   authSession: ['session.id', 'session.isPendingSyncReset', 'session.updatedAt', 'session.pinExpiresAt'],
   authSharedLink: [
@@ -333,6 +335,7 @@ export const columns = {
     'storageLabel',
     'quotaSizeInBytes',
     'quotaUsageInBytes',
+    'appVersion',
   ],
   tag: ['tag.id', 'tag.value', 'tag.createdAt', 'tag.updatedAt', 'tag.color', 'tag.parentId'],
   apiKey: ['id', 'name', 'userId', 'createdAt', 'updatedAt', 'permissions'],

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -159,6 +159,8 @@ export class UserAdminResponseDto extends UserResponseDto {
   deletedAt!: Date | null;
   updatedAt!: Date;
   oauthId!: string;
+  @ApiProperty({ type: 'string', required: false, nullable: true })
+  appVersion!: string | null;
   @ApiProperty({ type: 'integer', format: 'int64' })
   quotaSizeInBytes!: number | null;
   @ApiProperty({ type: 'integer', format: 'int64' })
@@ -182,6 +184,7 @@ export function mapUserAdmin(entity: UserAdmin): UserAdminResponseDto {
     deletedAt: entity.deletedAt,
     updatedAt: entity.updatedAt,
     oauthId: entity.oauthId,
+    appVersion: entity.appVersion ?? null,
     quotaSizeInBytes: entity.quotaSizeInBytes,
     quotaUsageInBytes: entity.quotaUsageInBytes,
     status: entity.status,

--- a/server/src/migrations/1753573198596-AddAppversionColumn.ts
+++ b/server/src/migrations/1753573198596-AddAppversionColumn.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAppversionColumn1753573198596 implements MigrationInterface {
+    name = 'AddAppversionColumn1753573198596';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" ADD COLUMN "appVersion" character varying DEFAULT null`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "appVersion"`);
+    }
+}
+

--- a/server/src/schema/migrations/1753574841837-AddAppversionColumn1753573198596.ts
+++ b/server/src/schema/migrations/1753574841837-AddAppversionColumn1753573198596.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" ADD "appVersion" character varying;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "user" DROP COLUMN "appVersion";`.execute(db);
+}

--- a/server/src/schema/tables/user.table.ts
+++ b/server/src/schema/tables/user.table.ts
@@ -81,4 +81,7 @@ export class UserTable {
 
   @UpdateIdColumn({ index: true })
   updateId!: Generated<string>;
+
+  @Column({ type: 'character varying', nullable: true, default: null })
+  appVersion!: string | null;
 }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -177,6 +177,18 @@ export class AuthService extends BaseService {
     const { adminRoute, sharedLinkRoute, uri } = metadata;
     const requestedPermission = metadata.permission ?? Permission.All;
 
+    if (authDto.user && headers['user-agent']) {
+      const userAgent = Array.isArray(headers['user-agent']) ? headers['user-agent'][0] : headers['user-agent'];
+      const match = /^Immich_(Android|iOS)_(.+)$/.exec(userAgent);
+      if (match) {
+        const appVersion = match[2];
+        if (authDto.user.appVersion !== appVersion) {
+          await this.userRepository.update(authDto.user.id, { appVersion });
+          authDto.user.appVersion = appVersion;
+        }
+      }
+    }
+
     if (!authDto.user.isAdmin && adminRoute) {
       this.logger.warn(`Denied access to admin only route: ${uri}`);
       throw new ForbiddenException('Forbidden');

--- a/web/src/routes/admin/users/+page.svelte
+++ b/web/src/routes/admin/users/+page.svelte
@@ -96,6 +96,7 @@
             >
             <th class="hidden sm:block w-3/12 text-center text-sm font-medium">{$t('name')}</th>
             <th class="hidden xl:block w-3/12 2xl:w-2/12 text-center text-sm font-medium">{$t('has_quota')}</th>
+            <th class="w-2/12 text-center text-sm font-medium">{$t('app_version')}</th>
             <th class="w-4/12 lg:w-3/12 xl:w-2/12 text-center text-sm font-medium">{$t('action')}</th>
           </tr>
         </thead>
@@ -119,6 +120,9 @@
                       <Icon path={mdiInfinity} size="16" />
                     {/if}
                   </div>
+                </td>
+                <td class="w-2/12 text-ellipsis break-all px-2 text-sm">
+                  {immichUser.appVersion ?? '-'}
                 </td>
                 <td
                   class="flex flex-row flex-wrap justify-center gap-x-2 gap-y-1 w-4/12 lg:w-3/12 xl:w-2/12 text-ellipsis break-all text-sm"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds information for the system administrator about which version each user is currently using. This is updated every time the user accesses one of the Android or iPhone mobile applications only by information coming from the User-Agent header.

This change also adds a **new database column** called appVersion to store the information for each user.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I tried accessing the app for Android and the app for iPhone and saw that the version is updated on the User Management page even if a version update is made to the app and even if the user accesses it.
To ensure that the latest version is always displayed for each user, it updates the App version every time a request is sent to the server by the user from one of the mobile applications.

I tried accessing from the browser and making sure that it does not affect the App version on the User Management page
Although it is not possible to access with port 2283 as we access from the app (I am not sure if this makes any difference at all?), I was able to connect with port 3000 as we access on the computer and verify that the App version did not change as expected.

Full disclosure: I'm not good with typescript but immich was an inspiration for me to start learning TS so I hope what's here is good enough.
Yes I had to use ML to solve some problems along the way and work with regex and kysely so I hope it's not too bad.
I tried to do all the testing to make sure it would be good enough :)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="892" height="302" alt="image" src="https://github.com/user-attachments/assets/c612da02-de2f-42c9-bab8-cae0a61fdfbc" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code (I hope so.)
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
