### PR TITLE
fix: retain filter and sort options when pulling to refresh

### DIFF
--- a/mobile/lib/presentation/pages/drift_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_album.page.dart
@@ -19,7 +19,7 @@ class DriftAlbumsPage extends ConsumerStatefulWidget {
 
 class _DriftAlbumsPageState extends ConsumerState<DriftAlbumsPage> {
   Future<void> onRefresh() async {
-    await ref.read(remoteAlbumProvider.notifier).refresh();
+    await ref.read(remoteAlbumProvider.notifier).refresh(keepFilters: true);
   }
 
   @override

--- a/mobile/lib/presentation/pages/drift_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_album.page.dart
@@ -19,7 +19,7 @@ class DriftAlbumsPage extends ConsumerStatefulWidget {
 
 class _DriftAlbumsPageState extends ConsumerState<DriftAlbumsPage> {
   Future<void> onRefresh() async {
-    await ref.read(remoteAlbumProvider.notifier).refresh(keepFilters: true);
+    await ref.read(remoteAlbumProvider.notifier).refresh();
   }
 
   @override

--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
@@ -14,11 +15,13 @@ import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/album_filter.utils.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/search_field.dart';
@@ -39,8 +42,11 @@ class AlbumSelector extends ConsumerStatefulWidget {
 class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
   bool isGrid = false;
   final searchController = TextEditingController();
-  QuickFilterMode filterMode = QuickFilterMode.all;
   final searchFocusNode = FocusNode();
+  List<RemoteAlbum> albums = [];
+
+  AlbumFilter filter = AlbumFilter(query: "", mode: QuickFilterMode.all);
+  AlbumSort sort = AlbumSort(mode: RemoteAlbumSortMode.lastModified);
 
   @override
   void initState() {
@@ -52,7 +58,7 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
     });
 
     searchController.addListener(() {
-      onSearch(searchController.text, filterMode);
+      onSearch(searchController.text, filter.mode);
     });
 
     searchFocusNode.addListener(() {
@@ -64,7 +70,9 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
 
   void onSearch(String searchTerm, QuickFilterMode sortMode) {
     final userId = ref.watch(currentUserProvider)?.id;
-    ref.read(remoteAlbumProvider.notifier).searchAlbums(searchTerm, userId, sortMode);
+    filter = filter.copyWith(query: searchTerm, userId: userId, mode: sortMode);
+
+    filterAlbums();
   }
 
   Future<void> onRefresh() async {
@@ -77,17 +85,63 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
     });
   }
 
-  void changeFilter(QuickFilterMode sortMode) {
+  void changeFilter(QuickFilterMode mode) {
     setState(() {
-      filterMode = sortMode;
+      filter = filter.copyWith(mode: mode);
     });
+
+    filterAlbums();
+  }
+
+  Future<void> changeSort(AlbumSort sort) async {
+    setState(() {
+      this.sort = sort;
+    });
+
+    await sortAlbums();
   }
 
   void clearSearch() {
     setState(() {
-      filterMode = QuickFilterMode.all;
+      filter = filter.copyWith(mode: QuickFilterMode.all, query: null);
       searchController.clear();
-      ref.read(remoteAlbumProvider.notifier).clearSearch();
+    });
+
+    filterAlbums();
+  }
+
+  Future<void> sortAlbums() async {
+    final sorted = await ref.read(remoteAlbumProvider.notifier).sortAlbums(
+          albums,
+          sort.mode,
+          isReverse: sort.isReverse,
+        );
+
+
+    setState(() {
+      albums = sorted;
+    });
+  }
+
+  Future<void> filterAlbums() async {
+    if (filter.query == null) {
+      setState(() {
+        albums = ref.read(remoteAlbumProvider).albums;
+      });
+
+      sortAlbums();
+      return;
+    }
+
+    final filteredAlbums = ref.read(remoteAlbumProvider.notifier).searchAlbums(
+          ref.read(remoteAlbumProvider).albums,
+          filter.query!,
+          filter.userId,
+          filter.mode,
+        );
+
+    setState(() {
+      albums = filteredAlbums;
     });
   }
 
@@ -100,9 +154,10 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
 
   @override
   Widget build(BuildContext context) {
-    final albums = ref.watch(remoteAlbumProvider.select((s) => s.filteredAlbums));
-
     final userId = ref.watch(currentUserProvider)?.id;
+
+    // refilter and sort when albums change
+    ref.listen(remoteAlbumProvider.select((state) => state.albums), (_,_) => filterAlbums());
 
     return MultiSliver(
       children: [
@@ -110,16 +165,16 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
           searchController: searchController,
           searchFocusNode: searchFocusNode,
           onSearch: onSearch,
-          filterMode: filterMode,
+          filterMode: filter.mode,
           onClearSearch: clearSearch,
         ),
         _QuickFilterButtonRow(
-          filterMode: filterMode,
+          filterMode: filter.mode,
           onChangeFilter: changeFilter,
           onSearch: onSearch,
           searchController: searchController,
         ),
-        _QuickSortAndViewMode(isGrid: isGrid, onToggleViewMode: toggleViewMode),
+        _QuickSortAndViewMode(isGrid: isGrid, onToggleViewMode: toggleViewMode, onSortChanged: changeSort),
         isGrid
             ? _AlbumGrid(albums: albums, userId: userId, onAlbumSelected: widget.onAlbumSelected)
             : _AlbumList(albums: albums, userId: userId, onAlbumSelected: widget.onAlbumSelected),
@@ -129,7 +184,9 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
 }
 
 class _SortButton extends ConsumerStatefulWidget {
-  const _SortButton();
+  const _SortButton(this.onSortChanged);
+
+  final Future<void> Function(AlbumSort) onSortChanged;
 
   @override
   ConsumerState<_SortButton> createState() => _SortButtonState();
@@ -148,14 +205,14 @@ class _SortButtonState extends ConsumerState<_SortButton> {
         albumSortIsReverse = !albumSortIsReverse;
         isSorting = true;
       });
-      await ref.read(remoteAlbumProvider.notifier).sortFilteredAlbums(sortMode, isReverse: albumSortIsReverse);
     } else {
       setState(() {
         albumSortOption = sortMode;
         isSorting = true;
       });
-      await ref.read(remoteAlbumProvider.notifier).sortFilteredAlbums(sortMode, isReverse: albumSortIsReverse);
     }
+    
+    await widget.onSortChanged.call(AlbumSort(mode: albumSortOption, isReverse: albumSortIsReverse));
 
     setState(() {
       isSorting = false;
@@ -394,10 +451,11 @@ class _QuickFilterButton extends StatelessWidget {
 }
 
 class _QuickSortAndViewMode extends StatelessWidget {
-  const _QuickSortAndViewMode({required this.isGrid, required this.onToggleViewMode});
+  const _QuickSortAndViewMode({required this.isGrid, required this.onToggleViewMode, required this.onSortChanged});
 
   final bool isGrid;
   final VoidCallback onToggleViewMode;
+  final Future<void> Function(AlbumSort) onSortChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -407,7 +465,7 @@ class _QuickSortAndViewMode extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            const _SortButton(),
+            _SortButton(onSortChanged),
             IconButton(
               icon: Icon(isGrid ? Icons.view_list_outlined : Icons.grid_view_outlined, size: 24),
               onPressed: onToggleViewMode,

--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -44,7 +44,7 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
   List<RemoteAlbum> albums = [];
 
   AlbumFilter filter = AlbumFilter(query: "", mode: QuickFilterMode.all);
-  AlbumSort sort = AlbumSort(mode: RemoteAlbumSortMode.lastModified);
+  AlbumSort sort = AlbumSort(mode: RemoteAlbumSortMode.lastModified, isReverse: true);
 
   @override
   void initState() {

--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
@@ -15,7 +14,6 @@ import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
-import 'package:immich_mobile/providers/album/album_sort_by_options.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -111,12 +109,9 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
   }
 
   Future<void> sortAlbums() async {
-    final sorted = await ref.read(remoteAlbumProvider.notifier).sortAlbums(
-          albums,
-          sort.mode,
-          isReverse: sort.isReverse,
-        );
-
+    final sorted = await ref
+        .read(remoteAlbumProvider.notifier)
+        .sortAlbums(albums, sort.mode, isReverse: sort.isReverse);
 
     setState(() {
       albums = sorted;
@@ -133,12 +128,9 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
       return;
     }
 
-    final filteredAlbums = ref.read(remoteAlbumProvider.notifier).searchAlbums(
-          ref.read(remoteAlbumProvider).albums,
-          filter.query!,
-          filter.userId,
-          filter.mode,
-        );
+    final filteredAlbums = ref
+        .read(remoteAlbumProvider.notifier)
+        .searchAlbums(ref.read(remoteAlbumProvider).albums, filter.query!, filter.userId, filter.mode);
 
     setState(() {
       albums = filteredAlbums;
@@ -157,7 +149,10 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
     final userId = ref.watch(currentUserProvider)?.id;
 
     // refilter and sort when albums change
-    ref.listen(remoteAlbumProvider.select((state) => state.albums), (_,_) => filterAlbums());
+    ref.listen(remoteAlbumProvider.select((state) => state.albums), (_, _) async {
+      filterAlbums();
+      await sortAlbums();
+    });
 
     return MultiSliver(
       children: [
@@ -211,7 +206,7 @@ class _SortButtonState extends ConsumerState<_SortButton> {
         isSorting = true;
       });
     }
-    
+
     await widget.onSortChanged.call(AlbumSort(mode: albumSortOption, isReverse: albumSortIsReverse));
 
     setState(() {

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -13,48 +13,42 @@ import 'album.provider.dart';
 
 class RemoteAlbumState {
   final List<RemoteAlbum> albums;
-  final List<RemoteAlbum> filteredAlbums;
 
-  const RemoteAlbumState({required this.albums, List<RemoteAlbum>? filteredAlbums})
-    : filteredAlbums = filteredAlbums ?? albums;
+  const RemoteAlbumState({required this.albums});
 
-  RemoteAlbumState copyWith({List<RemoteAlbum>? albums, List<RemoteAlbum>? filteredAlbums}) {
-    return RemoteAlbumState(albums: albums ?? this.albums, filteredAlbums: filteredAlbums ?? this.filteredAlbums);
+  RemoteAlbumState copyWith({List<RemoteAlbum>? albums}) {
+    return RemoteAlbumState(albums: albums ?? this.albums);
   }
 
   @override
-  String toString() => 'RemoteAlbumState(albums: ${albums.length}, filteredAlbums: ${filteredAlbums.length})';
+  String toString() => 'RemoteAlbumState(albums: ${albums.length})';
 
   @override
   bool operator ==(covariant RemoteAlbumState other) {
     if (identical(this, other)) return true;
     final listEquals = const DeepCollectionEquality().equals;
 
-    return listEquals(other.albums, albums) && listEquals(other.filteredAlbums, filteredAlbums);
+    return listEquals(other.albums, albums);
   }
 
   @override
-  int get hashCode => albums.hashCode ^ filteredAlbums.hashCode;
+  int get hashCode => albums.hashCode;
 }
 
 class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
   late RemoteAlbumService _remoteAlbumService;
   final _logger = Logger('RemoteAlbumNotifier');
 
-  // values used for filtering and sorting when a refresh occurs
-  AlbumSortState? _lastSortState;
-  AlbumFilterState? _lastFilterState;
-
   @override
   RemoteAlbumState build() {
     _remoteAlbumService = ref.read(remoteAlbumServiceProvider);
-    return const RemoteAlbumState(albums: [], filteredAlbums: []);
+    return const RemoteAlbumState(albums: []);
   }
 
   Future<List<RemoteAlbum>> _getAll() async {
     try {
       final albums = await _remoteAlbumService.getAll();
-      state = state.copyWith(albums: albums, filteredAlbums: albums);
+      state = state.copyWith(albums: albums);
       return albums;
     } catch (error, stack) {
       _logger.severe('Failed to fetch albums', error, stack);
@@ -62,40 +56,25 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     }
   }
 
-  Future<void> refresh({bool keepFilters = false}) async {
+  Future<void> refresh() async {
     await _getAll();
-
-    // Restore previous search and filters when pulling to refresh
-    if (keepFilters) {
-      if (_lastFilterState != null) {
-        searchAlbums(_lastFilterState!.query, _lastFilterState!.userId, _lastFilterState!.filterMode);
-      }
-
-      if (_lastSortState != null) {
-        await sortFilteredAlbums(_lastSortState!.sortMode, isReverse: _lastSortState!.isReverse);
-      }
-    } else {
-      _lastFilterState = null;
-      _lastSortState = null;
-    }
   }
 
-  void searchAlbums(String query, String? userId, [QuickFilterMode filterMode = QuickFilterMode.all]) {
-    final filtered = _remoteAlbumService.searchAlbums(state.albums, query, userId, filterMode);
-    state = state.copyWith(filteredAlbums: filtered);
-
-    _lastFilterState = AlbumFilterState(userId: userId, query: query, filterMode: filterMode);
+  List<RemoteAlbum> searchAlbums(
+    List<RemoteAlbum> albums,
+    String query,
+    String? userId, [
+    QuickFilterMode filterMode = QuickFilterMode.all,
+  ]) {
+    return _remoteAlbumService.searchAlbums(albums, query, userId, filterMode);
   }
 
-  void clearSearch() {
-    state = state.copyWith(filteredAlbums: state.albums);
-  }
-
-  Future<void> sortFilteredAlbums(RemoteAlbumSortMode sortMode, {bool isReverse = false}) async {
-    final sortedAlbums = await _remoteAlbumService.sortAlbums(state.filteredAlbums, sortMode, isReverse: isReverse);
-    state = state.copyWith(filteredAlbums: sortedAlbums);
-
-    _lastSortState = AlbumSortState(sortMode: sortMode, isReverse: isReverse);
+  Future<List<RemoteAlbum>> sortAlbums(
+    List<RemoteAlbum> albums,
+    RemoteAlbumSortMode sortMode, {
+    bool isReverse = false,
+  }) async {
+    return await _remoteAlbumService.sortAlbums(albums, sortMode, isReverse: isReverse);
   }
 
   Future<RemoteAlbum?> createAlbum({
@@ -106,7 +85,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     try {
       final album = await _remoteAlbumService.createAlbum(title: title, description: description, assetIds: assetIds);
 
-      state = state.copyWith(albums: [...state.albums, album], filteredAlbums: [...state.filteredAlbums, album]);
+      state = state.copyWith(albums: [...state.albums, album]);
 
       return album;
     } catch (error, stack) {
@@ -137,11 +116,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
         return album.id == albumId ? updatedAlbum : album;
       }).toList();
 
-      final updatedFilteredAlbums = state.filteredAlbums.map((album) {
-        return album.id == albumId ? updatedAlbum : album;
-      }).toList();
-
-      state = state.copyWith(albums: updatedAlbums, filteredAlbums: updatedFilteredAlbums);
+      state = state.copyWith(albums: updatedAlbums);
 
       return updatedAlbum;
     } catch (error, stack) {
@@ -162,9 +137,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     await _remoteAlbumService.deleteAlbum(albumId);
 
     final updatedAlbums = state.albums.where((album) => album.id != albumId).toList();
-    final updatedFilteredAlbums = state.filteredAlbums.where((album) => album.id != albumId).toList();
-
-    state = state.copyWith(albums: updatedAlbums, filteredAlbums: updatedFilteredAlbums);
+    state = state.copyWith(albums: updatedAlbums);
   }
 
   Future<List<RemoteAsset>> getAssets(String albumId) {
@@ -187,9 +160,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     await _remoteAlbumService.removeUser(albumId, userId: userId);
 
     final updatedAlbums = state.albums.where((album) => album.id != albumId).toList();
-    final updatedFilteredAlbums = state.filteredAlbums.where((album) => album.id != albumId).toList();
-
-    state = state.copyWith(albums: updatedAlbums, filteredAlbums: updatedFilteredAlbums);
+    state = state.copyWith(albums: updatedAlbums);
   }
 
   Future<void> setActivityStatus(String albumId, bool enabled) {

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -84,11 +84,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     final filtered = _remoteAlbumService.searchAlbums(state.albums, query, userId, filterMode);
     state = state.copyWith(filteredAlbums: filtered);
 
-    _lastFilterState = AlbumFilterState(
-      userId: userId,
-      query: query,
-      filterMode: filterMode,
-    );
+    _lastFilterState = AlbumFilterState(userId: userId, query: query, filterMode: filterMode);
   }
 
   void clearSearch() {
@@ -99,10 +95,7 @@ class RemoteAlbumNotifier extends Notifier<RemoteAlbumState> {
     final sortedAlbums = await _remoteAlbumService.sortAlbums(state.filteredAlbums, sortMode, isReverse: isReverse);
     state = state.copyWith(filteredAlbums: sortedAlbums);
 
-    _lastSortState = AlbumSortState(
-      sortMode: sortMode,
-      isReverse: isReverse,
-    );
+    _lastSortState = AlbumSortState(sortMode: sortMode, isReverse: isReverse);
   }
 
   Future<RemoteAlbum?> createAlbum({

--- a/mobile/lib/providers/infrastructure/remote_album.provider.dart
+++ b/mobile/lib/providers/infrastructure/remote_album.provider.dart
@@ -5,7 +5,6 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
-import 'package:immich_mobile/utils/album_filter.utils.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 

--- a/mobile/lib/utils/album_filter.utils.dart
+++ b/mobile/lib/utils/album_filter.utils.dart
@@ -6,19 +6,12 @@ class AlbumFilterState {
   String query;
   QuickFilterMode filterMode;
 
-  AlbumFilterState({
-    this.userId,
-    required this.query,
-    required this.filterMode,
-  });
+  AlbumFilterState({this.userId, required this.query, required this.filterMode});
 }
 
 class AlbumSortState {
   RemoteAlbumSortMode sortMode;
   bool isReverse;
 
-  AlbumSortState({
-    required this.sortMode,
-    this.isReverse = false,
-  });
+  AlbumSortState({required this.sortMode, this.isReverse = false});
 }

--- a/mobile/lib/utils/album_filter.utils.dart
+++ b/mobile/lib/utils/album_filter.utils.dart
@@ -9,11 +9,7 @@ class AlbumFilter {
   AlbumFilter({required this.mode, this.userId, this.query});
 
   AlbumFilter copyWith({String? userId, String? query, QuickFilterMode? mode}) {
-    return AlbumFilter(
-      userId: userId ?? this.userId,
-      query: query ?? this.query,
-      mode: mode ?? this.mode,
-    );
+    return AlbumFilter(userId: userId ?? this.userId, query: query ?? this.query, mode: mode ?? this.mode);
   }
 }
 
@@ -24,9 +20,6 @@ class AlbumSort {
   AlbumSort({required this.mode, this.isReverse = false});
 
   AlbumSort copyWith({RemoteAlbumSortMode? mode, bool? isReverse}) {
-    return AlbumSort(
-      mode: mode ?? this.mode,
-      isReverse: isReverse ?? this.isReverse,
-    );
+    return AlbumSort(mode: mode ?? this.mode, isReverse: isReverse ?? this.isReverse);
   }
 }

--- a/mobile/lib/utils/album_filter.utils.dart
+++ b/mobile/lib/utils/album_filter.utils.dart
@@ -1,0 +1,24 @@
+import 'package:immich_mobile/domain/services/remote_album.service.dart';
+import 'package:immich_mobile/models/albums/album_search.model.dart';
+
+class AlbumFilterState {
+  String? userId;
+  String query;
+  QuickFilterMode filterMode;
+
+  AlbumFilterState({
+    this.userId,
+    required this.query,
+    required this.filterMode,
+  });
+}
+
+class AlbumSortState {
+  RemoteAlbumSortMode sortMode;
+  bool isReverse;
+
+  AlbumSortState({
+    required this.sortMode,
+    this.isReverse = false,
+  });
+}

--- a/mobile/lib/utils/album_filter.utils.dart
+++ b/mobile/lib/utils/album_filter.utils.dart
@@ -1,17 +1,32 @@
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/albums/album_search.model.dart';
 
-class AlbumFilterState {
+class AlbumFilter {
   String? userId;
-  String query;
-  QuickFilterMode filterMode;
+  String? query;
+  QuickFilterMode mode;
 
-  AlbumFilterState({this.userId, required this.query, required this.filterMode});
+  AlbumFilter({required this.mode, this.userId, this.query});
+
+  AlbumFilter copyWith({String? userId, String? query, QuickFilterMode? mode}) {
+    return AlbumFilter(
+      userId: userId ?? this.userId,
+      query: query ?? this.query,
+      mode: mode ?? this.mode,
+    );
+  }
 }
 
-class AlbumSortState {
-  RemoteAlbumSortMode sortMode;
+class AlbumSort {
+  RemoteAlbumSortMode mode;
   bool isReverse;
 
-  AlbumSortState({required this.sortMode, this.isReverse = false});
+  AlbumSort({required this.mode, this.isReverse = false});
+
+  AlbumSort copyWith({RemoteAlbumSortMode? mode, bool? isReverse}) {
+    return AlbumSort(
+      mode: mode ?? this.mode,
+      isReverse: isReverse ?? this.isReverse,
+    );
+  }
 }


### PR DESCRIPTION
## Description

Fixes #20141 

## How Has This Been Tested?
Tested in the album selector on mobile with demo instance. Search and sort is retained when pull to refresh occurs.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
