### PR TITLE
chore: update build and test mobile actions to not use npm

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -106,7 +106,7 @@ jobs:
         run: flutter pub get
 
       - name: Generate translation file
-        run: make translation
+        run: dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
         working-directory: ./mobile
 
       - name: Generate platform APIs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -462,10 +462,8 @@ jobs:
         with:
           channel: 'stable'
           flutter-version-file: ./mobile/pubspec.yaml
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Generate translation file
-        run: make translation
+        run: dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
         working-directory: ./mobile
       - name: Run tests
         working-directory: ./mobile


### PR DESCRIPTION
## Description

Similar to #21070, but updates the other actions that use the `make translation` as well