### PR TITLE
fix: android widget periodic updates

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImageDownloadWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImageDownloadWorker.kt
@@ -69,7 +69,7 @@ class ImageDownloadWorker(
         .build()
 
       manager.enqueueUniqueWork(
-        "$uniqueWorkName-$appWidgetId",
+        "$uniqueWorkName-$appWidgetId-singleShot",
         ExistingWorkPolicy.REPLACE,
         workRequest
       )

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/MemoryReceiver.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/MemoryReceiver.kt
@@ -28,17 +28,19 @@ class MemoryReceiver : GlanceAppWidgetReceiver() {
 
   override fun onReceive(context: Context, intent: Intent) {
     val fromMainApp = intent.getBooleanExtra(HomeWidgetPlugin.TRIGGERED_FROM_HOME_WIDGET, false)
+    val provider = ComponentName(context, MemoryReceiver::class.java)
+    val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
 
     // Launch coroutine to setup a single shot if the app requested the update
     if (fromMainApp) {
-      CoroutineScope(Dispatchers.Default).launch {
-        val provider = ComponentName(context, MemoryReceiver::class.java)
-        val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
-
-        glanceIds.forEach { widgetID ->
-          ImageDownloadWorker.singleShot(context, widgetID, WidgetType.MEMORIES)
-        }
+      glanceIds.forEach { widgetID ->
+        ImageDownloadWorker.singleShot(context, widgetID, WidgetType.MEMORIES)
       }
+    }
+
+    // make sure the periodic jobs are running
+    glanceIds.forEach { widgetID ->
+      ImageDownloadWorker.enqueuePeriodic(context, widgetID, WidgetType.MEMORIES)
     }
 
     super.onReceive(context, intent)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/RandomReceiver.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/RandomReceiver.kt
@@ -28,17 +28,19 @@ class RandomReceiver : GlanceAppWidgetReceiver() {
 
   override fun onReceive(context: Context, intent: Intent) {
     val fromMainApp = intent.getBooleanExtra(HomeWidgetPlugin.TRIGGERED_FROM_HOME_WIDGET, false)
+    val provider = ComponentName(context, RandomReceiver::class.java)
+    val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
 
     // Launch coroutine to setup a single shot if the app requested the update
     if (fromMainApp) {
-      CoroutineScope(Dispatchers.Default).launch {
-        val provider = ComponentName(context, RandomReceiver::class.java)
-        val glanceIds = AppWidgetManager.getInstance(context).getAppWidgetIds(provider)
-
-        glanceIds.forEach { widgetID ->
-          ImageDownloadWorker.singleShot(context, widgetID, WidgetType.RANDOM)
-        }
+      glanceIds.forEach { widgetID ->
+        ImageDownloadWorker.singleShot(context, widgetID, WidgetType.RANDOM)
       }
+    }
+
+    // make sure the periodic jobs are running
+    glanceIds.forEach { widgetID ->
+      ImageDownloadWorker.enqueuePeriodic(context, widgetID, WidgetType.RANDOM)
     }
 
     super.onReceive(context, intent)


### PR DESCRIPTION
## Description

We were enqueuing single shot workers with the same job name which would cancel the periodic worker. We now use a different worker name for single-shot runs of widget updates.

Fixes #20301

## How Has This Been Tested?

Tested over the span of 2 hours, triggering single shot updates periodically and background worker still fires properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
