### PR TITLE
fix: process upload only after successful remote sync

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -598,6 +598,7 @@
   "backup_controller_page_turn_on": "Turn on foreground backup",
   "backup_controller_page_uploading_file_info": "Uploading file info",
   "backup_err_only_album": "Cannot remove the only album",
+  "backup_error_sync_failed": "Sync failed. Cannot start backup.",
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_in_progress": "Upload already in progress. Try after sometime",

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -28,7 +28,6 @@ import 'package:immich_mobile/repositories/file_media.repository.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/auth.service.dart';
 import 'package:immich_mobile/services/localization.service.dart';
-import 'package:immich_mobile/services/server_info.service.dart';
 import 'package:immich_mobile/services/upload.service.dart';
 import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
@@ -130,30 +129,33 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
 
   @override
   Future<void> onAndroidUpload() async {
+    _logger.info('Android background processing started');
+    final sw = Stopwatch()..start();
     try {
-      _logger.info('Android background processing started');
-      final sw = Stopwatch()..start();
-
-      await _syncAssets(hashTimeout: Duration(minutes: _isBackupEnabled ? 3 : 6));
+      if (!await _syncAssets(hashTimeout: Duration(minutes: _isBackupEnabled ? 3 : 6))) {
+        _logger.warning("Remote sync did not complete successfully, skipping backup");
+        return;
+      }
       await _handleBackup();
-
-      sw.stop();
-      _logger.info("Android background processing completed in ${sw.elapsed.inSeconds}s");
     } catch (error, stack) {
       _logger.severe("Failed to complete Android background processing", error, stack);
     } finally {
+      sw.stop();
+      _logger.info("Android background processing completed in ${sw.elapsed.inSeconds}s");
       await _cleanup();
     }
   }
 
   @override
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds) async {
+    _logger.info('iOS background upload started with maxSeconds: ${maxSeconds}s');
+    final sw = Stopwatch()..start();
     try {
-      _logger.info('iOS background upload started with maxSeconds: ${maxSeconds}s');
-      final sw = Stopwatch()..start();
-
       final timeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
-      await _syncAssets(hashTimeout: timeout);
+      if (!await _syncAssets(hashTimeout: timeout)) {
+        _logger.warning("Remote sync did not complete successfully, skipping backup");
+        return;
+      }
 
       final backupFuture = _handleBackup();
       if (maxSeconds != null) {
@@ -161,12 +163,11 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       } else {
         await backupFuture;
       }
-
-      sw.stop();
-      _logger.info("iOS background upload completed in ${sw.elapsed.inSeconds}s");
     } catch (error, stack) {
       _logger.severe("Failed to complete iOS background upload", error, stack);
     } finally {
+      sw.stop();
+      _logger.info("iOS background upload completed in ${sw.elapsed.inSeconds}s");
       await _cleanup();
     }
   }
@@ -227,27 +228,18 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         }
 
         if (!_isBackupEnabled) {
-          _logger.info("[_handleBackup 1] Backup is disabled. Skipping backup routine");
+          _logger.info("Backup is disabled. Skipping backup routine");
           return;
         }
-
-        _logger.info("[_handleBackup 2] Enqueuing assets for backup from the background service");
 
         final currentUser = _ref?.read(currentUserProvider);
         if (currentUser == null) {
-          _logger.warning("[_handleBackup 3] No current user found. Skipping backup from background");
+          _logger.warning("No current user found. Skipping backup from background");
           return;
         }
 
-        _logger.info("[_handleBackup 4] Resume backup from background");
         if (Platform.isIOS) {
           return _ref?.read(driftBackupProvider.notifier).handleBackupResume(currentUser.id);
-        }
-
-        final canPing = await _ref?.read(serverInfoServiceProvider).ping() ?? false;
-        if (!canPing) {
-          _logger.warning("[_handleBackup 5] Server is not reachable. Skipping backup from background");
-          return;
         }
 
         final networkCapabilities = await _ref?.read(connectivityApiProvider).getCapabilities() ?? [];
@@ -261,15 +253,15 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
     );
   }
 
-  Future<void> _syncAssets({Duration? hashTimeout}) async {
+  Future<bool> _syncAssets({Duration? hashTimeout}) async {
     await _ref?.read(backgroundSyncProvider).syncLocal();
     if (_isCleanedUp) {
-      return;
+      return false;
     }
 
-    await _ref?.read(backgroundSyncProvider).syncRemote();
+    final isSuccess = await _ref?.read(backgroundSyncProvider).syncRemote() ?? false;
     if (_isCleanedUp) {
-      return;
+      return isSuccess;
     }
 
     var hashFuture = _ref?.read(backgroundSyncProvider).hashAssets();
@@ -283,6 +275,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
     }
 
     await hashFuture;
+    return isSuccess;
   }
 }
 

--- a/mobile/lib/domain/services/sync_stream.service.dart
+++ b/mobile/lib/domain/services/sync_stream.service.dart
@@ -23,7 +23,7 @@ class SyncStreamService {
 
   bool get isCancelled => _cancelChecker?.call() ?? false;
 
-  Future<void> sync() async {
+  Future<bool> sync() async {
     _logger.info("Remote sync request for user");
     // Start the sync stream and handle events
     bool shouldReset = false;
@@ -32,6 +32,7 @@ class SyncStreamService {
       _logger.info("Resetting sync state as requested by server");
       await _syncApiRepository.streamChanges(_handleEvents);
     }
+    return true;
   }
 
   Future<void> _handleEvents(List<SyncEvent> events, Function() abort, Function() reset) async {

--- a/mobile/lib/domain/utils/background_sync.dart
+++ b/mobile/lib/domain/utils/background_sync.dart
@@ -21,7 +21,7 @@ class BackgroundSyncManager {
   final SyncCallback? onHashingComplete;
   final SyncErrorCallback? onHashingError;
 
-  Cancelable<void>? _syncTask;
+  Cancelable<bool?>? _syncTask;
   Cancelable<void>? _syncWebsocketTask;
   Cancelable<void>? _deviceAlbumSyncTask;
   Cancelable<void>? _linkedAlbumSyncTask;
@@ -144,9 +144,9 @@ class BackgroundSyncManager {
         });
   }
 
-  Future<void> syncRemote() {
+  Future<bool> syncRemote() {
     if (_syncTask != null) {
-      return _syncTask!.future;
+      return _syncTask!.future.then((result) => result ?? false).catchError((_) => false);
     }
 
     onRemoteSyncStart?.call();
@@ -156,6 +156,7 @@ class BackgroundSyncManager {
       debugLabel: 'remote-sync',
     );
     return _syncTask!
+        .then((result) => result ?? false)
         .whenComplete(() {
           onRemoteSyncComplete?.call();
           _syncTask = null;
@@ -163,6 +164,7 @@ class BackgroundSyncManager {
         .catchError((error) {
           onRemoteSyncError?.call(error.toString());
           _syncTask = null;
+          return false;
         });
   }
 

--- a/mobile/lib/infrastructure/repositories/sync_api.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_api.repository.dart
@@ -110,7 +110,6 @@ class SyncApiRepository {
         await onData(_parseLines(lines), abort, reset);
       }
     } catch (error, stack) {
-      _logger.severe("Error processing stream", error, stack);
       return Future.error(error, stack);
     } finally {
       client.close();

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -62,13 +62,23 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
             infoProvider.getServerInfo();
 
             if (Store.isBetaTimelineEnabled) {
-              await Future.wait([backgroundManager.syncLocal(), backgroundManager.syncRemote()]);
+              bool syncSuccess = false;
               await Future.wait([
-                backgroundManager.hashAssets().then((_) {
-                  _resumeBackup(backupProvider);
-                }),
-                _resumeBackup(backupProvider),
+                backgroundManager.syncLocal(),
+                backgroundManager.syncRemote().then((success) => syncSuccess = success),
               ]);
+
+              if (syncSuccess) {
+                await Future.wait([
+                  backgroundManager.hashAssets().then((_) {
+                    _resumeBackup(backupProvider);
+                  }),
+                  _resumeBackup(backupProvider),
+                ]);
+              } else {
+                backupProvider.updateError(BackupError.syncFailed);
+                await backgroundManager.hashAssets();
+              }
 
               if (Store.get(StoreKey.syncAlbums, false)) {
                 await backgroundManager.syncLinkedAlbum();

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -119,6 +119,8 @@ class DriftUploadStatus {
       DriftUploadStatus.fromMap(json.decode(source) as Map<String, dynamic>);
 }
 
+enum BackupError { none, syncFailed }
+
 class DriftBackupState {
   final int totalCount;
   final int backupCount;
@@ -129,6 +131,7 @@ class DriftBackupState {
   final int enqueueTotalCount;
 
   final bool isCanceling;
+  final BackupError error;
 
   final Map<String, DriftUploadStatus> uploadItems;
 
@@ -141,6 +144,7 @@ class DriftBackupState {
     required this.enqueueTotalCount,
     required this.isCanceling,
     required this.uploadItems,
+    this.error = BackupError.none,
   });
 
   DriftBackupState copyWith({
@@ -152,6 +156,7 @@ class DriftBackupState {
     int? enqueueTotalCount,
     bool? isCanceling,
     Map<String, DriftUploadStatus>? uploadItems,
+    BackupError? error,
   }) {
     return DriftBackupState(
       totalCount: totalCount ?? this.totalCount,
@@ -162,12 +167,13 @@ class DriftBackupState {
       enqueueTotalCount: enqueueTotalCount ?? this.enqueueTotalCount,
       isCanceling: isCanceling ?? this.isCanceling,
       uploadItems: uploadItems ?? this.uploadItems,
+      error: error ?? this.error,
     );
   }
 
   @override
   String toString() {
-    return 'DriftBackupState(totalCount: $totalCount, backupCount: $backupCount, remainderCount: $remainderCount, processingCount: $processingCount, enqueueCount: $enqueueCount, enqueueTotalCount: $enqueueTotalCount, isCanceling: $isCanceling, uploadItems: $uploadItems)';
+    return 'DriftBackupState(totalCount: $totalCount, backupCount: $backupCount, remainderCount: $remainderCount, processingCount: $processingCount, enqueueCount: $enqueueCount, enqueueTotalCount: $enqueueTotalCount, isCanceling: $isCanceling, uploadItems: $uploadItems, error: $error)';
   }
 
   @override
@@ -182,7 +188,8 @@ class DriftBackupState {
         other.enqueueCount == enqueueCount &&
         other.enqueueTotalCount == enqueueTotalCount &&
         other.isCanceling == isCanceling &&
-        mapEquals(other.uploadItems, uploadItems);
+        mapEquals(other.uploadItems, uploadItems) &&
+        other.error == error;
   }
 
   @override
@@ -194,7 +201,8 @@ class DriftBackupState {
         enqueueCount.hashCode ^
         enqueueTotalCount.hashCode ^
         isCanceling.hashCode ^
-        uploadItems.hashCode;
+        uploadItems.hashCode ^
+        error.hashCode;
   }
 }
 
@@ -214,6 +222,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
           enqueueTotalCount: 0,
           isCanceling: false,
           uploadItems: {},
+          error: BackupError.none,
         ),
       ) {
     {
@@ -330,7 +339,12 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     );
   }
 
+  Future<void> updateError(BackupError error) async {
+    state = state.copyWith(error: error);
+  }
+
   Future<void> startBackup(String userId) {
+    state = state.copyWith(error: BackupError.none);
     return _uploadService.startBackup(userId, _updateEnqueueCount);
   }
 
@@ -340,7 +354,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
 
   Future<void> cancel() async {
     dPrint(() => "Canceling backup tasks...");
-    state = state.copyWith(enqueueCount: 0, enqueueTotalCount: 0, isCanceling: true);
+    state = state.copyWith(enqueueCount: 0, enqueueTotalCount: 0, isCanceling: true, error: BackupError.none);
 
     final activeTaskCount = await _uploadService.cancelBackup();
 
@@ -356,6 +370,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
 
   Future<void> handleBackupResume(String userId) async {
     _logger.info("Resuming backup tasks...");
+    state = state.copyWith(error: BackupError.none);
     final tasks = await _uploadService.getActiveTasks(kBackupGroup);
     _logger.info("Found ${tasks.length} tasks");
 

--- a/mobile/lib/services/server_info.service.dart
+++ b/mobile/lib/services/server_info.service.dart
@@ -14,15 +14,6 @@ class ServerInfoService {
 
   const ServerInfoService(this._apiService);
 
-  Future<bool> ping() async {
-    try {
-      await _apiService.serverInfoApi.pingServer().timeout(const Duration(seconds: 5));
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
-
   Future<ServerDiskInfo?> getDiskInfo() async {
     try {
       final dto = await _apiService.serverInfoApi.getStorage();

--- a/mobile/lib/utils/isolate.dart
+++ b/mobile/lib/utils/isolate.dart
@@ -32,6 +32,7 @@ Cancelable<T?> runInIsolateGentle<T>({
   }
 
   return workerManager.executeGentle((cancelledChecker) async {
+    T? result;
     await runZonedGuarded(
       () async {
         BackgroundIsolateBinaryMessenger.ensureInitialized(token);
@@ -53,7 +54,7 @@ Cancelable<T?> runInIsolateGentle<T>({
 
         try {
           HttpSSLOptions.apply(applyNative: false);
-          return await computation(ref);
+          result = await computation(ref);
         } on CanceledError {
           log.warning("Computation cancelled ${debugLabel == null ? '' : ' for $debugLabel'}");
         } catch (error, stack) {
@@ -83,12 +84,11 @@ Cancelable<T?> runInIsolateGentle<T>({
             await Future.delayed(const Duration(seconds: 2));
           }
         }
-        return null;
       },
       (error, stack) {
         dPrint(() => "Error in isolate $debugLabel zone: $error, $stack");
       },
     );
-    return null;
+    return result;
   });
 }

--- a/mobile/lib/widgets/common/immich_sliver_app_bar.dart
+++ b/mobile/lib/widgets/common/immich_sliver_app_bar.dart
@@ -9,8 +9,8 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/server_info/server_info.model.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/cast.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -168,8 +168,16 @@ class _BackupIndicator extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     const widgetSize = 30.0;
-    final indicatorIcon = _getBackupBadgeIcon(context, ref);
-    final badgeBackground = context.colorScheme.surfaceContainer;
+    final hasError = ref.watch(driftBackupProvider.select((state) => state.error != BackupError.none));
+    final indicatorIcon = hasError
+        ? Icon(
+            Icons.warning_rounded,
+            size: 12,
+            color: context.colorScheme.error,
+            semanticLabel: 'backup_controller_page_backup'.tr(),
+          )
+        : _getBackupBadgeIcon(context, ref);
+    final badgeBackground = hasError ? context.colorScheme.errorContainer : context.colorScheme.surfaceContainer;
 
     return InkWell(
       onTap: () => context.pushRoute(const DriftBackupRoute()),


### PR DESCRIPTION
## Description

- Backup is now started only after a successful remote sync. This will prevent unwanted uploads of duplicates that are already on the server

<details><summary><h2>Screenshots</h2></summary>

Indicator:
<img width="283" height="43" alt="Screenshot 2025-09-24 at 7 38 00 PM" src="https://github.com/user-attachments/assets/89e0418a-4998-4c21-bca8-725eefc2874e" /> 

Backup page:
<img width="200" height="700" alt="Screenshot_1758722866" src="https://github.com/user-attachments/assets/5cd20553-8b3e-4cc5-8ff8-8b1640f726a7" />


</details>
