### PR TITLE
chore: don't run translations merge from prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,15 +24,6 @@ concurrency:
 permissions: {}
 
 jobs:
-  merge_translations:
-    uses: ./.github/workflows/merge-translations.yml
-    permissions:
-      pull-requests: write
-    secrets:
-      PUSH_O_MATIC_APP_ID: ${{ secrets.PUSH_O_MATIC_APP_ID }}
-      PUSH_O_MATIC_APP_KEY: ${{ secrets.PUSH_O_MATIC_APP_KEY }}
-      WEBLATE_TOKEN: ${{ secrets.WEBLATE_TOKEN }}
-
   bump_version:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
To be reverted once the workflow actually works
