### PR TITLE
fix(web): do not upscale small pictures

### DIFF
--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -240,7 +240,7 @@
       use:zoomImageAction
       use:swipe={() => ({})}
       onswipe={onSwipe}
-      class="h-full w-full"
+      class="h-full w-full flex"
       transition:fade={{ duration: haveFadeTransition ? assetViewerFadeDuration : 0 }}
     >
       {#if $slideshowState !== SlideshowState.None && $slideshowLook === SlideshowLook.BlurredBackground}
@@ -255,7 +255,7 @@
         bind:this={$photoViewerImgElement}
         src={assetFileUrl}
         alt={$getAltText(toTimelineAsset(asset))}
-        class="h-full w-full {$slideshowState === SlideshowState.None
+        class="max-h-full max-w-full h-auto w-auto mx-auto my-auto {$slideshowState === SlideshowState.None
           ? 'object-contain'
           : slideshowLookCssMapping[$slideshowLook]}"
         draggable="false"


### PR DESCRIPTION
Do not upscale small pictures above their actual size.

Fixes #16290

| Before | After |
| - | - |
| <img width="2256" height="1247" alt="image" src="https://github.com/user-attachments/assets/3e716f94-1ae9-40fd-8346-9b754b5d6301" /> | <img width="2256" height="1247" alt="image" src="https://github.com/user-attachments/assets/9cfe68da-5509-4adb-9945-2b1ef02b9025" /> |