### PR TITLE
fix: use composite cache key in user circle avatar

### DIFF
--- a/mobile/lib/widgets/common/user_circle_avatar.dart
+++ b/mobile/lib/widgets/common/user_circle_avatar.dart
@@ -48,7 +48,7 @@ class UserCircleAvatar extends ConsumerWidget {
                   borderRadius: const BorderRadius.all(Radius.circular(50)),
                   child: CachedNetworkImage(
                     fit: BoxFit.cover,
-                    cacheKey: user.profileChangedAt.toIso8601String(),
+                    cacheKey: '${user.id}-${user.profileChangedAt.toIso8601String()}',
                     width: size,
                     height: size,
                     placeholder: (_, __) => Image.memory(kTransparentImage),


### PR DESCRIPTION
## Description

Possibly Fixes #21177

The UserCircleAvatar widget is using the profileChangedAt value as the cache key, so all users with a profile picture will reuse the same picture as the user who logged in, if they share the same profileChangedAt value. This PR fixes it by using a composite `id-profileChangedAt` value as the cache key that provides user specific caching.

Note: I was thinking about how this could be since we also reset the sync checkpoint for the user entity during the release. I believe what happened is that the server got updated first and reset the sync checkpoint, but since the app was not aware of the new fields, it ignored and processed the sync events. Then when the app got updated, it defaulted to using `Date.now` for all users as the profileChangedAt value. After the update, since the sync was already acknowledged, the server did not be send any updates for users, unless the user is updated again.

This could be addressed if we add proper migration handling inside the app as well. Currently, we only do migration on the DB, but it might be useful to have access to all the providers during migrations, especially the API ones as we can also conditionally reset sync entities on the server on a per session basis (i.e, per client basis).