### PR TITLE
fix(mobile): memory lane rebuild

### DIFF
--- a/mobile/lib/infrastructure/repositories/memory.repository.dart
+++ b/mobile/lib/infrastructure/repositories/memory.repository.dart
@@ -30,6 +30,9 @@ class DriftMemoryRepository extends DriftDatabaseRepository {
           ..orderBy([OrderingTerm.desc(_db.memoryEntity.memoryAt), OrderingTerm.asc(_db.remoteAssetEntity.createdAt)]);
 
     final rows = await query.get();
+    if (rows.isEmpty) {
+      return const [];
+    }
 
     final Map<String, DriftMemory> memoriesMap = {};
 
@@ -46,7 +49,7 @@ class DriftMemoryRepository extends DriftDatabaseRepository {
       }
     }
 
-    return memoriesMap.values.toList();
+    return memoriesMap.values.toList(growable: false);
   }
 
   Future<DriftMemory?> get(String memoryId) async {

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -4,7 +4,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
-import 'package:immich_mobile/providers/user.provider.dart';
 
 @RoutePage()
 class MainTimelinePage extends ConsumerWidget {
@@ -12,22 +11,10 @@ class MainTimelinePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
-    final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
-
-    return memoryLaneProvider.maybeWhen(
-      data: (memories) {
-        return memories.isEmpty || !memoriesEnabled
-            ? const Timeline()
-            : Timeline(
-                topSliverWidget: SliverToBoxAdapter(
-                  key: Key('memory-lane-${memories.first.assets.first.id}'),
-                  child: DriftMemoryLane(memories: memories),
-                ),
-                topSliverWidgetHeight: 200,
-              );
-      },
-      orElse: () => const Timeline(),
+    final hasMemories = ref.watch(driftMemoryFutureProvider.select((state) => state.value?.isNotEmpty ?? false));
+    return Timeline(
+      topSliverWidget: const SliverToBoxAdapter(child: DriftMemoryLane()),
+      topSliverWidgetHeight: hasMemories ? 200 : 0,
     );
   }
 }

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -8,7 +8,6 @@ import 'package:immich_mobile/providers/asset_viewer/video_player_value_provider
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
-import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class DriftMemoryLane extends ConsumerWidget {
@@ -16,11 +15,6 @@ class DriftMemoryLane extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
-    if (!memoriesEnabled) {
-      return const SizedBox.shrink();
-    }
-
     final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
     final memories = memoryLaneProvider.value ?? const [];
     if (memories.isEmpty) {

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -7,15 +7,26 @@ import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart'
 import 'package:immich_mobile/providers/asset_viewer/video_player_value_provider.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class DriftMemoryLane extends ConsumerWidget {
-  final List<DriftMemory> memories;
-
-  const DriftMemoryLane({super.key, required this.memories});
+  const DriftMemoryLane({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final memoriesEnabled = ref.watch(currentUserProvider.select((user) => user?.memoryEnabled ?? true));
+    if (!memoriesEnabled) {
+      return const SizedBox.shrink();
+    }
+
+    final memoryLaneProvider = ref.watch(driftMemoryFutureProvider);
+    final memories = memoryLaneProvider.value ?? const [];
+    if (memories.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
     return ConstrainedBox(
       constraints: const BoxConstraints(maxHeight: 200),
       child: CarouselView(
@@ -38,7 +49,7 @@ class DriftMemoryLane extends ConsumerWidget {
 
           context.pushRoute(DriftMemoryRoute(memories: memories, memoryIndex: index));
         },
-        children: memories.map((memory) => DriftMemoryCard(memory: memory)).toList(),
+        children: memories.map((memory) => DriftMemoryCard(memory: memory)).toList(growable: false),
       ),
     );
   }

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -49,7 +49,9 @@ class DriftMemoryLane extends ConsumerWidget {
 
           context.pushRoute(DriftMemoryRoute(memories: memories, memoryIndex: index));
         },
-        children: memories.map((memory) => DriftMemoryCard(memory: memory)).toList(growable: false),
+        children: memories
+            .map((memory) => DriftMemoryCard(key: Key(memory.id), memory: memory))
+            .toList(growable: false),
       ),
     );
   }

--- a/mobile/lib/providers/infrastructure/memory.provider.dart
+++ b/mobile/lib/providers/infrastructure/memory.provider.dart
@@ -14,13 +14,12 @@ final driftMemoryServiceProvider = Provider<DriftMemoryService>(
   (ref) => DriftMemoryService(ref.watch(driftMemoryRepositoryProvider)),
 );
 
-final driftMemoryFutureProvider = FutureProvider.autoDispose<List<DriftMemory>>((ref) async {
+final driftMemoryFutureProvider = FutureProvider.autoDispose<List<DriftMemory>>((ref) {
   final user = ref.watch(currentUserProvider);
   if (user == null) {
-    return [];
+    return const [];
   }
 
   final service = ref.watch(driftMemoryServiceProvider);
-
   return service.getMemoryLane(user.id);
 });

--- a/mobile/lib/providers/infrastructure/memory.provider.dart
+++ b/mobile/lib/providers/infrastructure/memory.provider.dart
@@ -15,11 +15,11 @@ final driftMemoryServiceProvider = Provider<DriftMemoryService>(
 );
 
 final driftMemoryFutureProvider = FutureProvider.autoDispose<List<DriftMemory>>((ref) {
-  final user = ref.watch(currentUserProvider);
-  if (user == null) {
+  final (userId, enabled) = ref.watch(currentUserProvider.select((user) => (user?.id, user?.memoryEnabled ?? true)));
+  if (userId == null || !enabled) {
     return const [];
   }
 
   final service = ref.watch(driftMemoryServiceProvider);
-  return service.getMemoryLane(user.id);
+  return service.getMemoryLane(userId);
 });


### PR DESCRIPTION
## Description

The timeline only needs to know whether there are memories to display. Moving the memory watching to the memory lane avoids unnecessary rebuilds. Additionally, the key meant that the memory lane and its subtree was entirely removed from the widget tree and put back again, which can cause flickering and is more expensive than updating the widget.