### PR TITLE
fix(web): only copy images via canvas

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -920,7 +920,6 @@
     "cant_get_number_of_comments": "Can't get number of comments",
     "cant_search_people": "Can't search people",
     "cant_search_places": "Can't search places",
-    "clipboard_unsupported_mime_type": "The system clipboard does not support copying this type of content: {mimeType}",
     "error_adding_assets_to_album": "Error adding assets to album",
     "error_adding_users_to_album": "Error adding users to album",
     "error_deleting_shared_user": "Error deleting shared user",

--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -23,6 +23,7 @@
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/button-context-menu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { AppRoute } from '$lib/constants';
+  import { photoViewerImgElement } from '$lib/stores/assets-store.svelte';
   import { featureFlags } from '$lib/stores/server-config.store';
   import { user } from '$lib/stores/user.store';
   import { photoZoomState } from '$lib/stores/zoom-image.store';
@@ -151,7 +152,7 @@
         onclick={onZoomImage}
       />
     {/if}
-    {#if canCopyImageToClipboard() && asset.type === AssetTypeEnum.Image}
+    {#if canCopyImageToClipboard() && asset.type === AssetTypeEnum.Image && $photoViewerImgElement}
       <IconButton
         color="secondary"
         variant="ghost"

--- a/web/src/lib/components/asset-viewer/photo-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/photo-viewer.svelte
@@ -92,20 +92,13 @@
   };
 
   copyImage = async () => {
-    if (!canCopyImageToClipboard()) {
+    if (!canCopyImageToClipboard() || !$photoViewerImgElement) {
       return;
     }
 
     try {
-      const result = await copyImageToClipboard($photoViewerImgElement ?? assetFileUrl);
-      if (result.success) {
-        notificationController.show({ type: NotificationType.Info, message: $t('copied_image_to_clipboard') });
-      } else {
-        notificationController.show({
-          type: NotificationType.Error,
-          message: $t('errors.clipboard_unsupported_mime_type', { values: { mimeType: result.mimeType } }),
-        });
-      }
+      await copyImageToClipboard($photoViewerImgElement);
+      notificationController.show({ type: NotificationType.Info, message: $t('copied_image_to_clipboard') });
     } catch (error) {
       handleError(error, $t('copy_error'));
     }

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -620,26 +620,7 @@ const imgToBlob = async (imageElement: HTMLImageElement) => {
   throw new Error('Canvas context is null');
 };
 
-const urlToBlob = async (imageSource: string) => {
-  const response = await fetch(imageSource);
-  return await response.blob();
-};
-
-export const copyImageToClipboard = async (
-  source: HTMLImageElement | string,
-): Promise<{ success: true } | { success: false; mimeType: string }> => {
-  if (source instanceof HTMLImageElement) {
-    // do not await, so the Safari clipboard write happens in the context of the user gesture
-    await navigator.clipboard.write([new ClipboardItem({ ['image/png']: imgToBlob(source) })]);
-    return { success: true };
-  }
-
-  // if we had a way to get the mime type synchronously, we could do the same thing here
-  const blob = await urlToBlob(source);
-  if (!ClipboardItem.supports(blob.type)) {
-    return { success: false, mimeType: blob.type };
-  }
-
-  await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
-  return { success: true };
+export const copyImageToClipboard = async (source: HTMLImageElement) => {
+  // do not await, so the Safari clipboard write happens in the context of the user gesture
+  await navigator.clipboard.write([new ClipboardItem({ ['image/png']: imgToBlob(source) })]);
 };


### PR DESCRIPTION
Follow up to #22217, fixes #14043

When the HTML image element isn't available the code would attempt to copy the http response, but the clipboard basically only supports image/png. It doesn't support image/jpeg or most other mime types. This changes the code to not show the copy-image-to-clipboard icon unless the HTML image element is available to copy from, removing the need for a fallback. The keyboard shortcut is ignored if the element is not available.