### PR TITLE
fix(devcontainer): logging typo

### DIFF
--- a/.devcontainer/server/container-start-backend.sh
+++ b/.devcontainer/server/container-start-backend.sh
@@ -11,7 +11,7 @@ run_cmd pnpm --filter immich install
 log "Starting Nest API Server"
 log ""
 cd "${IMMICH_WORKSPACE}/server" || (
-    log "Immich workspace not found"jj
+    log "Immich workspace not found"
     exit 1
 )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#19572 introduced an unfixed typo that added "jj" to the end of a .devcontainer server log for if the immich working directory was not found. This PR removes that.

~~put me in the contributors listttt~~

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

i did nothing :3
<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

clearly i am the king at merge requests /j