### PR TITLE
fix(mobile): load original image

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/images/ThumbnailsImpl.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/images/ThumbnailsImpl.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.CancellationSignal
 import android.os.OperationCanceledException
-import android.provider.MediaStore
 import android.provider.MediaStore.Images
 import android.provider.MediaStore.Video
 import android.util.Size
@@ -19,7 +18,6 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.Priority
 import com.bumptech.glide.load.DecodeFormat
 import java.util.Base64
-import java.util.HashMap
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Future
@@ -202,8 +200,10 @@ class ThumbnailsImpl(context: Context) : ThumbnailApi {
       val source = ImageDecoder.createSource(resolver, uri)
       signal.throwIfCanceled()
       ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
-        val sampleSize = max(1, min(info.size.width / targetWidth, info.size.height / targetHeight))
-        decoder.setTargetSampleSize(sampleSize)
+        if (targetWidth > 0 && targetHeight > 0) {
+          val sample = max(1, min(info.size.width / targetWidth, info.size.height / targetHeight))
+          decoder.setTargetSampleSize(sample)
+        }
         decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
         decoder.setTargetColorSpace(ColorSpace.get(ColorSpace.Named.SRGB))
       }

--- a/mobile/ios/Runner/Images/ThumbnailsImpl.swift
+++ b/mobile/ios/Runner/Images/ThumbnailsImpl.swift
@@ -105,7 +105,7 @@ class ThumbnailApiImpl: ThumbnailApi {
       var image: UIImage?
       Self.imageManager.requestImage(
         for: asset,
-        targetSize: CGSize(width: Double(width), height: Double(height)),
+        targetSize: width > 0 && height > 0 ? CGSize(width: Double(width), height: Double(height)) : PHImageManagerMaximumSize,
         contentMode: .aspectFill,
         options: Self.requestOptions,
         resultHandler: { (_image, info) -> Void in

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -4,6 +4,8 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/loaders/image_request.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/one_frame_multi_image_stream_completer.dart';
@@ -88,11 +90,24 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
     }
 
     final devicePixelRatio = PlatformDispatcher.instance.views.first.devicePixelRatio;
-    final request = this.request = LocalImageRequest(
+    var request = this.request = LocalImageRequest(
       localId: key.id,
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
+
+    yield* loadRequest(request, decode);
+
+    if (!Store.get(StoreKey.loadOriginal, false)) {
+      return;
+    }
+
+    if (isCancelled) {
+      evict();
+      return;
+    }
+
+    request = this.request = LocalImageRequest(localId: key.id, assetType: key.assetType, size: Size.zero);
 
     yield* loadRequest(request, decode);
   }


### PR DESCRIPTION
## Description

The "Load original image" setting currently isn't respected for local images in the new timeline. This PR applies this setting and updates the platform side to only conditionally resize the image.

## How Has This Been Tested?

Tested on iOS, confirming the resolution is higher when this setting is enabled.