### PR TITLE
fix: welcome email password

### DIFF
--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -81,7 +81,7 @@ type EventMap = {
   StackDeleteAll: [{ stackIds: string[]; userId: string }];
 
   // user events
-  UserSignup: [{ notify: boolean; id: string; tempPassword?: string }];
+  UserSignup: [{ notify: boolean; id: string; password?: string }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -147,7 +147,7 @@ describe(NotificationService.name, () => {
       await sut.onUserSignup({ id: '', notify: true });
       expect(mocks.job.queue).toHaveBeenCalledWith({
         name: JobName.NotifyUserSignup,
-        data: { id: '', tempPassword: undefined },
+        data: { id: '', password: undefined },
       });
     });
   });

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -38,7 +38,7 @@ export class UserAdminService extends BaseService {
     await this.eventRepository.emit('UserSignup', {
       notify: !!notify,
       id: user.id,
-      tempPassword: user.shouldChangePassword ? userDto.password : undefined,
+      password: userDto.password,
     });
 
     return mapUserAdmin(user);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -249,7 +249,7 @@ export interface IEmailJob {
 }
 
 export interface INotifySignupJob extends IEntityJob {
-  tempPassword?: string;
+  password?: string;
 }
 
 export interface INotifyAlbumInviteJob extends IEntityJob {


### PR DESCRIPTION
The welcome email used to only include the password when `shouldChangePassword` was set to true. Now, it always includes the password.

Fixes #17700