### PR TITLE
feat: support self-signed certs for redis/valkey

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -113,6 +113,8 @@ When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSW
 | `REDIS_TLS`      | Redis TLS      | `false` | server     |
 | `REDIS_INSECURE_TLS` | Allow Insecure Connection to Redis | `false` | server |
 | `REDIS_TLS_CERT` | Path to Redis TLS Cert | | server |
+| `REDIS_TLS_CA`   | Path to Redis TLS CA   | | server |
+| `REDIS_TLS_KEY`  | Path to Redis TLS Key  | | server |
 
 :::info
 All `REDIS_` variables must be provided to all Immich workers, including `api` and `microservices`.
@@ -121,6 +123,10 @@ All `REDIS_` variables must be provided to all Immich workers, including `api` a
 More information can be found in the upstream [ioredis] documentation.
 
 When `REDIS_URL` or `REDIS_SOCKET` are defined, the `REDIS_HOSTNAME`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, and `REDIS_DBINDEX` variables are ignored.
+
+When `REDIS_TLS` is enable is requiring to emable `REDIS_INSECURE_TLS` if the server allow connection without verifing the certificate, otherwise specify the path using `REDIS_TLS_CERT`
+
+The `REDIS_TLS_CA`and `REDIS_TLS_KEY` are only required when redis connection require client certificates for the TLS handshake.
 :::
 
 Redis (Sentinel) URL example JSON before encoding:

--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -110,6 +110,9 @@ When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSW
 | `REDIS_USERNAME` | Redis username |         | server     |
 | `REDIS_PASSWORD` | Redis password |         | server     |
 | `REDIS_DBINDEX`  | Redis DB index |   `0`   | server     |
+| `REDIS_TLS`      | Redis TLS      | `false` | server     |
+| `REDIS_INSECURE_TLS` | Allow Insecure Connection to Redis | `false` | server |
+| `REDIS_TLS_CERT` | Path to Redis TLS Cert | | server |
 
 :::info
 All `REDIS_` variables must be provided to all Immich workers, including `api` and `microservices`.

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -1,7 +1,7 @@
 import { Transform, Type } from 'class-transformer';
-import { IsEnum, IsInt, IsString, Matches } from 'class-validator';
+import { IsEnum, IsInt, IsString, Matches, ValidateIf } from 'class-validator';
 import { DatabaseSslMode, ImmichEnvironment, LogLevel } from 'src/enum';
-import { IsIPRange, Optional, ValidateBoolean } from 'src/validation';
+import { IsIPRange, Optional, ValidateBoolean, FileExist } from 'src/validation';
 
 export class EnvDto {
   @IsInt()
@@ -204,6 +204,8 @@ export class EnvDto {
   @Optional()
   REDIS_TLS_INSECURE?: boolean;
 
+  @ValidateIf((o) => o.REDIS_TLS === true && o.REDIS_TLS_INSECURE === false)
   @IsString()
+  @FileExist({ message: 'Redis Cert must exist on the server' })
   REDIS_TLS_CERT?: string;
 }

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -206,6 +206,18 @@ export class EnvDto {
 
   @ValidateIf((o) => o.REDIS_TLS === true && o.REDIS_TLS_INSECURE === false)
   @IsString()
-  @FileExist({ message: 'Redis Cert must exist on the server' })
+  @FileExist({ message: 'Redis TLS Cert must exist on the server' })
   REDIS_TLS_CERT?: string;
+
+  @Optional()
+  @ValidateIf((o) => o.REDIS_TLS === true && o.REDIS_TLS_INSECURE === false)
+  @IsString()
+  @FileExist({ message: 'Redis TLS CA must exist on the server' })
+  REDIS_TLS_CA?: string;
+
+  @Optional()
+  @ValidateIf((o) => o.REDIS_TLS === true && o.REDIS_TLS_INSECURE === false)
+  @IsString()
+  @FileExist({ message: 'Redis TLS Key must exist on the server' })
+  REDIS_TLS_KEY?: string;
 }

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -195,4 +195,15 @@ export class EnvDto {
   @IsString()
   @Optional()
   REDIS_URL?: string;
+
+  @ValidateBoolean({ optional: false })
+  @Optional()
+  REDIS_TLS?: boolean;
+
+  @ValidateBoolean({ optional: false })
+  @Optional()
+  REDIS_TLS_INSECURE?: boolean;
+
+  @IsString()
+  REDIS_TLS_CERT?: string;
 }

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -35,6 +35,9 @@ const resetEnv = () => {
     'REDIS_PASSWORD',
     'REDIS_SOCKET',
     'REDIS_URL',
+    'REDIS_TLS',
+    'REDIS_TLS_INSECURE',
+    'REDIS_TLS_CERT',
 
     'NO_COLOR',
   ]) {

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -4,6 +4,7 @@ import { QueueOptions } from 'bullmq';
 import { plainToInstance } from 'class-transformer';
 import { validateSync } from 'class-validator';
 import { Request, Response } from 'express';
+import { readFileSync } from 'fs';
 import { RedisOptions } from 'ioredis';
 import { CLS_ID, ClsModuleOptions } from 'nestjs-cls';
 import { OpenTelemetryModuleOptions } from 'nestjs-otel/lib/interfaces';
@@ -156,13 +157,21 @@ const getEnv = (): EnvData => {
     web: join(buildFolder, 'www'),
   };
 
-  let redisConfig = {
+  let redisConfig: RedisOptions = {
     host: dto.REDIS_HOSTNAME || 'redis',
     port: dto.REDIS_PORT || 6379,
     db: dto.REDIS_DBINDEX || 0,
     username: dto.REDIS_USERNAME || undefined,
     password: dto.REDIS_PASSWORD || undefined,
     path: dto.REDIS_SOCKET || undefined,
+    ...(dto.REDIS_TLS
+      ? {
+          tls: {
+            rejectUnauthorized: !dto.REDIS_TLS_INSECURE,
+            ...(dto.REDIS_TLS_CERT ? { ca: readFileSync(dto.REDIS_TLS_CERT) } : {}),
+          },
+        }
+      : {}),
   };
 
   const redisUrl = dto.REDIS_URL;

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -168,7 +168,9 @@ const getEnv = (): EnvData => {
       ? {
           tls: {
             rejectUnauthorized: !dto.REDIS_TLS_INSECURE,
-            ...(dto.REDIS_TLS_CERT ? { ca: readFileSync(dto.REDIS_TLS_CERT) } : {}),
+            ...(dto.REDIS_TLS_CERT ? { cert: readFileSync(dto.REDIS_TLS_CERT) } : {}),
+            ...(dto.REDIS_TLS_CA ? { ca: readFileSync(dto.REDIS_TLS_CA) } : {}),
+            ...(dto.REDIS_TLS_KEY ? { key: readFileSync(dto.REDIS_TLS_KEY) } : {}),
           },
         }
       : {}),

--- a/server/src/validation.ts
+++ b/server/src/validation.ts
@@ -34,6 +34,8 @@ import { CronJob } from 'cron';
 import { DateTime } from 'luxon';
 import sanitize from 'sanitize-filename';
 import { isIP, isIPRange } from 'validator';
+import {existsSync} from 'fs';
+import { join } from 'path';
 
 @Injectable()
 export class ParseMeUUIDPipe extends ParseUUIDPipe {
@@ -355,6 +357,28 @@ export function IsIPRange(options: IsIPRangeOptions, validationOptions?: Validat
         },
         defaultMessage: buildMessage(
           (eachPrefix) => eachPrefix + '$property must be an ip address, or ip address range',
+          validationOptions,
+        ),
+      },
+    },
+    validationOptions,
+  );
+}
+
+export function FileExist(validationOptions?: ValidationOptions) {
+  return ValidateBy(
+    {
+      name: 'fileExist',
+      validator: {
+        validate(value: any) {
+          if (typeof value !== 'string') {
+            return false;
+          }
+          const filePath = join(value);
+          return existsSync(filePath);
+        },
+        defaultMessage: buildMessage(
+          (eachPrefix) => `${eachPrefix}$property file does not exist`,
           validationOptions,
         ),
       },


### PR DESCRIPTION
## Description
Despite ioredis supported TLS connection out of the box, the support never was implemented in immich.

This means if a user already have Redis/Valkey setup on there environment will need a separate instance of Redis to run immich, since the authentication will fail

So this PR allow, by the use of environment variable to:
- Enable TLS, by using `REDIS_TLS = true` (disable by default)
- Allow the use of Insecure Connection by using `REDIS_INSECURE_TLS = true`
- Allow to specify TLS cert (REDIS_TLS_CERT) and client certs (REDIS_TLS_CA and REDIS_TLS_KEY) for setup that require (my valkey setup)
- Add ValidateIf and FileExist validation to all the TLS files environment

## How Has This Been Tested?
In this [link](url) you have a docker image (v1.140.1) and there 2 ways to test the changes, these test assume a existing Redis/Valkey is already setup with TLS

- [ ] Test 1: Setup the Redis as describe in documentation (I using REDIS_HOSTNAME, REDIS_USERNAME and REDIS_PASSWORD) and then enable both REDIS_TLS and REDIS_TLS_INSECURE, this way no certs need to be provided

- [x] Test 2: Setup the Redis as describe in documentation and setup a mount point with the Redis Certificates (I just mounted the secret `valkey-tls` in `/tls-redis`). Then you just add the following env:
```yaml
  REDIS_TLS_CERT: /tls-redis/ca.crt
  # This one are only need if `tls.authClients` is on
  REDIS_TLS_CA: /tls-redis/tls.crt
  REDIS_TLS_KEY: /tls-redis/tls.key
```

Notes: In my k3s cluster I use valkey bitnami chart with the following values for tls:
```yaml
tls:
  authClients: true
  autoGenerated: false
  certCAFilename: ca.crt
  certFilename: tls.crt
  certKeyFilename: tls.key
  dhParamsFilename: ''
  enabled: true
  existingSecret: valkey-tls
 ```

Exemple deployment for Test 2 (based on my setup):
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: immich
  namespace: immich
spec:
  replicas: 1
  selector:
    matchLabels:
      app: immich
  template:
    metadata:
      labels:
        app: immich
    spec:
      containers:
      - name: immich-server
        #image: ghcr.io/immich-app/immich-server:release
        image: mrduartept/immich-server-redis-tls:latest
        imagePullPolicy: Always
        envFrom:
        - configMapRef:
            name: immich-env
        - secretRef:
            name: immich
        volumeMounts:
        - name: immich-photos
          mountPath: /usr/src/app/upload
        - name: localtime
          mountPath: /etc/localtime
          readOnly: true
        - name: valkey-tls
          mountPath: /tls-redis
          readOnly: true
        ports:
        - containerPort: 2283
      nodeName: master1-k3s
      volumes:
      - name: immich-vol
        persistentVolumeClaim:
          claimName: immich-pvc
      - name: localtime
        hostPath:
          path: /etc/localtime
          type: File
      - name: immich-photos
        hostPath:
          path: /mnt/nfs-proxmox/immich-photos/
          type: DirectoryOrCreate
      - name: valkey-tls
        secret:
          secretName: valkey-tls
---
apiVersion: v1
kind: Service
metadata:
  name: immich
  namespace: immich
spec:
  type: ClusterIP
  selector:
    app: immich
  ports:
  - name: web
    port: 2283
    targetPort: 2283
    protocol: TCP
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: immich-env
  namespace: immich
data:
  UPLOAD_LOCATION: "./photos"
  TZ: "Europe/Lisbon"
  IMMICH_HOST: "0.0.0.0"
  IMMICH_PORT: "2283"
  REDIS_TLS: "true"
  REDIS_TLS_INSECURE: "false"
  REDIS_TLS_CERT: /tls-redis/ca.crt
  REDIS_TLS_CA: /tls-redis/tls.crt
  REDIS_TLS_KEY: /tls-redis/tls.key
---
apiVersion: v1
kind: Secret
metadata:
  name: immich
  namespace: immich
stringData:
  DB_URL: <hidden>
  REDIS_HOSTNAME: <hidden>
  REDIS_USERNAME: <hidden>
  REDIS_PASSWORD: <hidden>
  type: Opaque
---
```

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
