### PR TITLE
fix(mobile): thumbnail requests not being cancelled

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -50,11 +50,10 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
   Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode) async* {
     if (isCancelled) {
+      this.request = null;
       evict();
       return;
     }
-
-    this.request = request;
 
     try {
       final image = await request.load(decode);

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -35,7 +35,8 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
   }
 
   Stream<ImageInfo> _codec(LocalThumbProvider key, ImageDecoderCallback decode) {
-    return loadRequest(LocalImageRequest(localId: key.id, size: key.size, assetType: key.assetType), decode);
+    final request = this.request = LocalImageRequest(localId: key.id, size: key.size, assetType: key.assetType);
+    return loadRequest(request, decode);
   }
 
   @override
@@ -87,7 +88,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     }
 
     final devicePixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
-    final request = LocalImageRequest(
+    final request = this.request = LocalImageRequest(
       localId: key.id,
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -36,7 +36,7 @@ class RemoteThumbProvider extends CancellableImageProvider<RemoteThumbProvider>
   }
 
   Stream<ImageInfo> _codec(RemoteThumbProvider key, ImageDecoderCallback decode) {
-    final request = RemoteImageRequest(
+    final request = this.request = RemoteImageRequest(
       uri: getThumbnailUrlForRemoteId(key.assetId),
       headers: ApiService.getRequestHeaders(),
       cacheManager: cacheManager,
@@ -92,16 +92,12 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     }
 
     final headers = ApiService.getRequestHeaders();
-    try {
-      final request = RemoteImageRequest(
-        uri: getPreviewUrlForRemoteId(key.assetId),
-        headers: headers,
-        cacheManager: cacheManager,
-      );
-      yield* loadRequest(request, decode);
-    } finally {
-      request = null;
-    }
+    final request = this.request = RemoteImageRequest(
+      uri: getPreviewUrlForRemoteId(key.assetId),
+      headers: headers,
+      cacheManager: cacheManager,
+    );
+    yield* loadRequest(request, decode);
 
     if (isCancelled) {
       evict();
@@ -109,12 +105,8 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     }
 
     if (AppSetting.get(Setting.loadOriginal)) {
-      try {
-        final request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId), headers: headers);
-        yield* loadRequest(request, decode);
-      } finally {
-        request = null;
-      }
+      final request = this.request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId), headers: headers);
+      yield* loadRequest(request, decode);
     }
   }
 

--- a/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
+++ b/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
@@ -17,11 +17,12 @@ class ThumbHashProvider extends CancellableImageProvider<ThumbHashProvider>
 
   @override
   ImageStreamCompleter loadImage(ThumbHashProvider key, ImageDecoderCallback decode) {
-    return OneFramePlaceholderImageStreamCompleter(_loadCodec(key, decode))..addOnLastListenerRemovedCallback(cancel);
+    return OneFramePlaceholderImageStreamCompleter(_loadCodec(key, decode), onDispose: cancel);
   }
 
   Stream<ImageInfo> _loadCodec(ThumbHashProvider key, ImageDecoderCallback decode) {
-    return loadRequest(ThumbhashImageRequest(thumbhash: key.thumbHash), decode);
+    final request = this.request = ThumbhashImageRequest(thumbhash: key.thumbHash);
+    return loadRequest(request, decode);
   }
 
   @override

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -241,6 +241,11 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
       imageProvider.cancel();
     }
 
+    final thumbhashProvider = widget.thumbhashProvider;
+    if (thumbhashProvider is CancellableImageProvider) {
+      thumbhashProvider.cancel();
+    }
+
     _fadeController.removeStatusListener(_onAnimationStatusChanged);
     _fadeController.dispose();
     _stopListeningToStream();

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/local_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumb_hash_provider.dart';
@@ -235,6 +236,11 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
 
   @override
   void dispose() {
+    final imageProvider = widget.imageProvider;
+    if (imageProvider is CancellableImageProvider) {
+      imageProvider.cancel();
+    }
+
     _fadeController.removeStatusListener(_onAnimationStatusChanged);
     _fadeController.dispose();
     _stopListeningToStream();


### PR DESCRIPTION
## Description

Setting `this.request` in the mixin apparently has very different results than setting it in the providers. Additionally, the stream completer's `onDisposed` callback hardly ever gets called, and when it does it's too late. Cancelling when the thumbnail widget is disposed is much more reliable.

## How Has This Been Tested?

Confirmed that requests are being cancelled and that scrolling through remote assets is snappier as expected.