### PR TITLE
fix(server): folder sort order

### DIFF
--- a/server/src/queries/view.repository.sql
+++ b/server/src/queries/view.repository.sql
@@ -12,6 +12,8 @@ where
   and "fileCreatedAt" is not null
   and "fileModifiedAt" is not null
   and "localDateTime" is not null
+order by
+  "directoryPath" asc
 
 -- ViewRepository.getAssetsByOriginalPath
 select

--- a/server/src/repositories/view-repository.ts
+++ b/server/src/repositories/view-repository.ts
@@ -20,6 +20,7 @@ export class ViewRepository {
       .where('fileCreatedAt', 'is not', null)
       .where('fileModifiedAt', 'is not', null)
       .where('localDateTime', 'is not', null)
+      .orderBy('directoryPath', 'asc')
       .execute();
 
     return results.map((row) => row.directoryPath.replaceAll(/\/$/g, ''));


### PR DESCRIPTION
## Description

This is a server-side workaround for https://github.com/immich-app/immich/issues/19439. Aimed to get back alphabetical sorting in Folder View/Explorer in web UI. Later it can be reverted after fixing frontend.

**Does it make sense to merge this PR? Or should we wait for a proper fix in frontend instead?**

Motivation. Apart from the linked issue, people asked about this issue several times, for example:
- https://discord.com/channels/979116623879368755/1398689711328854036 "Folder sort order in Explorer"
- https://www.reddit.com/r/immich/comments/1lzjmky/comment/n32m2ji/ "my files and folders are all over the place in Immich and there is no way to specify how the files and folders should be sorted"

Fixes #19439 (workaround with caveats).

## Caveats

1. It adds database-side sorting.

For large collections (100K+ assets) it will not fit into work_mem 16MB and will use disk-based merge sort.

Tested by reducing work_mem from 16MB to 2MB on my instance with 15K assets. Planner switched from `Sort Method: quicksort  Memory: 2125kB` to `Sort Method: external merge  Disk: 1008kB`.

So it will be slower. IMO it's worth it: having order in large collections vs waiting a bit longer when loading Explorer for the first time.

2. Still not 100% perfect sorting.

The database returns properly ordered records, then frontend puts collapsed folders after regular folders (see the screenshot section).

## How Has This Been Tested?

Tested on my own Immich instance and in dev setup. Also people who applied a monkey patch confirmed that it works for them.

<details><summary><h2>Screenshots</h2></summary>

<img width="2020" height="1112" alt="image" src="https://github.com/user-attachments/assets/f8bfbb28-dbff-406a-a7b7-c55d55e39ab9" />

</details>
