### PR TITLE
fix(mobile): skip animation for offscreen thumbnails

### DIFF
--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -207,7 +207,7 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
 
     final topLeft = renderObject.localToGlobal(Offset.zero);
     final bottomRight = renderObject.localToGlobal(Offset(renderObject.size.width, renderObject.size.height));
-    return topLeft.dy < MediaQuery.sizeOf(context).height && bottomRight.dy > 0;
+    return topLeft.dy < context.height && bottomRight.dy > 0;
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -125,7 +125,7 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
           return;
         }
 
-        if (synchronousCall && _providerImage == null) {
+        if ((synchronousCall && _providerImage == null) || !_isVisible()) {
           _fadeController.value = 1.0;
         } else if (_fadeController.isAnimating) {
           _fadeController.forward();
@@ -199,6 +199,15 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
   void _loadImage() {
     _loadFromImageProvider();
     _loadFromThumbhashProvider();
+  }
+
+  bool _isVisible() {
+    final renderObject = context.findRenderObject() as RenderBox?;
+    if (renderObject == null || !renderObject.attached) return false;
+
+    final topLeft = renderObject.localToGlobal(Offset.zero);
+    final bottomRight = renderObject.localToGlobal(Offset(renderObject.size.width, renderObject.size.height));
+    return topLeft.dy < MediaQuery.sizeOf(context).height && bottomRight.dy > 0;
   }
 
   @override


### PR DESCRIPTION
## Description

If the thumbnail is offscreen, but close to the viewport, it results in a redundant pseudo-transition as it comes into view partway into the animation. This PR changes it to only do a transition for changes that happen on-screen.