### PR TITLE
fix: motion video extraction race condition

### DIFF
--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -27,7 +27,7 @@ import { BaseService } from 'src/services/base.service';
 import { UploadFile } from 'src/types';
 import { requireUploadAccess } from 'src/utils/access';
 import { asRequest, getAssetFiles, onBeforeLink } from 'src/utils/asset.util';
-import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
+import { isAssetChecksumConstraint } from 'src/utils/database';
 import { getFilenameExtension, getFileNameWithoutExtension, ImmichFileResponse } from 'src/utils/file';
 import { mimeTypes } from 'src/utils/mime-types';
 import { fromChecksum } from 'src/utils/request';
@@ -318,7 +318,7 @@ export class AssetMediaService extends BaseService {
     });
 
     // handle duplicates with a success response
-    if (error.constraint_name === ASSET_CHECKSUM_CONSTRAINT) {
+    if (isAssetChecksumConstraint(error)) {
       const duplicateId = await this.assetRepository.getUploadAssetIdByChecksum(auth.user.id, file.checksum);
       if (!duplicateId) {
         this.logger.error(`Error locating duplicate for checksum constraint`);

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -14,7 +14,7 @@ import {
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
 import { parse } from 'pg-connection-string';
-import postgres, { Notice } from 'postgres';
+import postgres, { Notice, PostgresError } from 'postgres';
 import { columns, Exif, Person } from 'src/database';
 import { AssetFileType, AssetVisibility, DatabaseExtension, DatabaseSslMode } from 'src/enum';
 import { AssetSearchBuilderOptions } from 'src/repositories/search.repository';
@@ -152,6 +152,10 @@ export function toJson<DB, TB extends keyof DB & string, T extends TB | Expressi
 }
 
 export const ASSET_CHECKSUM_CONSTRAINT = 'UQ_assets_owner_checksum';
+
+export const isAssetChecksumConstraint = (error: unknown) => {
+  return (error as PostgresError)?.constraint_name === 'UQ_assets_owner_checksum';
+};
 
 export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'asset', O>) {
   return qb.where('asset.visibility', 'in', [sql.lit(AssetVisibility.Archive), sql.lit(AssetVisibility.Timeline)]);


### PR DESCRIPTION
Fixes #13492

It was possible for this process to query for a checksum (and get nothing back), and then try to create an asset with said checksum, only for it to throw a UQ constraint error, because of the checksum. Presumably this is due to a race condition. The updated code handles this scenario, by checking if the error is due to this constraint and re-query for the asset by checksum before proceeding.
