### PR TITLE
chore: improve context button accessibility

### DIFF
--- a/web/src/lib/components/album-page/album-card.svelte
+++ b/web/src/lib/components/album-page/album-card.svelte
@@ -48,7 +48,7 @@
         aria-label={$t('show_album_options')}
         icon={mdiDotsVertical}
         shape="round"
-        variant="ghost"
+        variant="filled"
         size="medium"
         class="icon-white-drop-shadow"
         onclick={showAlbumContextMenu}

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -64,9 +64,10 @@
   {#if showVerticalDots}
     <div class="absolute top-2 end-2 z-1">
       <ButtonContextMenu
-        buttonClass="icon-white-drop-shadow focus:opacity-100 {showVerticalDots ? 'opacity-100' : 'opacity-0'}"
-        color="primary"
+        buttonClass="icon-white-drop-shadow"
+        color="secondary"
         size="medium"
+        variant="filled"
         icon={mdiDotsVertical}
         title={$t('show_person_options')}
       >


### PR DESCRIPTION
## Description

Currently, the context menu on the faces page and album list page are hard to see. This changes the button style so it's filled rather than translucent, so it is more visible.

## How Has This Been Tested?

Viewed the pages

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

Faces page before:
<img width="557" height="414" alt="image" src="https://github.com/user-attachments/assets/07ab8184-3836-42e0-976c-1e754c06b7b5" />


Faces page after: 
<img width="505" height="351" alt="image" src="https://github.com/user-attachments/assets/eb4330f9-86ec-4598-8e68-11934f074392" />


Album page before:
<img width="486" height="454" alt="image" src="https://github.com/user-attachments/assets/e8623171-6f66-4d2d-9773-41f1c57b5dc6" />


Album page after:

<img width="704" height="393" alt="image" src="https://github.com/user-attachments/assets/5dbd980e-92ad-4cb3-ab93-75bb125b3c64" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
