### PR TITLE
fix(mobile): prevent concurrent refresh and processing tasks

### DIFF
--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -64,6 +64,8 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
     if taskSemaphore.wait(timeout: .now()) == .success {
       // Restrict the refresh task to run only for a maximum of (maxSeconds) seconds
       runBackgroundWorker(task: task, taskType: .refresh, maxSeconds: 20)
+    } else {
+      task.setTaskCompleted(success: false)
     }
   }
   

--- a/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorkerApiImpl.swift
@@ -16,6 +16,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   
   private static let refreshTaskID = "app.alextran.immich.background.refreshUpload"
   private static let processingTaskID = "app.alextran.immich.background.processingUpload"
+  private static let taskSemaphore = DispatchSemaphore(value: 1)
 
   public static func registerBackgroundWorkers() {
       BGTaskScheduler.shared.register(
@@ -59,12 +60,16 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
   
   private static func handleBackgroundRefresh(task: BGAppRefreshTask) {
     scheduleRefreshWorker()
-    // Restrict the refresh task to run only for a maximum of (maxSeconds) seconds
-    runBackgroundWorker(task: task, taskType: .refresh, maxSeconds: 20)
+    // If another task is running, cede the background time back to the OS
+    if taskSemaphore.wait(timeout: .now()) == .success {
+      // Restrict the refresh task to run only for a maximum of (maxSeconds) seconds
+      runBackgroundWorker(task: task, taskType: .refresh, maxSeconds: 20)
+    }
   }
   
   private static func handleBackgroundProcessing(task: BGProcessingTask) {
     scheduleProcessingWorker()
+    taskSemaphore.wait()
     // There are no restrictions for processing tasks. Although, the OS could signal expiration at any time
     runBackgroundWorker(task: task, taskType: .processing, maxSeconds: nil)
   }
@@ -80,6 +85,7 @@ class BackgroundWorkerApiImpl: BackgroundWorkerFgHostApi {
    *   - maxSeconds: Optional timeout for the operation in seconds
    */
   private static func runBackgroundWorker(task: BGTask, taskType: BackgroundTaskType, maxSeconds: Int?) {
+    defer { taskSemaphore.signal() }
     let semaphore = DispatchSemaphore(value: 0)
     var isSuccess = true
     


### PR DESCRIPTION
## Description

It's possible for processing and refresh tasks to run concurrently, which can cause duplicate syncing and hashing at the same time. This PR adds a semaphore to control background task execution to prevent this. Refresh tasks that start while another task is running are rescheduled and end immediately. Processing tasks wait for other tasks to complete.

## How Has This Been Tested?

I haven't been able to simulate them running at the same time, so I can't verify that this change fixes it. I can verify that it doesn't break anything when either task runs.