### PR TITLE
fix(server): valid backups with `DB_URL` env variable config

### DIFF
--- a/server/src/services/backup.service.ts
+++ b/server/src/services/backup.service.ts
@@ -118,7 +118,7 @@ export class BackupService extends BaseService {
           {
             env: {
               PATH: process.env.PATH,
-              PGPASSWORD: isUrlConnection ? undefined : config.password,
+              PGPASSWORD: isUrlConnection ? new URL(config.url).password : config.password,
             },
           },
         );


### PR DESCRIPTION
## Description

Fixes generation of valid backups when using `DB_URL` config variable that need a password too passed to `pg_dumpall` utility, otherwise the Immich backup process will hang and generate 0-sized archives.

Fixes [#21550](https://github.com/immich-app/immich/issues/21550)

## How Has This Been Tested?

Tests have been done as proposed in the [issue discussion](https://github.com/immich-app/immich/issues/21550#issuecomment-3256487229).


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used.