### PR TITLE
chore(deps): bump exoplayer to 1.8.0

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1208,8 +1208,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "5459d54"
-      resolved-ref: "5459d54cdc1cf4d99e2193b310052f1ebb5dcf43"
+      ref: "893894b"
+      resolved-ref: "893894b98b832be8a995a8d5d4c2289d0ad2d246"
       url: "https://github.com/immich-app/native_video_player"
     source: git
     version: "1.3.1"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -77,7 +77,7 @@ dependencies:
   native_video_player:
     git:
       url: https://github.com/immich-app/native_video_player
-      ref: '5459d54'
+      ref: '893894b'
   openapi:
     path: openapi
   isar:


### PR DESCRIPTION
## Description

This uses the updated player dependencies without the seeking changes in [this](https://github.com/immich-app/immich/pull/22346) PR in order to keep this change independent and patch-level.