### PR TITLE
fix(web): add primary text color to file upload toast

### DIFF
--- a/web/src/lib/components/shared-components/upload-asset-preview.svelte
+++ b/web/src/lib/components/shared-components/upload-asset-preview.svelte
@@ -93,7 +93,7 @@
   {#if uploadAsset.state === UploadState.STARTED}
     <div class="text-black relative mt-[5px] h-[15px] w-full rounded-md bg-gray-300 dark:bg-immich-dark-gray">
       <div class="h-[15px] rounded-md bg-immich-primary transition-all" style={`width: ${uploadAsset.progress}%`}></div>
-      <p class="absolute top-0 h-full w-full text-center text-[10px]">
+      <p class="absolute top-0 h-full w-full text-center text-immich-primary dark:text-immich-dark-primary text-[10px]">
         {#if uploadAsset.message}
           {uploadAsset.message}
         {:else}

--- a/web/src/lib/components/shared-components/upload-asset-preview.svelte
+++ b/web/src/lib/components/shared-components/upload-asset-preview.svelte
@@ -93,7 +93,7 @@
   {#if uploadAsset.state === UploadState.STARTED}
     <div class="text-black relative mt-[5px] h-[15px] w-full rounded-md bg-gray-300 dark:bg-gray-700">
       <div class="h-[15px] rounded-md bg-immich-primary transition-all" style={`width: ${uploadAsset.progress}%`}></div>
-      <p class="absolute top-0 h-full w-full text-center text-immich-primary dark:text-immich-dark-primary text-[10px]">
+      <p class="absolute top-0 h-full w-full text-center text-primary text-[10px]">
         {#if uploadAsset.message}
           {uploadAsset.message}
         {:else}

--- a/web/src/lib/components/shared-components/upload-asset-preview.svelte
+++ b/web/src/lib/components/shared-components/upload-asset-preview.svelte
@@ -91,7 +91,7 @@
   </div>
 
   {#if uploadAsset.state === UploadState.STARTED}
-    <div class="text-black relative mt-[5px] h-[15px] w-full rounded-md bg-gray-300 dark:bg-immich-dark-gray">
+    <div class="text-black relative mt-[5px] h-[15px] w-full rounded-md bg-gray-300 dark:bg-gray-700">
       <div class="h-[15px] rounded-md bg-immich-primary transition-all" style={`width: ${uploadAsset.progress}%`}></div>
       <p class="absolute top-0 h-full w-full text-center text-immich-primary dark:text-immich-dark-primary text-[10px]">
         {#if uploadAsset.message}


### PR DESCRIPTION
## Description
Add text color to the progress bar in the upload files toast displayed at the bottom right corner
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes [#21300](https://github.com/immich-app/immich/issues/21300#issue-3354905342)

| Before | After |
| - | - |
|  <img width="289" height="203" alt="image" src="https://github.com/user-attachments/assets/7b25f9a4-10a2-4ae5-b448-045731869a71" /> | <img width="337" height="220" alt="image" src="https://github.com/user-attachments/assets/c9944578-fd56-4c22-a0be-9f4d554e922a" /> |
|  <img width="335" height="208" alt="image" src="https://github.com/user-attachments/assets/cd7e3623-6530-46bd-906a-c6e18853d48b" /> | <img width="313" height="207" alt="image" src="https://github.com/user-attachments/assets/bcea7645-2757-48d1-af0c-31e59af96cbd" /> |


<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable (not applicable for this pr)
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary. (not applicable for this pr)
- [ ] I have written tests for new code (not applicable for this pr)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc. (not applicable for this pr)
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)  (not applicable for this pr)
