### PR TITLE
fix: adjust search bar padding and visibility based on input state

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -230,7 +230,8 @@
         type="text"
         name="q"
         id="main-search-bar"
-        class="w-full transition-all border-2 px-14 py-4 max-md:py-2 text-immich-fg/75 dark:text-immich-dark-fg
+        class="w-full transition-all border-2 ps-14 py-4 max-md:py-2 text-immich-fg/75 dark:text-immich-dark-fg
+        {showClearIcon ? 'pe-[90px]' : 'pe-14'}
         {grayTheme ? 'dark:bg-immich-dark-gray' : 'dark:bg-immich-dark-bg'}
         {showSuggestions && isSearchSuggestions ? 'rounded-t-3xl' : 'rounded-3xl bg-gray-200'}
         {searchStore.isSearchEnabled ? 'border-gray-200 dark:border-gray-700 bg-white' : 'border-transparent'}"
@@ -285,6 +286,7 @@
     {#if isFocus}
       <div
         class="absolute inset-y-0 flex items-center"
+        class:max-md:hidden={value}
         class:end-16={isFocus}
         class:end-28={isFocus && value.length > 0}
       >


### PR DESCRIPTION
## Description
Updated accessibility of web search component on smaller screen devices.
Prevent showing input behind search settings icon
Hide showing search type pill when typing on small screen.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # ([issue](https://github.com/immich-app/immich/issues/19409))

## How Has This Been Tested?
Tested on web smaller and bigger screens. Tested both on device (Samsung S23) and chrome developer tools.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
BEFORE:
<img width="327" height="623" alt="image" src="https://github.com/user-attachments/assets/0ad287ca-1e85-4d06-a7da-79507e649fc9" />
<img width="324" height="618" alt="image" src="https://github.com/user-attachments/assets/6f8a085c-72ff-4979-817b-57a74749096b" />

AFTER:
<img width="321" height="622" alt="image" src="https://github.com/user-attachments/assets/2a02e437-b026-4504-96a5-e845eb46ede0" />
<img width="323" height="623" alt="image" src="https://github.com/user-attachments/assets/d7d13d44-caf1-46d3-94c1-a8f6334b3897" />
<img width="319" height="619" alt="image" src="https://github.com/user-attachments/assets/cc9f2e54-ea10-407b-9d27-884195f6a11d" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
