### PR TITLE
fix: skip albums selected or excluded from backups from deletions

### DIFF
--- a/mobile/lib/pages/common/tab_shell.page.dart
+++ b/mobile/lib/pages/common/tab_shell.page.dart
@@ -134,6 +134,10 @@ void _onNavigationSelected(TabsRouter router, int index, WidgetRef ref) {
     ref.read(remoteAlbumProvider.notifier).refresh();
   }
 
+  if (index == 3) {
+    ref.invalidate(localAlbumProvider);
+  }
+
   ref.read(hapticFeedbackProvider.notifier).selectionClick();
   router.setActiveIndex(index);
   ref.read(tabProvider.notifier).state = TabEnum.values[index];

--- a/mobile/lib/providers/infrastructure/album.provider.dart
+++ b/mobile/lib/providers/infrastructure/album.provider.dart
@@ -18,7 +18,9 @@ final localAlbumServiceProvider = Provider<LocalAlbumService>(
 );
 
 final localAlbumProvider = FutureProvider<List<LocalAlbum>>(
-  (ref) => LocalAlbumService(ref.watch(localAlbumRepository)).getAll(sortBy: {SortLocalAlbumsBy.newestAsset}),
+  (ref) => LocalAlbumService(ref.watch(localAlbumRepository))
+      .getAll(sortBy: {SortLocalAlbumsBy.newestAsset})
+      .then((albums) => albums.where((album) => album.assetCount > 0).toList()),
 );
 
 final localAlbumThumbnailProvider = FutureProvider.family<LocalAsset?, String>(


### PR DESCRIPTION
## Description

The current behaviour is that during local syncing, the albums that do not have any assets are removed from the SQLite DB and when they come back, the album selection is lost. This is a common workflow where once assets are backed up, the local part of them are removed essentially emptying the album (folder in case of android). On Android, this means that the folder no longer has a media and will not be returned from the MediaStore query used and will be removed during the local sync

The PR addresses this by skipping the albums that are either selected or excluded from being deleted when there are no assets in them. When the album is deselected for backups, it will be removed during the next local sync. The library page is also updated to filter out the empty albums