### PR TITLE
fix: change translation key for archive action button

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/archive_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/archive_action_button.widget.dart
@@ -46,7 +46,7 @@ class ArchiveActionButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return BaseActionButton(
       iconData: Icons.archive_outlined,
-      label: "archive".t(context: context),
+      label: "to_archive".t(context: context),
       onPressed: () => _onTap(context, ref),
     );
   }

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -49,9 +49,9 @@ class DriftMemoryBottomInfo extends StatelessWidget {
           message: 'view_in_timeline'.tr(),
           child: MaterialButton(
             minWidth: 0,
-            onPressed: () {
-              context.maybePop();
-              context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+            onPressed: () async {
+              await context.maybePop();
+              await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
               EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate));
             },
             shape: const CircleBorder(),


### PR DESCRIPTION
## Description

Fixes #19701

- Changes the archive translation key used in the action button
- Awaits the navigation to main timeline before emitting the scroll to date event from memory widget
