### PR TITLE
fix(web): Show full date when hovering over photos date groups

### DIFF
--- a/web/src/lib/components/photos-page/asset-date-group.svelte
+++ b/web/src/lib/components/photos-page/asset-date-group.svelte
@@ -14,6 +14,8 @@
 
   import { flip } from 'svelte/animate';
   import { fly, scale } from 'svelte/transition';
+  import type { DayGroup } from '$lib/managers/timeline-manager/day-group.svelte';
+  import { fromTimelinePlainDate, getDateLocaleString } from '$lib/utils/timeline-util';
 
   let { isUploading } = uploadAssetsStore;
 
@@ -108,6 +110,16 @@
     return intersectable.filter((int) => int.intersecting);
   }
 
+  const getDayGroupFullDate = (dayGroup: DayGroup): string => {
+    const { month, year } = dayGroup.monthGroup.yearMonth;
+    const date = fromTimelinePlainDate({
+      year,
+      month,
+      day: dayGroup.day,
+    });
+    return getDateLocaleString(date);
+  };
+
   $effect.root(() => {
     if (timelineManager.scrollCompensation.monthGroup === monthGroup) {
       onScrollCompensation(timelineManager.scrollCompensation);
@@ -157,7 +169,7 @@
         </div>
       {/if}
 
-      <span class="w-full truncate first-letter:capitalize" title={dayGroup.groupTitle}>
+      <span class="w-full truncate first-letter:capitalize" title={getDayGroupFullDate(dayGroup)}>
         {dayGroup.groupTitle}
       </span>
     </div>


### PR DESCRIPTION
## Description

Show the full date for asset grid date groups when hovering over the element.

Reimplements #16561, regression from #19007.

## How Has This Been Tested?

- [x] Hovered over the date group elements to show the full dates when the dates are relative and absolute

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="567" height="442" alt="image" src="https://github.com/user-attachments/assets/f2905463-da9d-41e2-ba31-db9d05b96cca" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
