### PR TITLE
feat: add i18n formatting to `make translation` in mobile makefile

### DIFF
--- a/mobile/makefile
+++ b/mobile/makefile
@@ -25,6 +25,7 @@ migration:
 	dart run drift_dev make-migrations
 
 translation:
+	npm --prefix ../web run format:i18n
 	dart run easy_localization:generate -S ../i18n
 	dart run bin/generate_keys.dart
 	dart format lib/generated/codegen_loader.g.dart


### PR DESCRIPTION
## Description

This adds the i18n formatting command to the `make translation` command in the mobile dir.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Ran it.

## Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.