### PR TITLE
fix(mobile): cleanly handle logout when no host is set

### DIFF
--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -86,7 +86,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
       await _secureStorageService.delete(kSecuredPinCode);
       await _widgetService.clearCredentials();
 
-      await _authService.logout();
+      if (_apiService.apiClient.basePath.isNotEmpty) {
+        await _authService.logout();
+      } else {
+        _log.warning("No base path set for API client, skipping logout request.");
+      }
+
       await _uploadService.cancelBackup();
     } finally {
       await _cleanUp();

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -86,12 +86,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       await _secureStorageService.delete(kSecuredPinCode);
       await _widgetService.clearCredentials();
 
-      if (_apiService.apiClient.basePath.isNotEmpty) {
-        await _authService.logout();
-      } else {
-        _log.warning("No base path set for API client, skipping logout request.");
-      }
-
+      await _authService.logout();
       await _uploadService.cancelBackup();
     } finally {
       await _cleanUp();

--- a/mobile/lib/repositories/auth_api.repository.dart
+++ b/mobile/lib/repositories/auth_api.repository.dart
@@ -25,6 +25,8 @@ class AuthApiRepository extends ApiRepository {
   }
 
   Future<void> logout() async {
+    if (_apiService.apiClient.basePath.isEmpty) return;
+
     await _apiService.authenticationApi.logout().timeout(const Duration(seconds: 7));
   }
 


### PR DESCRIPTION
## Description

Fixes

```
flutter: Error: Invalid argument(s): No host specified in URI /auth/logout
flutter: Stack: #0      _HttpClient._openUrl (dart:_http/http_impl.dart:3019:9)
flutter: #1      _HttpClient.openUrl (dart:_http/http_impl.dart:2875:7)
flutter: #2      IOClient.send (package:http/src/io_client.dart:117:38)
flutter: #3      BaseClient._sendUnstreamed (package:http/src/base_client.dart:93:38)
flutter: #4      BaseClient.post (package:http/src/base_client.dart:32:7)
flutter: #5      ApiClient.invokeAPI (package:openapi/api_client.dart:96:43)
flutter: <asynchronous suspension>
flutter: #6      AuthenticationApi.logout (package:openapi/api/authentication_api.dart:263:22)
flutter: <asynchronous suspension>
flutter: #7      Future.timeout.<anonymous closure> (dart:async/future_impl.dart:1064:7)
flutter: <asynchronous suspension>
flutter: #8      AuthApiRepository.logout (package:immich_mobile/repositories/auth_api.repository.dart:28:5)
flutter: <asynchronous suspension>
flutter: #9      AuthService.logout (package:immich_mobile/services/auth.service.dart:106:7)
flutter: <asynchronous suspension>
flutter: #10     AuthNotifier.logout (package:immich_mobile/providers/auth.provider.dart:89:7)
flutter: <asynchronous suspension>
```


## How Has This Been Tested?

Tested on mobile app clean start and also logging in/out still works

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
