### PR TITLE
fix: check if preferencesStore is defined

### DIFF
--- a/web/src/lib/utils/cast/gcast-destination.svelte.ts
+++ b/web/src/lib/utils/cast/gcast-destination.svelte.ts
@@ -27,7 +27,7 @@ export class GCastDestination implements ICastDestination {
 
   async initialize(): Promise<boolean> {
     const preferencesStore = get(preferences);
-    if (!preferencesStore.cast.gCastEnabled) {
+    if (!preferencesStore || !preferencesStore.cast.gCastEnabled) {
       this.isAvailable = false;
       return false;
     }


### PR DESCRIPTION
## Description

This test if the `preferenceStore` variable is initialized. For anonymous users visiting a share link URL this is not the case and that leads to a javascript error described in #21957

By checking if the `preferencesStore` is defined anonymous users should not get the javascript error and chrome cast initialisation will be disabled.

Fixes #21957

## How Has This Been Tested?
no tests

## API Changes
none 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none
