### PR TITLE
fix: show TabShellRoute when cold starting from deeplink

### DIFF
--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -66,7 +66,7 @@ class DeepLinkService {
     return DeepLink([
       // we need something to segue back to if the app was cold started
       // TODO: use MainTimelineRoute this when beta is default
-      if (isColdStart) (Store.isBetaTimelineEnabled) ? const MainTimelineRoute() : const PhotosRoute(),
+      if (isColdStart) (Store.isBetaTimelineEnabled) ? const TabShellRoute() : const PhotosRoute(),
       route,
     ]);
   }


### PR DESCRIPTION
`TabShellRoute` would not show when deeplinking cold start on beta timeline.