### PR TITLE
fix(web): use correct sliding window offset for search results

### DIFF
--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -53,6 +53,7 @@
   const MAX_ASSET_COUNT = 5000;
   let { isViewing: showAssetViewer } = assetViewingStore;
   const viewport: Viewport = $state({ width: 0, height: 0 });
+  let searchResultsElement: HTMLElement | undefined = $state();
 
   // The GalleryViewer pushes it's own history state, which causes weird
   // behavior for history.back(). To prevent that we store the previous page
@@ -366,6 +367,7 @@
   class="mb-12 bg-immich-bg dark:bg-immich-dark-bg m-4"
   bind:clientHeight={viewport.height}
   bind:clientWidth={viewport.width}
+  bind:this={searchResultsElement}
 >
   {#if searchResultAlbums.length > 0}
     <section>
@@ -385,8 +387,8 @@
         onIntersected={loadNextPage}
         showArchiveIcon={true}
         {viewport}
-        pageHeaderOffset={54}
         onReload={onSearchQueryUpdate}
+        slidingWindowOffset={searchResultsElement.offsetTop}
       />
     {:else if !isLoading}
       <div class="flex min-h-[calc(66vh-11rem)] w-full place-content-center items-center dark:text-white">


### PR DESCRIPTION
## Description

The contents of search results are slightly offset by the search bar, search terms and spacing (margins/padding), and needs to be factored in when calculating whether an asset is visible or not. The offset was 0, which meant that assets were removed from view too early.


## How Has This Been Tested?

Locally, but can also test on the preview instance.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before:

<img width="2744" height="231" alt="image" src="https://github.com/user-attachments/assets/8e4dc829-356f-4060-9320-2952f5230224" />

After:

<img width="2742" height="257" alt="image" src="https://github.com/user-attachments/assets/4cfce214-038f-4bf5-ae81-bd594ca3e2d8" />


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
