### PR TITLE
fix: hashing not running from the background engine

### DIFF
--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -23,6 +23,7 @@ import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/http_ssl_options.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
+import 'package:worker_manager/worker_manager.dart';
 
 class BackgroundWorkerFgService {
   final BackgroundWorkerFgHostApi _foregroundHostApi;
@@ -68,6 +69,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
       await Future.wait([
         loadTranslations(),
+        workerManager.init(dynamicSpawning: true),
         _ref.read(authServiceProvider).setOpenApiServiceEndpoint(),
         // Initialize the file downloader
         FileDownloader().configure(
@@ -155,6 +157,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       _isCleanedUp = true;
       _logger.info("Cleaning up background worker");
       final cleanupFutures = [
+        workerManager.dispose(),
         _drift.close(),
         _driftLogger.close(),
         _ref.read(backgroundSyncProvider).cancel(),
@@ -174,22 +177,29 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
   Future<void> _handleBackup({bool processBulk = true}) async {
     if (!_isBackupEnabled) {
+      _logger.info("Backup is disabled. Skipping backup routine");
       return;
     }
 
+    _logger.info("Enqueuing assets for backup from the background service");
+
     final currentUser = _ref.read(currentUserProvider);
     if (currentUser == null) {
+      _logger.warning("No current user found. Skipping backup from background");
       return;
     }
 
     if (processBulk) {
+      _logger.info("Resume backup from background");
       return _ref.read(driftBackupProvider.notifier).handleBackupResume(currentUser.id);
     }
 
     final activeTask = await _ref.read(uploadServiceProvider).getActiveTasks(currentUser.id);
     if (activeTask.isNotEmpty) {
+      _logger.info("Resuming backup for active tasks from background");
       await _ref.read(uploadServiceProvider).resumeBackup();
     } else {
+      _logger.info("Starting serial backup for new tasks from background");
       await _ref.read(uploadServiceProvider).startBackupSerial(currentUser.id);
     }
   }

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -177,29 +177,29 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
   Future<void> _handleBackup({bool processBulk = true}) async {
     if (!_isBackupEnabled) {
-      _logger.info("Backup is disabled. Skipping backup routine");
+      _logger.info("[_handleBackup 1] Backup is disabled. Skipping backup routine");
       return;
     }
 
-    _logger.info("Enqueuing assets for backup from the background service");
+    _logger.info("[_handleBackup 2] Enqueuing assets for backup from the background service");
 
     final currentUser = _ref.read(currentUserProvider);
     if (currentUser == null) {
-      _logger.warning("No current user found. Skipping backup from background");
+      _logger.warning("[_handleBackup 3] No current user found. Skipping backup from background");
       return;
     }
 
     if (processBulk) {
-      _logger.info("Resume backup from background");
+      _logger.info("[_handleBackup 4] Resume backup from background");
       return _ref.read(driftBackupProvider.notifier).handleBackupResume(currentUser.id);
     }
 
     final activeTask = await _ref.read(uploadServiceProvider).getActiveTasks(currentUser.id);
     if (activeTask.isNotEmpty) {
-      _logger.info("Resuming backup for active tasks from background");
+      _logger.info("[_handleBackup 5] Resuming backup for active tasks from background");
       await _ref.read(uploadServiceProvider).resumeBackup();
     } else {
-      _logger.info("Starting serial backup for new tasks from background");
+      _logger.info("[_handleBackup 6] Starting serial backup for new tasks from background");
       await _ref.read(uploadServiceProvider).startBackupSerial(currentUser.id);
     }
   }


### PR DESCRIPTION
## Description

- Hashing was not executed from the background engine when workmanager hasn't been initialized yet. This is because, on init, workmanager warms up and initialises isolates and schedules the job when it receives them. If there are not enough isolates available when we invoke the task, it fails silently.