### PR TITLE
fix: local share action not working on iPad

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/share_action_button.widget.dart
@@ -42,7 +42,7 @@ class ShareActionButton extends ConsumerWidget {
     showDialog(
       context: context,
       builder: (BuildContext buildContext) {
-        ref.read(actionProvider.notifier).shareAssets(source).then((ActionResult result) {
+        ref.read(actionProvider.notifier).shareAssets(source, context).then((ActionResult result) {
           ref.read(multiSelectProvider.notifier).reset();
 
           if (!context.mounted) {

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -342,11 +342,11 @@ class ActionNotifier extends Notifier<void> {
     }
   }
 
-  Future<ActionResult> shareAssets(ActionSource source) async {
+  Future<ActionResult> shareAssets(ActionSource source, BuildContext context) async {
     final ids = _getAssets(source).toList(growable: false);
 
     try {
-      await _service.shareAssets(ids);
+      await _service.shareAssets(ids, context);
       return ActionResult(count: ids.length, success: true);
     } catch (error, stack) {
       _logger.severe('Failed to share assets', error, stack);

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -1,17 +1,19 @@
 import 'dart:io';
 
+import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/asset.entity.dart' as asset_entity;
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:immich_mobile/repositories/asset_api.repository.dart';
 import 'package:immich_mobile/utils/hash.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_manager/photo_manager.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/extensions/response_extensions.dart';
 import 'package:share_plus/share_plus.dart';
 
 final assetMediaRepositoryProvider = Provider((ref) => AssetMediaRepository(ref.watch(assetApiRepositoryProvider)));
@@ -68,7 +70,7 @@ class AssetMediaRepository {
   }
 
   // TODO: make this more efficient
-  Future<int> shareAssets(List<BaseAsset> assets) async {
+  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context) async {
     final downloadedXFiles = <XFile>[];
 
     for (var asset in assets) {
@@ -105,8 +107,12 @@ class AssetMediaRepository {
     }
 
     // we dont want to await the share result since the
-    // "preparing" dialog will not disappear unti
-    Share.shareXFiles(downloadedXFiles).then((result) async {
+    // "preparing" dialog will not disappear until
+    final size = context.sizeData;
+    Share.shareXFiles(
+      downloadedXFiles,
+      sharePositionOrigin: Rect.fromPoints(Offset.zero, Offset(size.width / 3, size.height)),
+    ).then((result) async {
       for (var file in downloadedXFiles) {
         try {
           await File(file.path).delete();

--- a/mobile/lib/services/action.service.dart
+++ b/mobile/lib/services/action.service.dart
@@ -224,8 +224,8 @@ class ActionService {
     await _assetApiRepository.unStack(stackIds);
   }
 
-  Future<int> shareAssets(List<BaseAsset> assets) {
-    return _assetMediaRepository.shareAssets(assets);
+  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context) {
+    return _assetMediaRepository.shareAssets(assets, context);
   }
 
   Future<List<bool>> downloadAll(List<RemoteAsset> assets) {


### PR DESCRIPTION
## Description

- `share_plus` requires the `sharePositionOrigin` parameter to be set for it to work properly on iPad. This is handled in the old implementation but was missed in the new one