### PR TITLE
refactor: platform channel invocation on main thread

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -75,26 +75,25 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
     )
     notificationManager.createNotificationChannel(notificationChannel)
 
-    loader.ensureInitializationCompleteAsync(ctx, null, Handler(Looper.getMainLooper())) {
-      engine = FlutterEngine(ctx)
+    loader.ensureInitializationComplete(ctx, null)
 
-      // Register custom plugins
-      MainActivity.registerPlugins(ctx, engine!!)
-      flutterApi =
-        BackgroundWorkerFlutterApi(binaryMessenger = engine!!.dartExecutor.binaryMessenger)
-      BackgroundWorkerBgHostApi.setUp(
-        binaryMessenger = engine!!.dartExecutor.binaryMessenger,
-        api = this
-      )
+    engine = FlutterEngine(ctx)
+    // Register custom plugins
+    MainActivity.registerPlugins(ctx, engine!!)
+    flutterApi =
+      BackgroundWorkerFlutterApi(binaryMessenger = engine!!.dartExecutor.binaryMessenger)
+    BackgroundWorkerBgHostApi.setUp(
+      binaryMessenger = engine!!.dartExecutor.binaryMessenger,
+      api = this
+    )
 
-      engine!!.dartExecutor.executeDartEntrypoint(
-        DartExecutor.DartEntrypoint(
-          loader.findAppBundlePath(),
-          "package:immich_mobile/domain/services/background_worker.service.dart",
-          "backgroundSyncNativeEntrypoint"
-        )
+    engine!!.dartExecutor.executeDartEntrypoint(
+      DartExecutor.DartEntrypoint(
+        loader.findAppBundlePath(),
+        "package:immich_mobile/domain/services/background_worker.service.dart",
+        "backgroundSyncNativeEntrypoint"
       )
-    }
+    )
 
     return completionHandler
   }
@@ -105,7 +104,10 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
    * This method acts as a bridge between the native Android background task system and Flutter.
    */
   override fun onInitialized() {
-    flutterApi?.onAndroidUpload { handleHostResult(it) }
+    Handler(Looper.getMainLooper()).postAtFrontOfQueue {
+      flutterApi?.onAndroidUpload { handleHostResult(it) }
+    }
+
   }
 
   // TODO: Move this to a separate NotificationManager class

--- a/mobile/ios/Runner/Background/BackgroundWorker.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.swift
@@ -114,9 +114,13 @@ class BackgroundWorker: BackgroundWorkerBgHostApi {
    * This method acts as a bridge between the native iOS background task system and Flutter.
    */
   func onInitialized() throws {
-    flutterApi?.onIosUpload(isRefresh: self.taskType == .refresh, maxSeconds: maxSeconds.map { Int64($0) }, completion: { result in
-      self.handleHostResult(result: result)
-    })
+    DispatchQueue.main.async {
+      self.flutterApi?.onIosUpload(
+        isRefresh: self.taskType == .refresh,
+        maxSeconds: self.maxSeconds.map { Int64($0) },
+        completion: { result in self.handleHostResult(result: result) }
+      )
+    }
   }
   
   func showNotification(title: String, content: String) throws {
@@ -133,8 +137,10 @@ class BackgroundWorker: BackgroundWorkerBgHostApi {
       return
     }
 
-    flutterApi?.cancel { result in
-      self.complete(success: false)
+    DispatchQueue.main.async {
+      self.flutterApi?.cancel { result in
+        self.complete(success: false)
+      }
     }
 
     // Fallback safety mechanism: ensure completion is called within 2 seconds

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -89,9 +89,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     }
 
     task.expirationHandler = {
-      DispatchQueue.main.async {
-        backgroundWorker.close()
-      }
+      backgroundWorker.close()
       isSuccess = false
       
       // Schedule a timer to signal the semaphore after 2 seconds
@@ -100,10 +98,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
       }
     }
 
-    DispatchQueue.main.async {
-      backgroundWorker.run()
-    }
-
+    backgroundWorker.run()
     semaphore.wait()
     task.setTaskCompleted(success: isSuccess)
     print("Background task completed with success: \(isSuccess)")


### PR DESCRIPTION
## Description

The previous implementation ran the engine and all the plugin registrations on the main thread. This moves all those to be executed in the background task thread and only invokes the platform channel method on the main thread
