### PR TITLE
fix: keyboard not dismissed in places page

### DIFF
--- a/mobile/lib/presentation/pages/drift_place.page.dart
+++ b/mobile/lib/presentation/pages/drift_place.page.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
@@ -38,14 +39,14 @@ class DriftPlacePage extends StatelessWidget {
   }
 }
 
-class _PlaceSliverAppBar extends StatelessWidget {
+class _PlaceSliverAppBar extends HookWidget {
   const _PlaceSliverAppBar({required this.search});
 
   final ValueNotifier<String?> search;
 
   @override
   Widget build(BuildContext context) {
-    final searchFocusNode = FocusNode();
+    final searchFocusNode = useFocusNode();
 
     return SliverAppBar(
       floating: true,


### PR DESCRIPTION
## Description

- The keyboard was not dismissed since the FocusNode was recreated on each rebuild, making it useless

## How was this tested

- Navigate to a search result from pages page without dismissing the keyboard and confirm that it gets auto-dismissed
- Pressing the done button dismisses the keyboard as well