### PR TITLE
chore(server): fix logger context in StorageCore

### DIFF
--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -43,7 +43,9 @@ export class StorageCore {
     private storageRepository: StorageRepository,
     private systemMetadataRepository: SystemMetadataRepository,
     private logger: LoggingRepository,
-  ) {}
+  ) {
+    this.logger.setContext(StorageCore.name);
+  }
 
   static create(
     assetRepository: AssetRepository,

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -34,6 +34,8 @@ let instance: StorageCore | null;
 let mediaLocation: string | undefined;
 
 export class StorageCore {
+  private logger = LoggingRepository.create(StorageCore.name);
+
   private constructor(
     private assetRepository: AssetRepository,
     private configRepository: ConfigRepository,
@@ -42,7 +44,6 @@ export class StorageCore {
     private personRepository: PersonRepository,
     private storageRepository: StorageRepository,
     private systemMetadataRepository: SystemMetadataRepository,
-    private logger: LoggingRepository,
   ) {}
 
   static create(
@@ -53,7 +54,6 @@ export class StorageCore {
     personRepository: PersonRepository,
     storageRepository: StorageRepository,
     systemMetadataRepository: SystemMetadataRepository,
-    logger: LoggingRepository,
   ) {
     if (!instance) {
       instance = new StorageCore(
@@ -64,7 +64,6 @@ export class StorageCore {
         personRepository,
         storageRepository,
         systemMetadataRepository,
-        logger,
       );
     }
 

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -34,8 +34,6 @@ let instance: StorageCore | null;
 let mediaLocation: string | undefined;
 
 export class StorageCore {
-  private logger = LoggingRepository.create(StorageCore.name);
-
   private constructor(
     private assetRepository: AssetRepository,
     private configRepository: ConfigRepository,
@@ -44,6 +42,7 @@ export class StorageCore {
     private personRepository: PersonRepository,
     private storageRepository: StorageRepository,
     private systemMetadataRepository: SystemMetadataRepository,
+    private logger: LoggingRepository,
   ) {}
 
   static create(
@@ -54,6 +53,7 @@ export class StorageCore {
     personRepository: PersonRepository,
     storageRepository: StorageRepository,
     systemMetadataRepository: SystemMetadataRepository,
+    logger: LoggingRepository,
   ) {
     if (!instance) {
       instance = new StorageCore(
@@ -64,6 +64,7 @@ export class StorageCore {
         personRepository,
         storageRepository,
         systemMetadataRepository,
+        logger,
       );
     }
 

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -162,7 +162,6 @@ export class BaseService {
       personRepository,
       storageRepository,
       systemMetadataRepository,
-      this.logger,
     );
   }
 

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -162,6 +162,7 @@ export class BaseService {
       personRepository,
       storageRepository,
       systemMetadataRepository,
+      this.logger,
     );
   }
 


### PR DESCRIPTION
## Description

Fix logger context of StorageCore to be `[Microservices:StorageCore]` instead of the current wrong `[Microservices:ApiKeyService]`. 

See below example log line (before and after the fix) produced by this logger: https://github.com/immich-app/immich/blob/4f7702c6bf885f23145900c83de83c76da8ed289/server/src/cores/storage.core.ts#L211

- Observed (before): `DEBUG [Microservices:ApiKeyService] Attempting to rename file: ...`
- Expected (after): `DEBUG [Microservices:StorageCore] Attempting to rename file: ...`

It seems ApiKeyService is the first service that creates the StorageCore instance/singleton through BaseService, therefore its logging context "sticks" and remains ApiKeyService for all subsequent invocations.

This PR creates a dedicated logger for StorageCore instead of passing it from BaseService.

## How Has This Been Tested?

Tested by uploading new assets when Storage Template is enabled. With the fix it emits `[Microservices:StorageCore]`

Log:

```rust
[Nest] 156176  - 09/02/2025, 7:40:12 PM   DEBUG [Microservices:StorageCore] Attempting to rename file: /data/upload/ff5e354e-34fa-4d25-9093-ac372ff14a43/b6/a6/b6a67229-4061-4ab4-8444-14a902063872.heic => /data/library/admin/2019/2019-12/IMG_3982.heic
[Nest] 156176  - 09/02/2025, 7:40:12 PM   DEBUG [Microservices:StorageCore] Unable to rename file. Falling back to copy, verify and delete
[Nest] 156176  - 09/02/2025, 7:40:12 PM   DEBUG [Microservices:StorageCore] File size check: 1062371 === 1062371
[Nest] 156176  - 09/02/2025, 7:40:12 PM   DEBUG [Microservices:StorageCore] File checksum check: TB5j1q71lrdaMrkk4Na4e2kqd+Q= === TB5j1q71lrdaMrkk4Na4e2kqd+Q=
```

## Discussion

My motivation here is just to reduce confusion when seeing unexpected `Microservices:ApiKeyService` in logs from StorageCore.
This patch may not be aligned with the architecture. So if there is better alternative / fix then feel free to close this PR.
