### PR TITLE
fix(pump-version): fix immich-ml pyproject.toml path

### DIFF
--- a/machine-learning/pyproject.toml
+++ b/machine-learning/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "immich-ml"
-version = "1.129.0"
+version = "1.143.1"
 description = ""
 authors = [{ name = "Hau Tran", email = "alex.tran1502@gmail.com" }]
 requires-python = ">=3.10,<4.0"

--- a/misc/release/pump-version.sh
+++ b/misc/release/pump-version.sh
@@ -80,7 +80,7 @@ if [ "$CURRENT_SERVER" != "$NEXT_SERVER" ]; then
 
   jq --arg version "$NEXT_SERVER" '.version = $version' e2e/package.json > e2e/package.json.tmp && mv e2e/package.json.tmp e2e/package.json
   pnpm install --frozen-lockfile --prefix e2e
-  uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version "$SERVER_PUMP"
+  uvx --from=toml-cli toml set --toml-path=machine-learning/pyproject.toml project.version "$SERVER_PUMP"
 fi
 
 if [ "$CURRENT_MOBILE" != "$NEXT_MOBILE" ]; then


### PR DESCRIPTION
## Description

Since the migration to uv, this has not worked because the Python toml CLI has been looking for a pyproject.toml in the root folder.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tried the new command `uvx...`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- - I'm fairly sure bumping the immich-ml version to 1.143.1 is a related change.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

washing the dishes