### PR TITLE
fix(web): Search chip key value heights don't match

### DIFF
--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -330,9 +330,9 @@
   >
     {#each getObjectKeys(terms) as searchKey (searchKey)}
       {@const value = terms[searchKey]}
-      <div class="flex place-content-center place-items-center text-xs">
+      <div class="flex place-content-center place-items-center items-stretch text-xs">
         <div
-          class="bg-immich-primary py-2 px-4 text-white dark:text-black dark:bg-immich-dark-primary
+          class="flex items-center justify-center bg-immich-primary py-2 px-4 text-white dark:text-black dark:bg-immich-dark-primary
           {value === true ? 'rounded-full' : 'rounded-s-full'}"
         >
           {getHumanReadableSearchKey(searchKey as keyof SearchTerms)}


### PR DESCRIPTION
## Description

Stretch search chip key height to match the value height when it is long and displaying on a smaller screen.
Tested with truncate/ellipsis, but settled on this since listing the included search parameters is more important.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Old:
<img width="338" height="104" alt="old" src="https://github.com/user-attachments/assets/4175eef4-4450-47a7-a408-b2b94df51bea" />

New:
<img width="332" height="88" alt="image" src="https://github.com/user-attachments/assets/05304a11-921e-4622-9370-84b2106145d7" />

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
