### PR TITLE
fix(mobile): fetch serverConfig before building shared link

### DIFF
--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -264,11 +264,15 @@ class SharedLinkEditPage extends HookConsumerWidget {
             expiresAt: expiryAfter.value == 0 ? null : calculateExpiry(),
           );
       ref.invalidate(sharedLinksStateProvider);
+
+      await ref.read(serverInfoProvider.notifier).getServerConfig();
       final externalDomain = ref.read(serverInfoProvider.select((s) => s.serverConfig.externalDomain));
+
       var serverUrl = externalDomain.isNotEmpty ? externalDomain : getServerUrl();
       if (serverUrl != null && !serverUrl.endsWith('/')) {
         serverUrl += '/';
       }
+
       if (newLink != null && serverUrl != null) {
         newShareLink.value = "${serverUrl}share/${newLink.key}";
         copyLinkToClipboard();


### PR DESCRIPTION

## Description

serverConfig was not being fetched from the server before attempting to read externalDomain. Thus, it would always fall back to the currently connected endpoint. 

Fixes #20258

## How Has This Been Tested?
Tested with `main` server with a externalDomain both set and unset

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
