### PR TITLE
chore(docs): TypeORM error: force recommend v1.132.3 and avoid v1.136

### DIFF
--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -8,7 +8,7 @@ In order to update to Immich `v1.137.0` or above, the application must be starte
 
 We recommend users upgrade to `1.132.3` since it does not have any breaking changes or bugs on this upgrade path.
 
-Note: avoid v1.136.0 if upgrading from v1.131.* (or earlier) due to a bug blocking this upgrade in some installations.
+Note: avoid v1.136.0 if upgrading from v1.131 (or earlier) due to a bug blocking this upgrade in some installations.
 
 ## Inconsistent Media Location
 

--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -7,6 +7,7 @@ If you encountered "Migrations failed: Error: Invalid upgrade path" then perform
 In order to update to Immich `v1.137.0` or above, the application must be started at least once on a version in the range between `1.132.0` and `1.136.0`. Doing so will complete database schema upgrades that are required for `v1.137.0` (and above). After Immich has successfully updated to a version in this range, you can now attempt to update to `v1.137.0` (or above).
 
 We recommend users upgrade to `1.132.3` since it does not have any breaking changes or bugs on this upgrade path.
+
 Note: avoid v1.136.0 if upgrading from v1.131.* (or earlier) due to a bug blocking this upgrade in some installations.
 
 ## Inconsistent Media Location

--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -4,11 +4,15 @@
 
 If you encountered "Migrations failed: Error: Invalid upgrade path" then perform an intermediate upgrade to `v1.132.3` first.
 
+:::tip
+We recommend users upgrade to `v1.132.3` since it does not have any breaking changes or bugs on this upgrade path.
+:::
+
 In order to update to Immich `v1.137.0` or above, the application must be started at least once on a version in the range between `1.132.0` and `1.136.0`. Doing so will complete database schema upgrades that are required for `v1.137.0` (and above). After Immich has successfully updated to a version in this range, you can now attempt to update to `v1.137.0` (or above).
 
-We recommend users upgrade to `1.132.3` since it does not have any breaking changes or bugs on this upgrade path.
-
-Note: avoid v1.136.0 if upgrading from v1.131 (or earlier) due to a bug blocking this upgrade in some installations.
+:::caution
+Avoid `v1.136.0` if upgrading from `v1.131.0` (or earlier) due to a bug blocking this upgrade in some installations.
+:::
 
 ## Inconsistent Media Location
 

--- a/docs/src/pages/errors.md
+++ b/docs/src/pages/errors.md
@@ -2,7 +2,12 @@
 
 ## TypeORM Upgrade
 
-In order to update to Immich to `v1.137.0` (or above), the application must be started at least once on a version in the range between `1.132.0` and `1.136.0`. Doing so will complete database schema upgrades that are required for `v1.137.0` (and above). After Immich has successfully updated to a version in this range, you can now attempt to update to v1.137.0 (or above). We recommend users upgrade to `1.132.0` since it does not have any other breaking changes.
+If you encountered "Migrations failed: Error: Invalid upgrade path" then perform an intermediate upgrade to `v1.132.3` first.
+
+In order to update to Immich `v1.137.0` or above, the application must be started at least once on a version in the range between `1.132.0` and `1.136.0`. Doing so will complete database schema upgrades that are required for `v1.137.0` (and above). After Immich has successfully updated to a version in this range, you can now attempt to update to `v1.137.0` (or above).
+
+We recommend users upgrade to `1.132.3` since it does not have any breaking changes or bugs on this upgrade path.
+Note: avoid v1.136.0 if upgrading from v1.131.* (or earlier) due to a bug blocking this upgrade in some installations.
 
 ## Inconsistent Media Location
 


### PR DESCRIPTION
This PR is an attempt to avoid a typical upgrade scenario/failure:
1. Have an old Immich version
2. Attempt yolo upgrade to v1.140+-
3. Encounter `Invalid upgrade path. For more information, see https://immich.app/errors#typeorm-upgrade`
4. Read the linked article
5. Overlook the v1.132 recommendation OR ignore it thinking "v1.136 is closer to v1.140, yolo"
6. Encounter another error `multiple primary keys for table "geodata_places" are not allowed`

Refs:
- "This really should be mentioned in the breaking changes" 2025-09-14 https://github.com/immich-app/immich/issues/20167#issuecomment-3288932130. 
  The comment quotes the bug affecting upgrades from `pre-1.132` to `1.136`.
- "Immich broken after latest update" 2025-09-15 [Discord](https://discord.com/channels/979116623879368755/1416989589050232932/1417194867741822997)
- "Immich not starting after upgrade" 2025-09-08 [Discord](https://discord.com/channels/979116623879368755/1414599345197809724/1414601847880028221)

If you have better wording suggestions - shoot! Because I'm stuck 😄 