### PR TITLE
fix: storage indicator

### DIFF
--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -15,6 +15,7 @@ class MainTimelinePage extends ConsumerWidget {
     return Timeline(
       topSliverWidget: const SliverToBoxAdapter(child: DriftMemoryLane()),
       topSliverWidgetHeight: hasMemories ? 200 : 0,
+      showStorageIndicator: true,
     );
   }
 }

--- a/mobile/lib/presentation/pages/local_timeline.page.dart
+++ b/mobile/lib/presentation/pages/local_timeline.page.dart
@@ -26,6 +26,7 @@ class LocalTimelinePage extends StatelessWidget {
       child: Timeline(
         appBar: MesmerizingSliverAppBar(title: album.name),
         bottomSheet: const LocalAlbumBottomSheet(),
+        showStorageIndicator: true,
       ),
     );
   }

--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -633,6 +633,7 @@ class _SearchResultGrid extends ConsumerWidget {
             groupBy: GroupAssetsBy.none,
             appBar: null,
             bottomSheet: const GeneralBottomSheet(minChildSize: 0.20),
+            withScrubber: false,
           ),
         ),
       ),

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -32,7 +32,7 @@ class Timeline extends StatelessWidget {
     super.key,
     this.topSliverWidget,
     this.topSliverWidgetHeight,
-    this.showStorageIndicator,
+    this.showStorageIndicator = false,
     this.withStack = false,
     this.appBar = const ImmichSliverAppBar(floating: true, pinned: false, snap: false),
     this.bottomSheet = const GeneralBottomSheet(minChildSize: 0.18),
@@ -42,7 +42,7 @@ class Timeline extends StatelessWidget {
 
   final Widget? topSliverWidget;
   final double? topSliverWidgetHeight;
-  final bool? showStorageIndicator;
+  final bool showStorageIndicator;
   final Widget? appBar;
   final Widget? bottomSheet;
   final bool withStack;


### PR DESCRIPTION
- Only show indicator on the timeline and in the local album page
- Remove the scrubber in the search page since the result are sort by relevance score, not by date
