### PR TITLE
fix(web): copy to clipboard on safari

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -920,6 +920,7 @@
     "cant_get_number_of_comments": "Can't get number of comments",
     "cant_search_people": "Can't search people",
     "cant_search_places": "Can't search places",
+    "clipboard_unsupported_mime_type": "The system clipboard does not support copying this type of content: {mimeType}",
     "error_adding_assets_to_album": "Error adding assets to album",
     "error_adding_users_to_album": "Error adding users to album",
     "error_deleting_shared_user": "Error deleting shared user",

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -97,12 +97,15 @@
     }
 
     try {
-      await copyImageToClipboard($photoViewerImgElement ?? assetFileUrl);
-      notificationController.show({
-        type: NotificationType.Info,
-        message: $t('copied_image_to_clipboard'),
-        timeout: 3000,
-      });
+      const result = await copyImageToClipboard($photoViewerImgElement ?? assetFileUrl);
+      if (result.success) {
+        notificationController.show({ type: NotificationType.Info, message: $t('copied_image_to_clipboard') });
+      } else {
+        notificationController.show({
+          type: NotificationType.Error,
+          message: $t('errors.clipboard_unsupported_mime_type', { values: { mimeType: result.mimeType } }),
+        });
+      }
     } catch (error) {
       handleError(error, $t('copy_error'));
     }


### PR DESCRIPTION
Fix #16148 by copying to the clipboard _immediately_, instead of waiting for the blob to load. If the clipboard write happens without an `await` it happens in the user-initiated gesture. Otherwise, it results in an error (`NotAllowedError`).