### PR TITLE
fix(web): album multi-select filter doesn't include other selected albums

### DIFF
--- a/web/src/lib/modals/AlbumPickerModal.svelte
+++ b/web/src/lib/modals/AlbumPickerModal.svelte
@@ -74,9 +74,9 @@
   };
 
   const handleMultiSubmit = () => {
-    const albums = new Set(albumModalRows.filter((row) => row.multiSelected).map(({ album }) => album!));
-    if (albums.size > 0) {
-      onClose([...albums]);
+    const selectedAlbums = new Set(albums.filter(({ id }) => multiSelectedAlbumIds.includes(id)));
+    if (selectedAlbums.size > 0) {
+      onClose([...selectedAlbums]);
     } else {
       onClose();
     }


### PR DESCRIPTION
## Description

Filtering the album picker modal and submitting would not include previously selected albums.

Fixes #21294

## How Has This Been Tested?

1. select an album for multi-add
2. filter the albums and select another
3. Submit now adds to all previously selected albums, even though they're now 'hidden'



## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
