### PR TITLE
fix: default zoom level when location is not set

### DIFF
--- a/web/src/lib/components/shared-components/change-location.svelte
+++ b/web/src/lib/components/shared-components/change-location.svelte
@@ -44,7 +44,7 @@
   let mapLat = $derived(assetLat ?? previousLocation?.lat ?? undefined);
   let mapLng = $derived(assetLng ?? previousLocation?.lng ?? undefined);
 
-  let zoom = $derived(mapLat !== undefined && mapLng !== undefined ? 12.5 : 1);
+  let zoom = $derived(mapLat && mapLng ? 12.5 : 1);
 
   $effect(() => {
     if (mapElement && initialPoint) {


### PR DESCRIPTION
## Description

Map defaults to a zoom level 12.5 on the new "Manage locations" tool when no location is set. This is caused by the zoom level check only checking if the value is undefined and not if its also 0. 

Result of the incorrect behavior is it looks like the map is broken (Lat/Lng of 0,0 is the middle of the ocean) see pic below:

<img width="649" height="857" alt="image" src="https://github.com/user-attachments/assets/88e21238-4e6b-4149-a0d7-113e134ae13c" />

This pr changes the check to be for both 0 and undefined (just checks truthiness of the value) in order to determine zoom level.

Result: 

<img width="644" height="860" alt="image" src="https://github.com/user-attachments/assets/21a1d353-881f-4f9a-b9cb-5e75e255920a" />

## How Has This Been Tested?

Tested on latest webUI

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
