### PR TITLE
chore(mobile): const platform checks

### DIFF
--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/utils/exif.converter.dart';
@@ -70,7 +70,7 @@ class AssetService {
       height = exif?.height ?? asset.height?.toDouble();
     } else if (asset is LocalAsset) {
       isFlipped =
-          defaultTargetPlatform == TargetPlatform.android && (asset.orientation == 90 || asset.orientation == 270);
+          CurrentPlatform.isAndroid && (asset.orientation == 90 || asset.orientation == 270);
       width = asset.width?.toDouble();
       height = asset.height?.toDouble();
     } else {

--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -1,22 +1,20 @@
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/utils/exif.converter.dart';
-import 'package:platform/platform.dart';
 
 class AssetService {
   final RemoteAssetRepository _remoteAssetRepository;
   final DriftLocalAssetRepository _localAssetRepository;
-  final Platform _platform;
 
   const AssetService({
     required RemoteAssetRepository remoteAssetRepository,
     required DriftLocalAssetRepository localAssetRepository,
   }) : _remoteAssetRepository = remoteAssetRepository,
-       _localAssetRepository = localAssetRepository,
-       _platform = const LocalPlatform();
+       _localAssetRepository = localAssetRepository;
 
   Future<BaseAsset?> getAsset(BaseAsset asset) {
     final id = asset is LocalAsset ? asset.id : (asset as RemoteAsset).id;
@@ -71,7 +69,8 @@ class AssetService {
       width = exif?.width ?? asset.width?.toDouble();
       height = exif?.height ?? asset.height?.toDouble();
     } else if (asset is LocalAsset) {
-      isFlipped = _platform.isAndroid && (asset.orientation == 90 || asset.orientation == 270);
+      isFlipped =
+          defaultTargetPlatform == TargetPlatform.android && (asset.orientation == 90 || asset.orientation == 270);
       width = asset.width?.toDouble();
       height = asset.height?.toDouble();
     } else {

--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -69,8 +69,7 @@ class AssetService {
       width = exif?.width ?? asset.width?.toDouble();
       height = exif?.height ?? asset.height?.toDouble();
     } else if (asset is LocalAsset) {
-      isFlipped =
-          CurrentPlatform.isAndroid && (asset.orientation == 90 || asset.orientation == 270);
+      isFlipped = CurrentPlatform.isAndroid && (asset.orientation == 90 || asset.orientation == 270);
       width = asset.width?.toDouble();
       height = asset.height?.toDouble();
     } else {

--- a/mobile/lib/domain/services/local_sync.service.dart
+++ b/mobile/lib/domain/services/local_sync.service.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:immich_mobile/utils/datetime_helpers.dart';
@@ -47,14 +48,14 @@ class LocalSyncService {
       final dbAlbums = await _localAlbumRepository.getAll();
       // On Android, we need to sync all albums since it is not possible to
       // detect album deletions from the native side
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (CurrentPlatform.isAndroid) {
         for (final album in dbAlbums) {
           final deviceIds = await _nativeSyncApi.getAssetIdsForAlbum(album.id);
           await _localAlbumRepository.syncDeletes(album.id, deviceIds);
         }
       }
 
-      if (defaultTargetPlatform == TargetPlatform.iOS) {
+      if (CurrentPlatform.isIOS) {
         // On iOS, we need to full sync albums that are marked as cloud as the delta sync
         // does not include changes for cloud albums. If ignoreIcloudAssets is enabled,
         // remove the albums from the local database from the previous sync

--- a/mobile/lib/domain/services/local_sync.service.dart
+++ b/mobile/lib/domain/services/local_sync.service.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
@@ -9,21 +9,15 @@ import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:immich_mobile/utils/datetime_helpers.dart';
 import 'package:immich_mobile/utils/diff.dart';
 import 'package:logging/logging.dart';
-import 'package:platform/platform.dart';
 
 class LocalSyncService {
   final DriftLocalAlbumRepository _localAlbumRepository;
   final NativeSyncApi _nativeSyncApi;
-  final Platform _platform;
   final Logger _log = Logger("DeviceSyncService");
 
-  LocalSyncService({
-    required DriftLocalAlbumRepository localAlbumRepository,
-    required NativeSyncApi nativeSyncApi,
-    Platform? platform,
-  }) : _localAlbumRepository = localAlbumRepository,
-       _nativeSyncApi = nativeSyncApi,
-       _platform = platform ?? const LocalPlatform();
+  LocalSyncService({required DriftLocalAlbumRepository localAlbumRepository, required NativeSyncApi nativeSyncApi})
+    : _localAlbumRepository = localAlbumRepository,
+      _nativeSyncApi = nativeSyncApi;
 
   Future<void> sync({bool full = false}) async {
     final Stopwatch stopwatch = Stopwatch()..start();
@@ -53,14 +47,14 @@ class LocalSyncService {
       final dbAlbums = await _localAlbumRepository.getAll();
       // On Android, we need to sync all albums since it is not possible to
       // detect album deletions from the native side
-      if (_platform.isAndroid) {
+      if (defaultTargetPlatform == TargetPlatform.android) {
         for (final album in dbAlbums) {
           final deviceIds = await _nativeSyncApi.getAssetIdsForAlbum(album.id);
           await _localAlbumRepository.syncDeletes(album.id, deviceIds);
         }
       }
 
-      if (_platform.isIOS) {
+      if (defaultTargetPlatform == TargetPlatform.iOS) {
         // On iOS, we need to full sync albums that are marked as cloud as the delta sync
         // does not include changes for cloud albums. If ignoreIcloudAssets is enabled,
         // remove the albums from the local database from the previous sync

--- a/mobile/lib/extensions/platform_extensions.dart
+++ b/mobile/lib/extensions/platform_extensions.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/foundation.dart';
+
+extension CurrentPlatform on TargetPlatform {
+  @pragma('vm:prefer-inline')
+  static bool get isIOS => defaultTargetPlatform == TargetPlatform.iOS;
+
+  @pragma('vm:prefer-inline')
+  static bool get isAndroid => defaultTargetPlatform == TargetPlatform.android;
+}

--- a/mobile/lib/infrastructure/repositories/local_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_album.repository.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart';
-import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/entities/local_album.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/local_album.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/entities/local_album_asset.entity.drift.dart';
@@ -59,7 +59,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
     // Remove all assets that are only in this particular album
     // We cannot remove all assets in the album because they might be in other albums in iOS
     // That is not the case on Android since asset <-> album has one:one mapping
-    final assetsToDelete = defaultTargetPlatform == TargetPlatform.iOS
+    final assetsToDelete = CurrentPlatform.isIOS
         ? await _getUniqueAssetsInAlbum(albumId)
         : await getAssetIds(albumId);
     await _deleteAssets(assetsToDelete);
@@ -144,7 +144,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
         }
       });
 
-      if (defaultTargetPlatform == TargetPlatform.android) {
+      if (CurrentPlatform.isAndroid) {
         // On Android, an asset can only be in one album
         // So, get the albums that are marked for deletion
         // and delete all the assets that are in those albums
@@ -265,7 +265,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
       return Future.value();
     }
 
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (CurrentPlatform.isAndroid) {
       return _deleteAssets(assetIds);
     }
 

--- a/mobile/lib/infrastructure/repositories/local_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_album.repository.dart
@@ -59,9 +59,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
     // Remove all assets that are only in this particular album
     // We cannot remove all assets in the album because they might be in other albums in iOS
     // That is not the case on Android since asset <-> album has one:one mapping
-    final assetsToDelete = CurrentPlatform.isIOS
-        ? await _getUniqueAssetsInAlbum(albumId)
-        : await getAssetIds(albumId);
+    final assetsToDelete = CurrentPlatform.isIOS ? await _getUniqueAssetsInAlbum(albumId) : await getAssetIds(albumId);
     await _deleteAssets(assetsToDelete);
 
     await _db.managers.localAlbumEntity

--- a/mobile/lib/infrastructure/repositories/local_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_album.repository.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/infrastructure/entities/local_album.entity.dart';
@@ -7,16 +8,13 @@ import 'package:immich_mobile/infrastructure/entities/local_album_asset.entity.d
 import 'package:immich_mobile/infrastructure/entities/local_asset.entity.dart';
 import 'package:immich_mobile/infrastructure/entities/local_asset.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
-import 'package:platform/platform.dart';
 
 enum SortLocalAlbumsBy { id, backupSelection, isIosSharedAlbum, name, assetCount, newestAsset }
 
 class DriftLocalAlbumRepository extends DriftDatabaseRepository {
   final Drift _db;
-  final Platform _platform;
-  const DriftLocalAlbumRepository(this._db, {Platform? platform})
-    : _platform = platform ?? const LocalPlatform(),
-      super(_db);
+
+  const DriftLocalAlbumRepository(this._db) : super(_db);
 
   Future<List<LocalAlbum>> getAll({Set<SortLocalAlbumsBy> sortBy = const {}}) {
     final assetCount = _db.localAlbumAssetEntity.assetId.count();
@@ -61,7 +59,9 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
     // Remove all assets that are only in this particular album
     // We cannot remove all assets in the album because they might be in other albums in iOS
     // That is not the case on Android since asset <-> album has one:one mapping
-    final assetsToDelete = _platform.isIOS ? await _getUniqueAssetsInAlbum(albumId) : await getAssetIds(albumId);
+    final assetsToDelete = defaultTargetPlatform == TargetPlatform.iOS
+        ? await _getUniqueAssetsInAlbum(albumId)
+        : await getAssetIds(albumId);
     await _deleteAssets(assetsToDelete);
 
     await _db.managers.localAlbumEntity
@@ -144,7 +144,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
         }
       });
 
-      if (_platform.isAndroid) {
+      if (defaultTargetPlatform == TargetPlatform.android) {
         // On Android, an asset can only be in one album
         // So, get the albums that are marked for deletion
         // and delete all the assets that are in those albums
@@ -265,7 +265,7 @@ class DriftLocalAlbumRepository extends DriftDatabaseRepository {
       return Future.value();
     }
 
-    if (_platform.isAndroid) {
+    if (defaultTargetPlatform == TargetPlatform.android) {
       return _deleteAssets(assetIds);
     }
 

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -30,7 +31,6 @@ import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view.dart';
 import 'package:immich_mobile/widgets/photo_view/photo_view_gallery.dart';
-import 'package:platform/platform.dart';
 
 @RoutePage()
 class AssetViewerPage extends StatelessWidget {
@@ -53,10 +53,9 @@ class AssetViewerPage extends StatelessWidget {
 
 class AssetViewer extends ConsumerStatefulWidget {
   final int initialIndex;
-  final Platform? platform;
   final int? heroOffset;
 
-  const AssetViewer({super.key, required this.initialIndex, this.platform, this.heroOffset});
+  const AssetViewer({super.key, required this.initialIndex, this.heroOffset});
 
   @override
   ConsumerState createState() => _AssetViewerState();
@@ -86,7 +85,6 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
   PhotoViewControllerBase? viewController;
   StreamSubscription? reloadSubscription;
 
-  late Platform platform;
   late final int heroOffset;
   late PhotoViewControllerValue initialPhotoViewState;
   bool? hasDraggedDown;
@@ -114,7 +112,6 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     super.initState();
     assert(ref.read(currentAssetNotifier) != null, "Current asset should not be null when opening the AssetViewer");
     pageController = PageController(initialPage: widget.initialIndex);
-    platform = widget.platform ?? const LocalPlatform();
     totalAssets = ref.read(timelineServiceProvider).totalAssets;
     bottomSheetController = DraggableScrollableController();
     WidgetsBinding.instance.addPostFrameCallback(_onAssetInit);
@@ -638,7 +635,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
           gaplessPlayback: true,
           loadingBuilder: _placeholderBuilder,
           pageController: pageController,
-          scrollPhysics: platform.isIOS
+          scrollPhysics: defaultTargetPlatform == TargetPlatform.iOS
               ? const FastScrollPhysics() // Use bouncing physics for iOS
               : const FastClampingScrollPhysics(), // Use heavy physics for Android
           itemCount: totalAssets,

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -11,6 +10,7 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/extensions/scroll_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.widget.dart';
@@ -635,7 +635,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
           gaplessPlayback: true,
           loadingBuilder: _placeholderBuilder,
           pageController: pageController,
-          scrollPhysics: defaultTargetPlatform == TargetPlatform.iOS
+          scrollPhysics: CurrentPlatform.isIOS
               ? const FastScrollPhysics() // Use bouncing physics for iOS
               : const FastClampingScrollPhysics(), // Use heavy physics for Android
           itemCount: totalAssets,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1429,7 +1429,7 @@ packages:
     source: hosted
     version: "5.0.1"
   platform:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -57,7 +57,6 @@ dependencies:
   photo_manager: ^3.6.4
   photo_manager_image_provider: ^2.2.0
   pinput: ^5.0.1
-  platform: ^3.1.6
   punycode: ^1.0.0
   riverpod_annotation: ^2.6.1
   scrollable_positioned_list: ^0.3.8


### PR DESCRIPTION
## Description

This PR switches to `defaultTargetPlatform` instead of injected `Platform` objects, the former of which has better compilation behavior. It removes `platform` as a dependency as there is no use for it anymore.