### PR TITLE
fix: poll counts from DB rather than using callbacks from library

### DIFF
--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -12,8 +12,8 @@ import 'package:immich_mobile/infrastructure/repositories/backup.repository.dart
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/services/upload.service.dart';
-import 'package:logging/logging.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
+import 'package:logging/logging.dart';
 
 class EnqueueStatus {
   final int enqueueCount;
@@ -234,10 +234,6 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
 
     switch (update.status) {
       case TaskStatus.complete:
-        if (update.task.group == kBackupGroup) {
-          state = state.copyWith(backupCount: state.backupCount + 1, remainderCount: state.remainderCount - 1);
-        }
-
         // Remove the completed task from the upload items
         if (state.uploadItems.containsKey(taskId)) {
           Future.delayed(const Duration(milliseconds: 1000), () {


### PR DESCRIPTION
## Description

- Changes the logic to update the count in the backup page to poll from the DB every 5 seconds, rather than relying on the callbacks from the library. This should be keep the count updated as long as the websocket communication is working properly between the client and server
- The count is polled only when backup is enabled and is stopped when backup is disabled