### PR TITLE
feat(mobile): Add basic auth support for experimental networking features

### DIFF
--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -92,8 +92,9 @@ class ApiService implements Authentication {
 
   /// Takes a server URL and attempts to resolve the API endpoint.
   ///
-  /// Input: [schema://]host[:port][/path]
+  /// Input: [schema://][basicAuth:password@]host[:port][/path]
   ///  schema - optional (default: https)
+  ///  userInfo - optional
   ///  host   - required
   ///  port   - optional (default: based on schema)
   ///  path   - optional

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -16,15 +16,15 @@ String? getServerUrl() {
   if (serverUri == null) {
     return null;
   }
-  var URIToDecodeFull = "${serverUri.scheme}://";
+  var UriToDecodeToFull = "${serverUri.scheme}://";
   if (serverUri.userInfo.isNotEmpty){
-    URIToDecodeFull += "${serverUri.userInfo}@";
+    UriToDecodeToFull += "${serverUri.userInfo}@";
   }
-  URIToDecodeFull += "${serverUri.host}";
+  UriToDecodeToFull += serverUri.host;
   if(serverUri.hasPort){
-      URIToDecodeFull += ":${serverUri.port}";
+      UriToDecodeToFull += ":${serverUri.port}";
   }
-  return Uri.decodeFull(URIToDecodeFull);
+  return Uri.decodeFull(UriToDecodeToFull);
 }
 
 /// Converts a Unicode URL to its ASCII-compatible encoding (Punycode).

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -16,12 +16,15 @@ String? getServerUrl() {
   if (serverUri == null) {
     return null;
   }
-
-  return Uri.decodeFull(
-    serverUri.hasPort
-        ? "${serverUri.scheme}://${serverUri.host}:${serverUri.port}"
-        : "${serverUri.scheme}://${serverUri.host}",
-  );
+  var URIToDecodeFull = "${serverUri.scheme}://";
+  if (serverUri.userInfo.isNotEmpty){
+    URIToDecodeFull += "${serverUri.userInfo}@";
+  }
+  URIToDecodeFull += "${serverUri.host}";
+  if(serverUri.hasPort){
+      URIToDecodeFull += ":${serverUri.port}";
+  }
+  return Uri.decodeFull(URIToDecodeFull);
 }
 
 /// Converts a Unicode URL to its ASCII-compatible encoding (Punycode).

--- a/mobile/lib/utils/url_helper.dart
+++ b/mobile/lib/utils/url_helper.dart
@@ -16,15 +16,15 @@ String? getServerUrl() {
   if (serverUri == null) {
     return null;
   }
-  var UriToDecodeToFull = "${serverUri.scheme}://";
-  if (serverUri.userInfo.isNotEmpty){
-    UriToDecodeToFull += "${serverUri.userInfo}@";
+  var uriToDecodeToFull = "${serverUri.scheme}://";
+  if (serverUri.userInfo.isNotEmpty) {
+    uriToDecodeToFull += "${serverUri.userInfo}@";
   }
-  UriToDecodeToFull += serverUri.host;
-  if(serverUri.hasPort){
-      UriToDecodeToFull += ":${serverUri.port}";
+  uriToDecodeToFull += serverUri.host;
+  if (serverUri.hasPort) {
+    uriToDecodeToFull += ":${serverUri.port}";
   }
-  return Uri.decodeFull(UriToDecodeToFull);
+  return Uri.decodeFull(uriToDecodeToFull);
 }
 
 /// Converts a Unicode URL to its ASCII-compatible encoding (Punycode).

--- a/mobile/test/services/auth.service_test.dart
+++ b/mobile/test/services/auth.service_test.dart
@@ -59,7 +59,7 @@ void main() {
       db.writeTxnSync(() => db.clearSync());
       await StoreService.init(storeRepository: IsarStoreRepository(db));
     });
-    // add test here
+
     test('Should resolve HTTP endpoint', () async {
       const testUrl = 'http://ip:2283';
       const resolvedUrl = 'http://ip:2283/api';

--- a/mobile/test/services/auth.service_test.dart
+++ b/mobile/test/services/auth.service_test.dart
@@ -59,7 +59,7 @@ void main() {
       db.writeTxnSync(() => db.clearSync());
       await StoreService.init(storeRepository: IsarStoreRepository(db));
     });
-
+    // add test here
     test('Should resolve HTTP endpoint', () async {
       const testUrl = 'http://ip:2283';
       const resolvedUrl = 'http://ip:2283/api';

--- a/mobile/test/utils/url_helper_test.dart
+++ b/mobile/test/utils/url_helper_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/utils/url_helper.dart';
+import 'package:isar/isar.dart';
+
+import '../test_utils.dart';
+import '../fixtures/user.stub.dart';
+
+void main() {
+  late Isar db;
+
+  setUpAll(() async {
+    db = await TestUtils.initIsar();
+    await StoreService.init(storeRepository: IsarStoreRepository(db));
+  });
+
+
+  group('sanitizeUrl', () {
+    test('Should encode correctly', () {
+      var unEncodedURL = 'user:password@example.com/addSchemaAndRemovesSlashes////';
+      expect(sanitizeUrl(unEncodedURL), 'https://user:password@example.com/addSchemaAndRemovesSlashes');
+    });
+
+    test('does not switch http to https', () {
+      var unEncodedURL = 'http://user:password@example.com/addSchemaAndRemovesSlashes////';
+      expect(sanitizeUrl(unEncodedURL), 'http://user:password@example.com/addSchemaAndRemovesSlashes');
+    });
+  });
+
+  group('punycodeEncode', () {
+    test('malformed URL returns a blank string', () {
+      var badURL = 'example.com/missing a scheme';
+      expect(punycodeEncodeUrl(badURL), '');
+    });
+
+    test('Encodes IDNs correctly', () {
+      var idn = 'https://bücher.de';
+      expect(punycodeEncodeUrl(idn), 'https://xn--bcher-kva.de');
+    });
+   
+    test('Keeps basic auth in encoding', () {
+      var basicAuthURL = 'https://user:password@example.com';
+      expect(punycodeEncodeUrl(basicAuthURL), 'https://user:password@example.com');
+    });
+  });
+
+  group('punycodeDecode', () {
+   test('malformed URL returns a null', () {
+      var badURL = 'example.com/missing%20a%20scheme';
+      expect(punycodeDecodeUrl(badURL), null);
+    });
+
+    test('Decodes IDNs correctly', () {
+      var idn = 'https://xn--bcher-kva.de';
+      expect(punycodeDecodeUrl(idn), 'https://bücher.de');
+    });
+   
+    test('Keeps basic auth in encoding', () {
+      var basicAuthURL = 'https://user:password@example.com/%20with%20spaces';
+      expect(punycodeDecodeUrl(basicAuthURL), 'https://user:password@example.com/ with spaces');
+    });
+  });
+
+  group('getServerUrl', () {
+    test('Returns null if not set', () {
+      expect(getServerUrl(), null);
+    });
+
+    test('Returns null if what was set is not a correct url', () {
+      Store.put(StoreKey.serverEndpoint, 'example.com');
+      expect(getServerUrl(), null);
+    });
+    
+    test('Returns decoded basic URL', () async {
+      var encodedURL = 'https://example.com/ clears extra paths';
+      await Store.put(StoreKey.serverEndpoint, encodedURL);
+      expect(getServerUrl(), 'https://example.com');
+    });
+
+    test('Returns decoded basic auth URL', () async {
+      var basicAuthURL = 'https://user:password@example.com';
+      await Store.put(StoreKey.serverEndpoint, basicAuthURL);
+      expect(getServerUrl(), basicAuthURL);
+    });
+
+    test('Returns decoded URL with a port', () async {
+      var portURL = 'https://example.com:1337';
+      await Store.put(StoreKey.serverEndpoint, portURL);
+      expect(getServerUrl(), portURL);
+    });
+
+      test('Returns decoded complex URL', () async {
+      var complexURL = 'https://user:password@example.com:1337/123/abc';
+      await Store.put(StoreKey.serverEndpoint, complexURL);
+      expect(getServerUrl(), 'https://user:password@example.com:1337');
+    });
+
+  });
+}

--- a/mobile/test/utils/url_helper_test.dart
+++ b/mobile/test/utils/url_helper_test.dart
@@ -7,7 +7,6 @@ import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:isar/isar.dart';
 
 import '../test_utils.dart';
-import '../fixtures/user.stub.dart';
 
 void main() {
   late Isar db;

--- a/mobile/test/utils/url_helper_test.dart
+++ b/mobile/test/utils/url_helper_test.dart
@@ -16,7 +16,6 @@ void main() {
     await StoreService.init(storeRepository: IsarStoreRepository(db));
   });
 
-
   group('sanitizeUrl', () {
     test('Should encode correctly', () {
       var unEncodedURL = 'user:password@example.com/addSchemaAndRemovesSlashes////';
@@ -39,7 +38,7 @@ void main() {
       var idn = 'https://bücher.de';
       expect(punycodeEncodeUrl(idn), 'https://xn--bcher-kva.de');
     });
-   
+
     test('Keeps basic auth in encoding', () {
       var basicAuthURL = 'https://user:password@example.com';
       expect(punycodeEncodeUrl(basicAuthURL), 'https://user:password@example.com');
@@ -47,7 +46,7 @@ void main() {
   });
 
   group('punycodeDecode', () {
-   test('malformed URL returns a null', () {
+    test('malformed URL returns a null', () {
       var badURL = 'example.com/missing%20a%20scheme';
       expect(punycodeDecodeUrl(badURL), null);
     });
@@ -56,7 +55,7 @@ void main() {
       var idn = 'https://xn--bcher-kva.de';
       expect(punycodeDecodeUrl(idn), 'https://bücher.de');
     });
-   
+
     test('Keeps basic auth in encoding', () {
       var basicAuthURL = 'https://user:password@example.com/%20with%20spaces';
       expect(punycodeDecodeUrl(basicAuthURL), 'https://user:password@example.com/ with spaces');
@@ -68,11 +67,11 @@ void main() {
       expect(getServerUrl(), null);
     });
 
-    test('Returns null if what was set is not a correct url', () {
-      Store.put(StoreKey.serverEndpoint, 'example.com');
+    test('Returns null if what was set is not a correct url', () async {
+      await Store.put(StoreKey.serverEndpoint, 'example.com');
       expect(getServerUrl(), null);
     });
-    
+
     test('Returns decoded basic URL', () async {
       var encodedURL = 'https://example.com/ clears extra paths';
       await Store.put(StoreKey.serverEndpoint, encodedURL);
@@ -91,11 +90,10 @@ void main() {
       expect(getServerUrl(), portURL);
     });
 
-      test('Returns decoded complex URL', () async {
+    test('Returns decoded complex URL', () async {
       var complexURL = 'https://user:password@example.com:1337/123/abc';
       await Store.put(StoreKey.serverEndpoint, complexURL);
       expect(getServerUrl(), 'https://user:password@example.com:1337');
     });
-
   });
 }


### PR DESCRIPTION
## Description
As part of #15230 I've added support for basic auth encoding for server URL's. This will allow users to set the server URL with a basic auth encoding (e.g https://user:password@example.com) and have that URL used throughout the mobile app for api access.  

## How Has This Been Tested?

Yes, and I also added tests for the rest of the url_helper.dart file as well.

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
