### PR TITLE
fix: download feedback

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -133,6 +133,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		B2CF7F8C2DDE4EBB00744BF6 /* Sync */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = Sync;
 			sourceTree = "<group>";
 		};
@@ -519,13 +521,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -555,13 +553,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/mobile/lib/presentation/pages/download_info.page.dart
+++ b/mobile/lib/presentation/pages/download_info.page.dart
@@ -1,0 +1,57 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/pages/common/download_panel.dart';
+import 'package:immich_mobile/providers/asset_viewer/download.provider.dart';
+
+@RoutePage()
+class DownloadInfoPage extends ConsumerWidget {
+  const DownloadInfoPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tasks = ref.watch(downloadStateProvider.select((state) => state.taskProgress)).entries.toList();
+
+    onCancelDownload(String id) {
+      ref.watch(downloadStateProvider.notifier).cancelDownload(id);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("download".t(context: context)),
+        actions: [],
+      ),
+      body: ListView.builder(
+        physics: const ClampingScrollPhysics(),
+        shrinkWrap: true,
+        itemCount: tasks.length,
+        itemBuilder: (context, index) {
+          final task = tasks[index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: DownloadTaskTile(
+              progress: task.value.progress,
+              fileName: task.value.fileName,
+              status: task.value.status,
+              onCancelDownload: () => onCancelDownload(task.key),
+            ),
+          );
+        },
+      ),
+      persistentFooterButtons: [
+        OutlinedButton(
+          onPressed: () {
+            tasks.map((e) => e.key).forEach(onCancelDownload);
+          },
+          style: OutlinedButton.styleFrom(side: BorderSide(color: context.colorScheme.primary)),
+          child: Text(
+            'clear_all'.t(context: context),
+            style: context.textTheme.labelLarge?.copyWith(color: context.colorScheme.primary),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/action_buttons/download_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/download_action_button.widget.dart
@@ -1,54 +1,45 @@
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/utils/background_sync.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class DownloadActionButton extends ConsumerWidget {
   final ActionSource source;
+  final bool menuItem;
+  const DownloadActionButton({super.key, required this.source, this.menuItem = false});
 
-  const DownloadActionButton({super.key, required this.source});
-
-  void _onTap(BuildContext context, WidgetRef ref) async {
+  void _onTap(BuildContext context, WidgetRef ref, BackgroundSyncManager backgroundSyncManager) async {
     if (!context.mounted) {
       return;
     }
 
-    final result = await ref.read(actionProvider.notifier).downloadAll(source);
-    ref.read(multiSelectProvider.notifier).reset();
+    try {
+      await ref.read(actionProvider.notifier).downloadAll(source);
 
-    if (!context.mounted) {
-      return;
-    }
-
-    if (!result.success) {
-      ImmichToast.show(
-        context: context,
-        msg: 'scaffold_body_error_occurred'.t(context: context),
-        gravity: ToastGravity.BOTTOM,
-        toastType: ToastType.error,
-      );
-    } else if (result.count > 0) {
-      ImmichToast.show(
-        context: context,
-        msg: 'download_action_prompt'.t(context: context, args: {'count': result.count.toString()}),
-        gravity: ToastGravity.BOTTOM,
-        toastType: ToastType.success,
-      );
+      Future.delayed(const Duration(seconds: 1), () async {
+        await backgroundSyncManager.syncLocal();
+        await backgroundSyncManager.hashAssets();
+      });
+    } finally {
+      ref.read(multiSelectProvider.notifier).reset();
     }
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final backgroundManager = ref.watch(backgroundSyncProvider);
+
     return BaseActionButton(
       iconData: Icons.download,
       maxWidth: 95,
       label: "download".t(context: context),
-      onPressed: () => _onTap(context, ref),
+      menuItem: menuItem,
+      onPressed: () => _onTap(context, ref, backgroundManager),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/action_buttons/download_status_floating_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/download_status_floating_button.widget.dart
@@ -19,38 +19,44 @@ class DownloadStatusFloatingButton extends ConsumerWidget {
         .isNotEmpty;
 
     return shouldShow
-        ? FloatingActionButton(
-            shape: RoundedRectangleBorder(
-              borderRadius: const BorderRadius.all(Radius.circular(16)),
-              side: BorderSide(color: context.colorScheme.outlineVariant),
-            ),
-            backgroundColor: context.colorScheme.surfaceBright,
-            onPressed: () {
-              context.pushRoute(const DownloadInfoRoute());
-            },
-            child: Stack(
-              alignment: AlignmentDirectional.center,
-              children: [
-                Badge.count(
-                  count: itemCount,
-                  backgroundColor: context.colorScheme.primary.withValues(alpha: 1),
-                  child: Icon(
-                    Icons.downloading_rounded,
-                    color: isDownloading ? context.colorScheme.primary : context.logoGreen,
-                    size: 28,
-                  ),
-                ),
-                if (isDownloading)
-                  const SizedBox(
-                    height: 31,
-                    width: 31,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      backgroundColor: Colors.transparent,
-                      value: null, // Indeterminate progress
+        ? Badge.count(
+            count: itemCount,
+            textColor: context.colorScheme.onPrimary,
+            backgroundColor: context.colorScheme.primary,
+            child: FloatingActionButton(
+              shape: RoundedRectangleBorder(
+                borderRadius: const BorderRadius.all(Radius.circular(20)),
+                side: BorderSide(color: context.colorScheme.outlineVariant, width: 1),
+              ),
+              backgroundColor: context.isDarkTheme
+                  ? context.colorScheme.surfaceContainer
+                  : context.colorScheme.surfaceBright,
+              elevation: 2,
+              onPressed: () {
+                context.pushRoute(const DownloadInfoRoute());
+              },
+              child: Stack(
+                alignment: AlignmentDirectional.center,
+                children: [
+                  isDownloading
+                      ? Icon(Icons.downloading_rounded, color: context.colorScheme.primary, size: 28)
+                      : Icon(
+                          Icons.download_done,
+                          color: context.isDarkTheme ? Colors.green[200] : Colors.green[400],
+                          size: 28,
+                        ),
+                  if (isDownloading)
+                    const SizedBox(
+                      height: 31,
+                      width: 31,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        backgroundColor: Colors.transparent,
+                        value: null, // Indeterminate progress
+                      ),
                     ),
-                  ),
-              ],
+                ],
+              ),
             ),
           )
         : const SizedBox.shrink();

--- a/mobile/lib/presentation/widgets/action_buttons/download_status_floating_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/download_status_floating_button.widget.dart
@@ -1,0 +1,58 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/providers/asset_viewer/download.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
+
+class DownloadStatusFloatingButton extends ConsumerWidget {
+  const DownloadStatusFloatingButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shouldShow = ref.watch(downloadStateProvider.select((state) => state.showProgress));
+    final itemCount = ref.watch(downloadStateProvider.select((state) => state.taskProgress.length));
+    final isDownloading = ref
+        .watch(downloadStateProvider.select((state) => state.taskProgress))
+        .values
+        .where((element) => element.progress != 1)
+        .isNotEmpty;
+
+    return shouldShow
+        ? FloatingActionButton(
+            shape: RoundedRectangleBorder(
+              borderRadius: const BorderRadius.all(Radius.circular(16)),
+              side: BorderSide(color: context.colorScheme.outlineVariant),
+            ),
+            backgroundColor: context.colorScheme.surfaceBright,
+            onPressed: () {
+              context.pushRoute(const DownloadInfoRoute());
+            },
+            child: Stack(
+              alignment: AlignmentDirectional.center,
+              children: [
+                Badge.count(
+                  count: itemCount,
+                  backgroundColor: context.colorScheme.primary.withValues(alpha: 1),
+                  child: Icon(
+                    Icons.downloading_rounded,
+                    color: isDownloading ? context.colorScheme.primary : context.logoGreen,
+                    size: 28,
+                  ),
+                ),
+                if (isDownloading)
+                  const SizedBox(
+                    height: 31,
+                    width: 31,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      backgroundColor: Colors.transparent,
+                      value: null, // Indeterminate progress
+                    ),
+                  ),
+              ],
+            ),
+          )
+        : const SizedBox.shrink();
+  }
+}

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -12,7 +12,7 @@ import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/extensions/scroll_extensions.dart';
-import 'package:immich_mobile/pages/common/download_panel.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/download_status_floating_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
@@ -650,6 +650,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
         appBar: const ViewerTopAppBar(),
         extendBody: true,
         extendBodyBehindAppBar: true,
+        floatingActionButton: const DownloadStatusFloatingButton(),
         body: Stack(
           children: [
             PhotoViewGallery.builder(
@@ -667,7 +668,6 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
               backgroundDecoration: BoxDecoration(color: backgroundColor),
               enablePanAlways: true,
             ),
-            const DownloadPanel(),
           ],
         ),
         bottomNavigationBar: showingBottomSheet

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -12,6 +12,7 @@ import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/extensions/scroll_extensions.dart';
+import 'package:immich_mobile/pages/common/download_panel.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.provider.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_stack.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
@@ -649,20 +650,25 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
         appBar: const ViewerTopAppBar(),
         extendBody: true,
         extendBodyBehindAppBar: true,
-        body: PhotoViewGallery.builder(
-          gaplessPlayback: true,
-          loadingBuilder: _placeholderBuilder,
-          pageController: pageController,
-          scrollPhysics: CurrentPlatform.isIOS
-              ? const FastScrollPhysics() // Use bouncing physics for iOS
-              : const FastClampingScrollPhysics(), // Use heavy physics for Android
-          itemCount: totalAssets,
-          onPageChanged: _onPageChanged,
-          onPageBuild: _onPageBuild,
-          scaleStateChangedCallback: _onScaleStateChanged,
-          builder: _assetBuilder,
-          backgroundDecoration: BoxDecoration(color: backgroundColor),
-          enablePanAlways: true,
+        body: Stack(
+          children: [
+            PhotoViewGallery.builder(
+              gaplessPlayback: true,
+              loadingBuilder: _placeholderBuilder,
+              pageController: pageController,
+              scrollPhysics: CurrentPlatform.isIOS
+                  ? const FastScrollPhysics() // Use bouncing physics for iOS
+                  : const FastClampingScrollPhysics(), // Use heavy physics for Android
+              itemCount: totalAssets,
+              onPageChanged: _onPageChanged,
+              onPageBuild: _onPageBuild,
+              scaleStateChangedCallback: _onScaleStateChanged,
+              builder: _assetBuilder,
+              backgroundDecoration: BoxDecoration(color: backgroundColor),
+              enablePanAlways: true,
+            ),
+            const DownloadPanel(),
+          ],
         ),
         bottomNavigationBar: showingBottomSheet
             ? const SizedBox.shrink()

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/cast_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/favorite_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart';
@@ -56,6 +57,7 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
 
     final actions = <Widget>[
+      if (asset.hasRemote) const DownloadActionButton(source: ActionSource.viewer, menuItem: true),
       if (isCasting || (asset.hasRemote)) const CastActionButton(menuItem: true),
       if (album != null && album.isActivityEnabled && album.isShared)
         IconButton(

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -14,6 +14,7 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/download_status_floating_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scrubber.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
@@ -53,6 +54,7 @@ class Timeline extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
+      floatingActionButton: const DownloadStatusFloatingButton(),
       body: LayoutBuilder(
         builder: (_, constraints) => ProviderScope(
           overrides: [

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -356,7 +356,6 @@ class ActionNotifier extends Notifier<void> {
 
   Future<ActionResult> downloadAll(ActionSource source) async {
     final assets = _getAssets(source).whereType<RemoteAsset>().toList(growable: false);
-
     try {
       final didEnqueue = await _service.downloadAll(assets);
       final enqueueCount = didEnqueue.where((e) => e).length;

--- a/mobile/lib/repositories/download.repository.dart
+++ b/mobile/lib/repositories/download.repository.dart
@@ -90,7 +90,11 @@ class DownloadRepository {
       final isVideo = asset.isVideo;
       final url = getOriginalUrlForRemoteId(id);
 
-      if (Platform.isAndroid || livePhotoVideoId == null || isVideo) {
+      // on iOS it cannot link the image, check if the filename has .MP extension
+      // to avoid downloading the video part
+      final isAndroidMotionPhoto = asset.name.contains(".MP");
+
+      if (Platform.isAndroid || livePhotoVideoId == null || isVideo || isAndroidMotionPhoto) {
         tasks[taskIndex++] = DownloadTask(
           taskId: id,
           url: url,

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -81,6 +81,7 @@ import 'package:immich_mobile/pages/share_intent/share_intent.page.dart';
 import 'package:immich_mobile/presentation/pages/dev/feat_in_development.page.dart';
 import 'package:immich_mobile/presentation/pages/dev/main_timeline.page.dart';
 import 'package:immich_mobile/presentation/pages/dev/media_stat.page.dart';
+import 'package:immich_mobile/presentation/pages/download_info.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_activities.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_album.page.dart';
 import 'package:immich_mobile/presentation/pages/drift_album_options.page.dart';
@@ -345,6 +346,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: DriftActivitiesRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: DriftBackupAssetDetailRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: AssetTroubleshootRoute.page, guards: [_authGuard, _duplicateGuard]),
+    AutoRoute(page: DownloadInfoRoute.page, guards: [_authGuard, _duplicateGuard]),
     // required to handle all deeplinks in deep_link.service.dart
     // auto_route_library#1722
     RedirectRoute(path: '*', redirectTo: '/'),

--- a/mobile/lib/routing/router.gr.dart
+++ b/mobile/lib/routing/router.gr.dart
@@ -689,6 +689,22 @@ class CropImageRouteArgs {
 }
 
 /// generated route for
+/// [DownloadInfoPage]
+class DownloadInfoRoute extends PageRouteInfo<void> {
+  const DownloadInfoRoute({List<PageRouteInfo>? children})
+    : super(DownloadInfoRoute.name, initialChildren: children);
+
+  static const String name = 'DownloadInfoRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const DownloadInfoPage();
+    },
+  );
+}
+
+/// generated route for
 /// [DriftActivitiesPage]
 class DriftActivitiesRoute extends PageRouteInfo<void> {
   const DriftActivitiesRoute({List<PageRouteInfo>? children})


### PR DESCRIPTION
Show download feedback in the asset viewer and the timeline

fixes #22127

| asset viewer | timeline | details |
| - | - | - |
| <img width="435" height="916" alt="image" src="https://github.com/user-attachments/assets/64c83dfb-4f52-4810-86fc-672d75c80143" /> | <img width="433" height="874" alt="image" src="https://github.com/user-attachments/assets/a2ad0126-7e72-431e-8996-7b028d2424fe" /> | <img width="435" height="942" alt="image" src="https://github.com/user-attachments/assets/0bf5f477-bfd2-427b-9893-b4a9adcaae0f" /> |
