### PR TITLE
fix: filter null duplicate assets

### DIFF
--- a/server/src/queries/duplicate.repository.sql
+++ b/server/src/queries/duplicate.repository.sql
@@ -12,7 +12,7 @@ with
       ) as "assets"
     from
       "asset"
-      left join lateral (
+      inner join lateral (
         select
           "asset".*,
           "asset_exif" as "exifInfo"

--- a/server/src/repositories/duplicate.repository.ts
+++ b/server/src/repositories/duplicate.repository.ts
@@ -34,7 +34,7 @@ export class DuplicateRepository {
           qb
             .selectFrom('asset')
             .$call(withDefaultVisibility)
-            .leftJoinLateral(
+            .innerJoinLateral(
               (qb) =>
                 qb
                   .selectFrom('asset_exif')


### PR DESCRIPTION
## Description

Fixes #18884

On my Immich instance, trying to use the `/utilities/duplicates` menu resulted in an internal server error:

```
TypeError: Cannot read properties of null (reading 'id')
    at mapAsset (/usr/src/app/server/dist/dtos/asset-response.dto.js:186:20)
    at /usr/src/app/server/dist/services/duplicate.service.js:25:77
    at Array.map (<anonymous>)
    at /usr/src/app/server/dist/services/duplicate.service.js:25:28
    at Array.map (<anonymous>)
    at DuplicateService.getDuplicates (/usr/src/app/server/dist/services/duplicate.service.js:23:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## How Has This Been Tested?

- [x] Tested functionality on a fresh Immich installation
- [x] Built the prod container and ran it in production, verifying that `/utilities/duplicates` worked now.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Same error screen as #18884

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## other notes

Not sure if a test is applicable here, would be nice to prevent regressions, but I wasn't able to cleanly replicate the bug in a test environment. 

I believe it's related to an asset not having a corresponding asset_exif entry, but I've tried uploading duplicates stripped of exif data and that didn't reproduce the error. My production instance is >1tb, so trying to debug that didn't seem feasible. So, in the end, I just added a null check.