### PR TITLE
fix: timeline scroll error handling

### DIFF
--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -419,14 +419,22 @@ export class TimelineManager {
     if (!this.isInitialized) {
       await this.initTask.waitUntilCompletion();
     }
+
     let { monthGroup } = findMonthGroupForAssetUtil(this, id) ?? {};
     if (monthGroup) {
       return monthGroup;
     }
-    const asset = toTimelineAsset(await getAssetInfo({ ...authManager.params, id }));
+
+    const response = await getAssetInfo({ ...authManager.params, id }).catch(() => null);
+    if (!response) {
+      return;
+    }
+
+    const asset = toTimelineAsset(response);
     if (!asset || this.isExcluded(asset)) {
       return;
     }
+
     monthGroup = await this.#loadMonthGroupAtTime(asset.localDateTime, { cancelable: false });
     if (monthGroup?.findAssetById({ id })) {
       return monthGroup;


### PR DESCRIPTION
Fix an issue when navigating to an asset that doesn't exist.

<img width="1318" height="630" alt="image" src="https://github.com/user-attachments/assets/3ecd2291-9e29-43f8-9eab-10bc72172c6f" />
