### PR TITLE
docs: update backup-and-restore.md

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -77,12 +77,11 @@ gunzip --stdout "/path/to/backup/dump.sql.gz" \
 docker compose up -d            # Start remainder of Immich apps
 ```
 
-</TabItem>
+  </TabItem>
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
 
-    Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
-
 ```powershell title='Backup'
+# Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 [System.IO.File]::WriteAllLines("C:\absolute\path\to\backup\dump.sql", (docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME>))
 ```
 
@@ -104,7 +103,7 @@ exit                                              # Exit the Docker shell
 docker compose up -d                              # Start remainder of Immich apps
 ```
 
-</TabItem>
+  </TabItem>
 </Tabs>
 
 Note that for the database restore to proceed properly, it requires a completely fresh install (i.e. the Immich server has never run since creating the Docker containers). If the Immich app has run, Postgres conflicts may be encountered upon database restoration (relation already exists, violated foreign key constraints, multiple primary keys, etc.), in which case you need to delete the `DB_DATA_LOCATION` folder to reset the database.

--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -57,6 +57,7 @@ Then please follow the steps in the following section for restoring the database
   <TabItem value="Linux system" label="Linux system" default>
 
 ```bash title='Backup'
+# Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME> | gzip > "/path/to/backup/dump.sql.gz"
 ```
 
@@ -69,6 +70,7 @@ docker compose create           # Create Docker containers for Immich apps witho
 docker start immich_postgres    # Start Postgres server
 sleep 10                        # Wait for Postgres server to start up
 # Check the database user if you deviated from the default
+# Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 gunzip --stdout "/path/to/backup/dump.sql.gz" \
 | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
 | docker exec -i immich_postgres psql --dbname=postgres --username=<DB_USERNAME>  # Restore Backup
@@ -77,6 +79,8 @@ docker compose up -d            # Start remainder of Immich apps
 
 </TabItem>
   <TabItem value="Windows system (PowerShell)" label="Windows system (PowerShell)">
+
+    Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 
 ```powershell title='Backup'
 [System.IO.File]::WriteAllLines("C:\absolute\path\to\backup\dump.sql", (docker exec -t immich_postgres pg_dumpall --clean --if-exists --username=<DB_USERNAME>))
@@ -92,7 +96,9 @@ docker compose create                             # Create Docker containers for
 docker start immich_postgres                      # Start Postgres server
 sleep 10                                          # Wait for Postgres server to start up
 docker exec -it immich_postgres bash              # Enter the Docker shell and run the following command
-# Check the database user if you deviated from the default. If your backup ends in `.gz`, replace `cat` with `gunzip --stdout`
+# If your backup ends in `.gz`, replace `cat` with `gunzip --stdout`
+# Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
+
 cat "/dump.sql" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | psql --dbname=postgres --username=<DB_USERNAME>
 exit                                              # Exit the Docker shell
 docker compose up -d                              # Start remainder of Immich apps


### PR DESCRIPTION
Added, and consolidated messaging across the md file in relation to updating the username when running scripts.

## Description

<!--- Describe your changes in detail -->
Added in a section to each command block reminding users to add the DB username
<!--- Why is this change required? What problem does it solve? -->
Came across this issue whilst trying to restore a database. The md file had one instance where this was highlighted, at the end. This pull consolidates this message to each code block.
<!--- If it fixes an open issue, please link to the issue here. -->



## How Has This Been Tested?

No test required.


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
