### PR TITLE
fix(mobile): user storage quota not showing

### DIFF
--- a/mobile/lib/domain/models/user.model.dart
+++ b/mobile/lib/domain/models/user.model.dart
@@ -75,6 +75,8 @@ profileChangedAt: $profileChangedAt
     bool? isPartnerSharedWith,
     bool? hasProfileImage,
     DateTime? profileChangedAt,
+    int? quotaSizeInBytes,
+    int? quotaUsageInBytes,
   }) => UserDto(
     id: id ?? this.id,
     email: email ?? this.email,
@@ -88,6 +90,8 @@ profileChangedAt: $profileChangedAt
     isPartnerSharedWith: isPartnerSharedWith ?? this.isPartnerSharedWith,
     hasProfileImage: hasProfileImage ?? this.hasProfileImage,
     profileChangedAt: profileChangedAt ?? this.profileChangedAt,
+    quotaSizeInBytes: quotaSizeInBytes ?? this.quotaSizeInBytes,
+    quotaUsageInBytes: quotaUsageInBytes ?? this.quotaUsageInBytes,
   );
 
   @override
@@ -105,7 +109,9 @@ profileChangedAt: $profileChangedAt
         other.memoryEnabled == memoryEnabled &&
         other.inTimeline == inTimeline &&
         other.hasProfileImage == hasProfileImage &&
-        other.profileChangedAt.isAtSameMomentAs(profileChangedAt);
+        other.profileChangedAt.isAtSameMomentAs(profileChangedAt) &&
+        other.quotaSizeInBytes == quotaSizeInBytes &&
+        other.quotaUsageInBytes == quotaUsageInBytes;
   }
 
   @override
@@ -121,7 +127,9 @@ profileChangedAt: $profileChangedAt
       isPartnerSharedBy.hashCode ^
       isPartnerSharedWith.hashCode ^
       hasProfileImage.hashCode ^
-      profileChangedAt.hashCode;
+      profileChangedAt.hashCode ^
+      quotaSizeInBytes.hashCode ^
+      quotaUsageInBytes.hashCode;
 }
 
 class PartnerUserDto {

--- a/mobile/lib/infrastructure/entities/user.entity.dart
+++ b/mobile/lib/infrastructure/entities/user.entity.dart
@@ -54,6 +54,8 @@ class User {
     avatarColor: dto.avatarColor,
     memoryEnabled: dto.memoryEnabled,
     inTimeline: dto.inTimeline,
+    quotaUsageInBytes: dto.quotaUsageInBytes,
+    quotaSizeInBytes: dto.quotaSizeInBytes,
   );
 
   UserDto toDto() => UserDto(

--- a/mobile/lib/infrastructure/utils/user.converter.dart
+++ b/mobile/lib/infrastructure/utils/user.converter.dart
@@ -29,6 +29,8 @@ abstract final class UserConverter {
     isPartnerSharedWith: false,
     profileChangedAt: adminDto.profileChangedAt,
     hasProfileImage: adminDto.profileImagePath.isNotEmpty,
+    quotaSizeInBytes: adminDto.quotaSizeInBytes ?? 0,
+    quotaUsageInBytes: adminDto.quotaUsageInBytes ?? 0,
   );
 
   static UserDto fromPartnerDto(PartnerResponseDto dto) => UserDto(


### PR DESCRIPTION
## Description
Fixes the storage indicator showing server storage instead of user quota if available.

**This only affects the old timeline**

## How Has This Been Tested?

Logging in with a user that has storage limit defined.

## Screenshots

<img width="241" height="75" alt="Screenshot 2025-08-25 at 20 33 08" src="https://github.com/user-attachments/assets/41366f22-e3f5-44c7-8521-f72ebb274764" />