### PR TITLE
chore(mobile): add `debugPrint` lint rule

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -134,6 +134,13 @@ custom_lint:
 
 dart_code_metrics:
   rules:
+    - banned-usage:
+        entries:
+          - name: debugPrint
+            description: Use dPrint instead of debugPrint for proper tree-shaking in release builds.
+            exclude-paths:
+              - 'lib/utils/debug_print.dart'
+            severity: perf
     # All rules from "recommended" preset
     # Show potential errors
   #  - avoid-cascade-after-if-null

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -1,5 +1,8 @@
-import 'package:analyzer/error/error.dart' show ErrorSeverity;
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/error/error.dart' show ErrorSeverity, AnalysisError;
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 // ignore: depend_on_referenced_packages
 import 'package:glob/glob.dart';
@@ -19,6 +22,10 @@ class ImmichLinter extends PluginBase {
         rules.add(ImportRule(code, buildGlob(allowedPaths),
             buildGlob(forbiddenPaths), restrict));
       }
+    }
+
+    if (configs.rules[NoDebugPrintRule.name]?.enabled ?? true) {
+      rules.add(NoDebugPrintRule());
     }
     return rules;
   }
@@ -82,6 +89,153 @@ class ImportRule extends DartLintRule {
         if (uri.startsWith(restricted) == true) {
           reporter.atNode(node, code);
           return;
+        }
+      }
+    });
+  }
+}
+
+class NoDebugPrintRule extends DartLintRule {
+  static const name = 'no_debug_print';
+  static const importPath = 'package:flutter/src/foundation/print.dart';
+  static const _code = LintCode(
+    name: name,
+    problemMessage:
+        'Use dPrint instead of debugPrint for proper tree-shaking in release builds.',
+    correctionMessage: 'Replace debugPrint with dPrint',
+    errorSeverity: ErrorSeverity.WARNING,
+  );
+
+  NoDebugPrintRule() : super(code: _code);
+
+  @pragma('vm:prefer-inline')
+  static bool isDebugPrint(Element2? element) {
+    return element is PropertyAccessorElement2 &&
+        element.variable3?.getter2?.name3 == 'debugPrint' &&
+        element.library2.identifier == importPath;
+  }
+
+  @pragma('vm:prefer-inline')
+  static bool isWrapped(AstNode node) {
+    AstNode? parent = node.parent;
+    while (parent != null) {
+      if (parent case IfStatement(:SimpleIdentifier expression)
+          when expression.name == 'kDebugMode') {
+        return true;
+      }
+      parent = parent.parent;
+    }
+
+    return false;
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addFunctionExpressionInvocation((node) {
+      final function = node.function;
+      if (function case SimpleIdentifier(:final element)
+          when isDebugPrint(element) && !isWrapped(node)) {
+        reporter.atNode(function, code);
+      }
+    });
+
+    context.registry.addMethodInvocation((node) {
+      final methodName = node.methodName;
+      if (isDebugPrint(methodName.element) && !isWrapped(node)) {
+        reporter.atNode(methodName, code);
+      }
+    });
+  }
+
+  @override
+  List<Fix> getFixes() => [ReplaceDebugPrintFix()];
+}
+
+class ReplaceDebugPrintFix extends DartFix {
+  static const dPrintImportPath =
+      "import 'package:immich_mobile/utils/debug_print.dart';";
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError error,
+    List<AnalysisError> allErrors,
+  ) {
+    context.registry.addFunctionExpressionInvocation((node) {
+      final function = node.function;
+      if (error.sourceRange == function.sourceRange &&
+          function is SimpleIdentifier &&
+          NoDebugPrintRule.isDebugPrint(function.element)) {
+        _createFix(reporter, resolver, function, node);
+      }
+    });
+
+    context.registry.addMethodInvocation((node) {
+      final methodName = node.methodName;
+      if (error.sourceRange == methodName.sourceRange &&
+          NoDebugPrintRule.isDebugPrint(methodName.element)) {
+        _createFix(reporter, resolver, methodName, node);
+      }
+    });
+  }
+
+  void _createFix(
+    ChangeReporter reporter,
+    CustomLintResolver resolver,
+    SimpleIdentifier identifier,
+    AstNode node,
+  ) {
+    final arguments = switch (node) {
+      MethodInvocation(:final argumentList) => argumentList,
+      FunctionExpressionInvocation(:final argumentList) => argumentList,
+      _ => null,
+    };
+    if (arguments == null) {
+      return;
+    }
+
+    final changeBuilder = reporter.createChangeBuilder(
+      message: 'Replace with dPrint',
+      priority: 1,
+    );
+
+    changeBuilder.addDartFileEdit((builder) {
+      builder.addSimpleReplacement(identifier.sourceRange, 'dPrint');
+      final firstArg = arguments.arguments.firstOrNull;
+      if (firstArg != null) {
+        final argSource = resolver.source.contents.data.substring(
+          firstArg.offset,
+          firstArg.end,
+        );
+
+        builder.addSimpleReplacement(
+          SourceRange(firstArg.offset, firstArg.length),
+          '() => $argSource',
+        );
+      }
+
+      if (resolver.source.contents.data.contains(dPrintImportPath)) {
+        return;
+      }
+
+      final unit = node.root;
+      if (unit is CompilationUnit) {
+        final lastImport =
+            unit.directives.whereType<ImportDirective>().lastOrNull;
+
+        if (lastImport != null) {
+          builder.addSimpleInsertion(lastImport.end, '\n$dPrintImportPath');
+        } else if (unit.directives.isNotEmpty) {
+          builder.addSimpleInsertion(
+              unit.directives.last.end, '\n\n$dPrintImportPath');
+        } else {
+          builder.addSimpleInsertion(0, '$dPrintImportPath\n\n');
         }
       }
     });

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -20,7 +20,6 @@ class ImmichLinter extends PluginBase {
             buildGlob(forbiddenPaths), restrict));
       }
     }
-
     return rules;
   }
 

--- a/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
+++ b/mobile/immich_lint/lib/immich_mobile_immich_lint.dart
@@ -1,8 +1,5 @@
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element2.dart';
-import 'package:analyzer/error/error.dart' show ErrorSeverity, AnalysisError;
+import 'package:analyzer/error/error.dart' show ErrorSeverity;
 import 'package:analyzer/error/listener.dart';
-import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 // ignore: depend_on_referenced_packages
 import 'package:glob/glob.dart';
@@ -24,9 +21,6 @@ class ImmichLinter extends PluginBase {
       }
     }
 
-    if (configs.rules[NoDebugPrintRule.name]?.enabled ?? true) {
-      rules.add(NoDebugPrintRule());
-    }
     return rules;
   }
 
@@ -89,153 +83,6 @@ class ImportRule extends DartLintRule {
         if (uri.startsWith(restricted) == true) {
           reporter.atNode(node, code);
           return;
-        }
-      }
-    });
-  }
-}
-
-class NoDebugPrintRule extends DartLintRule {
-  static const name = 'no_debug_print';
-  static const importPath = 'package:flutter/src/foundation/print.dart';
-  static const _code = LintCode(
-    name: name,
-    problemMessage:
-        'Use dPrint instead of debugPrint for proper tree-shaking in release builds.',
-    correctionMessage: 'Replace debugPrint with dPrint',
-    errorSeverity: ErrorSeverity.WARNING,
-  );
-
-  NoDebugPrintRule() : super(code: _code);
-
-  @pragma('vm:prefer-inline')
-  static bool isDebugPrint(Element2? element) {
-    return element is PropertyAccessorElement2 &&
-        element.variable3?.getter2?.name3 == 'debugPrint' &&
-        element.library2.identifier == importPath;
-  }
-
-  @pragma('vm:prefer-inline')
-  static bool isWrapped(AstNode node) {
-    AstNode? parent = node.parent;
-    while (parent != null) {
-      if (parent case IfStatement(:SimpleIdentifier expression)
-          when expression.name == 'kDebugMode') {
-        return true;
-      }
-      parent = parent.parent;
-    }
-
-    return false;
-  }
-
-  @override
-  void run(
-    CustomLintResolver resolver,
-    ErrorReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addFunctionExpressionInvocation((node) {
-      final function = node.function;
-      if (function case SimpleIdentifier(:final element)
-          when isDebugPrint(element) && !isWrapped(node)) {
-        reporter.atNode(function, code);
-      }
-    });
-
-    context.registry.addMethodInvocation((node) {
-      final methodName = node.methodName;
-      if (isDebugPrint(methodName.element) && !isWrapped(node)) {
-        reporter.atNode(methodName, code);
-      }
-    });
-  }
-
-  @override
-  List<Fix> getFixes() => [ReplaceDebugPrintFix()];
-}
-
-class ReplaceDebugPrintFix extends DartFix {
-  static const dPrintImportPath =
-      "import 'package:immich_mobile/utils/debug_print.dart';";
-
-  @override
-  void run(
-    CustomLintResolver resolver,
-    ChangeReporter reporter,
-    CustomLintContext context,
-    AnalysisError error,
-    List<AnalysisError> allErrors,
-  ) {
-    context.registry.addFunctionExpressionInvocation((node) {
-      final function = node.function;
-      if (error.sourceRange == function.sourceRange &&
-          function is SimpleIdentifier &&
-          NoDebugPrintRule.isDebugPrint(function.element)) {
-        _createFix(reporter, resolver, function, node);
-      }
-    });
-
-    context.registry.addMethodInvocation((node) {
-      final methodName = node.methodName;
-      if (error.sourceRange == methodName.sourceRange &&
-          NoDebugPrintRule.isDebugPrint(methodName.element)) {
-        _createFix(reporter, resolver, methodName, node);
-      }
-    });
-  }
-
-  void _createFix(
-    ChangeReporter reporter,
-    CustomLintResolver resolver,
-    SimpleIdentifier identifier,
-    AstNode node,
-  ) {
-    final arguments = switch (node) {
-      MethodInvocation(:final argumentList) => argumentList,
-      FunctionExpressionInvocation(:final argumentList) => argumentList,
-      _ => null,
-    };
-    if (arguments == null) {
-      return;
-    }
-
-    final changeBuilder = reporter.createChangeBuilder(
-      message: 'Replace with dPrint',
-      priority: 1,
-    );
-
-    changeBuilder.addDartFileEdit((builder) {
-      builder.addSimpleReplacement(identifier.sourceRange, 'dPrint');
-      final firstArg = arguments.arguments.firstOrNull;
-      if (firstArg != null) {
-        final argSource = resolver.source.contents.data.substring(
-          firstArg.offset,
-          firstArg.end,
-        );
-
-        builder.addSimpleReplacement(
-          SourceRange(firstArg.offset, firstArg.length),
-          '() => $argSource',
-        );
-      }
-
-      if (resolver.source.contents.data.contains(dPrintImportPath)) {
-        return;
-      }
-
-      final unit = node.root;
-      if (unit is CompilationUnit) {
-        final lastImport =
-            unit.directives.whereType<ImportDirective>().lastOrNull;
-
-        if (lastImport != null) {
-          builder.addSimpleInsertion(lastImport.end, '\n$dPrintImportPath');
-        } else if (unit.directives.isNotEmpty) {
-          builder.addSimpleInsertion(
-              unit.directives.last.end, '\n\n$dPrintImportPath');
-        } else {
-          builder.addSimpleInsertion(0, '$dPrintImportPath\n\n');
         }
       }
     });

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -31,6 +31,7 @@ import 'package:immich_mobile/utils/http_ssl_options.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
 import 'package:worker_manager/worker_manager.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class BackgroundWorkerFgService {
   final BackgroundWorkerFgHostApi _foregroundHostApi;
@@ -159,7 +160,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
     try {
       await _cleanup();
     } catch (error, stack) {
-      debugPrint('Failed to cleanup background worker: $error with stack: $stack');
+      dPrint(() => 'Failed to cleanup background worker: $error with stack: $stack');
     }
   }
 
@@ -192,7 +193,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       await Future.wait(cleanupFutures);
       _logger.info("Background worker resources cleaned up");
     } catch (error, stack) {
-      debugPrint('Failed to cleanup background worker: $error with stack: $stack');
+      dPrint(() => 'Failed to cleanup background worker: $error with stack: $stack');
     }
   }
 
@@ -230,7 +231,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
             .startBackupWithHttpClient(currentUser.id, networkCapabilities.hasWifi, _cancellationToken);
       },
       (error, stack) {
-        debugPrint("Error in backup zone $error, $stack");
+        dPrint(() => "Error in backup zone $error, $stack");
       },
     );
   }

--- a/mobile/lib/domain/services/log.service.dart
+++ b/mobile/lib/domain/services/log.service.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/log.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/log.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:logging/logging.dart';
 
 /// Service responsible for handling application logging.
@@ -66,13 +66,12 @@ class LogService {
   }
 
   void _handleLogRecord(LogRecord r) {
-    if (kDebugMode) {
-      debugPrint(
+    dPrint(
+      () =>
         '[${r.level.name}] [${r.time}] [${r.loggerName}] ${r.message}'
         '${r.error == null ? '' : '\nError: ${r.error}'}'
         '${r.stackTrace == null ? '' : '\nStack: ${r.stackTrace}'}',
-      );
-    }
+    );
 
     final record = LogMessage(
       message: r.message,

--- a/mobile/lib/domain/services/log.service.dart
+++ b/mobile/lib/domain/services/log.service.dart
@@ -68,9 +68,9 @@ class LogService {
   void _handleLogRecord(LogRecord r) {
     dPrint(
       () =>
-        '[${r.level.name}] [${r.time}] [${r.loggerName}] ${r.message}'
-        '${r.error == null ? '' : '\nError: ${r.error}'}'
-        '${r.stackTrace == null ? '' : '\nStack: ${r.stackTrace}'}',
+          '[${r.level.name}] [${r.time}] [${r.loggerName}] ${r.message}'
+          '${r.error == null ? '' : '\nError: ${r.error}'}'
+          '${r.stackTrace == null ? '' : '\nStack: ${r.stackTrace}'}',
     );
 
     final record = LogMessage(

--- a/mobile/lib/domain/services/partner.service.dart
+++ b/mobile/lib/domain/services/partner.service.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/partner.repository.dart';
 import 'package:immich_mobile/repositories/partner_api.repository.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class DriftPartnerService {
   final DriftPartnerRepository _driftPartnerRepository;
@@ -30,7 +30,7 @@ class DriftPartnerService {
   Future<void> toggleShowInTimeline(String partnerId, String userId) async {
     final partner = await _driftPartnerRepository.getPartner(partnerId, userId);
     if (partner == null) {
-      debugPrint("Partner not found: $partnerId for user: $userId");
+      dPrint(() => "Partner not found: $partnerId for user: $userId");
       return;
     }
 

--- a/mobile/lib/domain/services/sync_linked_album.service.dart
+++ b/mobile/lib/domain/services/sync_linked_album.service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
@@ -6,6 +5,7 @@ import 'package:immich_mobile/infrastructure/repositories/remote_album.repositor
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/repositories/drift_album_api_repository.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final syncLinkedAlbumServiceProvider = Provider(
   (ref) => SyncLinkedAlbumService(
@@ -100,7 +100,7 @@ class SyncLinkedAlbumService {
 
   /// Creates a new remote album and links it to the local album
   Future<void> _createAndLinkNewRemoteAlbum(LocalAlbum localAlbum) async {
-    debugPrint("Creating new remote album for local album: ${localAlbum.name}");
+    dPrint(() => "Creating new remote album for local album: ${localAlbum.name}");
     final newRemoteAlbum = await _albumApiRepository.createDriftAlbum(localAlbum.name, assetIds: []);
     await _remoteAlbumRepository.create(newRemoteAlbum, []);
     return _localAlbumRepository.linkRemoteAlbum(localAlbum.id, newRemoteAlbum.id);

--- a/mobile/lib/extensions/translate_extensions.dart
+++ b/mobile/lib/extensions/translate_extensions.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:intl/message_format.dart';
 import 'package:flutter/material.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 extension StringTranslateExtension on String {
   String t({BuildContext? context, Map<String, Object>? args}) {
@@ -39,7 +40,7 @@ String _translateHelper(BuildContext? context, String key, [Map<String, Object>?
         ? MessageFormat(translatedMessage, locale: Intl.defaultLocale ?? 'en').format(args)
         : translatedMessage;
   } catch (e) {
-    debugPrint('Translation failed for key "$key". Error: $e');
+    dPrint(() => 'Translation failed for key "$key". Error: $e');
     return key;
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -39,6 +39,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:logging/logging.dart';
 import 'package:timezone/data/latest.dart';
 import 'package:worker_manager/worker_manager.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 void main() async {
   ImmichWidgetsBinding();
@@ -69,9 +70,9 @@ Future<void> initApp() async {
   if (kReleaseMode && Platform.isAndroid) {
     try {
       await FlutterDisplayMode.setHighRefreshRate();
-      debugPrint("Enabled high refresh mode");
+      dPrint(() => "Enabled high refresh mode");
     } catch (e) {
-      debugPrint("Error setting high refresh rate: $e");
+      dPrint(() => "Error setting high refresh rate: $e");
     }
   }
 
@@ -126,23 +127,23 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        debugPrint("[APP STATE] resumed");
+        dPrint(() => "[APP STATE] resumed");
         ref.read(appStateProvider.notifier).handleAppResume();
         break;
       case AppLifecycleState.inactive:
-        debugPrint("[APP STATE] inactive");
+        dPrint(() => "[APP STATE] inactive");
         ref.read(appStateProvider.notifier).handleAppInactivity();
         break;
       case AppLifecycleState.paused:
-        debugPrint("[APP STATE] paused");
+        dPrint(() => "[APP STATE] paused");
         ref.read(appStateProvider.notifier).handleAppPause();
         break;
       case AppLifecycleState.detached:
-        debugPrint("[APP STATE] detached");
+        dPrint(() => "[APP STATE] detached");
         ref.read(appStateProvider.notifier).handleAppDetached();
         break;
       case AppLifecycleState.hidden:
-        debugPrint("[APP STATE] hidden");
+        dPrint(() => "[APP STATE] hidden");
         ref.read(appStateProvider.notifier).handleAppHidden();
         break;
     }
@@ -200,7 +201,7 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
   @override
   initState() {
     super.initState();
-    initApp().then((_) => debugPrint("App Init Completed"));
+    initApp().then((_) => dPrint(() => "App Init Completed"));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // needs to be delayed so that EasyLocalization is working
       if (Store.isBetaTimelineEnabled) {

--- a/mobile/lib/presentation/pages/drift_partner_detail.page.dart
+++ b/mobile/lib/presentation/pages/drift_partner_detail.page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/providers/infrastructure/user.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/mesmerizing_sliver_app_bar.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 @RoutePage()
 class DriftPartnerDetailPage extends StatelessWidget {
@@ -68,7 +69,7 @@ class _InfoBoxState extends ConsumerState<_InfoBox> {
         _inTimeline = !_inTimeline;
       });
     } catch (error, stack) {
-      debugPrint("Failed to toggle in timeline: $error $stack");
+      dPrint(() => "Failed to toggle in timeline: $error $stack");
       ImmichToast.show(
         context: context,
         toastType: ToastType.error,

--- a/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_birthday_modal.widget.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:scroll_date_picker/scroll_date_picker.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class DriftPersonBirthdayEditForm extends ConsumerStatefulWidget {
   final DriftPerson person;
@@ -36,7 +37,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonBirthdayEdi
         context.pop<DateTime>(_selectedDate);
       }
     } catch (error) {
-      debugPrint('Error updating birthday: $error');
+      dPrint(() => 'Error updating birthday: $error');
 
       if (!context.mounted) {
         return;

--- a/mobile/lib/presentation/widgets/people/person_edit_name_modal.widget.dart
+++ b/mobile/lib/presentation/widgets/people/person_edit_name_modal.widget.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class DriftPersonNameEditForm extends ConsumerStatefulWidget {
   final DriftPerson person;
@@ -34,7 +35,7 @@ class _DriftPersonNameEditFormState extends ConsumerState<DriftPersonNameEditFor
         context.pop<String>(newName);
       }
     } catch (error) {
-      debugPrint('Error updating name: $error');
+      dPrint(() => 'Error updating name: $error');
 
       if (!context.mounted) {
         return;

--- a/mobile/lib/providers/asset.provider.dart
+++ b/mobile/lib/providers/asset.provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
@@ -13,6 +12,7 @@ import 'package:immich_mobile/services/etag.service.dart';
 import 'package:immich_mobile/services/exif.service.dart';
 import 'package:immich_mobile/services/sync.service.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final assetProvider = StateNotifierProvider<AssetNotifier, bool>((ref) {
   return AssetNotifier(
@@ -68,7 +68,7 @@ class AssetNotifier extends StateNotifier<bool> {
       }
       final bool newRemote = await _assetService.refreshRemoteAssets();
       final bool newLocal = await _albumService.refreshDeviceAlbums();
-      debugPrint("changedUsers: $changedUsers, newRemote: $newRemote, newLocal: $newLocal");
+      dPrint(() => "changedUsers: $changedUsers, newRemote: $newRemote, newLocal: $newLocal");
       if (newRemote) {
         _ref.invalidate(memoryFutureProvider);
       }

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_udid/flutter_udid.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
@@ -18,6 +17,7 @@ import 'package:immich_mobile/services/widget.service.dart';
 import 'package:immich_mobile/utils/hash.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final authProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
   return AuthNotifier(
@@ -150,10 +150,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       _log.severe("Error getting user information from the server [API EXCEPTION]", stackTrace);
     } catch (error, stackTrace) {
       _log.severe("Error getting user information from the server [CATCH ALL]", error, stackTrace);
-
-      if (kDebugMode) {
-        debugPrint("Error getting user information from the server [CATCH ALL] $error $stackTrace");
-      }
+      dPrint(() => "Error getting user information from the server [CATCH ALL] $error $stackTrace");
     }
 
     // If the user is null, the login was not successful

--- a/mobile/lib/providers/backup/backup.provider.dart
+++ b/mobile/lib/providers/backup/backup.provider.dart
@@ -2,8 +2,6 @@ import 'dart:io';
 
 import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/album.entity.dart';
@@ -33,6 +31,7 @@ import 'package:immich_mobile/utils/diff.dart';
 import 'package:logging/logging.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final backupProvider = StateNotifierProvider<BackupNotifier, BackUpState>((ref) {
   return BackupNotifier(
@@ -286,7 +285,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
     state = state.copyWith(selectedBackupAlbums: selectedAlbums, excludedBackupAlbums: excludedAlbums);
 
     log.info("_getBackupAlbumsInfo: Found ${availableAlbums.length} available albums");
-    debugPrint("_getBackupAlbumsInfo takes ${stopwatch.elapsedMilliseconds}ms");
+    dPrint(() => "_getBackupAlbumsInfo takes ${stopwatch.elapsedMilliseconds}ms");
   }
 
   ///
@@ -428,7 +427,7 @@ class BackupNotifier extends StateNotifier<BackUpState> {
 
   /// Invoke backup process
   Future<void> startBackupProcess() async {
-    debugPrint("Start backup process");
+    dPrint(() => "Start backup process");
     assert(state.backupProgress == BackUpProgressEnum.idle);
     state = state.copyWith(backupProgress: BackUpProgressEnum.inProgress);
 

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
@@ -14,6 +13,7 @@ import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/upload.service.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class EnqueueStatus {
   final int enqueueCount;
@@ -329,16 +329,16 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   }
 
   Future<void> cancel() async {
-    debugPrint("Canceling backup tasks...");
+    dPrint(() => "Canceling backup tasks...");
     state = state.copyWith(enqueueCount: 0, enqueueTotalCount: 0, isCanceling: true);
 
     final activeTaskCount = await _uploadService.cancelBackup();
 
     if (activeTaskCount > 0) {
-      debugPrint("$activeTaskCount tasks left, continuing to cancel...");
+      dPrint(() => "$activeTaskCount tasks left, continuing to cancel...");
       await cancel();
     } else {
-      debugPrint("All tasks canceled successfully.");
+      dPrint(() => "All tasks canceled successfully.");
       // Clear all upload items when cancellation is complete
       state = state.copyWith(isCanceling: false, uploadItems: {});
     }

--- a/mobile/lib/providers/backup/manual_upload.provider.dart
+++ b/mobile/lib/providers/backup/manual_upload.provider.dart
@@ -30,6 +30,7 @@ import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:logging/logging.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final manualUploadProvider = StateNotifierProvider<ManualUploadNotifier, ManualUploadState>((ref) {
   return ManualUploadNotifier(
@@ -216,7 +217,7 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
         );
 
         if (uploadAssets.isEmpty) {
-          debugPrint("[_startUpload] No Assets to upload - Abort Process");
+          dPrint(() => "[_startUpload] No Assets to upload - Abort Process");
           _backupProvider.updateBackupProgress(BackUpProgressEnum.idle);
           return false;
         }
@@ -294,10 +295,10 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
         }
       } else {
         openAppSettings();
-        debugPrint("[_startUpload] Do not have permission to the gallery");
+        dPrint(() => "[_startUpload] Do not have permission to the gallery");
       }
     } catch (e) {
-      debugPrint("ERROR _startUpload: ${e.toString()}");
+      dPrint(() => "ERROR _startUpload: ${e.toString()}");
       hasErrors = true;
     } finally {
       _backupProvider.updateBackupProgress(BackUpProgressEnum.idle);
@@ -340,7 +341,7 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
     // waits until it has stopped to start the backup.
     final bool hasLock = await ref.read(backgroundServiceProvider).acquireLock();
     if (!hasLock) {
-      debugPrint("[uploadAssets] could not acquire lock, exiting");
+      dPrint(() => "[uploadAssets] could not acquire lock, exiting");
       ImmichToast.show(
         context: context,
         msg: "failed".tr(),
@@ -355,18 +356,18 @@ class ManualUploadNotifier extends StateNotifier<ManualUploadState> {
 
     // check if backup is already in process - then return
     if (_backupProvider.backupProgress == BackUpProgressEnum.manualInProgress) {
-      debugPrint("[uploadAssets] Manual upload is already running - abort");
+      dPrint(() => "[uploadAssets] Manual upload is already running - abort");
       showInProgress = true;
     }
 
     if (_backupProvider.backupProgress == BackUpProgressEnum.inProgress) {
-      debugPrint("[uploadAssets] Auto Backup is already in progress - abort");
+      dPrint(() => "[uploadAssets] Auto Backup is already in progress - abort");
       showInProgress = true;
       return false;
     }
 
     if (_backupProvider.backupProgress == BackUpProgressEnum.inBackground) {
-      debugPrint("[uploadAssets] Background backup is running - abort");
+      dPrint(() => "[uploadAssets] Background backup is running - abort");
       showInProgress = true;
     }
 

--- a/mobile/lib/providers/theme.provider.dart
+++ b/mobile/lib/providers/theme.provider.dart
@@ -7,11 +7,12 @@ import 'package:immich_mobile/theme/theme_data.dart';
 import 'package:immich_mobile/theme/dynamic_theme.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final immichThemeModeProvider = StateProvider<ThemeMode>((ref) {
   final themeMode = ref.watch(appSettingsServiceProvider).getSetting(AppSettingsEnum.themeMode);
 
-  debugPrint("Current themeMode $themeMode");
+  dPrint(() => "Current themeMode $themeMode");
 
   if (themeMode == ThemeMode.light.name) {
     return ThemeMode.light;
@@ -26,12 +27,12 @@ final immichThemePresetProvider = StateProvider<ImmichColorPreset>((ref) {
   final appSettingsProvider = ref.watch(appSettingsServiceProvider);
   final primaryColorPreset = appSettingsProvider.getSetting(AppSettingsEnum.primaryColor);
 
-  debugPrint("Current theme preset $primaryColorPreset");
+  dPrint(() => "Current theme preset $primaryColorPreset");
 
   try {
     return ImmichColorPreset.values.firstWhere((e) => e.name == primaryColorPreset);
   } catch (e) {
-    debugPrint("Theme preset $primaryColorPreset not found. Applying default preset.");
+    dPrint(() => "Theme preset $primaryColorPreset not found. Applying default preset.");
     appSettingsProvider.setSetting(AppSettingsEnum.primaryColor, defaultColorPresetName);
     return defaultColorPreset;
   }

--- a/mobile/lib/providers/upload_profile_image.provider.dart
+++ b/mobile/lib/providers/upload_profile_image.provider.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:immich_mobile/domain/services/user.service.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 enum UploadProfileStatus { idle, loading, success, failure }
 
@@ -67,7 +67,7 @@ class UploadProfileImageNotifier extends StateNotifier<UploadProfileImageState> 
     var profileImagePath = await _userService.createProfileImage(file.name, await file.readAsBytes());
 
     if (profileImagePath != null) {
-      debugPrint("Successfully upload profile image");
+      dPrint(() => "Successfully upload profile image");
       state = state.copyWith(status: UploadProfileStatus.success, profileImagePath: profileImagePath);
       return true;
     }

--- a/mobile/lib/providers/websocket.provider.dart
+++ b/mobile/lib/providers/websocket.provider.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
@@ -20,6 +18,7 @@ import 'package:immich_mobile/utils/debounce.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 import 'package:socket_io_client/socket_io_client.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 enum PendingAction { assetDelete, assetUploaded, assetHidden, assetTrash }
 
@@ -105,7 +104,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
           headers["Authorization"] = "Basic ${base64.encode(utf8.encode(endpoint.userInfo))}";
         }
 
-        debugPrint("Attempting to connect to websocket");
+        dPrint(() => "Attempting to connect to websocket");
         // Configure socket transports must be specified
         Socket socket = io(
           endpoint.origin,
@@ -121,12 +120,12 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
         );
 
         socket.onConnect((_) {
-          debugPrint("Established Websocket Connection");
+          dPrint(() => "Established Websocket Connection");
           state = WebsocketState(isConnected: true, socket: socket, pendingChanges: state.pendingChanges);
         });
 
         socket.onDisconnect((_) {
-          debugPrint("Disconnect to Websocket Connection");
+          dPrint(() => "Disconnect to Websocket Connection");
           state = WebsocketState(isConnected: false, socket: null, pendingChanges: state.pendingChanges);
         });
 
@@ -150,13 +149,13 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
         socket.on('on_config_update', _handleOnConfigUpdate);
         socket.on('on_new_release', _handleReleaseUpdates);
       } catch (e) {
-        debugPrint("[WEBSOCKET] Catch Websocket Error - ${e.toString()}");
+        dPrint(() => "[WEBSOCKET] Catch Websocket Error - ${e.toString()}");
       }
     }
   }
 
   void disconnect() {
-    debugPrint("Attempting to disconnect from websocket");
+    dPrint(() => "Attempting to disconnect from websocket");
 
     _batchedAssetUploadReady.clear();
 
@@ -200,7 +199,7 @@ class WebsocketNotifier extends StateNotifier<WebsocketState> {
   }
 
   void listenUploadEvent() {
-    debugPrint("Start listening to event on_upload_success");
+    dPrint(() => "Start listening to event on_upload_success");
     state.socket?.on('on_upload_success', _handleOnUploadSuccess);
   }
 

--- a/mobile/lib/repositories/upload.repository.dart
+++ b/mobile/lib/repositories/upload.repository.dart
@@ -88,7 +88,8 @@ class UploadRepository {
       Canceled: ${canceledTasks.length}
       Waiting: ${waitingTasks.length}
       Paused: ${pausedTasks.length}
-    """);
+    """,
+    );
   }
 
   Future<void> backupWithDartClient(Iterable<UploadTaskWithFile> tasks, CancellationToken cancelToken) async {

--- a/mobile/lib/repositories/upload.repository.dart
+++ b/mobile/lib/repositories/upload.repository.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:cancellation_token_http/http.dart';
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class UploadTaskWithFile {
   final File file;
@@ -79,7 +79,9 @@ class UploadRepository {
       FileDownloader().database.allRecordsWithStatus(TaskStatus.paused, group: kBackupGroup),
     ]);
 
-    debugPrint("""
+    dPrint(
+      () =>
+          """
       Upload Info:
       Enqueued: ${enqueuedTasks.length}
       Running: ${runningTasks.length}

--- a/mobile/lib/routing/duplicate_guard.dart
+++ b/mobile/lib/routing/duplicate_guard.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/foundation.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 /// Guards against duplicate navigation to this route
 class DuplicateGuard extends AutoRouteGuard {
@@ -8,7 +8,7 @@ class DuplicateGuard extends AutoRouteGuard {
   void onNavigation(NavigationResolver resolver, StackRouter router) async {
     // Duplicate navigation
     if (resolver.route.name == router.current.name) {
-      debugPrint('DuplicateGuard: Preventing duplicate route navigation for ${resolver.route.name}');
+      dPrint(() => 'DuplicateGuard: Preventing duplicate route navigation for ${resolver.route.name}');
       resolver.next(false);
     } else {
       resolver.next(true);

--- a/mobile/lib/services/album.service.dart
+++ b/mobile/lib/services/album.service.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
@@ -24,6 +23,7 @@ import 'package:immich_mobile/services/entity.service.dart';
 import 'package:immich_mobile/services/sync.service.dart';
 import 'package:immich_mobile/utils/hash.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final albumServiceProvider = Provider(
   (ref) => AlbumService(
@@ -124,7 +124,7 @@ class AlbumService {
     } finally {
       _localCompleter.complete(changes);
     }
-    debugPrint("refreshDeviceAlbums took ${sw.elapsedMilliseconds}ms");
+    dPrint(() => "refreshDeviceAlbums took ${sw.elapsedMilliseconds}ms");
     return changes;
   }
 
@@ -172,7 +172,7 @@ class AlbumService {
     } finally {
       _remoteCompleter.complete(changes);
     }
-    debugPrint("refreshRemoteAlbums took ${sw.elapsedMilliseconds}ms");
+    dPrint(() => "refreshRemoteAlbums took ${sw.elapsedMilliseconds}ms");
     return changes;
   }
 
@@ -220,7 +220,7 @@ class AlbumService {
 
       return AlbumAddAssetsResponse(alreadyInAlbum: result.duplicates, successfullyAdded: addedAssets.length);
     } catch (e) {
-      debugPrint("Error addAssets  ${e.toString()}");
+      dPrint(() => "Error addAssets  ${e.toString()}");
     }
     return null;
   }
@@ -242,7 +242,7 @@ class AlbumService {
       await _albumRepository.update(album);
       return true;
     } catch (e) {
-      debugPrint("Error setActivityEnabled  ${e.toString()}");
+      dPrint(() => "Error setActivityEnabled  ${e.toString()}");
     }
     return false;
   }
@@ -271,7 +271,7 @@ class AlbumService {
       }
       return true;
     } catch (e) {
-      debugPrint("Error deleteAlbum  ${e.toString()}");
+      dPrint(() => "Error deleteAlbum  ${e.toString()}");
     }
     return false;
   }
@@ -281,7 +281,7 @@ class AlbumService {
       await _albumApiRepository.removeUser(album.remoteId!, userId: "me");
       return true;
     } catch (e) {
-      debugPrint("Error leaveAlbum ${e.toString()}");
+      dPrint(() => "Error leaveAlbum ${e.toString()}");
       return false;
     }
   }
@@ -293,7 +293,7 @@ class AlbumService {
       await _updateAssets(album.id, remove: toRemove.toList());
       return true;
     } catch (e) {
-      debugPrint("Error removeAssetFromAlbum ${e.toString()}");
+      dPrint(() => "Error removeAssetFromAlbum ${e.toString()}");
     }
     return false;
   }
@@ -310,7 +310,7 @@ class AlbumService {
 
       return true;
     } catch (error) {
-      debugPrint("Error removeUser  ${error.toString()}");
+      dPrint(() => "Error removeUser  ${error.toString()}");
       return false;
     }
   }
@@ -327,7 +327,7 @@ class AlbumService {
 
       return true;
     } catch (error) {
-      debugPrint("Error addUsers ${error.toString()}");
+      dPrint(() => "Error addUsers ${error.toString()}");
     }
     return false;
   }
@@ -340,7 +340,7 @@ class AlbumService {
       await _albumRepository.update(album);
       return true;
     } catch (e) {
-      debugPrint("Error changeTitleAlbum  ${e.toString()}");
+      dPrint(() => "Error changeTitleAlbum  ${e.toString()}");
       return false;
     }
   }
@@ -353,7 +353,7 @@ class AlbumService {
       await _albumRepository.update(album);
       return true;
     } catch (e) {
-      debugPrint("Error changeDescriptionAlbum  ${e.toString()}");
+      dPrint(() => "Error changeDescriptionAlbum  ${e.toString()}");
       return false;
     }
   }

--- a/mobile/lib/services/api.service.dart
+++ b/mobile/lib/services/api.service.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
-import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -11,6 +10,7 @@ import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 import 'package:immich_mobile/utils/user_agent.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class ApiService implements Authentication {
   late ApiClient _apiClient;
@@ -155,7 +155,7 @@ class ApiService implements Authentication {
         return endpoint;
       }
     } catch (e) {
-      debugPrint("Could not locate /.well-known/immich at $baseUrl");
+      dPrint(() => "Could not locate /.well-known/immich at $baseUrl");
     }
 
     return "";

--- a/mobile/lib/services/asset.service.dart
+++ b/mobile/lib/services/asset.service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
@@ -26,6 +25,7 @@ import 'package:immich_mobile/services/sync.service.dart';
 import 'package:logging/logging.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:openapi/api.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final assetServiceProvider = Provider(
   (ref) => AssetService(
@@ -87,7 +87,7 @@ class AssetService {
       getChangedAssets: _getRemoteAssetChanges,
       loadAssets: _getRemoteAssets,
     );
-    debugPrint("refreshRemoteAssets full took ${sw.elapsedMilliseconds}ms");
+    dPrint(() => "refreshRemoteAssets full took ${sw.elapsedMilliseconds}ms");
     return changes;
   }
 
@@ -156,7 +156,7 @@ class AssetService {
             if (a.isInDb) {
               await _assetRepository.transaction(() => _assetRepository.update(a));
             } else {
-              debugPrint("[loadExif] parameter Asset is not from DB!");
+              dPrint(() => "[loadExif] parameter Asset is not from DB!");
             }
           }
         }

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -33,6 +33,7 @@ import 'package:immich_mobile/utils/diff.dart';
 import 'package:immich_mobile/utils/http_ssl_options.dart';
 import 'package:path_provider_foundation/path_provider_foundation.dart';
 import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final backgroundServiceProvider = Provider((ref) => BackgroundService());
 
@@ -165,7 +166,7 @@ class BackgroundService {
         ]);
       }
     } catch (error) {
-      debugPrint("[_updateNotification] failed to communicate with plugin");
+      dPrint(() => "[_updateNotification] failed to communicate with plugin");
     }
     return false;
   }
@@ -177,7 +178,7 @@ class BackgroundService {
         return await _backgroundChannel.invokeMethod('showError', [title, content, individualTag]);
       }
     } catch (error) {
-      debugPrint("[_showErrorNotification] failed to communicate with plugin");
+      dPrint(() => "[_showErrorNotification] failed to communicate with plugin");
     }
     return false;
   }
@@ -188,7 +189,7 @@ class BackgroundService {
         return await _backgroundChannel.invokeMethod('clearErrorNotifications');
       }
     } catch (error) {
-      debugPrint("[_clearErrorNotifications] failed to communicate with plugin");
+      dPrint(() => "[_clearErrorNotifications] failed to communicate with plugin");
     }
     return false;
   }
@@ -196,7 +197,7 @@ class BackgroundService {
   /// await to ensure this thread (foreground or background) has exclusive access
   Future<bool> acquireLock() async {
     if (_hasLock) {
-      debugPrint("WARNING: [acquireLock] called more than once");
+      dPrint(() => "WARNING: [acquireLock] called more than once");
       return true;
     }
     final int lockTime = Timeline.now;
@@ -302,19 +303,19 @@ class BackgroundService {
 
           final bool hasAccess = await waitForLock;
           if (!hasAccess) {
-            debugPrint("[_callHandler] could not acquire lock, exiting");
+            dPrint(() => "[_callHandler] could not acquire lock, exiting");
             return false;
           }
 
           final translationsOk = await loadTranslations();
           if (!translationsOk) {
-            debugPrint("[_callHandler] could not load translations");
+            dPrint(() => "[_callHandler] could not load translations");
           }
 
           final bool ok = await _onAssetsChanged();
           return ok;
         } catch (error) {
-          debugPrint(error.toString());
+          dPrint(() => error.toString());
           return false;
         } finally {
           releaseLock();
@@ -324,7 +325,7 @@ class BackgroundService {
         _cancellationToken?.cancel();
         return true;
       default:
-        debugPrint("Unknown method ${call.method}");
+        dPrint(() => "Unknown method ${call.method}");
         return false;
     }
   }

--- a/mobile/lib/services/background.service.dart
+++ b/mobile/lib/services/background.service.dart
@@ -7,7 +7,6 @@ import 'dart:ui' show DartPluginRegistrant, IsolateNameServer, PluginUtilities;
 import 'package:cancellation_token_http/http.dart';
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -345,9 +344,7 @@ class BackgroundService {
     HttpSSLOptions.apply();
     ref.read(apiServiceProvider).setAccessToken(Store.get(StoreKey.accessToken));
     await ref.read(authServiceProvider).setOpenApiServiceEndpoint();
-    if (kDebugMode) {
-      debugPrint("[BG UPLOAD] Using endpoint: ${ref.read(apiServiceProvider).apiClient.basePath}");
-    }
+    dPrint(() => "[BG UPLOAD] Using endpoint: ${ref.read(apiServiceProvider).apiClient.basePath}");
 
     final selectedAlbums = await ref.read(backupAlbumRepositoryProvider).getAllBySelection(BackupSelection.select);
     final excludedAlbums = await ref.read(backupAlbumRepositoryProvider).getAllBySelection(BackupSelection.exclude);

--- a/mobile/lib/services/backup.service.dart
+++ b/mobile/lib/services/backup.service.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:cancellation_token_http/http.dart' as http;
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/album.entity.dart';
@@ -29,6 +28,7 @@ import 'package:openapi/api.dart';
 import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart' as pm;
 import 'package:photo_manager/photo_manager.dart' show PMProgressHandler;
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final backupServiceProvider = Provider(
   (ref) => BackupService(
@@ -69,7 +69,7 @@ class BackupService {
     try {
       return await _apiService.assetsApi.getAllUserAssetsByDeviceId(deviceId);
     } catch (e) {
-      debugPrint('Error [getDeviceBackupAsset] ${e.toString()}');
+      dPrint(() => 'Error [getDeviceBackupAsset] ${e.toString()}');
       return null;
     }
   }
@@ -356,8 +356,9 @@ class BackupService {
             final error = responseBody;
             final errorMessage = error['message'] ?? error['error'];
 
-            debugPrint(
-              "Error(${error['statusCode']}) uploading ${asset.localId} | $originalFileName | Created on ${asset.fileCreatedAt} | ${error['error']}",
+            dPrint(
+              () =>
+                  "Error(${error['statusCode']}) uploading ${asset.localId} | $originalFileName | Created on ${asset.fileCreatedAt} | ${error['error']}",
             );
 
             onError(
@@ -398,11 +399,11 @@ class BackupService {
           }
         }
       } on http.CancelledException {
-        debugPrint("Backup was cancelled by the user");
+        dPrint(() => "Backup was cancelled by the user");
         anyErrors = true;
         break;
       } catch (error, stackTrace) {
-        debugPrint("Error backup asset: ${error.toString()}: $stackTrace");
+        dPrint(() => "Error backup asset: ${error.toString()}: $stackTrace");
         anyErrors = true;
         continue;
       } finally {
@@ -411,7 +412,7 @@ class BackupService {
             await file?.delete();
             await livePhotoFile?.delete();
           } catch (e) {
-            debugPrint("ERROR deleting file: ${e.toString()}");
+            dPrint(() => "ERROR deleting file: ${e.toString()}");
           }
         }
       }
@@ -454,7 +455,9 @@ class BackupService {
     if (![200, 201].contains(response.statusCode)) {
       var error = responseBody;
 
-      debugPrint("Error(${error['statusCode']}) uploading livePhoto for assetId | $livePhotoTitle | ${error['error']}");
+      dPrint(
+        () => "Error(${error['statusCode']}) uploading livePhoto for assetId | $livePhotoTitle | ${error['error']}",
+      );
     }
 
     return responseBody.containsKey('id') ? responseBody['id'] : null;

--- a/mobile/lib/services/local_notification.service.dart
+++ b/mobile/lib/services/local_notification.service.dart
@@ -1,9 +1,9 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/backup/manual_upload.provider.dart';
 import 'package:immich_mobile/providers/notification_permission.provider.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final localNotificationService = Provider(
   (ref) => LocalNotificationService(ref.watch(notificationPermissionProvider), ref),
@@ -110,7 +110,7 @@ class LocalNotificationService {
     switch (notificationResponse.actionId) {
       case cancelUploadActionID:
         {
-          debugPrint("User cancelled manual upload operation");
+          dPrint(() => "User cancelled manual upload operation");
           ref.read(manualUploadProvider.notifier).cancelBackup();
         }
     }

--- a/mobile/lib/services/localization.service.dart
+++ b/mobile/lib/services/localization.service.dart
@@ -2,9 +2,9 @@
 
 import 'package:easy_localization/src/easy_localization_controller.dart';
 import 'package:easy_localization/src/localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/constants/locales.dart';
 import 'package:immich_mobile/generated/codegen_loader.g.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 /// Workaround to manually load translations in another Isolate
 Future<bool> loadTranslations() async {
@@ -17,7 +17,7 @@ Future<bool> loadTranslations() async {
     assetLoader: const CodegenLoader(),
     path: translationsPath,
     useOnlyLangCode: false,
-    onLoadError: (e) => debugPrint(e.toString()),
+    onLoadError: (e) => dPrint(() => e.toString()),
     fallbackLocale: locales.values.first,
   );
 

--- a/mobile/lib/services/search.service.dart
+++ b/mobile/lib/services/search.service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/string_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/search_api.repository.dart';
@@ -10,6 +9,7 @@ import 'package:immich_mobile/repositories/asset.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final searchServiceProvider = Provider(
   (ref) => SearchService(
@@ -43,7 +43,7 @@ class SearchService {
         model: model,
       );
     } catch (e) {
-      debugPrint("[ERROR] [getSearchSuggestions] ${e.toString()}");
+      dPrint(() => "[ERROR] [getSearchSuggestions] ${e.toString()}");
       return [];
     }
   }

--- a/mobile/lib/services/server_info.service.dart
+++ b/mobile/lib/services/server_info.service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/models/server_info/server_config.model.dart';
 import 'package:immich_mobile/models/server_info/server_disk_info.model.dart';
@@ -6,6 +5,7 @@ import 'package:immich_mobile/models/server_info/server_features.model.dart';
 import 'package:immich_mobile/models/server_info/server_version.model.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final serverInfoServiceProvider = Provider((ref) => ServerInfoService(ref.watch(apiServiceProvider)));
 
@@ -30,7 +30,7 @@ class ServerInfoService {
         return ServerDiskInfo.fromDto(dto);
       }
     } catch (e) {
-      debugPrint("Error [getDiskInfo] ${e.toString()}");
+      dPrint(() => "Error [getDiskInfo] ${e.toString()}");
     }
     return null;
   }
@@ -42,7 +42,7 @@ class ServerInfoService {
         return ServerVersion.fromDto(dto);
       }
     } catch (e) {
-      debugPrint("Error [getServerVersion] ${e.toString()}");
+      dPrint(() => "Error [getServerVersion] ${e.toString()}");
     }
     return null;
   }
@@ -54,7 +54,7 @@ class ServerInfoService {
         return ServerFeatures.fromDto(dto);
       }
     } catch (e) {
-      debugPrint("Error [getServerFeatures] ${e.toString()}");
+      dPrint(() => "Error [getServerFeatures] ${e.toString()}");
     }
     return null;
   }
@@ -66,7 +66,7 @@ class ServerInfoService {
         return ServerConfig.fromDto(dto);
       }
     } catch (e) {
-      debugPrint("Error [getServerConfig] ${e.toString()}");
+      dPrint(() => "Error [getServerConfig] ${e.toString()}");
     }
     return null;
   }

--- a/mobile/lib/services/stack.service.dart
+++ b/mobile/lib/services/stack.service.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/repositories/asset.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:openapi/api.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class StackService {
   const StackService(this._api, this._assetRepository);
@@ -16,7 +16,7 @@ class StackService {
     try {
       return _api.stacksApi.getStack(stackId);
     } catch (error) {
-      debugPrint("Error while fetching stack: $error");
+      dPrint(() => "Error while fetching stack: $error");
     }
     return null;
   }
@@ -25,7 +25,7 @@ class StackService {
     try {
       return _api.stacksApi.createStack(StackCreateDto(assetIds: assetIds));
     } catch (error) {
-      debugPrint("Error while creating stack: $error");
+      dPrint(() => "Error while creating stack: $error");
     }
     return null;
   }
@@ -34,7 +34,7 @@ class StackService {
     try {
       return await _api.stacksApi.updateStack(stackId, StackUpdateDto(primaryAssetId: primaryAssetId));
     } catch (error) {
-      debugPrint("Error while updating stack children: $error");
+      dPrint(() => "Error while updating stack children: $error");
     }
     return null;
   }
@@ -54,7 +54,7 @@ class StackService {
       }
       await _assetRepository.transaction(() => _assetRepository.updateAll(removeAssets));
     } catch (error) {
-      debugPrint("Error while deleting stack: $error");
+      dPrint(() => "Error while deleting stack: $error");
     }
   }
 }

--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:background_downloader/background_downloader.dart';
 import 'package:cancellation_token_http/http.dart';
-import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -22,6 +21,7 @@ import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:immich_mobile/utils/debug_print.dart';
 
 final uploadServiceProvider = Provider((ref) {
   final service = UploadService(
@@ -253,7 +253,7 @@ class UploadService {
 
       enqueueTasks([uploadTask]);
     } catch (error, stackTrace) {
-      debugPrint("Error handling live photo upload task: $error $stackTrace");
+      dPrint(() => "Error handling live photo upload task: $error $stackTrace");
     }
   }
 

--- a/mobile/lib/theme/dynamic_theme.dart
+++ b/mobile/lib/theme/dynamic_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 
 import 'package:immich_mobile/theme/theme_data.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 abstract final class DynamicTheme {
   const DynamicTheme._();
@@ -13,7 +14,7 @@ abstract final class DynamicTheme {
       final corePalette = await DynamicColorPlugin.getCorePalette();
       if (corePalette != null) {
         final primaryColor = corePalette.toColorScheme().primary;
-        debugPrint('dynamic_color: Core palette detected.');
+        dPrint(() => 'dynamic_color: Core palette detected.');
 
         // Some palettes do not generate surface container colors accurately,
         // so we regenerate all colors using the primary color
@@ -23,7 +24,7 @@ abstract final class DynamicTheme {
         );
       }
     } catch (error) {
-      debugPrint('dynamic_color: Failed to obtain core palette: $error');
+      dPrint(() => 'dynamic_color: Failed to obtain core palette: $error');
     }
   }
 

--- a/mobile/lib/utils/debug_print.dart
+++ b/mobile/lib/utils/debug_print.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+
+@pragma('vm:prefer-inline')
+void dPrint(String Function() message) {
+  if (kDebugMode) {
+    debugPrint(message());
+  }
+}

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
@@ -85,7 +84,7 @@ Cancelable<T?> runInIsolateGentle<T>({
         return null;
       },
       (error, stack) {
-        debugPrint("Error in isolate zone: $error, $stack");
+        dPrint(() => "Error in isolate zone: $error, $stack");
       },
     );
     return null;

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
@@ -12,6 +11,7 @@ import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/http_ssl_options.dart';
 import 'package:logging/logging.dart';
 import 'package:worker_manager/worker_manager.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class InvalidIsolateUsageException implements Exception {
   const InvalidIsolateUsageException();
@@ -71,10 +71,10 @@ Cancelable<T?> runInIsolateGentle<T>({
                 await isar.close();
               }
             } catch (e) {
-              debugPrint("Error closing Isar: $e");
+              dPrint(() => "Error closing Isar: $e");
             }
           } catch (error, stack) {
-            debugPrint("Error closing resources in isolate: $error, $stack");
+            dPrint(() => "Error closing resources in isolate: $error, $stack");
           } finally {
             ref.dispose();
             // Delay to ensure all resources are released
@@ -84,7 +84,7 @@ Cancelable<T?> runInIsolateGentle<T>({
         return null;
       },
       (error, stack) {
-        debugPrint("Error in isolate zone: $error, $stack");
+        dPrint(() => "Error in isolate zone: $error, $stack");
       },
     );
     return null;

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
@@ -84,7 +85,7 @@ Cancelable<T?> runInIsolateGentle<T>({
         return null;
       },
       (error, stack) {
-        dPrint(() => "Error in isolate zone: $error, $stack");
+        debugPrint("Error in isolate zone: $error, $stack");
       },
     );
     return null;

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -26,6 +26,7 @@ import 'package:immich_mobile/utils/diff.dart';
 import 'package:isar/isar.dart';
 // ignore: import_rule_photo_manager
 import 'package:photo_manager/photo_manager.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 const int targetVersion = 15;
 
@@ -117,7 +118,7 @@ Future<bool> _isNewInstallation(Isar db, Drift drift) async {
 
     return true;
   } catch (error) {
-    debugPrint("[MIGRATION] Error checking if new installation: $error");
+    dPrint(() => "[MIGRATION] Error checking if new installation: $error");
     return false;
   }
 }
@@ -166,8 +167,8 @@ Future<void> _migrateDeviceAsset(Isar db) async {
     localAssets = allDeviceAssets.map((a) => _DeviceAsset(assetId: a.id, dateTime: a.modifiedDateTime)).toList();
   }
 
-  debugPrint("[MIGRATION] Device Asset Ids length - ${ids.length}");
-  debugPrint("[MIGRATION] Local Asset Ids length - ${localAssets.length}");
+  dPrint(() => "[MIGRATION] Device Asset Ids length - ${ids.length}");
+  dPrint(() => "[MIGRATION] Local Asset Ids length - ${localAssets.length}");
   ids.sort((a, b) => a.assetId.compareTo(b.assetId));
   localAssets.sort((a, b) => a.assetId.compareTo(b.assetId));
   final List<DeviceAssetEntity> toAdd = [];
@@ -215,7 +216,7 @@ Future<void> migrateDeviceAssetToSqlite(Isar db, Drift drift) async {
       }
     });
   } catch (error) {
-    debugPrint("[MIGRATION] Error while migrating device assets to SQLite: $error");
+    dPrint(() => "[MIGRATION] Error while migrating device assets to SQLite: $error");
   }
 }
 
@@ -263,7 +264,7 @@ Future<void> migrateBackupAlbumsToSqlite(Isar db, Drift drift) async {
       }
     });
   } catch (error) {
-    debugPrint("[MIGRATION] Error while migrating backup albums to SQLite: $error");
+    dPrint(() => "[MIGRATION] Error while migrating backup albums to SQLite: $error");
   }
 }
 
@@ -281,7 +282,7 @@ Future<void> migrateStoreToSqlite(Isar db, Drift drift) async {
       }
     });
   } catch (error) {
-    debugPrint("[MIGRATION] Error while migrating store values to SQLite: $error");
+    dPrint(() => "[MIGRATION] Error while migrating store values to SQLite: $error");
   }
 }
 
@@ -296,7 +297,7 @@ Future<void> migrateStoreToIsar(Isar db, Drift drift) async {
       await db.storeValues.putAll(driftStoreValues);
     });
   } catch (error) {
-    debugPrint("[MIGRATION] Error while migrating store values to Isar: $error");
+    dPrint(() => "[MIGRATION] Error while migrating store values to Isar: $error");
   }
 }
 

--- a/mobile/lib/utils/migration.dart
+++ b/mobile/lib/utils/migration.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/album.entity.dart';
@@ -144,10 +143,7 @@ Future<void> _migrateDeviceAsset(Isar db) async {
 
   final PermissionState ps = await PhotoManager.requestPermissionExtend();
   if (!ps.hasAccess) {
-    if (kDebugMode) {
-      debugPrint("[MIGRATION] Photo library permission not granted. Skipping device asset migration.");
-    }
-
+    dPrint(() => "[MIGRATION] Photo library permission not granted. Skipping device asset migration.");
     return;
   }
 
@@ -183,20 +179,14 @@ Future<void> _migrateDeviceAsset(Isar db) async {
       return false;
     },
     onlyFirst: (deviceAsset) {
-      if (kDebugMode) {
-        debugPrint('[MIGRATION] Local asset not found in DeviceAsset: ${deviceAsset.assetId}');
-      }
+      dPrint(() => '[MIGRATION] Local asset not found in DeviceAsset: ${deviceAsset.assetId}');
     },
     onlySecond: (asset) {
-      if (kDebugMode) {
-        debugPrint('[MIGRATION] Local asset not found in DeviceAsset: ${asset.assetId}');
-      }
+      dPrint(() => '[MIGRATION] Local asset not found in DeviceAsset: ${asset.assetId}');
     },
   );
 
-  if (kDebugMode) {
-    debugPrint("[MIGRATION] Total number of device assets migrated - ${toAdd.length}");
-  }
+  dPrint(() => "[MIGRATION] Total number of device assets migrated - ${toAdd.length}");
 
   await db.writeTxn(() async {
     await db.deviceAssetEntitys.putAll(toAdd);

--- a/mobile/lib/widgets/asset_viewer/detail_panel/exif_map.dart
+++ b/mobile/lib/widgets/asset_viewer/detail_panel/exif_map.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/widgets/map/map_thumbnail.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class ExifMap extends StatelessWidget {
   final ExifInfo exifInfo;
@@ -66,7 +67,7 @@ class ExifMap extends StatelessWidget {
               return;
             }
 
-            debugPrint('Opening Map Uri: $uri');
+            dPrint(() => 'Opening Map Uri: $uri');
             launchUrl(uri);
           },
           onCreated: onMapCreated,

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/search/thumbnail_with_info.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class SharedLinkItem extends ConsumerWidget {
   final SharedLink sharedLink;
@@ -36,7 +37,7 @@ class SharedLinkItem extends ConsumerWidget {
         return Text("expired", style: TextStyle(color: Colors.red[300])).tr();
       }
       final difference = sharedLink.expiresAt!.difference(DateTime.now());
-      debugPrint("Difference: $difference");
+      dPrint(() => "Difference: $difference");
       if (difference.inDays > 0) {
         var dayDifference = difference.inDays;
         if (difference.inHours % 24 > 12) {

--- a/mobile/test/modules/utils/throttler_test.dart
+++ b/mobile/test/modules/utils/throttler_test.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/utils/throttle.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 
 class _Counter {
   int _count = 0;
@@ -8,7 +8,7 @@ class _Counter {
 
   int get count => _count;
   void increment() {
-    debugPrint("Counter inside increment: $count");
+    dPrint(() => "Counter inside increment: $count");
     _count = _count + 1;
   }
 }


### PR DESCRIPTION
## Description

This PR adds a `dPrint` function that is completely removed in release builds, as if it never existed. It disallows using `debugPrint` without a `kDebugMode` guard using a new lint rule that can automatically convert usages to `dPrint` instead.

See https://godbolt.org/z/dTnb4Gszd for a demo of how the compiler treats this function. Changing `if (true)` to `if (false)` will make it omit anything inside the callback.