### PR TITLE
chore(server): proper log context formatting

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -57,28 +57,28 @@ export class MediaRepository {
       const buffer = await exiftool.extractBinaryTagToBuffer('JpgFromRaw2', input);
       return { buffer, format: RawExtractedFormat.Jpeg };
     } catch (error: any) {
-      this.logger.debug('Could not extract JpgFromRaw2 buffer from image, trying JPEG from RAW next', error.message);
+      this.logger.debug(`Could not extract JpgFromRaw2 buffer from image, trying JPEG from RAW next: ${error}`);
     }
 
     try {
       const buffer = await exiftool.extractBinaryTagToBuffer('JpgFromRaw', input);
       return { buffer, format: RawExtractedFormat.Jpeg };
     } catch (error: any) {
-      this.logger.debug('Could not extract JPEG buffer from image, trying PreviewJXL next', error.message);
+      this.logger.debug(`Could not extract JPEG buffer from image, trying PreviewJXL next: ${error}`);
     }
 
     try {
       const buffer = await exiftool.extractBinaryTagToBuffer('PreviewJXL', input);
       return { buffer, format: RawExtractedFormat.Jxl };
     } catch (error: any) {
-      this.logger.debug('Could not extract PreviewJXL buffer from image, trying PreviewImage next', error.message);
+      this.logger.debug(`Could not extract PreviewJXL buffer from image, trying PreviewImage next: ${error}`);
     }
 
     try {
       const buffer = await exiftool.extractBinaryTagToBuffer('PreviewImage', input);
       return { buffer, format: RawExtractedFormat.Jpeg };
     } catch (error: any) {
-      this.logger.debug('Could not extract preview buffer from image', error.message);
+      this.logger.debug(`Could not extract preview buffer from image: ${error}`);
       return null;
     }
   }

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -103,7 +103,7 @@ export class MetadataRepository {
 
   readTags(path: string): Promise<ImmichTags> {
     return this.exiftool.read(path).catch((error) => {
-      this.logger.warn(`Error reading exif data (${path}): ${error}`, error?.stack);
+      this.logger.warn(`Error reading exif data (${path}): ${error}\n${error?.stack}`);
       return {};
     }) as Promise<ImmichTags>;
   }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -344,7 +344,7 @@ export class AuthService extends BaseService {
         await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [oldPath] } });
       }
     } catch (error: Error | any) {
-      this.logger.warn(`Unable to sync oauth profile picture: ${error}`, error?.stack);
+      this.logger.warn(`Unable to sync oauth profile picture: ${error}\n${error?.stack}`);
     }
   }
 

--- a/server/src/services/backup.service.ts
+++ b/server/src/services/backup.service.ts
@@ -132,12 +132,12 @@ export class BackupService extends BaseService {
         gzip.stdout.pipe(fileStream);
 
         pgdump.on('error', (err) => {
-          this.logger.error('Backup failed with error', err);
+          this.logger.error(`Backup failed with error: ${err}`);
           reject(err);
         });
 
         gzip.on('error', (err) => {
-          this.logger.error('Gzip failed with error', err);
+          this.logger.error(`Gzip failed with error: ${err}`);
           reject(err);
         });
 
@@ -175,10 +175,10 @@ export class BackupService extends BaseService {
       });
       await this.storageRepository.rename(backupFilePath, backupFilePath.replace('.tmp', ''));
     } catch (error) {
-      this.logger.error('Database Backup Failure', error);
+      this.logger.error(`Database Backup Failure: ${error}`);
       await this.storageRepository
         .unlink(backupFilePath)
-        .catch((error) => this.logger.error('Failed to delete failed backup file', error));
+        .catch((error) => this.logger.error(`Failed to delete failed backup file: ${error}`));
       throw error;
     }
 

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -245,7 +245,7 @@ export class LibraryService extends BaseService {
       job.paths.map((path) =>
         this.processEntity(path, library.ownerId, job.libraryId)
           .then((asset) => assetImports.push(asset))
-          .catch((error: any) => this.logger.error(`Error processing ${path} for library ${job.libraryId}`, error)),
+          .catch((error: any) => this.logger.error(`Error processing ${path} for library ${job.libraryId}: ${error}`)),
       ),
     );
 

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -40,7 +40,7 @@ export class MemoryService extends BaseService {
         try {
           await Promise.all(users.map((owner, i) => this.createOnThisDayMemories(owner.id, usersIds[i], target)));
         } catch (error) {
-          this.logger.error(`Failed to create memories for ${target.toISO()}`, error);
+          this.logger.error(`Failed to create memories for ${target.toISO()}: ${error}`);
         }
         // update system metadata even when there is an error to minimize the chance of duplicates
         await this.systemMetadataRepository.set(SystemMetadataKey.MemoriesState, {

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -338,7 +338,7 @@ export class StorageTemplateService extends BaseService {
 
       return destination;
     } catch (error: any) {
-      this.logger.error(`Unable to get template path for ${filename}`, error);
+      this.logger.error(`Unable to get template path for ${filename}: ${error}`);
       return asset.originalPath;
     }
   }

--- a/server/src/services/version.service.ts
+++ b/server/src/services/version.service.ts
@@ -95,7 +95,7 @@ export class VersionService extends BaseService {
         this.eventRepository.clientBroadcast('on_new_release', asNotification(metadata));
       }
     } catch (error: Error | any) {
-      this.logger.warn(`Unable to run version check: ${error}`, error?.stack);
+      this.logger.warn(`Unable to run version check: ${error}\n${error?.stack}`);
       return JobStatus.Failed;
     }
 

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -73,7 +73,7 @@ export const sendFile = async (
 
     // log non-http errors
     if (error instanceof HttpException === false) {
-      logger.error(`Unable to send file: ${error.name}`, error.stack);
+      logger.error(`Unable to send file: ${error}`, error.stack);
     }
 
     res.header('Cache-Control', 'none');


### PR DESCRIPTION
## Description

Fix cases when error message or error stack gets printed inside the [context] field instead of a log body.

Example: stack in [context] field.
```log
[Nest] 17  - 06/24/2025, 1:32:56 PM    WARN [Api:Error: Failed to fetch GitHub release: TypeError: fetch failed
    at ServerInfoRepository.getGitHubRelease (/usr/src/app/dist/repositories/server-info.repository.js:60:19)
    at ...
    at ...)] Unable to run version check: Error: Failed to fetch GitHub release: TypeError: fetch failed
```

<details><summary>Two more log examples</summary>

```log
[Nest] 7  - 08/03/2025, 12:48:06 AM   ERROR [Microservices:Error: EAGAIN: resource temporarily unavailable, rename '/usr/src/app/upload/backups/immich-db-backup-20250803T004608-v1.137.3-pg14.18.sql.gz.tmp' -> '/usr/src/app/upload/backups/immich-db-backup-20250803T004608-v1.137.3-pg14.18.sql.gz'] Database Backup Failure
```

```log
[Nest] 7  - 09/14/2025, 11:39:47 PM    WARN [Microservices:Error: BatchCluster has ended, cannot enqueue -json
-api
largefilesupport=1
-api
struct=1
-use
MWG
-*Duration*#
-GPSAltitude#
-GPSLatitude#
-GPSLongitude#
-GPSPosition#
-Orientation#
-FocalLength#
-FileSize#
-all
/data/upload/5dde03f5-062a-47ea-90a2-c7be97a9b0f9/19/e6/19e6e37f-de2e-455d-9bf9-06954bb3bb73.png
-ignoreMinorErrors
-execute

    at BatchCluster.enqueueTask (/usr/src/app/server/node_modules/.pnpm/batch-cluster@13.0.0/node_modules/batch-cluster/dist/BatchCluster.js:186:25)
    at f (/usr/src/app/server/node_modules/.pnpm/exiftool-vendored@28.8.0/node_modules/exiftool-vendored/dist/ExifTool.js:402:38)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async g (/usr/src/app/server/node_modules/.pnpm/exiftool-vendored@28.8.0/node_modules/exiftool-vendored/dist/AsyncRetry.js:8:20)] Error reading exif data (/data/upload/5dde03f5-062a-47ea-90a2-c7be97a9b0f9/19/e6/19e6e37f-de2e-455d-9bf9-06954bb3bb73.png): Error: BatchCluster has ended, cannot enqueue -json
-api
largefilesupport=1
-api
struct=1
-use
MWG
-*Duration*#
-GPSAltitude#
-GPSLatitude#
-GPSLongitude#
-GPSPosition#
-Orientation#
-FocalLength#
-FileSize#
-all
/data/upload/5dde03f5-062a-47ea-90a2-c7be97a9b0f9/19/e6/19e6e37f-de2e-455d-9bf9-06954bb3bb73.png
-ignoreMinorErrors
-execute
```
</details>

### Overview of Immich logger calls

<details><summary>Error, warn, debug outcomes with error/stack/details passed as 2nd arg</summary>

```
| Logger line (signature)                                     | 2nd argument   | Outcome                                      | Example                                                                                                         |
| :---------------------------------------------------------- | :------------- | :------------------------------------------- | :-------------------------------------------------------------------------------------------------------------- |
| logger.error (..., error);                                  | Error object   | ⚠️ Error msg appears in [context]            | this.logger.error('Backup failed with error', err);                                                             |
| logger.error (..., error?.stack);                           | Stack string   | Stack on the next line                       | this.logger.error(`Websocket connection error: ${error}`, error?.stack);                                        |
| logger.error (..., error?.stack, JSON.stringify(job.data)); | Stack string   | Stack on the next line, details in [context] | this.logger.error(`Unable to run job handler (${job.name}): ${error}`, error?.stack, JSON.stringify(job.data)); |
| logger.error (..., error?.stack, { id, oldPath, newPath }); | Stack string   | Stack printed as 2nd log, details as 3rd log | this.logger.error(`Problem applying storage template`, error?.stack, { id, oldPath, newPath });                 |
| logger.warn  (..., error?.stack);                           | Stack string   | ⚠️ Stack appears in [context]                | this.logger.warn(`Unable to sync oauth profile picture: ${error}`, error?.stack);                               |
| logger.warn  (..., error);                                  | Error object   | Stack printed as 2nd log                     | this.logger.warn('Request error while uploading file, cleaning up', error);                                     |
| logger.warn  (..., { originalPath });                       | Details object | Details object printed as 2nd log            | this.logger.warn('Unable to resolve realpath', { originalPath });                                               |
| logger.debug (..., error.message);                          | Error msg      | ⚠️ Error msg appears in [context]            | this.logger.debug('Could not extract preview buffer from image', error.message);                                |
```
</details>

### Discussion
Special handling of stacks at the error log level in NestJS is perhaps common knowledge (or cursed knowledge, I dunno). Introduced in "fix(common): ConsoleLogger doesn't log stacktrace" https://github.com/nestjs/nest/pull/11571.
So `logger.error(msg, stack)` and `logger.warn(msg, stack)` format the output quite differently. Which can be surprising initially (at least it was for me) because it produces unexpected formatting at non-error log levels if one is used to **logger.error**'s special handling / auto-detection of stacks.

I understand that eventually™ Immich will migrate to another log framework with structured logging support and whatnot. So for now, in this PR, I simply adjust affected logger calls to print stacks/messages in the log body instead of [context] field.

### Affected logger calls + how to fix

1. When passing `error` object as 2nd arg to `logger.error()`, the error message appears in [context]. This happens with `error` level/method only.
```ts
// affected line
logger.error(..., error);
// fix
logger.error(`...: ${error}`);
```

2. When passing `error.stack` string as 2nd arg to `logger.warn`, it appears in [context]. This happens with any level/method except for `error` level (at the "error" level NestJS auto-detects stacks vs context as 2nd arg).
```ts
// affected line
logger.warn (..., error?.stack);
// fix
logger.warn(..., error);              // stack as 2nd log, or
logger.warn(`...\n${error?.stack}`);  // stack on the next line
```

3. When passing `error.message` string as 2nd arg to `logger.debug`, it appears in [context].
```ts
// affected line
logger.debug(..., error.message);
// fix
logger.debug(`...: ${error}`);
```

4. When passing `error.name` it appears as literal "Error".
  Fix: `error.name -> error`. Or simply remove it because the logger call in question prints the stack as well and it includes the error message.

## How Has This Been Tested?

Strictly speaking, the changes were not tested. But they follow the common pattern of moving/including 2nd args into the 1st arg's template string.

To identify affected signatures I used a script to print synthetic logs at various log levels and with various arguments (signatures).

<details><summary>Script to check various logger calls/signatures</summary>

```ts
// ts-node --require tsconfig-paths/register --project tsconfig.json logger.ts

import { LoggingRepository } from "src/repositories/logging.repository";
import { LogLevel } from "src/enum";

const logger = LoggingRepository.create("MetadataRepository");
logger.setAppName("Microservices");
logger.setLogLevel(LogLevel.Debug);

const errorMessage = "BatchCluster has ended, cannot enqueue";
const error = new Error(errorMessage);
error.stack = `${errorMessage}
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)`;

const details = { id: "0123456789" };
const detailsString = JSON.stringify(details);

["warn", "error"].forEach((level) => {
  let log: (...args: any[]) => void;
  switch (level) {
    case "error":
      log = logger.error.bind(logger);
      break;
    case "warn":
      log = logger.warn.bind(logger);
      break;
    case "log":
      log = logger.log.bind(logger);
      break;
    case "debug":
      log = logger.debug.bind(logger);
      break;
    default:
      throw new Error(`Unsupported log level: ${level}`);
  }

  let test: string;

  test = `logger.${level}(msg, details string)`;
  console.log(`\n=== ${test} ===`);
  log(test, detailsString);

  test = `logger.${level}(msg, details)`;
  console.log(`\n=== ${test} ===`);
  log(test, details);

  test = `logger.${level}(msg, error)`;
  console.log(`\n=== ${test} ===`);
  log(test, error);

  test = `logger.${level}(msg, error.message)`;
  console.log(`\n=== ${test} ===`);
  log(test, error.message);

  test = `logger.${level}(msg, error.stack)`;
  console.log(`\n=== ${test} ===`);
  log(test, error.stack);

  test = `logger.${level}(msg, error.stack, detailsString)`;
  console.log(`\n=== ${test} ===`);
  log(test, error.stack, detailsString);

  test = `logger.${level}(msg error, error.stack, details)`;
  console.log(`\n=== ${test} ===`);
  log(`${test}: ${error}`, error.stack, details);

  test = `logger.${level}(msg error, error.stack, details string)`;
  console.log(`\n=== ${test} ===`);
  log(`${test}: ${error}`, error.stack, detailsString);
});
```
</details>

<details><summary>Output: logs as printed by various logger calls (with ! marking poorly formatted logs)</summary>

```sh
=== logger.warn(msg, details string) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:{"id":"0123456789"}] logger.warn(msg, details string)

=== logger.warn(msg, details) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] logger.warn(msg, details)
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] Object(1) {
  id: '0123456789'
}

=== logger.warn(msg, error) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] logger.warn(msg, error)
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)

=== ⚠️ logger.warn(msg, error.message) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:BatchCluster has ended, cannot enqueue] logger.warn(msg, error.message)

=== ⚠️ logger.warn(msg, error.stack) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)] logger.warn(msg, error.stack)

=== logger.warn(msg, error.stack, detailsString) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:{"id":"0123456789"}] logger.warn(msg, error.stack, detailsString)
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:{"id":"0123456789"}] BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)

=== logger.warn(msg error, error.stack, details) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] logger.warn(msg error, error.stack, details): Error: BatchCluster has ended, cannot enqueue
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:MetadataRepository] Object(1) {
  id: '0123456789'
}

=== logger.warn(msg error, error.stack, details string) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:{"id":"0123456789"}] logger.warn(msg error, error.stack, details string): Error: BatchCluster has ended, cannot enqueue
[Nest] 88781  - 09/18/2025, 3:14:25 PM    WARN [Microservices:{"id":"0123456789"}] BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)

=== logger.error(msg, details string) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:{"id":"0123456789"}] logger.error(msg, details string)

=== ⚠️ logger.error(msg, details) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:[object Object]] logger.error(msg, details)

=== ⚠️ logger.error(msg, error) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:Error: BatchCluster has ended, cannot enqueue] logger.error(msg, error)

=== ⚠️ logger.error(msg, error.message) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:BatchCluster has ended, cannot enqueue] logger.error(msg, error.message)

=== logger.error(msg, error.stack) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:MetadataRepository] logger.error(msg, error.stack)
BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)

=== logger.error(msg, error.stack, detailsString) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:{"id":"0123456789"}] logger.error(msg, error.stack, detailsString)
BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)

=== logger.error(msg error, error.stack, details) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:MetadataRepository] logger.error(msg error, error.stack, details): Error: BatchCluster has ended, cannot enqueue
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:MetadataRepository] BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:MetadataRepository] Object(1) {
  id: '0123456789'
}

=== logger.error(msg error, error.stack, details string) ===
[Nest] 88781  - 09/18/2025, 3:14:25 PM   ERROR [Microservices:{"id":"0123456789"}] logger.error(msg error, error.stack, details string): Error: BatchCluster has ended, cannot enqueue
BatchCluster has ended, cannot enqueue
    at BatchCluster.enqueueTask (/usr/src/app/server/dist/services/batch-cluster.service.js:123:15)
    at f (/usr/src/app/server/dist/services/batch-cluster.service.js:456:12)
```
</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- To investigate the reason for unexpected formatting of affected logs
- To write a script for testing various logger calls/levels
