### PR TITLE
fix: move startInitialization to inside the doWork method

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -54,12 +54,6 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
 
   private var foregroundFuture: ListenableFuture<Void>? = null
 
-  init {
-    if (!loader.initialized()) {
-      loader.startInitialization(ctx)
-    }
-  }
-
   companion object {
     private const val NOTIFICATION_CHANNEL_ID = "immich::background_worker::notif"
     private const val NOTIFICATION_ID = 100
@@ -67,6 +61,10 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
 
   override fun startWork(): ListenableFuture<Result> {
     Log.i(TAG, "Starting background upload worker")
+
+    if (!loader.initialized()) {
+      loader.startInitialization(ctx)
+    }
 
     val notificationChannel = NotificationChannel(
       NOTIFICATION_CHANNEL_ID,


### PR DESCRIPTION
Fixes #21921