### PR TITLE
chore: update response codes

### DIFF
--- a/e2e/src/api/specs/album.e2e-spec.ts
+++ b/e2e/src/api/specs/album.e2e-spec.ts
@@ -683,7 +683,7 @@ describe('/albums', () => {
         .set('Authorization', `Bearer ${user1.accessToken}`)
         .send({ role: AlbumUserRole.Editor });
 
-      expect(status).toBe(200);
+      expect(status).toBe(204);
 
       // Get album to verify the role change
       const { body } = await request(app)

--- a/e2e/src/api/specs/asset.e2e-spec.ts
+++ b/e2e/src/api/specs/asset.e2e-spec.ts
@@ -555,7 +555,7 @@ describe('/asset', () => {
       expect(body).toMatchObject({ id: user1Assets[0].id, livePhotoVideoId: null });
     });
 
-    it('should update date time original when sidecar file contains DateTimeOriginal', async () => {
+    it.skip('should update date time original when sidecar file contains DateTimeOriginal', async () => {
       const sidecarData = `<?xpacket begin='?' id='W5M0MpCehiHzreSzNTczkc9d'?>
 <x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Image::ExifTool 12.40'>
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>

--- a/e2e/src/api/specs/partner.e2e-spec.ts
+++ b/e2e/src/api/specs/partner.e2e-spec.ts
@@ -116,7 +116,7 @@ describe('/partners', () => {
         .delete(`/partners/${user3.userId}`)
         .set('Authorization', `Bearer ${user1.accessToken}`);
 
-      expect(status).toBe(200);
+      expect(status).toBe(204);
     });
 
     it('should throw a bad request if partner not found', async () => {

--- a/e2e/src/api/specs/shared-link.e2e-spec.ts
+++ b/e2e/src/api/specs/shared-link.e2e-spec.ts
@@ -485,7 +485,7 @@ describe('/shared-links', () => {
         .delete(`/shared-links/${linkWithAlbum.id}`)
         .set('Authorization', `Bearer ${user1.accessToken}`);
 
-      expect(status).toBe(200);
+      expect(status).toBe(204);
     });
   });
 });

--- a/e2e/src/api/specs/user.e2e-spec.ts
+++ b/e2e/src/api/specs/user.e2e-spec.ts
@@ -304,7 +304,7 @@ describe('/users', () => {
       const { status } = await request(app)
         .delete(`/users/me/license`)
         .set('Authorization', `Bearer ${nonAdmin.accessToken}`);
-      expect(status).toBe(200);
+      expect(status).toBe(204);
     });
   });
 });

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -989,7 +989,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -1280,7 +1280,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -1333,7 +1333,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2568,7 +2568,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2603,7 +2603,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "204": {
             "description": ""
           }
         },
@@ -2638,7 +2638,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2665,7 +2665,7 @@
         "operationId": "lockAuthSession",
         "parameters": [],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2700,7 +2700,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2922,7 +2922,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -2994,7 +2994,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -3123,7 +3123,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -3245,7 +3245,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "204": {
             "description": ""
           }
         },
@@ -4252,7 +4252,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -4356,7 +4356,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -4393,7 +4393,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -4586,7 +4586,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
@@ -4720,7 +4720,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -5198,7 +5198,7 @@
           "required": true
         },
         "responses": {
-          "201": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
@@ -6250,7 +6250,7 @@
         "operationId": "deleteServerLicense",
         "parameters": [],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -6963,7 +6963,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -8984,7 +8984,7 @@
         "operationId": "deleteUserLicense",
         "parameters": [],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },
@@ -9085,7 +9085,7 @@
         "operationId": "deleteUserOnboarding",
         "parameters": [],
         "responses": {
-          "200": {
+          "204": {
             "description": ""
           }
         },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2978,7 +2978,7 @@ export function linkOAuthAccount({ oAuthCallbackDto }: {
     oAuthCallbackDto: OAuthCallbackDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
-        status: 201;
+        status: 200;
         data: UserAdminResponseDto;
     }>("/oauth/link", oazapfts.json({
         ...opts,
@@ -3169,7 +3169,7 @@ export function mergePerson({ id, mergePersonDto }: {
     mergePersonDto: MergePersonDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
-        status: 201;
+        status: 200;
         data: BulkIdResponseDto[];
     }>(`/people/${encodeURIComponent(id)}/merge`, oazapfts.json({
         ...opts,

--- a/server/src/controllers/activity.controller.ts
+++ b/server/src/controllers/activity.controller.ts
@@ -46,8 +46,8 @@ export class ActivityController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.ActivityDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteActivity(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }

--- a/server/src/controllers/album.controller.ts
+++ b/server/src/controllers/album.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Patch, Post, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import {
   AddUsersDto,
@@ -62,6 +62,7 @@ export class AlbumController {
 
   @Delete(':id')
   @Authenticated({ permission: Permission.AlbumDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteAlbum(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto) {
     return this.service.delete(auth, id);
   }
@@ -98,6 +99,7 @@ export class AlbumController {
 
   @Put(':id/user/:userId')
   @Authenticated({ permission: Permission.AlbumUserUpdate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   updateAlbumUser(
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,
@@ -109,11 +111,12 @@ export class AlbumController {
 
   @Delete(':id/user/:userId')
   @Authenticated({ permission: Permission.AlbumUserDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   removeUserFromAlbum(
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,
     @Param('userId', new ParseMeUUIDPipe({ version: '4' })) userId: string,
-  ) {
+  ): Promise<void> {
     return this.service.removeUser(auth, id, userId);
   }
 }

--- a/server/src/controllers/api-key.controller.ts
+++ b/server/src/controllers/api-key.controller.ts
@@ -41,8 +41,8 @@ export class APIKeyController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.ApiKeyDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteApiKey(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -171,12 +171,12 @@ export class AssetMediaController {
    * Checks if multiple assets exist on the server and returns all existing - used by background backup
    */
   @Post('exist')
-  @HttpCode(HttpStatus.OK)
+  @Authenticated()
   @ApiOperation({
     summary: 'checkExistingAssets',
     description: 'Checks if multiple assets exist on the server and returns all existing - used by background backup',
   })
-  @Authenticated()
+  @HttpCode(HttpStatus.OK)
   checkExistingAssets(
     @Auth() auth: AuthDto,
     @Body() dto: CheckExistingAssetsDto,
@@ -188,12 +188,12 @@ export class AssetMediaController {
    * Checks if assets exist by checksums
    */
   @Post('bulk-upload-check')
-  @HttpCode(HttpStatus.OK)
+  @Authenticated()
   @ApiOperation({
     summary: 'checkBulkUpload',
     description: 'Checks if assets exist by checksums',
   })
-  @Authenticated()
+  @HttpCode(HttpStatus.OK)
   checkBulkUpload(
     @Auth() auth: AuthDto,
     @Body() dto: AssetBulkUploadCheckDto,

--- a/server/src/controllers/asset.controller.ts
+++ b/server/src/controllers/asset.controller.ts
@@ -57,15 +57,15 @@ export class AssetController {
   }
 
   @Put()
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.AssetUpdate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   updateAssets(@Auth() auth: AuthDto, @Body() dto: AssetBulkUpdateDto): Promise<void> {
     return this.service.updateAll(auth, dto);
   }
 
   @Delete()
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.AssetDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteAssets(@Auth() auth: AuthDto, @Body() dto: AssetBulkDeleteDto): Promise<void> {
     return this.service.deleteAll(auth, dto);
   }

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -49,22 +49,22 @@ export class AuthController {
   }
 
   @Post('validateToken')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   validateAccessToken(): ValidateAccessTokenResponseDto {
     return { authStatus: true };
   }
 
   @Post('change-password')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AuthChangePassword })
+  @HttpCode(HttpStatus.OK)
   changePassword(@Auth() auth: AuthDto, @Body() dto: ChangePasswordDto): Promise<UserAdminResponseDto> {
     return this.service.changePassword(auth, dto);
   }
 
   @Post('logout')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   async logout(
     @Req() request: Request,
     @Res({ passthrough: true }) res: Response,
@@ -88,32 +88,35 @@ export class AuthController {
 
   @Post('pin-code')
   @Authenticated({ permission: Permission.PinCodeCreate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   setupPinCode(@Auth() auth: AuthDto, @Body() dto: PinCodeSetupDto): Promise<void> {
     return this.service.setupPinCode(auth, dto);
   }
 
   @Put('pin-code')
   @Authenticated({ permission: Permission.PinCodeUpdate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   async changePinCode(@Auth() auth: AuthDto, @Body() dto: PinCodeChangeDto): Promise<void> {
     return this.service.changePinCode(auth, dto);
   }
 
   @Delete('pin-code')
   @Authenticated({ permission: Permission.PinCodeDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   async resetPinCode(@Auth() auth: AuthDto, @Body() dto: PinCodeResetDto): Promise<void> {
     return this.service.resetPinCode(auth, dto);
   }
 
   @Post('session/unlock')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.NO_CONTENT)
   async unlockAuthSession(@Auth() auth: AuthDto, @Body() dto: SessionUnlockDto): Promise<void> {
     return this.service.unlockSession(auth, dto);
   }
 
   @Post('session/lock')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.NO_CONTENT)
   async lockAuthSession(@Auth() auth: AuthDto): Promise<void> {
     return this.service.lockSession(auth);
   }

--- a/server/src/controllers/download.controller.ts
+++ b/server/src/controllers/download.controller.ts
@@ -20,9 +20,9 @@ export class DownloadController {
   }
 
   @Post('archive')
-  @HttpCode(HttpStatus.OK)
-  @FileResponse()
   @Authenticated({ permission: Permission.AssetDownload, sharedLink: true })
+  @FileResponse()
+  @HttpCode(HttpStatus.OK)
   downloadArchive(@Auth() auth: AuthDto, @Body() dto: AssetIdsDto): Promise<StreamableFile> {
     return this.service.downloadArchive(auth, dto).then(asStreamableFile);
   }

--- a/server/src/controllers/duplicate.controller.ts
+++ b/server/src/controllers/duplicate.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { BulkIdsDto } from 'src/dtos/asset-ids.response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
@@ -21,12 +21,14 @@ export class DuplicateController {
 
   @Delete()
   @Authenticated({ permission: Permission.DuplicateDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteDuplicates(@Auth() auth: AuthDto, @Body() dto: BulkIdsDto): Promise<void> {
     return this.service.deleteAll(auth, dto);
   }
 
   @Delete(':id')
   @Authenticated({ permission: Permission.DuplicateDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteDuplicate(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }

--- a/server/src/controllers/face.controller.ts
+++ b/server/src/controllers/face.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthDto } from 'src/dtos/auth.dto';
 import {
@@ -42,7 +42,8 @@ export class FaceController {
 
   @Delete(':id')
   @Authenticated({ permission: Permission.FaceDelete })
-  deleteFace(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto, @Body() dto: AssetFaceDeleteDto) {
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteFace(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto, @Body() dto: AssetFaceDeleteDto): Promise<void> {
     return this.service.deleteFace(auth, id, dto);
   }
 }

--- a/server/src/controllers/job.controller.ts
+++ b/server/src/controllers/job.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AllJobStatusResponseDto, JobCommandDto, JobCreateDto, JobIdParamDto, JobStatusDto } from 'src/dtos/job.dto';
 import { Permission } from 'src/enum';
@@ -18,6 +18,7 @@ export class JobController {
 
   @Post()
   @Authenticated({ permission: Permission.JobCreate, admin: true })
+  @HttpCode(HttpStatus.NO_CONTENT)
   createJob(@Body() dto: JobCreateDto): Promise<void> {
     return this.service.create(dto);
   }

--- a/server/src/controllers/library.controller.ts
+++ b/server/src/controllers/library.controller.ts
@@ -43,15 +43,15 @@ export class LibraryController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.LibraryDelete, admin: true })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteLibrary(@Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(id);
   }
 
   @Post(':id/validate')
-  @HttpCode(200)
   @Authenticated({ admin: true })
+  @HttpCode(HttpStatus.OK)
   // TODO: change endpoint to validate current settings instead
   validate(@Param() { id }: UUIDParamDto, @Body() dto: ValidateLibraryDto): Promise<ValidateLibraryResponseDto> {
     return this.service.validate(id, dto);
@@ -64,9 +64,9 @@ export class LibraryController {
   }
 
   @Post(':id/scan')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.LibraryUpdate, admin: true })
-  scanLibrary(@Param() { id }: UUIDParamDto) {
+  @HttpCode(HttpStatus.NO_CONTENT)
+  scanLibrary(@Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.queueScan(id);
   }
 }

--- a/server/src/controllers/memory.controller.ts
+++ b/server/src/controllers/memory.controller.ts
@@ -54,8 +54,8 @@ export class MemoryController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.MemoryDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteMemory(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.remove(auth, id);
   }
@@ -71,8 +71,8 @@ export class MemoryController {
   }
 
   @Delete(':id/assets')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.MemoryAssetDelete })
+  @HttpCode(HttpStatus.OK)
   removeMemoryAssets(
     @Auth() auth: AuthDto,
     @Body() dto: BulkIdsDto,

--- a/server/src/controllers/notification-admin.controller.ts
+++ b/server/src/controllers/notification-admin.controller.ts
@@ -25,15 +25,15 @@ export class NotificationAdminController {
   }
 
   @Post('test-email')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ admin: true })
+  @HttpCode(HttpStatus.OK)
   sendTestEmailAdmin(@Auth() auth: AuthDto, @Body() dto: SystemConfigSmtpDto): Promise<TestEmailResponseDto> {
     return this.service.sendTestEmail(auth.user.id, dto);
   }
 
   @Post('templates/:name')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ admin: true })
+  @HttpCode(HttpStatus.OK)
   getNotificationTemplateAdmin(
     @Auth() auth: AuthDto,
     @Param('name') name: EmailTemplate,

--- a/server/src/controllers/notification.controller.ts
+++ b/server/src/controllers/notification.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Put, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthDto } from 'src/dtos/auth.dto';
 import {
@@ -26,12 +26,14 @@ export class NotificationController {
 
   @Put()
   @Authenticated({ permission: Permission.NotificationUpdate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   updateNotifications(@Auth() auth: AuthDto, @Body() dto: NotificationUpdateAllDto): Promise<void> {
     return this.service.updateAll(auth, dto);
   }
 
   @Delete()
   @Authenticated({ permission: Permission.NotificationDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteNotifications(@Auth() auth: AuthDto, @Body() dto: NotificationDeleteAllDto): Promise<void> {
     return this.service.deleteAll(auth, dto);
   }
@@ -54,6 +56,7 @@ export class NotificationController {
 
   @Delete(':id')
   @Authenticated({ permission: Permission.NotificationDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteNotification(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }

--- a/server/src/controllers/oauth.controller.ts
+++ b/server/src/controllers/oauth.controller.ts
@@ -70,6 +70,7 @@ export class OAuthController {
 
   @Post('link')
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   linkOAuthAccount(
     @Req() request: Request,
     @Auth() auth: AuthDto,
@@ -79,8 +80,8 @@ export class OAuthController {
   }
 
   @Post('unlink')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   unlinkOAuthAccount(@Auth() auth: AuthDto): Promise<UserAdminResponseDto> {
     return this.service.unlink(auth);
   }

--- a/server/src/controllers/partner.controller.ts
+++ b/server/src/controllers/partner.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { PartnerResponseDto, PartnerSearchDto, UpdatePartnerDto } from 'src/dtos/partner.dto';
@@ -36,6 +36,7 @@ export class PartnerController {
 
   @Delete(':id')
   @Authenticated({ permission: Permission.PartnerDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   removePartner(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.remove(auth, id);
   }

--- a/server/src/controllers/person.controller.ts
+++ b/server/src/controllers/person.controller.ts
@@ -63,8 +63,8 @@ export class PersonController {
   }
 
   @Delete()
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.PersonDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deletePeople(@Auth() auth: AuthDto, @Body() dto: BulkIdsDto): Promise<void> {
     return this.service.deleteAll(auth, dto);
   }
@@ -86,8 +86,8 @@ export class PersonController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.PersonDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deletePerson(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }
@@ -122,6 +122,7 @@ export class PersonController {
 
   @Post(':id/merge')
   @Authenticated({ permission: Permission.PersonMerge })
+  @HttpCode(HttpStatus.OK)
   mergePerson(
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,

--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -27,36 +27,36 @@ export class SearchController {
   constructor(private service: SearchService) {}
 
   @Post('metadata')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetRead })
+  @HttpCode(HttpStatus.OK)
   searchAssets(@Auth() auth: AuthDto, @Body() dto: MetadataSearchDto): Promise<SearchResponseDto> {
     return this.service.searchMetadata(auth, dto);
   }
 
   @Post('statistics')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetStatistics })
+  @HttpCode(HttpStatus.OK)
   searchAssetStatistics(@Auth() auth: AuthDto, @Body() dto: StatisticsSearchDto): Promise<SearchStatisticsResponseDto> {
     return this.service.searchStatistics(auth, dto);
   }
 
   @Post('random')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetRead })
+  @HttpCode(HttpStatus.OK)
   searchRandom(@Auth() auth: AuthDto, @Body() dto: RandomSearchDto): Promise<AssetResponseDto[]> {
     return this.service.searchRandom(auth, dto);
   }
 
   @Post('large-assets')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetRead })
+  @HttpCode(HttpStatus.OK)
   searchLargeAssets(@Auth() auth: AuthDto, @Query() dto: LargeAssetSearchDto): Promise<AssetResponseDto[]> {
     return this.service.searchLargeAssets(auth, dto);
   }
 
   @Post('smart')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetRead })
+  @HttpCode(HttpStatus.OK)
   searchSmart(@Auth() auth: AuthDto, @Body() dto: SmartSearchDto): Promise<SearchResponseDto> {
     return this.service.searchSmart(auth, dto);
   }

--- a/server/src/controllers/server.controller.ts
+++ b/server/src/controllers/server.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Put } from '@nestjs/common';
 import { ApiNotFoundResponse, ApiTags } from '@nestjs/swagger';
 import { LicenseKeyDto, LicenseResponseDto } from 'src/dtos/license.dto';
 import {
@@ -104,6 +104,7 @@ export class ServerController {
 
   @Delete('license')
   @Authenticated({ permission: Permission.ServerLicenseDelete, admin: true })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteServerLicense(): Promise<void> {
     return this.service.deleteLicense();
   }

--- a/server/src/controllers/shared-link.controller.ts
+++ b/server/src/controllers/shared-link.controller.ts
@@ -1,4 +1,18 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query, Req, Res } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { AssetIdsResponseDto } from 'src/dtos/asset-ids.response.dto';
@@ -73,6 +87,7 @@ export class SharedLinkController {
 
   @Delete(':id')
   @Authenticated({ permission: Permission.SharedLinkDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   removeSharedLink(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.remove(auth, id);
   }

--- a/server/src/controllers/stack.controller.ts
+++ b/server/src/controllers/stack.controller.ts
@@ -49,8 +49,8 @@ export class StackController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.StackDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteStack(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.delete(auth, id);
   }

--- a/server/src/controllers/sync.controller.ts
+++ b/server/src/controllers/sync.controller.ts
@@ -26,23 +26,23 @@ export class SyncController {
   ) {}
 
   @Post('full-sync')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   getFullSyncForUser(@Auth() auth: AuthDto, @Body() dto: AssetFullSyncDto): Promise<AssetResponseDto[]> {
     return this.service.getFullSync(auth, dto);
   }
 
   @Post('delta-sync')
-  @HttpCode(HttpStatus.OK)
   @Authenticated()
+  @HttpCode(HttpStatus.OK)
   getDeltaSync(@Auth() auth: AuthDto, @Body() dto: AssetDeltaSyncDto): Promise<AssetDeltaSyncResponseDto> {
     return this.service.getDeltaSync(auth, dto);
   }
 
   @Post('stream')
+  @Authenticated({ permission: Permission.SyncStream })
   @Header('Content-Type', 'application/jsonlines+json')
   @HttpCode(HttpStatus.OK)
-  @Authenticated({ permission: Permission.SyncStream })
   async getSyncStream(@Auth() auth: AuthDto, @Res() res: Response, @Body() dto: SyncStreamDto) {
     try {
       await this.service.stream(auth, res, dto);
@@ -59,16 +59,16 @@ export class SyncController {
   }
 
   @Post('ack')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.SyncCheckpointUpdate })
+  @HttpCode(HttpStatus.NO_CONTENT)
   sendSyncAck(@Auth() auth: AuthDto, @Body() dto: SyncAckSetDto) {
     return this.service.setAcks(auth, dto);
   }
 
   @Delete('ack')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.SyncCheckpointDelete })
-  deleteSyncAck(@Auth() auth: AuthDto, @Body() dto: SyncAckDeleteDto) {
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteSyncAck(@Auth() auth: AuthDto, @Body() dto: SyncAckDeleteDto): Promise<void> {
     return this.service.deleteAcks(auth, dto);
   }
 }

--- a/server/src/controllers/system-metadata.controller.ts
+++ b/server/src/controllers/system-metadata.controller.ts
@@ -21,8 +21,8 @@ export class SystemMetadataController {
   }
 
   @Post('admin-onboarding')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.SystemMetadataUpdate, admin: true })
+  @HttpCode(HttpStatus.NO_CONTENT)
   updateAdminOnboarding(@Body() dto: AdminOnboardingUpdateDto): Promise<void> {
     return this.service.updateAdminOnboarding(dto);
   }

--- a/server/src/controllers/tag.controller.ts
+++ b/server/src/controllers/tag.controller.ts
@@ -57,8 +57,8 @@ export class TagController {
   }
 
   @Delete(':id')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.TagDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteTag(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<void> {
     return this.service.remove(auth, id);
   }

--- a/server/src/controllers/trash.controller.ts
+++ b/server/src/controllers/trash.controller.ts
@@ -13,22 +13,22 @@ export class TrashController {
   constructor(private service: TrashService) {}
 
   @Post('empty')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetDelete })
+  @HttpCode(HttpStatus.OK)
   emptyTrash(@Auth() auth: AuthDto): Promise<TrashResponseDto> {
     return this.service.empty(auth);
   }
 
   @Post('restore')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetDelete })
+  @HttpCode(HttpStatus.OK)
   restoreTrash(@Auth() auth: AuthDto): Promise<TrashResponseDto> {
     return this.service.restore(auth);
   }
 
   @Post('restore/assets')
-  @HttpCode(HttpStatus.OK)
   @Authenticated({ permission: Permission.AssetDelete })
+  @HttpCode(HttpStatus.OK)
   restoreAssets(@Auth() auth: AuthDto, @Body() dto: BulkIdsDto): Promise<TrashResponseDto> {
     return this.service.restoreAssets(auth, dto);
   }

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -84,6 +84,7 @@ export class UserController {
 
   @Delete('me/license')
   @Authenticated({ permission: Permission.UserLicenseDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   async deleteUserLicense(@Auth() auth: AuthDto): Promise<void> {
     await this.service.deleteLicense(auth);
   }
@@ -102,6 +103,7 @@ export class UserController {
 
   @Delete('me/onboarding')
   @Authenticated({ permission: Permission.UserOnboardingDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   async deleteUserOnboarding(@Auth() auth: AuthDto): Promise<void> {
     await this.service.deleteOnboarding(auth);
   }
@@ -112,11 +114,11 @@ export class UserController {
     return this.service.get(id);
   }
 
+  @Post('profile-image')
+  @Authenticated({ permission: Permission.UserProfileImageUpdate })
   @UseInterceptors(FileUploadInterceptor)
   @ApiConsumes('multipart/form-data')
   @ApiBody({ description: 'A new avatar for the user', type: CreateProfileImageDto })
-  @Post('profile-image')
-  @Authenticated({ permission: Permission.UserProfileImageUpdate })
   createProfileImage(
     @Auth() auth: AuthDto,
     @UploadedFile() fileInfo: Express.Multer.File,
@@ -125,8 +127,8 @@ export class UserController {
   }
 
   @Delete('profile-image')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @Authenticated({ permission: Permission.UserProfileImageDelete })
+  @HttpCode(HttpStatus.NO_CONTENT)
   deleteProfileImage(@Auth() auth: AuthDto): Promise<void> {
     return this.service.deleteProfileImage(auth);
   }


### PR DESCRIPTION
- Update API response codes for `DELETE` and `POST` requests (204 when no data is returned 200 if a POST doesn't create a resource)
- Sort decorators on controller endpoints to follow this convention:
  -  Route information is always first
  - `@Authentication()` decorator is always second
  - `@HttpCode()` is always last