### PR TITLE
fix: always show resolution in details panel

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -415,9 +415,9 @@
                 <p>
                   {getMegapixel(asset.exifInfo.exifImageHeight, asset.exifInfo.exifImageWidth)} MP
                 </p>
-                {@const { width, height } = getDimensions(asset.exifInfo)}
-                <p>{width} x {height}</p>
               {/if}
+              {@const { width, height } = getDimensions(asset.exifInfo)}
+              <p>{width} x {height}</p>
             {/if}
             {#if asset.exifInfo?.fileSizeInByte}
               <p>{getByteUnitString(asset.exifInfo.fileSizeInByte, $locale)}</p>


### PR DESCRIPTION
## Description

For my use-case I have many sub-megapixel (think 750x750) images and I wanted to be able to see the resolution of them at a glance

I _was_ going to go add the resolution to the details panel, but then I realized it's already there!

It just only appears if the response from `getMegapixel` it truthy, but for my sub-megapixel images, `getMegapixel` returns `0` and therefore the image resolution isn't displayed _at all._ So I pulled that down and out of the condition

## How Has This Been Tested?

- View a sub-megapixel image (any image with less than 1 million pixels in it)
- Verify that the resolution is now displayed where it wasn't before

<details><summary><h2>Screenshots</h2></summary>

Before:
<img width="1271" height="611" alt="image" src="https://github.com/user-attachments/assets/3608968d-01bc-4aa6-b327-cc0c05bed3ae" />

After:
<img width="1279" height="622" alt="image" src="https://github.com/user-attachments/assets/9a0a4596-b30e-4367-b26b-f65be9c332bc" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
