### PR TITLE
fix: local sync task never runs on iOS

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
@@ -62,7 +62,7 @@ private open class BackgroundWorkerPigeonCodec : StandardMessageCodec() {
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface BackgroundWorkerFgHostApi {
   fun enableSyncWorker()
-  fun enableUploadWorker(callbackHandle: Long)
+  fun enableUploadWorker()
   fun disableUploadWorker()
 
   companion object {
@@ -93,11 +93,9 @@ interface BackgroundWorkerFgHostApi {
       run {
         val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker$separatedMessageChannelSuffix", codec)
         if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val callbackHandleArg = args[0] as Long
+          channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
-              api.enableUploadWorker(callbackHandleArg)
+              api.enableUploadWorker()
               listOf(null)
             } catch (exception: Throwable) {
               BackgroundWorkerPigeonUtils.wrapError(exception)
@@ -130,6 +128,7 @@ interface BackgroundWorkerFgHostApi {
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface BackgroundWorkerBgHostApi {
   fun onInitialized()
+  fun close()
 
   companion object {
     /** The codec used by BackgroundWorkerBgHostApi. */
@@ -146,6 +145,22 @@ interface BackgroundWorkerBgHostApi {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
               api.onInitialized()
+              listOf(null)
+            } catch (exception: Throwable) {
+              BackgroundWorkerPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerBgHostApi.close$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.close()
               listOf(null)
             } catch (exception: Throwable) {
               BackgroundWorkerPigeonUtils.wrapError(exception)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -11,9 +11,8 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.embedding.engine.dart.DartExecutor.DartCallback
+import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.loader.FlutterLoader
-import io.flutter.view.FlutterCallbackInformation
 
 private const val TAG = "BackgroundWorker"
 
@@ -58,25 +57,6 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
     loader.ensureInitializationCompleteAsync(ctx, null, Handler(Looper.getMainLooper())) {
       engine = FlutterEngine(ctx)
 
-      // Retrieve the callback handle stored by the main Flutter app
-      // This handle points to the Flutter function that should be executed in the background
-      val callbackHandle =
-        ctx.getSharedPreferences(BackgroundWorkerApiImpl.SHARED_PREF_NAME, Context.MODE_PRIVATE)
-          .getLong(BackgroundWorkerApiImpl.SHARED_PREF_CALLBACK_HANDLE, 0L)
-
-      if (callbackHandle == 0L) {
-        // Without a valid callback handle, we cannot start the Flutter background execution
-        complete(Result.failure())
-        return@ensureInitializationCompleteAsync
-      }
-
-      // Start the Flutter engine with the specified callback as the entry point
-      val callback = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
-      if (callback == null) {
-        complete(Result.failure())
-        return@ensureInitializationCompleteAsync
-      }
-
       // Register custom plugins
       MainActivity.registerPlugins(ctx, engine!!)
       flutterApi =
@@ -86,8 +66,12 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
         api = this
       )
 
-      engine!!.dartExecutor.executeDartCallback(
-        DartCallback(ctx.assets, loader.findAppBundlePath(), callback)
+      engine!!.dartExecutor.executeDartEntrypoint(
+        DartExecutor.DartEntrypoint(
+          loader.findAppBundlePath(),
+          "package:immich_mobile/domain/services/background_worker.service.dart",
+          "backgroundSyncNativeEntrypoint"
+        )
       )
     }
 
@@ -109,14 +93,7 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
     }
   }
 
-  /**
-   * Called when the system has to stop this worker because constraints are
-   * no longer met or the system needs resources for more important tasks
-   * This is also called when the worker has been explicitly cancelled or replaced
-   */
-  override fun onStopped() {
-    Log.d(TAG, "About to stop BackupWorker")
-
+  override fun close() {
     if (isComplete) {
       return
     }
@@ -132,6 +109,16 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
     Handler(Looper.getMainLooper()).postDelayed({
       complete(Result.failure())
     }, 5000)
+  }
+
+  /**
+   * Called when the system has to stop this worker because constraints are
+   * no longer met or the system needs resources for more important tasks
+   * This is also called when the worker has been explicitly cancelled or replaced
+   */
+  override fun onStopped() {
+    Log.d(TAG, "About to stop BackupWorker")
+    close()
   }
 
   private fun handleHostResult(result: kotlin.Result<Unit>) {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
@@ -21,9 +21,8 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
     Log.i(TAG, "Scheduled media observer")
   }
 
-  override fun enableUploadWorker(callbackHandle: Long) {
+  override fun enableUploadWorker() {
     updateUploadEnabled(ctx, true)
-    updateCallbackHandle(ctx, callbackHandle)
     Log.i(TAG, "Scheduled background upload tasks")
   }
 
@@ -41,17 +40,10 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
 
     const val SHARED_PREF_NAME = "Immich::Background"
     const val SHARED_PREF_BACKUP_ENABLED = "Background::backup::enabled"
-    const val SHARED_PREF_CALLBACK_HANDLE = "Background::backup::callbackHandle"
 
     private fun updateUploadEnabled(context: Context, enabled: Boolean) {
       context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE).edit {
         putBoolean(SHARED_PREF_BACKUP_ENABLED, enabled)
-      }
-    }
-
-    private fun updateCallbackHandle(context: Context, callbackHandle: Long) {
-      context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE).edit {
-        putLong(SHARED_PREF_CALLBACK_HANDLE, callbackHandle)
       }
     }
 

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -24,7 +24,7 @@ import UIKit
     BackgroundServicePlugin.register(with: self.registrar(forPlugin: "BackgroundServicePlugin")!)
 
     BackgroundServicePlugin.registerBackgroundProcessing()
-    BackgroundWorkerApiImpl.registerBackgroundProcessing()
+    BackgroundWorkerApiImpl.registerBackgroundWorkers()
 
     BackgroundServicePlugin.setPluginRegistrantCallback { registry in
       if !registry.hasPlugin("org.cocoapods.path-provider-foundation") {

--- a/mobile/ios/Runner/Background/BackgroundWorker.g.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.g.swift
@@ -74,7 +74,7 @@ class BackgroundWorkerPigeonCodec: FlutterStandardMessageCodec, @unchecked Senda
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol BackgroundWorkerFgHostApi {
   func enableSyncWorker() throws
-  func enableUploadWorker(callbackHandle: Int64) throws
+  func enableUploadWorker() throws
   func disableUploadWorker() throws
 }
 
@@ -99,11 +99,9 @@ class BackgroundWorkerFgHostApiSetup {
     }
     let enableUploadWorkerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      enableUploadWorkerChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let callbackHandleArg = args[0] as! Int64
+      enableUploadWorkerChannel.setMessageHandler { _, reply in
         do {
-          try api.enableUploadWorker(callbackHandle: callbackHandleArg)
+          try api.enableUploadWorker()
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
@@ -130,6 +128,7 @@ class BackgroundWorkerFgHostApiSetup {
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol BackgroundWorkerBgHostApi {
   func onInitialized() throws
+  func close() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -150,6 +149,19 @@ class BackgroundWorkerBgHostApiSetup {
       }
     } else {
       onInitializedChannel.setMessageHandler(nil)
+    }
+    let closeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerBgHostApi.close\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      closeChannel.setMessageHandler { _, reply in
+        do {
+          try api.close()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      closeChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -43,7 +43,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: processingUploadTaskID);
   }
 
-  public static func registerBackgroundProcessing() {
+  public static func registerBackgroundWorkers() {
       BGTaskScheduler.shared.register(
           forTaskWithIdentifier: processingUploadTaskID, using: nil) { task in
           if task is BGProcessingTask {

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -95,9 +95,22 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   }
   
   private static func handleBackgroundRefresh(task: BGAppRefreshTask, taskType: BackgroundTaskType) {
-    scheduleRefreshUpload()
-    // Restrict the refresh task to run only for a maximum of 20 seconds
-    runBackgroundWorker(task: task, taskType: taskType, maxSeconds: 20)
+    let maxSeconds: Int?
+    
+    switch taskType {
+    case .localSync:
+      maxSeconds = 15
+      scheduleLocalSync()
+    case .refreshUpload:
+      maxSeconds = 20
+      scheduleRefreshUpload()
+    case .processingUpload:
+      print("Unexpected background refresh task encountered")
+      return;
+    }
+
+    // Restrict the refresh task to run only for a maximum of (maxSeconds) seconds
+    runBackgroundWorker(task: task, taskType: taskType, maxSeconds: maxSeconds)
   }
   
   private static func handleBackgroundProcessing(task: BGProcessingTask) {

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -6,10 +6,8 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     print("BackgroundUploadImpl:enableSyncWorker Local Sync worker scheduled")
   }
   
-  func enableUploadWorker(callbackHandle: Int64) throws {
+  func enableUploadWorker() throws {
     BackgroundWorkerApiImpl.updateUploadEnabled(true)
-    // Store the callback handle for later use when starting background Flutter isolates
-    BackgroundWorkerApiImpl.updateUploadCallbackHandle(callbackHandle)
     
     BackgroundWorkerApiImpl.scheduleRefreshUpload()
     BackgroundWorkerApiImpl.scheduleProcessingUpload()
@@ -23,7 +21,6 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   }
   
   public static let backgroundUploadEnabledKey = "immich:background:backup:enabled"
-  public static let backgroundUploadCallbackHandleKey = "immich:background:backup:callbackHandle"
   
   private static let localSyncTaskID = "app.alextran.immich.background.localSync"
   private static let refreshUploadTaskID = "app.alextran.immich.background.refreshUpload"
@@ -31,10 +28,6 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
 
   private static func updateUploadEnabled(_ isEnabled: Bool) {
     return UserDefaults.standard.set(isEnabled, forKey: BackgroundWorkerApiImpl.backgroundUploadEnabledKey)
-  }
-
-  private static func updateUploadCallbackHandle(_ callbackHandle: Int64) {
-    return UserDefaults.standard.set(String(callbackHandle), forKey: BackgroundWorkerApiImpl.backgroundUploadCallbackHandleKey)
   }
 
   private static func cancelUploadTasks() {
@@ -134,7 +127,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
 
     task.expirationHandler = {
       DispatchQueue.main.async {
-        backgroundWorker.cancel()
+        backgroundWorker.close()
       }
       isSuccess = false
       

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -43,7 +43,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   final Drift _drift;
   final DriftLogger _driftLogger;
   final BackgroundWorkerBgHostApi _backgroundHostApi;
-  final Logger _logger = Logger('BackgroundUploadBgService');
+  final Logger _logger = Logger('BackgroundWorkerBgService');
 
   bool _isCleanedUp = false;
 
@@ -85,7 +85,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
       await _ref.read(fileMediaRepositoryProvider).enableBackgroundAccess();
 
-      // Notify the host that the background upload service has been initialized and is ready to use
+      // Notify the host that the background worker service has been initialized and is ready to use
       _backgroundHostApi.onInitialized();
     } catch (error, stack) {
       _logger.severe("Failed to initialize background worker", error, stack);
@@ -170,7 +170,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
   @override
   Future<void> cancel() async {
-    _logger.warning("Background upload cancelled");
+    _logger.warning("Background worker cancelled");
     try {
       await _cleanup();
     } catch (error, stack) {

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -75,12 +75,6 @@ class HashService {
         continue;
       }
 
-      final fileExists = await file.exists();
-      if (!fileExists) {
-        _log.warning("File does not exist for asset ${asset.id}: ${asset.name}");
-        continue;
-      }
-
       bytesProcessed += await file.length();
       toHash.add(_AssetToPath(asset: asset, path: file.path));
 

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -75,6 +75,12 @@ class HashService {
         continue;
       }
 
+      final fileExists = await file.exists();
+      if (!fileExists) {
+        _log.warning("File does not exist for asset ${asset.id}: ${asset.name}");
+        continue;
+      }
+
       bytesProcessed += await file.length();
       toHash.add(_AssetToPath(asset: asset, path: file.path));
 

--- a/mobile/lib/infrastructure/repositories/storage.repository.dart
+++ b/mobile/lib/infrastructure/repositories/storage.repository.dart
@@ -16,6 +16,13 @@ class StorageRepository {
       file = await entity?.originFile;
       if (file == null) {
         log.warning("Cannot get file for asset $assetId");
+        return null;
+      }
+
+      final exists = await file.exists();
+      if (!exists) {
+        log.warning("File for asset $assetId does not exist");
+        return null;
       }
     } catch (error, stackTrace) {
       log.warning("Error getting file for asset $assetId", error, stackTrace);
@@ -34,6 +41,13 @@ class StorageRepository {
         log.warning(
           "Cannot get motion file for asset ${asset.id}, name: ${asset.name}, created on: ${asset.createdAt}",
         );
+        return null;
+      }
+
+      final exists = await file.exists();
+      if (!exists) {
+        log.warning("Motion file for asset ${asset.id} does not exist");
+        return null;
       }
     } catch (error, stackTrace) {
       log.warning(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -206,14 +206,14 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // needs to be delayed so that EasyLocalization is working
       if (Store.isBetaTimelineEnabled) {
+        ref.read(backgroundServiceProvider).disableService();
         ref.read(driftBackgroundUploadFgService).enableSyncService();
         if (ref.read(appSettingsServiceProvider).getSetting(AppSettingsEnum.enableBackup)) {
-          ref.read(backgroundServiceProvider).disableService();
           ref.read(driftBackgroundUploadFgService).enableUploadService();
         }
       } else {
-        ref.read(backgroundServiceProvider).resumeServiceIfEnabled();
         ref.read(driftBackgroundUploadFgService).disableUploadService();
+        ref.read(backgroundServiceProvider).resumeServiceIfEnabled();
       }
     });
 

--- a/mobile/lib/platform/background_worker_api.g.dart
+++ b/mobile/lib/platform/background_worker_api.g.dart
@@ -82,7 +82,7 @@ class BackgroundWorkerFgHostApi {
     }
   }
 
-  Future<void> enableUploadWorker(int callbackHandle) async {
+  Future<void> enableUploadWorker() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -90,7 +90,7 @@ class BackgroundWorkerFgHostApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[callbackHandle]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
     if (pigeonVar_replyList == null) {
       throw _createConnectionError(pigeonVar_channelName);
@@ -145,6 +145,29 @@ class BackgroundWorkerBgHostApi {
   Future<void> onInitialized() async {
     final String pigeonVar_channelName =
         'dev.flutter.pigeon.immich_mobile.BackgroundWorkerBgHostApi.onInitialized$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> close() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerBgHostApi.close$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/mobile/pigeon/background_worker_api.dart
+++ b/mobile/pigeon/background_worker_api.dart
@@ -15,8 +15,7 @@ import 'package:pigeon/pigeon.dart';
 abstract class BackgroundWorkerFgHostApi {
   void enableSyncWorker();
 
-  // Enables the background upload service with the given callback handle
-  void enableUploadWorker(int callbackHandle);
+  void enableUploadWorker();
 
   // Disables the background upload service
   void disableUploadWorker();
@@ -27,6 +26,8 @@ abstract class BackgroundWorkerBgHostApi {
   // Called from the background flutter engine when it has bootstrapped and established the
   // required platform channels to notify the native side to start the background upload
   void onInitialized();
+
+  void close();
 }
 
 @FlutterApi()


### PR DESCRIPTION
## Description

- The iOS local sync task never ran as the task was cancelled by the call to `ref.read(backgroundServiceProvider).disableService()`. The order in which the calls are made is changed to fix this
- The local sync task is now properly rescheduled from the native side
- Add additional logs on the dart side for the background worker methods
- Wrap the methods in try catch block and handle cleanup on failures
- Refactored the background workers to directly invoke the dart entrypoint instead of using callbacks. Callbacks are useful only when the entry point is dynamic. Since this is all managed by us, calling the entry point is straight forward.