### PR TITLE
feat: add a counter to the duplicate utility

### DIFF
--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -268,7 +268,7 @@
           onStack={(assets) => handleStack(duplicates[duplicatesIndex].duplicateId, assets)}
         />
         <div class="max-w-216 mx-auto mb-16">
-          <div class="flex flex-wrap gap-y-6 mb-4 px-6 w-full place-content-end justify-between">
+          <div class="flex flex-wrap gap-y-6 mb-4 px-6 w-full place-content-end justify-between items-center">
             <div class="flex text-xs text-black">
               <Button
                 size="small"
@@ -291,6 +291,7 @@
                 {$t('previous')}
               </Button>
             </div>
+            <p>{duplicatesIndex + 1}/{duplicates.length.toLocaleString($locale)}</p>
             <div class="flex text-xs text-black">
               <Button
                 size="small"


### PR DESCRIPTION
## Description

_Love_ that I can skip dupes now, but I wanted a counter to help me remember where I'm at (granted maybe I'm the only weirdo who has 30k+ duplicates...)

## How Has This Been Tested?

- Open the duplicate utility
- Observe that there is now a counter at the bottom that responds to the next/previous buttons

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="906" height="528" alt="image" src="https://github.com/user-attachments/assets/395cd30d-ddf2-488d-9d58-d0277d49e815" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)


I will also mention that I _do_ like that the arrow keys pull you forward/backward in the dupes. But it seems that's broken the forward/backward arrow key functionality of `previous-asset-action.svelte` and `next-asset-action.svelte`. And I can't seem to easily fix that since the event handlers are registered right on `document`? So the new dupe shortcut event handlers will _always_ run before the asset actions (so we can't even catch the key downs and `.stopPropegation` or anything...) 🤔 I'll keep playing with it, but thought I'd mention it in case there was something simple I'm missing

Thanks!