### PR TITLE
fix: use native locks

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/MainActivity.kt
@@ -3,6 +3,7 @@ package app.alextran.immich
 import android.content.Context
 import android.os.Build
 import android.os.ext.SdkExtensions
+import app.alextran.immich.background.BackgroundEngineLock
 import app.alextran.immich.background.BackgroundWorkerApiImpl
 import app.alextran.immich.background.BackgroundWorkerFgHostApi
 import app.alextran.immich.connectivity.ConnectivityApi
@@ -25,6 +26,7 @@ class MainActivity : FlutterFragmentActivity() {
     fun registerPlugins(ctx: Context, flutterEngine: FlutterEngine) {
       flutterEngine.plugins.add(BackgroundServicePlugin())
       flutterEngine.plugins.add(HttpSSLOptionsPlugin())
+      flutterEngine.plugins.add(BackgroundEngineLock())
 
       val messenger = flutterEngine.dartExecutor.binaryMessenger
       val nativeSyncApiImpl =

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
@@ -1,0 +1,31 @@
+package app.alextran.immich.background
+
+import android.util.Log
+import androidx.work.WorkManager
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+
+private const val TAG = "BackgroundEngineLock"
+
+class BackgroundEngineLock : FlutterPlugin {
+  companion object {
+    const val ENGINE_CACHE_KEY = "immich::background_worker::engine"
+    var engineCount = 0
+  }
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    engineCount++
+    // work manager task is running while the main app is opened, cancel the worker
+    if (engineCount == 2 && FlutterEngineCache.getInstance().get(ENGINE_CACHE_KEY) != null) {
+      WorkManager.getInstance(binding.applicationContext)
+        .cancelUniqueWork(BackgroundWorkerApiImpl.BACKGROUND_WORKER_NAME)
+      FlutterEngineCache.getInstance().remove(ENGINE_CACHE_KEY)
+    }
+    Log.i(TAG, "Flutter engine attached. Attached Engines count: $engineCount")
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    engineCount--
+    Log.i(TAG, "Flutter engine detached. Attached Engines count: $engineCount")
+  }
+}

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
@@ -16,7 +16,7 @@ class BackgroundEngineLock : FlutterPlugin {
 
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     // work manager task is running while the main app is opened, cancel the worker
-    if (engineCount.incrementAndGet() == 2 && FlutterEngineCache.getInstance()
+    if (engineCount.incrementAndGet() > 1 && FlutterEngineCache.getInstance()
         .get(ENGINE_CACHE_KEY) != null
     ) {
       WorkManager.getInstance(binding.applicationContext)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
@@ -4,19 +4,21 @@ import android.util.Log
 import androidx.work.WorkManager
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import java.util.concurrent.atomic.AtomicInteger
 
 private const val TAG = "BackgroundEngineLock"
 
 class BackgroundEngineLock : FlutterPlugin {
   companion object {
     const val ENGINE_CACHE_KEY = "immich::background_worker::engine"
-    var engineCount = 0
+    var engineCount = AtomicInteger(0)
   }
 
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    engineCount++
     // work manager task is running while the main app is opened, cancel the worker
-    if (engineCount == 2 && FlutterEngineCache.getInstance().get(ENGINE_CACHE_KEY) != null) {
+    if (engineCount.incrementAndGet() == 2 && FlutterEngineCache.getInstance()
+        .get(ENGINE_CACHE_KEY) != null
+    ) {
       WorkManager.getInstance(binding.applicationContext)
         .cancelUniqueWork(BackgroundWorkerApiImpl.BACKGROUND_WORKER_NAME)
       FlutterEngineCache.getInstance().remove(ENGINE_CACHE_KEY)
@@ -25,7 +27,7 @@ class BackgroundEngineLock : FlutterPlugin {
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    engineCount--
+    engineCount.decrementAndGet()
     Log.i(TAG, "Flutter engine detached. Attached Engines count: $engineCount")
   }
 }

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.loader.FlutterLoader
 import java.util.concurrent.TimeUnit
@@ -75,6 +76,9 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
 
     loader.ensureInitializationCompleteAsync(ctx, null, Handler(Looper.getMainLooper())) {
       engine = FlutterEngine(ctx)
+      FlutterEngineCache.getInstance().remove(BackgroundEngineLock.ENGINE_CACHE_KEY);
+      FlutterEngineCache.getInstance()
+        .put(BackgroundEngineLock.ENGINE_CACHE_KEY, engine!!)
 
       // Register custom plugins
       MainActivity.registerPlugins(ctx, engine!!)
@@ -188,6 +192,7 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
     isComplete = true
     engine?.destroy()
     engine = null
+    FlutterEngineCache.getInstance().remove(BackgroundEngineLock.ENGINE_CACHE_KEY);
     flutterApi = null
     notificationManager.cancel(NOTIFICATION_ID)
     waitForForegroundPromotion()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorkerApiImpl.kt
@@ -26,7 +26,7 @@ class BackgroundWorkerApiImpl(context: Context) : BackgroundWorkerFgHostApi {
   }
 
   companion object {
-    private const val BACKGROUND_WORKER_NAME = "immich/BackgroundWorkerV1"
+    const val BACKGROUND_WORKER_NAME = "immich/BackgroundWorkerV1"
     private const val OBSERVER_WORKER_NAME = "immich/MediaObserverV1"
 
     fun enqueueMediaObserver(ctx: Context) {


### PR DESCRIPTION
## Description

- Uses native locks by using a custom plugin to keep track of the attached engines and cancels the worker when both the foreground and background engine run at the same time