### PR TITLE
fix: format point count numbers on map view

### DIFF
--- a/web/src/lib/components/shared-components/map/map.svelte
+++ b/web/src/lib/components/shared-components/map/map.svelte
@@ -353,7 +353,7 @@
           <div
             class="rounded-full w-[40px] h-[40px] bg-immich-primary text-white flex justify-center items-center font-mono font-bold shadow-lg hover:bg-immich-dark-primary transition-all duration-200 hover:text-immich-dark-bg opacity-90"
           >
-            {feature.properties?.point_count}
+            {feature.properties?.point_count?.toLocaleString()}
           </div>
         {/snippet}
       </MarkerLayer>


### PR DESCRIPTION
## Description

This adds a thousands separator (or whatever is locale-appropriate) to the circles on the map view.

## How Has This Been Tested?

Viewing the map

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

**Before:** 

<img width="233" height="222" alt="image" src="https://github.com/user-attachments/assets/b8e4c3fc-bee7-4625-a502-da8c5e4d62cc" />


**After:**

<img width="198" height="180" alt="image" src="https://github.com/user-attachments/assets/0b40a1e0-1b1c-404f-a721-621d1d66b505" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
