### PR TITLE
fix: wait for watched files to finish being written (#17100)

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -123,6 +123,10 @@ export class LibraryService extends BaseService {
       {
         usePolling: false,
         ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 5000,
+          pollInterval: 1000,
+        },
       },
       {
         onReady: () => _resolve(),


### PR DESCRIPTION
## Description

This makes the external library watcher wait for files in watched directories to finish being written before queuing jobs for each file.

This configures chokidar with `awaitWriteFinish` to wait for watched files to remain stable in size for 5 seconds before emitting its events. (https://github.com/paulmillr/chokidar?tab=readme-ov-file#performance)

This should fix issues with jobs prematurely running when there are slow writes to external libraries (e.g. when the external library is written to using Samba) and failing.

Fixes #17100

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
