### PR TITLE
fix: disk info is cleared when profile picture is uploaded

### DIFF
--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_profile_info.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_profile_info.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
+import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/upload_profile_image.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
@@ -48,6 +49,8 @@ class AppBarProfileInfoBox extends HookConsumerWidget {
           if (user != null) {
             ref.read(currentUserProvider.notifier).refresh();
           }
+
+          ref.read(backupProvider.notifier).updateDiskInfo();
         }
       }
     }


### PR DESCRIPTION
## Description
### Problem
When uploading a profile picture via the Immich mobile app, the disk usage component incorrectly displays "0 of 0 used" instead of showing the actual storage usage. The disk usage only displays correctly again after closing and reopening the dialog.
### Root Cause
The issue occurs in the AppBarProfileInfoBox.pickUserProfileImage() method. After a successful profile picture upload, the code refreshes the user data but doesn't refresh the server disk usage information. The disk usage display depends on both:
* Server disk information (from backupProvider)
* User quota information (from currentUserProvider)

Only the user data was being refreshed, leaving stale disk usage data.

**Fixes #18079**

## How Has This Been Tested?
- [x] Samsung Smartphone & Emulator
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
