### PR TITLE
fix(mobile): map theme not matching settings

### DIFF
--- a/mobile/lib/widgets/map/map_theme_override.dart
+++ b/mobile/lib/widgets/map/map_theme_override.dart
@@ -31,7 +31,7 @@ class _MapThemeOverrideState extends ConsumerState<MapThemeOverride> with Widget
   @override
   void initState() {
     super.initState();
-    _theme = widget.themeMode ?? ref.read(mapStateNotifierProvider.select((v) => v.themeMode));
+    _theme = widget.themeMode ?? ref.read(immichThemeModeProvider);
     setState(() {
       _isDarkTheme = checkDarkTheme();
     });
@@ -65,7 +65,7 @@ class _MapThemeOverrideState extends ConsumerState<MapThemeOverride> with Widget
 
   @override
   Widget build(BuildContext context) {
-    _theme = widget.themeMode ?? ref.watch(mapStateNotifierProvider.select((v) => v.themeMode));
+    _theme = widget.themeMode ?? ref.watch(immichThemeModeProvider);
     var appTheme = ref.watch(immichThemeProvider);
     final locale = ref.watch(localeProvider);
 


### PR DESCRIPTION
## Description

Fixes #21310

## How Has This Been Tested?

- [x] Phone in light mode, app in "system": map in light mode
- [x] Phone in dark mode, app in "system": map in dark mode
- [x] App set to light specifically: map in light mode
- [x] App set to dak specifically: map in dark mode
