### PR TITLE
fix: hide navigation bar in search page during multi-selection

### DIFF
--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/pages/search/paginated_search.provider.dart';
+import 'package:immich_mobile/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/search/search_input_focus.provider.dart';
@@ -627,7 +628,12 @@ class _SearchResultGrid extends ConsumerWidget {
               return timelineService;
             }),
           ],
-          child: Timeline(key: ValueKey(searchResult.totalAssets), appBar: null, groupBy: GroupAssetsBy.none),
+          child: Timeline(
+            key: ValueKey(searchResult.totalAssets),
+            groupBy: GroupAssetsBy.none,
+            appBar: null,
+            bottomSheet: const GeneralBottomSheet(minChildSize: 0.20),
+          ),
         ),
       ),
     );

--- a/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
@@ -22,13 +22,13 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
     this.slivers,
     this.controller,
     this.initialChildSize = 0.35,
-    this.minChildSize = 0.15,
+    double? minChildSize,
     this.maxChildSize = 0.65,
     this.expand = true,
     this.shouldCloseOnMinExtent = true,
     this.resizeOnScroll = true,
     this.backgroundColor,
-  });
+  }) : minChildSize = minChildSize ?? 0.15;
 
   @override
   ConsumerState<BaseBottomSheet> createState() => _BaseDraggableScrollableSheetState();

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -6,8 +6,8 @@ import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/archive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_date_time_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_location_action_button.widget.dart';
@@ -26,7 +26,8 @@ import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class GeneralBottomSheet extends ConsumerWidget {
-  const GeneralBottomSheet({super.key});
+  final double? minChildSize;
+  const GeneralBottomSheet({super.key, this.minChildSize});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -60,6 +61,7 @@ class GeneralBottomSheet extends ConsumerWidget {
 
     return BaseBottomSheet(
       initialChildSize: 0.45,
+      minChildSize: minChildSize,
       maxChildSize: 0.85,
       shouldCloseOnMinExtent: false,
       actions: [

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -115,6 +115,8 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
         _baseScaleFactor = _scaleFactor;
       });
     });
+
+    ref.listenManual(multiSelectProvider.select((s) => s.isEnabled), _onMultiSelectionToggled);
   }
 
   void _onEvent(Event event) {
@@ -128,6 +130,10 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
       default:
         break;
     }
+  }
+
+  void _onMultiSelectionToggled(_, bool isEnabled) {
+    EventStream.shared.emit(MultiSelectToggleEvent(isEnabled));
   }
 
   @override

--- a/mobile/lib/providers/timeline/multiselect.provider.dart
+++ b/mobile/lib/providers/timeline/multiselect.provider.dart
@@ -1,14 +1,19 @@
 import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 
 final multiSelectProvider = NotifierProvider<MultiSelectNotifier, MultiSelectState>(
   MultiSelectNotifier.new,
   dependencies: [timelineServiceProvider],
 );
+
+class MultiSelectToggleEvent extends Event {
+  final bool isEnabled;
+  const MultiSelectToggleEvent(this.isEnabled);
+}
 
 class MultiSelectState {
   final Set<BaseAsset> selectedAssets;


### PR DESCRIPTION
## Description

- The search page uses a scoped multi select provider so the navigation bar is not aware of the multi selection state within it. Replace the show / hide logic in the navigation bar to use a `MultiSelectToggleEvent` instead. This is emitted from the timeline whenever the selection state change and is independent of the scope of the provider