### PR TITLE
feat: add server.versionCheck permission

### DIFF
--- a/mobile/openapi/lib/api/server_api.dart
+++ b/mobile/openapi/lib/api/server_api.dart
@@ -477,7 +477,9 @@ class ServerApi {
     return null;
   }
 
-  /// Performs an HTTP 'GET /server/version-check' operation and returns the [Response].
+  /// This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
+  ///
+  /// Note: This method returns the HTTP [Response].
   Future<Response> getVersionCheckWithHttpInfo() async {
     // ignore: prefer_const_declarations
     final apiPath = r'/server/version-check';
@@ -503,6 +505,7 @@ class ServerApi {
     );
   }
 
+  /// This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
   Future<VersionCheckStateResponseDto?> getVersionCheck() async {
     final response = await getVersionCheckWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {

--- a/mobile/openapi/lib/api/server_api.dart
+++ b/mobile/openapi/lib/api/server_api.dart
@@ -477,7 +477,7 @@ class ServerApi {
     return null;
   }
 
-  /// This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
+  /// This endpoint requires the `server.versionCheck` permission.
   ///
   /// Note: This method returns the HTTP [Response].
   Future<Response> getVersionCheckWithHttpInfo() async {
@@ -505,7 +505,7 @@ class ServerApi {
     );
   }
 
-  /// This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
+  /// This endpoint requires the `server.versionCheck` permission.
   Future<VersionCheckStateResponseDto?> getVersionCheck() async {
     final response = await getVersionCheckWithHttpInfo();
     if (response.statusCode >= HttpStatus.badRequest) {

--- a/mobile/openapi/lib/model/permission.dart
+++ b/mobile/openapi/lib/model/permission.dart
@@ -101,6 +101,7 @@ class Permission {
   static const serverPeriodApkLinks = Permission._(r'server.apkLinks');
   static const serverPeriodStorage = Permission._(r'server.storage');
   static const serverPeriodStatistics = Permission._(r'server.statistics');
+  static const serverPeriodVersionCheck = Permission._(r'server.versionCheck');
   static const serverLicensePeriodRead = Permission._(r'serverLicense.read');
   static const serverLicensePeriodUpdate = Permission._(r'serverLicense.update');
   static const serverLicensePeriodDelete = Permission._(r'serverLicense.delete');
@@ -230,6 +231,7 @@ class Permission {
     serverPeriodApkLinks,
     serverPeriodStorage,
     serverPeriodStatistics,
+    serverPeriodVersionCheck,
     serverLicensePeriodRead,
     serverLicensePeriodUpdate,
     serverLicensePeriodDelete,
@@ -394,6 +396,7 @@ class PermissionTypeTransformer {
         case r'server.apkLinks': return Permission.serverPeriodApkLinks;
         case r'server.storage': return Permission.serverPeriodStorage;
         case r'server.statistics': return Permission.serverPeriodStatistics;
+        case r'server.versionCheck': return Permission.serverPeriodVersionCheck;
         case r'serverLicense.read': return Permission.serverLicensePeriodRead;
         case r'serverLicense.update': return Permission.serverLicensePeriodUpdate;
         case r'serverLicense.delete': return Permission.serverLicensePeriodDelete;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -6506,7 +6506,10 @@
         ],
         "tags": [
           "Server"
-        ]
+        ],
+        "x-immich-admin-only": true,
+        "x-immich-permission": "server.versionCheck",
+        "description": "This endpoint is an admin-only route, and requires the `server.versionCheck` permission."
       }
     },
     "/server/version-history": {
@@ -12631,6 +12634,7 @@
           "server.apkLinks",
           "server.storage",
           "server.statistics",
+          "server.versionCheck",
           "serverLicense.read",
           "serverLicense.update",
           "serverLicense.delete",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -6507,9 +6507,8 @@
         "tags": [
           "Server"
         ],
-        "x-immich-admin-only": true,
         "x-immich-permission": "server.versionCheck",
-        "description": "This endpoint is an admin-only route, and requires the `server.versionCheck` permission."
+        "description": "This endpoint requires the `server.versionCheck` permission."
       }
     },
     "/server/version-history": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3553,7 +3553,7 @@ export function getServerVersion(opts?: Oazapfts.RequestOpts) {
     }));
 }
 /**
- * This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
+ * This endpoint requires the `server.versionCheck` permission.
  */
 export function getVersionCheck(opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -3552,6 +3552,9 @@ export function getServerVersion(opts?: Oazapfts.RequestOpts) {
         ...opts
     }));
 }
+/**
+ * This endpoint is an admin-only route, and requires the `server.versionCheck` permission.
+ */
 export function getVersionCheck(opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
@@ -4616,6 +4619,7 @@ export enum Permission {
     ServerApkLinks = "server.apkLinks",
     ServerStorage = "server.storage",
     ServerStatistics = "server.statistics",
+    ServerVersionCheck = "server.versionCheck",
     ServerLicenseRead = "serverLicense.read",
     ServerLicenseUpdate = "serverLicense.update",
     ServerLicenseDelete = "serverLicense.delete",

--- a/server/src/controllers/server.controller.ts
+++ b/server/src/controllers/server.controller.ts
@@ -109,7 +109,7 @@ export class ServerController {
   }
 
   @Get('version-check')
-  @Authenticated()
+  @Authenticated({ permission: Permission.ServerVersionCheck, admin: true })
   getVersionCheck(): Promise<VersionCheckStateResponseDto> {
     return this.systemMetadataService.getVersionCheckState();
   }

--- a/server/src/controllers/server.controller.ts
+++ b/server/src/controllers/server.controller.ts
@@ -109,7 +109,7 @@ export class ServerController {
   }
 
   @Get('version-check')
-  @Authenticated({ permission: Permission.ServerVersionCheck, admin: true })
+  @Authenticated({ permission: Permission.ServerVersionCheck })
   getVersionCheck(): Promise<VersionCheckStateResponseDto> {
     return this.systemMetadataService.getVersionCheckState();
   }

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -172,6 +172,7 @@ export enum Permission {
   ServerApkLinks = 'server.apkLinks',
   ServerStorage = 'server.storage',
   ServerStatistics = 'server.statistics',
+  ServerVersionCheck = 'server.versionCheck',
 
   ServerLicenseRead = 'serverLicense.read',
   ServerLicenseUpdate = 'serverLicense.update',


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This adds the permission `server.checkVersion` to the [getVersionCheck](https://immich.app/docs/api/get-version-check) endpoint, so no `all` permission is needed anymore for this endpoint.

ref.: https://github.com/home-assistant/home-assistant.io/pull/40183

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

call against `/api/server/version-check` prior this change

```
$ curl -H 'Accept: application/json' -H 'x-api-key: APIKEYAPIKEYAPIKEY' http://localhost:3000/api/server/version-check
{"message":"Missing required permission: all","error":"Forbidden","statusCode":403,"correlationId":"ieqxc97k"}
```

call against `/api/server/version-check` with this change
```
$ curl -H 'Accept: application/json' -H 'x-api-key: APIKEYAPIKEYAPIKEY' http://localhost:3000/api/server/version-check
{"message":"Missing required permission: server.versionCheck","error":"Forbidden","statusCode":403,"correlationId":"dn4wrfxv"}

$ curl -H 'Accept: application/json' -H 'x-api-key: APIKEYAPIKEYAPIKEY' http://localhost:3000/api/server/version-check
{"checkedAt":null,"releaseVersion":null}
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="1106" height="620" alt="image" src="https://github.com/user-attachments/assets/486a079a-a9e7-4337-b18c-eac5fd2dd532" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
