### PR TITLE
fix: avoid unnecessary writes to system metadata repository

### DIFF
--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -99,7 +99,7 @@ export class StorageService extends BaseService {
       const savedValue = await this.systemMetadataRepository.get(SystemMetadataKey.MediaLocation);
       if (samples.length > 0) {
         const path = samples[0].path;
-        
+
         let previous = savedValue?.location || '';
 
         if (!previous && this.configRepository.getEnv().storage.mediaLocation) {

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -96,9 +96,10 @@ export class StorageService extends BaseService {
     await this.databaseRepository.withLock(DatabaseLock.MediaLocation, async () => {
       const current = StorageCore.getMediaLocation();
       const samples = await this.assetRepository.getFileSamples();
+      const savedValue = await this.systemMetadataRepository.get(SystemMetadataKey.MediaLocation);
       if (samples.length > 0) {
         const path = samples[0].path;
-        const savedValue = await this.systemMetadataRepository.get(SystemMetadataKey.MediaLocation);
+        
         let previous = savedValue?.location || '';
 
         if (!previous && this.configRepository.getEnv().storage.mediaLocation) {
@@ -125,7 +126,10 @@ export class StorageService extends BaseService {
         }
       }
 
-      await this.systemMetadataRepository.set(SystemMetadataKey.MediaLocation, { location: current });
+      // Only set MediaLocation in systemMetadataRepository if needed
+      if (savedValue?.location !== current) {
+        await this.systemMetadataRepository.set(SystemMetadataKey.MediaLocation, { location: current });
+      }
     });
   }
 


### PR DESCRIPTION
When running the server in a secondary, read-only role against a PostgreSQL read-only replica, the bootstrap process currently attempts to unconditionally write the media location to the metadata repository. This leads to the following error:

```
PostgresError: cannot execute INSERT in a read-only transaction
```

This PR updates the bootstrap logic to avoid unnecessary writes by writing MediaLocation only if it is missing or has changed compared to the current runtime-detected value.

This change make the bootstrap process safe to run in read-only environments.

## How Has This Been Tested?

- [x] Tested the change inside a docker container
- [x] Compiled the changed file

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
