### PR TITLE
fix(shared-links): handle Delete key to remove assets from shared link

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -242,15 +242,22 @@
     }
   };
 
-  const onDelete = () => {
-    const hasTrashedAsset = assetInteraction.selectedAssets.some((asset) => asset.isTrashed);
+const onDelete = () => {
+  const hasTrashedAsset = assetInteraction.selectedAssets.some((asset) => asset.isTrashed);
 
-    if ($showDeleteModal && (!isTrashEnabled || hasTrashedAsset)) {
-      isShowDeleteConfirmation = true;
-      return;
-    }
-    handlePromiseError(trashOrDelete(hasTrashedAsset));
-  };
+  if (isSharedLinkView) {
+    removeFromSharedLink(link.id, assetInteraction.selectedAssets.map(a => a.id));
+    return;
+  }
+
+  if ($showDeleteModal && (!isTrashEnabled || hasTrashedAsset)) {
+    isShowDeleteConfirmation = true;
+    return;
+  }
+
+  handlePromiseError(trashOrDelete(hasTrashedAsset));
+};
+
 
   const onForceDelete = () => {
     if ($showDeleteModal) {


### PR DESCRIPTION
Previously, pressing the Delete key on selected assets in the Shared Link view sent them to trash instead of removing them from the shared link. This commit updates the `onDelete` handler in the shared link view to call the `removeFromSharedLink` function, ensuring that both the Delete key and the UI delete button correctly remove assets from the shared link.

## Description

This fixes the bug where the Delete key in Shared Link view was incorrectly sending assets to trash. Now, pressing Delete or clicking the delete button removes assets from the shared link by calling the backend endpoint `/shared-links/:id/assets`.

Fixes #22292


## How Has This Been Tested?

- [x] Pressed Delete key on selected assets in Shared Link view → assets removed from shared link.
- [x] Clicked Delete button in Shared Link view → assets removed from shared link.
- [x] Verified that Delete key in main library still moves assets to trash.
- [x] Checked network tab → DELETE request sent to `/shared-links/:id/assets` with correct payload.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1363" height="827" alt="image" src="https://github.com/user-attachments/assets/05e96122-e3ee-4920-a27f-1d79768ab4f9" />
<img width="1915" height="984" alt="image" src="https://github.com/user-attachments/assets/f1c1c0ee-4c2a-48c5-83e3-f4fc2d968c7a" />
<img width="1912" height="956" alt="image" src="https://github.com/user-attachments/assets/6db354dc-89f8-4a62-b3cb-62747d8e0f7c" />
<img width="1919" height="968" alt="image" src="https://github.com/user-attachments/assets/12cc5bdc-ee42-472d-8d22-54738060206c" />
<img width="1877" height="935" alt="image" src="https://github.com/user-attachments/assets/83065bc2-af90-4319-a2bd-76c9406ad779" />

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repository implementations for DB calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is simple and does not contain immich-specific logic

## LLM usage

No LLM was used in creating this pull request.
