### PR TITLE
fix: local assets should not be added to album

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -28,6 +28,7 @@
   "add_to_album": "Add to album",
   "add_to_album_bottom_sheet_added": "Added to {album}",
   "add_to_album_bottom_sheet_already_exists": "Already in {album}",
+  "add_to_album_bottom_sheet_some_local_assets": "Some local assets could not be added to album",
   "add_to_album_toggle": "Toggle selection for {album}",
   "add_to_albums": "Add to albums",
   "add_to_albums_count": "Add to albums ({count})",

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/setting.model.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/advanced_info_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/archive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_action_button.widget.dart';
@@ -62,11 +63,19 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
         return;
       }
 
+      final remoteAssets = selectedAssets.whereType<RemoteAsset>();
       final addedCount = await ref
           .read(remoteAlbumProvider.notifier)
-          .addAssets(album.id, selectedAssets.map((e) => (e as RemoteAsset).id).toList());
+          .addAssets(album.id, remoteAssets.map((e) => e.id).toList());
 
-      if (addedCount != selectedAssets.length) {
+      if (selectedAssets.length != remoteAssets.length) {
+        ImmichToast.show(
+          context: context,
+          msg: 'add_to_album_bottom_sheet_some_local_assets'.t(context: context),
+        );
+      }
+
+      if (addedCount != remoteAssets.length) {
         ImmichToast.show(
           context: context,
           msg: 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {"album": album.name}),
@@ -113,10 +122,12 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
         if (multiselect.hasLocal || multiselect.hasMerged) const DeleteLocalActionButton(source: ActionSource.timeline),
         if (multiselect.hasLocal) const UploadActionButton(source: ActionSource.timeline),
       ],
-      slivers: [
-        const AddToAlbumHeader(),
-        AlbumSelector(onAlbumSelected: addAssetsToAlbum, onKeyboardExpanded: onKeyboardExpand),
-      ],
+      slivers: multiselect.hasRemote
+          ? [
+              const AddToAlbumHeader(),
+              AlbumSelector(onAlbumSelected: addAssetsToAlbum, onKeyboardExpanded: onKeyboardExpand),
+            ]
+          : [],
     );
   }
 }


### PR DESCRIPTION
## Description

hide album picker when selection is local only

<img width="382" height="407" alt="image" src="https://github.com/user-attachments/assets/472b4696-ee9d-4e98-b2f6-c01c6b1141ce" />

and also filter out adding to album

<img width="326" height="170" alt="image" src="https://github.com/user-attachments/assets/90f437ce-019d-408b-9357-1f0f64450909" />



Fixes #20571

## How Has This Been Tested?
Tested with a mix of local/remote, remote only, local only and all worked as expected
