### PR TITLE
feat(mobile): add image filters to androids random widget

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/BitmapUtils.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/BitmapUtils.kt
@@ -2,6 +2,10 @@ package app.alextran.immich.widget
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
 import java.io.File
 
 fun loadScaledBitmap(file: File, reqWidth: Int, reqHeight: Int): Bitmap? {
@@ -30,4 +34,25 @@ fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeig
   }
 
   return inSampleSize
+}
+
+fun applyBlackWhiteFilter(src: Bitmap): Bitmap {
+
+    val config = src.config ?: Bitmap.Config.ARGB_8888
+    val outputBitmap = Bitmap.createBitmap(src.width, src.height, config)
+    outputBitmap.setHasAlpha(src.hasAlpha())
+    
+    val canvas = Canvas(outputBitmap)
+
+    val paint = Paint().apply {
+        isFilterBitmap = true
+        val colorMatrix = ColorMatrix().apply {
+            setSaturation(0f)
+        }
+        colorFilter = ColorMatrixColorFilter(colorMatrix)
+    }
+    
+    canvas.drawBitmap(src, 0f, 0f, paint)
+
+    return outputBitmap
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImageDownloadWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImageDownloadWorker.kt
@@ -122,6 +122,13 @@ class ImageDownloadWorker(
         WidgetType.MEMORIES -> fetchMemory(serverConfig)
       }
 
+      // if needed apply our filter
+      val filter = WidgetImageFilter.fromString(widgetConfig[kImageFilter])
+      val filteredImage = when (filter) {
+        WidgetImageFilter.BLACK_WHITE -> applyBlackWhiteFilter(entry.image)
+        WidgetImageFilter.NONE -> entry.image
+      }
+
       // clear current image if it exists
       if (!currentImgUUID.isNullOrEmpty()) {
         deleteImage(currentImgUUID)
@@ -129,7 +136,7 @@ class ImageDownloadWorker(
 
       // save a new image
       val imgUUID = UUID.randomUUID().toString()
-      saveImage(entry.image, imgUUID)
+      saveImage(filteredImage, imgUUID)
 
       // trigger the update routine with new image uuid
       updateWidget(glanceId, imgUUID, entry.subtitle, entry.deeplink)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/configure/RandomConfigure.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/configure/RandomConfigure.kt
@@ -64,6 +64,7 @@ fun RandomConfiguration(context: Context, appWidgetId: Int, glanceId: GlanceId, 
 
   var selectedAlbum by remember { mutableStateOf<DropdownItem?>(null) }
   var showAlbumName by remember { mutableStateOf(false) }
+  var selectedFilter by remember { mutableStateOf<DropdownItem?>(null) }
   var availableAlbums by remember { mutableStateOf<List<DropdownItem>>(listOf()) }
   var state by remember { mutableStateOf(WidgetConfigState.LOADING) }
 
@@ -104,6 +105,16 @@ fun RandomConfiguration(context: Context, appWidgetId: Int, glanceId: GlanceId, 
     val albumEntity = availableAlbums.firstOrNull { it.id == currentAlbumId }
     selectedAlbum = albumEntity ?: availableAlbums.first()
 
+    // load filter configuration
+    val availableFilters = listOf(
+      DropdownItem("None", WidgetImageFilter.NONE.name), 
+      DropdownItem("Black & White", WidgetImageFilter.BLACK_WHITE.name)
+    )
+    
+    val savedFilterId = currentState[kImageFilter] ?: WidgetImageFilter.NONE.name
+    val selectedFilterItem = availableFilters.firstOrNull { it.id == savedFilterId }
+    selectedFilter = selectedFilterItem ?: availableFilters.first()
+
     // load showAlbumName
     showAlbumName = currentState[kShowAlbumName] == true
   }
@@ -113,6 +124,7 @@ fun RandomConfiguration(context: Context, appWidgetId: Int, glanceId: GlanceId, 
       prefs[kSelectedAlbum] = selectedAlbum?.id ?: ""
       prefs[kSelectedAlbumName] = selectedAlbum?.label ?: ""
       prefs[kShowAlbumName] = showAlbumName
+      prefs[kImageFilter] = selectedFilter?.id ?: WidgetImageFilter.NONE.name
     }
 
     ImageDownloadWorker.singleShot(context, appWidgetId, WidgetType.RANDOM)
@@ -184,6 +196,17 @@ fun RandomConfiguration(context: Context, appWidgetId: Int, glanceId: GlanceId, 
                   items = availableAlbums,
                   selectedItem = selectedAlbum,
                   onItemSelected = { selectedAlbum = it },
+                  enabled = (state != WidgetConfigState.NO_CONNECTION)
+                )
+
+                Text("Filter")
+                Dropdown(
+                  items = listOf(
+                    DropdownItem("None", WidgetImageFilter.NONE.name), 
+                    DropdownItem("Black & White", WidgetImageFilter.BLACK_WHITE.name)
+                  ),
+                  selectedItem = selectedFilter,
+                  onItemSelected = { selectedFilter = it },
                   enabled = (state != WidgetConfigState.NO_CONNECTION)
                 )
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
@@ -49,6 +49,20 @@ enum class WidgetConfigState {
   LOADING, SUCCESS, LOG_IN, NO_CONNECTION
 }
 
+enum class WidgetImageFilter {
+  NONE, BLACK_WHITE;
+  
+  companion object {
+    fun fromString(value: String?): WidgetImageFilter {
+      return try {
+        valueOf(value ?: NONE.name)
+      } catch (e: IllegalArgumentException) {
+        NONE
+      }
+    }
+  }
+}
+
 data class WidgetEntry (
   val image: Bitmap,
   val subtitle: String?,
@@ -70,6 +84,7 @@ val kSelectedAlbum = stringPreferencesKey("albumID")
 val kSelectedAlbumName = stringPreferencesKey("albumName")
 val kShowAlbumName = booleanPreferencesKey("showAlbumName")
 val kDeeplinkURL = stringPreferencesKey("deeplink")
+val kImageFilter = stringPreferencesKey("imageFiler")
 
 const val kWorkerWidgetType = "widgetType"
 const val kWorkerWidgetID = "widgetId"

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/model/Model.kt
@@ -84,7 +84,7 @@ val kSelectedAlbum = stringPreferencesKey("albumID")
 val kSelectedAlbumName = stringPreferencesKey("albumName")
 val kShowAlbumName = booleanPreferencesKey("showAlbumName")
 val kDeeplinkURL = stringPreferencesKey("deeplink")
-val kImageFilter = stringPreferencesKey("imageFiler")
+val kImageFilter = stringPreferencesKey("imageFilter")
 
 const val kWorkerWidgetType = "widgetType"
 const val kWorkerWidgetID = "widgetId"


### PR DESCRIPTION
## Description

Adds a dropdown in the random widget configuration to apply filter(s). I'm running NothingOS on my phone and the design language/launcher is very clean and simple, so I wanted to have an option to display the images in B/W.

I'm not entirely sure if that fits the scope of Immich, so I do understand if this ends up getting declined. (Also considering that it's only for the random widget on android. I don't have experience with iOS development nor a device to test on)

## How Has This Been Tested?
Nothing Phone 3a running Android 15.

<summary><h2>Screenshots</h2></summary>
<img width="360" height="2329" alt="Screenshot_20250831-150553" src="https://github.com/user-attachments/assets/64d3fab0-4a1e-40d9-b114-7fdc14f71145" />

<img width="360" alt="Screenshot_20250831-150632" src="https://github.com/user-attachments/assets/e2442b22-4fd0-48d7-86af-b43dbb568995" />


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
