### PR TITLE
chore(mobile): minor changes to bottom sheet

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -98,16 +98,16 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
         const ShareActionButton(source: ActionSource.timeline),
         if (multiselect.hasRemote) ...[
           const ShareLinkActionButton(source: ActionSource.timeline),
-          const ArchiveActionButton(source: ActionSource.timeline),
-          const FavoriteActionButton(source: ActionSource.timeline),
           const DownloadActionButton(source: ActionSource.timeline),
+          isTrashEnable
+              ? const TrashActionButton(source: ActionSource.timeline)
+              : const DeletePermanentActionButton(source: ActionSource.timeline),
+          const FavoriteActionButton(source: ActionSource.timeline),
+          const ArchiveActionButton(source: ActionSource.timeline),
           const EditDateTimeActionButton(source: ActionSource.timeline),
           const EditLocationActionButton(source: ActionSource.timeline),
           const MoveToLockFolderActionButton(source: ActionSource.timeline),
           if (multiselect.selectedAssets.length > 1) const StackActionButton(source: ActionSource.timeline),
-          isTrashEnable
-              ? const TrashActionButton(source: ActionSource.timeline)
-              : const DeletePermanentActionButton(source: ActionSource.timeline),
           const DeleteActionButton(source: ActionSource.timeline),
         ],
         if (multiselect.hasLocal || multiselect.hasMerged) const DeleteLocalActionButton(source: ActionSource.timeline),

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -35,7 +35,7 @@ class Timeline extends StatelessWidget {
     this.showStorageIndicator,
     this.withStack = false,
     this.appBar = const ImmichSliverAppBar(floating: true, pinned: false, snap: false),
-    this.bottomSheet = const GeneralBottomSheet(),
+    this.bottomSheet = const GeneralBottomSheet(minChildSize: 0.18),
     this.groupBy,
     this.withScrubber = true,
   });


### PR DESCRIPTION
## Description
Added two minor fixes:
- Moved the "Move to trash" button closer to the beginning of the sheet, because it's a more common action
- Added `minChildSize` for sheet in timeline to prevent overlapping the sheet text with bottom bar

## Screenshots
Moved icons:
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/d0c4fb1f-0827-4422-a5c9-07b4261487e8" />

Sheet at its most bottom:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/4befbb12-3c20-47c1-931a-f2aba65f235f" />
