### PR TITLE
fix(mobile): increase thumbnail resolution

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/constants.dart
+++ b/mobile/lib/presentation/widgets/timeline/constants.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 const double kTimelineHeaderExtent = 80.0;
 const Size kTimelineFixedTileExtent = Size.square(256);
-const Size kThumbnailResolution = kTimelineFixedTileExtent; // TODO: make the resolution vary based on actual tile size
+const Size kThumbnailResolution = Size.square(320); // TODO: make the resolution vary based on actual tile size
 const double kTimelineSpacing = 2.0;
 const int kTimelineColumnCount = 3;
 


### PR DESCRIPTION
## Description

On Android, the thumbnail API tries to ensure the larger edge is the target size, meaning the smaller edge can be below target. The current target size is low enough that it can serve unnecessarily small images. As a result, bumping it to 320 has a disproportionate effect on quality.

Fixes #21255

## How Has This Been Tested?

Tested on Android, confirming higher resolution images without compromising responsiveness. On iOS, even a target of 384 is still smooth so this shouldn't cause any issues.