### PR TITLE
fix(dev): use Docker-managed volumes for Postgres and upload folders

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -29,8 +29,9 @@ services:
     restart: unless-stopped
     volumes:
       - ..:/usr/src/app
-      - ${UPLOAD_LOCATION}/photos:/data
-      - ${UPLOAD_LOCATION}/photos/upload:/data/upload
+      # - ${UPLOAD_LOCATION}/photos:/data
+      # - ${UPLOAD_LOCATION}/photos/upload:/data/upload
+      - photos_data:/data
       - /etc/localtime:/etc/localtime:ro
       - pnpm-store:/usr/src/app/.pnpm-store
       - server-node_modules:/usr/src/app/server/node_modules
@@ -158,7 +159,8 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
-      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
+      # - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     shm_size: 128mb
@@ -217,3 +219,5 @@ volumes:
   app-node_modules:
   sveltekit:
   coverage:
+  postgres_data:
+  photos_data:


### PR DESCRIPTION
## Description

This PR updates the development Docker setup to use Docker-managed volumes for PostgreSQL data and the upload folders instead of host-mounted directories.  

This change fixes persistent permission errors that occurred on macOS/Windows when running `make dev`, ensuring that the container can properly read and write to database and storage directories.  

Fixes #<link-to-related-issue-if-any>

## How Has This Been Tested?

- [x] Run `make dev` on macOS, confirmed that PostgreSQL and Immich server start without permission errors.
- [x] Verified that Immich server can create folders and write to `/data` without `EACCES` errors.
- [x] Confirmed that PostgreSQL initializes correctly with `docker-managed volume`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- No UI changes for this fix -->

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (added note about using volumes)
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (not applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM used; PR written manually.
