### PR TITLE
chore: remove suppressed warnings

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -300,7 +300,7 @@ run = "tsc --noEmit"
 depends = "web:svelte-kit-sync"
 env._.path = "web/node_modules/.bin"
 dir = "web"
-run = "svelte-check --no-tsconfig --fail-on-warnings --compiler-warnings 'reactive_declaration_non_reactive_property:ignore' --ignore src/lib/components/timeline/Timeline.svelte"
+run = "svelte-check --no-tsconfig --fail-on-warnings"
 
 [tasks."web:checklist"]
 run = [

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build:stats": "BUILD_STATS=true vite build",
     "package": "svelte-kit package",
     "preview": "vite preview",
-    "check:svelte": "svelte-check --no-tsconfig --fail-on-warnings --compiler-warnings 'reactive_declaration_non_reactive_property:ignore' --ignore src/lib/components/timeline/Timeline.svelte",
+    "check:svelte": "svelte-check --no-tsconfig --fail-on-warnings",
     "check:typescript": "tsc --noEmit",
     "check:watch": "npm run check:svelte -- --watch",
     "check:code": "npm run format && npm run lint:p && npm run check:svelte && npm run check:typescript",


### PR DESCRIPTION
## Description
The removed params from the svelte-check command were added #16446. This supression was  originally added because, at the time, the new svelte 5 syntax for clientBind broke both svelte-check, and the vscode LSP (but otherwise compiled fine)

```
 bind:clientWidth={null, (v: number) => ((timelineManager.viewportWidth = v), updateSlidingWindow())}
```

this has seen been fixed. In the meantime, this has caused regressions like #17717 -- these would have been caught if the file handn't been ignored. 

This PR removes the suppressed warnings. 