### PR TITLE
fix(server): bulk edit rating

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -420,7 +420,7 @@ describe(AssetService.name, () => {
         ids: ['asset-1'],
         latitude: 0,
         longitude: 0,
-        visibility: undefined,
+        visibility: AssetVisibility.Archive,
         isFavorite: false,
         duplicateId: undefined,
         rating: undefined,


### PR DESCRIPTION
Bulk asset update writes to both the exif and the asset table, but rating was going to asset instead of exif.

Fixes #19781