### PR TITLE
feat: resurrect advanced info

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1982,6 +1982,7 @@
   "trash_page_select_assets_btn": "Select assets",
   "trash_page_title": "Trash ({count})",
   "trashed_items_will_be_permanently_deleted_after": "Trashed items will be permanently deleted after {days, plural, one {# day} other {# days}}.",
+  "troubleshoot": "Troubleshoot",
   "type": "Type",
   "unable_to_change_pin_code": "Unable to change PIN code",
   "unable_to_setup_pin_code": "Unable to setup PIN code",

--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -1,3 +1,4 @@
+import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
@@ -25,6 +26,14 @@ class AssetService {
   Stream<BaseAsset?> watchAsset(BaseAsset asset) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).id;
     return asset is LocalAsset ? _localAssetRepository.watch(id) : _remoteAssetRepository.watch(id);
+  }
+
+  Future<List<LocalAsset?>> getLocalAssetsByChecksum(String checksum) {
+    return _localAssetRepository.getByChecksum(checksum);
+  }
+
+  Future<RemoteAsset?> getRemoteAssetByChecksum(String checksum) {
+    return _remoteAssetRepository.getByChecksum(checksum);
   }
 
   Future<RemoteAsset?> getRemoteAsset(String id) {
@@ -88,5 +97,9 @@ class AssetService {
 
   Future<int> getLocalHashedCount() {
     return _localAssetRepository.getHashedCount();
+  }
+
+  Future<List<LocalAlbum>> getSourceAlbums(String localAssetId, {BackupSelection? backupSelection}) {
+    return _localAssetRepository.getSourceAlbums(localAssetId, backupSelection: backupSelection);
   }
 }

--- a/mobile/lib/infrastructure/repositories/backup.repository.dart
+++ b/mobile/lib/infrastructure/repositories/backup.repository.dart
@@ -4,7 +4,6 @@ import 'package:drift/drift.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/infrastructure/entities/local_album.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/local_asset.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
@@ -137,23 +136,5 @@ class DriftBackupRepository extends DriftDatabaseRepository {
       ..orderBy([(localAsset) => OrderingTerm.desc(localAsset.createdAt)]);
 
     return query.map((localAsset) => localAsset.toDto()).get();
-  }
-
-  FutureOr<List<LocalAlbum>> getSourceAlbums(String localAssetId) {
-    final query = _db.localAlbumEntity.select()
-      ..where(
-        (lae) =>
-            existsQuery(
-              _db.localAlbumAssetEntity.selectOnly()
-                ..addColumns([_db.localAlbumAssetEntity.albumId])
-                ..where(
-                  _db.localAlbumAssetEntity.albumId.equalsExp(lae.id) &
-                      _db.localAlbumAssetEntity.assetId.equals(localAssetId),
-                ),
-            ) &
-            lae.backupSelection.equalsValue(BackupSelection.selected),
-      )
-      ..orderBy([(lae) => OrderingTerm.asc(lae.name)]);
-    return query.map((localAlbum) => localAlbum.toDto()).get();
   }
 }

--- a/mobile/lib/infrastructure/repositories/remote_asset.repository.dart
+++ b/mobile/lib/infrastructure/repositories/remote_asset.repository.dart
@@ -55,6 +55,12 @@ class RemoteAssetRepository extends DriftDatabaseRepository {
     return _assetSelectable(id).getSingleOrNull();
   }
 
+  Future<RemoteAsset?> getByChecksum(String checksum) {
+    final query = _db.remoteAssetEntity.select()..where((row) => row.checksum.equals(checksum));
+
+    return query.map((row) => row.toDto()).getSingleOrNull();
+  }
+
   Future<List<RemoteAsset>> getStackChildren(RemoteAsset asset) {
     if (asset.stackId == null) {
       return Future.value([]);

--- a/mobile/lib/presentation/pages/drift_asset_troubleshoot.page.dart
+++ b/mobile/lib/presentation/pages/drift_asset_troubleshoot.page.dart
@@ -100,23 +100,25 @@ class _AssetPropertiesSectionState extends ConsumerState<_AssetPropertiesSection
     final asset = widget.asset;
     properties.addAll([
       _PropertyItem(label: 'Name', value: asset.name),
-      if (asset.checksum != null) _PropertyItem(label: 'Checksum', value: asset.checksum!),
+      _PropertyItem(label: 'Checksum', value: asset.checksum),
       _PropertyItem(label: 'Type', value: asset.type.toString()),
       _PropertyItem(label: 'Created At', value: asset.createdAt.toString()),
       _PropertyItem(label: 'Updated At', value: asset.updatedAt.toString()),
-      if (asset.width != null) _PropertyItem(label: 'Width', value: asset.width!.toString()),
-      if (asset.height != null) _PropertyItem(label: 'Height', value: asset.height!.toString()),
-      if (asset.durationInSeconds != null)
-        _PropertyItem(label: 'Duration', value: '${asset.durationInSeconds} seconds'),
+      _PropertyItem(label: 'Width', value: asset.width?.toString()),
+      _PropertyItem(label: 'Height', value: asset.height?.toString()),
+      _PropertyItem(
+        label: 'Duration',
+        value: asset.durationInSeconds != null ? '${asset.durationInSeconds} seconds' : 'N/A',
+      ),
       _PropertyItem(label: 'Is Favorite', value: asset.isFavorite.toString()),
-      if (asset.livePhotoVideoId != null) _PropertyItem(label: 'Live Photo Video ID', value: asset.livePhotoVideoId!),
+      _PropertyItem(label: 'Live Photo Video ID', value: asset.livePhotoVideoId),
     ]);
   }
 
   Future<void> _addLocalAssetProperties(LocalAsset asset) async {
     properties.insertAll(0, [
       _PropertyItem(label: 'Local ID', value: asset.id),
-      if (asset.remoteId != null) _PropertyItem(label: 'Remote ID', value: asset.remoteId!),
+      _PropertyItem(label: 'Remote ID', value: asset.remoteId),
     ]);
 
     properties.insert(4, _PropertyItem(label: 'Orientation', value: asset.orientation.toString()));
@@ -127,14 +129,14 @@ class _AssetPropertiesSectionState extends ConsumerState<_AssetPropertiesSection
   void _addRemoteAssetProperties(RemoteAsset asset) {
     properties.insertAll(0, [
       _PropertyItem(label: 'Remote ID', value: asset.id),
-      if (asset.localId != null) _PropertyItem(label: 'Local ID', value: asset.localId!),
+      _PropertyItem(label: 'Local ID', value: asset.localId),
       _PropertyItem(label: 'Owner ID', value: asset.ownerId),
     ]);
 
     final additionalProps = <_PropertyItem>[
-      if (asset.thumbHash != null) _PropertyItem(label: 'Thumb Hash', value: asset.thumbHash!),
+      _PropertyItem(label: 'Thumb Hash', value: asset.thumbHash),
       _PropertyItem(label: 'Visibility', value: asset.visibility.toString()),
-      if (asset.stackId != null) _PropertyItem(label: 'Stack ID', value: asset.stackId!),
+      _PropertyItem(label: 'Stack ID', value: asset.stackId),
     ];
 
     properties.insertAll(4, additionalProps);
@@ -281,9 +283,9 @@ class _PropertySectionCard extends StatelessWidget {
 
 class _PropertyItem extends StatelessWidget {
   final String label;
-  final String value;
+  final String? value;
 
-  const _PropertyItem({required this.label, required this.value});
+  const _PropertyItem({required this.label, this.value});
 
   @override
   Widget build(BuildContext context) {
@@ -297,7 +299,7 @@ class _PropertyItem extends StatelessWidget {
             child: Text('$label:', style: const TextStyle(fontWeight: FontWeight.w500)),
           ),
           Expanded(
-            child: Text(value, style: TextStyle(color: Theme.of(context).colorScheme.secondary)),
+            child: Text(value ?? 'N/A', style: TextStyle(color: Theme.of(context).colorScheme.secondary)),
           ),
         ],
       ),

--- a/mobile/lib/presentation/widgets/action_buttons/advanced_info_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/advanced_info_action_button.widget.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+
+class AdvancedInfoActionButton extends ConsumerWidget {
+  final ActionSource source;
+
+  const AdvancedInfoActionButton({super.key, required this.source});
+
+  void _onTap(BuildContext context, WidgetRef ref) async {
+    if (!context.mounted) {
+      return;
+    }
+
+    ref.read(actionProvider.notifier).troubleshoot(source, context);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BaseActionButton(
+      maxWidth: 115.0,
+      iconData: Icons.help_outline_rounded,
+      label: "troubleshoot".t(context: context),
+      onPressed: () => _onTap(context, ref),
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/archive_bottom_sheet.widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_date_time_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/edit_location_action_button.widget.dart';

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -4,6 +4,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/advanced_info_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/archive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
@@ -21,6 +23,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_
 import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
@@ -51,6 +54,7 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
   Widget build(BuildContext context) {
     final multiselect = ref.watch(multiSelectProvider);
     final isTrashEnable = ref.watch(serverInfoProvider.select((state) => state.serverFeatures.trash));
+    final advancedTroubleshooting = ref.watch(settingsProvider.notifier).get(Setting.advancedTroubleshooting);
 
     Future<void> addAssetsToAlbum(RemoteAlbum album) async {
       final selectedAssets = multiselect.selectedAssets;
@@ -88,6 +92,9 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
       maxChildSize: 0.85,
       shouldCloseOnMinExtent: false,
       actions: [
+        if (multiselect.selectedAssets.length == 1 && advancedTroubleshooting) ...[
+          const AdvancedInfoActionButton(source: ActionSource.timeline),
+        ],
         const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -6,11 +6,11 @@ import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/backup.repository.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/upload.service.dart';
 import 'package:logging/logging.dart';
@@ -380,5 +380,5 @@ final driftCandidateBackupAlbumInfoProvider = FutureProvider.autoDispose.family<
   ref,
   assetId,
 ) {
-  return ref.read(backupRepositoryProvider).getSourceAlbums(assetId);
+  return ref.read(localAssetRepository).getSourceAlbums(assetId, backupSelection: BackupSelection.selected);
 });

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/constants/enums.dart';
@@ -6,6 +7,7 @@ import 'package:immich_mobile/models/download/livephotos_medatada.model.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/action.service.dart';
 import 'package:immich_mobile/services/download.service.dart';
 import 'package:immich_mobile/services/timeline.service.dart';
@@ -113,6 +115,16 @@ class ActionNotifier extends Notifier<void> {
         null => const {},
       },
     };
+  }
+
+  Future<ActionResult> troubleshoot(ActionSource source, BuildContext context) async {
+    final assets = _getAssets(source);
+    if (assets.length > 1) {
+      return ActionResult(count: assets.length, success: false, error: 'Cannot troubleshoot multiple assets');
+    }
+    context.pushRoute(AssetTroubleshootRoute(asset: assets.first));
+
+    return ActionResult(count: assets.length, success: true);
   }
 
   Future<ActionResult> shareLink(ActionSource source, BuildContext context) async {

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -86,6 +86,7 @@ import 'package:immich_mobile/presentation/pages/drift_album.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_album_options.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_archive.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_asset_selection_timeline.page.dart';
+import 'package:immich_mobile/presentation/pages/drift_asset_troubleshoot.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_create_album.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_favorite.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_library.page.dart';
@@ -343,6 +344,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: DriftFilterImageRoute.page),
     AutoRoute(page: DriftActivitiesRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftBackupAssetDetailRoute.page, guards: [_authGuard, _duplicateGuard]),
+    AutoRoute(page: AssetTroubleshootRoute.page, guards: [_authGuard, _duplicateGuard]),
     // required to handle all deeplinks in deep_link.service.dart
     // auto_route_library#1722
     RedirectRoute(path: '*', redirectTo: '/'),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -404,6 +404,43 @@ class ArchiveRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
+/// [AssetTroubleshootPage]
+class AssetTroubleshootRoute extends PageRouteInfo<AssetTroubleshootRouteArgs> {
+  AssetTroubleshootRoute({
+    Key? key,
+    required BaseAsset asset,
+    List<PageRouteInfo>? children,
+  }) : super(
+         AssetTroubleshootRoute.name,
+         args: AssetTroubleshootRouteArgs(key: key, asset: asset),
+         initialChildren: children,
+       );
+
+  static const String name = 'AssetTroubleshootRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<AssetTroubleshootRouteArgs>();
+      return AssetTroubleshootPage(key: args.key, asset: args.asset);
+    },
+  );
+}
+
+class AssetTroubleshootRouteArgs {
+  const AssetTroubleshootRouteArgs({this.key, required this.asset});
+
+  final Key? key;
+
+  final BaseAsset asset;
+
+  @override
+  String toString() {
+    return 'AssetTroubleshootRouteArgs{key: $key, asset: $asset}';
+  }
+}
+
+/// generated route for
 /// [AssetViewerPage]
 class AssetViewerRoute extends PageRouteInfo<AssetViewerRouteArgs> {
   AssetViewerRoute({

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/advanced_info_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/archive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_action_button.widget.dart';
@@ -15,7 +17,6 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/share_link_act
 import 'package:immich_mobile/presentation/widgets/action_buttons/trash_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unarchive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_button.widget.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 
 class ActionButtonContext {
   final BaseAsset asset;
@@ -24,6 +25,7 @@ class ActionButtonContext {
   final bool isTrashEnabled;
   final bool isInLockedView;
   final RemoteAlbum? currentAlbum;
+  final bool advancedTroubleshooting;
   final ActionSource source;
 
   const ActionButtonContext({
@@ -33,11 +35,13 @@ class ActionButtonContext {
     required this.isTrashEnabled,
     required this.isInLockedView,
     required this.currentAlbum,
+    required this.advancedTroubleshooting,
     required this.source,
   });
 }
 
 enum ActionButtonType {
+  advancedInfo,
   share,
   shareLink,
   archive,
@@ -55,6 +59,7 @@ enum ActionButtonType {
 
   bool shouldShow(ActionButtonContext context) {
     return switch (this) {
+      ActionButtonType.advancedInfo => context.advancedTroubleshooting,
       ActionButtonType.share => true,
       ActionButtonType.shareLink =>
         !context.isInLockedView && //
@@ -115,6 +120,7 @@ enum ActionButtonType {
 
   Widget buildButton(ActionButtonContext context) {
     return switch (this) {
+      ActionButtonType.advancedInfo => AdvancedInfoActionButton(source: context.source),
       ActionButtonType.share => ShareActionButton(source: context.source),
       ActionButtonType.shareLink => ShareLinkActionButton(source: context.source),
       ActionButtonType.archive => ArchiveActionButton(source: context.source),
@@ -138,6 +144,7 @@ enum ActionButtonType {
 
 class ActionButtonBuilder {
   static const List<ActionButtonType> _actionTypes = [
+    ActionButtonType.advancedInfo,
     ActionButtonType.share,
     ActionButtonType.shareLink,
     ActionButtonType.likeActivity,

--- a/mobile/test/utils/action_button_utils_test.dart
+++ b/mobile/test/utils/action_button_utils_test.dart
@@ -81,6 +81,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 
@@ -110,6 +111,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -124,6 +126,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: true,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -141,6 +144,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -156,6 +160,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: true,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -171,6 +176,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -188,6 +194,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -203,6 +210,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -218,6 +226,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: true,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -233,6 +242,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -248,6 +258,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -265,6 +276,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -280,6 +292,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -295,6 +308,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -312,6 +326,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -327,6 +342,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -342,6 +358,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: true,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -359,6 +376,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -374,6 +392,7 @@ void main() {
           isTrashEnabled: false,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -391,6 +410,7 @@ void main() {
           isTrashEnabled: false,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -406,6 +426,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -423,6 +444,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -440,6 +462,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -457,6 +480,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -472,6 +496,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -489,6 +514,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -506,6 +532,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: album,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -520,6 +547,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -537,6 +565,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: album,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -552,6 +581,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: album,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -567,6 +597,7 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: album,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
@@ -581,10 +612,43 @@ void main() {
           isTrashEnabled: true,
           isInLockedView: false,
           currentAlbum: null,
+          advancedTroubleshooting: false,
           source: ActionSource.timeline,
         );
 
         expect(ActionButtonType.likeActivity.shouldShow(context), isFalse);
+      });
+    });
+
+    group('advancedTroubleshooting button', () {
+      test('should show when in advanced troubleshooting mode', () {
+        final context = ActionButtonContext(
+          asset: mergedAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: true,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: true,
+          source: ActionSource.timeline,
+        );
+
+        expect(ActionButtonType.advancedInfo.shouldShow(context), isTrue);
+      });
+
+      test('should not show when not in advanced troubleshooting mode', () {
+        final context = ActionButtonContext(
+          asset: mergedAsset,
+          isOwner: true,
+          isArchived: false,
+          isTrashEnabled: true,
+          isInLockedView: false,
+          currentAlbum: null,
+          advancedTroubleshooting: false,
+          source: ActionSource.timeline,
+        );
+
+        expect(ActionButtonType.advancedInfo.shouldShow(context), isFalse);
       });
     });
   });
@@ -602,6 +666,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
     });
@@ -617,6 +682,7 @@ void main() {
             isTrashEnabled: true,
             isInLockedView: false,
             currentAlbum: album,
+            advancedTroubleshooting: false,
             source: ActionSource.timeline,
           );
           final widget = buttonType.buildButton(contextWithAlbum);
@@ -639,6 +705,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 
@@ -658,6 +725,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: album,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 
@@ -675,6 +743,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 
@@ -693,6 +762,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 
@@ -705,6 +775,7 @@ void main() {
         isTrashEnabled: true,
         isInLockedView: false,
         currentAlbum: null,
+        advancedTroubleshooting: false,
         source: ActionSource.timeline,
       );
 


### PR DESCRIPTION
## Description

This PR brings back the Advanced Info bottom sheet as a new action that opens a info page, instead of replacing the bottom sheet. The new page displays all properties of the current asset, along with the properties of other assets matching the current asset's checksum.

Right now, the action will be displayed as the first item in the bottom sheet in the asset viewer when the advanced troubleshooting setting is enabled. The action is also displayed in the general bottom sheet (i.e, from main timeline) when the selection contains only one asset.

<details><summary><h2>Screenshots</h2></summary>

Action Button | Info Page
:-: | :-:
<img width="1280" height="2856" alt="Info_Button_Asset" src="https://github.com/user-attachments/assets/16be6794-999e-4834-9c7e-465631ab6c6e" /> | <img width="1280" height="2856" alt="Info_Page" src="https://github.com/user-attachments/assets/983fba24-4b53-48d0-8582-525f73dc648c" />
</details>