### PR TITLE
fix(server): update libmimalloc path

### DIFF
--- a/server/bin/start.sh
+++ b/server/bin/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 echo "Initializing Immich $IMMICH_SOURCE_REF"
 
-lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.2"
+lib_path="/usr/lib/$(arch)-linux-gnu/libmimalloc.so.3"
 if [ -f "$lib_path" ]; then
   export LD_PRELOAD="$lib_path"
 else


### PR DESCRIPTION
## Description

libmimalloc now has a different path with the Trixie base image, so it wasn't being used since that update. This caused an increase in memory usage and fragmentation as the default allocator is used instead.