### PR TITLE
fix(web): handle buckets before year 1000

### DIFF
--- a/web/src/lib/utils/timeline-util.spec.ts
+++ b/web/src/lib/utils/timeline-util.spec.ts
@@ -1,6 +1,6 @@
 import { locale } from '$lib/stores/preferences.store';
 import { parseUtcDate } from '$lib/utils/date-time';
-import { formatGroupTitle } from '$lib/utils/timeline-util';
+import { formatGroupTitle, toISOYearMonthUTC } from '$lib/utils/timeline-util';
 import { DateTime } from 'luxon';
 
 describe('formatGroupTitle', () => {
@@ -75,5 +75,15 @@ describe('formatGroupTitle', () => {
     expect(formatGroupTitle(date)).toBe('Invalid DateTime');
     locale.set('es');
     expect(formatGroupTitle(date)).toBe('Invalid DateTime');
+  });
+});
+
+describe('toISOYearMonthUTC', () => {
+  it('should prefix year with 0s', () => {
+    expect(toISOYearMonthUTC({ year: 28, month: 1 })).toBe('0028-01-01T00:00:00.000Z');
+  });
+
+  it('should prefix month with 0s', () => {
+    expect(toISOYearMonthUTC({ year: 2025, month: 1 })).toBe('2025-01-01T00:00:00.000Z');
   });
 });

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -94,8 +94,11 @@ export const fromTimelinePlainYearMonth = (timelineYearMonth: TimelineYearMonth)
     { zone: 'local', locale: get(locale) },
   ) as DateTime<true>;
 
-export const toISOYearMonthUTC = ({ year, month }: TimelineYearMonth): string =>
-  `${year}-${month.toString().padStart(2, '0')}-01T00:00:00.000Z`;
+export const toISOYearMonthUTC = ({ year, month }: TimelineYearMonth): string => {
+  const yearFull = `${year}`.padStart(4, '0');
+  const monthFull = `${month}`.padStart(2, '0');
+  return `${yearFull}-${monthFull}-01T00:00:00.000Z`;
+};
 
 export function formatMonthGroupTitle(_date: DateTime): string {
   if (!_date.isValid) {


### PR DESCRIPTION
Fixes #18871 by sending back years that are always at least 4 digits long.