### PR TITLE
fix(mobile): use storageIndicator setting for beta timeline

### DIFF
--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -1,8 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
@@ -18,17 +16,16 @@ class MainTimelinePage extends ConsumerWidget {
     return memoryLaneProvider.maybeWhen(
       data: (memories) {
         return memories.isEmpty
-            ? Timeline(showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true)
+            ? const Timeline()
             : Timeline(
                 topSliverWidget: SliverToBoxAdapter(
                   key: Key('memory-lane-${memories.first.assets.first.id}'),
                   child: DriftMemoryLane(memories: memories),
                 ),
                 topSliverWidgetHeight: 200,
-                showStorageIndicator: true,
               );
       },
-      orElse: () => Timeline(showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true),
+      orElse: () => const Timeline(),
     );
   }
 }

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -1,6 +1,8 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
@@ -16,7 +18,7 @@ class MainTimelinePage extends ConsumerWidget {
     return memoryLaneProvider.maybeWhen(
       data: (memories) {
         return memories.isEmpty
-            ? const Timeline(showStorageIndicator: true)
+            ? Timeline(showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true)
             : Timeline(
                 topSliverWidget: SliverToBoxAdapter(
                   key: Key('memory-lane-${memories.first.assets.first.id}'),
@@ -26,7 +28,7 @@ class MainTimelinePage extends ConsumerWidget {
                 showStorageIndicator: true,
               );
       },
-      orElse: () => const Timeline(showStorageIndicator: true),
+      orElse: () => Timeline(showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true),
     );
   }
 }

--- a/mobile/lib/presentation/pages/drift_trash.page.dart
+++ b/mobile/lib/presentation/pages/drift_trash.page.dart
@@ -9,11 +9,11 @@ import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
-class DriftTrashPage extends ConsumerWidget {
+class DriftTrashPage extends StatelessWidget {
   const DriftTrashPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return ProviderScope(
       overrides: [
         timelineServiceProvider.overrideWith((ref) {

--- a/mobile/lib/presentation/pages/drift_trash.page.dart
+++ b/mobile/lib/presentation/pages/drift_trash.page.dart
@@ -1,6 +1,8 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
@@ -28,7 +30,7 @@ class DriftTrashPage extends StatelessWidget {
         }),
       ],
       child: Timeline(
-        showStorageIndicator: true,
+        showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true,
         appBar: SliverAppBar(
           title: Text('trash'.t(context: context)),
           floating: true,

--- a/mobile/lib/presentation/pages/drift_trash.page.dart
+++ b/mobile/lib/presentation/pages/drift_trash.page.dart
@@ -1,8 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/trash_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
@@ -11,11 +9,11 @@ import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
-class DriftTrashPage extends StatelessWidget {
+class DriftTrashPage extends ConsumerWidget {
   const DriftTrashPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return ProviderScope(
       overrides: [
         timelineServiceProvider.overrideWith((ref) {
@@ -30,7 +28,6 @@ class DriftTrashPage extends StatelessWidget {
         }),
       ],
       child: Timeline(
-        showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true,
         appBar: SliverAppBar(
           title: Text('trash'.t(context: context)),
           floating: true,

--- a/mobile/lib/presentation/pages/local_timeline.page.dart
+++ b/mobile/lib/presentation/pages/local_timeline.page.dart
@@ -2,6 +2,8 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -26,7 +28,7 @@ class LocalTimelinePage extends StatelessWidget {
       child: Timeline(
         appBar: MesmerizingSliverAppBar(title: album.name),
         bottomSheet: const LocalAlbumBottomSheet(),
-        showStorageIndicator: true,
+        showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true,
       ),
     );
   }

--- a/mobile/lib/presentation/pages/local_timeline.page.dart
+++ b/mobile/lib/presentation/pages/local_timeline.page.dart
@@ -2,8 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
-import 'package:immich_mobile/domain/models/store.model.dart';
-import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -28,7 +26,6 @@ class LocalTimelinePage extends StatelessWidget {
       child: Timeline(
         appBar: MesmerizingSliverAppBar(title: album.name),
         bottomSheet: const LocalAlbumBottomSheet(),
-        showStorageIndicator: Store.tryGet(StoreKey.storageIndicator) ?? true,
       ),
     );
   }

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -54,8 +54,8 @@ class ThumbnailTile extends ConsumerWidget {
 
     final hasStack = asset is RemoteAsset && (asset as RemoteAsset).stackId != null;
 
-    final storageIndicator =
-        showStorageIndicator ?? ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator))) ?? true;
+    final bool storageIndicator =
+        showStorageIndicator ?? ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator)));
 
     return Stack(
       children: [

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -2,10 +2,12 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/duration_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 
 class ThumbnailTile extends ConsumerWidget {
@@ -13,7 +15,7 @@ class ThumbnailTile extends ConsumerWidget {
     this.asset, {
     this.size = const Size.square(256),
     this.fit = BoxFit.cover,
-    this.showStorageIndicator = true,
+    this.showStorageIndicator,
     this.lockSelection = false,
     this.heroOffset,
     super.key,
@@ -22,7 +24,7 @@ class ThumbnailTile extends ConsumerWidget {
   final BaseAsset asset;
   final Size size;
   final BoxFit fit;
-  final bool showStorageIndicator;
+  final bool? showStorageIndicator;
   final bool lockSelection;
   final int? heroOffset;
 
@@ -51,6 +53,9 @@ class ThumbnailTile extends ConsumerWidget {
         : const BoxDecoration();
 
     final hasStack = asset is RemoteAsset && (asset as RemoteAsset).stackId != null;
+
+    final storageIndicator =
+        showStorageIndicator ?? ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator))) ?? true;
 
     return Stack(
       children: [
@@ -86,7 +91,7 @@ class ThumbnailTile extends ConsumerWidget {
                       child: _VideoIndicator(asset.duration),
                     ),
                   ),
-                if (showStorageIndicator)
+                if (storageIndicator)
                   switch (asset.storage) {
                     AssetState.local => const Align(
                       alignment: Alignment.bottomRight,

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -14,7 +14,7 @@ class TimelineArgs {
   final double maxHeight;
   final double spacing;
   final int columnCount;
-  final bool showStorageIndicator;
+  final bool? showStorageIndicator;
   final bool withStack;
   final GroupAssetsBy? groupBy;
 
@@ -23,7 +23,7 @@ class TimelineArgs {
     required this.maxHeight,
     this.spacing = kTimelineSpacing,
     this.columnCount = kTimelineColumnCount,
-    this.showStorageIndicator = false,
+    this.showStorageIndicator,
     this.withStack = false,
     this.groupBy,
   });

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -31,7 +31,7 @@ class Timeline extends StatelessWidget {
     super.key,
     this.topSliverWidget,
     this.topSliverWidgetHeight,
-    this.showStorageIndicator = false,
+    this.showStorageIndicator,
     this.withStack = false,
     this.appBar = const ImmichSliverAppBar(floating: true, pinned: false, snap: false),
     this.bottomSheet = const GeneralBottomSheet(),
@@ -40,7 +40,7 @@ class Timeline extends StatelessWidget {
 
   final Widget? topSliverWidget;
   final double? topSliverWidgetHeight;
-  final bool showStorageIndicator;
+  final bool? showStorageIndicator;
   final Widget? appBar;
   final Widget? bottomSheet;
   final bool withStack;

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_settings.dart
@@ -2,11 +2,13 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
 import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
 import 'package:immich_mobile/widgets/settings/settings_sub_page_scaffold.dart';
 import 'package:immich_mobile/widgets/settings/settings_switch_list_tile.dart';
-import 'package:immich_mobile/utils/hooks/app_settings_update_hook.dart';
+
 import 'asset_list_layout_settings.dart';
 
 class AssetListSettings extends HookConsumerWidget {
@@ -20,7 +22,10 @@ class AssetListSettings extends HookConsumerWidget {
       SettingsSwitchListTile(
         valueNotifier: showStorageIndicator,
         title: 'theme_setting_asset_list_storage_indicator_title'.tr(),
-        onChanged: (_) => ref.invalidate(appSettingsServiceProvider),
+        onChanged: (_) {
+          ref.invalidate(appSettingsServiceProvider);
+          ref.invalidate(settingsProvider);
+        },
       ),
       const LayoutSettings(),
       const GroupSettings(),


### PR DESCRIPTION
## Description

Fixes #20139

## How Has This Been Tested?

Tested with both storage indicators enabled/disabled.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
