### PR TITLE
chore: replace immich.app/docs with docs.immich.app globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@
 
 ## Links
 
-- [Documentation](https://immich.app/docs)
-- [About](https://immich.app/docs/overview/introduction)
-- [Installation](https://immich.app/docs/install/requirements)
+- [Documentation](https://docs.immich.app/)
+- [About](https://docs.immich.app/overview/introduction)
+- [Installation](https://docs.immich.app/install/requirements)
 - [Roadmap](https://immich.app/roadmap)
 - [Demo](#demo)
 - [Features](#features)
-- [Translations](https://immich.app/docs/developer/translations)
-- [Contributing](https://immich.app/docs/overview/support-the-project)
+- [Translations](https://docs.immich.app/developer/translations)
+- [Contributing](https://docs.immich.app/overview/support-the-project)
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Access the demo [here](https://demo.immich.app). For the mobile app, you can use
 
 ## Translations
 
-Read more about translations [here](https://immich.app/docs/developer/translations).
+Read more about translations [here](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 A command-line interface for interfacing with the self-hosted photo manager [Immich](https://immich.app/).
 
-Please see the [Immich CLI documentation](https://immich.app/docs/features/command-line-interface).
+Please see the [Immich CLI documentation](https://docs.immich.app/features/command-line-interface).
 
 # For developers
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,5 @@
 #
-# WARNING: To install Immich, follow our guide: https://immich.app/docs/install/docker-compose
+# WARNING: To install Immich, follow our guide: https://docs.immich.app/install/docker-compose
 #
 # Make sure to use the docker-compose.yml of the current release:
 #
@@ -8,8 +8,8 @@
 # The compose file on main may not be compatible with the latest release.
 
 # For development see:
-# - https://immich.app/docs/developer/setup
-# - https://immich.app/docs/developer/troubleshooting
+# - https://docs.immich.app/developer/setup
+# - https://docs.immich.app/developer/troubleshooting
 
 name: immich-dev
 
@@ -55,8 +55,8 @@ services:
       IMMICH_BUILD_IMAGE_URL: https://github.com/immich-app/immich/pkgs/container/immich-server
       IMMICH_THIRD_PARTY_SOURCE_URL: https://github.com/immich-app/immich/
       IMMICH_THIRD_PARTY_BUG_FEATURE_URL: https://github.com/immich-app/immich/issues
-      IMMICH_THIRD_PARTY_DOCUMENTATION_URL: https://immich.app/docs
-      IMMICH_THIRD_PARTY_SUPPORT_URL: https://immich.app/docs/community-guides
+      IMMICH_THIRD_PARTY_DOCUMENTATION_URL: https://docs.immich.app
+      IMMICH_THIRD_PARTY_SUPPORT_URL: https://docs.immich.app/community-guides
     ulimits:
       nofile:
         soft: 1048576

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,5 +1,5 @@
 #
-# WARNING: To install Immich, follow our guide: https://immich.app/docs/install/docker-compose
+# WARNING: To install Immich, follow our guide: https://docs.immich.app/install/docker-compose
 #
 # Make sure to use the docker-compose.yml of the current release:
 #

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# WARNING: To install Immich, follow our guide: https://immich.app/docs/install/docker-compose
+# WARNING: To install Immich, follow our guide: https://docs.immich.app/install/docker-compose
 #
 # Make sure to use the docker-compose.yml of the current release:
 #
@@ -36,7 +36,7 @@ services:
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
     image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
-    # extends: # uncomment this section for hardware acceleration - see https://immich.app/docs/features/ml-hardware-acceleration
+    # extends: # uncomment this section for hardware acceleration - see https://docs.immich.app/features/ml-hardware-acceleration
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable
     volumes:

--- a/docker/example.env
+++ b/docker/example.env
@@ -1,4 +1,4 @@
-# You can find documentation for all the supported env variables at https://immich.app/docs/install/environment-variables
+# You can find documentation for all the supported env variables at https://docs.immich.app/install/environment-variables
 
 # The location where your uploaded files are stored
 UPLOAD_LOCATION=./library

--- a/docker/hwaccel.ml.yml
+++ b/docker/hwaccel.ml.yml
@@ -4,7 +4,7 @@
 # you can inline the config for a backend by copying its contents
 # into the immich-machine-learning service in the docker-compose.yml file.
 
-# See https://immich.app/docs/features/ml-hardware-acceleration for info on usage.
+# See https://docs.immich.app/features/ml-hardware-acceleration for info on usage.
 
 services:
   armnn:

--- a/docker/hwaccel.transcoding.yml
+++ b/docker/hwaccel.transcoding.yml
@@ -4,7 +4,7 @@
 # you can inline the config for a backend by copying its contents
 # into the immich-microservices service in the docker-compose.yml file.
 
-# See https://immich.app/docs/features/hardware-transcoding for more info on using hardware transcoding.
+# See https://docs.immich.app/features/hardware-transcoding for more info on using hardware transcoding.
 
 services:
   cpu: {}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -84,4 +84,4 @@ Below is how your code needs to be structured:
 
 ## Contributing
 
-Please refer to the [architecture](https://immich.app/docs/developer/architecture/) for contributing to the mobile app!
+Please refer to the [architecture](https://docs.immich.app/developer/architecture/) for contributing to the mobile app!

--- a/readme_i18n/README_ar_JO.md
+++ b/readme_i18n/README_ar_JO.md
@@ -46,13 +46,13 @@
 
 ## محتوى
 
-- [الوثائق الرسمية](https://immich.app/docs)
+- [الوثائق الرسمية](https://docs.immich.app)
 - [خريطة الطريق](https://github.com/orgs/immich-app/projects/1)
 - [تجريبي](#demo)
 - [سمات](#features)
-- [مقدمة](https://immich.app/docs/overview/introduction)
-- [تعليمات التحميل](https://immich.app/docs/install/requirements)
-- [قواعد المساهمة](https://immich.app/docs/overview/support-the-project)
+- [مقدمة](https://docs.immich.app/overview/introduction)
+- [تعليمات التحميل](https://docs.immich.app/install/requirements)
+- [قواعد المساهمة](https://docs.immich.app/overview/support-the-project)
 
 ## توثيق
 

--- a/readme_i18n/README_ca_ES.md
+++ b/readme_i18n/README_ca_ES.md
@@ -48,9 +48,9 @@
 - [Mapa de ruta](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Funcionalitats](#funcionalitats)
-- [Introducció](https://immich.app/docs/overview/introduction)
-- [Instal·lació](https://immich.app/docs/install/requirements)
-- [Directrius de contribució](https://immich.app/docs/overview/support-the-project)
+- [Introducció](https://docs.immich.app/overview/introduction)
+- [Instal·lació](https://docs.immich.app/install/requirements)
+- [Directrius de contribució](https://docs.immich.app/overview/support-the-project)
 
 ## Documentació
 

--- a/readme_i18n/README_ca_ES.md
+++ b/readme_i18n/README_ca_ES.md
@@ -44,7 +44,7 @@
 
 ## Contingut
 
-- [Documentació oficial](https://immich.app/docs)
+- [Documentació oficial](https://docs.immich.app)
 - [Mapa de ruta](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Funcionalitats](#funcionalitats)

--- a/readme_i18n/README_de_DE.md
+++ b/readme_i18n/README_de_DE.md
@@ -50,14 +50,14 @@
 
 ## Inhalt
 
-- [Offizielle Dokumentation](https://immich.app/docs)
-- [Über Immich](https://immich.app/docs/overview/introduction)
-- [Installation](https://immich.app/docs/install/requirements)
+- [Offizielle Dokumentation](https://docs.immich.app)
+- [Über Immich](https://docs.immich.app/overview/introduction)
+- [Installation](https://docs.immich.app/install/requirements)
 - [Roadmap](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Funktionen](#funktionen)
-- [Übersetzungen](https://immich.app/docs/developer/translations)
-- [Beitragsrichtlinien](https://immich.app/docs/overview/support-the-project)
+- [Übersetzungen](https://docs.immich.app/developer/translations)
+- [Beitragsrichtlinien](https://docs.immich.app/overview/support-the-project)
 
 ## Demo
 
@@ -107,7 +107,7 @@ Die Web-Demo kannst Du unter https://demo.immich.app finden. Für die Handy-App 
 
 ## Übersetzungen
 
-Mehr zum Thema Übersetzungen kannst du [hier](https://immich.app/docs/developer/translations) erfahren.
+Mehr zum Thema Übersetzungen kannst du [hier](https://docs.immich.app/developer/translations) erfahren.
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />

--- a/readme_i18n/README_es_ES.md
+++ b/readme_i18n/README_es_ES.md
@@ -45,13 +45,13 @@
 
 ## Contenido
 
-- [Documentación oficial](https://immich.app/docs)
+- [Documentación oficial](https://docs.immich.app)
 - [Hoja de ruta](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Funciones](#funciones)
-- [Introducción](https://immich.app/docs/overview/introduction)
-- [Instalación](https://immich.app/docs/install/requirements)
-- [Directrices para contribuir](https://immich.app/docs/overview/support-the-project)
+- [Introducción](https://docs.immich.app/overview/introduction)
+- [Instalación](https://docs.immich.app/install/requirements)
+- [Directrices para contribuir](https://docs.immich.app/overview/support-the-project)
 
 ## Documentación
 
@@ -99,7 +99,7 @@ contraseña: demo
 
 ## Traducciones
 
-Lea mas acerca de las traducciones [acá](https://immich.app/docs/developer/translations).
+Lea mas acerca de las traducciones [acá](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />

--- a/readme_i18n/README_fr_FR.md
+++ b/readme_i18n/README_fr_FR.md
@@ -45,13 +45,13 @@
 
 ## Sommaire
 
-- [Documentation officielle](https://immich.app/docs)
+- [Documentation officielle](https://docs.immich.app)
 - [Feuille de route](https://github.com/orgs/immich-app/projects/1)
 - [Démo](#démo)
 - [Fonctionnalités](#fonctionnalités)
-- [Introduction](https://immich.app/docs/overview/introduction)
-- [Installation](https://immich.app/docs/install/requirements)
-- [Contribution](https://immich.app/docs/overview/support-the-project)
+- [Introduction](https://docs.immich.app/overview/introduction)
+- [Installation](https://docs.immich.app/install/requirements)
+- [Contribution](https://docs.immich.app/overview/support-the-project)
 
 ## Documentation
 

--- a/readme_i18n/README_it_IT.md
+++ b/readme_i18n/README_it_IT.md
@@ -49,14 +49,14 @@
 
 ## Link utili
 
-- [Documentazione](https://immich.app/docs)  
-- [Informazioni](https://immich.app/docs/overview/introduction)  
-- [Installazione](https://immich.app/docs/install/requirements)  
+- [Documentazione](https://docs.immich.app)  
+- [Informazioni](https://docs.immich.app/overview/introduction)  
+- [Installazione](https://docs.immich.app/install/requirements)  
 - [Roadmap](https://immich.app/roadmap)  
 - [Demo](#demo)  
 - [Funzionalità](#funzionalità)  
-- [Traduzioni](https://immich.app/docs/developer/translations)  
-- [Contribuire](https://immich.app/docs/overview/support-the-project)  
+- [Traduzioni](https://docs.immich.app/developer/translations)  
+- [Contribuire](https://docs.immich.app/overview/support-the-project)  
 
 ## Demo
 
@@ -106,7 +106,7 @@ Per l’app mobile puoi usare `https://demo.immich.app` come `Server Endpoint UR
 
 ## Traduzioni
 
-Scopri di più sulle traduzioni [qui](https://immich.app/docs/developer/translations).  
+Scopri di più sulle traduzioni [qui](https://docs.immich.app/developer/translations).  
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Stato traduzioni" />

--- a/readme_i18n/README_ja_JP.md
+++ b/readme_i18n/README_ja_JP.md
@@ -44,13 +44,13 @@
 
 ## コンテンツ
 
-- [公式ドキュメント](https://immich.app/docs)
+- [公式ドキュメント](https://docs.immich.app)
 - [ロードマップ](https://github.com/orgs/immich-app/projects/1)
 - [デモ](#デモ)
 - [機能](#機能)
-- [紹介](https://immich.app/docs/overview/introduction)
-- [インストール](https://immich.app/docs/install/requirements)
-- [コントリビューションガイド](https://immich.app/docs/overview/support-the-project)
+- [紹介](https://docs.immich.app/overview/introduction)
+- [インストール](https://docs.immich.app/install/requirements)
+- [コントリビューションガイド](https://docs.immich.app/overview/support-the-project)
 
 ## ドキュメント
 

--- a/readme_i18n/README_ko_KR.md
+++ b/readme_i18n/README_ko_KR.md
@@ -50,14 +50,14 @@
 
 ## 링크
 
-- [문서](https://immich.app/docs)
-- [소개](https://immich.app/docs/overview/introduction)
-- [설치](https://immich.app/docs/install/requirements)
+- [문서](https://docs.immich.app)
+- [소개](https://docs.immich.app/overview/introduction)
+- [설치](https://docs.immich.app/install/requirements)
 - [로드맵](https://immich.app/roadmap)
 - [데모](#데모)
 - [기능](#기능)
-- [번역](https://immich.app/docs/developer/tranlations)
-- [기여](https://immich.app/docs/overview/support-the-project)
+- [번역](https://docs.immich.app/developer/tranlations)
+- [기여](https://docs.immich.app/overview/support-the-project)
 
 ## 데모
 
@@ -104,7 +104,7 @@
 
 ## 번역
 
-번역에 대한 자세한 정보는 [이곳](https://immich.app/docs/developer/translations)에서 확인하세요.
+번역에 대한 자세한 정보는 [이곳](https://docs.immich.app/developer/translations)에서 확인하세요.
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="번역 현황" />

--- a/readme_i18n/README_nl_NL.md
+++ b/readme_i18n/README_nl_NL.md
@@ -45,13 +45,13 @@
 
 ## Inhoud
 
-- [Officiële documentatie](https://immich.app/docs)
+- [Officiële documentatie](https://docs.immich.app)
 - [Toekomstplannen](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Functies](#functies)
-- [Introductie](https://immich.app/docs/overview/introduction)
-- [Installatie](https://immich.app/docs/install/requirements)
-- [Richtlijnen voor bijdragen](https://immich.app/docs/overview/support-the-project)
+- [Introductie](https://docs.immich.app/overview/introduction)
+- [Installatie](https://docs.immich.app/install/requirements)
+- [Richtlijnen voor bijdragen](https://docs.immich.app/overview/support-the-project)
 
 ## Documentatie
 
@@ -102,7 +102,7 @@ Je kunt de demo [hier](https://demo.immich.app/) bekijken. Voor de mobiele app k
 
 ## Vertalingen
 
-Je kunt [hier](https://immich.app/docs/developer/translations) meer over vertalingen lezen.
+Je kunt [hier](https://docs.immich.app/developer/translations) meer over vertalingen lezen.
 
 ## Repository activiteit
 

--- a/readme_i18n/README_pt_BR.md
+++ b/readme_i18n/README_pt_BR.md
@@ -55,14 +55,14 @@
 
 ## Links
 
-- [Documentação](https://immich.app/docs)
-- [Sobre](https://immich.app/docs/overview/introduction)
-- [Instalação](https://immich.app/docs/install/requirements)
+- [Documentação](https://docs.immich.app)
+- [Sobre](https://docs.immich.app/overview/introduction)
+- [Instalação](https://docs.immich.app/install/requirements)
 - [Roadmap](https://github.com/orgs/immich-app/projects/1)
 - [Demonstração](#demonstração)
 - [Funcionalidades](#funcionalidades)
-- [Traduções](https://immich.app/docs/developer/translations)
-- [Diretrizes de Contribuição](https://immich.app/docs/overview/support-the-project)
+- [Traduções](https://docs.immich.app/developer/translations)
+- [Diretrizes de Contribuição](https://docs.immich.app/overview/support-the-project)
 
 ## Demonstração
 
@@ -115,7 +115,7 @@ Acesse a demonstração [aqui](https://demo.immich.app). No aplicativo para disp
 ## Traduções
 
 Leia mais sobre as traduções
-[aqui](https://immich.app/docs/developer/translations).
+[aqui](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Status da tradução" />

--- a/readme_i18n/README_ru_RU.md
+++ b/readme_i18n/README_ru_RU.md
@@ -51,14 +51,14 @@
 
 ## Содержание
 
-- [Официальная документация](https://immich.app/docs)
-- [Введение](https://immich.app/docs/overview/introduction)
-- [Установка](https://immich.app/docs/install/requirements)
+- [Официальная документация](https://docs.immich.app)
+- [Введение](https://docs.immich.app/overview/introduction)
+- [Установка](https://docs.immich.app/install/requirements)
 - [План разработки](https://github.com/orgs/immich-app/projects/1)
 - [Демо](#demo)
 - [Возможности](#features)
-- [Перевод](https://immich.app/docs/developer/translations)
-- [Гид по участию и поддержке проекта](https://immich.app/docs/overview/support-the-project)
+- [Перевод](https://docs.immich.app/developer/translations)
+- [Гид по участию и поддержке проекта](https://docs.immich.app/overview/support-the-project)
 
 ## Демо
 
@@ -107,7 +107,7 @@
 
 ## Перевод
 
-Всё про перевод проекта [Здесь](https://immich.app/docs/developer/translations).
+Всё про перевод проекта [Здесь](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Translation status" />

--- a/readme_i18n/README_sv_SE.md
+++ b/readme_i18n/README_sv_SE.md
@@ -46,13 +46,13 @@
 
 ## Innehåll
 
-- [Officiell Dokumentation](https://immich.app/docs)
+- [Officiell Dokumentation](https://docs.immich.app)
 - [Roadmap](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Funktioner](#features)
-- [Introduktion](https://immich.app/docs/overview/introduction)
-- [Installation](https://immich.app/docs/install/requirements)
-- [Riktlinjer för Bidrag](https://immich.app/docs/overview/support-the-project)
+- [Introduktion](https://docs.immich.app/overview/introduction)
+- [Installation](https://docs.immich.app/install/requirements)
+- [Riktlinjer för Bidrag](https://docs.immich.app/overview/support-the-project)
 
 ## Dokumentation
 

--- a/readme_i18n/README_th_TH.md
+++ b/readme_i18n/README_th_TH.md
@@ -52,14 +52,14 @@
 
 ## ลิงก์
 
-- [คู่มือ](https://immich.app/docs)
-- [เกี่ยวกับ](https://immich.app/docs/overview/introduction)
-- [การติดตั้ง](https://immich.app/docs/install/requirements)
+- [คู่มือ](https://docs.immich.app)
+- [เกี่ยวกับ](https://docs.immich.app/overview/introduction)
+- [การติดตั้ง](https://docs.immich.app/install/requirements)
 - [โรดแมป](https://immich.app/roadmap)
 - [สาธิต](#สาธิต)
 - [คุณสมบัติ](#คุณสมบัติ)
-- [การแปลภาษา](https://immich.app/docs/developer/translations)
-- [สนับสนุนโพรเจกต์](https://immich.app/docs/overview/support-the-project)
+- [การแปลภาษา](https://docs.immich.app/developer/translations)
+- [สนับสนุนโพรเจกต์](https://docs.immich.app/overview/support-the-project)
 
 ## สาธิต
 
@@ -106,7 +106,7 @@
 
 ## การแปลภาษา
 
-อ่านเพิ่มเติมเกี่ยวกับการแปล [ที่นี่](https://immich.app/docs/developer/translations)
+อ่านเพิ่มเติมเกี่ยวกับการแปล [ที่นี่](https://docs.immich.app/developer/translations)
 
 <a href="https://hosted.weblate.org/engage/immich/">
   <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="สถานะการแปล" />

--- a/readme_i18n/README_tr_TR.md
+++ b/readme_i18n/README_tr_TR.md
@@ -44,13 +44,13 @@
 
 ## Content
 
-- [Resmi Belgeler](https://immich.app/docs)
+- [Resmi Belgeler](https://docs.immich.app)
 - [Yol Haritası](https://github.com/orgs/immich-app/projects/1)
 - [Demo](#demo)
 - [Özellikler](#özellikler)
-- [Giriş](https://immich.app/docs/overview/introduction)
-- [Kurulum](https://immich.app/docs/install/requirements)
-- [Katkı Sağlama Rehberi](https://immich.app/docs/overview/support-the-project)
+- [Giriş](https://docs.immich.app/overview/introduction)
+- [Kurulum](https://docs.immich.app/install/requirements)
+- [Katkı Sağlama Rehberi](https://docs.immich.app/overview/support-the-project)
 
 ## Belgeler
 

--- a/readme_i18n/README_uk_UA.md
+++ b/readme_i18n/README_uk_UA.md
@@ -50,14 +50,14 @@
 
 ## Посилання
 
-- [Документація](https://immich.app/docs)
-- [Про проєкт](https://immich.app/docs/overview/introduction)
-- [Встановлення](https://immich.app/docs/install/requirements)
+- [Документація](https://docs.immich.app)
+- [Про проєкт](https://docs.immich.app/overview/introduction)
+- [Встановлення](https://docs.immich.app/install/requirements)
 - [Дорожня карта](https://immich.app/roadmap)
 - [Демо](#демо)
 - [Функції](#функції)
-- [Переклади](https://immich.app/docs/developer/translations)
-- [Гід для розробки проєкту](https://immich.app/docs/overview/support-the-project)
+- [Переклади](https://docs.immich.app/developer/translations)
+- [Гід для розробки проєкту](https://docs.immich.app/overview/support-the-project)
 
 ## Демо
 
@@ -106,7 +106,7 @@
 
 ## Переклади
 
-Більше про переклади [тут](https://immich.app/docs/developer/translations).
+Більше про переклади [тут](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Статус перекладів" />

--- a/readme_i18n/README_vi_VN.md
+++ b/readme_i18n/README_vi_VN.md
@@ -52,14 +52,14 @@
 
 ## Liên kết
 
-- [Tài liệu](https://immich.app/docs)
-- [Giới thiệu](https://immich.app/docs/overview/introduction)
-- [Cài đặt](https://immich.app/docs/install/requirements)
+- [Tài liệu](https://docs.immich.app)
+- [Giới thiệu](https://docs.immich.app/overview/introduction)
+- [Cài đặt](https://docs.immich.app/install/requirements)
 - [Lộ trình](https://immich.app/roadmap)
 - [Demo](#demo)
 - [Tính năng](#Tính-năng)
-- [Dịch thuật](https://immich.app/docs/developer/translations)
-- [Đóng góp](https://immich.app/docs/overview/support-the-project)
+- [Dịch thuật](https://docs.immich.app/developer/translations)
+- [Đóng góp](https://docs.immich.app/overview/support-the-project)
 
 ## Demo
 
@@ -106,7 +106,7 @@ Truy cập bản demo [tại đây](https://demo.immich.app). Đối với ứng
 
 ## Dịch thuật
 
-Đọc thêm về dịch thuật [tại đây](https://immich.app/docs/developer/translations).
+Đọc thêm về dịch thuật [tại đây](https://docs.immich.app/developer/translations).
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="Tình trạng dịch thuật" />

--- a/readme_i18n/README_zh_CN.md
+++ b/readme_i18n/README_zh_CN.md
@@ -54,14 +54,14 @@
 
 ## 目录
 
-- [官方文档](https://immich.app/docs)
-- [项目总览](https://immich.app/docs/overview/introduction)
-- [安装教程](https://immich.app/docs/install/requirements)
+- [官方文档](https://docs.immich.app)
+- [项目总览](https://docs.immich.app/overview/introduction)
+- [安装教程](https://docs.immich.app/install/requirements)
 - [路线图](https://immich.app/roadmap)
 - [在线演示](#示例)
 - [功能特性](#功能特性)
-- [多语言](https://immich.app/docs/developer/translations)
-- [贡献者](https://immich.app/docs/overview/support-the-project)
+- [多语言](https://docs.immich.app/developer/translations)
+- [贡献者](https://docs.immich.app/overview/support-the-project)
 
 ## 示例
 
@@ -110,7 +110,7 @@
 
 ## 多语言
 
-关于翻译的更多信息请参见[此处](https://immich.app/docs/developer/translations)。
+关于翻译的更多信息请参见[此处](https://docs.immich.app/developer/translations)。
 
 <a href="https://hosted.weblate.org/engage/immich/">
 <img src="https://hosted.weblate.org/widget/immich/immich/multi-auto.svg" alt="翻译进度" />

--- a/server/src/services/database.service.ts
+++ b/server/src/services/database.service.ts
@@ -22,7 +22,7 @@ const messages = {
     The ${name} extension version is ${version}, which means it is a nightly release.
 
     Please run 'DROP EXTENSION IF EXISTS ${extension}' and switch to a release version.
-    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+    See https://docs.immich.app/guides/database-queries for how to query the database.`,
   outOfRange: ({ name, version, range }: OutOfRangeArgs) =>
     `The ${name} extension version is ${version}, but Immich only supports ${range}.
     Please change ${name} to a compatible version in the Postgres instance.`,
@@ -32,20 +32,20 @@ const messages = {
 
     If the Postgres instance already has ${name} installed, Immich may not have the necessary permissions to activate it.
     In this case, please run 'CREATE EXTENSION IF NOT EXISTS ${extension} CASCADE' manually as a superuser.
-    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+    See https://docs.immich.app/guides/database-queries for how to query the database.`,
   updateFailed: ({ name, extension, availableVersion }: UpdateFailedArgs) =>
     `The ${name} extension can be updated to ${availableVersion}.
     Immich attempted to update the extension, but failed to do so.
     This may be because Immich does not have the necessary permissions to update the extension.
 
     Please run 'ALTER EXTENSION ${extension} UPDATE' manually as a superuser.
-    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+    See https://docs.immich.app/guides/database-queries for how to query the database.`,
   dropFailed: ({ name, extension }: DropFailedArgs) =>
     `The ${name} extension is no longer needed, but could not be dropped.
     This may be because Immich does not have the necessary permissions to drop the extension.
 
     Please run 'DROP EXTENSION ${extension};' manually as a superuser.
-    See https://immich.app/docs/guides/database-queries for how to query the database.`,
+    See https://docs.immich.app/guides/database-queries for how to query the database.`,
   restartRequired: ({ name, availableVersion }: RestartRequiredArgs) =>
     `The ${name} extension has been updated to ${availableVersion}.
     Please restart the Postgres instance to complete the update.`,
@@ -55,7 +55,7 @@ const messages = {
     If ${name} ${installedVersion} is compatible with Immich, please ensure the Postgres instance has this available.`,
   deprecatedExtension: (name: string) =>
     `DEPRECATION WARNING: The ${name} extension is deprecated and support for it will be removed very soon.
-     See https://immich.app/docs/install/upgrading#migrating-to-vectorchord in order to switch to the VectorChord extension instead.`,
+     See https://docs.immich.app/install/upgrading#migrating-to-vectorchord in order to switch to the VectorChord extension instead.`,
 };
 
 @Injectable()

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -15,7 +15,7 @@ import { BaseService } from 'src/services/base.service';
 import { JobOf, SystemFlags } from 'src/types';
 import { ImmichStartupError } from 'src/utils/misc';
 
-const docsMessage = `Please see https://immich.app/docs/administration/system-integrity#folder-checks for more information.`;
+const docsMessage = `Please see https://docs.immich.app/administration/system-integrity#folder-checks for more information.`;
 
 @Injectable()
 export class StorageService extends BaseService {

--- a/web/src/lib/components/admin-settings/AuthSettings.svelte
+++ b/web/src/lib/components/admin-settings/AuthSettings.svelte
@@ -86,7 +86,7 @@
               <FormatMessage key="admin.oauth_settings_more_details">
                 {#snippet children({ message })}
                   <a
-                    href="https://immich.app/docs/administration/oauth"
+                    href="https://docs.immich.app/administration/oauth"
                     class="underline"
                     target="_blank"
                     rel="noreferrer"

--- a/web/src/lib/components/admin-settings/MapSettings.svelte
+++ b/web/src/lib/components/admin-settings/MapSettings.svelte
@@ -67,7 +67,7 @@
               <FormatMessage key="admin.map_manage_reverse_geocoding_settings">
                 {#snippet children({ message })}
                   <a
-                    href="https://immich.app/docs/features/reverse-geocoding"
+                    href="https://docs.immich.app/features/reverse-geocoding"
                     class="underline"
                     target="_blank"
                     rel="noreferrer"

--- a/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
+++ b/web/src/lib/components/admin-settings/StorageTemplateSettings.svelte
@@ -119,7 +119,7 @@
         {#snippet children({ tag, message })}
           {#if tag === 'template-link'}
             <a
-              href="https://immich.app/docs/administration/storage-template"
+              href="https://docs.immich.app/administration/storage-template"
               class="underline"
               target="_blank"
               rel="noreferrer"
@@ -128,7 +128,7 @@
             </a>
           {:else if tag === 'implications-link'}
             <a
-              href="https://immich.app/docs/administration/backup-and-restore#asset-types-and-storage-locations"
+              href="https://docs.immich.app/administration/backup-and-restore#asset-types-and-storage-locations"
               class="underline"
               target="_blank"
               rel="noreferrer"

--- a/web/src/lib/components/layouts/ErrorLayout.svelte
+++ b/web/src/lib/components/layouts/ErrorLayout.svelte
@@ -91,7 +91,7 @@
             </a>
 
             <a
-              href="https://immich.app/docs/guides/docker-help"
+              href="https://docs.immich.app/guides/docker-help"
               target="_blank"
               rel="noopener noreferrer"
               class="flex grow basis-0 justify-center p-4"

--- a/web/src/lib/components/onboarding-page/onboarding-backup.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-backup.svelte
@@ -53,7 +53,7 @@
         <FormatMessage key="admin.backup_onboarding_footer">
           {#snippet children({ message })}
             <a
-              href="https://immich.app/docs/administration/backup-and-restore/"
+              href="https://docs.immich.app/administration/backup-and-restore/"
               class="underline"
               target="_blank"
               rel="noreferrer"

--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -21,7 +21,7 @@
   <p>
     <FormatMessage key="admin.storage_template_onboarding_description_v2">
       {#snippet children({ message })}
-        <a class="underline" href="https://immich.app/docs/administration/storage-template">{message}</a>
+        <a class="underline" href="https://docs.immich.app/administration/storage-template">{message}</a>
       {/snippet}
     </FormatMessage>
   </p>

--- a/web/src/lib/modals/AuthDisableLoginConfirmModal.svelte
+++ b/web/src/lib/modals/AuthDisableLoginConfirmModal.svelte
@@ -19,7 +19,7 @@
         <FormatMessage key="admin.authentication_settings_reenable">
           {#snippet children({ message })}
             <a
-              href="https://immich.app/docs/administration/server-commands"
+              href="https://docs.immich.app/administration/server-commands"
               rel="noreferrer"
               target="_blank"
               class="underline"

--- a/web/src/lib/modals/HelpAndFeedbackModal.svelte
+++ b/web/src/lib/modals/HelpAndFeedbackModal.svelte
@@ -18,7 +18,7 @@
     <p>{$t('official_immich_resources')}</p>
     <div class="flex flex-col sm:grid sm:grid-cols-2 gap-2 mt-5">
       <div>
-        <a href="https://{info.version}.archive.immich.app/docs/overview/introduction" target="_blank" rel="noreferrer">
+        <a href="https://{info.version}.archive.docs.immich.app/overview/introduction" target="_blank" rel="noreferrer">
           <Icon icon={mdiInformationOutline} size="1.5em" class="inline-block" />
           <p class="font-medium text-primary text-sm underline inline-block" id="documentation-label">
             {$t('documentation')}


### PR DESCRIPTION
## Description

This PR updates documentation links across **ALL** the repo files by replacing  
`https://immich.app/docs` with the canonical domain `https://docs.immich.app`.  

Unlike previous changes in #22417 , which kept the old domain and relied on redirection,  
this update points directly to the correct destination (docs.immich.app).  

This ensures consistency, avoids unnecessary redirects, and helps prevent future issues with link resolution.

Fixes #22561 and #22569.

## How Has This Been Tested?

- [X] Verified that all updated links resolve to the correct domain

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
 not at all :)
