### PR TITLE
fix(mobile): capitalize month & day labels in beta timeline

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/header.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/header.widget.dart
@@ -57,7 +57,10 @@ class TimelineHeader extends StatelessWidget {
             if (isMonthHeader)
               Row(
                 children: [
-                  Text(_formatMonth(context, date), style: context.textTheme.labelLarge?.copyWith(fontSize: 24)),
+                  Text(
+                    toBeginningOfSentenceCase(_formatMonth(context, date)),
+                    style: context.textTheme.labelLarge?.copyWith(fontSize: 24),
+                  ),
                   const Spacer(),
                   if (header != HeaderType.monthAndDay) _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
                 ],
@@ -65,7 +68,10 @@ class TimelineHeader extends StatelessWidget {
             if (isDayHeader)
               Row(
                 children: [
-                  Text(_formatDay(context, date), style: context.textTheme.labelLarge?.copyWith(fontSize: 15)),
+                  Text(
+                    toBeginningOfSentenceCase(_formatDay(context, date)),
+                    style: context.textTheme.labelLarge?.copyWith(fontSize: 15),
+                  ),
                   const Spacer(),
                   _BulkSelectIconButton(bucket: bucket, assetOffset: assetOffset),
                 ],


### PR DESCRIPTION
## Description

Fixes #21313
Beta timeline had #17803, fixes this issue by manually capitalizing the labels using `toBeginningOfSentenceCase` from `intl` library.

## How Has This Been Tested?
Tested the labels in:
- [x] English
- [x] French
- [x] Spanish
- [x] Ukrainian

## Screenshots

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/0371736d-e71f-4d5c-85d5-97550a05b5ac" />
