### PR TITLE
feat: add bottom panel for clusters with bulk asset loading

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -1732,6 +1732,70 @@
         "description": "This endpoint requires the `asset.update` permission."
       }
     },
+    "/assets/bulk": {
+      "post": {
+        "operationId": "getBulkAssets",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slug",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetBulkGetDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssetResponseDto"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Assets"
+        ],
+        "x-immich-permission": "asset.read",
+        "description": "This endpoint requires the `asset.read` permission."
+      }
+    },
     "/assets/bulk-upload-check": {
       "post": {
         "description": "Checks if assets exist by checksums",
@@ -9959,6 +10023,21 @@
           "force": {
             "type": "boolean"
           },
+          "ids": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "type": "object"
+      },
+      "AssetBulkGetDto": {
+        "properties": {
           "ids": {
             "items": {
               "format": "uuid",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2209,6 +2209,26 @@ export function getAssetInfo({ id, key, slug }: {
     }));
 }
 /**
+ * This endpoint requires the `asset.read` permission.
+ */
+export function getBulkAssets({ assetBulkGetDto, key, slug }: {
+    assetBulkGetDto: { ids: string[] };
+    key?: string;
+    slug?: string;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: AssetResponseDto[];
+    }>(`/assets/bulk${QS.query(QS.explode({
+        key,
+        slug
+    }))}`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: assetBulkGetDto
+    })));
+}
+/**
  * This endpoint requires the `asset.update` permission.
  */
 export function updateAsset({ id, updateAssetDto }: {

--- a/server/src/controllers/asset.controller.ts
+++ b/server/src/controllers/asset.controller.ts
@@ -4,6 +4,7 @@ import { EndpointLifecycle } from 'src/decorators';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import {
   AssetBulkDeleteDto,
+  AssetBulkGetDto,
   AssetBulkUpdateDto,
   AssetJobsDto,
   AssetStatsDto,
@@ -68,6 +69,12 @@ export class AssetController {
   @Authenticated({ permission: Permission.AssetDelete })
   deleteAssets(@Auth() auth: AuthDto, @Body() dto: AssetBulkDeleteDto): Promise<void> {
     return this.service.deleteAll(auth, dto);
+  }
+
+  @Post('bulk')
+  @Authenticated({ permission: Permission.AssetRead, sharedLink: true })
+  getBulkAssets(@Auth() auth: AuthDto, @Body() dto: AssetBulkGetDto): Promise<AssetResponseDto[]> {
+    return this.service.getBulk(auth, dto);
   }
 
   @Get(':id')

--- a/server/src/dtos/asset.dto.ts
+++ b/server/src/dtos/asset.dto.ts
@@ -90,6 +90,8 @@ export class AssetIdsDto {
   assetIds!: string[];
 }
 
+export class AssetBulkGetDto extends BulkIdsDto {}
+
 export enum AssetJobName {
   REFRESH_FACES = 'refresh-faces',
   REFRESH_METADATA = 'refresh-metadata',

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -57,6 +57,7 @@
     rounded?: boolean;
     showSimpleControls?: boolean;
     autoFitBounds?: boolean;
+    fullscreenContainer?: HTMLElement | string;
   }
 
   let {
@@ -75,6 +76,7 @@
     rounded = false,
     showSimpleControls = true,
     autoFitBounds = true,
+    fullscreenContainer = undefined,
   }: Props = $props();
 
   // Calculate initial bounds from markers once during initialization
@@ -310,7 +312,7 @@
 
       {#if !simplified}
         <GeolocateControl position="top-left" />
-        <FullscreenControl position="top-left" />
+        <FullscreenControl position="top-left" container={fullscreenContainer} />
         <ScaleControl />
         <AttributionControl compact={false} />
       {/if}

--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -121,7 +121,7 @@
     }
 
     const mapSource = map?.getSource('geojson') as GeoJSONSource;
-    const leaves = await mapSource.getClusterLeaves(clusterId, 10_000, 0);
+    const leaves = await mapSource.getClusterLeaves(clusterId, Infinity, 0);
     const ids = leaves.map((leaf) => leaf.properties?.id);
     onSelect(ids);
   }

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -6,10 +6,15 @@
   import Map from '$lib/components/shared-components/map/map.svelte';
   import Portal from '$lib/components/shared-components/portal/portal.svelte';
   import { AppRoute } from '$lib/constants';
+  import { authManager } from '$lib/managers/auth-manager.svelte';
+  import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { featureFlags } from '$lib/stores/server-config.store';
-  import { handlePromiseError } from '$lib/utils';
+  import { getAssetThumbnailUrl, handlePromiseError } from '$lib/utils';
   import { navigate } from '$lib/utils/navigation';
+  import { getAltText } from '$lib/utils/thumbnail-util';
+  import { toTimelineAsset } from '$lib/utils/timeline-util';
+  import { AssetMediaSize, getAssetInfo } from '@immich/sdk';
   import { onDestroy } from 'svelte';
   import type { PageData } from './$types';
 
@@ -19,33 +24,83 @@
 
   let { data }: Props = $props();
 
-  let { isViewing: showAssetViewer, asset: viewingAsset, setAssetId } = assetViewingStore;
+  let {
+    isViewing: showAssetViewer,
+    asset: viewingAsset,
+    setAssetId,
+    showAssetViewer: showAssetViewerFn,
+  } = assetViewingStore;
 
   let viewingAssets: string[] = $state([]);
   let viewingAssetCursor = 0;
 
+  // New state for bottom panel
+  let showBottomPanel = $state(false);
+  let panelAssets: TimelineAsset[] = $state([]);
+  let selectedAssetId: string | null = $state(null);
+
+  // Debug: Log component initialization
+  console.log('Map page component initialized', { data, featureFlags: $featureFlags });
+  console.log('🔥 Hot-reload test - this should update immediately!');
+
   onDestroy(() => {
+    console.log('Map page component destroyed');
     assetViewingStore.showAssetViewer(false);
   });
 
   run(() => {
+    console.log('Feature flags check:', { mapEnabled: $featureFlags.map, loaded: $featureFlags.loaded });
     if (!$featureFlags.map) {
+      console.log('Map feature disabled, redirecting to photos');
       handlePromiseError(goto(AppRoute.PHOTOS));
     }
   });
 
   async function onViewAssets(assetIds: string[]) {
+    console.log('onViewAssets called with asset IDs:', assetIds);
+
+    // Load the assets for the bottom panel
+    const assets = await Promise.all(
+      assetIds.map(async (id) => {
+        const asset = await getAssetInfo({ ...authManager.params, id });
+        return toTimelineAsset(asset);
+      }),
+    );
+
+    panelAssets = assets;
     viewingAssets = assetIds;
     viewingAssetCursor = 0;
-    await setAssetId(assetIds[0]);
+    showBottomPanel = true;
+    selectedAssetId = assetIds[0];
+
+    console.log('Set panel assets:', panelAssets.length, 'selected:', selectedAssetId);
+  }
+
+  async function onPanelAssetClick(asset: TimelineAsset) {
+    console.log('Panel asset clicked:', asset.id);
+    selectedAssetId = asset.id;
+    viewingAssetCursor = viewingAssets.indexOf(asset.id);
+    await setAssetId(asset.id);
+    showAssetViewerFn(true);
+    console.log('Asset viewer should now be open');
+  }
+
+  function closeBottomPanel() {
+    console.log('Closing bottom panel');
+    showBottomPanel = false;
+    panelAssets = [];
+    selectedAssetId = null;
   }
 
   async function navigateNext() {
+    console.log('navigateNext called, current cursor:', viewingAssetCursor, 'total assets:', viewingAssets.length);
     if (viewingAssetCursor < viewingAssets.length - 1) {
       await setAssetId(viewingAssets[++viewingAssetCursor]);
+      console.log('Navigated to next asset, new cursor:', viewingAssetCursor);
       await navigate({ targetRoute: 'current', assetId: $viewingAsset.id });
       return true;
     }
+    console.log('Already at last asset, cannot navigate next');
     return false;
   }
 
@@ -75,6 +130,61 @@
       <Map hash onSelect={onViewAssets} />
     </div>
   </UserPageLayout>
+
+  <!-- Bottom Panel -->
+  {#if showBottomPanel}
+    <div
+      class="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 shadow-lg z-50"
+    >
+      <div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+          Photos ({panelAssets.length})
+        </h3>
+        <button
+          onclick={closeBottomPanel}
+          class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          aria-label="Close photo panel"
+        >
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+
+      <div class="p-4 max-h-64 overflow-y-auto">
+        <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-12 gap-1">
+          {#each panelAssets as asset (asset.id)}
+            <div
+              class="relative cursor-pointer rounded-lg overflow-hidden hover:opacity-80 transition-opacity aspect-square"
+              class:ring-2={selectedAssetId === asset.id}
+              class:ring-blue-500={selectedAssetId === asset.id}
+            >
+              <div
+                class="w-full h-full cursor-pointer rounded-lg overflow-hidden hover:opacity-80 transition-opacity"
+                onclick={() => onPanelAssetClick(asset)}
+                onkeydown={(e) => e.key === 'Enter' && onPanelAssetClick(asset)}
+                role="button"
+                tabindex="0"
+                data-asset-id={asset.id}
+              >
+                <img
+                  src={getAssetThumbnailUrl({
+                    id: asset.id,
+                    size: AssetMediaSize.Thumbnail,
+                    cacheKey: asset.thumbhash,
+                  })}
+                  alt={$getAltText(asset)}
+                  class="w-full h-full object-cover"
+                  draggable="false"
+                />
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {/if}
+
   <Portal target="body">
     {#if $showAssetViewer}
       {#await import('../../../../../lib/components/asset-viewer/asset-viewer.svelte') then { default: AssetViewer }}
@@ -85,8 +195,18 @@
           onPrevious={navigatePrevious}
           onRandom={navigateRandom}
           onClose={() => {
+            console.log('Asset viewer closed');
+            const currentAssetId = $viewingAsset?.id;
             assetViewingStore.showAssetViewer(false);
             handlePromiseError(navigate({ targetRoute: 'current', assetId: null }));
+
+            // Restore focus to the thumbnail that was viewing
+            if (currentAssetId) {
+              setTimeout(() => {
+                const thumbnail = document.querySelector(`[data-asset-id="${currentAssetId}"]`) as HTMLElement;
+                thumbnail?.focus();
+              }, 0);
+            }
           }}
           isShared={false}
         />

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -22,6 +22,7 @@
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
+  import { isSelectingAllAssets } from '$lib/stores/assets-store.svelte';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { sidebarStore } from '$lib/stores/sidebar.svelte';
   import { preferences } from '$lib/stores/user.store';
@@ -30,7 +31,7 @@
   import { navigate } from '$lib/utils/navigation';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
   import { IconButton } from '@immich/ui';
-  import { mdiClose, mdiDotsVertical, mdiPlus, mdiSelectAll } from '@mdi/js';
+  import { mdiClose, mdiDotsVertical, mdiPlus, mdiSelectAll, mdiSelectRemove } from '@mdi/js';
   import { onDestroy } from 'svelte';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
@@ -259,6 +260,11 @@
   // Asset action handlers
   const handleSelectAll = () => {
     assetInteraction.selectAssets(panelAssets);
+    isSelectingAllAssets.set(true);
+  };
+
+  const handleCancel = () => {
+    cancelMultiselect(assetInteraction);
   };
 
   const handleDeleteOrArchiveAssets = (assetIds: string[]) => {
@@ -289,7 +295,7 @@
 
   <!-- Asset selection control bar at the top -->
   {#if assetInteraction.selectionActive}
-    <div class="fixed top-0 left-0 right-0 z-[100]">
+    <div class="fixed top-0 left-0 right-0">
       <AssetSelectControlBar
         assets={assetInteraction.selectedAssets}
         clearSelect={() => cancelMultiselect(assetInteraction)}
@@ -299,9 +305,9 @@
           shape="round"
           color="secondary"
           variant="ghost"
-          aria-label={$t('select_all')}
-          icon={mdiSelectAll}
-          onclick={handleSelectAll}
+          aria-label={$isSelectingAllAssets ? $t('unselect_all') : $t('select_all')}
+          icon={$isSelectingAllAssets ? mdiSelectRemove : mdiSelectAll}
+          onclick={$isSelectingAllAssets ? handleCancel : handleSelectAll}
         />
 
         <ButtonContextMenu icon={mdiPlus} title={$t('add_to')}>
@@ -329,7 +335,7 @@
   <!-- Bottom Panel with GalleryViewer -->
   {#if showBottomPanel}
     <div
-      class="fixed bottom-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 shadow-lg z-0"
+      class="fixed bottom-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 shadow-lg"
       class:left-0={!sidebarStore.isOpen}
       class:left-64={sidebarStore.isOpen}
       bind:this={panelElement}


### PR DESCRIPTION
## Description

This PR introduces a **bottom panel feature** for the map view that significantly improves the user experience when browsing photos from map clusters. When users click on a cluster, instead of immediately opening the asset viewer, a bottom panel slides up showing thumbnail previews of all photos in that cluster.

Implements feature: https://github.com/immich-app/immich/discussions/4519

### Key Features:
- **Bottom Panel UI**: A collapsible panel that displays photo thumbnails when clicking map clusters
- **Batch Asset Loading**: New bulk API endpoint for efficient loading of multiple assets
- **Improved Performance**: Changed cluster leaves limit from 10,000 to `Infinity` to show all photos in clusters

### Why This Change?
- **Better UX**: Users can now preview and select specific photos from clusters before opening the full viewer
- **Performance**: Batch loading reduces API calls from potentially hundreds to just a few requests

### Technical Changes:

**Backend:**
- Added `/assets/bulk` POST endpoint for fetching multiple assets efficiently
- New `AssetBulkGetDto` for bulk asset requests

**Web:**
- Bottom panel component with thumbnail grid layout
- Batch asset loading with 500-asset chunks for optimal performance
- Loading states and progress indicators
- Proper cleanup and abort controllers for navigation
- Focus management for accessibility

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] **Map Cluster Interaction**: Verified clicking on map clusters opens bottom panel with correct photos
- [x] **Batch Loading Performance**: Tested with large clusters (14269 photos)
- [x] **Asset Viewer Integration**: Confirmed clicking thumbnails opens asset viewer with proper navigation
- [x] **Keyboard Accessibility**: Verified tab navigation and enter key functionality work correctly
- [x] **Panel Close/Open**: Tested panel close button and reopening with different clusters
- [x] **Loading States**: Confirmed loading indicators show during asset fetching
- [x] **API Endpoint**: Tested bulk asset endpoint with various cluster sizes

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

https://github.com/user-attachments/assets/79496cca-29d5-42cf-9897-ca7d5e70cf66


https://github.com/user-attachments/assets/9fd40553-d44b-4526-b989-cfd45a54a561



</details>

## API Changes
- **New endpoint**: `POST /api/assets/bulk` - Accepts array of asset IDs and returns asset details in bulk
- **Request format**: `{ "ids": ["uuid1", "uuid2", ...] }`
- **Response**: Array of `AssetResponseDto` objects

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)