### PR TITLE
fix(server): fix devcontainer JRE and curl in Trixie

### DIFF
--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -27,8 +27,8 @@ ENTRYPOINT ["tini", "--", "/bin/bash", "-c"]
 FROM dev AS dev-container-server
 
 RUN apt-get update --allow-releaseinfo-change && \
-  apt-get install sudo inetutils-ping openjdk-11-jre-headless \
-  vim nano \
+  apt-get install sudo inetutils-ping openjdk-21-jre-headless \
+  vim nano curl \
   -y --no-install-recommends --fix-missing
 
 RUN usermod -aG sudo node && \


### PR DESCRIPTION
## Description

JRE in devcontainer dockerfile (required for "make open-api") cannot be installed since switching to Trixie (https://github.com/immich-app/immich/pull/21786, https://github.com/immich-app/base-images/pull/264 - see here why testing/sid sources are disabled).
```
E: Package 'openjdk-11-jre-headless' has no installation candidate
```

I can think of the following options:
- **This PR: switch to newer JRE from default Trixie packaging**
- Alternatively, re-add testing/sid to keep java 11 if it makes sense (installation size: 11 - 170MB, 21 - 200MB, 25 - 240MB)
- Do not add java package 😛 assuming whoever needs it can install it upon encountering "/bin/sh: java: command not found"

## How Has This Been Tested?

I've run `make open-api` on versions 11, 21, 25. They all produce the same output in `open-api` and `mobile/openapi`. As expected.

## Unrelated

There are a few more missing deps. But this is for the `base-images` repo, I guess.
- curl - prevents devcontainer frontend from starting
- (arm64) libdrm2 and libx265 - non-fatal; ffmpeg/ffprobe fails when generating thumbnails

<details>
<summary>Missing deps info</summary>

curl
```sh
Waiting for api server...
/immich-devcontainer/container-start-frontend.sh: line 20: curl: command not found
```

(arm64) libdrm2 and libx265
```sh
/usr/bin/ffprobe: error while loading shared libraries: libdrm.so.2: cannot open shared object file: No such file or directory
/usr/bin/ffprobe: error while loading shared libraries: libx265.so.215: cannot open shared object file: No such file or directory

docker exec immich_server sudo apt-get install -y --no-install-recommends libdrm2 libx265-215
docker exec immich_server ldd /usr/bin/ffprobe | egrep 'not|libdrm|libx265'
	libdrm.so.2 => /lib/aarch64-linux-gnu/libdrm.so.2 (0x0000ffffa4560000)
	libx265.so.215 => /lib/aarch64-linux-gnu/libx265.so.215 (0x0000ffffa19b0000)
```
</details>

## UPD

Added `curl` to this PR as suggested by @Chuckame 