### PR TITLE
fix: border around dark theme button on onboarding page

### DIFF
--- a/web/src/lib/components/onboarding-page/onboarding-theme.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-theme.svelte
@@ -24,7 +24,7 @@
     </button>
     <button
       type="button"
-      class="dark w-1/2 aspect-square bg-light rounded-3xl dark:border-[3px] dark:border-immich-dark-primary border border-transparent"
+      class="w-1/2 aspect-square bg-dark dark:bg-light rounded-3xl transition-all shadow-sm hover:shadow-xl dark:border-[3px] dark:border-immich-dark-primary border border-transparent"
       onclick={() => themeManager.setTheme(Theme.DARK)}
     >
       <div


### PR DESCRIPTION
## Description

This fixes the border around the dark theme button on the theme onboarding page. The border was previously always active, but now it responds to theme change.

This depends on https://github.com/immich-app/ui/pull/238 to make the color look right.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] `make dev`

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<!-- Images go below this line. -->
<h3>Before:</h3>
<img width="703" height="547" alt="Screenshot_20250818_230448" src="https://github.com/user-attachments/assets/f0863dfb-2c72-4ab5-b78e-89676449bf43" />
<img width="703" height="546" alt="Screenshot_20250818_230427" src="https://github.com/user-attachments/assets/4deb3e45-98f1-43ed-acca-5a70b435ecb1" />

<h3>After:</h3>
<img width="713" height="553" alt="Screenshot_20250818_230354" src="https://github.com/user-attachments/assets/5a80c608-893a-44c2-8090-ea2603f488fb" />
<img width="702" height="546" alt="Screenshot_20250818_230404" src="https://github.com/user-attachments/assets/f5c6cedf-1314-4836-8a61-3994a306832b" />

</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have no unrelated changes in the PR.