### PR TITLE
fix: iOS portrait photo saved as jpg extension

### DIFF
--- a/server/src/middleware/file-upload.interceptor.ts
+++ b/server/src/middleware/file-upload.interceptor.ts
@@ -12,7 +12,7 @@ import { AuthRequest } from 'src/middleware/auth.guard';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { AssetMediaService } from 'src/services/asset-media.service';
 import { ImmichFile, UploadFile, UploadFiles } from 'src/types';
-import { asRequest, mapToUploadFile } from 'src/utils/asset.util';
+import { asUploadRequest, mapToUploadFile } from 'src/utils/asset.util';
 
 export function getFile(files: UploadFiles, property: 'assetData' | 'sidecarData') {
   const file = files[property]?.[0];
@@ -99,18 +99,21 @@ export class FileUploadInterceptor implements NestInterceptor {
   }
 
   private fileFilter(request: AuthRequest, file: Express.Multer.File, callback: multer.FileFilterCallback) {
-    return callbackify(() => this.assetService.canUploadFile(asRequest(request, file)), callback);
+    return callbackify(() => this.assetService.canUploadFile(asUploadRequest(request, file)), callback);
   }
 
   private filename(request: AuthRequest, file: Express.Multer.File, callback: DiskStorageCallback) {
     return callbackify(
-      () => this.assetService.getUploadFilename(asRequest(request, file)),
+      () => this.assetService.getUploadFilename(asUploadRequest(request, file)),
       callback as Callback<string>,
     );
   }
 
   private destination(request: AuthRequest, file: Express.Multer.File, callback: DiskStorageCallback) {
-    return callbackify(() => this.assetService.getUploadFolder(asRequest(request, file)), callback as Callback<string>);
+    return callbackify(
+      () => this.assetService.getUploadFolder(asUploadRequest(request, file)),
+      callback as Callback<string>,
+    );
   }
 
   private handleFile(request: AuthRequest, file: Express.Multer.File, callback: Callback<Partial<ImmichFile>>) {

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -25,6 +25,7 @@ const file1 = Buffer.from('d2947b871a706081be194569951b7db246907957', 'hex');
 const uploadFile = {
   nullAuth: {
     auth: null,
+    body: {},
     fieldName: UploadFieldName.ASSET_DATA,
     file: {
       uuid: 'random-uuid',
@@ -37,6 +38,7 @@ const uploadFile = {
   filename: (fieldName: UploadFieldName, filename: string) => {
     return {
       auth: authStub.admin,
+      body: {},
       fieldName,
       file: {
         uuid: 'random-uuid',
@@ -897,7 +899,10 @@ describe(AssetMediaService.name, () => {
 
   describe('onUploadError', () => {
     it('should queue a job to delete the uploaded file', async () => {
-      const request = { user: authStub.user1 } as AuthRequest;
+      const request = {
+        body: {},
+        user: authStub.user1,
+      } as AuthRequest;
 
       const file = {
         fieldname: UploadFieldName.ASSET_DATA,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,5 +1,7 @@
 import { SystemConfig } from 'src/config';
 import { VECTOR_EXTENSIONS } from 'src/constants';
+import { UploadFieldName } from 'src/dtos/asset-media.dto';
+import { AuthDto } from 'src/dtos/auth.dto';
 import {
   AssetMetadataKey,
   AssetOrder,
@@ -407,6 +409,16 @@ export interface UploadFile {
   originalName: string;
   size: number;
 }
+
+export type UploadRequest = {
+  auth: AuthDto | null;
+  fieldName: UploadFieldName;
+  file: UploadFile;
+  body: {
+    filename?: string;
+    [key: string]: unknown;
+  };
+};
 
 export interface UploadFiles {
   assetData: ImmichFile[];

--- a/server/src/utils/asset.util.ts
+++ b/server/src/utils/asset.util.ts
@@ -10,7 +10,7 @@ import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { EventRepository } from 'src/repositories/event.repository';
 import { PartnerRepository } from 'src/repositories/partner.repository';
-import { IBulkAsset, ImmichFile, UploadFile } from 'src/types';
+import { IBulkAsset, ImmichFile, UploadFile, UploadRequest } from 'src/types';
 import { checkAccess } from 'src/utils/access';
 
 export const getAssetFile = (files: AssetFile[], type: AssetFileType | GeneratedImageType) => {
@@ -190,9 +190,10 @@ export function mapToUploadFile(file: ImmichFile): UploadFile {
   };
 }
 
-export const asRequest = (request: AuthRequest, file: Express.Multer.File) => {
+export const asUploadRequest = (request: AuthRequest, file: Express.Multer.File): UploadRequest => {
   return {
     auth: request.user || null,
+    body: request.body,
     fieldName: file.fieldname as UploadFieldName,
     file: mapToUploadFile(file as ImmichFile),
   };


### PR DESCRIPTION
fixes #21117


With the new upload library, the filename for Portrait mode on iOS will have a similar name as 

```
8585491C-16A0-4582-8E11-172D278E9289_L0_001_1756095605.449717_o_FullSizeRender.jpg
```

While the originalFileName is `IMG_8488.HEIC`, which leads to the name is saved as `.jpg` extension.

Open for a better fix for this issue as I am not fond of pulling out the body information like this