### PR TITLE
fix: adjust margin and gap for trailing elements in control app bar

### DIFF
--- a/web/src/lib/components/shared-components/control-app-bar.svelte
+++ b/web/src/lib/components/shared-components/control-app-bar.svelte
@@ -97,7 +97,7 @@
       {@render children?.()}
     </div>
 
-    <div class="me-4 flex place-items-center gap-1 justify-self-end">
+    <div class="max-[350px]:me-0 max-[350px]:gap-0 me-4 flex place-items-center gap-1 justify-self-end">
       {@render trailing?.()}
     </div>
   </nav>


### PR DESCRIPTION
## Description
Fixed displaying album control panel on smaller devices.
Removed `gap` and `margin-end` for devices smaller than 350px wide
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # ([issue](https://github.com/immich-app/immich/issues/19018))

## How Has This Been Tested?
I tested it using chrome developer tools
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

| BEFORE | AFTER |
|--------|-------|
| <img width="421" height="658" alt="image" src="https://github.com/user-attachments/assets/a5bcf3d3-0493-43b3-bf7e-a58511502b02" /> <br> <img width="428" height="685" alt="image" src="https://github.com/user-attachments/assets/048de417-ce40-4d21-8214-f92efaaf49fb" /> | <img width="426" height="687" alt="image" src="https://github.com/user-attachments/assets/bcf006a9-5d9b-40aa-9502-dcb80b9211c0" /> <br> <img width="429" height="685" alt="image" src="https://github.com/user-attachments/assets/11d1e65c-e65f-4d49-8e43-cad7de6fdb25" /> |

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
