### PR TITLE
feat(server): include reason in null reverse geocoding logs

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -55,6 +55,7 @@ export const MACHINE_LEARNING_AVAILABILITY_BACKOFF_TIME = Number(
 );
 
 export const citiesFile = 'cities500.txt';
+export const reverseGeocodeMaxDistance = 25_000;
 
 export const MOBILE_REDIRECT = 'app.immich:///oauth-callback';
 export const LOGIN_URL = '/auth/login?autoLaunch=0';

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -166,7 +166,7 @@ export class MapRepository {
     }
 
     this.logger.warn(
-      `Response from database for reverse geocoding latitude: ${point.latitude}, longitude: ${point.longitude} was null`,
+      `Empty response from database for reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within 25km)`,
     );
 
     const ne_response = await this.db

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -166,7 +166,7 @@ export class MapRepository {
     }
 
     this.logger.log(
-      `Empty response from database for reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within ${reverseGeocodeMaxDistance / 1000}km)`,
+      `Empty response from database for city reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within ${reverseGeocodeMaxDistance / 1000}km). Falling back to country boundaries.`,
     );
 
     const ne_response = await this.db

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -177,7 +177,7 @@ export class MapRepository {
       .executeTakeFirst();
 
     if (!ne_response) {
-      this.logger.warn(
+      this.logger.log(
         `Empty response from database for natural earth country reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}`,
       );
 

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -165,7 +165,7 @@ export class MapRepository {
       return { country, state, city };
     }
 
-    this.logger.warn(
+    this.logger.log(
       `Empty response from database for reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within 25km)`,
     );
 

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -5,7 +5,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { createReadStream, existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import readLine from 'node:readline';
-import { citiesFile } from 'src/constants';
+import { citiesFile, reverseGeocodeMaxDistance } from 'src/constants';
 import { DummyValue, GenerateSql } from 'src/decorators';
 import { AssetVisibility, SystemMetadataKey } from 'src/enum';
 import { ConfigRepository } from 'src/repositories/config.repository';
@@ -145,7 +145,7 @@ export class MapRepository {
       .selectFrom('geodata_places')
       .selectAll()
       .where(
-        sql`earth_box(ll_to_earth_public(${point.latitude}, ${point.longitude}), 25000)`,
+        sql`earth_box(ll_to_earth_public(${point.latitude}, ${point.longitude}), ${reverseGeocodeMaxDistance})`,
         '@>',
         sql`ll_to_earth_public(latitude, longitude)`,
       )
@@ -166,7 +166,7 @@ export class MapRepository {
     }
 
     this.logger.log(
-      `Empty response from database for reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within 25km)`,
+      `Empty response from database for reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}. Likely cause: no nearby large populated place (500+ within ${reverseGeocodeMaxDistance / 1000}km)`,
     );
 
     const ne_response = await this.db

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -178,7 +178,7 @@ export class MapRepository {
 
     if (!ne_response) {
       this.logger.warn(
-        `Response from database for natural earth reverse geocoding latitude: ${point.latitude}, longitude: ${point.longitude} was null`,
+        `Empty response from database for natural earth country reverse geocoding lat: ${point.latitude}, lon: ${point.longitude}`,
       );
 
       return { country: null, state: null, city: null };


### PR DESCRIPTION
Currently warning is logged when reverse geocoding returns nothing. It is unclear from the log why it happened. Also it contains a red flag - "null". So people consider this a bug and ask for help.
> WARN [Microservices:MapRepository] Response from database for reverse geocoding latitude: 61.9393777777778, longitude: 7.26987222222222 was null

In this PR:
- Add the likely cause: no large populated place nearby.
- Rephrase: "empty" instead of "null".
- Shorten latitude/longitude to lat/lon. Hopefully it is clear from context.
- Decrease log level from WARN to LOG.
- (UPD) Define `reverseGeocodeMaxDistance` for the magic 25000 meters.
- (UPD) Mention fallback to countries after unsuccessful cities500.

Related:
- https://github.com/immich-app/immich/issues/5809
- https://github.com/immich-app/immich/discussions/7556
- https://discord.com/channels/979116623879368755/1398758853071339611/1399118162389368885
- https://discord.com/channels/979116623879368755/994044917355663450/1350088703485411378
- https://discord.com/channels/979116623879368755/1314139981224087603/1314139981224087603
