### PR TITLE
fix: delete temp file on iOS after upload

### DIFF
--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -9,6 +9,7 @@ import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/backup.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/storage.repository.dart';
@@ -19,9 +20,9 @@ import 'package:immich_mobile/providers/infrastructure/storage.provider.dart';
 import 'package:immich_mobile/repositories/upload.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
+import 'package:immich_mobile/utils/debug_print.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
-import 'package:immich_mobile/utils/debug_print.dart';
 
 final uploadServiceProvider = Provider((ref) {
   final service = UploadService(
@@ -205,10 +206,20 @@ class UploadService {
     return _uploadRepository.start();
   }
 
-  void _handleTaskStatusUpdate(TaskStatusUpdate update) {
+  void _handleTaskStatusUpdate(TaskStatusUpdate update) async {
     switch (update.status) {
       case TaskStatus.complete:
         _handleLivePhoto(update);
+
+        if (CurrentPlatform.isIOS) {
+          try {
+            final path = await update.task.filePath();
+            await File(path).delete();
+          } catch (e) {
+            _logger.severe('Error deleting file path for iOS: $e');
+          }
+        }
+
         break;
 
       default:


### PR DESCRIPTION
## Description

The app do not use the originals from PhotoManager anymore for hashing / thumbnails. They can now be safely deleted once uploaded