### PR TITLE
fix(server): validate token permission

### DIFF
--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -49,7 +49,7 @@ export class AuthController {
   }
 
   @Post('validateToken')
-  @Authenticated()
+  @Authenticated({ permission: false })
   @HttpCode(HttpStatus.OK)
   validateAccessToken(): ValidateAccessTokenResponseDto {
     return { authStatus: true };


### PR DESCRIPTION
Don't require a specific permission to validate an auth token.

Fixes #21710

<img width="2107" height="559" alt="image" src="https://github.com/user-attachments/assets/118bb573-4a4b-475b-9555-1ff52732694a" />
