### PR TITLE
chore: remove main timeline query watch throttle

### DIFF
--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -42,14 +42,10 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
       throw UnsupportedError("GroupAssetsBy.none is not supported for watchMainBucket");
     }
 
-    return _db.mergedAssetDrift
-        .mergedBucket(userIds: userIds, groupBy: groupBy.index)
-        .map((row) {
-          final date = row.bucketDate.dateFmt(groupBy);
-          return TimeBucket(date: date, assetCount: row.assetCount);
-        })
-        .watch()
-        .throttle(const Duration(seconds: 3), trailing: true);
+    return _db.mergedAssetDrift.mergedBucket(userIds: userIds, groupBy: groupBy.index).map((row) {
+      final date = row.bucketDate.dateFmt(groupBy);
+      return TimeBucket(date: date, assetCount: row.assetCount);
+    }).watch();
   }
 
   Future<List<BaseAsset>> _getMainBucketAssets(List<String> userIds, {required int offset, required int count}) {


### PR DESCRIPTION
This PR removes the artificial throttle due to concerns of timeline flashing while syncing remote assets and layout shifting. 

The perceived effect is not causing major concerns. Removing this helps improve interface feedback when receiving WebSocket events. Since local assets are already present on the timeline, there are no layout shift concerns when merging the sync indicator.

Tested on 10,000 local assets and 86,000 remote assets instance for initial sync
