### PR TITLE
fix(server): correct immich-cli symlink in Immich docker image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -125,7 +125,7 @@ ENV NODE_ENV=production \
 COPY --from=server-prod /output/server-pruned ./server
 COPY --from=web-prod /usr/src/app/web/build /build/www
 COPY --from=cli-prod /output/cli-pruned ./cli
-RUN ln -s ./cli/bin/immich server/bin/immich
+RUN ln -s ../../cli/bin/immich server/bin/immich
 COPY LICENSE /licenses/LICENSE.txt
 COPY LICENSE /LICENSE
 


### PR DESCRIPTION
Fix broken symlink for immich-cli after recent changes in Dockerfile.

Reported in https://discord.com/channels/979116623879368755/1409944625141252157.

```sh
docker exec -ti immich_server bash

# everything below is executed from default /usr/src/app

env | grep ^PATH
    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/src/app/server/bin

find . -name immich -exec ls -l {} \;
    lrwxrwxrwx    ./server/bin/immich -> ./cli/bin/immich
    -rwxr-xr-x    ./cli/bin/immich

immich
    bash: immich: command not found

/usr/src/app/server/bin/immich
    bash: /usr/src/app/server/bin/immich: No such file or directory

/usr/src/app/cli/bin/immich 
    Usage: immich [options] [command]
    ...

ln -sf ../../cli/bin/immich server/bin/immich

immich
    Usage: immich [options] [command]
    ...
```
