### PR TITLE
feat: add support for custom headers to TS SDK

### DIFF
--- a/open-api/typescript-sdk/src/index.ts
+++ b/open-api/typescript-sdk/src/index.ts
@@ -29,9 +29,7 @@ export const setApiKey = (apiKey: string) => {
 };
 
 export const setHeader = (key: string, value: string) => {
-  if (key.toLowerCase() === 'x-api-key') {
-    throw new Error('The API key header can only be set using setApiKey().');
-  }
+  assertNoApiKey(key);
   defaults.headers = defaults.headers || {};
   defaults.headers[key] = value;
 };
@@ -39,10 +37,14 @@ export const setHeader = (key: string, value: string) => {
 export const setHeaders = (headers: Record<string, string>) => {
   defaults.headers = defaults.headers || {};
   for (const [key, value] of Object.entries(headers)) {
-    if (key.toLowerCase() === 'x-api-key') {
-      throw new Error('The API key header can only be set using setApiKey().');
-    }
+    assertNoApiKey(key);
     defaults.headers[key] = value;
+  }
+};
+
+const assertNoApiKey = (headerKey: string) => {
+  if (headerKey.toLowerCase() === 'x-api-key') {
+    throw new Error('The API key header can only be set using setApiKey().');
   }
 };
 

--- a/open-api/typescript-sdk/src/index.ts
+++ b/open-api/typescript-sdk/src/index.ts
@@ -6,11 +6,15 @@ export * from './fetch-errors.js';
 export interface InitOptions {
   baseUrl: string;
   apiKey: string;
+  headers?: Record<string, string>;
 }
 
-export const init = ({ baseUrl, apiKey }: InitOptions) => {
+export const init = ({ baseUrl, apiKey, headers }: InitOptions) => {
   setBaseUrl(baseUrl);
   setApiKey(apiKey);
+  if (headers) {
+    setHeaders(headers);
+  }
 };
 
 export const getBaseUrl = () => defaults.baseUrl;
@@ -22,6 +26,24 @@ export const setBaseUrl = (baseUrl: string) => {
 export const setApiKey = (apiKey: string) => {
   defaults.headers = defaults.headers || {};
   defaults.headers['x-api-key'] = apiKey;
+};
+
+export const setHeader = (key: string, value: string) => {
+  if (key.toLowerCase() === 'x-api-key') {
+    throw new Error('The API key header can only be set using setApiKey().');
+  }
+  defaults.headers = defaults.headers || {};
+  defaults.headers[key] = value;
+};
+
+export const setHeaders = (headers: Record<string, string>) => {
+  defaults.headers = defaults.headers || {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === 'x-api-key') {
+      throw new Error('The API key header can only be set using setApiKey().');
+    }
+    defaults.headers[key] = value;
+  }
 };
 
 export const getAssetOriginalPath = (id: string) => `/assets/${id}/original`;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This is a VERY simple change simply allowing for custom headers to be included in the API requests, in this instance I have a need to bypass auth on a reverse proxy to properly make API requests
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->



<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
