### PR TITLE
fix(server): override reserved color metadata for video thumbnails

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -203,6 +203,9 @@ export class MediaRepository {
           isHDR: stream.color_transfer === 'smpte2084' || stream.color_transfer === 'arib-std-b67',
           bitrate: this.parseInt(stream.bit_rate),
           pixelFormat: stream.pix_fmt || 'yuv420p',
+          colorPrimaries: stream.color_primaries,
+          colorSpace: stream.color_space,
+          colorTransfer: stream.color_transfer,
         })),
       audioStreams: results.streams
         .filter((stream) => stream.codec_type === 'audio')

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -445,6 +445,7 @@ describe(MediaService.name, () => {
         }),
       );
     });
+
     it('should not skip intra frames for MTS file', async () => {
       mocks.media.probe.mockResolvedValue(probeStub.videoStreamMTS);
       mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(assetStub.video);
@@ -455,6 +456,25 @@ describe(MediaService.name, () => {
         expect.any(String),
         expect.objectContaining({
           inputOptions: ['-sws_flags accurate_rnd+full_chroma_int'],
+          outputOptions: expect.any(Array),
+          progress: expect.any(Object),
+          twoPass: false,
+        }),
+      );
+    });
+
+    it('should override reserved color metadata', async () => {
+      mocks.media.probe.mockResolvedValue(probeStub.videoStreamReserved);
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(assetStub.video);
+      await sut.handleGenerateThumbnails({ id: assetStub.video.id });
+
+      expect(mocks.media.transcode).toHaveBeenCalledWith(
+        '/original/path.ext',
+        expect.any(String),
+        expect.objectContaining({
+          inputOptions: expect.arrayContaining([
+            '-bsf:v hevc_metadata=colour_primaries=1:matrix_coefficients=1:transfer_characteristics=1',
+          ]),
           outputOptions: expect.any(Array),
           progress: expect.any(Object),
           twoPass: false,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -88,6 +88,9 @@ export interface VideoStreamInfo {
   isHDR: boolean;
   bitrate: number;
   pixelFormat: string;
+  colorPrimaries?: string;
+  colorSpace?: string;
+  colorTransfer?: string;
 }
 
 export interface AudioStreamInfo {

--- a/server/test/fixtures/media.stub.ts
+++ b/server/test/fixtures/media.stub.ts
@@ -261,4 +261,15 @@ export const probeStub = {
       bitrate: 0,
     },
   }),
+  videoStreamReserved: Object.freeze<VideoInfo>({
+    ...probeStubDefault,
+    videoStreams: [
+      {
+        ...probeStubDefaultVideoStream[0],
+        colorPrimaries: 'reserved',
+        colorSpace: 'reserved',
+        colorTransfer: 'reserved',
+      },
+    ],
+  }),
 };


### PR DESCRIPTION
## Description

ffmpeg now propagates more color metadata from the source video into filters. In the case of videos using "reserved" metadata entries, this causes a failure during thumbnail generation as this is invalid. This PR overrides the "reserved" types into bt709.

Tested that a sample video where thumbnail generation failed with the "Invalid color space" error now gets processed as expected.