### PR TITLE
fix(mobile): filter people that have less than 3 faces

### DIFF
--- a/mobile/lib/infrastructure/repositories/people.repository.dart
+++ b/mobile/lib/infrastructure/repositories/people.repository.dart
@@ -24,7 +24,7 @@ class DriftPeopleRepository extends DriftDatabaseRepository {
             leftOuterJoin(_db.assetFaceEntity, _db.assetFaceEntity.personId.equalsExp(_db.personEntity.id)),
           ])
           ..where(_db.personEntity.isHidden.equals(false))
-          ..groupBy([_db.personEntity.id])
+          ..groupBy([_db.personEntity.id], having: _db.assetFaceEntity.id.count().isBiggerOrEqualValue(3))
           ..orderBy([
             OrderingTerm(expression: _db.personEntity.name.equals('').not(), mode: OrderingMode.desc),
             OrderingTerm(expression: _db.assetFaceEntity.id.count(), mode: OrderingMode.desc),


### PR DESCRIPTION
## Description

Mobile app currently does not filter people with less than 3 faces. In the future, this will be a value from the server as well as a configurable user preference (hence the TODO). 

Fixes #20502

## How Has This Been Tested?

Tested on my personal instance and properly filtered people with less than 3 faces

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
