### PR TITLE
refactor: simplify background worker

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
@@ -61,9 +61,8 @@ private open class BackgroundWorkerPigeonCodec : StandardMessageCodec() {
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface BackgroundWorkerFgHostApi {
-  fun enableSyncWorker()
-  fun enableUploadWorker()
-  fun disableUploadWorker()
+  fun enable()
+  fun disable()
 
   companion object {
     /** The codec used by BackgroundWorkerFgHostApi. */
@@ -75,11 +74,11 @@ interface BackgroundWorkerFgHostApi {
     fun setUp(binaryMessenger: BinaryMessenger, api: BackgroundWorkerFgHostApi?, messageChannelSuffix: String = "") {
       val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableSyncWorker$separatedMessageChannelSuffix", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enable$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
-              api.enableSyncWorker()
+              api.enable()
               listOf(null)
             } catch (exception: Throwable) {
               BackgroundWorkerPigeonUtils.wrapError(exception)
@@ -91,27 +90,11 @@ interface BackgroundWorkerFgHostApi {
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker$separatedMessageChannelSuffix", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disable$separatedMessageChannelSuffix", codec)
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             val wrapped: List<Any?> = try {
-              api.enableUploadWorker()
-              listOf(null)
-            } catch (exception: Throwable) {
-              BackgroundWorkerPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disableUploadWorker$separatedMessageChannelSuffix", codec)
-        if (api != null) {
-          channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              api.disableUploadWorker()
+              api.disable()
               listOf(null)
             } catch (exception: Throwable) {
               BackgroundWorkerPigeonUtils.wrapError(exception)
@@ -180,23 +163,6 @@ class BackgroundWorkerFlutterApi(private val binaryMessenger: BinaryMessenger, p
     /** The codec used by BackgroundWorkerFlutterApi. */
     val codec: MessageCodec<Any?> by lazy {
       BackgroundWorkerPigeonCodec()
-    }
-  }
-  fun onLocalSync(maxSecondsArg: Long?, callback: (Result<Unit>) -> Unit)
-{
-    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
-    val channelName = "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onLocalSync$separatedMessageChannelSuffix"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(maxSecondsArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(BackgroundWorkerPigeonUtils.createConnectionError(channelName)))
-      } 
     }
   }
   fun onIosUpload(isRefreshArg: Boolean, maxSecondsArg: Long?, callback: (Result<Unit>) -> Unit)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -16,11 +16,6 @@ import io.flutter.embedding.engine.loader.FlutterLoader
 
 private const val TAG = "BackgroundWorker"
 
-enum class BackgroundTaskType {
-  LOCAL_SYNC,
-  UPLOAD,
-}
-
 class BackgroundWorker(context: Context, params: WorkerParameters) :
   ListenableWorker(context, params), BackgroundWorkerBgHostApi {
   private val ctx: Context = context.applicationContext
@@ -84,13 +79,7 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
    * This method acts as a bridge between the native Android background task system and Flutter.
    */
   override fun onInitialized() {
-    val taskTypeIndex = inputData.getInt(BackgroundWorkerApiImpl.WORKER_DATA_TASK_TYPE, 0)
-    val taskType = BackgroundTaskType.entries[taskTypeIndex]
-
-    when (taskType) {
-      BackgroundTaskType.LOCAL_SYNC -> flutterApi?.onLocalSync(null) { handleHostResult(it) }
-      BackgroundTaskType.UPLOAD -> flutterApi?.onAndroidUpload { handleHostResult(it) }
-    }
+    flutterApi?.onAndroidUpload { handleHostResult(it) }
   }
 
   override fun close() {

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
@@ -53,8 +53,8 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
         .addContentUriTrigger(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, true)
         .addContentUriTrigger(MediaStore.Video.Media.INTERNAL_CONTENT_URI, true)
         .addContentUriTrigger(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true)
-        .setTriggerContentUpdateDelay(5, TimeUnit.SECONDS)
-        .setTriggerContentMaxDelay(1, TimeUnit.MINUTES)
+        .setTriggerContentUpdateDelay(30, TimeUnit.SECONDS)
+        .setTriggerContentMaxDelay(3, TimeUnit.MINUTES)
         .build()
 
       val work = OneTimeWorkRequest.Builder(MediaObserver::class.java)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
@@ -3,10 +3,8 @@ package app.alextran.immich.background
 import android.content.Context
 import android.provider.MediaStore
 import android.util.Log
-import androidx.core.content.edit
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
-import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
@@ -16,18 +14,13 @@ private const val TAG = "BackgroundUploadImpl"
 
 class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
   private val ctx: Context = context.applicationContext
-  override fun enableSyncWorker() {
+
+  override fun enable() {
     enqueueMediaObserver(ctx)
-    Log.i(TAG, "Scheduled media observer")
   }
 
-  override fun enableUploadWorker() {
-    updateUploadEnabled(ctx, true)
-    Log.i(TAG, "Scheduled background upload tasks")
-  }
-
-  override fun disableUploadWorker() {
-    updateUploadEnabled(ctx, false)
+  override fun disable() {
+    WorkManager.getInstance(ctx).cancelUniqueWork(OBSERVER_WORKER_NAME)
     WorkManager.getInstance(ctx).cancelUniqueWork(BACKGROUND_WORKER_NAME)
     Log.i(TAG, "Cancelled background upload tasks")
   }
@@ -35,17 +28,6 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
   companion object {
     private const val BACKGROUND_WORKER_NAME = "immich/BackgroundWorkerV1"
     private const val OBSERVER_WORKER_NAME = "immich/MediaObserverV1"
-
-    const val WORKER_DATA_TASK_TYPE = "taskType"
-
-    const val SHARED_PREF_NAME = "Immich::Background"
-    const val SHARED_PREF_BACKUP_ENABLED = "Background::backup::enabled"
-
-    private fun updateUploadEnabled(context: Context, enabled: Boolean) {
-      context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE).edit {
-        putBoolean(SHARED_PREF_BACKUP_ENABLED, enabled)
-      }
-    }
 
     fun enqueueMediaObserver(ctx: Context) {
       val constraints = Constraints.Builder()
@@ -66,15 +48,13 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
       Log.i(TAG, "Enqueued media observer worker with name: $OBSERVER_WORKER_NAME")
     }
 
-    fun enqueueBackgroundWorker(ctx: Context, taskType: BackgroundTaskType) {
+    fun enqueueBackgroundWorker(ctx: Context) {
       val constraints = Constraints.Builder().setRequiresBatteryNotLow(true).build()
 
-      val data = Data.Builder()
-      data.putInt(WORKER_DATA_TASK_TYPE, taskType.ordinal)
       val work = OneTimeWorkRequest.Builder(BackgroundWorker::class.java)
         .setConstraints(constraints)
         .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.MINUTES)
-        .setInputData(data.build()).build()
+        .build()
       WorkManager.getInstance(ctx)
         .enqueueUniqueWork(BACKGROUND_WORKER_NAME, ExistingWorkPolicy.REPLACE, work)
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/MediaObserver.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/MediaObserver.kt
@@ -6,29 +6,17 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 
 class MediaObserver(context: Context, params: WorkerParameters) : Worker(context, params) {
-    private val ctx: Context = context.applicationContext
+  private val ctx: Context = context.applicationContext
 
-    override fun doWork(): Result {
-        Log.i("MediaObserver", "Content change detected, starting background worker")
+  override fun doWork(): Result {
+    Log.i("MediaObserver", "Content change detected, starting background worker")
+    // Re-enqueue itself to listen for future changes
+    BackgroundWorkerApiImpl.enqueueMediaObserver(ctx)
 
-        // Enqueue backup worker only if there are new media changes
-        if (triggeredContentUris.isNotEmpty()) {
-            val type =
-                if (isBackupEnabled(ctx)) BackgroundTaskType.UPLOAD else BackgroundTaskType.LOCAL_SYNC
-            BackgroundWorkerApiImpl.enqueueBackgroundWorker(ctx, type)
-        }
-
-        // Re-enqueue itself to listen for future changes
-        BackgroundWorkerApiImpl.enqueueMediaObserver(ctx)
-        return Result.success()
+    // Enqueue backup worker only if there are new media changes
+    if (triggeredContentUris.isNotEmpty()) {
+      BackgroundWorkerApiImpl.enqueueBackgroundWorker(ctx)
     }
-
-    private fun isBackupEnabled(context: Context): Boolean {
-        val prefs =
-            context.getSharedPreferences(
-                BackgroundWorkerApiImpl.SHARED_PREF_NAME,
-                Context.MODE_PRIVATE
-            )
-        return prefs.getBoolean(BackgroundWorkerApiImpl.SHARED_PREF_BACKUP_ENABLED, false)
-    }
+    return Result.success()
+  }
 }

--- a/mobile/ios/Runner/Background/BackgroundWorker.g.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.g.swift
@@ -73,9 +73,8 @@ class BackgroundWorkerPigeonCodec: FlutterStandardMessageCodec, @unchecked Senda
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol BackgroundWorkerFgHostApi {
-  func enableSyncWorker() throws
-  func enableUploadWorker() throws
-  func disableUploadWorker() throws
+  func enable() throws
+  func disable() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -84,44 +83,31 @@ class BackgroundWorkerFgHostApiSetup {
   /// Sets up an instance of `BackgroundWorkerFgHostApi` to handle messages through the `binaryMessenger`.
   static func setUp(binaryMessenger: FlutterBinaryMessenger, api: BackgroundWorkerFgHostApi?, messageChannelSuffix: String = "") {
     let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let enableSyncWorkerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableSyncWorker\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    let enableChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enable\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      enableSyncWorkerChannel.setMessageHandler { _, reply in
+      enableChannel.setMessageHandler { _, reply in
         do {
-          try api.enableSyncWorker()
+          try api.enable()
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
         }
       }
     } else {
-      enableSyncWorkerChannel.setMessageHandler(nil)
+      enableChannel.setMessageHandler(nil)
     }
-    let enableUploadWorkerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    let disableChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disable\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      enableUploadWorkerChannel.setMessageHandler { _, reply in
+      disableChannel.setMessageHandler { _, reply in
         do {
-          try api.enableUploadWorker()
+          try api.disable()
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))
         }
       }
     } else {
-      enableUploadWorkerChannel.setMessageHandler(nil)
-    }
-    let disableUploadWorkerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disableUploadWorker\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      disableUploadWorkerChannel.setMessageHandler { _, reply in
-        do {
-          try api.disableUploadWorker()
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      disableUploadWorkerChannel.setMessageHandler(nil)
+      disableChannel.setMessageHandler(nil)
     }
   }
 }
@@ -167,7 +153,6 @@ class BackgroundWorkerBgHostApiSetup {
 }
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol BackgroundWorkerFlutterApiProtocol {
-  func onLocalSync(maxSeconds maxSecondsArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onIosUpload(isRefresh isRefreshArg: Bool, maxSeconds maxSecondsArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func onAndroidUpload(completion: @escaping (Result<Void, PigeonError>) -> Void)
   func cancel(completion: @escaping (Result<Void, PigeonError>) -> Void)
@@ -181,24 +166,6 @@ class BackgroundWorkerFlutterApi: BackgroundWorkerFlutterApiProtocol {
   }
   var codec: BackgroundWorkerPigeonCodec {
     return BackgroundWorkerPigeonCodec.shared
-  }
-  func onLocalSync(maxSeconds maxSecondsArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onLocalSync\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([maxSecondsArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(PigeonError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(()))
-      }
-    }
   }
   func onIosUpload(isRefresh isRefreshArg: Bool, maxSeconds maxSecondsArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void) {
     let channelName: String = "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onIosUpload\(messageChannelSuffix)"

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -1,77 +1,40 @@
 import BackgroundTasks
 
 class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
-  func enableSyncWorker() throws {
-    BackgroundWorkerApiImpl.scheduleLocalSync()
-    print("BackgroundUploadImpl:enableSyncWorker Local Sync worker scheduled")
-  }
-  
-  func enableUploadWorker() throws {
-    BackgroundWorkerApiImpl.updateUploadEnabled(true)
-    
-    BackgroundWorkerApiImpl.scheduleRefreshUpload()
-    BackgroundWorkerApiImpl.scheduleProcessingUpload()
-    print("BackgroundUploadImpl:enableUploadWorker Scheduled background upload tasks")
-  }
-  
-  func disableUploadWorker() throws {
-    BackgroundWorkerApiImpl.updateUploadEnabled(false)
-    BackgroundWorkerApiImpl.cancelUploadTasks()
-    print("BackgroundUploadImpl:disableUploadWorker Disabled background upload tasks")
-  }
-  
-  public static let backgroundUploadEnabledKey = "immich:background:backup:enabled"
-  
-  private static let localSyncTaskID = "app.alextran.immich.background.localSync"
-  private static let refreshUploadTaskID = "app.alextran.immich.background.refreshUpload"
-  private static let processingUploadTaskID = "app.alextran.immich.background.processingUpload"
 
-  private static func updateUploadEnabled(_ isEnabled: Bool) {
-    return UserDefaults.standard.set(isEnabled, forKey: BackgroundWorkerApiImpl.backgroundUploadEnabledKey)
+  func enable() throws {
+    BackgroundWorkerApiImpl.scheduleRefreshWorker()
+    BackgroundWorkerApiImpl.scheduleProcessingWorker()
+    print("BackgroundUploadImpl:enbale Background worker scheduled")
   }
-
-  private static func cancelUploadTasks() {
-    BackgroundWorkerApiImpl.updateUploadEnabled(false)
-    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: refreshUploadTaskID);
-    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: processingUploadTaskID);
+  
+  func disable() throws {
+    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundWorkerApiImpl.refreshTaskID);
+    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundWorkerApiImpl.processingTaskID);
+    print("BackgroundUploadImpl:disableUploadWorker Disabled background workers")
   }
+  
+  private static let refreshTaskID = "app.alextran.immich.background.refreshUpload"
+  private static let processingTaskID = "app.alextran.immich.background.processingUpload"
 
   public static func registerBackgroundWorkers() {
       BGTaskScheduler.shared.register(
-          forTaskWithIdentifier: processingUploadTaskID, using: nil) { task in
+          forTaskWithIdentifier: processingTaskID, using: nil) { task in
           if task is BGProcessingTask {
             handleBackgroundProcessing(task: task as! BGProcessingTask)
           }
       }
 
       BGTaskScheduler.shared.register(
-          forTaskWithIdentifier: refreshUploadTaskID, using: nil) { task in
+          forTaskWithIdentifier: refreshTaskID, using: nil) { task in
           if task is BGAppRefreshTask {
-            handleBackgroundRefresh(task: task as! BGAppRefreshTask, taskType: .refreshUpload)
+            handleBackgroundRefresh(task: task as! BGAppRefreshTask)
           }
       }
-    
-    BGTaskScheduler.shared.register(
-        forTaskWithIdentifier: localSyncTaskID, using: nil) { task in
-        if task is BGAppRefreshTask {
-          handleBackgroundRefresh(task: task as! BGAppRefreshTask, taskType: .localSync)
-        }
-    }
   }
   
-  private static func scheduleLocalSync() {
-    let backgroundRefresh = BGAppRefreshTaskRequest(identifier: localSyncTaskID)
-      backgroundRefresh.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60) // 5 mins
-
-      do {
-          try BGTaskScheduler.shared.submit(backgroundRefresh)
-      } catch {
-          print("Could not schedule the local sync task \(error.localizedDescription)")
-      }
-  }
-  
-  private static func scheduleRefreshUpload() {
-    let backgroundRefresh = BGAppRefreshTaskRequest(identifier: refreshUploadTaskID)
+  private static func scheduleRefreshWorker() {
+    let backgroundRefresh = BGAppRefreshTaskRequest(identifier: refreshTaskID)
       backgroundRefresh.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60) // 5 mins
 
       do {
@@ -81,8 +44,8 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
       }
   }
 
-  private static func scheduleProcessingUpload() {
-    let backgroundProcessing = BGProcessingTaskRequest(identifier: processingUploadTaskID)
+  private static func scheduleProcessingWorker() {
+    let backgroundProcessing = BGProcessingTaskRequest(identifier: processingTaskID)
     
     backgroundProcessing.requiresNetworkConnectivity = true
     backgroundProcessing.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60) // 15 mins
@@ -94,29 +57,16 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     }
   }
   
-  private static func handleBackgroundRefresh(task: BGAppRefreshTask, taskType: BackgroundTaskType) {
-    let maxSeconds: Int?
-    
-    switch taskType {
-    case .localSync:
-      maxSeconds = 15
-      scheduleLocalSync()
-    case .refreshUpload:
-      maxSeconds = 20
-      scheduleRefreshUpload()
-    case .processingUpload:
-      print("Unexpected background refresh task encountered")
-      return;
-    }
-
+  private static func handleBackgroundRefresh(task: BGAppRefreshTask) {
+    scheduleRefreshWorker()
     // Restrict the refresh task to run only for a maximum of (maxSeconds) seconds
-    runBackgroundWorker(task: task, taskType: taskType, maxSeconds: maxSeconds)
+    runBackgroundWorker(task: task, taskType: .refresh, maxSeconds: 20)
   }
   
   private static func handleBackgroundProcessing(task: BGProcessingTask) {
-    scheduleProcessingUpload()
+    scheduleProcessingWorker()
     // There are no restrictions for processing tasks. Although, the OS could signal expiration at any time
-    runBackgroundWorker(task: task, taskType: .processingUpload, maxSeconds: nil)
+    runBackgroundWorker(task: task, taskType: .processing, maxSeconds: nil)
   }
   
   /**

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -1,190 +1,189 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>AppGroupId</key>
-    <string>$(CUSTOM_GROUP_ID)</string>
-    <key>BGTaskSchedulerPermittedIdentifiers</key>
-    <array>
-      <string>app.alextran.immich.background.localSync</string>
-      <string>app.alextran.immich.background.refreshUpload</string>
-      <string>app.alextran.immich.background.processingUpload</string>
-      <string>app.alextran.immich.backgroundFetch</string>
-      <string>app.alextran.immich.backgroundProcessing</string>
-    </array>
-    <key>CADisableMinimumFrameDurationOnPhone</key>
-    <true />
-    <key>CFBundleDevelopmentRegion</key>
-    <string>$(DEVELOPMENT_LANGUAGE)</string>
-    <key>CFBundleDisplayName</key>
-    <string>${PRODUCT_NAME}</string>
-    <key>CFBundleDocumentTypes</key>
-    <array>
-      <dict>
-        <key>CFBundleTypeName</key>
-        <string>ShareHandler</string>
-        <key>LSHandlerRank</key>
-        <string>Alternate</string>
-        <key>LSItemContentTypes</key>
-        <array>
-          <string>public.file-url</string>
-          <string>public.image</string>
-          <string>public.text</string>
-          <string>public.movie</string>
-          <string>public.url</string>
-          <string>public.data</string>
-        </array>
-      </dict>
-    </array>
-    <key>CFBundleExecutable</key>
-    <string>$(EXECUTABLE_NAME)</string>
-    <key>CFBundleIdentifier</key>
-    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleLocalizations</key>
-    <array>
-      <string>en</string>
-      <string>ar</string>
-      <string>ca</string>
-      <string>cs</string>
-      <string>da</string>
-      <string>de</string>
-      <string>es</string>
-      <string>fi</string>
-      <string>fr</string>
-      <string>he</string>
-      <string>hi</string>
-      <string>hu</string>
-      <string>it</string>
-      <string>ja</string>
-      <string>ko</string>
-      <string>lv</string>
-      <string>mn</string>
-      <string>nb</string>
-      <string>nl</string>
-      <string>pl</string>
-      <string>pt</string>
-      <string>ro</string>
-      <string>ru</string>
-      <string>sk</string>
-      <string>sl</string>
-      <string>sr</string>
-      <string>sv</string>
-      <string>th</string>
-      <string>uk</string>
-      <string>vi</string>
-      <string>zh</string>
-    </array>
-    <key>CFBundleName</key>
-    <string>immich_mobile</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.140.0</string>
-    <key>CFBundleSignature</key>
-    <string>????</string>
-    <key>CFBundleURLTypes</key>
-    <array>
-      <dict>
-        <key>CFBundleTypeRole</key>
-        <string>Editor</string>
-        <key>CFBundleURLName</key>
-        <string>Share Extension</string>
-        <key>CFBundleURLSchemes</key>
-        <array>
-          <string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-        </array>
-      </dict>
-      <dict>
-        <key>CFBundleTypeRole</key>
-        <string>Editor</string>
-        <key>CFBundleURLName</key>
-        <string>Deep Link</string>
-        <key>CFBundleURLSchemes</key>
-        <array>
-          <string>immich</string>
-        </array>
-      </dict>
-    </array>
-    <key>CFBundleVersion</key>
-    <string>219</string>
-    <key>FLTEnableImpeller</key>
-    <true />
-    <key>ITSAppUsesNonExemptEncryption</key>
-    <false />
-    <key>LSApplicationQueriesSchemes</key>
-    <array>
-      <string>https</string>
-    </array>
-    <key>LSRequiresIPhoneOS</key>
-    <true />
-    <key>LSSupportsOpeningDocumentsInPlace</key>
-    <string>No</string>
-    <key>MGLMapboxMetricsEnabledSettingShownInApp</key>
-    <true />
-    <key>NSAppTransportSecurity</key>
-    <dict>
-      <key>NSAllowsArbitraryLoads</key>
-      <true />
-    </dict>
-    <key>NSBonjourServices</key>
-    <array>
-      <string>_googlecast._tcp</string>
-      <string>_CC1AD845._googlecast._tcp</string>
-    </array>
-    <key>NSCameraUsageDescription</key>
-    <string>We need to access the camera to let you take beautiful video using this app</string>
-    <key>NSFaceIDUsageDescription</key>
-    <string>We need to use FaceID to allow access to your locked folder</string>
-    <key>NSLocalNetworkUsageDescription</key>
-    <string>We need local network permission to connect to the local server using IP address and
+<dict>
+	<key>AppGroupId</key>
+	<string>$(CUSTOM_GROUP_ID)</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>app.alextran.immich.background.refreshUpload</string>
+		<string>app.alextran.immich.background.processingUpload</string>
+		<string>app.alextran.immich.backgroundFetch</string>
+		<string>app.alextran.immich.backgroundProcessing</string>
+	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>ShareHandler</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.file-url</string>
+				<string>public.image</string>
+				<string>public.text</string>
+				<string>public.movie</string>
+				<string>public.url</string>
+				<string>public.data</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ar</string>
+		<string>ca</string>
+		<string>cs</string>
+		<string>da</string>
+		<string>de</string>
+		<string>es</string>
+		<string>fi</string>
+		<string>fr</string>
+		<string>he</string>
+		<string>hi</string>
+		<string>hu</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>lv</string>
+		<string>mn</string>
+		<string>nb</string>
+		<string>nl</string>
+		<string>pl</string>
+		<string>pt</string>
+		<string>ro</string>
+		<string>ru</string>
+		<string>sk</string>
+		<string>sl</string>
+		<string>sr</string>
+		<string>sv</string>
+		<string>th</string>
+		<string>uk</string>
+		<string>vi</string>
+		<string>zh</string>
+	</array>
+	<key>CFBundleName</key>
+	<string>immich_mobile</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.140.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Share Extension</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Deep Link</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>immich</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>219</string>
+	<key>FLTEnableImpeller</key>
+	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<string>No</string>
+	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_googlecast._tcp</string>
+		<string>_CC1AD845._googlecast._tcp</string>
+	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>We need to access the camera to let you take beautiful video using this app</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>We need to use FaceID to allow access to your locked folder</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>We need local network permission to connect to the local server using IP address and
       allow the casting feature to work</string>
-    <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>We require this permission to access the local WiFi name for background upload mechanism</string>
-    <key>NSLocationUsageDescription</key>
-    <string>We require this permission to access the local WiFi name</string>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>We require this permission to access the local WiFi name</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>We need to access the microphone to let you take beautiful video using this app</string>
-    <key>NSPhotoLibraryAddUsageDescription</key>
-    <string>We need to manage backup your photos album</string>
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>We need to manage backup your photos album</string>
-    <key>NSUserActivityTypes</key>
-    <array>
-      <string>INSendMessageIntent</string>
-    </array>
-    <key>UIApplicationSupportsIndirectInputEvents</key>
-    <true />
-    <key>UIBackgroundModes</key>
-    <array>
-      <string>fetch</string>
-      <string>processing</string>
-    </array>
-    <key>UILaunchStoryboardName</key>
-    <string>LaunchScreen</string>
-    <key>UIMainStoryboardFile</key>
-    <string>Main</string>
-    <key>UIStatusBarHidden</key>
-    <false />
-    <key>UISupportedInterfaceOrientations</key>
-    <array>
-      <string>UIInterfaceOrientationPortrait</string>
-      <string>UIInterfaceOrientationLandscapeLeft</string>
-      <string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>UISupportedInterfaceOrientations~ipad</key>
-    <array>
-      <string>UIInterfaceOrientationPortrait</string>
-      <string>UIInterfaceOrientationPortraitUpsideDown</string>
-      <string>UIInterfaceOrientationLandscapeLeft</string>
-      <string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>UIViewControllerBasedStatusBarAppearance</key>
-    <true />
-    <key>io.flutter.embedded_views_preview</key>
-    <true />
-  </dict>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>We require this permission to access the local WiFi name for background upload mechanism</string>
+	<key>NSLocationUsageDescription</key>
+	<string>We require this permission to access the local WiFi name</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>We require this permission to access the local WiFi name</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>We need to access the microphone to let you take beautiful video using this app</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>We need to manage backup your photos album</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>We need to manage backup your photos album</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIStatusBarHidden</key>
+	<false/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
+</dict>
 </plist>

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -35,6 +35,7 @@ class HashService {
   bool get isCancelled => _cancelChecker?.call() ?? false;
 
   Future<void> hashAssets() async {
+    _log.info("Starting hashing of assets");
     final Stopwatch stopwatch = Stopwatch()..start();
     // Sorted by backupSelection followed by isCloud
     final localAlbums = await _localAlbumRepository.getAll(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/generated/codegen_loader.g.dart';
 import 'package:immich_mobile/providers/app_life_cycle.provider.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/share_intent_upload.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/db.provider.dart';
@@ -26,7 +25,6 @@ import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/theme.provider.dart';
 import 'package:immich_mobile/routing/app_navigation_observer.dart';
 import 'package:immich_mobile/routing/router.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/background.service.dart';
 import 'package:immich_mobile/services/deep_link.service.dart';
 import 'package:immich_mobile/services/local_notification.service.dart';
@@ -207,12 +205,9 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
       // needs to be delayed so that EasyLocalization is working
       if (Store.isBetaTimelineEnabled) {
         ref.read(backgroundServiceProvider).disableService();
-        ref.read(driftBackgroundUploadFgService).enableSyncService();
-        if (ref.read(appSettingsServiceProvider).getSetting(AppSettingsEnum.enableBackup)) {
-          ref.read(driftBackgroundUploadFgService).enableUploadService();
-        }
+        ref.read(driftBackgroundUploadFgService).enable();
       } else {
-        ref.read(driftBackgroundUploadFgService).disableUploadService();
+        ref.read(driftBackgroundUploadFgService).disable();
         ref.read(backgroundServiceProvider).resumeServiceIfEnabled();
       }
     });

--- a/mobile/lib/pages/backup/drift_backup.page.dart
+++ b/mobile/lib/pages/backup/drift_backup.page.dart
@@ -8,7 +8,6 @@ import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/backup/backup_toggle_button.widget.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
-import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
@@ -43,12 +42,10 @@ class _DriftBackupPageState extends ConsumerState<DriftBackupPage> {
 
     await ref.read(backgroundSyncProvider).syncRemote();
     await ref.read(driftBackupProvider.notifier).getBackupStatus(currentUser.id);
-    await ref.read(driftBackgroundUploadFgService).enableUploadService();
     await ref.read(driftBackupProvider.notifier).startBackup(currentUser.id);
   }
 
   Future<void> stopBackup() async {
-    await ref.read(driftBackgroundUploadFgService).disableUploadService();
     await ref.read(driftBackupProvider.notifier).cancel();
   }
 

--- a/mobile/lib/pages/common/change_experience.page.dart
+++ b/mobile/lib/pages/common/change_experience.page.dart
@@ -79,7 +79,7 @@ class _ChangeExperiencePageState extends ConsumerState<ChangeExperiencePage> {
         ref.read(readonlyModeProvider.notifier).setReadonlyMode(false);
         await migrateStoreToIsar(ref.read(isarProvider), ref.read(driftProvider));
         await ref.read(backgroundServiceProvider).resumeServiceIfEnabled();
-        await ref.read(driftBackgroundUploadFgService).disableUploadService();
+        await ref.read(driftBackgroundUploadFgService).disable();
       }
 
       await IsarStoreRepository(ref.read(isarProvider)).upsert(StoreKey.betaTimeline, widget.switchingToBeta);

--- a/mobile/lib/platform/background_worker_api.g.dart
+++ b/mobile/lib/platform/background_worker_api.g.dart
@@ -59,9 +59,9 @@ class BackgroundWorkerFgHostApi {
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<void> enableSyncWorker() async {
+  Future<void> enable() async {
     final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableSyncWorker$pigeonVar_messageChannelSuffix';
+        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enable$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -82,32 +82,9 @@ class BackgroundWorkerFgHostApi {
     }
   }
 
-  Future<void> enableUploadWorker() async {
+  Future<void> disable() async {
     final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.enableUploadWorker$pigeonVar_messageChannelSuffix';
-    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-      pigeonVar_channelName,
-      pigeonChannelCodec,
-      binaryMessenger: pigeonVar_binaryMessenger,
-    );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
-    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
-    if (pigeonVar_replyList == null) {
-      throw _createConnectionError(pigeonVar_channelName);
-    } else if (pigeonVar_replyList.length > 1) {
-      throw PlatformException(
-        code: pigeonVar_replyList[0]! as String,
-        message: pigeonVar_replyList[1] as String?,
-        details: pigeonVar_replyList[2],
-      );
-    } else {
-      return;
-    }
-  }
-
-  Future<void> disableUploadWorker() async {
-    final String pigeonVar_channelName =
-        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disableUploadWorker$pigeonVar_messageChannelSuffix';
+        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFgHostApi.disable$pigeonVar_messageChannelSuffix';
     final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
@@ -192,8 +169,6 @@ class BackgroundWorkerBgHostApi {
 abstract class BackgroundWorkerFlutterApi {
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
-  Future<void> onLocalSync(int? maxSeconds);
-
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds);
 
   Future<void> onAndroidUpload();
@@ -206,35 +181,6 @@ abstract class BackgroundWorkerFlutterApi {
     String messageChannelSuffix = '',
   }) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
-    {
-      final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onLocalSync$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
-      if (api == null) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          assert(
-            message != null,
-            'Argument for dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onLocalSync was null.',
-          );
-          final List<Object?> args = (message as List<Object?>?)!;
-          final int? arg_maxSeconds = (args[0] as int?);
-          try {
-            await api.onLocalSync(arg_maxSeconds);
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
-          }
-        });
-      }
-    }
     {
       final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onIosUpload$messageChannelSuffix',

--- a/mobile/pigeon/background_worker_api.dart
+++ b/mobile/pigeon/background_worker_api.dart
@@ -13,12 +13,9 @@ import 'package:pigeon/pigeon.dart';
 )
 @HostApi()
 abstract class BackgroundWorkerFgHostApi {
-  void enableSyncWorker();
+  void enable();
 
-  void enableUploadWorker();
-
-  // Disables the background upload service
-  void disableUploadWorker();
+  void disable();
 }
 
 @HostApi()
@@ -32,10 +29,6 @@ abstract class BackgroundWorkerBgHostApi {
 
 @FlutterApi()
 abstract class BackgroundWorkerFlutterApi {
-  // Android & iOS: Called when the local sync is triggered
-  @async
-  void onLocalSync(int? maxSeconds);
-
   // iOS Only: Called when the iOS background upload is triggered
   @async
   void onIosUpload(bool isRefresh, int? maxSeconds);


### PR DESCRIPTION
## Description

- Simplifies the background worker to always enqueue the background workers on iOS and Android with the beta timeline.
The following table lists the type of operations performed on both the platforms

<table>
<tr>
 <td>
 <td> Backup Disabled
 <td> Backup Enabled
<tr>
 <td> Android / iOS Background Processing
 <td> - Syncs Local Assets <br /> - Syncs Remote Assets <br /> - Hashes assets for 6 minutes <br />
 <td> - Syncs Local Assets <br /> - Syncs Remote Assets <br /> - Hashes assets for 3 minutes <br /> - Enqueues Assets for backup
<tr>
 <td> iOS Background Refresh (Restricted to only run for 20 seconds)
 <td> - Syncs Local Assets <br /> - Syncs Remote Assets <br /> - Hashes assets for 5 seconds <br />
 <td> - Syncs Local Assets <br /> - Syncs Remote Assets <br /> - Hashes assets for 5 seconds <br /> -  Enqueues Assets for backup
</table> 

- The content update delay for the MediaObserver on Android is increased to 30 seconds from the current 5 seconds. This means that the OS waits for 30 seconds before invoking our background observer. This acts as a better default and waits for all new media to be indexed by MediaStore before starting to process them. The maximum delay is also updated along with this change from the previous 1 minute to 3 minutes
