### PR TITLE
fix(web): fix layout loop with single row grids in explore page

### DIFF
--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -52,7 +52,7 @@
           draggable="false">{$t('view_all')}</a
         >
       </div>
-      <SingleGridRow class="grid md:grid-auto-fill-28 grid-auto-fill-20 gap-x-4">
+      <SingleGridRow class="grid grid-flow-col md:grid-auto-fill-28 grid-auto-fill-20 gap-x-4">
         {#snippet children({ itemCount })}
           {#each people.slice(0, itemCount) as person (person.id)}
             <a href="{AppRoute.PEOPLE}/{person.id}" class="text-center relative">
@@ -86,7 +86,7 @@
           draggable="false">{$t('view_all')}</a
         >
       </div>
-      <SingleGridRow class="grid md:grid-auto-fill-36 grid-auto-fill-28 gap-x-4">
+      <SingleGridRow class="grid grid-flow-col md:grid-auto-fill-36 grid-auto-fill-28 gap-x-4">
         {#snippet children({ itemCount })}
           {#each places.slice(0, itemCount) as item (item.data.id)}
             <a


### PR DESCRIPTION
## Description

Fixes #20829.

[`SingleGridRow`](https://github.com/immich-app/immich/blob/4b9019e7627dfc3ddfbd9f9f54c95395ebc0b5a0/web/src/lib/components/shared-components/single-grid-row.svelte) doesn't actually enforce through grid styles that the grid should be laid out in a single row.

This makes Firefox get stuck in an infinite layout loop in the Explore page:

1. SingleGridRow, by a very small amount, picks an `itemCount` N that Firefox lays out in two rows.
2. The increase in height overflows the parent container.
3. This causes a vertical scrollbar to be shown, which decreases the width of the grid.
4. SingleGridRow observes the resize event and recalculates `itemCount`, now N-1, which Firefox lays out in a single row.
5. The decrease in height stops overflowing the parent container.
6. The scrollbar is hidden, which increases the width of the grid.
7. SingleGridRow observes the resize event. Repeat from step 1.

This patch stops the People and Places grids from being laid out in two rows using `grid-flow-col`.

SingleGridRow is also used in SearchPeopleSection but I haven't been able to reproduce a similar layout loop there.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Could no longer reproduce #20829.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
