### PR TITLE
ci: mise mobile tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -309,3 +309,170 @@ run = [
   "mise run web:test --run",
   "mise run web:lint",
 ]
+
+
+# mobile
+[tasks."mobile:codegen:dart"]
+alias = "mobile:codegen"
+description = "Execute build_runner to auto-generate dart code"
+dir = "mobile"
+sources = [
+  "pubspec.yaml",
+  "build.yaml",
+  "lib/**/*.dart"
+]
+outputs = { auto = true }
+run = "dart run build_runner build --delete-conflicting-outputs"
+
+[tasks."mobile:codegen:pigeon"]
+alias = "mobile:pigeon"
+description = "Generate pigeon platform code"
+dir = "mobile"
+depends = [
+  "mobile:pigeon:native-sync",
+  "mobile:pigeon:thumbnail",
+  "mobile:pigeon:background-worker",
+]
+
+[tasks."mobile:codegen:translation"]
+alias = "mobile:translation"
+description = "Generate translations from i18n JSONs"
+dir = "mobile"
+run = [
+  { task = "i18n:format-fix" },
+  { tasks = ["mobile:i18n:loader", "mobile:i18n:keys"] }
+]
+
+[tasks."mobile:codegen:app-icon"]
+description = "Generate app icons"
+dir = "mobile"
+run = "flutter pub run flutter_launcher_icons:main"
+
+[tasks."mobile:codegen:splash"]
+description = "Generate splash screen"
+dir = "mobile"
+run = "flutter pub run flutter_native_splash:create"
+
+[tasks."mobile:test"]
+description = "Run mobile tests"
+dir = "mobile"
+run = "flutter test"
+
+[tasks."mobile:lint"]
+description = "Analyze Dart code"
+dir = "mobile"
+depends = ["mobile:analyze:dart", "mobile:analyze:dcm"]
+
+[tasks."mobile:lint-fix"]
+description = "Auto-fix Dart code"
+dir = "mobile"
+depends = ["mobile:analyze:fix:dart", "mobile:analyze:fix:dcm"]
+
+[tasks."mobile:format"]
+description = "Format Dart code"
+dir = "mobile"
+run = "dart format --set-exit-if-changed $(find lib -name '*.dart' -not \\( -name '*.g.dart' -o -name '*.drift.dart' -o -name '*.gr.dart' \\))"
+
+[tasks."mobile:build:android"]
+description = "Build Android release"
+dir = "mobile"
+run = "flutter build appbundle"
+
+[tasks."mobile:drift:migration"]
+alias = "mobile:migration"
+description = "Generate database migrations"
+dir = "mobile"
+run = "dart run drift_dev make-migrations"
+
+
+# mobile internal tasks
+[tasks."mobile:pigeon:native-sync"]
+description = "Generate native sync API pigeon code"
+dir = "mobile"
+hide = true
+sources = ["pigeon/native_sync_api.dart"]
+outputs = [
+  "lib/platform/native_sync_api.g.dart",
+  "ios/Runner/Sync/Messages.g.swift",
+  "android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt",
+]
+run = [
+  "dart run pigeon --input pigeon/native_sync_api.dart",
+  "dart format lib/platform/native_sync_api.g.dart",
+]
+
+[tasks."mobile:pigeon:thumbnail"]
+description = "Generate thumbnail API pigeon code"
+dir = "mobile"
+hide = true
+sources = ["pigeon/thumbnail_api.dart"]
+outputs = [
+  "lib/platform/thumbnail_api.g.dart",
+  "ios/Runner/Images/Thumbnails.g.swift",
+  "android/app/src/main/kotlin/app/alextran/immich/images/Thumbnails.g.kt",
+]
+run = [
+  "dart run pigeon --input pigeon/thumbnail_api.dart",
+  "dart format lib/platform/thumbnail_api.g.dart",
+]
+
+[tasks."mobile:pigeon:background-worker"]
+description = "Generate background worker API pigeon code"
+dir = "mobile"
+hide = true
+sources = ["pigeon/background_worker_api.dart"]
+outputs = [
+  "lib/platform/background_worker_api.g.dart",
+  "ios/Runner/Background/BackgroundWorker.g.swift",
+  "android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt",
+]
+run = [
+  "dart run pigeon --input pigeon/background_worker_api.dart",
+  "dart format lib/platform/background_worker_api.g.dart",
+]
+
+[tasks."mobile:i18n:loader"]
+description = "Generate i18n loader"
+dir = "mobile"
+hide = true
+sources = ["i18n/"]
+outputs = "lib/generated/codegen_loader.g.dart"
+run = [
+  "dart run easy_localization:generate -S ../i18n",
+  "dart format lib/generated/codegen_loader.g.dart",
+]
+
+[tasks."mobile:i18n:keys"]
+description = "Generate i18n keys"
+dir = "mobile"
+hide = true
+sources = ["i18n/en.json"]
+outputs = "lib/generated/intl_keys.g.dart"
+run = [
+  "dart run bin/generate_keys.dart",
+  "dart format lib/generated/intl_keys.g.dart",
+]
+
+[tasks."mobile:analyze:dart"]
+description = "Run Dart analysis"
+dir = "mobile"
+hide = true
+run = "dart analyze --fatal-infos"
+
+[tasks."mobile:analyze:dcm"]
+description = "Run Dart Code Metrics"
+dir = "mobile"
+hide = true
+run = "dcm analyze lib --fatal-style --fatal-warnings"
+
+[tasks."mobile:analyze:fix:dart"]
+description = "Auto-fix Dart analysis"
+dir = "mobile"
+hide = true
+run = "dart fix --apply"
+
+[tasks."mobile:analyze:fix:dcm"]
+description = "Auto-fix Dart Code Metrics"
+dir = "mobile"
+hide = true
+run = "dcm fix lib"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,6 @@
 node = "22.19.0"
 flutter = "3.35.4"
 pnpm = "10.15.1"
-dart = "3.8.2"
 
 [tools."github:CQLabs/homebrew-dcm"]
 version = "1.30.0"

--- a/mise.toml
+++ b/mise.toml
@@ -315,11 +315,7 @@ run = [
 alias = "mobile:codegen"
 description = "Execute build_runner to auto-generate dart code"
 dir = "mobile"
-sources = [
-  "pubspec.yaml",
-  "build.yaml",
-  "lib/**/*.dart"
-]
+sources = ["pubspec.yaml", "build.yaml", "lib/**/*.dart"]
 outputs = { auto = true }
 run = "dart run build_runner build --delete-conflicting-outputs"
 
@@ -331,6 +327,7 @@ depends = [
   "mobile:pigeon:native-sync",
   "mobile:pigeon:thumbnail",
   "mobile:pigeon:background-worker",
+  "mobile:pigeon:connectivity",
 ]
 
 [tasks."mobile:codegen:translation"]
@@ -339,7 +336,10 @@ description = "Generate translations from i18n JSONs"
 dir = "mobile"
 run = [
   { task = "i18n:format-fix" },
-  { tasks = ["mobile:i18n:loader", "mobile:i18n:keys"] }
+  { tasks = [
+    "mobile:i18n:loader",
+    "mobile:i18n:keys",
+  ] },
 ]
 
 [tasks."mobile:codegen:app-icon"]
@@ -428,6 +428,21 @@ outputs = [
 run = [
   "dart run pigeon --input pigeon/background_worker_api.dart",
   "dart format lib/platform/background_worker_api.g.dart",
+]
+
+[tasks."mobile:pigeon:connectivity"]
+description = "Generate connectivity API pigeon code"
+dir = "mobile"
+hide = true
+sources = ["pigeon/connectivity_api.dart"]
+outputs = [
+  "lib/platform/connectivity_api.g.dart",
+  "ios/Runner/Connectivity/Connectivity.g.swift",
+  "android/app/src/main/kotlin/app/alextran/immich/connectivity/Connectivity.g.kt",
+]
+run = [
+  "dart run pigeon --input pigeon/connectivity_api.dart",
+  "dart format lib/platform/connectivity_api.g.dart",
 ]
 
 [tasks."mobile:i18n:loader"]

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ pnpm = "10.15.1"
 dart = "3.8.2"
 
 [tools."github:CQLabs/homebrew-dcm"]
-version = "1.31.4"
+version = "1.30.0"
 bin = "dcm"
 postinstall = "chmod +x $MISE_TOOL_INSTALL_PATH/dcm"
 


### PR DESCRIPTION
## Description

- Downgrades DCM to `1.30.0` since our dcm_global has the following range: `version: '>=1.29.0 <=1.30.0'`
- Migrates the mobile make tasks to mise
- Split few tasks into multiple internal tasks to execute them in parallel