### PR TITLE
fix(docs): fix the SQL query for finding assets with missing thumbnails

### DIFF
--- a/docs/docs/guides/database-queries.md
+++ b/docs/docs/guides/database-queries.md
@@ -147,7 +147,10 @@ SELECT "key", "value" FROM "system_metadata" WHERE "key" = 'system-config';
 ### File properties
 
 ```sql title="Without thumbnails"
-SELECT * FROM "asset" WHERE "asset"."previewPath" IS NULL OR "asset"."thumbnailPath" IS NULL;
+SELECT * FROM "asset"
+WHERE (NOT EXISTS (SELECT 1 FROM "asset_file" WHERE "asset"."id" = "asset_file"."assetId" AND "asset_file"."type" = 'thumbnail')
+    OR NOT EXISTS (SELECT 1 FROM "asset_file" WHERE "asset"."id" = "asset_file"."assetId" AND "asset_file"."type" = 'preview'))
+AND "asset"."visibility" = 'timeline';
 ```
 
 ```sql title="Failed file movements"


### PR DESCRIPTION
Adjust the query in docs to use `asset_file` instead of (invalid) `asset.previewPath` and `asset.thumbnailPath`.

Error reported on Discord [How to find image ID when given thumbnail path in error log](https://discord.com/channels/979116623879368755/1414751394950545509/1414751394950545509).