### PR TITLE
fix: invalid storage quota with decimals

### DIFF
--- a/server/src/controllers/user-admin.controller.spec.ts
+++ b/server/src/controllers/user-admin.controller.spec.ts
@@ -1,0 +1,79 @@
+import { UserAdminController } from 'src/controllers/user-admin.controller';
+import { UserAdminCreateDto } from 'src/dtos/user.dto';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { UserAdminService } from 'src/services/user-admin.service';
+import request from 'supertest';
+import { errorDto } from 'test/medium/responses';
+import { factory } from 'test/small.factory';
+import { automock, ControllerContext, controllerSetup, mockBaseService } from 'test/utils';
+
+describe(UserAdminController.name, () => {
+  let ctx: ControllerContext;
+  const service = mockBaseService(UserAdminService);
+
+  beforeAll(async () => {
+    ctx = await controllerSetup(UserAdminController, [
+      { provide: LoggingRepository, useValue: automock(LoggingRepository, { strict: false }) },
+      { provide: UserAdminService, useValue: service },
+    ]);
+    return () => ctx.close();
+  });
+
+  beforeEach(() => {
+    service.resetAllMocks();
+    ctx.reset();
+  });
+
+  describe('GET /admin/users', () => {
+    it('should be an authenticated route', async () => {
+      await request(ctx.getHttpServer()).get('/admin/users');
+      expect(ctx.authenticate).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /admin/users', () => {
+    it('should be an authenticated route', async () => {
+      await request(ctx.getHttpServer()).post('/admin/users');
+      expect(ctx.authenticate).toHaveBeenCalled();
+    });
+
+    it(`should not allow decimal quota`, async () => {
+      const dto: UserAdminCreateDto = {
+        email: 'user@immich.app',
+        password: 'test',
+        name: 'Test User',
+        quotaSizeInBytes: 1.2,
+      };
+
+      const { status, body } = await request(ctx.getHttpServer())
+        .post(`/admin/users`)
+        .set('Authorization', `Bearer token`)
+        .send(dto);
+      expect(status).toBe(400);
+      expect(body).toEqual(errorDto.badRequest(expect.arrayContaining(['quotaSizeInBytes must be an integer number'])));
+    });
+  });
+
+  describe('GET /admin/users/:id', () => {
+    it('should be an authenticated route', async () => {
+      await request(ctx.getHttpServer()).get(`/admin/users/${factory.uuid()}`);
+      expect(ctx.authenticate).toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT /admin/users/:id', () => {
+    it('should be an authenticated route', async () => {
+      await request(ctx.getHttpServer()).put(`/admin/users/${factory.uuid()}`);
+      expect(ctx.authenticate).toHaveBeenCalled();
+    });
+
+    it(`should not allow decimal quota`, async () => {
+      const { status, body } = await request(ctx.getHttpServer())
+        .put(`/admin/users/${factory.uuid()}`)
+        .set('Authorization', `Bearer token`)
+        .send({ quotaSizeInBytes: 1.2 });
+      expect(status).toBe(400);
+      expect(body).toEqual(errorDto.badRequest(expect.arrayContaining(['quotaSizeInBytes must be an integer number'])));
+    });
+  });
+});

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEmail, IsNotEmpty, IsNumber, IsString, Min } from 'class-validator';
+import { IsEmail, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 import { User, UserAdmin } from 'src/database';
 import { UserAvatarColor, UserMetadataKey, UserStatus } from 'src/enum';
 import { UserMetadataItem } from 'src/types';
@@ -91,7 +91,7 @@ export class UserAdminCreateDto {
   storageLabel?: string | null;
 
   @Optional({ nullable: true })
-  @IsNumber()
+  @IsInt()
   @Min(0)
   @ApiProperty({ type: 'integer', format: 'int64' })
   quotaSizeInBytes?: number | null;
@@ -137,7 +137,7 @@ export class UserAdminUpdateDto {
   shouldChangePassword?: boolean;
 
   @Optional({ nullable: true })
-  @IsNumber()
+  @IsInt()
   @Min(0)
   @ApiProperty({ type: 'integer', format: 'int64' })
   quotaSizeInBytes?: number | null;

--- a/web/src/lib/modals/UserCreateModal.svelte
+++ b/web/src/lib/modals/UserCreateModal.svelte
@@ -122,7 +122,7 @@
         </Field>
 
         <Field label={$t('admin.quota_size_gib')}>
-          <Input bind:value={quotaSize} type="number" placeholder={$t('unlimited')} min="0" />
+          <Input bind:value={quotaSize} type="number" placeholder={$t('unlimited')} min="0" step="1" />
           {#if quotaSizeWarning}
             <HelperText color="danger">{$t('errors.quota_higher_than_disk_size')}</HelperText>
           {/if}

--- a/web/src/lib/modals/UserEditModal.svelte
+++ b/web/src/lib/modals/UserEditModal.svelte
@@ -83,6 +83,7 @@
           name="quotaSize"
           placeholder={$t('unlimited')}
           type="number"
+          step="1"
           min="0"
           bind:value={quotaSize}
         />


### PR DESCRIPTION
Fixes #20982 

- Set an input step of 1 on both storage quota inputs
- Enforce whole numbers in the api
- Add tests for the controller validation