### PR TITLE
Update backup-and-restore.md

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -57,7 +57,7 @@ Then please follow the steps in the following section for restoring the database
   <TabItem value="Linux system" label="Linux system" default>
 
 ```bash title='Backup'
-docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME> | gzip > "/path/to/backup/dump.sql.gz"
+docker exec -t immich-postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME> | gzip > "/path/to/backup/dump.sql.gz"
 ```
 
 ```bash title='Restore'
@@ -66,12 +66,12 @@ docker compose down -v  # CAUTION! Deletes all Immich data to start from scratch
 # rm -rf DB_DATA_LOCATION # CAUTION! Deletes all Immich data to start from scratch
 docker compose pull             # Update to latest version of Immich (if desired)
 docker compose create           # Create Docker containers for Immich apps without running them
-docker start immich_postgres    # Start Postgres server
+docker start immich-postgres    # Start Postgres server
 sleep 10                        # Wait for Postgres server to start up
 # Check the database user if you deviated from the default
 gunzip --stdout "/path/to/backup/dump.sql.gz" \
 | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
-| docker exec -i immich_postgres psql --dbname=postgres --username=<DB_USERNAME>  # Restore Backup
+| docker exec -i immich-postgres psql --dbname=postgres --username=<DB_USERNAME>  # Restore Backup
 docker compose up -d            # Start remainder of Immich apps
 ```
 
@@ -79,19 +79,19 @@ docker compose up -d            # Start remainder of Immich apps
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
 
 ```powershell title='Backup'
-[System.IO.File]::WriteAllLines("C:\absolute\path\to\backup\dump.sql", (docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME>))
+[System.IO.File]::WriteAllLines("C:\absolute\path\to\backup\dump.sql", (docker exec -t immich-postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME>))
 ```
 
 ```powershell title='Restore'
 docker compose down -v  # CAUTION! Deletes all Immich data to start from scratch
 ## Uncomment the next line and replace DB_DATA_LOCATION with your Postgres path to permanently reset the Postgres database
 # Remove-Item -Recurse -Force DB_DATA_LOCATION # CAUTION! Deletes all Immich data to start from scratch
-## You should mount the backup (as a volume, example: `- 'C:\path\to\backup\dump.sql:/dump.sql'`) into the immich_postgres container using the docker-compose.yml
+## You should mount the backup (as a volume, example: `- 'C:\path\to\backup\dump.sql:/dump.sql'`) into the immich-postgres container using the docker-compose.yml
 docker compose pull                               # Update to latest version of Immich (if desired)
 docker compose create                             # Create Docker containers for Immich apps without running them
-docker start immich_postgres                      # Start Postgres server
+docker start immich-postgres                      # Start Postgres server
 sleep 10                                          # Wait for Postgres server to start up
-docker exec -it immich_postgres bash              # Enter the Docker shell and run the following command
+docker exec -it immich-postgres bash              # Enter the Docker shell and run the following command
 # Check the database user if you deviated from the default. If your backup ends in `.gz`, replace `cat` with `gunzip --stdout`
 cat "/dump.sql" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | psql --dbname=postgres --username=<DB_USERNAME>
 exit                                              # Exit the Docker shell


### PR DESCRIPTION
Fix: Replace `immich_` with `immich-` in documentation commands

## Description

This commit addresses an inconsistency in the documentation by replacing all instances of `immich_` with `immich-` in command-line examples.

The previous usage of `immich_` was incorrect and could lead to errors or confusion when users copy-pasted commands directly from the documentation. This change ensures that the commands provided in the documentation accurately reflect the correct `immich-` naming convention required for proper execution.

## How Has This Been Tested?

This change primarily affects documentation content.

* **Manual Review:** The relevant docker compose files  were manually reviewed to ensure all occurrences of `immich_` were correctly updated to `immich-`.
* **Command Verification:** While not a code change, a few key commands using the corrected `immich-` prefix were briefly run to confirm their expected behavior in a docker environment . 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
