### PR TITLE
fix(mobile): allow gestures in asset viewer before image is loaded

### DIFF
--- a/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
+++ b/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
@@ -198,7 +198,7 @@ class _ImageWrapperState extends State<ImageWrapper> {
         tightMode: widget.tightMode,
         filterQuality: widget.filterQuality,
         disableGestures: widget.disableGestures,
-        disableScaleGestures: widget.disableScaleGestures,
+        disableScaleGestures: true,
         enablePanAlways: widget.enablePanAlways,
         child: _loading ? _buildLoading(context) : _buildError(context),
       );

--- a/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
+++ b/mobile/lib/widgets/photo_view/src/photo_view_wrappers.dart
@@ -172,12 +172,36 @@ class _ImageWrapperState extends State<ImageWrapper> {
 
   @override
   Widget build(BuildContext context) {
-    if (_loading) {
-      return _buildLoading(context);
-    }
-
-    if (_lastException != null) {
-      return _buildError(context);
+    if (_loading || _lastException != null) {
+      return CustomChildWrapper(
+        childSize: null,
+        backgroundDecoration: widget.backgroundDecoration,
+        heroAttributes: widget.heroAttributes,
+        scaleStateChangedCallback: widget.scaleStateChangedCallback,
+        enableRotation: widget.enableRotation,
+        controller: widget.controller,
+        scaleStateController: widget.scaleStateController,
+        maxScale: widget.maxScale,
+        minScale: widget.minScale,
+        initialScale: widget.initialScale,
+        basePosition: widget.basePosition,
+        scaleStateCycle: widget.scaleStateCycle,
+        onTapUp: widget.onTapUp,
+        onTapDown: widget.onTapDown,
+        onDragStart: widget.onDragStart,
+        onDragEnd: widget.onDragEnd,
+        onDragUpdate: widget.onDragUpdate,
+        onScaleEnd: widget.onScaleEnd,
+        onLongPressStart: widget.onLongPressStart,
+        outerSize: widget.outerSize,
+        gestureDetectorBehavior: widget.gestureDetectorBehavior,
+        tightMode: widget.tightMode,
+        filterQuality: widget.filterQuality,
+        disableGestures: widget.disableGestures,
+        disableScaleGestures: widget.disableScaleGestures,
+        enablePanAlways: widget.enablePanAlways,
+        child: _loading ? _buildLoading(context) : _buildError(context),
+      );
     }
 
     final scaleBoundaries = ScaleBoundaries(


### PR DESCRIPTION
## Description

This lets you use gestures like leaving the asset viewer even if the asset takes a while to load or fails altogether.