### PR TITLE
feat(docker-compose): configurable exposed ports

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     env_file:
       - .env
     ports:
-      - '2283:2283'
+      - ${EXPOSE_PORT-:2283:2283}
     depends_on:
       - redis
       - database


### PR DESCRIPTION
## Description

Use a `EXPOSE_PORTS` environment variable if defined. Otherwise, behavior is the same as before.
This allows to specify a different port, of bind to a specific IP address without touching the `docker-compose.yml` after each release.
Personally, I want to only publish the immich app on a private IP (tailscale VPN). Without this change, I have to update the `docker-compose.yml` file after each release.

This is different from the `IMMICH_HOST` environment variable which is only used by the application inside the container.

**I am waiting for a consensus about this new change to update the documentation.**

## How Has This Been Tested?

- [ ] `docker-compose up -d` without the env
- [ ] `docker-compose up -d` with the env

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none
