### PR TITLE
chore: build bcrypt dependency from source

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   canvas: 2.11.2
   sharp: ^0.34.3
 
-packageExtensionsChecksum: sha256-DAYr0FTkvKYnvBH4muAER9UE1FVGKhqfRU4/QwA2xPQ=
+packageExtensionsChecksum: sha256-3l4AQg4iuprBDup+q+2JaPvbPg/7XodWCE0ZteH+s54=
 
 pnpmfileChecksum: sha256-AG/qwrPNpmy9q60PZwCpecoYVptglTHgH+N6RKQHOM0=
 
@@ -17333,7 +17333,10 @@ snapshots:
   bcrypt@6.0.0:
     dependencies:
       node-addon-api: 8.5.0
+      node-gyp: 11.3.0
       node-gyp-build: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
 
   big.js@5.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ ignoredBuiltDependencies:
   - '@nestjs/core'
   - '@scarf/scarf'
   - '@swc/core'
-  - bcrypt
   - canvas
   - core-js
   - core-js-pure
@@ -25,6 +24,7 @@ ignoredBuiltDependencies:
 onlyBuiltDependencies:
   - sharp
   - '@tailwindcss/oxide'
+  - bcrypt
 overrides:
   canvas: 2.11.2
   sharp: ^0.34.3
@@ -51,6 +51,10 @@ packageExtensions:
   tailwind-variants:
     dependencies:
       tailwindcss: '>=4.1'
+  bcrypt:
+    dependencies:
+      node-addon-api: '*'
+      node-gyp: '*'
 dedupePeerDependents: false
 preferWorkspacePackages: true
 injectWorkspacePackages: true


### PR DESCRIPTION
## Description

`bcrypt` is not available as a prebuilt dependency for some platforms, so building it from source keeps compatibility with unsupported environments. The change should not have any impact on builds for supported platforms.

Fixes #22113 

## How Has This Been Tested?

Tested on a local build and deployment.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
