### PR TITLE
fix: improve duplicate utility text contrast

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -54,7 +54,7 @@
       <div
         class="absolute bottom-1 end-3 px-4 py-1 rounded-xl text-xs transition-colors {isSelected
           ? 'bg-green-400/90'
-          : 'bg-red-300/90'}"
+          : 'bg-red-300/90'} text-black"
       >
         {isSelected ? $t('keep') : $t('to_trash')}
       </div>


### PR DESCRIPTION
## Description

Fixed the text contrast of the text in the duplicate utility "keep"/"trash" icon

## How Has This Been Tested?

- Open duplicate utility
- Notice the contrast of the "Keep" and "Trash" buttons is improved

<details><summary><h2>Screenshots</h2></summary>

Before:
<img width="919" height="490" alt="image" src="https://github.com/user-attachments/assets/1ce0ddb3-89f3-40f1-8b09-aaf2ee6ea91e" />
After:
<img width="912" height="455" alt="image" src="https://github.com/user-attachments/assets/8d79d883-e45e-4197-995d-d1e28cf19c72" />

Before:
<img width="734" height="943" alt="image" src="https://github.com/user-attachments/assets/3b5616a0-4640-40ec-ad40-9b62b46d53ae" />
After:
<img width="744" height="935" alt="image" src="https://github.com/user-attachments/assets/9dd85465-bca8-4cb1-94a6-5a099ba86479" />

[Link to contrast checker I used](https://webaim.org/resources/contrastchecker/)


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

(Sorry if the PR is a bit basic, just wanted to run through the process once before I PR a handful of the other things I'm working on (filter by resolution and a "query by example" filter and I may PR my changes to the duplicate utility but those may be very specific to my use-case...))