### PR TITLE
reverse-proxy docs: .well-known bypass for let's encrypt in Apache

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -85,6 +85,21 @@ Below is an example config for Apache2 site configuration.
 </VirtualHost>
 ```
 
+#### Compatibility with Let's Encrypt
+
+In the event that your Apache configuration requires a section for Let's Encrypt, make sure you restrict it only to the ACME endpoint:
+
+```ApacheConf
+        ProxyPass /.well-known/acme-challenge/ !
+```
+
+... because Immich expects the `/.well-known/immich` endpoint to be used for client discovery. In other words, this is *not* correct and will cause issues:
+
+```ApacheConf
+        # THIS IS WRONG AND WILL BREAK THE APP!
+        ProxyPass /.well-known/ !
+```
+
 ### Traefik Proxy example config
 
 The example below is for Traefik version 3.


### PR DESCRIPTION
## Description

The reverse proxy documentation has good tips on how to *not* shoot yourself in the foot when configuring Let's Encrypt ACME authentication in the virtual host, but doesn't show how to do it in Apache.

I got bit by this because I incorrectly assumed `.well-known` wasn't used by Immich, which broke discovery for the Android web app.

See: https://github.com/immich-app/immich/discussions/21757

## How Has This Been Tested?

This was previewed in the GitHub editor but otherwise not tested.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not at all.