### PR TITLE
fix(mobile+server): handle missing EXIF by using actual asset creation date on iOS

### DIFF
--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -289,6 +289,8 @@ class UploadService {
       priority: priority,
       isFavorite: asset.isFavorite,
       requiresWiFi: requiresWiFi,
+      assetCreatedAt: asset.createdAt,
+      assetUpdatedAt: asset.updatedAt,
     );
   }
 
@@ -316,6 +318,8 @@ class UploadService {
       priority: 0, // Highest priority to get upload immediately
       isFavorite: asset.isFavorite,
       requiresWiFi: requiresWiFi,
+      assetCreatedAt: asset.createdAt,
+      assetUpdatedAt: asset.updatedAt,
     );
   }
 
@@ -341,15 +345,26 @@ class UploadService {
     int? priority,
     bool? isFavorite,
     bool requiresWiFi = true,
+    required DateTime assetCreatedAt,
+    required DateTime assetUpdatedAt,
   }) async {
     final serverEndpoint = Store.get(StoreKey.serverEndpoint);
     final url = Uri.parse('$serverEndpoint/assets').toString();
     final headers = ApiService.getRequestHeaders();
     final deviceId = Store.get(StoreKey.deviceId);
     final (baseDirectory, directory, filename) = await Task.split(filePath: file.path);
-    final stats = await file.stat();
-    final fileCreatedAt = stats.changed;
-    final fileModifiedAt = stats.modified;
+
+    DateTime fileCreatedAt;
+    DateTime fileModifiedAt;
+    if (Platform.isIOS) {
+      fileCreatedAt = assetCreatedAt;
+      fileModifiedAt = assetUpdatedAt;
+    } else {
+      final stats = await file.stat();
+      fileCreatedAt = stats.changed;
+      fileModifiedAt = stats.modified;
+    }
+    
     final fieldsMap = {
       'filename': originalFileName ?? filename,
       'deviceAssetId': deviceAssetId ?? '',

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -793,7 +793,7 @@ export class MetadataService extends BaseService {
     }
   }
 
-  private getDates(asset: { id: string; originalPath: string }, exifTags: ImmichTags, stats: Stats) {
+  private getDates(asset: { id: string; originalPath: string; fileCreatedAt: Date }, exifTags: ImmichTags, stats: Stats) {
     const result = firstDateTime(exifTags);
     const tag = result?.tag;
     const dateTime = result?.dateTime;
@@ -822,7 +822,7 @@ export class MetadataService extends BaseService {
     if (!localDateTime || !dateTimeOriginal) {
       // FileCreateDate is not available on linux, likely because exiftool hasn't integrated the statx syscall yet
       // birthtime is not available in Docker on macOS, so it appears as 0
-      const earliestDate = stats.birthtimeMs ? new Date(Math.min(stats.mtimeMs, stats.birthtimeMs)) : stats.mtime;
+      const earliestDate = new Date(Math.min(asset.fileCreatedAt.getTime(), stats.birthtimeMs ? Math.min(stats.mtimeMs, stats.birthtimeMs) : stats.mtime.getTime()));
       this.logger.debug(
         `No exif date time found, falling back on ${earliestDate.toISOString()}, earliest of file creation and modification for asset ${asset.id}: ${asset.originalPath}`,
       );


### PR DESCRIPTION
## Description
This PR fixes an issue where photos on iOS (e.g., from WhatsApp) with missing creation date EXIF metadata tags were uploaded with the local file creation date (upload time) instead of their actual creation date.  

Changes:
- **mobile/lib/services/upload.service.dart**: on iOS, use `assetCreatedAt` / `assetUpdatedAt` instead of `file.stat()`; Android and others unchanged.
- **server/src/services/metadata.service.ts**: when EXIF `creationDate`s are missing, also consider `asset.fileCreatedAt`.

## How Has This Been Tested?
- Environment: iPhone 15 Pro, iOS app 1.140.0, server 1.140.0 (Docker dev).  
- Unit and e2e tests.
- Manually:  
  - Photos without EXIF creation date tags → displayed with correct creation date, matching iOS Photos app.  
  - Photos with full EXIF → no regression.  
  - Tested single uploads, grouped uploads, and full backup.  

### Checklist
- [x] I have performed a self-review of my code  
- [x] I have made corresponding changes to the documentation (N/A)  
- [x] My changes generate no new warnings  
- [x] I have not introduced unrelated changes  
- [x] Any dependent changes have been merged and published in downstream modules (N/A)  
- [x] I have added tests that prove my fix is effective or that my feature works (existing test suite covers this)  
- [x] My code follows the style guidelines of this project (naming, formatting)  
- [x] My code respects the services/repositories separation principle  
