### PR TITLE
feat: ack sync reset

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -202,7 +202,6 @@ export type Album = Selectable<AlbumTable> & {
 
 export type AuthSession = {
   id: string;
-  isPendingSyncReset: boolean;
   hasElevatedPermission: boolean;
 };
 
@@ -309,7 +308,7 @@ export const columns = {
   assetFiles: ['asset_file.id', 'asset_file.path', 'asset_file.type'],
   authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes'],
   authApiKey: ['api_key.id', 'api_key.permissions'],
-  authSession: ['session.id', 'session.isPendingSyncReset', 'session.updatedAt', 'session.pinExpiresAt'],
+  authSession: ['session.id', 'session.updatedAt', 'session.pinExpiresAt'],
   authSharedLink: [
     'shared_link.id',
     'shared_link.userId',

--- a/server/src/dtos/session.dto.ts
+++ b/server/src/dtos/session.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsPositive, IsString } from 'class-validator';
+import { Equals, IsInt, IsPositive, IsString } from 'class-validator';
 import { Session } from 'src/database';
 import { Optional, ValidateBoolean } from 'src/validation';
 
@@ -22,7 +22,8 @@ export class SessionCreateDto {
 
 export class SessionUpdateDto {
   @ValidateBoolean({ optional: true })
-  isPendingSyncReset?: boolean;
+  @Equals(true)
+  isPendingSyncReset?: true;
 }
 
 export class SessionResponseDto {

--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -10,10 +10,17 @@ from
 where
   "id" = $1
 
+-- SessionRepository.isPendingSyncReset
+select
+  "isPendingSyncReset"
+from
+  "session"
+where
+  "id" = $1
+
 -- SessionRepository.getByToken
 select
   "session"."id",
-  "session"."isPendingSyncReset",
   "session"."updatedAt",
   "session"."pinExpiresAt",
   (

--- a/server/src/repositories/session.repository.ts
+++ b/server/src/repositories/session.repository.ts
@@ -37,6 +37,16 @@ export class SessionRepository {
       .executeTakeFirst();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  async isPendingSyncReset(id: string) {
+    const result = await this.db
+      .selectFrom('session')
+      .select(['isPendingSyncReset'])
+      .where('id', '=', id)
+      .executeTakeFirst();
+    return result?.isPendingSyncReset ?? false;
+  }
+
   @GenerateSql({ params: [DummyValue.STRING] })
   getByToken(token: string) {
     return this.db

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -241,7 +241,6 @@ describe(AuthService.name, () => {
       const sessionWithToken = {
         id: session.id,
         updatedAt: session.updatedAt,
-        isPendingSyncReset: false,
         user: factory.authUser(),
         pinExpiresAt: null,
       };
@@ -259,7 +258,6 @@ describe(AuthService.name, () => {
         session: {
           id: session.id,
           hasElevatedPermission: false,
-          isPendingSyncReset: session.isPendingSyncReset,
         },
       });
     });
@@ -409,7 +407,6 @@ describe(AuthService.name, () => {
         id: session.id,
         updatedAt: session.updatedAt,
         user: factory.authUser(),
-        isPendingSyncReset: false,
         pinExpiresAt: null,
       };
 
@@ -426,7 +423,6 @@ describe(AuthService.name, () => {
         session: {
           id: session.id,
           hasElevatedPermission: false,
-          isPendingSyncReset: session.isPendingSyncReset,
         },
       });
     });

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -487,7 +487,6 @@ export class AuthService extends BaseService {
         user: session.user,
         session: {
           id: session.id,
-          isPendingSyncReset: session.isPendingSyncReset,
           hasElevatedPermission,
         },
       };

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -60,7 +60,6 @@ const authFactory = ({
   if (session) {
     auth.session = {
       id: session.id,
-      isPendingSyncReset: false,
       hasElevatedPermission: false,
     };
   }


### PR DESCRIPTION
You now receive an ack from a SyncResetV1 stream event and can ack that to tell the server to remove all previous checkpoints 