### PR TITLE
fix(mobile): use cached thumbnail in full size image provider

### DIFF
--- a/mobile/lib/extensions/build_context_extensions.dart
+++ b/mobile/lib/extensions/build_context_extensions.dart
@@ -13,6 +13,9 @@ extension ContextHelper on BuildContext {
   // Returns the current height from MediaQuery
   double get height => MediaQuery.sizeOf(this).height;
 
+  // Returns the current size from MediaQuery
+  Size get sizeData => MediaQuery.sizeOf(this);
+
   // Returns true if the app is running on a mobile device (!tablets)
   bool get isMobile => width < 550;
 

--- a/mobile/lib/extensions/codec_extensions.dart
+++ b/mobile/lib/extensions/codec_extensions.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+import 'package:flutter/painting.dart';
+
+extension CodecImageInfoExtension on Codec {
+  Future<ImageInfo> getImageInfo({double scale = 1.0}) async {
+    final frame = await getNextFrame();
+    return ImageInfo(image: frame.image, scale: scale);
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -147,11 +147,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     // Precache both thumbnail and full image for smooth transitions
     unawaited(
       Future.wait([
-        precacheImage(
-          getThumbnailImageProvider(asset: asset, size: screenSize),
-          context,
-          onError: (_, __) {},
-        ),
+        precacheImage(getThumbnailImageProvider(asset: asset), context, onError: (_, __) {}),
         precacheImage(getFullImageProvider(asset, size: screenSize), context, onError: (_, __) {}),
       ]),
     );
@@ -482,7 +478,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       width: double.infinity,
       height: double.infinity,
       color: backgroundColor,
-      child: Thumbnail(asset: asset, fit: BoxFit.contain, size: Size(ctx.width, ctx.height)),
+      child: Thumbnail(asset: asset, fit: BoxFit.contain),
     );
   }
 
@@ -513,7 +509,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
   }
 
   PhotoViewGalleryPageOptions _imageBuilder(BuildContext ctx, BaseAsset asset) {
-    final size = Size(ctx.width, ctx.height);
+    final size = ctx.sizeData;
     return PhotoViewGalleryPageOptions(
       key: ValueKey(asset.heroTag),
       imageProvider: getFullImageProvider(asset, size: size),
@@ -529,10 +525,10 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       onTapDown: _onTapDown,
       onLongPressStart: asset.isMotionPhoto ? _onLongPress : null,
       errorBuilder: (_, __, ___) => Container(
-        width: ctx.width,
-        height: ctx.height,
+        width: size.width,
+        height: size.height,
         color: backgroundColor,
-        child: Thumbnail(asset: asset, fit: BoxFit.contain, size: size),
+        child: Thumbnail(asset: asset, fit: BoxFit.contain),
       ),
     );
   }
@@ -562,7 +558,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
           asset: asset,
           image: Image(
             key: ValueKey(asset),
-            image: getFullImageProvider(asset, size: Size(ctx.width, ctx.height)),
+            image: getFullImageProvider(asset, size: ctx.sizeData),
             fit: BoxFit.contain,
             height: ctx.height,
             width: ctx.width,

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -4,13 +4,14 @@ import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/domain/services/setting.service.dart';
 import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 
 ImageProvider getFullImageProvider(BaseAsset asset, {Size size = const Size(1080, 1920)}) {
   // Create new provider and cache it
   final ImageProvider provider;
   if (_shouldUseLocalAsset(asset)) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).localId!;
-    provider = LocalFullImageProvider(id: id, name: asset.name, size: size, type: asset.type);
+    provider = LocalFullImageProvider(id: id, size: size, type: asset.type, updatedAt: asset.updatedAt);
   } else {
     final String assetId;
     if (asset is LocalAsset && asset.hasRemote) {
@@ -26,7 +27,7 @@ ImageProvider getFullImageProvider(BaseAsset asset, {Size size = const Size(1080
   return provider;
 }
 
-ImageProvider getThumbnailImageProvider({BaseAsset? asset, String? remoteId, Size size = const Size.square(256)}) {
+ImageProvider getThumbnailImageProvider({BaseAsset? asset, String? remoteId, Size size = kThumbnailResolution}) {
   assert(asset != null || remoteId != null, 'Either asset or remoteId must be provided');
 
   if (remoteId != null) {
@@ -35,7 +36,7 @@ ImageProvider getThumbnailImageProvider({BaseAsset? asset, String? remoteId, Siz
 
   if (_shouldUseLocalAsset(asset!)) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).localId!;
-    return LocalThumbProvider(id: id, updatedAt: asset.updatedAt, name: asset.name, size: size);
+    return LocalThumbProvider(id: id, updatedAt: asset.updatedAt, size: size);
   }
 
   final String assetId;
@@ -52,3 +53,25 @@ ImageProvider getThumbnailImageProvider({BaseAsset? asset, String? remoteId, Siz
 
 bool _shouldUseLocalAsset(BaseAsset asset) =>
     asset.hasLocal && (!asset.hasRemote || !AppSetting.get(Setting.preferRemoteImage));
+
+ImageInfo? getCachedImage(ImageProvider key) {
+  ImageInfo? thumbnail;
+  final ImageStreamCompleter? stream = PaintingBinding.instance.imageCache.putIfAbsent(
+    key,
+    () => throw Exception(), // don't bother loading if it isn't cached
+  );
+
+  if (stream != null) {
+    void listener(ImageInfo info, bool synchronousCall) {
+      thumbnail = info;
+    }
+
+    try {
+      stream.addListener(ImageStreamListener(listener));
+    } finally {
+      stream.removeListener(ImageStreamListener(listener));
+    }
+  }
+
+  return thumbnail;
+}

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -22,11 +22,7 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
   }) {
     _initialImage = initialImage;
     images.listen(
-      (image) {
-        setImage(image);
-        _initialImage?.dispose();
-        _initialImage = null;
-      },
+      _onImage,
       onError: (Object error, StackTrace stack) {
         reportError(
           context: ErrorDescription('resolving a single-frame image stream'),
@@ -37,6 +33,12 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
         );
       },
     );
+  }
+
+  _onImage(ImageInfo image) {
+    setImage(image);
+    _initialImage?.dispose();
+    _initialImage = null;
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -1,0 +1,117 @@
+// The below code is adapted from cached_network_image package's
+// MultiImageStreamCompleter to better suit one-frame image loading.
+// In particular, it allows providing an initial image to emit synchronously.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+/// An ImageStreamCompleter with support for loading multiple images.
+class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
+  ImageInfo? _initialImage;
+
+  /// The constructor to create an OneFramePlaceholderImageStreamCompleter. The [image]
+  /// should be the primary image to display. The [initialImage] is an optional
+  /// image that will be emitted synchronously, useful as a thumbnail or placeholder.
+  OneFramePlaceholderImageStreamCompleter(
+    Stream<ImageInfo> image, {
+    ImageInfo? initialImage,
+    InformationCollector? informationCollector,
+  }) {
+    _initialImage = initialImage;
+    image.listen(
+      setImage,
+      onError: (Object error, StackTrace stack) {
+        reportError(
+          context: ErrorDescription('resolving a single-frame image stream'),
+          exception: error,
+          stack: stack,
+          informationCollector: informationCollector,
+          silent: true,
+        );
+      },
+    );
+  }
+
+  /// We must avoid disposing a completer if it never had a listener, even
+  /// if all [keepAlive] handles get disposed.
+  bool __hadAtLeastOneListener = false;
+
+  bool __disposed = false;
+
+  @override
+  void addListener(ImageStreamListener listener) {
+    __hadAtLeastOneListener = true;
+    final initialImage = _initialImage;
+    if (initialImage != null) {
+      try {
+        listener.onImage(initialImage.clone(), true);
+      } catch (exception, stack) {
+        reportError(
+          context: ErrorDescription('by a synchronously-called image listener'),
+          exception: exception,
+          stack: stack,
+        );
+      }
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(ImageStreamListener listener) {
+    super.removeListener(listener);
+    if (!hasListeners) {
+      __maybeDispose();
+    }
+  }
+
+  int __keepAliveHandles = 0;
+
+  @override
+  ImageStreamCompleterHandle keepAlive() {
+    final delegateHandle = super.keepAlive();
+    return _OneFramePlaceholderImageStreamCompleterHandle(this, delegateHandle);
+  }
+
+  void __maybeDispose() {
+    if (!__hadAtLeastOneListener || __disposed || hasListeners || __keepAliveHandles != 0) {
+      return;
+    }
+
+    __disposed = true;
+  }
+
+  @override
+  void onDisposed() {
+    _initialImage?.dispose();
+    _initialImage = null;
+    super.onDisposed();
+  }
+}
+
+class _OneFramePlaceholderImageStreamCompleterHandle implements ImageStreamCompleterHandle {
+  _OneFramePlaceholderImageStreamCompleterHandle(this._completer, this._delegateHandle) {
+    _completer!.__keepAliveHandles += 1;
+  }
+
+  OneFramePlaceholderImageStreamCompleter? _completer;
+  final ImageStreamCompleterHandle _delegateHandle;
+
+  /// Call this method to signal the [ImageStreamCompleter] that it can now be
+  /// disposed when its last listener drops.
+  ///
+  /// This method must only be called once per object.
+  @override
+  void dispose() {
+    assert(_completer != null);
+    assert(_completer!.__keepAliveHandles > 0);
+    assert(!_completer!.__disposed);
+
+    _delegateHandle.dispose();
+
+    _completer!.__keepAliveHandles -= 1;
+    _completer!.__maybeDispose();
+    _completer = null;
+  }
+}

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -35,7 +35,7 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
     );
   }
 
-  _onImage(ImageInfo image) {
+  void _onImage(ImageInfo image) {
     setImage(image);
     _initialImage?.dispose();
     _initialImage = null;

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -19,7 +19,7 @@ class Thumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final thumbHash = asset is RemoteAsset ? (asset as RemoteAsset).thumbHash : null;
-    final provider = getThumbnailImageProvider(asset: asset, remoteId: remoteId, size: size);
+    final provider = getThumbnailImageProvider(asset: asset, remoteId: remoteId);
 
     return OctoImage.fromSet(
       image: provider,

--- a/mobile/lib/presentation/widgets/timeline/constants.dart
+++ b/mobile/lib/presentation/widgets/timeline/constants.dart
@@ -1,5 +1,8 @@
+import 'dart:ui';
+
 const double kTimelineHeaderExtent = 80.0;
-const double kTimelineFixedTileExtent = 256;
+const Size kTimelineFixedTileExtent = Size.square(256);
+const Size kThumbnailResolution = kTimelineFixedTileExtent;
 const double kTimelineSpacing = 2.0;
 const int kTimelineColumnCount = 3;
 

--- a/mobile/lib/presentation/widgets/timeline/segment_builder.dart
+++ b/mobile/lib/presentation/widgets/timeline/segment_builder.dart
@@ -21,7 +21,7 @@ abstract class SegmentBuilder {
   static Widget buildPlaceholder(
     BuildContext context,
     int count, {
-    Size size = const Size.square(kTimelineFixedTileExtent),
+    Size size = kTimelineFixedTileExtent,
     double spacing = kTimelineSpacing,
   }) => RepaintBoundary(
     child: FixedTimelineRow(


### PR DESCRIPTION
## Description

This is a more minimal PR extracted from #19822 to improve hero animations and asset viewer gestures before the asset is fully loaded.

Fixes #20392

#20581 is a separate issue not addressed by this

## How Has This Been Tested?

Tested on the beta timeline on local and remote photos and local videos.