### PR TITLE
fix(mobile): decoding at higher resolution than necessary

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/ThumbnailsImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/ThumbnailsImpl.kt
@@ -202,8 +202,7 @@ class ThumbnailsImpl(context: Context) : ThumbnailApi {
       val source = ImageDecoder.createSource(resolver, uri)
       signal.throwIfCanceled()
       ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
-        val sampleSize =
-          getSampleSize(info.size.width, info.size.height, targetWidth, targetHeight)
+        val sampleSize = max(1, min(info.size.width / targetWidth, info.size.height / targetHeight))
         decoder.setTargetSampleSize(sampleSize)
         decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
         decoder.setTargetColorSpace(ColorSpace.get(ColorSpace.Named.SRGB))
@@ -215,16 +214,5 @@ class ThumbnailsImpl(context: Context) : ThumbnailApi {
       signal.setOnCancelListener { Glide.with(ctx).clear(ref) }
       ref.get()
     }
-  }
-
-  private fun getSampleSize(fullWidth: Int, fullHeight: Int, reqWidth: Int, reqHeight: Int): Int {
-    return 1 shl max(
-      0, floor(
-        min(
-          log2(fullWidth / reqWidth.toDouble()),
-          log2(fullHeight / reqHeight.toDouble()),
-        )
-      ).toInt()
-    )
   }
 }


### PR DESCRIPTION
## Description

On Android, the sample size calculation forces the factor to be a power of two. This meant that an image that could be decoded at 1/3 resolution was decoded at 1/2 resolution instead. This change can make local full size images affected by this load more quickly.

## How Has This Been Tested?

Confirmed that a 8160 x 6120 image was decoded at 2720 x 2040 instead of 4080 x 3060.