### PR TITLE
fix(web): Album multi-select 'm' shortcut prevents typing m in title box

### DIFF
--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -133,7 +133,7 @@
         await onEnter();
         break;
       }
-      case 'm': {
+      case 'Control': {
         e.preventDefault();
         handleMultiSelect();
         break;


### PR DESCRIPTION
## Description
Change the shortcut to ctrl

Fixes #21234 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
