### PR TITLE
chore: update android background worker notification text

### DIFF
--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -116,7 +116,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       if (Platform.isAndroid) {
         await _backgroundHostApi.showNotification(
           IntlKeys.uploading_media.t(),
-          IntlKeys.backup_background_service_in_progress_notification.t(),
+          IntlKeys.backup_background_service_default_notification.t(),
         );
       }
 


### PR DESCRIPTION
## Description

- The notification of the background worker on android is updated to say "Checking for new assets" instead of the previous "Backing up your assets". The background worker is always run irrespective of the backup settings to sync and hash new assets and the backup is executed only when it is enabled. The older text caused a bit of confusion as it was disabled even when backup wasn't running due to unmet network constraints
