### PR TITLE
fix: don't show remove from album action from the main timeline

### DIFF
--- a/mobile/lib/presentation/pages/drift_remote_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_remote_album.page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/presentation/widgets/bottom_sheet/remote_album_bot
 import 'package:immich_mobile/presentation/widgets/remote_album/drift_album_option.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
@@ -215,22 +216,34 @@ class _RemoteAlbumPageState extends ConsumerState<RemoteAlbumPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ProviderScope(
-      overrides: [
-        timelineServiceProvider.overrideWith((ref) {
-          final timelineService = ref.watch(timelineFactoryProvider).remoteAlbum(albumId: _album.id);
-          ref.onDispose(timelineService.dispose);
-          return timelineService;
-        }),
-      ],
-      child: Timeline(
-        appBar: RemoteAlbumSliverAppBar(
-          icon: Icons.photo_album_outlined,
-          onShowOptions: () => showOptionSheet(context),
-          onToggleAlbumOrder: () => toggleAlbumOrder(),
-          onEditTitle: () => showEditTitleAndDescription(context),
+    return PopScope(
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          Future.microtask(() {
+            if (mounted) {
+              ref.read(currentRemoteAlbumProvider.notifier).dispose();
+              ref.read(remoteAlbumProvider.notifier).refresh();
+            }
+          });
+        }
+      },
+      child: ProviderScope(
+        overrides: [
+          timelineServiceProvider.overrideWith((ref) {
+            final timelineService = ref.watch(timelineFactoryProvider).remoteAlbum(albumId: _album.id);
+            ref.onDispose(timelineService.dispose);
+            return timelineService;
+          }),
+        ],
+        child: Timeline(
+          appBar: RemoteAlbumSliverAppBar(
+            icon: Icons.photo_album_outlined,
+            onShowOptions: () => showOptionSheet(context),
+            onToggleAlbumOrder: () => toggleAlbumOrder(),
+            onEditTitle: () => showEditTitleAndDescription(context),
+          ),
+          bottomSheet: RemoteAlbumBottomSheet(album: _album),
         ),
-        bottomSheet: RemoteAlbumBottomSheet(album: _album),
       ),
     );
   }

--- a/mobile/lib/providers/infrastructure/current_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/current_album.provider.dart
@@ -28,14 +28,9 @@ class CurrentAlbumNotifier extends AutoDisposeNotifier<RemoteAlbum?> {
     _keepAliveLink = ref.keepAlive();
   }
 
-  void unsetAlbum() {
-    _keepAliveLink?.close();
-    _assetSubscription?.cancel();
-    state = null;
-  }
-
   void dispose() {
     _keepAliveLink?.close();
     _assetSubscription?.cancel();
+    state = null;
   }
 }

--- a/mobile/lib/providers/infrastructure/current_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/current_album.provider.dart
@@ -28,6 +28,12 @@ class CurrentAlbumNotifier extends AutoDisposeNotifier<RemoteAlbum?> {
     _keepAliveLink = ref.keepAlive();
   }
 
+  void unsetAlbum() {
+    _keepAliveLink?.close();
+    _assetSubscription?.cancel();
+    state = null;
+  }
+
   void dispose() {
     _keepAliveLink?.close();
     _assetSubscription?.cancel();

--- a/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
@@ -14,7 +14,6 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
-import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
@@ -74,77 +73,75 @@ class _MesmerizingSliverAppBarState extends ConsumerState<RemoteAlbumSliverAppBa
         const Shadow(offset: Offset(0, 2), blurRadius: 0, color: Colors.transparent),
     ];
 
-    return isMultiSelectEnabled
-        ? SliverToBoxAdapter(
-            child: switch (_scrollProgress) {
-              < 0.8 => const SizedBox(height: 120),
-              _ => const SizedBox(height: 452),
-            },
-          )
-        : SliverAppBar(
-            expandedHeight: 400.0,
-            floating: false,
-            pinned: true,
-            snap: false,
-            elevation: 0,
-            leading: IconButton(
-              icon: Icon(
-                Platform.isIOS ? Icons.arrow_back_ios_new_rounded : Icons.arrow_back,
-                color: actionIconColor,
-                shadows: actionIconShadows,
-              ),
-              onPressed: () {
-                ref.read(currentRemoteAlbumProvider.notifier).unsetAlbum();
-                ref.read(remoteAlbumProvider.notifier).refresh();
-                context.navigateTo(const TabShellRoute(children: [DriftAlbumsRoute()]));
-              },
+    if (isMultiSelectEnabled) {
+      return SliverToBoxAdapter(
+        child: switch (_scrollProgress) {
+          < 0.8 => const SizedBox(height: 120),
+          _ => const SizedBox(height: 452),
+        },
+      );
+    } else {
+      return SliverAppBar(
+        expandedHeight: 400.0,
+        floating: false,
+        pinned: true,
+        snap: false,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(
+            Platform.isIOS ? Icons.arrow_back_ios_new_rounded : Icons.arrow_back,
+            color: actionIconColor,
+            shadows: actionIconShadows,
+          ),
+          onPressed: () => context.navigateTo(const TabShellRoute(children: [DriftAlbumsRoute()])),
+        ),
+        actions: [
+          if (widget.onToggleAlbumOrder != null)
+            IconButton(
+              icon: Icon(Icons.swap_vert_rounded, color: actionIconColor, shadows: actionIconShadows),
+              onPressed: widget.onToggleAlbumOrder,
             ),
-            actions: [
-              if (widget.onToggleAlbumOrder != null)
-                IconButton(
-                  icon: Icon(Icons.swap_vert_rounded, color: actionIconColor, shadows: actionIconShadows),
-                  onPressed: widget.onToggleAlbumOrder,
-                ),
-              if (widget.onShowOptions != null)
-                IconButton(
-                  icon: Icon(Icons.more_vert, color: actionIconColor, shadows: actionIconShadows),
-                  onPressed: widget.onShowOptions,
-                ),
-            ],
-            flexibleSpace: Builder(
-              builder: (context) {
-                final settings = context.dependOnInheritedWidgetOfExactType<FlexibleSpaceBarSettings>();
-                final scrollProgress = _calculateScrollProgress(settings);
+          if (widget.onShowOptions != null)
+            IconButton(
+              icon: Icon(Icons.more_vert, color: actionIconColor, shadows: actionIconShadows),
+              onPressed: widget.onShowOptions,
+            ),
+        ],
+        flexibleSpace: Builder(
+          builder: (context) {
+            final settings = context.dependOnInheritedWidgetOfExactType<FlexibleSpaceBarSettings>();
+            final scrollProgress = _calculateScrollProgress(settings);
 
-                // Update scroll progress for the leading button
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (mounted && _scrollProgress != scrollProgress) {
-                    setState(() {
-                      _scrollProgress = scrollProgress;
-                    });
-                  }
+            // Update scroll progress for the leading button
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted && _scrollProgress != scrollProgress) {
+                setState(() {
+                  _scrollProgress = scrollProgress;
                 });
+              }
+            });
 
-                return FlexibleSpaceBar(
-                  centerTitle: true,
-                  title: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 200),
-                    child: scrollProgress > 0.95
-                        ? Text(
-                            currentAlbum.name,
-                            style: TextStyle(color: context.primaryColor, fontWeight: FontWeight.w600, fontSize: 18),
-                          )
-                        : null,
-                  ),
-                  background: _ExpandedBackground(
-                    scrollProgress: scrollProgress,
-                    icon: widget.icon,
-                    onEditTitle: widget.onEditTitle,
-                  ),
-                );
-              },
-            ),
-          );
+            return FlexibleSpaceBar(
+              centerTitle: true,
+              title: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: scrollProgress > 0.95
+                    ? Text(
+                        currentAlbum.name,
+                        style: TextStyle(color: context.primaryColor, fontWeight: FontWeight.w600, fontSize: 18),
+                      )
+                    : null,
+              ),
+              background: _ExpandedBackground(
+                scrollProgress: scrollProgress,
+                icon: widget.icon,
+                onEditTitle: widget.onEditTitle,
+              ),
+            );
+          },
+        ),
+      );
+    }
   }
 }
 

--- a/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/remote_album_sliver_app_bar.dart
@@ -94,6 +94,7 @@ class _MesmerizingSliverAppBarState extends ConsumerState<RemoteAlbumSliverAppBa
                 shadows: actionIconShadows,
               ),
               onPressed: () {
+                ref.read(currentRemoteAlbumProvider.notifier).unsetAlbum();
                 ref.read(remoteAlbumProvider.notifier).refresh();
                 context.navigateTo(const TabShellRoute(children: [DriftAlbumsRoute()]));
               },


### PR DESCRIPTION
After navigating to an album and viewing an asset on the main timeline, the option to remove the asset from the album will be displayed because the current album provider state is not null.