### PR TITLE
fix: improvements to sync and upload when resuming app

### DIFF
--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -86,11 +86,12 @@ class AppLifeCycleNotifier extends StateNotifier<AppLifeCycleEnum> {
       // Ensure proper cleanup before starting new background tasks
       try {
         await Future.wait([
-          backgroundManager.syncLocal().then((_) {
+          Future(() async {
+            await backgroundManager.syncLocal();
             Logger("AppLifeCycleNotifier").fine("Hashing assets after syncLocal");
             // Check if app is still active before hashing
-            if (state == AppLifeCycleEnum.resumed) {
-              backgroundManager.hashAssets();
+            if ([AppLifeCycleEnum.resumed, AppLifeCycleEnum.active].contains(state)) {
+              await backgroundManager.hashAssets();
             }
           }),
           backgroundManager.syncRemote(),


### PR DESCRIPTION
- App will now kick off hashing after local sync if the lifecycle is in resumed or active state
- We now wait for hashing to complete before we kick off the upload process