### PR TITLE
fix(server): only asset owner should see favorite status

### DIFF
--- a/server/src/dtos/asset-response.dto.ts
+++ b/server/src/dtos/asset-response.dto.ts
@@ -212,7 +212,7 @@ export function mapAsset(entity: MapAsset, options: AssetMapOptions = {}): Asset
     fileModifiedAt: entity.fileModifiedAt,
     localDateTime: entity.localDateTime,
     updatedAt: entity.updatedAt,
-    isFavorite: options.auth?.user.id === entity.ownerId ? entity.isFavorite : false,
+    isFavorite: options.auth?.user.id === entity.ownerId && entity.isFavorite,
     isArchived: entity.visibility === AssetVisibility.Archive,
     isTrashed: !!entity.deletedAt,
     visibility: entity.visibility,

--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -296,7 +296,8 @@ with
       "asset"."duration",
       "asset"."id",
       "asset"."visibility",
-      "asset"."isFavorite",
+      asset."isFavorite"
+      and asset."ownerId" = $1 as "isFavorite",
       asset.type = 'IMAGE' as "isImage",
       asset."deletedAt" is not null as "isTrashed",
       "asset"."livePhotoVideoId",
@@ -341,14 +342,14 @@ with
         where
           "stacked"."stackId" = "asset"."stackId"
           and "stacked"."deletedAt" is null
-          and "stacked"."visibility" = $1
+          and "stacked"."visibility" = $2
         group by
           "stacked"."stackId"
       ) as "stacked_assets" on true
     where
       "asset"."deletedAt" is null
       and "asset"."visibility" in ('archive', 'timeline')
-      and date_trunc('MONTH', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $2
+      and date_trunc('MONTH', "localDateTime" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' = $3
       and not exists (
         select
         from

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -590,7 +590,7 @@ export class AssetRepository {
   }
 
   @GenerateSql({
-    params: [DummyValue.TIME_BUCKET, { withStacked: true }],
+    params: [DummyValue.TIME_BUCKET, { withStacked: true }, { user: { id: DummyValue.UUID } }],
   })
   getTimeBucket(timeBucket: string, options: TimeBucketOptions, auth: AuthDto) {
     const query = this.db

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -691,16 +691,19 @@ export class AssetRepository {
             eb.fn.coalesce(eb.fn('array_agg', ['duration']), sql.lit('{}')).as('duration'),
             eb.fn.coalesce(eb.fn('array_agg', ['id']), sql.lit('{}')).as('id'),
             eb.fn.coalesce(eb.fn('array_agg', ['visibility']), sql.lit('{}')).as('visibility'),
-            eb.fn.coalesce(
-              eb.fn('array_agg', [
-                eb.case()
-                  .when(eb.ref('ownerId'), '=', auth?.user.id || '')
-                  .then(eb.ref('isFavorite'))
-                  .else(sql.lit(false))
-                  .end()
-              ]), 
-              sql.lit('{}')
-            ).as('isFavorite'),
+            eb.fn
+              .coalesce(
+                eb.fn('array_agg', [
+                  eb
+                    .case()
+                    .when(eb.ref('ownerId'), '=', auth?.user.id || '')
+                    .then(eb.ref('isFavorite'))
+                    .else(sql.lit(false))
+                    .end(),
+                ]),
+                sql.lit('{}'),
+              )
+              .as('isFavorite'),
             eb.fn.coalesce(eb.fn('array_agg', ['isImage']), sql.lit('{}')).as('isImage'),
             // TODO: isTrashed is redundant as it will always be all true or false depending on the options
             eb.fn.coalesce(eb.fn('array_agg', ['isTrashed']), sql.lit('{}')).as('isTrashed'),

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -162,7 +162,7 @@ export class NotificationService extends BaseService {
 
     const [asset] = await this.assetRepository.getByIdsWithAllRelationsButStacks([assetId]);
     if (asset) {
-      this.eventRepository.clientSend('on_asset_update', userId, mapAsset(asset));
+      this.eventRepository.clientSend('on_asset_update', userId, mapAsset(asset, { auth: { user: { id: userId } } as AuthDto }));
     }
   }
 

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -162,7 +162,11 @@ export class NotificationService extends BaseService {
 
     const [asset] = await this.assetRepository.getByIdsWithAllRelationsButStacks([assetId]);
     if (asset) {
-      this.eventRepository.clientSend('on_asset_update', userId, mapAsset(asset, { auth: { user: { id: userId } } as AuthDto }));
+      this.eventRepository.clientSend(
+        'on_asset_update',
+        userId,
+        mapAsset(asset, { auth: { user: { id: userId } } as AuthDto }),
+      );
     }
   }
 

--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -36,10 +36,14 @@ describe(TimelineService.name, () => {
       );
 
       expect(mocks.access.album.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['album-id']));
-      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith('bucket', {
-        timeBucket: 'bucket',
-        albumId: 'album-id',
-      });
+      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+        'bucket',
+        {
+          timeBucket: 'bucket',
+          albumId: 'album-id',
+        },
+        authStub.admin,
+      );
     });
 
     it('should return the assets for a archive time bucket if user has archive.read', async () => {
@@ -60,6 +64,7 @@ describe(TimelineService.name, () => {
           visibility: AssetVisibility.Archive,
           userIds: [authStub.admin.user.id],
         }),
+        authStub.admin,
       );
     });
 
@@ -76,12 +81,16 @@ describe(TimelineService.name, () => {
           withPartners: true,
         }),
       ).resolves.toEqual(json);
-      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith('bucket', {
-        timeBucket: 'bucket',
-        visibility: AssetVisibility.Timeline,
-        withPartners: true,
-        userIds: [authStub.admin.user.id],
-      });
+      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+        'bucket',
+        {
+          timeBucket: 'bucket',
+          visibility: AssetVisibility.Timeline,
+          withPartners: true,
+          userIds: [authStub.admin.user.id],
+        },
+        authStub.admin,
+      );
     });
 
     it('should check permissions to read tag', async () => {
@@ -96,11 +105,15 @@ describe(TimelineService.name, () => {
           tagId: 'tag-123',
         }),
       ).resolves.toEqual(json);
-      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith('bucket', {
-        tagId: 'tag-123',
-        timeBucket: 'bucket',
-        userIds: [authStub.admin.user.id],
-      });
+      expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
+        'bucket',
+        {
+          tagId: 'tag-123',
+          timeBucket: 'bucket',
+          userIds: [authStub.admin.user.id],
+        },
+        authStub.admin,
+      );
     });
 
     it('should return the assets for a library time bucket if user has library.read', async () => {
@@ -119,6 +132,7 @@ describe(TimelineService.name, () => {
           timeBucket: 'bucket',
           userIds: [authStub.admin.user.id],
         }),
+        authStub.admin,
       );
     });
 

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -21,7 +21,7 @@ export class TimelineService extends BaseService {
     const timeBucketOptions = await this.buildTimeBucketOptions(auth, { ...dto });
 
     // TODO: use id cursor for pagination
-    const bucket = await this.assetRepository.getTimeBucket(dto.timeBucket, timeBucketOptions);
+    const bucket = await this.assetRepository.getTimeBucket(dto.timeBucket, timeBucketOptions, auth);
     return bucket.assets;
   }
 


### PR DESCRIPTION
Fixed: Any asset update disables isFavorite action in GUI. Only owner of asset in album should see favorited image.

## Description
I was trying to fix issue from link below.
Other than that I noticed that /buckets request was returning isFavorite: true for non asset owners inside album.
There was fix for that long time ago: https://github.com/immich-app/immich/pull/7580, but it looks like /buckets request was introduced without that workaround. 
Issue from https://github.com/immich-app/immich/issues/19089 was caused by previous workaround. I fixed that by passing userId required for recognizing owner.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # ([issue](https://github.com/immich-app/immich/issues/19089))

## How Has This Been Tested?
Main fix:
1. I added photo to favorite -> Favorite icon is enabled
2. I modified photo location
3. Favorite was not reset

Additional fix:
1. I added assets to album with user A and user B
2. I favorited owned assets using user A and user B
3. Both users see only their own favorited assets, they're not able to see other person favorite assets and are not able to favorite them. 


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
User B only asset is:
<img width="1286" height="801" alt="image" src="https://github.com/user-attachments/assets/16ebdbdf-903d-4474-9794-15498ea179b4" /> 

**Before fix:**
User A:
<img width="1290" height="708" alt="image" src="https://github.com/user-attachments/assets/bd917b05-69db-46bd-9814-5d3f521adb56" />
User B:
<img width="1290" height="807" alt="image" src="https://github.com/user-attachments/assets/3fc8fb91-8790-485e-b681-a232bf426baa" />


**After fix:**
User A:
<img width="1287" height="708" alt="image" src="https://github.com/user-attachments/assets/474a8ad3-c93a-4e10-9a1b-dd63e28bc232" />
User B:
<img width="1288" height="807" alt="image" src="https://github.com/user-attachments/assets/f569dc99-ef1e-4fa5-8ab7-9aa1d5dc95ef" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
