### PR TITLE
fix(mobile): Correction of image creation date by using mtime instead…

### DIFF
--- a/mobile/lib/providers/asset_viewer/share_intent_upload.provider.dart
+++ b/mobile/lib/providers/asset_viewer/share_intent_upload.provider.dart
@@ -115,7 +115,7 @@ class ShareIntentUploadStateNotifier extends StateNotifier<List<ShareIntentAttac
 
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final stats = await file.stat();
-    final fileCreatedAt = stats.changed;
+    final fileCreatedAt = stats.modified;
     final fileModifiedAt = stats.modified;
 
     final fieldsMap = {

--- a/mobile/lib/providers/asset_viewer/share_intent_upload.provider.dart
+++ b/mobile/lib/providers/asset_viewer/share_intent_upload.provider.dart
@@ -115,7 +115,7 @@ class ShareIntentUploadStateNotifier extends StateNotifier<List<ShareIntentAttac
 
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final stats = await file.stat();
-    final fileCreatedAt = stats.modified;
+    final fileCreatedAt = stats.changed;
     final fileModifiedAt = stats.modified;
 
     final fieldsMap = {

--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -282,6 +282,8 @@ class UploadService {
 
     return buildUploadTask(
       file,
+      createdAt: asset.createdAt,
+      modifiedAt: asset.updatedAt,
       originalFileName: originalFileName,
       deviceAssetId: asset.id,
       metadata: metadata,
@@ -309,6 +311,8 @@ class UploadService {
 
     return buildUploadTask(
       file,
+      createdAt: asset.createdAt,
+      modifiedAt: asset.updatedAt,
       originalFileName: asset.name,
       deviceAssetId: asset.id,
       fields: fields,
@@ -334,6 +338,8 @@ class UploadService {
   Future<UploadTask> buildUploadTask(
     File file, {
     required String group,
+    required DateTime createdAt,
+    required DateTime modifiedAt,
     Map<String, String>? fields,
     String? originalFileName,
     String? deviceAssetId,
@@ -347,15 +353,12 @@ class UploadService {
     final headers = ApiService.getRequestHeaders();
     final deviceId = Store.get(StoreKey.deviceId);
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
-    final stats = await file.stat();
-    final fileCreatedAt = stats.modified;
-    final fileModifiedAt = stats.modified;
     final fieldsMap = {
       'filename': originalFileName ?? filename,
       'deviceAssetId': deviceAssetId ?? '',
       'deviceId': deviceId,
-      'fileCreatedAt': fileCreatedAt.toUtc().toIso8601String(),
-      'fileModifiedAt': fileModifiedAt.toUtc().toIso8601String(),
+      'fileCreatedAt': createdAt.toUtc().toIso8601String(),
+      'fileModifiedAt': modifiedAt.toUtc().toIso8601String(),
       'isFavorite': isFavorite?.toString() ?? 'false',
       'duration': '0',
       if (fields != null) ...fields,

--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -348,7 +348,7 @@ class UploadService {
     final deviceId = Store.get(StoreKey.deviceId);
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
     final stats = await file.stat();
-    final fileCreatedAt = stats.changed;
+    final fileCreatedAt = stats.modified;
     final fileModifiedAt = stats.modified;
     final fieldsMap = {
       'filename': originalFileName ?? filename,


### PR DESCRIPTION
## Description

When uploading an image via "share to" or "backup" without EXIF data indicating the date taken or created, the image is uploaded with an incorrect date. This occurs because fileCreatedAt is set using the file attribute change time (ctime) instead of the last modification time of the file's content (mtime).

- **ctime (changed)**: the time when the file's attributes (inode) were changed, such as permission or ownership changes.

- **mtime (modified)**: the time of the last modification of the file's content, which more accurately reflects the time when the data within the file was first created.

It is expected that fileCreatedAt should indicate the time when the data within the file was first recorded. Using mtime for this purpose aligns better with these expectations than using ctime.

Fixes #15855

## How Has This Been Tested?

The changes have been tested on Android: a file without EXIF data was successfully uploaded with the correct creation date through "share to."

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)