### PR TITLE
feat(web): auto fit bounds for map modal.

### DIFF
--- a/web/src/lib/modals/MapModal.svelte
+++ b/web/src/lib/modals/MapModal.svelte
@@ -8,10 +8,9 @@
   type Props = {
     onClose: (assetIds?: string[]) => void;
     mapMarkers: MapMarkerResponseDto[];
-    zoom?: number;
   };
 
-  let { onClose, mapMarkers, zoom }: Props = $props();
+  let { onClose, mapMarkers }: Props = $props();
 </script>
 
 <Modal title={$t('map')} size="giant" {onClose}>
@@ -26,15 +25,7 @@
             </div>
           {/await}
         {:then { default: Map }}
-          <Map
-            center={undefined}
-            {zoom}
-            clickable={false}
-            {mapMarkers}
-            onSelect={onClose}
-            showSettings={false}
-            rounded
-          />
+          <Map clickable={false} {mapMarkers} onSelect={onClose} showSettings={false} rounded autoFitBounds />
         {/await}
       </div>
     </div>


### PR DESCRIPTION
## Description

When opening the map modal, it will now automatically fit the bounds of the markers displayed on the map. The previous implementation started completely zoomed out, which was unnecessary since most albums only contain images from a relatively small area.

Before:
<img width="1023" height="712" alt="image" src="https://github.com/user-attachments/assets/35b784bc-88d7-40ad-bf8e-b0e89fd3120f" />

After:
<img width="1025" height="714" alt="image" src="https://github.com/user-attachments/assets/15809062-c0bf-4c54-bdbf-8aa8e39d53cd" />

## How Has This Been Tested?

Tested manually in Chrome.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
