### PR TITLE
fix(server): use GPSLongitudeRef and GPSLatitudeRef EXIF fields

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -34,7 +34,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^60.0.0",
-    "exiftool-vendored": "^28.3.1",
+    "exiftool-vendored": "^30.4.0",
     "globals": "^16.0.0",
     "jose": "^5.6.3",
     "luxon": "^3.4.4",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -34,7 +34,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^60.0.0",
-    "exiftool-vendored": "^30.4.0",
+    "exiftool-vendored": "^31.1.0",
     "globals": "^16.0.0",
     "jose": "^5.6.3",
     "luxon": "^3.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^60.0.0
         version: 60.0.0(eslint@9.37.0(jiti@2.6.1))
       exiftool-vendored:
-        specifier: ^30.4.0
-        version: 30.4.0
+        specifier: ^31.1.0
+        version: 31.1.0
       globals:
         specifier: ^16.0.0
         version: 16.4.0
@@ -404,8 +404,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       exiftool-vendored:
-        specifier: ^30.4.0
-        version: 30.4.0
+        specifier: ^31.1.0
+        version: 31.1.0
       express:
         specifier: ^5.1.0
         version: 5.1.0
@@ -3495,8 +3495,8 @@ packages:
     peerDependencies:
       '@photo-sphere-viewer/core': 5.14.0
 
-  '@photostructure/tz-lookup@11.2.0':
-    resolution: {integrity: sha512-DwrvodcXHNSdGdeSF7SBL5o8aBlsaeuCuG7633F04nYsL3hn5Hxe3z/5kCqxv61J1q7ggKZ27GPylR3x0cPNXQ==}
+  '@photostructure/tz-lookup@11.2.1':
+    resolution: {integrity: sha512-ugPtvpdLwGQ8IWezSGFgUCYOpO/XXetfKLNv+UN2jjTYyfIDq9dA21GydGyzXuoQ06nN3VGBd3JxmEu+ZtXScg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -6547,17 +6547,17 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  exiftool-vendored.exe@13.34.0:
-    resolution: {integrity: sha512-wncOhdEZuNFxv1hBu6/iqLEx9TmvepSs29LWG8TmS9XQBcZDbJVVXtlSkfAQ5PN5Mc10qG6JUlgWTJfmcT0v5A==}
+  exiftool-vendored.exe@13.38.0:
+    resolution: {integrity: sha512-oZx5enTAvSiIAXL+OEk7nNWrfUhEdKUpaGwDjCmz4VKwOa4HbisqyM808xPGPYj8X7XikcME/fq5hvevPeE3cw==}
     os: [win32]
 
-  exiftool-vendored.pl@13.34.0:
-    resolution: {integrity: sha512-xzgPIqHyf7+zV/mWNQpdxEJx8mkh5oa+nXWCB8va5yvtyAqotDsXXqeg/ChU8LTu3KtbSYEV1nC2IVwe2Ep9zw==}
+  exiftool-vendored.pl@13.38.0:
+    resolution: {integrity: sha512-Q3xl1nnwswrsR5344z4NyqvI74fKwla+VJHY1N+32gcDgt8cs9KBsDUwcNzKHSOSa/MjEfniuCJVrQiqR05iag==}
     os: ['!win32']
     hasBin: true
 
-  exiftool-vendored@30.4.0:
-    resolution: {integrity: sha512-DQo+4KudDXVa47TmhMqk0m3wS8ZR+hjx2/jL24Fp1kyN2wqfPCm4Q/XwGPhhrep8Ib0fo8kgLFSyr8J9foygnQ==}
+  exiftool-vendored@31.1.0:
+    resolution: {integrity: sha512-q8StxLawHLDvhqv/uoBYCfVbDskn49Cr5ouNCZhh4lgryGu1aymHwK9AvO6RcW2SbPm5MSnQDJOfGp2MW5Nnrw==}
     engines: {node: '>=20.0.0'}
 
   expect-type@1.2.1:
@@ -15130,7 +15130,7 @@ snapshots:
       '@photo-sphere-viewer/core': 5.14.0
       three: 0.180.0
 
-  '@photostructure/tz-lookup@11.2.0': {}
+  '@photostructure/tz-lookup@11.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -18610,21 +18610,21 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  exiftool-vendored.exe@13.34.0:
+  exiftool-vendored.exe@13.38.0:
     optional: true
 
-  exiftool-vendored.pl@13.34.0: {}
+  exiftool-vendored.pl@13.38.0: {}
 
-  exiftool-vendored@30.4.0:
+  exiftool-vendored@31.1.0:
     dependencies:
-      '@photostructure/tz-lookup': 11.2.0
+      '@photostructure/tz-lookup': 11.2.1
       '@types/luxon': 3.7.1
       batch-cluster: 15.0.1
-      exiftool-vendored.pl: 13.34.0
+      exiftool-vendored.pl: 13.38.0
       he: 1.2.0
       luxon: 3.7.2
     optionalDependencies:
-      exiftool-vendored.exe: 13.34.0
+      exiftool-vendored.exe: 13.38.0
 
   expect-type@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,8 +238,8 @@ importers:
         specifier: ^60.0.0
         version: 60.0.0(eslint@9.37.0(jiti@2.6.1))
       exiftool-vendored:
-        specifier: ^28.3.1
-        version: 28.8.0
+        specifier: ^30.4.0
+        version: 30.4.0
       globals:
         specifier: ^16.0.0
         version: 16.4.0
@@ -404,8 +404,8 @@ importers:
         specifier: 4.3.3
         version: 4.3.3
       exiftool-vendored:
-        specifier: ^28.8.0
-        version: 28.8.0
+        specifier: ^30.4.0
+        version: 30.4.0
       express:
         specifier: ^5.1.0
         version: 5.1.0
@@ -5210,9 +5210,9 @@ packages:
     resolution: {integrity: sha512-qsJ8/X+UypqxHXN75M7dF88jNK37dLBRW7LeUzCPz+TNs37G8cfWy9nWzS+LS//g600zrt2le9KuXt0rWfDz5Q==}
     hasBin: true
 
-  batch-cluster@13.0.0:
-    resolution: {integrity: sha512-EreW0Vi8TwovhYUHBXXRA5tthuU2ynGsZFlboyMJHCCUXYa2AjgwnE3ubBOJs2xJLcuXFJbi6c/8pH5+FVj8Og==}
-    engines: {node: '>=14'}
+  batch-cluster@15.0.1:
+    resolution: {integrity: sha512-eUmh0ld1AUPKTEmdzwGF9QTSexXAyt9rA1F5zDfW1wUi3okA3Tal4NLdCeFI6aiKpBenQhR6NmK9bW9tBHTGPQ==}
+    engines: {node: '>=20'}
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -6547,16 +6547,18 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  exiftool-vendored.exe@13.0.0:
-    resolution: {integrity: sha512-4zAMuFGgxZkOoyQIzZMHv1HlvgyJK3AkNqjAgm8A8V0UmOZO7yv3pH49cDV1OduzFJqgs6yQ6eG4OGydhKtxlg==}
+  exiftool-vendored.exe@13.34.0:
+    resolution: {integrity: sha512-wncOhdEZuNFxv1hBu6/iqLEx9TmvepSs29LWG8TmS9XQBcZDbJVVXtlSkfAQ5PN5Mc10qG6JUlgWTJfmcT0v5A==}
     os: [win32]
 
-  exiftool-vendored.pl@13.0.1:
-    resolution: {integrity: sha512-+BRRzjselpWudKR0ltAW5SUt9T82D+gzQN8DdOQUgnSVWWp7oLCeTGBRptbQz+436Ihn/mPzmo/xnf0cv/Qw1A==}
+  exiftool-vendored.pl@13.34.0:
+    resolution: {integrity: sha512-xzgPIqHyf7+zV/mWNQpdxEJx8mkh5oa+nXWCB8va5yvtyAqotDsXXqeg/ChU8LTu3KtbSYEV1nC2IVwe2Ep9zw==}
     os: ['!win32']
+    hasBin: true
 
-  exiftool-vendored@28.8.0:
-    resolution: {integrity: sha512-R7tirJLr9fWuH9JS/KFFLB+O7jNGKuPXGxREc6YybYangEudGb+X8ERsYXk9AifMiAWh/2agNfbgkbcQcF+MxA==}
+  exiftool-vendored@30.4.0:
+    resolution: {integrity: sha512-DQo+4KudDXVa47TmhMqk0m3wS8ZR+hjx2/jL24Fp1kyN2wqfPCm4Q/XwGPhhrep8Ib0fo8kgLFSyr8J9foygnQ==}
+    engines: {node: '>=20.0.0'}
 
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
@@ -17069,7 +17071,7 @@ snapshots:
 
   baseline-browser-mapping@2.8.15: {}
 
-  batch-cluster@13.0.0: {}
+  batch-cluster@15.0.1: {}
 
   batch@0.6.1: {}
 
@@ -18608,21 +18610,21 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  exiftool-vendored.exe@13.0.0:
+  exiftool-vendored.exe@13.34.0:
     optional: true
 
-  exiftool-vendored.pl@13.0.1: {}
+  exiftool-vendored.pl@13.34.0: {}
 
-  exiftool-vendored@28.8.0:
+  exiftool-vendored@30.4.0:
     dependencies:
       '@photostructure/tz-lookup': 11.2.0
       '@types/luxon': 3.7.1
-      batch-cluster: 13.0.0
-      exiftool-vendored.pl: 13.0.1
+      batch-cluster: 15.0.1
+      exiftool-vendored.pl: 13.34.0
       he: 1.2.0
       luxon: 3.7.2
     optionalDependencies:
-      exiftool-vendored.exe: 13.0.0
+      exiftool-vendored.exe: 13.34.0
 
   expect-type@1.2.1: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -68,7 +68,7 @@
     "cookie": "^1.0.2",
     "cookie-parser": "^1.4.7",
     "cron": "4.3.3",
-    "exiftool-vendored": "^28.8.0",
+    "exiftool-vendored": "^30.4.0",
     "express": "^5.1.0",
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -68,7 +68,7 @@
     "cookie": "^1.0.2",
     "cookie-parser": "^1.4.7",
     "cron": "4.3.3",
-    "exiftool-vendored": "^30.4.0",
+    "exiftool-vendored": "^31.1.0",
     "express": "^5.1.0",
     "fast-glob": "^3.3.2",
     "fluent-ffmpeg": "^2.1.2",

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { BinaryField, DefaultReadTaskOptions, ExifTool, Tags } from 'exiftool-vendored';
 import geotz from 'geo-tz';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 
 interface ExifDuration {
@@ -71,6 +73,8 @@ export interface ImmichTags extends Omit<Tags, TagsWithWrongTypes> {
 
   AndroidMake?: string;
   AndroidModel?: string;
+
+  MIMEEncoding?: string;
 }
 
 @Injectable()
@@ -84,6 +88,7 @@ export class MetadataRepository {
     numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength', 'FileSize'],
     /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
     geoTz: (lat, lon) => geotz.find(lat, lon)[0],
+    geolocation: true,
     // Enable exiftool LFS to parse metadata for files larger than 2GB.
     readArgs: ['-api', 'largefilesupport=1'],
     writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
@@ -101,11 +106,39 @@ export class MetadataRepository {
     await this.exiftool.end();
   }
 
-  readTags(path: string): Promise<ImmichTags> {
-    return this.exiftool.read(path).catch((error) => {
-      this.logger.warn(`Error reading exif data (${path}): ${error}\n${error?.stack}`);
+  async readTags(filePath: string): Promise<ImmichTags> {
+    try {
+      const tags = (await this.exiftool.read(filePath)) as ImmichTags;
+
+      // exiftool 13.25+ may skip XMP payload parsing for UTF-16LE XMP
+      // (https://github.com/exiftool/exiftool/issues/348)
+      const needsUtf8Normalization = tags.FileType === 'XMP' && tags.MIMEEncoding === 'utf-16le';
+
+      if (!needsUtf8Normalization) {
+        return tags;
+      }
+
+      try {
+        // Create a temporary UTF-8 copy
+        const xmpContent = await fs.readFile(filePath, 'utf-16le');
+        const tmpDir = await fs.mkdtemp('immich-metadata-');
+        const tmpFile = path.join(tmpDir, path.basename(filePath));
+        await fs.writeFile(tmpFile, xmpContent, 'utf8');
+
+        // Try parsing the converted XMP file using exiftool
+        try {
+          return (await this.exiftool.read(tmpFile)) as ImmichTags;
+        } finally {
+          await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        }
+      } catch (fallbackError) {
+        this.logger.warn(`UTF-8 normalization failed (${filePath}): ${fallbackError}`);
+        return tags;
+      }
+    } catch (error) {
+      this.logger.warn(`Error reading exif data (${filePath}): ${error}`, (error as Error).stack);
       return {};
-    }) as Promise<ImmichTags>;
+    }
   }
 
   extractBinaryTag(path: string, tagName: string): Promise<Buffer> {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -447,7 +447,7 @@ export class MetadataService extends BaseService {
      * For RAW images in the CR2 or RAF format, the "ImageSize" value seems to be correct,
      * but ImageWidth and ImageHeight are not correct (they contain the dimensions of the preview image).
      */
-    let [width, height] = exifTags.ImageSize?.split('x').map((dim) => Number.parseInt(dim) || undefined) || [];
+    let [width, height] = exifTags.ImageSize?.toString().split('x').map((dim) => Number.parseInt(dim) || undefined) || [];
     if (!width || !height) {
       [width, height] = [exifTags.ImageWidth, exifTags.ImageHeight];
     }

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -447,7 +447,10 @@ export class MetadataService extends BaseService {
      * For RAW images in the CR2 or RAF format, the "ImageSize" value seems to be correct,
      * but ImageWidth and ImageHeight are not correct (they contain the dimensions of the preview image).
      */
-    let [width, height] = exifTags.ImageSize?.toString().split('x').map((dim) => Number.parseInt(dim) || undefined) || [];
+    let [width, height] =
+      exifTags.ImageSize?.toString()
+        ?.split('x')
+        ?.map((dim) => Number.parseInt(dim) || undefined) ?? [];
     if (!width || !height) {
       [width, height] = [exifTags.ImageWidth, exifTags.ImageHeight];
     }


### PR DESCRIPTION
## Description

Re-submission of #18403, which fixes EXIF parsing for GPS tags.

The solution for the issue requires updating `exiftool-vendored` and enabling the `geolocation` option. However, exiftool v13.22 seems to have introduced some issues with UTF-16LE file parsing (https://github.com/exiftool/exiftool/issues/348), which is causing some e2e test assets to not work anymore.

Given upgrading exiftool could break Immich support for existing library files, I'm implementing fallback logic in `metadata.repository.spec` to convert XMP files to UTF-8 if needed. I'm not sure if this is the best way to go, other suggestions are appreciated.

Fixes #13053.

## How Has This Been Tested?

`e2e/src/api/specs/library.e2e-spec.ts` uses UTF-16LE test assets and shows that those XMP files continue to be supported.

Followed the test plan in #18403 and confirmed the geolocation fix still worked. I can also upload test assets with affected geo tags and put them in an e2e test if needed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
