### PR TITLE
feat(mobile): make hashed asset count reactive

### DIFF
--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -95,8 +95,8 @@ class AssetService {
     return (await _localAssetRepository.getCount(), await _remoteAssetRepository.getCount());
   }
 
-  Future<int> getLocalHashedCount() {
-    return _localAssetRepository.getHashedCount();
+  Stream<int> watchLocalHashedCount() {
+    return _localAssetRepository.watchHashedCount();
   }
 
   Future<List<LocalAlbum>> getSourceAlbums(String localAssetId, {BackupSelection? backupSelection}) {

--- a/mobile/lib/infrastructure/repositories/local_asset.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_asset.repository.dart
@@ -74,8 +74,8 @@ class DriftLocalAssetRepository extends DriftDatabaseRepository {
     return _db.managers.localAssetEntity.count();
   }
 
-  Future<int> getHashedCount() {
-    return _db.managers.localAssetEntity.filter((e) => e.checksum.isNull().not()).count();
+  Stream<int> watchHashedCount() {
+    return _db.localAssetEntity.count(where: (e) => e.checksum.isNull().not()).watchSingle();
   }
 
   Future<List<LocalAlbum>> getSourceAlbums(String localAssetId, {BackupSelection? backupSelection}) {

--- a/mobile/lib/providers/sync_status.provider.dart
+++ b/mobile/lib/providers/sync_status.provider.dart
@@ -1,5 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 
 enum SyncStatus {
   idle,
@@ -112,3 +113,8 @@ class SyncStatusNotifier extends Notifier<SyncStatusState> {
 }
 
 final syncStatusProvider = NotifierProvider<SyncStatusNotifier, SyncStatusState>(SyncStatusNotifier.new);
+
+final localHashedCountProvider = StreamProvider<int>((ref) {
+  final assetService = ref.read(assetServiceProvider);
+  return assetService.watchLocalHashedCount();
+});

--- a/mobile/lib/providers/sync_status.provider.dart
+++ b/mobile/lib/providers/sync_status.provider.dart
@@ -1,6 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 
 enum SyncStatus {
   idle,
@@ -113,8 +112,3 @@ class SyncStatusNotifier extends Notifier<SyncStatusState> {
 }
 
 final syncStatusProvider = NotifierProvider<SyncStatusNotifier, SyncStatusState>(SyncStatusNotifier.new);
-
-final localHashedCountProvider = StreamProvider<int>((ref) {
-  final assetService = ref.read(assetServiceProvider);
-  return assetService.watchLocalHashedCount();
-});

--- a/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
@@ -231,9 +231,8 @@ class _SyncStatsCounts extends ConsumerWidget {
       final localAlbumCounts = localAlbumService.getCount();
       final remoteAlbumCounts = remoteAlbumService.getCount();
       final memoryCount = memoryService.getCount();
-      final getLocalHashedCount = assetService.getLocalHashedCount();
 
-      return await Future.wait([assetCounts, localAlbumCounts, remoteAlbumCounts, memoryCount, getLocalHashedCount]);
+      return await Future.wait([assetCounts, localAlbumCounts, remoteAlbumCounts, memoryCount]);
     }
 
     return FutureBuilder(
@@ -266,7 +265,6 @@ class _SyncStatsCounts extends ConsumerWidget {
         final localAlbumCount = snapshot.data![1]! as int;
         final remoteAlbumCount = snapshot.data![2]! as int;
         final memoryCount = snapshot.data![3]! as int;
-        final localHashedCount = snapshot.data![4]! as int;
 
         return Column(
           mainAxisAlignment: MainAxisAlignment.start,
@@ -338,10 +336,24 @@ class _SyncStatsCounts extends ConsumerWidget {
                     ),
                   ),
                   Expanded(
-                    child: EntitiyCountTile(
-                      label: "hashed_assets".t(context: context),
-                      count: localHashedCount,
-                      icon: Icons.tag,
+                    child: Consumer(
+                      key: const ValueKey("hashed_assets_count_tile"),
+                      builder: (context, ref, _) {
+                        final assetService = ref.watch(assetServiceProvider);
+
+                        return StreamBuilder<int>(
+                          stream: assetService.watchLocalHashedCount(),
+                          initialData: 0,
+                          builder: (context, snapshot) {
+                            final localHashedCount = snapshot.data ?? 0;
+                            return EntitiyCountTile(
+                              label: "hashed_assets".t(context: context),
+                              count: localHashedCount,
+                              icon: Icons.tag,
+                            );
+                          },
+                        );
+                      },
                     ),
                   ),
                 ],


### PR DESCRIPTION
## Description

This change enables the hashed assets count in the Beta Sync Status to react to database updates, removing the need to leave/reopen the page.

Fixes #21434, #21447

### Open points

With large hashing batches (currently 256 assets or 1 GB), the visible count can stay flat for a while because most time is spent downloading before DB updates occur. From a UX point of view, I would suggest either lowering the limits defined in the constants file (e.g., 32 assets, 128 MB) or implementing sub-flushes in the batch processing, so that the counter updates more frequently.

## How Has This Been Tested?
- Environment: iPhone 15 Pro, iOS 26.
- Automated tests. 
- Manual:
  - Started a local hashing job both from a fresh app install and from an already started app with hashed assets; observed the “Hashed assets” count increment automatically without reopening the page.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)