### PR TITLE
fix(web): show danger/warning when taken dates overlap

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1916,6 +1916,7 @@
   "stacktrace": "Stacktrace",
   "start": "Start",
   "start_date": "Start date",
+  "start_date_before_end_date": "Start date must be before end date",
   "state": "State",
   "status": "Status",
   "stop_casting": "Stop casting",

--- a/web/src/lib/components/shared-components/search-bar/search-date-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-date-section.svelte
@@ -7,6 +7,7 @@
 
 <script lang="ts">
   import DateInput from '$lib/elements/DateInput.svelte';
+  import { Text } from '@immich/ui';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -14,31 +15,27 @@
   }
 
   let { filters = $bindable() }: Props = $props();
+
+  let invalid = $derived(filters.takenAfter && filters.takenBefore && filters.takenAfter > filters.takenBefore);
+
+  const inputClasses = $derived(
+    `immich-form-input w-full mt-1 hover:cursor-pointer ${invalid ? 'border border-danger' : ''}`,
+  );
 </script>
 
-<div id="date-range-selection" class="grid grid-auto-fit-40 gap-5">
-  <label class="immich-form-label" for="start-date">
-    <span class="uppercase">{$t('start_date')}</span>
-    <DateInput
-      class="immich-form-input w-full mt-1 hover:cursor-pointer"
-      type="date"
-      id="start-date"
-      name="start-date"
-      max={filters.takenBefore}
-      bind:value={filters.takenAfter}
-    />
-  </label>
+<div class="flex flex-col gap-1">
+  <div id="date-range-selection" class="grid grid-auto-fit-40 gap-5">
+    <label class="immich-form-label" for="start-date">
+      <span class="uppercase">{$t('start_date')}</span>
+      <DateInput class={inputClasses} type="date" id="start-date" name="start-date" bind:value={filters.takenAfter} />
+    </label>
 
-  <label class="immich-form-label" for="end-date">
-    <span class="uppercase">{$t('end_date')}</span>
-    <DateInput
-      class="immich-form-input w-full mt-1 hover:cursor-pointer"
-      type="date"
-      id="end-date"
-      name="end-date"
-      placeholder=""
-      min={filters.takenAfter}
-      bind:value={filters.takenBefore}
-    />
-  </label>
+    <label class="immich-form-label" for="end-date">
+      <span class="uppercase">{$t('end_date')}</span>
+      <DateInput class={inputClasses} type="date" id="end-date" name="end-date" bind:value={filters.takenBefore} />
+    </label>
+  </div>
+  {#if invalid}
+    <Text color="danger">{$t('start_date_before_end_date')}</Text>
+  {/if}
 </div>


### PR DESCRIPTION
Fixes #16218 by showing a red border and error message when the dates are overlapping.

<img width="1507" height="172" alt="image" src="https://github.com/user-attachments/assets/942e5fc9-6374-491d-9f19-18fe81cda29b" />
<img width="1507" height="172" alt="image" src="https://github.com/user-attachments/assets/ae33d10a-7e11-4ffc-87ce-73da43a7813c" />

