### PR TITLE
fix(web): Make Manage location utility header responsive

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1735,7 +1735,7 @@
   "select_user_for_sharing_page_err_album": "Failed to create album",
   "selected": "Selected",
   "selected_count": "{count, plural, other {# selected}}",
-  "selected_gps_coordinates": "selected gps coordinates",
+  "selected_gps_coordinates": "Selected GPS Coordinates",
   "send_message": "Send message",
   "send_welcome_email": "Send welcome email",
   "server_endpoint": "Server Endpoint",

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -228,8 +228,8 @@
         <Text class="hidden md:block text-xs mr-4 text-dark/50">{$t('geolocation_instruction_location')}</Text>
       {/if}
       <div class="border flex place-items-center place-content-center px-2 py-1 bg-primary/10 rounded-2xl">
-        <Text class="hidden md:inline-block">
-          <p class="text-xs text-gray-500 font-mono mr-5 ml-2 uppercase">{$t('selected_gps_coordinates')}</p>
+        <Text class="hidden md:inline-block text-xs text-gray-500 font-mono mr-5 ml-2 uppercase">
+          {$t('selected_gps_coordinates')}
         </Text>
         <Text
           title="latitude, longitude"

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -228,7 +228,9 @@
         <Text class="hidden md:block text-xs mr-4 text-dark/50">{$t('geolocation_instruction_location')}</Text>
       {/if}
       <div class="border flex place-items-center place-content-center px-2 py-1 bg-primary/10 rounded-2xl">
-        <p class="text-xs text-gray-500 font-mono mr-5 ml-2 uppercase">{$t('selected_gps_coordinates')}</p>
+        <Text class="hidden md:inline-block">
+          <p class="text-xs text-gray-500 font-mono mr-5 ml-2 uppercase">{$t('selected_gps_coordinates')}</p>
+        </Text>
         <Text
           title="latitude, longitude"
           class="rounded-3xl font-mono text-sm text-primary px-2 py-1 transition-all duration-100 ease-in-out {locationUpdated
@@ -237,9 +239,9 @@
         >
       </div>
 
-      <Button size="small" color="secondary" variant="ghost" leadingIcon={mdiPencilOutline} onclick={handlePickOnMap}
-        >{$t('location_picker_choose_on_map')}</Button
-      >
+      <Button size="small" color="secondary" variant="ghost" leadingIcon={mdiPencilOutline} onclick={handlePickOnMap}>
+        <Text class="hidden sm:inline-block">{$t('location_picker_choose_on_map')}</Text>
+      </Button>
       <Button
         leadingIcon={mdiMapMarkerMultipleOutline}
         size="small"
@@ -247,7 +249,9 @@
         disabled={assetInteraction.selectedAssets.length === 0}
         onclick={() => handleUpdate()}
       >
-        {$t('apply_count', { values: { count: assetInteraction.selectedAssets.length } })}
+        <Text class="hidden sm:inline-block">
+          {$t('apply_count', { values: { count: assetInteraction.selectedAssets.length } })}
+        </Text>
       </Button>
     </div>
   {/snippet}


### PR DESCRIPTION
## Description
The Manage location utility page's header is cut off at smaller viewport widths, making the "Choose on map" and "Apply" buttons inaccessible. The header has been made more responsive by hiding some text at smaller viewport widths to allow for full functionality.

The casing of the Selected GPS Coordinates text has also been updated.

Fixes #21476

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Viewed the Manage location utility page at different viewport widths

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


https://github.com/user-attachments/assets/770d6c7a-bd8a-4c1b-84c5-f5b3ddb39479



</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
