### PR TITLE
feat: share memories via shared albums

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1295,6 +1295,7 @@
   "memories_start_over": "Start Over",
   "memories_swipe_to_close": "Swipe up to close",
   "memory": "Memory",
+  "memory_from_shared_album": "From shared album",
   "memory_lane_title": "Memory Lane {title}",
   "menu": "Menu",
   "merge": "Merge",

--- a/i18n/zh_SIMPLIFIED.json
+++ b/i18n/zh_SIMPLIFIED.json
@@ -1273,6 +1273,7 @@
   "memories_start_over": "再看一次",
   "memories_swipe_to_close": "上划关闭",
   "memory": "回忆",
+  "memory_from_shared_album": "来自共享相册",
   "memory_lane_title": "记忆线{title}",
   "menu": "菜单",
   "merge": "合并",

--- a/mobile/lib/pages/photos/memory.page.dart
+++ b/mobile/lib/pages/photos/memory.page.dart
@@ -80,7 +80,6 @@ class MemoryPage extends HookConsumerWidget {
       if (currentAssetIndex + 1 < currentMemory.value.assets.length) {
         // Go to the next asset
         PageController controller = memoryAssetPageControllers[currentMemoryIndex.value];
-
         controller.nextPage(curve: Curves.easeInOut, duration: const Duration(milliseconds: 500));
       } else {
         // Go to the next memory since we are at the end of our assets
@@ -157,7 +156,6 @@ class MemoryPage extends HookConsumerWidget {
       ref.read(hapticFeedbackProvider.notifier).selectionClick();
       currentAssetPage.value = otherIndex;
       updateProgressText();
-
       // Wait for page change animation to finish
       await Future.delayed(const Duration(milliseconds: 400));
       // And then precache the next asset
@@ -316,7 +314,7 @@ class MemoryPage extends HookConsumerWidget {
                       ],
                     ),
                   ),
-                  MemoryBottomInfo(memory: memories[mIndex]),
+                  MemoryBottomInfo(memory: memories[mIndex], currentAssetIndex: currentAssetPage.value),
                 ],
               );
             },

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -317,7 +317,11 @@ class DriftMemoryPage extends HookConsumerWidget {
                       ],
                     ),
                   ),
-                  DriftMemoryBottomInfo(memory: memories[mIndex], title: title),
+                  DriftMemoryBottomInfo(
+                    memory: memories[mIndex],
+                    title: title,
+                    currentAssetIndex: currentAssetPage.value,
+                  ),
                 ],
               );
             },

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -7,15 +7,25 @@ import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/utils/hash.dart';
 
 class DriftMemoryBottomInfo extends StatelessWidget {
   final DriftMemory memory;
   final String title;
-  const DriftMemoryBottomInfo({super.key, required this.memory, required this.title});
+  final int currentAssetIndex;
+  const DriftMemoryBottomInfo({super.key, required this.memory, required this.title, required this.currentAssetIndex});
 
   @override
   Widget build(BuildContext context) {
     final df = DateFormat.yMMMMd();
+    // When changing the memory page, this method is called before onPageChanged,
+    // which might cause currentAssetIndex to go out of the range of memory.assets.length.
+    if (currentAssetIndex >= memory.assets.length) {
+      return Container();
+    }
+    final isOwner = fastHash(Store.get(StoreKey.currentUser).id) == fastHash(memory.assets[currentAssetIndex].ownerId);
     final fileCreatedDate = memory.assets.first.createdAt;
     return Padding(
       padding: const EdgeInsets.all(16.0),
@@ -30,25 +40,27 @@ class DriftMemoryBottomInfo extends StatelessWidget {
                 style: TextStyle(color: Colors.grey[400], fontSize: 13.0, fontWeight: FontWeight.w500),
               ),
               Text(
-                df.format(fileCreatedDate),
+                isOwner ? df.format(fileCreatedDate) : "${df.format(fileCreatedDate)}, From Shared",
                 style: const TextStyle(color: Colors.white, fontSize: 15.0, fontWeight: FontWeight.w500),
               ),
             ],
           ),
           Tooltip(
             message: 'view_in_timeline'.tr(),
-            child: MaterialButton(
-              minWidth: 0,
-              onPressed: () async {
-                await context.maybePop();
-                await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-                EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate));
-              },
-              shape: const CircleBorder(),
-              color: Colors.white.withValues(alpha: 0.2),
-              elevation: 0,
-              child: const Icon(Icons.open_in_new, color: Colors.white),
-            ),
+            child: isOwner
+                ? MaterialButton(
+                    minWidth: 0,
+                    onPressed: () async {
+                      await context.maybePop();
+                      await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+                      EventStream.shared.emit(ScrollToDateEvent(fileCreatedDate));
+                    },
+                    shape: const CircleBorder(),
+                    color: Colors.white.withValues(alpha: 0.2),
+                    elevation: 0,
+                    child: const Icon(Icons.open_in_new, color: Colors.white),
+                  )
+                : Container(),
           ),
         ],
       ),

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -40,7 +40,9 @@ class DriftMemoryBottomInfo extends StatelessWidget {
                 style: TextStyle(color: Colors.grey[400], fontSize: 13.0, fontWeight: FontWeight.w500),
               ),
               Text(
-                isOwner ? df.format(fileCreatedDate) : "${df.format(fileCreatedDate)}, From Shared",
+                isOwner
+                    ? df.format(fileCreatedDate)
+                    : "${df.format(fileCreatedDate)}, ${'memory_from_shared_album'.tr()}",
                 style: const TextStyle(color: Colors.white, fontSize: 15.0, fontWeight: FontWeight.w500),
               ),
             ],

--- a/mobile/lib/widgets/memories/memory_bottom_info.dart
+++ b/mobile/lib/widgets/memories/memory_bottom_info.dart
@@ -5,15 +5,25 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/models/memories/memory.model.dart';
 import 'package:immich_mobile/providers/asset_viewer/scroll_to_date_notifier.provider.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/utils/hash.dart';
 
 class MemoryBottomInfo extends StatelessWidget {
   final Memory memory;
+  final int currentAssetIndex;
 
-  const MemoryBottomInfo({super.key, required this.memory});
+  const MemoryBottomInfo({super.key, required this.memory, required this.currentAssetIndex});
 
   @override
   Widget build(BuildContext context) {
     final df = DateFormat.yMMMMd();
+    // When changing the memory page, this method is called before onPageChanged,
+    // which might cause currentAssetIndex to go out of the range of memory.assets.length.
+    if (currentAssetIndex >= memory.assets.length) {
+      return Container();
+    }
+    final isOwner = fastHash(Store.get(StoreKey.currentUser).id) == memory.assets[currentAssetIndex].ownerId;
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Row(
@@ -27,22 +37,26 @@ class MemoryBottomInfo extends StatelessWidget {
                 style: TextStyle(color: Colors.grey[400], fontSize: 13.0, fontWeight: FontWeight.w500),
               ),
               Text(
-                df.format(memory.assets[0].fileCreatedAt),
+                isOwner
+                    ? df.format(memory.assets[0].fileCreatedAt)
+                    : "${df.format(memory.assets[0].fileCreatedAt)}, From Shared",
                 style: const TextStyle(color: Colors.white, fontSize: 15.0, fontWeight: FontWeight.w500),
               ),
             ],
           ),
-          MaterialButton(
-            minWidth: 0,
-            onPressed: () {
-              context.maybePop();
-              scrollToDateNotifierProvider.scrollToDate(memory.assets[0].fileCreatedAt);
-            },
-            shape: const CircleBorder(),
-            color: Colors.white.withValues(alpha: 0.2),
-            elevation: 0,
-            child: const Icon(Icons.open_in_new, color: Colors.white),
-          ),
+          isOwner
+              ? MaterialButton(
+                  minWidth: 0,
+                  onPressed: () {
+                    context.maybePop();
+                    scrollToDateNotifierProvider.scrollToDate(memory.assets[0].fileCreatedAt);
+                  },
+                  shape: const CircleBorder(),
+                  color: Colors.white.withValues(alpha: 0.2),
+                  elevation: 0,
+                  child: const Icon(Icons.open_in_new, color: Colors.white),
+                )
+              : Container(),
         ],
       ),
     );

--- a/mobile/lib/widgets/memories/memory_bottom_info.dart
+++ b/mobile/lib/widgets/memories/memory_bottom_info.dart
@@ -39,7 +39,7 @@ class MemoryBottomInfo extends StatelessWidget {
               Text(
                 isOwner
                     ? df.format(memory.assets[0].fileCreatedAt)
-                    : "${df.format(memory.assets[0].fileCreatedAt)}, From Shared",
+                    : "${df.format(memory.assets[0].fileCreatedAt)}, ${'memory_from_shared_album'.tr()}",
                 style: const TextStyle(color: Colors.white, fontSize: 15.0, fontWeight: FontWeight.w500),
               ),
             ],

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -218,8 +218,8 @@ export class AssetRepository {
     return this.db.insertInto('asset').values(assets).returningAll().execute();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, { day: 1, month: 1 }] })
-  getByDayOfYear(ownerIds: string[], { day, month }: MonthDay) {
+  @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID, { day: 1, month: 1 }] })
+  getByDayOfYear(ownerIds: string[], albumIds: string[], { day, month }: MonthDay) {
     return this.db
       .with('res', (qb) =>
         qb
@@ -240,11 +240,24 @@ export class AssetRepository {
             (qb) =>
               qb
                 .selectFrom('asset')
+                .distinctOn(['asset.id'])
                 .selectAll('asset')
                 .innerJoin('asset_job_status', 'asset.id', 'asset_job_status.assetId')
                 .where('asset_job_status.previewAt', 'is not', null)
                 .where(sql`(asset."localDateTime" at time zone 'UTC')::date`, '=', sql`today.date`)
-                .where('asset.ownerId', '=', anyUuid(ownerIds))
+                .where((eb) =>
+                  eb('asset.ownerId', '=', anyUuid(ownerIds)).or(
+                    eb.and([
+                      eb.exists(
+                        eb
+                          .selectFrom('album_asset')
+                          .whereRef('album_asset.assetsId', '=', 'asset.id')
+                          .where('album_asset.albumsId', '=', anyUuid(albumIds)),
+                      ),
+                      eb.not(eb('asset.ownerId', '=', anyUuid(ownerIds))),
+                    ]),
+                  ),
+                )
                 .where('asset.visibility', '=', AssetVisibility.Timeline)
                 .where((eb) =>
                   eb.exists((qb) =>
@@ -255,6 +268,7 @@ export class AssetRepository {
                   ),
                 )
                 .where('asset.deletedAt', 'is', null)
+                .orderBy('asset.id')
                 .orderBy(sql`(asset."localDateTime" at time zone 'UTC')::date`, 'desc')
                 .limit(20)
                 .as('a'),

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -54,7 +54,12 @@ export class MemoryService extends BaseService {
   private async createOnThisDayMemories(ownerId: string, userIds: string[], target: DateTime) {
     const showAt = target.startOf('day').toISO();
     const hideAt = target.endOf('day').toISO();
-    const memories = await this.assetRepository.getByDayOfYear([ownerId, ...userIds], target);
+    const sharedAlbums = await this.albumRepository.getShared(ownerId);
+    const memories = await this.assetRepository.getByDayOfYear(
+      [ownerId, ...userIds],
+      sharedAlbums.map((album) => album.id),
+      target,
+    );
     await Promise.all(
       memories.map(({ year, assets }) =>
         this.memoryRepository.create(

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -32,7 +32,7 @@
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { type MemoryAsset, memoryStore } from '$lib/stores/memory.store.svelte';
   import { locale, videoViewerMuted, videoViewerVolume } from '$lib/stores/preferences.store';
-  import { preferences } from '$lib/stores/user.store';
+  import { preferences, user } from '$lib/stores/user.store';
   import { getAssetThumbnailUrl, handlePromiseError, memoryLaneTitle } from '$lib/utils';
   import { cancelMultiselect } from '$lib/utils/asset-utils';
   import { fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
@@ -518,17 +518,18 @@
                   <!-- shortcut={{ key: 'l', shift: shared }} -->
                 </ButtonContextMenu>
               </div>
-
-              <div>
-                <IconButton
-                  href="{AppRoute.PHOTOS}?at={current.asset.id}"
-                  icon={mdiImageSearch}
-                  aria-label={$t('view_in_timeline')}
-                  color="secondary"
-                  variant="ghost"
-                  shape="round"
-                />
-              </div>
+              {#if current.asset.ownerId === $user.id}
+                <div>
+                  <IconButton
+                    href="{AppRoute.PHOTOS}?at={current.asset.id}"
+                    icon={mdiImageSearch}
+                    aria-label={$t('view_in_timeline')}
+                    color="secondary"
+                    variant="ghost"
+                    shape="round"
+                  />
+                </div>
+              {/if}
             </div>
             <!-- CONTROL BUTTONS -->
             {#if current.previous}

--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -529,6 +529,10 @@
                     shape="round"
                   />
                 </div>
+              {:else}
+                <div class="text-sm font-medium text-white">
+                  <p>{$t('memory_from_shared_album')}</p>
+                </div>
               {/if}
             </div>
             <!-- CONTROL BUTTONS -->


### PR DESCRIPTION
## Description

1. Modified the `getByDayOfYear` method in `asset.repository.ts` of the server to expand the query scope to shared albums.
2. Added a judgment in the web page `memory-view.svelte` to hide the navigation buttons of assets in memories that do not belong to the current user.
3. Similar to the web page, added a judgment in `memory_button_info.dart` of the mobile version to hide the navigation buttons of assets in memories that do not belong to the current user. Both the old and new versions of the components have been modified. 

## How Has This Been Tested?

There are multiple users and shared albums on my Immich server. The modified version has been running stably on my NAS for over 3 days, and based on v1.135.3, it has been operating reliably for more than a month. The modifications to the web and mobile versions are also functioning well.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
