### PR TITLE
fix(web): don't refer to inexistent file

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -12,6 +12,5 @@
     "strict": true,
     "target": "es2022",
     "types": ["vitest/globals"]
-  },
-  "extends": "./.svelte-kit/tsconfig.json"
+  }
 }


### PR DESCRIPTION
## Description

Currently the following warning is printed:
```
▲ [WARNING] Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]

    tsconfig.json:16:13:
      16 │   "extends": "./.svelte-kit/tsconfig.json"
         ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None was.