### PR TITLE
chore: making order of background tasks better

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
-import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
@@ -12,7 +11,6 @@ import 'package:immich_mobile/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
-import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:logging/logging.dart';
 
 @RoutePage()
@@ -116,9 +114,9 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
   }
 
   Future<void> _resumeBackup(DriftBackupNotifier notifier) async {
-    final isEnableBackup = Store.tryGet(StoreKey.enableBackup);
+    final isEnableBackup = Store.get(StoreKey.enableBackup, false);
 
-    if (isEnableBackup != null && isEnableBackup) {
+    if (isEnableBackup) {
       final currentUser = Store.tryGet(StoreKey.currentUser);
       if (currentUser != null) {
         notifier.handleBackupResume(currentUser.id);

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -3,13 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/auth.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
+import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:logging/logging.dart';
 
 @RoutePage()
@@ -22,6 +25,7 @@ class SplashScreenPage extends StatefulHookConsumerWidget {
 
 class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
   final log = Logger("SplashScreenPage");
+
   @override
   void initState() {
     super.initState();
@@ -49,6 +53,7 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
       final infoProvider = ref.read(serverInfoProvider.notifier);
       final wsProvider = ref.read(websocketProvider.notifier);
       final backgroundManager = ref.read(backgroundSyncProvider);
+      final backupProvider = ref.read(driftBackupProvider.notifier);
 
       ref.read(authProvider.notifier).saveAuthInfo(accessToken: accessToken).then(
         (_) async {
@@ -57,13 +62,17 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
             infoProvider.getServerInfo();
 
             if (Store.isBetaTimelineEnabled) {
-              await backgroundManager.syncLocal();
-              await backgroundManager.syncRemote();
-              await backgroundManager.hashAssets();
-            }
+              await Future.wait([backgroundManager.syncLocal(), backgroundManager.syncRemote()]);
+              await Future.wait([
+                backgroundManager.hashAssets().then((_) {
+                  _resumeBackup(backupProvider);
+                }),
+                _resumeBackup(backupProvider),
+              ]);
 
-            if (Store.get(StoreKey.syncAlbums, false)) {
-              await backgroundManager.syncLinkedAlbum();
+              if (Store.get(StoreKey.syncAlbums, false)) {
+                await backgroundManager.syncLinkedAlbum();
+              }
             }
           } catch (e) {
             log.severe('Failed establishing connection to the server: $e');
@@ -103,6 +112,17 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
     if (hasPermission) {
       // Resume backup (if enable) then navigate
       ref.watch(backupProvider.notifier).resumeBackup();
+    }
+  }
+
+  Future<void> _resumeBackup(DriftBackupNotifier notifier) async {
+    final isEnableBackup = Store.tryGet(StoreKey.enableBackup);
+
+    if (isEnableBackup != null && isEnableBackup) {
+      final currentUser = Store.tryGet(StoreKey.currentUser);
+      if (currentUser != null) {
+        notifier.handleBackupResume(currentUser.id);
+      }
     }
   }
 

--- a/mobile/lib/providers/app_life_cycle.provider.dart
+++ b/mobile/lib/providers/app_life_cycle.provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/services/log.service.dart';
@@ -20,7 +19,6 @@ import 'package:immich_mobile/providers/memory.provider.dart';
 import 'package:immich_mobile/providers/notification_permission.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/tab.provider.dart';
-import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/background.service.dart';

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -345,7 +345,6 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   }
 
   Future<void> handleBackupResume(String userId) async {
-    print("Resuming backup tasks...");
     _logger.info("Resuming backup tasks...");
     final tasks = await _uploadService.getActiveTasks(kBackupGroup);
     _logger.info("Found ${tasks.length} tasks");

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -345,6 +345,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
   }
 
   Future<void> handleBackupResume(String userId) async {
+    print("Resuming backup tasks...");
     _logger.info("Resuming backup tasks...");
     final tasks = await _uploadService.getActiveTasks(kBackupGroup);
     _logger.info("Found ${tasks.length} tasks");


### PR DESCRIPTION
Currently, the upload doesn't run until the hashing process is done. With the intial onboarding steps, this will cause a long wait time before the upload operation run unless the user triggers the button. 

This PR changes the behavior by starting the upload process before running the hash operation, and is triggered again after the operation is completed