### PR TITLE
feat(web): reactively update shared link expiration

### DIFF
--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -103,7 +103,7 @@
     try {
       const expirationDate = expirationOption > 0 ? DateTime.now().plus(expirationOption).toISO() : null;
 
-      await updateSharedLink({
+      const updatedLink = await updateSharedLink({
         id: editingLink.id,
         sharedLinkEditDto: {
           description,
@@ -121,7 +121,7 @@
         message: $t('edited'),
       });
 
-      onClose();
+      onClose(updatedLink);
     } catch (error) {
       handleError(error, $t('errors.failed_to_edit_shared_link'));
     }

--- a/web/src/routes/(user)/shared-links/[[id=id]]/+page.svelte
+++ b/web/src/routes/(user)/shared-links/[[id=id]]/+page.svelte
@@ -54,8 +54,15 @@
     }
   };
 
-  const handleEditDone = async () => {
-    await refresh();
+  const handleEditDone = async (updatedLink?: SharedLinkResponseDto) => {
+    if (updatedLink) {
+      const index = sharedLinks.findIndex((link) => link.id === updatedLink.id);
+      if (index !== -1) {
+        sharedLinks[index] = updatedLink;
+      }
+    } else {
+      await refresh();
+    }
     await goto(AppRoute.SHARED_LINKS);
   };
 


### PR DESCRIPTION
## Description

fix(web): update shared link expiration in UI without full refresh

This commit fixes a UI bug where the expiration date of a shared link was not updating correctly after being edited.

The `SharedLinkCreateModal` is modified to return the updated shared link data upon successful edit. The parent page now uses this data to update its local state directly, avoiding a full page refresh and providing a better user experience.


Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A
- [x] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
