### PR TITLE
chore: tweak photo sphere fov and zoom speed constants

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
+++ b/web/src/lib/components/asset-viewer/photo-sphere-viewer-adapter.svelte
@@ -63,8 +63,9 @@
       touchmoveTwoFingers: false,
       mousewheelCtrlKey: false,
       navbar,
-      minFov: 10,
-      maxFov: 120,
+      minFov: 15,
+      maxFov: 90,
+      zoomSpeed: 0.5,
       fisheye: false,
     });
     const resolutionPlugin = viewer.getPlugin(ResolutionPlugin) as ResolutionPlugin;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR updates the `minFov`, `maxFov`, and `zoomSpeed` constants to better match the photo sphere constants the **_App-Which-Must-Not-Be-Named_** uses. See screenshots.

<!--- Why is this change required? What problem does it solve? -->
This change isn't required for _functionality_. It is purely cosmetic. However, _it does_ improve the accessibility of zoom levels. The default value of `1` is far too sensitive to meaningfully set a desired photo sphere zoom level on the first try. Users (myself included) often transition from `minFov` to `maxFov` (and back) by scrubbing the trackpad just half-a-millimeter. Overshoots and undershoots are too common. I am on a 2024 MacBook Pro, this is a huge pain to get the zoom right! Reducing the `zoomSpeed` gives users better control over the zoom level.

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)
N/A

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Visual and functional inspection of web app in comparison to **_App-Which-Must-Not-Be-Named_**
- [x] Chrome, Edge, and Safari tested

<details><summary><h2>Screenshots (click to view)</h2></summary>

<!-- Images go below this line. -->
**Min FoV**
Current (`main`):
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 17 53 PM Medium" src="https://github.com/user-attachments/assets/fb5ef876-d2b9-4453-acac-4c1e442641a0" />
Ideal (**_App-Which-Must-Not-Be-Named_**):
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 18 04 PM Medium" src="https://github.com/user-attachments/assets/179fa1ec-abf0-484c-85c4-d93c5d590e3e" />
This PR:
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 18 08 PM Medium" src="https://github.com/user-attachments/assets/64c912a3-1ba5-4714-9272-06bd21b02137" />

**Max Fov**
Current (`main`):
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 18 34 PM Medium" src="https://github.com/user-attachments/assets/7c1a2025-7202-44c2-89d3-a6e3a2c5dba9" />
Ideal (**_App-Which-Must-Not-Be-Named_**):
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 18 37 PM Medium" src="https://github.com/user-attachments/assets/ea64cea8-45b6-4636-b485-573bebc611e7" />
This PR:
<img width="320" height="192" alt="Screenshot 2025-08-03 at 12 18 39 PM Medium" src="https://github.com/user-attachments/assets/5866457f-3774-4957-b2d7-af99af98e33f" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
