### PR TITLE
Fix issue where web mobile scroll was activating pull to refresh in chrome browser 

### DIFF
--- a/web/src/lib/components/shared-components/scrubber/scrubber.svelte
+++ b/web/src/lib/components/shared-components/scrubber/scrubber.svelte
@@ -330,6 +330,7 @@
     isHover = isHoverScrollbar;
 
     if (isHoverScrollbar) {
+      event.preventDefault();
       handleMouseEvent({
         clientY: touch.clientY,
         isDragging: true,
@@ -348,6 +349,7 @@
   const onTouchMove = (event: TouchEvent) => {
     const touch = getTouch(event);
     if (touch && isDragging) {
+      event.preventDefault();
       handleMouseEvent({
         clientY: touch.clientY,
       });
@@ -357,14 +359,14 @@
   };
   /* eslint-enable tscompat/tscompat */
   onMount(() => {
-    document.addEventListener('touchmove', onTouchMove, { capture: true, passive: true });
+    document.addEventListener('touchmove', onTouchMove, { capture: true, passive: false });
     return () => {
       document.removeEventListener('touchmove', onTouchMove, true);
     };
   });
 
   onMount(() => {
-    document.addEventListener('touchstart', onTouchStart, { capture: true, passive: true });
+    document.addEventListener('touchstart', onTouchStart, { capture: true, passive: false });
     document.addEventListener('touchend', onTouchEnd, { capture: true, passive: true });
     return () => {
       document.removeEventListener('touchstart', onTouchStart, true);

--- a/web/src/lib/components/shared-components/scrubber/scrubber.svelte
+++ b/web/src/lib/components/shared-components/scrubber/scrubber.svelte
@@ -462,6 +462,7 @@
   style:width
   style:height={height + 'px'}
   style:background-color={isDragging ? 'transparent' : 'transparent'}
+  style:touch-action="none"
   bind:this={scrollBar}
   onmouseenter={() => (isHover = true)}
   onmouseleave={() => (isHover = false)}


### PR DESCRIPTION
## Description
Updated touch handling on scroll/date element. 
This issue made Immich completely unusable for me in mobile browser.  When I tried to grab scrubber component and drag, it was activating pull to refresh browser functionality (even if it was on bottom of the screen already)
 
Change fixes component by preventing default functionality when grabbing scrubber component.

Fixes #18356

## How Has This Been Tested?
I tested my change on full dev environment from latest `main` branch. When I made sure it is working correctly on mobile device (Samsung S23) in chrome browser, I tested also on desktop if all scrolling functionalities are intact.

**How to reproduce issue?**
1. Open web interface on Android phone in chrome browser
2. Open Library big enough that it is easily possible to scroll
3. Try to grab `id="time-label"` scroll handler and drag it.
4. Drag activates pull to refresh action 90% of times. Even if sometimes it starts to scroll, it is very slow it stutters,

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Issue before fix:
![Screen_Recording_20250802_004506_Chrome-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ed64b159-02d0-4296-9eb2-a8e8d2b814cc)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
