### PR TITLE
fix: sidebar link hightlight

### DIFF
--- a/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
@@ -28,7 +28,7 @@
   }: Props = $props();
 
   $effect(() => {
-    isSelected = page.url.pathname === href;
+    isSelected = page.url.pathname.startsWith(href);
   });
 </script>
 

--- a/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
+++ b/web/src/lib/components/shared-components/side-bar/side-bar-link.svelte
@@ -28,7 +28,7 @@
   }: Props = $props();
 
   $effect(() => {
-    isSelected = (page.url.pathname.match(/^\/(admin|user)\/[^/]*/) || [])[0] === href;
+    isSelected = page.url.pathname === href;
   });
 </script>
 


### PR DESCRIPTION
Look like `page.url.pathname` doesn't include (user) or (admin) anymore.

I think it is from ref: https://github.com/sveltejs/kit/pull/13864 after updating sveltekit to 2.27 in #20736