### PR TITLE
docs: update oauth.md - Authentik link leads to Page Not Found error

### DIFF
--- a/docs/docs/administration/oauth.md
+++ b/docs/docs/administration/oauth.md
@@ -10,7 +10,7 @@ Unable to set `app.immich:///oauth-callback` as a valid redirect URI? See [Mobil
 
 Immich supports 3rd party authentication via [OpenID Connect][oidc] (OIDC), an identity layer built on top of OAuth2. OIDC is supported by most identity providers, including:
 
-- [Authentik](https://goauthentik.io/integrations/sources/oauth/#openid-connect)
+- [Authentik](https://integrations.goauthentik.io/media/immich/)
 - [Authelia](https://www.authelia.com/integration/openid-connect/immich/)
 - [Okta](https://www.okta.com/openid-connect/)
 - [Google](https://developers.google.com/identity/openid-connect/openid-connect)


### PR DESCRIPTION
Updated Authentik url

## Description

<!--- Describe your changes in detail -->
Current link to Authentik docs ( https://goauthentik.io/integrations/sources/oauth/#openid-connect ) leads to a Page Not Found message. 
Updated it to the current valid link: https://integrations.goauthentik.io/media/immich/
<!--- Why is this change required? What problem does it solve? -->
invalid url for the Authentik docs

