### PR TITLE
fix(mobile): double hero animation

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -240,7 +240,7 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
         theme: getThemeData(colorScheme: immichTheme.light, locale: context.locale),
         routerConfig: router.config(
           deepLinkBuilder: _deepLinkBuilder,
-          navigatorObservers: () => [AppNavigationObserver(ref: ref), HeroController()],
+          navigatorObservers: () => [AppNavigationObserver(ref: ref)],
         ),
       ),
     );


### PR DESCRIPTION
## Description

A `HeroController` is added automatically, so adding another one led to two animations on pop. The "double image" effect is because the automatically added one creates a different `RectTween` curve than the default from `HeroController()`.

Fixes #20581