### PR TITLE
fix: prevent an offline asset from being used as a person feature photo

### DIFF
--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -42,7 +42,6 @@ describe(MediaService.name, () => {
       mocks.assetJob.streamForThumbnailJob.mockReturnValue(makeStream([assetStub.image]));
 
       mocks.person.getAll.mockReturnValue(makeStream([personStub.newThumbnail]));
-      mocks.person.getFacesByIds.mockResolvedValue([faceStub.face1]);
 
       await sut.handleQueueGenerateThumbnails({ force: true });
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -197,6 +197,10 @@ export class PersonService extends BaseService {
         throw new BadRequestException('Invalid assetId for feature face');
       }
 
+      if (face.asset.isOffline) {
+        throw new BadRequestException('An offline asset cannot be used for feature face');
+      }
+
       faceId = face.id;
     }
 


### PR DESCRIPTION
Fixes #13055

Throw an error when trying to update a feature photo to an asset that is offline.