### PR TITLE
fix(ml): Resolve IPv6 startup crash and healthcheck failure

### DIFF
--- a/machine-learning/immich_ml/__main__.py
+++ b/machine-learning/immich_ml/__main__.py
@@ -15,7 +15,7 @@ module_dir = Path(__file__).parent
 
 bind_host = non_prefixed_settings.immich_host
 if ip_address(bind_host).version == 6:
-  bind_host = f"[{bind_host}]"
+    bind_host = f"[{bind_host}]"
 bind_address = f"{bind_host}:{non_prefixed_settings.immich_port}"
 
 try:

--- a/machine-learning/immich_ml/__main__.py
+++ b/machine-learning/immich_ml/__main__.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import subprocess
+from ipaddress import ip_address
 from pathlib import Path
 
 from .config import log, non_prefixed_settings, settings
@@ -13,8 +14,8 @@ else:
 module_dir = Path(__file__).parent
 
 bind_host = non_prefixed_settings.immich_host
-if ":" in bind_host and not bind_host.startswith("["):
-    bind_host = f"[{bind_host}]"
+if ip_address(bind_host).version == 6:
+  bind_host = f"[{bind_host}]"
 bind_address = f"{bind_host}:{non_prefixed_settings.immich_port}"
 
 try:

--- a/machine-learning/immich_ml/__main__.py
+++ b/machine-learning/immich_ml/__main__.py
@@ -12,6 +12,11 @@ else:
 
 module_dir = Path(__file__).parent
 
+bind_host = non_prefixed_settings.immich_host
+if ":" in bind_host and not bind_host.startswith("["):
+    bind_host = f"[{bind_host}]"
+bind_address = f"{bind_host}:{non_prefixed_settings.immich_port}"
+
 try:
     with subprocess.Popen(
         [
@@ -24,7 +29,7 @@ try:
             "-c",
             module_dir / "gunicorn_conf.py",
             "-b",
-            f"{non_prefixed_settings.immich_host}:{non_prefixed_settings.immich_port}",
+            bind_address,
             "-w",
             str(settings.workers),
             "-t",

--- a/machine-learning/scripts/healthcheck.py
+++ b/machine-learning/scripts/healthcheck.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from ipaddress import ip_address
 
 import requests
 
@@ -7,7 +8,7 @@ port = os.getenv("IMMICH_PORT", 3003)
 host = os.getenv("IMMICH_HOST", "0.0.0.0")
 
 host = "localhost" if host == "0.0.0.0" else host
-host = f"[{host}]" if ":" in host else host
+host = f"[{host}]" if ip_address(host).version == 6 else host
 
 try:
     response = requests.get(f"http://{host}:{port}/ping", timeout=2)

--- a/machine-learning/scripts/healthcheck.py
+++ b/machine-learning/scripts/healthcheck.py
@@ -7,6 +7,7 @@ port = os.getenv("IMMICH_PORT", 3003)
 host = os.getenv("IMMICH_HOST", "0.0.0.0")
 
 host = "localhost" if host == "0.0.0.0" else host
+host = f"[{host}]" if ":" in host else host
 
 try:
     response = requests.get(f"http://{host}:{port}/ping", timeout=2)


### PR DESCRIPTION
## Description

When IMMICH_HOST is set to a bare IPv6 address (e.g., ::), the machine-learning container fails to start and enters a restart loop.

This is caused by two related issues:

- Startup Crash: The `immich_ml/__main__.py` script incorrectly constructs the bind address for the Gunicorn subprocess, creating an invalid string (e.g., :::3003) which Gunicorn cannot parse.

- Healthcheck Failure: The scripts/healthcheck.py script creates an invalid URL for IPv6 hosts by not enclosing the address in brackets.

This PR fixes both issues by ensuring the IPv6 address is correctly enclosed in square brackets [] in both the Gunicorn bind address at startup and in the healthcheck URL.

Fixes #13782 

## How Has This Been Tested?
I have tested this fix locally by building and running a custom image with the changes

### Steps to Reproduce:
1. get the .env file ( `wget -O .env https://github.com/immich-app/immich/releases/latest/download/example.env` )
2. create a dedicated compose file for testing
```compose.test.yml
services:
  immich-machine-learning:
    container_name: immich_machine_learning_test
    image: immich-ml-test-image
    build:
      context: ./machine-learning
      dockerfile: ./Dockerfile
    env_file:
      - .env
     environment:
      - "IMMICH_HOST=::"
    restart: always
    healthcheck:
       disable: false
```
3. From the root of the repo, `run docker compose -f compose.test.yml up --build`
4. Before this PR: the container fails to start with a port parsing error
5. With this PR: the container builds and starts success
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used Gemini to help debug the testing environment and refine the final code changes and this PR message.
