### PR TITLE
feat(mobile): use custom headers when connecting in widget

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
@@ -59,16 +59,18 @@ class ImmichAPI(cfg: ServerConfig) {
     return URL(urlString.toString())
   }
 
+  private fun HttpURLConnection.applyCustomHeaders() {
+    serverConfig.customHeaders.forEach { (key, value) ->
+      setRequestProperty(key, value)
+    }
+  }
+
   suspend fun fetchSearchResults(filters: SearchFilters): List<Asset> = withContext(Dispatchers.IO) {
     val url = buildRequestURL("/search/random")
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "POST"
       setRequestProperty("Content-Type", "application/json")
-
-      // Custom Headers
-      serverConfig.customHeaders.forEach { (key, value) ->
-        setRequestProperty(key, value)
-      }
+      applyCustomHeaders()
 
       doOutput = true
     }
@@ -90,11 +92,7 @@ class ImmichAPI(cfg: ServerConfig) {
     val url = buildRequestURL("/memories", listOf("for" to iso8601))
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "GET"
-
-      // Custom Headers
-      serverConfig.customHeaders.forEach { (key, value) ->
-        setRequestProperty(key, value)
-      }
+      applyCustomHeaders()
     }
 
     val response = connection.inputStream.bufferedReader().readText()
@@ -114,11 +112,7 @@ class ImmichAPI(cfg: ServerConfig) {
     val url = buildRequestURL("/albums")
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "GET"
-
-      // Custom Headers
-      serverConfig.customHeaders.forEach { (key, value) ->
-        setRequestProperty(key, value)
-      }
+      applyCustomHeaders()
     }
 
     val response = connection.inputStream.bufferedReader().readText()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
@@ -3,7 +3,6 @@ package app.alextran.immich.widget
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.util.Log
 import app.alextran.immich.widget.model.*
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
@@ -55,7 +55,11 @@ data class WidgetEntry (
   val deeplink: String?
 )
 
-data class ServerConfig(val serverEndpoint: String, val sessionKey: String)
+data class ServerConfig(
+  val serverEndpoint: String,
+  val sessionKey: String,
+  val customHeaders: Map<String, String>
+)
 
 // MARK: Widget State Keys
 val kImageUUID = stringPreferencesKey("uuid")

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -104,10 +104,13 @@ struct Album: Codable, Equatable {
 // MARK: API
 
 class ImmichAPI {
+  typealias CustomHeaders = [String:String]
   struct ServerConfig {
     let serverEndpoint: String
     let sessionKey: String
+    let customHeaders: CustomHeaders
   }
+  
   let serverConfig: ServerConfig
 
   init() async throws {
@@ -122,10 +125,20 @@ class ImmichAPI {
     if serverURL == "" || sessionKey == "" {
       throw WidgetError.noLogin
     }
+    
+    // custom headers come in the form of KV pairs in JSON
+    var customHeadersJSON = (defaults.string(forKey: "widget_custom_headers") ?? "")
+    var customHeaders: CustomHeaders = [:]
+    
+    if customHeadersJSON != "",
+       let parsedHeaders = try? JSONDecoder().decode(CustomHeaders.self, from: customHeadersJSON.data(using: .utf8)!) {
+      customHeaders = parsedHeaders
+    }
 
     serverConfig = ServerConfig(
       serverEndpoint: serverURL,
-      sessionKey: sessionKey
+      sessionKey: sessionKey,
+      customHeaders: customHeaders
     )
   }
 
@@ -155,6 +168,12 @@ class ImmichAPI {
 
     return components?.url
   }
+  
+  func applyHeaders(for request: inout URLRequest) {
+    for (header, value) in serverConfig.customHeaders {
+      request.addValue(value, forHTTPHeaderField: header)
+    }
+  }
 
   func fetchSearchResults(with filters: SearchFilter = Album.NONE.filter)
     async throws
@@ -174,7 +193,8 @@ class ImmichAPI {
     request.httpMethod = "POST"
     request.httpBody = try JSONEncoder().encode(filters)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
+    applyHeaders(for: &request)
+    
     let (data, _) = try await URLSession.shared.data(for: request)
 
     // decode data
@@ -196,6 +216,7 @@ class ImmichAPI {
 
     var request = URLRequest(url: searchURL)
     request.httpMethod = "GET"
+    applyHeaders(for: &request)
 
     let (data, _) = try await URLSession.shared.data(for: request)
 
@@ -254,7 +275,8 @@ class ImmichAPI {
 
     var request = URLRequest(url: searchURL)
     request.httpMethod = "GET"
-
+    applyHeaders(for: &request)
+    
     let (data, _) = try await URLSession.shared.data(for: request)
 
     // decode data

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -169,7 +169,7 @@ class ImmichAPI {
     return components?.url
   }
   
-  func applyHeaders(for request: inout URLRequest) {
+  func applyCustomHeaders(for request: inout URLRequest) {
     for (header, value) in serverConfig.customHeaders {
       request.addValue(value, forHTTPHeaderField: header)
     }
@@ -193,7 +193,7 @@ class ImmichAPI {
     request.httpMethod = "POST"
     request.httpBody = try JSONEncoder().encode(filters)
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    applyHeaders(for: &request)
+    applyCustomHeaders(for: &request)
     
     let (data, _) = try await URLSession.shared.data(for: request)
 
@@ -216,7 +216,7 @@ class ImmichAPI {
 
     var request = URLRequest(url: searchURL)
     request.httpMethod = "GET"
-    applyHeaders(for: &request)
+    applyCustomHeaders(for: &request)
 
     let (data, _) = try await URLSession.shared.data(for: request)
 
@@ -275,7 +275,7 @@ class ImmichAPI {
 
     var request = URLRequest(url: searchURL)
     request.httpMethod = "GET"
-    applyHeaders(for: &request)
+    applyCustomHeaders(for: &request)
     
     let (data, _) = try await URLSession.shared.data(for: request)
 

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -30,9 +30,10 @@ const int kTimelineAssetLoadBatchSize = 256;
 const int kTimelineAssetLoadOppositeSize = 64;
 
 // Widget keys
+const String appShareGroupId = "group.app.immich.share";
 const String kWidgetAuthToken = "widget_auth_token";
 const String kWidgetServerEndpoint = "widget_server_url";
-const String appShareGroupId = "group.app.immich.share";
+const String kWidgetCustomHeaders = "widget_custom_headers";
 
 // add widget identifiers here for new widgets
 // these are used to force a widget refresh

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -121,7 +121,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<bool> saveAuthInfo({required String accessToken}) async {
     await _apiService.setAccessToken(accessToken);
 
-    await _widgetService.writeCredentials(Store.get(StoreKey.serverEndpoint), accessToken);
+    final serverEndpoint = Store.get(StoreKey.serverEndpoint);
+    final customHeaders = Store.get(StoreKey.customHeaders);
+    await _widgetService.writeCredentials(serverEndpoint, accessToken, customHeaders);
 
     // Get the deviceid from the store if it exists, otherwise generate a new one
     String deviceId = Store.tryGet(StoreKey.deviceId) ?? await FlutterUdid.consistentUdid;

--- a/mobile/lib/services/widget.service.dart
+++ b/mobile/lib/services/widget.service.dart
@@ -11,10 +11,11 @@ class WidgetService {
 
   const WidgetService(this._repository);
 
-  Future<void> writeCredentials(String serverURL, String sessionKey) async {
+  Future<void> writeCredentials(String serverURL, String sessionKey, String customHeaders) async {
     await _repository.setAppGroupId(appShareGroupId);
     await _repository.saveData(kWidgetServerEndpoint, serverURL);
     await _repository.saveData(kWidgetAuthToken, sessionKey);
+    await _repository.saveData(kWidgetCustomHeaders, customHeaders);
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);
@@ -24,6 +25,7 @@ class WidgetService {
     await _repository.setAppGroupId(appShareGroupId);
     await _repository.saveData(kWidgetServerEndpoint, "");
     await _repository.saveData(kWidgetAuthToken, "");
+    await _repository.saveData(kWidgetCustomHeaders, "");
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);


### PR DESCRIPTION
## Description

The widget previously did not use the custom headers set by app. This caused authentication errors to occur if users were using headers to bypass auth providers like Cloudflare Zero Trust.

Fixes #20452

## How Has This Been Tested?
Tested on both iOS and android widgets. Headers are properly loaded on both platforms and headers are applied to the request objects. I do not have an easy way of dumping headers from the server but the headers are applied in an identical way to the Content-Type field we use for the search API.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
