### PR TITLE
fix: use relative path in start.sh

### DIFF
--- a/server/bin/start.sh
+++ b/server/bin/start.sh
@@ -8,7 +8,7 @@ else
   echo "skipping libmimalloc - path not found $lib_path"
 fi
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/jellyfin-ffmpeg/lib"
-SERVER_HOME=/usr/src/app/server
+SERVER_HOME="$(readlink -f "$(dirname "$0")/..")"
 
 read_file_and_export() {
 	fname="${!1}"


### PR DESCRIPTION
## Description

Currently, `start.sh` hardcodes the path to Immich code as `/usr/src/app`. This works in the official containers, but breaks local development or more esoteric deployments. This PR changes the code to look for the directory relative to the script file.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I ran `start.sh` with Immich cloned to another directory (after `npm install` and `npm run build`).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] (N/A) I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] (N/A) I have confirmed that any new dependencies are strictly necessary.
- [x] (N/A) I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] (N/A) All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] (N/A) All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
