### PR TITLE
refactor: hashing service

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
@@ -209,6 +209,40 @@ data class SyncDelta (
 
   override fun hashCode(): Int = toList().hashCode()
 }
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class HashResult (
+  val assetId: String,
+  val error: String? = null,
+  val hash: String? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): HashResult {
+      val assetId = pigeonVar_list[0] as String
+      val error = pigeonVar_list[1] as String?
+      val hash = pigeonVar_list[2] as String?
+      return HashResult(assetId, error, hash)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      assetId,
+      error,
+      hash,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is HashResult) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return MessagesPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
 private open class MessagesPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -225,6 +259,11 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
       131.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           SyncDelta.fromList(it)
+        }
+      }
+      132.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HashResult.fromList(it)
         }
       }
       else -> super.readValueOfType(type, buffer)
@@ -244,10 +283,15 @@ private open class MessagesPigeonCodec : StandardMessageCodec() {
         stream.write(131)
         writeValue(stream, value.toList())
       }
+      is HashResult -> {
+        stream.write(132)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
 }
+
 
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface NativeSyncApi {
@@ -259,7 +303,7 @@ interface NativeSyncApi {
   fun getAlbums(): List<PlatformAlbum>
   fun getAssetsCountSince(albumId: String, timestamp: Long): Long
   fun getAssetsForAlbum(albumId: String, updatedTimeCond: Long?): List<PlatformAsset>
-  fun hashPaths(paths: List<String>): List<ByteArray?>
+  fun hashAssets(assetIds: List<String>, allowNetworkAccess: Boolean, callback: (Result<List<HashResult>>) -> Unit)
 
   companion object {
     /** The codec used by NativeSyncApi. */
@@ -402,17 +446,21 @@ interface NativeSyncApi {
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashPaths$separatedMessageChannelSuffix", codec, taskQueue)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashAssets$separatedMessageChannelSuffix", codec, taskQueue)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pathsArg = args[0] as List<String>
-            val wrapped: List<Any?> = try {
-              listOf(api.hashPaths(pathsArg))
-            } catch (exception: Throwable) {
-              MessagesPigeonUtils.wrapError(exception)
+            val assetIdsArg = args[0] as List<String>
+            val allowNetworkAccessArg = args[1] as Boolean
+            api.hashAssets(assetIdsArg, allowNetworkAccessArg) { result: Result<List<HashResult>> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(MessagesPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(MessagesPigeonUtils.wrapResult(data))
+              }
             }
-            reply.reply(wrapped)
           }
         } else {
           channel.setMessageHandler(null)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
@@ -304,6 +304,7 @@ interface NativeSyncApi {
   fun getAssetsCountSince(albumId: String, timestamp: Long): Long
   fun getAssetsForAlbum(albumId: String, updatedTimeCond: Long?): List<PlatformAsset>
   fun hashAssets(assetIds: List<String>, allowNetworkAccess: Boolean, callback: (Result<List<HashResult>>) -> Unit)
+  fun cancelHashing()
 
   companion object {
     /** The codec used by NativeSyncApi. */
@@ -461,6 +462,22 @@ interface NativeSyncApi {
                 reply.reply(MessagesPigeonUtils.wrapResult(data))
               }
             }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.cancelHashing$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.cancelHashing()
+              listOf(null)
+            } catch (exception: Throwable) {
+              MessagesPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
           }
         } else {
           channel.setMessageHandler(null)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -241,6 +241,7 @@ open class NativeSyncApiImplBase(context: Context) {
       return
     }
 
+    hashTask?.cancel()
     hashTask = CoroutineScope(Dispatchers.IO).launch {
       try {
         val results = assetIds.map { assetId ->

--- a/mobile/ios/.gitignore
+++ b/mobile/ios/.gitignore
@@ -4,7 +4,6 @@
 *.moved-aside
 *.pbxuser
 *.perspectivev3
-**/*sync/
 .sconsign.dblite
 .tags*
 **/.vagrant/

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -5,7 +5,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   func enable() throws {
     BackgroundWorkerApiImpl.scheduleRefreshWorker()
     BackgroundWorkerApiImpl.scheduleProcessingWorker()
-    print("BackgroundUploadImpl:enbale Background worker scheduled")
+    print("BackgroundWorkerApiImpl:enable Background worker scheduled")
   }
   
   func configure(settings: BackgroundWorkerSettings) throws {
@@ -15,7 +15,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   func disable() throws {
     BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundWorkerApiImpl.refreshTaskID);
     BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundWorkerApiImpl.processingTaskID);
-    print("BackgroundUploadImpl:disableUploadWorker Disabled background workers")
+    print("BackgroundWorkerApiImpl:disableUploadWorker Disabled background workers")
   }
   
   private static let refreshTaskID = "app.alextran.immich.background.refreshUpload"

--- a/mobile/ios/Runner/Sync/Messages.g.swift
+++ b/mobile/ios/Runner/Sync/Messages.g.swift
@@ -267,6 +267,39 @@ struct SyncDelta: Hashable {
   }
 }
 
+/// Generated class from Pigeon that represents data sent in messages.
+struct HashResult: Hashable {
+  var assetId: String
+  var error: String? = nil
+  var hash: String? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> HashResult? {
+    let assetId = pigeonVar_list[0] as! String
+    let error: String? = nilOrValue(pigeonVar_list[1])
+    let hash: String? = nilOrValue(pigeonVar_list[2])
+
+    return HashResult(
+      assetId: assetId,
+      error: error,
+      hash: hash
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      assetId,
+      error,
+      hash,
+    ]
+  }
+  static func == (lhs: HashResult, rhs: HashResult) -> Bool {
+    return deepEqualsMessages(lhs.toList(), rhs.toList())  }
+  func hash(into hasher: inout Hasher) {
+    deepHashMessages(value: toList(), hasher: &hasher)
+  }
+}
+
 private class MessagesPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -276,6 +309,8 @@ private class MessagesPigeonCodecReader: FlutterStandardReader {
       return PlatformAlbum.fromList(self.readValue() as! [Any?])
     case 131:
       return SyncDelta.fromList(self.readValue() as! [Any?])
+    case 132:
+      return HashResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -292,6 +327,9 @@ private class MessagesPigeonCodecWriter: FlutterStandardWriter {
       super.writeValue(value.toList())
     } else if let value = value as? SyncDelta {
       super.writeByte(131)
+      super.writeValue(value.toList())
+    } else if let value = value as? HashResult {
+      super.writeByte(132)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -313,6 +351,7 @@ class MessagesPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
   static let shared = MessagesPigeonCodec(readerWriter: MessagesPigeonCodecReaderWriter())
 }
 
+
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol NativeSyncApi {
   func shouldFullSync() throws -> Bool
@@ -323,7 +362,7 @@ protocol NativeSyncApi {
   func getAlbums() throws -> [PlatformAlbum]
   func getAssetsCountSince(albumId: String, timestamp: Int64) throws -> Int64
   func getAssetsForAlbum(albumId: String, updatedTimeCond: Int64?) throws -> [PlatformAsset]
-  func hashPaths(paths: [String]) throws -> [FlutterStandardTypedData?]
+  func hashAssets(assetIds: [String], allowNetworkAccess: Bool, completion: @escaping (Result<[HashResult], Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -459,22 +498,25 @@ class NativeSyncApiSetup {
     } else {
       getAssetsForAlbumChannel.setMessageHandler(nil)
     }
-    let hashPathsChannel = taskQueue == nil
-      ? FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashPaths\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-      : FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashPaths\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec, taskQueue: taskQueue)
+    let hashAssetsChannel = taskQueue == nil
+      ? FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashAssets\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+      : FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hashAssets\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec, taskQueue: taskQueue)
     if let api = api {
-      hashPathsChannel.setMessageHandler { message, reply in
+      hashAssetsChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
-        let pathsArg = args[0] as! [String]
-        do {
-          let result = try api.hashPaths(paths: pathsArg)
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
+        let assetIdsArg = args[0] as! [String]
+        let allowNetworkAccessArg = args[1] as! Bool
+        api.hashAssets(assetIds: assetIdsArg, allowNetworkAccess: allowNetworkAccessArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
         }
       }
     } else {
-      hashPathsChannel.setMessageHandler(nil)
+      hashAssetsChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Sync/Messages.g.swift
+++ b/mobile/ios/Runner/Sync/Messages.g.swift
@@ -363,6 +363,7 @@ protocol NativeSyncApi {
   func getAssetsCountSince(albumId: String, timestamp: Int64) throws -> Int64
   func getAssetsForAlbum(albumId: String, updatedTimeCond: Int64?) throws -> [PlatformAsset]
   func hashAssets(assetIds: [String], allowNetworkAccess: Bool, completion: @escaping (Result<[HashResult], Error>) -> Void)
+  func cancelHashing() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -517,6 +518,19 @@ class NativeSyncApiSetup {
       }
     } else {
       hashAssetsChannel.setMessageHandler(nil)
+    }
+    let cancelHashingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.cancelHashing\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      cancelHashingChannel.setMessageHandler { _, reply in
+        do {
+          try api.cancelHashing()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      cancelHashingChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -262,10 +262,7 @@ class NativeSyncApiImpl: NativeSyncApi {
         var results = [HashResult]()
         results.reserveCapacity(assets.count)
         for asset in assets {
-          taskGroup.addTask { [weak self] in
-            guard let self = self else {
-              return HashResult(assetId: asset.localIdentifier, error: "NativeSyncApiImpl deallocated", hash: nil)
-            }
+          taskGroup.addTask { [self] in
             return await self.hashAsset(asset, allowNetworkAccess: allowNetworkAccess)
           }
         }

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -17,23 +17,6 @@ struct AssetWrapper: Hashable, Equatable {
   }
 }
 
-extension PHAsset {
-  func toPlatformAsset() -> PlatformAsset {
-    return PlatformAsset(
-      id: localIdentifier,
-      name: title,
-      type: Int64(mediaType.rawValue),
-      createdAt: creationDate.map { Int64($0.timeIntervalSince1970) },
-      updatedAt: modificationDate.map { Int64($0.timeIntervalSince1970) },
-      width: Int64(pixelWidth),
-      height: Int64(pixelHeight),
-      durationInSeconds: Int64(duration),
-      orientation: 0,
-      isFavorite: isFavorite
-    )
-  }
-}
-
 class NativeSyncApiImpl: NativeSyncApi {
   private let defaults: UserDefaults
   private let changeTokenKey = "immich:changeToken"

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -281,9 +281,7 @@ class NativeSyncApiImpl: NativeSyncApi {
             return completion(Self.hashCancelled)
           }
           taskGroup.addTask {
-            guard let self = self else {
-              return HashResult(assetId: asset.localIdentifier, error: "Instance deallocated", hash: nil)
-            }
+            guard let self = self else { return nil }
             return await self.hashAsset(asset, allowNetworkAccess: allowNetworkAccess)
           }
         }

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -24,6 +24,7 @@ class NativeSyncApiImpl: NativeSyncApi {
   private let recoveredAlbumSubType = 1000000219
   private var hashTask: Task<Void, Error>?
   private var hashCancelled: Bool
+  private let hashCancelledCode = "HASH_CANCELLED"
   
   
   init(with defaults: UserDefaults = .standard) {
@@ -264,7 +265,7 @@ class NativeSyncApiImpl: NativeSyncApi {
       }
       
       if hashCancelled {
-        completion(.failure(PigeonError(code: "HASH_CANCELLED", message: "Hashing cancelled", details: nil)))
+        completion(.failure(PigeonError(code: hashCancelledCode, message: "Hashing cancelled", details: nil)))
       }
       
       await withTaskGroup(of: HashResult.self) { taskGroup in
@@ -285,7 +286,7 @@ class NativeSyncApiImpl: NativeSyncApi {
         }
         
         if hashCancelled {
-          completion(.failure(PigeonError(code: "HASH_CANCELLED", message: "Hashing cancelled", details: nil)))
+          completion(.failure(PigeonError(code: hashCancelledCode, message: "Hashing cancelled", details: nil)))
         } else {
           completion(.success(results))
         }

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -1,0 +1,64 @@
+import Photos
+
+extension PHAsset {
+
+  var title: String {
+    return filename ?? originalFilename ?? "<unknown>"
+  }
+  
+  var filename: String? {
+    return value(forKey: "filename") as? String
+  }
+  
+  // This method is expected to be slow as it goes through the asset resources to fetch the originalFilename
+  var originalFilename: String? {
+    return getResource()?.originalFilename
+  }
+  
+  func getResource() -> PHAssetResource? {
+    let resources = PHAssetResource.assetResources(for: self)
+    
+    var bestResource: PHAssetResource?
+    var bestPriority = Int.max
+    
+    for resource in resources {
+      let priority = getPriority(for: resource)
+      if priority == 0 {
+        return resource
+      }
+      
+      if priority < bestPriority {
+        bestResource = resource
+        bestPriority = priority
+      }
+    }
+    
+    return bestResource ?? resources.first
+  }
+  
+  private func getPriority(for resource: PHAssetResource) -> Int {
+    if (mediaType == .image && resource.type == .photo) ||
+       (mediaType == .video && resource.type == .video) {
+      return 0
+    }
+    
+    if mediaType == .image && resource.type == .alternatePhoto {
+      return 1
+    }
+    
+    if (mediaType == .image && resource.type == .fullSizePhoto) ||
+        (mediaType == .video && resource.type == .fullSizeVideo) {
+      return 2
+    }
+    
+    if resource.isCurrent {
+      return 3
+    }
+    
+    if resource.isMediaResource {
+      return 4
+    }
+    
+    return 5
+  }
+}

--- a/mobile/ios/Runner/Sync/PHAssetExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetExtensions.swift
@@ -15,63 +15,63 @@ extension PHAsset {
       isFavorite: isFavorite
     )
   }
-  
+
   var title: String {
     return filename ?? originalFilename ?? "<unknown>"
   }
-  
+
   var filename: String? {
     return value(forKey: "filename") as? String
   }
-  
+
   // This method is expected to be slow as it goes through the asset resources to fetch the originalFilename
   var originalFilename: String? {
     return getResource()?.originalFilename
   }
-  
+
   func getResource() -> PHAssetResource? {
     let resources = PHAssetResource.assetResources(for: self)
-    
-    let filteredResources = resources.filter { resource in
-      guard resource.isMediaResource else {
-        return false
-      }
-      
-      switch self.mediaType {
-      case .image:
-        return resource.type == .photo || resource.type == .alternatePhoto || resource.type == .fullSizePhoto
-      case .video:
-        return resource.type == .video || resource.type == .fullSizeVideo || resource.type == .fullSizePairedVideo
-      case .audio:
-        return resource.type == .audio
-      case .unknown:
-        return false
-      @unknown default:
-        return false
-      }
-    }
-    
+
+    let filteredResources = resources.filter { $0.isMediaResource && isValidResourceType($0.type) }
+
     guard !filteredResources.isEmpty else {
       return nil
     }
-    
+
     if filteredResources.count == 1 {
       return filteredResources.first
     }
-    
-    if let currentResource = filteredResources.first(where: {
-      ($0.value(forKey: "isCurrent") as? Bool) ?? false
-    }) {
+
+    if let currentResource = filteredResources.first(where: { $0.isCurrent }) {
       return currentResource
     }
-    
-    if let fullSizeResource = filteredResources.first(where: {
-      (self.mediaType == .image && $0.type == .fullSizePhoto) ||
-      (self.mediaType == .video && $0.type == .fullSizeVideo)
-    }) {
+
+    if let fullSizeResource = filteredResources.first(where: { isFullSizeResourceType($0.type) }) {
       return fullSizeResource
     }
-    
+
     return nil
+  }
+
+  private func isValidResourceType(_ type: PHAssetResourceType) -> Bool {
+    switch mediaType {
+    case .image:
+      return [.photo, .alternatePhoto, .fullSizePhoto].contains(type)
+    case .video:
+      return [.video, .fullSizeVideo, .fullSizePairedVideo].contains(type)
+    default:
+      return false
+    }
+  }
+
+  private func isFullSizeResourceType(_ type: PHAssetResourceType) -> Bool {
+    switch mediaType {
+    case .image:
+      return type == .fullSizePhoto
+    case .video:
+      return type == .fullSizeVideo
+    default:
+      return false
+    }
   }
 }

--- a/mobile/ios/Runner/Sync/PHAssetResourceExtensions.swift
+++ b/mobile/ios/Runner/Sync/PHAssetResourceExtensions.swift
@@ -1,0 +1,16 @@
+
+import Photos
+
+extension PHAssetResource {
+  var isCurrent: Bool {
+    return value(forKey: "isCurrent") as? Bool ?? false
+  }
+  
+  var isMediaResource: Bool {
+    var isMedia = type != .adjustmentData
+    if #available(iOS 17, *) {
+      isMedia = isMedia && type != .photoProxy
+    }
+    return isMedia
+  }
+}

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 const int noDbId = -9223372036854775808; // from Isar
 const double downloadCompleted = -1;
 const double downloadFailed = -2;
@@ -10,7 +12,7 @@ const int kSyncEventBatchSize = 5000;
 const int kFetchLocalAssetsBatchSize = 40000;
 
 // Hash batch limits
-const int kBatchHashFileLimit = 256;
+final int kBatchHashFileLimit = Platform.isIOS ? 32 : 512;
 const int kBatchHashSizeLimit = 1024 * 1024 * 1024; // 1GB
 
 // Secure storage keys

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -12,6 +12,7 @@ const int kFetchLocalAssetsBatchSize = 40000;
 // Hash batch limits
 const int kBatchHashFileLimit = 256;
 const int kBatchHashSizeLimit = 1024 * 1024 * 1024; // 1GB
+const int kHashBatchLimit = 1024;
 
 // Secure storage keys
 const String kSecuredPinCode = "secured_pin_code";

--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -12,7 +12,6 @@ const int kFetchLocalAssetsBatchSize = 40000;
 // Hash batch limits
 const int kBatchHashFileLimit = 256;
 const int kBatchHashSizeLimit = 1024 * 1024 * 1024; // 1GB
-const int kHashBatchLimit = 1024;
 
 // Secure storage keys
 const String kSecuredPinCode = "secured_pin_code";

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -200,7 +200,6 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         _drift.close(),
         _driftLogger.close(),
         backgroundSyncManager.cancel(),
-        backgroundSyncManager.cancelLocal(),
         nativeSyncApi.cancelHashing(),
       ];
 

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -184,6 +184,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
     try {
       final backgroundSyncManager = _ref.read(backgroundSyncProvider);
+      final nativeSyncApi = _ref.read(nativeSyncApiProvider);
       _isCleanedUp = true;
       _ref.dispose();
 
@@ -200,6 +201,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         _driftLogger.close(),
         backgroundSyncManager.cancel(),
         backgroundSyncManager.cancelLocal(),
+        nativeSyncApi.cancelHashing(),
       ];
 
       if (_isar.isOpen) {

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -10,8 +8,7 @@ import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:logging/logging.dart';
 
 class HashService {
-  final int batchSizeLimit;
-  final int batchFileLimit;
+  final int _batchSize;
   final DriftLocalAlbumRepository _localAlbumRepository;
   final DriftLocalAssetRepository _localAssetRepository;
   final StorageRepository _storageRepository;
@@ -25,13 +22,13 @@ class HashService {
     required StorageRepository storageRepository,
     required NativeSyncApi nativeSyncApi,
     bool Function()? cancelChecker,
-    this.batchSizeLimit = kBatchHashSizeLimit,
-    this.batchFileLimit = kBatchHashFileLimit,
+    int batchSize = kBatchHashFileLimit,
   }) : _localAlbumRepository = localAlbumRepository,
        _localAssetRepository = localAssetRepository,
        _storageRepository = storageRepository,
        _cancelChecker = cancelChecker,
-       _nativeSyncApi = nativeSyncApi;
+       _nativeSyncApi = nativeSyncApi,
+       _batchSize = batchSize;
 
   bool get isCancelled => _cancelChecker?.call() ?? false;
 
@@ -51,7 +48,7 @@ class HashService {
 
       final assetsToHash = await _localAlbumRepository.getAssetsToHash(album.id);
       if (assetsToHash.isNotEmpty) {
-        await _hashAssets(album, assetsToHash);
+        await _hashAssets(album, assetsToHash, album.backupSelection == BackupSelection.selected);
       }
     }
 
@@ -62,9 +59,8 @@ class HashService {
   /// Processes a list of [LocalAsset]s, storing their hash and updating the assets in the DB
   /// with hash for those that were successfully hashed. Hashes are looked up in a table
   /// [LocalAssetHashEntity] by local id. Only missing entries are newly hashed and added to the DB.
-  Future<void> _hashAssets(LocalAlbum album, List<LocalAsset> assetsToHash) async {
-    int bytesProcessed = 0;
-    final toHash = <_AssetToPath>[];
+  Future<void> _hashAssets(LocalAlbum album, List<LocalAsset> assetsToHash, bool allowNetworkAccess) async {
+    final toHash = <String>[];
 
     for (final asset in assetsToHash) {
       if (isCancelled) {
@@ -72,55 +68,43 @@ class HashService {
         return;
       }
 
-      final file = await _storageRepository.getFileForAsset(asset.id);
-      if (file == null) {
-        _log.warning(
-          "Cannot get file for asset ${asset.id}, name: ${asset.name}, created on: ${asset.createdAt} from album: ${album.name}",
-        );
-        continue;
-      }
-
-      bytesProcessed += await file.length();
-      toHash.add(_AssetToPath(asset: asset, path: file.path));
-
-      if (toHash.length >= batchFileLimit || bytesProcessed >= batchSizeLimit) {
-        await _processBatch(album, toHash);
+      toHash.add(asset.id);
+      if (toHash.length >= _batchSize) {
+        await _processBatch(album, toHash, allowNetworkAccess);
         toHash.clear();
-        bytesProcessed = 0;
       }
     }
 
-    await _processBatch(album, toHash);
+    await _processBatch(album, toHash, allowNetworkAccess);
   }
 
   /// Processes a batch of assets.
-  Future<void> _processBatch(LocalAlbum album, List<_AssetToPath> toHash) async {
+  Future<void> _processBatch(LocalAlbum album, List<String> toHash, bool allowNetworkAccess) async {
     if (toHash.isEmpty) {
       return;
     }
 
     _log.fine("Hashing ${toHash.length} files");
 
-    final hashed = <LocalAsset>[];
-    final hashes = await _nativeSyncApi.hashPaths(toHash.map((e) => e.path).toList());
+    final hashed = <String, String>{};
+    final hashResults = await _nativeSyncApi.hashAssets(toHash, allowNetworkAccess: allowNetworkAccess);
     assert(
-      hashes.length == toHash.length,
-      "Hashes length does not match toHash length: ${hashes.length} != ${toHash.length}",
+      hashResults.length == toHash.length,
+      "Hashes length does not match toHash length: ${hashResults.length} != ${toHash.length}",
     );
 
-    for (int i = 0; i < hashes.length; i++) {
+    for (int i = 0; i < hashResults.length; i++) {
       if (isCancelled) {
         _log.warning("Hashing cancelled. Stopped processing batch.");
         return;
       }
 
-      final hash = hashes[i];
-      final asset = toHash[i].asset;
-      if (hash?.length == 20) {
-        hashed.add(asset.copyWith(checksum: base64.encode(hash!)));
+      final hashResult = hashResults[i];
+      if (hashResult.hash != null) {
+        hashed[hashResult.assetId] = hashResult.hash!;
       } else {
         _log.warning(
-          "Failed to hash file for ${asset.id}: ${asset.name} created at ${asset.createdAt} from album: ${album.name}",
+          "Failed to hash file for ${hashResult.assetId} from album: ${album.name}. Error: ${hashResult.error ?? "unknown"}",
         );
       }
     }
@@ -130,11 +114,4 @@ class HashService {
     await _localAssetRepository.updateHashes(hashed);
     await _storageRepository.clearCache();
   }
-}
-
-class _AssetToPath {
-  final LocalAsset asset;
-  final String path;
-
-  const _AssetToPath({required this.asset, required this.path});
 }

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -19,7 +19,7 @@ class HashService {
     required DriftLocalAssetRepository localAssetRepository,
     required NativeSyncApi nativeSyncApi,
     bool Function()? cancelChecker,
-    int batchSize = kHashBatchLimit,
+    int batchSize = kBatchHashFileLimit,
   }) : _localAlbumRepository = localAlbumRepository,
        _localAssetRepository = localAssetRepository,
        _cancelChecker = cancelChecker,

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -19,12 +19,12 @@ class HashService {
     required DriftLocalAssetRepository localAssetRepository,
     required NativeSyncApi nativeSyncApi,
     bool Function()? cancelChecker,
-    int batchSize = kBatchHashFileLimit,
+    int? batchSize,
   }) : _localAlbumRepository = localAlbumRepository,
        _localAssetRepository = localAssetRepository,
        _cancelChecker = cancelChecker,
        _nativeSyncApi = nativeSyncApi,
-       _batchSize = batchSize;
+       _batchSize = batchSize ?? kBatchHashFileLimit;
 
   bool get isCancelled => _cancelChecker?.call() ?? false;
 

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -3,7 +3,6 @@ import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
-import 'package:immich_mobile/infrastructure/repositories/storage.repository.dart';
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:logging/logging.dart';
 
@@ -11,7 +10,6 @@ class HashService {
   final int _batchSize;
   final DriftLocalAlbumRepository _localAlbumRepository;
   final DriftLocalAssetRepository _localAssetRepository;
-  final StorageRepository _storageRepository;
   final NativeSyncApi _nativeSyncApi;
   final bool Function()? _cancelChecker;
   final _log = Logger('HashService');
@@ -19,13 +17,11 @@ class HashService {
   HashService({
     required DriftLocalAlbumRepository localAlbumRepository,
     required DriftLocalAssetRepository localAssetRepository,
-    required StorageRepository storageRepository,
     required NativeSyncApi nativeSyncApi,
     bool Function()? cancelChecker,
     int batchSize = kBatchHashFileLimit,
   }) : _localAlbumRepository = localAlbumRepository,
        _localAssetRepository = localAssetRepository,
-       _storageRepository = storageRepository,
        _cancelChecker = cancelChecker,
        _nativeSyncApi = nativeSyncApi,
        _batchSize = batchSize;
@@ -69,7 +65,7 @@ class HashService {
       }
 
       toHash.add(asset.id);
-      if (toHash.length >= _batchSize) {
+      if (toHash.length == _batchSize) {
         await _processBatch(album, toHash, allowNetworkAccess);
         toHash.clear();
       }
@@ -112,6 +108,5 @@ class HashService {
     _log.fine("Hashed ${hashed.length}/${toHash.length} assets");
 
     await _localAssetRepository.updateHashes(hashed);
-    await _storageRepository.clearCache();
   }
 }

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -19,7 +19,7 @@ class HashService {
     required DriftLocalAssetRepository localAssetRepository,
     required NativeSyncApi nativeSyncApi,
     bool Function()? cancelChecker,
-    int batchSize = kBatchHashFileLimit,
+    int batchSize = kHashBatchLimit,
   }) : _localAlbumRepository = localAlbumRepository,
        _localAssetRepository = localAssetRepository,
        _cancelChecker = cancelChecker,

--- a/mobile/lib/domain/services/hash.service.dart
+++ b/mobile/lib/domain/services/hash.service.dart
@@ -7,6 +7,8 @@ import 'package:immich_mobile/infrastructure/repositories/local_asset.repository
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:logging/logging.dart';
 
+const String _kHashCancelledCode = "HASH_CANCELLED";
+
 class HashService {
   final int _batchSize;
   final DriftLocalAlbumRepository _localAlbumRepository;
@@ -48,7 +50,7 @@ class HashService {
         }
       }
     } on PlatformException catch (e) {
-      if (e.code == "HASH_CANCELLED") {
+      if (e.code == _kHashCancelledCode) {
         _log.warning("Hashing cancelled by platform");
         return;
       }

--- a/mobile/lib/infrastructure/repositories/local_asset.repository.dart
+++ b/mobile/lib/infrastructure/repositories/local_asset.repository.dart
@@ -36,17 +36,17 @@ class DriftLocalAssetRepository extends DriftDatabaseRepository {
 
   Stream<LocalAsset?> watch(String id) => _assetSelectable(id).watchSingleOrNull();
 
-  Future<void> updateHashes(Iterable<LocalAsset> hashes) {
+  Future<void> updateHashes(Map<String, String> hashes) {
     if (hashes.isEmpty) {
       return Future.value();
     }
 
     return _db.batch((batch) async {
-      for (final asset in hashes) {
+      for (final entry in hashes.entries) {
         batch.update(
           _db.localAssetEntity,
-          LocalAssetEntityCompanion(checksum: Value(asset.checksum)),
-          where: (e) => e.id.equals(asset.id),
+          LocalAssetEntityCompanion(checksum: Value(entry.value)),
+          where: (e) => e.id.equals(entry.key),
         );
       }
     });

--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -13,8 +13,6 @@ import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
-import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/widgets/backup/drift_album_info_list_tile.dart';
@@ -108,17 +106,9 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
           final totalChanged = currentTotalAssetCount != _initialTotalAssetCount;
           final backupNotifier = ref.read(driftBackupProvider.notifier);
           final backgroundSync = ref.read(backgroundSyncProvider);
-          final nativeSync = ref.read(nativeSyncApiProvider);
-          final syncStatus = ref.read(syncStatusProvider);
           if (totalChanged) {
-            unawaited(nativeSync.cancelHashing());
-            if (syncStatus.isHashing) {
-              // Waits for hashing to be cancelled before starting a new one
-              unawaited(backgroundSync.hashAssets().whenComplete(() => backgroundSync.hashAssets()));
-            } else {
-              unawaited(backgroundSync.hashAssets());
-            }
-
+            // Waits for hashing to be cancelled before starting a new one
+            unawaited(backgroundSync.hashAssets());
             if (isBackupEnabled) {
               unawaited(backupNotifier.cancel().whenComplete(() => backupNotifier.startBackup(user.id)));
             }

--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/widgets/backup/drift_album_info_list_tile.dart';
@@ -106,9 +107,10 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
           final totalChanged = currentTotalAssetCount != _initialTotalAssetCount;
           final backupNotifier = ref.read(driftBackupProvider.notifier);
           final backgroundSync = ref.read(backgroundSyncProvider);
+          final nativeSync = ref.read(nativeSyncApiProvider);
           if (totalChanged) {
             // Waits for hashing to be cancelled before starting a new one
-            unawaited(backgroundSync.hashAssets());
+            unawaited(nativeSync.cancelHashing().whenComplete(() => backgroundSync.hashAssets()));
             if (isBackupEnabled) {
               unawaited(backupNotifier.cancel().whenComplete(() => backupNotifier.startBackup(user.id)));
             }

--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:auto_route/auto_route.dart';
@@ -5,12 +6,14 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
+import 'package:immich_mobile/domain/services/sync_linked_album.service.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
-import 'package:immich_mobile/domain/services/sync_linked_album.service.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/widgets/backup/drift_album_info_list_tile.dart';
@@ -64,16 +67,6 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
       });
       await _handleLinkedAlbumFuture;
     }
-
-    // Restart backup if total count changed and backup is enabled
-    final currentTotalAssetCount = ref.read(driftBackupProvider.select((p) => p.totalCount));
-    final totalChanged = currentTotalAssetCount != _initialTotalAssetCount;
-    final isBackupEnabled = ref.read(appSettingsServiceProvider).getSetting(AppSettingsEnum.enableBackup);
-
-    if (totalChanged && isBackupEnabled) {
-      await ref.read(driftBackupProvider.notifier).cancel();
-      await ref.read(driftBackupProvider.notifier).startBackup(user.id);
-    }
   }
 
   @override
@@ -102,6 +95,29 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
       onPopInvokedWithResult: (didPop, _) async {
         if (!didPop) {
           await _handlePagePopped();
+
+          final user = ref.read(currentUserProvider);
+          if (user == null) {
+            return;
+          }
+
+          final isBackupEnabled = ref.read(appSettingsServiceProvider).getSetting(AppSettingsEnum.enableBackup);
+          await ref.read(driftBackupProvider.notifier).getBackupStatus(user.id);
+          final currentTotalAssetCount = ref.read(driftBackupProvider.select((p) => p.totalCount));
+          final totalChanged = currentTotalAssetCount != _initialTotalAssetCount;
+          final backupNotifier = ref.read(driftBackupProvider.notifier);
+          final backgroundSync = ref.read(backgroundSyncProvider);
+          final nativeSync = ref.read(nativeSyncApiProvider);
+          if (totalChanged) {
+            unawaited(nativeSync.cancelHashing());
+            // Waits for hashing to be cancelled before starting a new one
+            unawaited(backgroundSync.hashAssets().whenComplete(() => backgroundSync.hashAssets()));
+
+            if (isBackupEnabled) {
+              unawaited(backupNotifier.cancel().whenComplete(() => backupNotifier.startBackup(user.id)));
+            }
+          }
+
           Navigator.of(context).pop();
         }
       },

--- a/mobile/lib/platform/native_sync_api.g.dart
+++ b/mobile/lib/platform/native_sync_api.g.dart
@@ -539,4 +539,27 @@ class NativeSyncApi {
       return (pigeonVar_replyList[0] as List<Object?>?)!.cast<HashResult>();
     }
   }
+
+  Future<void> cancelHashing() async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NativeSyncApi.cancelHashing$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
 }

--- a/mobile/lib/providers/infrastructure/sync.provider.dart
+++ b/mobile/lib/providers/infrastructure/sync.provider.dart
@@ -10,7 +10,6 @@ import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/cancel.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 
 final syncStreamServiceProvider = Provider(
   (ref) => SyncStreamService(
@@ -35,7 +34,6 @@ final hashServiceProvider = Provider(
   (ref) => HashService(
     localAlbumRepository: ref.watch(localAlbumRepository),
     localAssetRepository: ref.watch(localAssetRepository),
-    storageRepository: ref.watch(storageRepositoryProvider),
     nativeSyncApi: ref.watch(nativeSyncApiProvider),
   ),
 );

--- a/mobile/lib/services/hash.service.dart
+++ b/mobile/lib/services/hash.service.dart
@@ -16,9 +16,10 @@ class HashService {
     required IsarDeviceAssetRepository deviceAssetRepository,
     required BackgroundService backgroundService,
     this.batchSizeLimit = kBatchHashSizeLimit,
-    this.batchFileLimit = kBatchHashFileLimit,
+    int? batchFileLimit,
   }) : _deviceAssetRepository = deviceAssetRepository,
-       _backgroundService = backgroundService;
+       _backgroundService = backgroundService,
+       batchFileLimit = batchFileLimit ?? kBatchHashFileLimit;
 
   final IsarDeviceAssetRepository _deviceAssetRepository;
   final BackgroundService _backgroundService;

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -71,6 +71,14 @@ class SyncDelta {
   });
 }
 
+class HashResult {
+  final String assetId;
+  final String? error;
+  final String? hash;
+
+  const HashResult({required this.assetId, this.error, this.hash});
+}
+
 @HostApi()
 abstract class NativeSyncApi {
   bool shouldFullSync();
@@ -94,6 +102,7 @@ abstract class NativeSyncApi {
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   List<PlatformAsset> getAssetsForAlbum(String albumId, {int? updatedTimeCond});
 
+  @async
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
-  List<Uint8List?> hashPaths(List<String> paths);
+  List<HashResult> hashAssets(List<String> assetIds, {bool allowNetworkAccess = false});
 }

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -105,4 +105,6 @@ abstract class NativeSyncApi {
   @async
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   List<HashResult> hashAssets(List<String> assetIds, {bool allowNetworkAccess = false});
+
+  void cancelHashing();
 }

--- a/mobile/test/domain/services/hash_service_test.dart
+++ b/mobile/test/domain/services/hash_service_test.dart
@@ -1,11 +1,8 @@
-import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/services/hash.service.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
+import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../fixtures/album.stub.dart';
@@ -13,34 +10,29 @@ import '../../fixtures/asset.stub.dart';
 import '../../infrastructure/repository.mock.dart';
 import '../service.mock.dart';
 
-class MockFile extends Mock implements File {}
-
 void main() {
   late HashService sut;
   late MockLocalAlbumRepository mockAlbumRepo;
   late MockLocalAssetRepository mockAssetRepo;
-  late MockStorageRepository mockStorageRepo;
   late MockNativeSyncApi mockNativeApi;
   final sortBy = {SortLocalAlbumsBy.backupSelection, SortLocalAlbumsBy.isIosSharedAlbum};
 
   setUp(() {
     mockAlbumRepo = MockLocalAlbumRepository();
     mockAssetRepo = MockLocalAssetRepository();
-    mockStorageRepo = MockStorageRepository();
     mockNativeApi = MockNativeSyncApi();
 
     sut = HashService(
       localAlbumRepository: mockAlbumRepo,
       localAssetRepository: mockAssetRepo,
-      storageRepository: mockStorageRepo,
       nativeSyncApi: mockNativeApi,
     );
 
     registerFallbackValue(LocalAlbumStub.recent);
     registerFallbackValue(LocalAssetStub.image1);
+    registerFallbackValue(<String, String>{});
 
     when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
-    when(() => mockStorageRepo.clearCache()).thenAnswer((_) async => {});
   });
 
   group('HashService hashAssets', () {
@@ -52,153 +44,104 @@ void main() {
 
       await sut.hashAssets();
 
-      verifyNever(() => mockStorageRepo.getFileForAsset(any()));
-      verifyNever(() => mockNativeApi.hashPaths(any()));
+      verifyNever(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess')));
     });
   });
 
   group('HashService _hashAssets', () {
-    test('skips assets without files', () async {
+    test('skips empty batches', () async {
       final album = LocalAlbumStub.recent;
-      final asset = LocalAssetStub.image1;
       when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
-      when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
-      when(() => mockStorageRepo.getFileForAsset(asset.id)).thenAnswer((_) async => null);
+      when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => []);
 
       await sut.hashAssets();
 
-      verifyNever(() => mockNativeApi.hashPaths(any()));
+      verifyNever(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess')));
     });
 
     test('processes assets when available', () async {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
-      final mockFile = MockFile();
-      final hash = Uint8List.fromList(List.generate(20, (i) => i));
-
-      when(() => mockFile.length()).thenAnswer((_) async => 1000);
-      when(() => mockFile.path).thenReturn('image-path');
 
       when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
-      when(() => mockStorageRepo.getFileForAsset(asset.id)).thenAnswer((_) async => mockFile);
-      when(() => mockNativeApi.hashPaths(['image-path'])).thenAnswer((_) async => [hash]);
+      when(
+        () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
+      ).thenAnswer((_) async => [HashResult(assetId: asset.id, hash: 'test-hash')]);
 
       await sut.hashAssets();
 
-      verify(() => mockNativeApi.hashPaths(['image-path'])).called(1);
-      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as List<LocalAsset>;
+      verify(() => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false)).called(1);
+      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as Map<String, String>;
       expect(captured.length, 1);
-      expect(captured[0].checksum, base64.encode(hash));
+      expect(captured[asset.id], 'test-hash');
     });
 
     test('handles failed hashes', () async {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
-      final mockFile = MockFile();
-      when(() => mockFile.length()).thenAnswer((_) async => 1000);
-      when(() => mockFile.path).thenReturn('image-path');
 
       when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
-      when(() => mockStorageRepo.getFileForAsset(asset.id)).thenAnswer((_) async => mockFile);
-      when(() => mockNativeApi.hashPaths(['image-path'])).thenAnswer((_) async => [null]);
-      when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
+      when(
+        () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
+      ).thenAnswer((_) async => [HashResult(assetId: asset.id, error: 'Failed to hash')]);
 
       await sut.hashAssets();
 
-      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as List<LocalAsset>;
+      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as Map<String, String>;
       expect(captured.length, 0);
     });
 
-    test('handles invalid hash length', () async {
+    test('handles null hash results', () async {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
-      final mockFile = MockFile();
-      when(() => mockFile.length()).thenAnswer((_) async => 1000);
-      when(() => mockFile.path).thenReturn('image-path');
 
       when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
-      when(() => mockStorageRepo.getFileForAsset(asset.id)).thenAnswer((_) async => mockFile);
-
-      final invalidHash = Uint8List.fromList([1, 2, 3]);
-      when(() => mockNativeApi.hashPaths(['image-path'])).thenAnswer((_) async => [invalidHash]);
-      when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
+      when(
+        () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
+      ).thenAnswer((_) async => [HashResult(assetId: asset.id, hash: null)]);
 
       await sut.hashAssets();
 
-      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as List<LocalAsset>;
+      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as Map<String, String>;
       expect(captured.length, 0);
-    });
-
-    test('batches by file count limit', () async {
-      final sut = HashService(
-        localAlbumRepository: mockAlbumRepo,
-        localAssetRepository: mockAssetRepo,
-        storageRepository: mockStorageRepo,
-        nativeSyncApi: mockNativeApi,
-        batchFileLimit: 1,
-      );
-
-      final album = LocalAlbumStub.recent;
-      final asset1 = LocalAssetStub.image1;
-      final asset2 = LocalAssetStub.image2;
-      final mockFile1 = MockFile();
-      final mockFile2 = MockFile();
-      when(() => mockFile1.length()).thenAnswer((_) async => 100);
-      when(() => mockFile1.path).thenReturn('path-1');
-      when(() => mockFile2.length()).thenAnswer((_) async => 100);
-      when(() => mockFile2.path).thenReturn('path-2');
-
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
-      when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2]);
-      when(() => mockStorageRepo.getFileForAsset(asset1.id)).thenAnswer((_) async => mockFile1);
-      when(() => mockStorageRepo.getFileForAsset(asset2.id)).thenAnswer((_) async => mockFile2);
-
-      final hash = Uint8List.fromList(List.generate(20, (i) => i));
-      when(() => mockNativeApi.hashPaths(any())).thenAnswer((_) async => [hash]);
-      when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
-
-      await sut.hashAssets();
-
-      verify(() => mockNativeApi.hashPaths(['path-1'])).called(1);
-      verify(() => mockNativeApi.hashPaths(['path-2'])).called(1);
-      verify(() => mockAssetRepo.updateHashes(any())).called(2);
     });
 
     test('batches by size limit', () async {
+      const batchSize = 2;
       final sut = HashService(
         localAlbumRepository: mockAlbumRepo,
         localAssetRepository: mockAssetRepo,
-        storageRepository: mockStorageRepo,
         nativeSyncApi: mockNativeApi,
-        batchSizeLimit: 80,
+        batchSize: batchSize,
       );
 
       final album = LocalAlbumStub.recent;
       final asset1 = LocalAssetStub.image1;
       final asset2 = LocalAssetStub.image2;
-      final mockFile1 = MockFile();
-      final mockFile2 = MockFile();
-      when(() => mockFile1.length()).thenAnswer((_) async => 100);
-      when(() => mockFile1.path).thenReturn('path-1');
-      when(() => mockFile2.length()).thenAnswer((_) async => 100);
-      when(() => mockFile2.path).thenReturn('path-2');
+      final asset3 = LocalAssetStub.image1.copyWith(id: 'image3', name: 'image3.jpg');
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
-      when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2]);
-      when(() => mockStorageRepo.getFileForAsset(asset1.id)).thenAnswer((_) async => mockFile1);
-      when(() => mockStorageRepo.getFileForAsset(asset2.id)).thenAnswer((_) async => mockFile2);
+      final capturedCalls = <List<String>>[];
 
-      final hash = Uint8List.fromList(List.generate(20, (i) => i));
-      when(() => mockNativeApi.hashPaths(any())).thenAnswer((_) async => [hash]);
       when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
+      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2, asset3]);
+      when(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess'))).thenAnswer((
+        invocation,
+      ) async {
+        final assetIds = invocation.positionalArguments[0] as List<String>;
+        capturedCalls.add(List<String>.from(assetIds));
+        return assetIds.map((id) => HashResult(assetId: id, hash: '$id-hash')).toList();
+      });
 
       await sut.hashAssets();
 
-      verify(() => mockNativeApi.hashPaths(['path-1'])).called(1);
-      verify(() => mockNativeApi.hashPaths(['path-2'])).called(1);
+      expect(capturedCalls.length, 2, reason: 'Should make exactly 2 calls to hashAssets');
+      expect(capturedCalls[0], [asset1.id, asset2.id], reason: 'First call should batch the first two assets');
+      expect(capturedCalls[1], [asset3.id], reason: 'Second call should have the remaining asset');
+
       verify(() => mockAssetRepo.updateHashes(any())).called(2);
     });
 
@@ -206,27 +149,43 @@ void main() {
       final album = LocalAlbumStub.recent;
       final asset1 = LocalAssetStub.image1;
       final asset2 = LocalAssetStub.image2;
-      final mockFile1 = MockFile();
-      final mockFile2 = MockFile();
-      when(() => mockFile1.length()).thenAnswer((_) async => 100);
-      when(() => mockFile1.path).thenReturn('path-1');
-      when(() => mockFile2.length()).thenAnswer((_) async => 100);
-      when(() => mockFile2.path).thenReturn('path-2');
 
       when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2]);
-      when(() => mockStorageRepo.getFileForAsset(asset1.id)).thenAnswer((_) async => mockFile1);
-      when(() => mockStorageRepo.getFileForAsset(asset2.id)).thenAnswer((_) async => mockFile2);
-
-      final validHash = Uint8List.fromList(List.generate(20, (i) => i));
-      when(() => mockNativeApi.hashPaths(['path-1', 'path-2'])).thenAnswer((_) async => [validHash, null]);
-      when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
+      when(() => mockNativeApi.hashAssets([asset1.id, asset2.id], allowNetworkAccess: false)).thenAnswer(
+        (_) async => [
+          HashResult(assetId: asset1.id, hash: 'asset1-hash'),
+          HashResult(assetId: asset2.id, error: 'Failed to hash asset2'),
+        ],
+      );
 
       await sut.hashAssets();
 
-      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as List<LocalAsset>;
+      final captured = verify(() => mockAssetRepo.updateHashes(captureAny())).captured.first as Map<String, String>;
       expect(captured.length, 1);
-      expect(captured.first.id, asset1.id);
+      expect(captured[asset1.id], 'asset1-hash');
+    });
+
+    test('uses allowNetworkAccess based on album backup selection', () async {
+      final selectedAlbum = LocalAlbumStub.recent.copyWith(backupSelection: BackupSelection.selected);
+      final nonSelectedAlbum = LocalAlbumStub.recent.copyWith(id: 'album2', backupSelection: BackupSelection.excluded);
+      final asset1 = LocalAssetStub.image1;
+      final asset2 = LocalAssetStub.image2;
+
+      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [selectedAlbum, nonSelectedAlbum]);
+      when(() => mockAlbumRepo.getAssetsToHash(selectedAlbum.id)).thenAnswer((_) async => [asset1]);
+      when(() => mockAlbumRepo.getAssetsToHash(nonSelectedAlbum.id)).thenAnswer((_) async => [asset2]);
+      when(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess'))).thenAnswer((
+        invocation,
+      ) async {
+        final assetIds = invocation.positionalArguments[0] as List<String>;
+        return assetIds.map((id) => HashResult(assetId: id, hash: '$id-hash')).toList();
+      });
+
+      await sut.hashAssets();
+
+      verify(() => mockNativeApi.hashAssets([asset1.id], allowNetworkAccess: true)).called(1);
+      verify(() => mockNativeApi.hashAssets([asset2.id], allowNetworkAccess: false)).called(1);
     });
   });
 }

--- a/mobile/test/domain/services/hash_service_test.dart
+++ b/mobile/test/domain/services/hash_service_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/domain/services/hash.service.dart';
-import 'package:immich_mobile/infrastructure/repositories/local_album.repository.dart';
 import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -15,7 +14,6 @@ void main() {
   late MockLocalAlbumRepository mockAlbumRepo;
   late MockLocalAssetRepository mockAssetRepo;
   late MockNativeSyncApi mockNativeApi;
-  final sortBy = {SortLocalAlbumsBy.backupSelection, SortLocalAlbumsBy.isIosSharedAlbum};
 
   setUp(() {
     mockAlbumRepo = MockLocalAlbumRepository();
@@ -38,7 +36,7 @@ void main() {
   group('HashService hashAssets', () {
     test('skips albums with no assets to hash', () async {
       when(
-        () => mockAlbumRepo.getAll(sortBy: sortBy),
+        () => mockAlbumRepo.getBackupAlbums(),
       ).thenAnswer((_) async => [LocalAlbumStub.recent.copyWith(assetCount: 0)]);
       when(() => mockAlbumRepo.getAssetsToHash(LocalAlbumStub.recent.id)).thenAnswer((_) async => []);
 
@@ -51,7 +49,7 @@ void main() {
   group('HashService _hashAssets', () {
     test('skips empty batches', () async {
       final album = LocalAlbumStub.recent;
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => []);
 
       await sut.hashAssets();
@@ -63,7 +61,7 @@ void main() {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
       when(
         () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
@@ -81,7 +79,7 @@ void main() {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
       when(
         () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
@@ -97,7 +95,7 @@ void main() {
       final album = LocalAlbumStub.recent;
       final asset = LocalAssetStub.image1;
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset]);
       when(
         () => mockNativeApi.hashAssets([asset.id], allowNetworkAccess: false),
@@ -126,7 +124,7 @@ void main() {
       final capturedCalls = <List<String>>[];
 
       when(() => mockAssetRepo.updateHashes(any())).thenAnswer((_) async => {});
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2, asset3]);
       when(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess'))).thenAnswer((
         invocation,
@@ -150,7 +148,7 @@ void main() {
       final asset1 = LocalAssetStub.image1;
       final asset2 = LocalAssetStub.image2;
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [album]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [album]);
       when(() => mockAlbumRepo.getAssetsToHash(album.id)).thenAnswer((_) async => [asset1, asset2]);
       when(() => mockNativeApi.hashAssets([asset1.id, asset2.id], allowNetworkAccess: false)).thenAnswer(
         (_) async => [
@@ -172,7 +170,7 @@ void main() {
       final asset1 = LocalAssetStub.image1;
       final asset2 = LocalAssetStub.image2;
 
-      when(() => mockAlbumRepo.getAll(sortBy: sortBy)).thenAnswer((_) async => [selectedAlbum, nonSelectedAlbum]);
+      when(() => mockAlbumRepo.getBackupAlbums()).thenAnswer((_) async => [selectedAlbum, nonSelectedAlbum]);
       when(() => mockAlbumRepo.getAssetsToHash(selectedAlbum.id)).thenAnswer((_) async => [asset1]);
       when(() => mockAlbumRepo.getAssetsToHash(nonSelectedAlbum.id)).thenAnswer((_) async => [asset2]);
       when(() => mockNativeApi.hashAssets(any(), allowNetworkAccess: any(named: 'allowNetworkAccess'))).thenAnswer((


### PR DESCRIPTION
## Description

- Hashing is now concurrent on both iOS and the Android implementation
- The iOS implementation does not create a new temporary file for hashing but uses a streaming implementation
- Reduced the number of data transfer between the platform side and the flutter side as we now send only the assetIds to the platform side which fetches the file, hashes, base64 encodes them and shares back the result
- Hashes all the local assets on iOS. For assets not available on the device, it only downloads assets from iCloud from albums that have been selected for backups.