### PR TITLE
fix: trigger for weblate checks

### DIFF
--- a/.github/workflows/weblate-lock.yml
+++ b/.github/workflows/weblate-lock.yml
@@ -1,7 +1,8 @@
 name: Weblate checks
 
 on:
-  pull_request_review:
+  pull_request:
+    branches: [main]
 
 permissions: {}
 


### PR DESCRIPTION
This trigger should also include `auto_merge_enabled` events, which means the merge workflow would trigger it and all things should be happy.