### PR TITLE
feat(web): toggle theme shortcut

### DIFF
--- a/web/src/lib/components/shared-components/theme-button.svelte
+++ b/web/src/lib/components/shared-components/theme-button.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
+  import { shortcut } from '$lib/actions/shortcut';
   import { defaultLang, langs, Theme } from '$lib/constants';
   import { themeManager } from '$lib/managers/theme-manager.svelte';
   import { lang } from '$lib/stores/preferences.store';
   import { ThemeSwitcher } from '@immich/ui';
   import { get } from 'svelte/store';
+
+  const handleToggleTheme = () => {
+    if (themeManager.theme.system) {
+      return;
+    }
+
+    themeManager.toggleTheme();
+  };
 </script>
+
+<svelte:window use:shortcut={{ shortcut: { key: 't', alt: true }, onShortcut: () => handleToggleTheme() }} />
 
 {#if !themeManager.theme.system}
   {#await langs


### PR DESCRIPTION
Adds a keyboard shortcut for toggling the theme `ALT` + `t`

I find myself using this all the time in local development to test both light and dark theme.