### PR TITLE
fix: align asset viewer context menu to the left of activator icon

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -176,7 +176,14 @@
     {#if isOwner}
       <DeleteAction {asset} {onAction} {preAction} />
 
-      <ButtonContextMenu direction="left" align="top-right" color="secondary" title={$t('more')} icon={mdiDotsVertical}>
+      <ButtonContextMenu
+        offset={{ x: 50, y: 0 }}
+        direction="left"
+        align="top-right"
+        color="secondary"
+        title={$t('more')}
+        icon={mdiDotsVertical}
+      >
         {#if showSlideshow && !isLocked}
           <MenuOption icon={mdiPresentationPlay} text={$t('slideshow')} onClick={onPlaySlideshow} />
         {/if}


### PR DESCRIPTION
## Description

It a hassle, in my opinion, to not be able to close the context menu from the same button you click on to open it.

This moves the context menu popover to the left of the context menu button when it's open. This allows the menu to be opened and closed from the same location of the page, without needing to move your mouse to close the menu.

I don't know if the purpose of this project is explicitly to copy the UI of Google Photos. The status quo in Immich is the same as Google Photos, but it's not an ideal UX, in my opinion.

## How Has This Been Tested?


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

**Before:**


https://github.com/user-attachments/assets/a7bc704a-57bd-4fa2-90ea-f5f1896a9627



**After:**

https://github.com/user-attachments/assets/63abcaa3-d440-4968-b19c-7b77b929e213


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
