### PR TITLE
fix(mobile): memory lane query

### DIFF
--- a/mobile/lib/infrastructure/repositories/memory.repository.dart
+++ b/mobile/lib/infrastructure/repositories/memory.repository.dart
@@ -15,8 +15,8 @@ class DriftMemoryRepository extends DriftDatabaseRepository {
 
     final query =
         _db.select(_db.memoryEntity).join([
-            leftOuterJoin(_db.memoryAssetEntity, _db.memoryAssetEntity.memoryId.equalsExp(_db.memoryEntity.id)),
-            leftOuterJoin(
+            innerJoin(_db.memoryAssetEntity, _db.memoryAssetEntity.memoryId.equalsExp(_db.memoryEntity.id)),
+            innerJoin(
               _db.remoteAssetEntity,
               _db.remoteAssetEntity.id.equalsExp(_db.memoryAssetEntity.assetId) &
                   _db.remoteAssetEntity.deletedAt.isNull() &


### PR DESCRIPTION
## Description

The query should use inner joins instead of left joins; it doesn't make sense to have memories without assets.

Fixes #21418