### PR TITLE
fix(mobile): Hide system UI when entering immersive mode in asset viewer

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
@@ -129,6 +130,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     reloadSubscription?.cancel();
     _prevPreCacheStream?.removeListener(_dummyListener);
     _nextPreCacheStream?.removeListener(_dummyListener);
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     super.dispose();
   }
 
@@ -596,6 +598,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     // Rebuild the widget when the asset viewer state changes
     // Using multiple selectors to avoid unnecessary rebuilds for other state changes
     ref.watch(assetViewerProvider.select((s) => s.showingBottomSheet));
+    ref.watch(assetViewerProvider.select((s) => s.showingControls));
     ref.watch(assetViewerProvider.select((s) => s.backgroundOpacity));
     ref.watch(assetViewerProvider.select((s) => s.stackIndex));
     ref.watch(isPlayingMotionVideoProvider);
@@ -610,6 +613,15 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _handleCasting();
       });
+    });
+
+    // Listen for control visibility changes and change system UI mode accordingly
+    ref.listen(assetViewerProvider.select((value) => value.showingControls), (_, showingControls) async {
+      if (showingControls) {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      } else {
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      }
     });
 
     // Currently it is not possible to scroll the asset when the bottom sheet is open all the way.


### PR DESCRIPTION
## Description

Adds the functionality of hiding the system UI (status and navigation bar) when entering the asset viewer's immersive mode (when the controls are hidden). This avoids having the system UI block parts of the image/video while viewing with the controls hidden.

Fixes #21410

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested on OnePlus 6t running Android 15 (Lineage OS 22). 

- Opened asset viewer and hid/unhid the controls and swiped between assets. 
- Returned to timeline while UI is hidden to test that it becomes visible again. 
- Tested memory viewer.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
Before
<img width="1080" height="2340" alt="Screenshot_20250902-160219_Immich" src="https://github.com/user-attachments/assets/4529a016-2a91-4f2c-b3cf-6b165368100d" />
<img width="1080" height="2340" alt="Screenshot_20250902-160223_Immich" src="https://github.com/user-attachments/assets/ecc1f942-28a8-48e6-b089-952b324bfed4" />


After
<img width="1080" height="2340" alt="Screenshot_20250902-160141_Immich-Debug" src="https://github.com/user-attachments/assets/bf9f3008-3e32-4b07-b78c-4f5b347facce" />
<img width="1080" height="2340" alt="Screenshot_20250902-160147_Immich-Debug" src="https://github.com/user-attachments/assets/16a20173-141a-4237-a72e-c27b4ddf19a3" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
