### PR TITLE
fix(server): always use zip64 instead of zip-classic

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -82,7 +82,7 @@ export class StorageRepository {
   }
 
   createZipStream(): ImmichZipStream {
-    const archive = archiver('zip', { store: true });
+    const archive = archiver('zip', { store: true, forceZip64: true });
 
     const addFile = (input: string, filename: string) => {
       archive.file(input, { name: filename, mode: 0o644 });


### PR DESCRIPTION
Use zip 64 (2001) instead of zip classic (1989) which supports individual files and total archive sizes bigger than 4GiB.

Fixes #20095