### PR TITLE
fix(mobile): disable memory lane when memories are disabled

### DIFF
--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
 class MainTimelinePage extends ConsumerWidget {
@@ -12,10 +13,11 @@ class MainTimelinePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
+    final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
 
     return memoryLaneProvider.maybeWhen(
       data: (memories) {
-        return memories.isEmpty
+        return memories.isEmpty || !memoriesEnabled
             ? const Timeline(showStorageIndicator: true)
             : Timeline(
                 topSliverWidget: SliverToBoxAdapter(

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -15,6 +15,9 @@ class MainTimelinePage extends ConsumerWidget {
     final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
     final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
 
+    // TODO: the user preferences need to be updated 
+    // from the server to get live hiding/showing of memory lane
+    
     return memoryLaneProvider.maybeWhen(
       data: (memories) {
         return memories.isEmpty || !memoriesEnabled

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -15,9 +15,9 @@ class MainTimelinePage extends ConsumerWidget {
     final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
     final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
 
-    // TODO: the user preferences need to be updated 
+    // TODO: the user preferences need to be updated
     // from the server to get live hiding/showing of memory lane
-    
+
     return memoryLaneProvider.maybeWhen(
       data: (memories) {
         return memories.isEmpty || !memoriesEnabled


### PR DESCRIPTION
## Description

Fixes #20171

## How Has This Been Tested?

Tested with personal instance (on 1.137.3)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
