### PR TITLE
refactor: remove scroll compensation logic from photostream components

### DIFF
--- a/web/src/lib/components/search/SearchResults.svelte
+++ b/web/src/lib/components/search/SearchResults.svelte
@@ -58,10 +58,8 @@
       <Skeleton height={segment.height - segment.timelineManager.headerHeight} {stylePaddingHorizontalPx} />
     {/snippet}
 
-    {#snippet segment({ segment, onScrollCompensationMonthInDOM })}
+    {#snippet segment({ segment })}
       <SelectableSegment
-        {segment}
-        {onScrollCompensationMonthInDOM}
         timelineManager={searchResultsManager}
         {assetInteraction}
         isSelectionMode={false}

--- a/web/src/lib/components/timeline/Photostream.svelte
+++ b/web/src/lib/components/timeline/Photostream.svelte
@@ -15,7 +15,6 @@
         {
           segment: PhotostreamSegment;
           scrollToFunction: (top: number) => void;
-          onScrollCompensationMonthInDOM: (compensation: { heightDelta?: number; scrollTop?: number }) => void;
         },
       ]
     >;
@@ -107,44 +106,13 @@
     updateSlidingWindow();
   };
 
-  const scrollBy = (y: number) => {
-    if (element) {
-      element.scrollBy(0, y);
-    }
-    updateSlidingWindow();
-  };
-
-  const handleTriggeredScrollCompensation = (compensation: { heightDelta?: number; scrollTop?: number }) => {
-    const { heightDelta, scrollTop } = compensation;
-    if (heightDelta !== undefined) {
-      scrollBy(heightDelta);
-    } else if (scrollTop !== undefined) {
-      scrollTo(scrollTop);
-    }
-    timelineManager.clearScrollCompensation();
-  };
-
-  const getAssetHeight = (assetId: string, monthGroup: PhotostreamSegment) => {
-    // the following method may trigger any layouts, so need to
-    // handle any scroll compensation that may have been set
-    const height = monthGroup.findAssetAbsolutePosition(assetId);
-
-    // this is in a while loop, since scrollCompensations invoke scrolls
-    // which may load months, triggering more scrollCompensations. Call
-    // this in a loop, until no more layouts occur.
-    while (timelineManager.scrollCompensation.monthGroup) {
-      handleTriggeredScrollCompensation(timelineManager.scrollCompensation);
-    }
-    return height;
-  };
-
   export const scrollToAssetId = async (assetId: string) => {
     const monthGroup = await timelineManager.findSegmentForAssetId(assetId);
     if (!monthGroup) {
       return false;
     }
 
-    const height = getAssetHeight(assetId, monthGroup);
+    const height = monthGroup.findAssetAbsolutePosition(assetId);
     scrollTo(height);
     return true;
   };
@@ -274,7 +242,6 @@
           {@render segment({
             segment: monthGroup,
             scrollToFunction: scrollTo,
-            onScrollCompensationMonthInDOM: handleTriggeredScrollCompensation,
           })}
         {/if}
       </div>

--- a/web/src/lib/components/timeline/PhotostreamWithScrubber.svelte
+++ b/web/src/lib/components/timeline/PhotostreamWithScrubber.svelte
@@ -24,7 +24,6 @@
       [
         {
           segment: PhotostreamSegment;
-          onScrollCompensationMonthInDOM: (compensation: { heightDelta?: number; scrollTop?: number }) => void;
         },
       ]
     >;

--- a/web/src/lib/components/timeline/SelectableSegment.svelte
+++ b/web/src/lib/components/timeline/SelectableSegment.svelte
@@ -5,7 +5,6 @@
   import { navigate } from '$lib/utils/navigation';
 
   import type { PhotostreamManager } from '$lib/managers/photostream-manager/PhotostreamManager.svelte';
-  import type { PhotostreamSegment } from '$lib/managers/photostream-manager/PhotostreamSegment.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
   import { searchStore } from '$lib/stores/search.svelte';
@@ -21,28 +20,17 @@
         },
       ]
     >;
-    segment: PhotostreamSegment;
+
     isSelectionMode: boolean;
     singleSelect: boolean;
     timelineManager: PhotostreamManager;
     assetInteraction: AssetInteraction;
     onAssetOpen?: (asset: TimelineAsset, defaultAssetOpen: () => void) => void;
     onAssetSelect?: (asset: TimelineAsset) => void;
-
-    onScrollCompensationMonthInDOM: (compensation: { heightDelta?: number; scrollTop?: number }) => void;
   }
 
-  let {
-    segment,
-    content,
-    isSelectionMode,
-    singleSelect,
-    assetInteraction,
-    timelineManager,
-    onAssetOpen,
-    onAssetSelect,
-    onScrollCompensationMonthInDOM,
-  }: Props = $props();
+  let { content, isSelectionMode, singleSelect, assetInteraction, timelineManager, onAssetOpen, onAssetSelect }: Props =
+    $props();
 
   let shiftKeyIsDown = $state(false);
   let isEmpty = $derived(timelineManager.isInitialized && timelineManager.months.length === 0);
@@ -189,12 +177,6 @@
     const assets = assetsSnapshot(timelineManager.retrieveLoadedRange(startAsset, endAsset));
     assetInteraction.setAssetSelectionCandidates(assets);
   };
-
-  $effect.root(() => {
-    if (timelineManager.scrollCompensation.monthGroup === segment) {
-      onScrollCompensationMonthInDOM(timelineManager.scrollCompensation);
-    }
-  });
 </script>
 
 <svelte:document onkeydown={onKeyDown} onkeyup={onKeyUp} />

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -99,10 +99,8 @@
         title={(segment as MonthGroup).monthGroupTitle}
       />
     {/snippet}
-    {#snippet segment({ segment, onScrollCompensationMonthInDOM })}
+    {#snippet segment({ segment })}
       <SelectableSegment
-        {segment}
-        {onScrollCompensationMonthInDOM}
         {timelineManager}
         {assetInteraction}
         {isSelectionMode}

--- a/web/src/lib/managers/photostream-manager/PhotostreamManager.svelte.ts
+++ b/web/src/lib/managers/photostream-manager/PhotostreamManager.svelte.ts
@@ -1,7 +1,7 @@
 import { updateIntersectionMonthGroup } from '$lib/managers/timeline-manager/internal/intersection-support.svelte';
 import { updateGeometry } from '$lib/managers/timeline-manager/internal/layout-support.svelte';
 import { CancellableTask } from '$lib/utils/cancellable-task';
-import { clamp, debounce } from 'lodash-es';
+import { debounce } from 'lodash-es';
 
 import {
   PhotostreamSegment,
@@ -21,15 +21,14 @@ import { setDifference } from '$lib/utils/timeline-util';
 
 export abstract class PhotostreamManager {
   isInitialized = $state(false);
+
   topSectionHeight = $state(0);
   bottomSectionHeight = $state(60);
-  abstract get months(): PhotostreamSegment[];
+
+  assetCount = $derived.by(() => this.months.reduce((accumulator, b) => accumulator + b.assetsCount, 0));
   timelineHeight = $derived.by(
     () => this.months.reduce((accumulator, b) => accumulator + b.height, 0) + this.topSectionHeight,
   );
-  assetCount = $derived.by(() => this.months.reduce((accumulator, b) => accumulator + b.assetsCount, 0));
-
-  topIntersectingMonthGroup: PhotostreamSegment | undefined = $state();
 
   visibleWindow = $derived.by(() => ({
     top: this.#scrollTop,
@@ -54,17 +53,9 @@ export abstract class PhotostreamManager {
   #suspendTransitions = $state(false);
   #resetScrolling = debounce(() => (this.#scrolling = false), 1000);
   #resetSuspendTransitions = debounce(() => (this.suspendTransitions = false), 1000);
-  scrollCompensation: {
-    heightDelta: number | undefined;
-    scrollTop: number | undefined;
-    monthGroup: PhotostreamSegment | undefined;
-  } = $state({
-    heightDelta: 0,
-    scrollTop: 0,
-    monthGroup: undefined,
-  });
+  #updatingIntersections = false;
 
-  constructor() {}
+  abstract get months(): PhotostreamSegment[];
 
   setLayoutOptions({ headerHeight = 48, rowHeight = 235, gap = 12 }: TimelineManagerLayoutOptions) {
     let changed = false;
@@ -163,39 +154,17 @@ export abstract class PhotostreamManager {
     }
   }
 
-  clearScrollCompensation() {
-    this.scrollCompensation = {
-      heightDelta: undefined,
-      scrollTop: undefined,
-      monthGroup: undefined,
-    };
-  }
-
   updateIntersections() {
-    if (!this.isInitialized || this.visibleWindow.bottom === this.visibleWindow.top) {
+    if (this.#updatingIntersections || !this.isInitialized || this.visibleWindow.bottom === this.visibleWindow.top) {
       return;
     }
-    let topIntersectingMonthGroup = undefined;
+    this.#updatingIntersections = true;
+
     for (const month of this.months) {
       updateIntersectionMonthGroup(this, month);
-      if (!topIntersectingMonthGroup && month.actuallyIntersecting) {
-        topIntersectingMonthGroup = month;
-      }
     }
-    if (topIntersectingMonthGroup !== undefined && this.topIntersectingMonthGroup !== topIntersectingMonthGroup) {
-      this.topIntersectingMonthGroup = topIntersectingMonthGroup;
-    }
-    for (const month of this.months) {
-      if (month === this.topIntersectingMonthGroup) {
-        this.topIntersectingMonthGroup.percent = clamp(
-          (this.visibleWindow.top - this.topIntersectingMonthGroup.top) / this.topIntersectingMonthGroup.height,
-          0,
-          1,
-        );
-      } else {
-        month.percent = 0;
-      }
-    }
+
+    this.#updatingIntersections = false;
   }
 
   async init() {

--- a/web/src/lib/managers/photostream-manager/PhotostreamSegment.svelte.ts
+++ b/web/src/lib/managers/photostream-manager/PhotostreamSegment.svelte.ts
@@ -4,6 +4,7 @@ import { t } from 'svelte-i18n';
 import { get } from 'svelte/store';
 
 import type { PhotostreamManager } from '$lib/managers/photostream-manager/PhotostreamManager.svelte';
+import { getTestHook } from '$lib/managers/photostream-manager/TestHooks.svelte';
 import type { AssetOperation, MoveAsset, TimelineAsset } from '$lib/managers/timeline-manager/types';
 import type { ViewerAsset } from '$lib/managers/timeline-manager/viewer-asset.svelte';
 
@@ -20,7 +21,6 @@ export abstract class PhotostreamSegment {
   #assets = $derived.by(() => this.viewerAssets.map((viewerAsset) => viewerAsset.asset));
 
   initialCount = $state(0);
-  percent = $state(0);
 
   assetsCount = $derived.by(() => (this.isLoaded ? this.viewerAssets.length : this.initialCount));
   loader = new CancellableTask(
@@ -29,6 +29,10 @@ export abstract class PhotostreamSegment {
     () => this.handleLoadError,
   );
   isHeightActual = $state(false);
+
+  constructor() {
+    getTestHook()?.hookSegment(this);
+  }
 
   abstract get timelineManager(): PhotostreamManager;
 
@@ -66,9 +70,13 @@ export abstract class PhotostreamSegment {
   }
 
   async load(cancelable: boolean): Promise<'DONE' | 'WAITED' | 'CANCELED' | 'LOADED' | 'ERRORED'> {
-    return await this.loader.execute(async (signal: AbortSignal) => {
+    const executionStatus = await this.loader.execute(async (signal: AbortSignal) => {
       await this.fetch(signal);
     }, cancelable);
+    if (executionStatus === 'LOADED') {
+      this.layout();
+    }
+    return executionStatus;
   }
 
   protected abstract fetch(signal: AbortSignal): Promise<void>;
@@ -88,42 +96,34 @@ export abstract class PhotostreamSegment {
     if (this.#height === height) {
       return;
     }
-    const { timelineManager: store, percent } = this;
-    const index = store.months.indexOf(this);
+
+    let needsIntersectionUpdate = false;
+    const timelineManager = this.timelineManager;
+    const index = timelineManager.months.indexOf(this);
     const heightDelta = height - this.#height;
     this.#height = height;
-    const prevMonthGroup = store.months[index - 1];
+    const prevMonthGroup = timelineManager.months[index - 1];
     if (prevMonthGroup) {
       const newTop = prevMonthGroup.#top + prevMonthGroup.#height;
       if (this.#top !== newTop) {
         this.#top = newTop;
       }
     }
-    for (let cursor = index + 1; cursor < store.months.length; cursor++) {
-      const monthGroup = this.timelineManager.months[cursor];
+    if (heightDelta === 0) {
+      return;
+    }
+
+    for (let cursor = index + 1; cursor < timelineManager.months.length; cursor++) {
+      const monthGroup = timelineManager.months[cursor];
       const newTop = monthGroup.#top + heightDelta;
       if (monthGroup.#top !== newTop) {
         monthGroup.#top = newTop;
+        needsIntersectionUpdate = true;
       }
     }
-    if (store.topIntersectingMonthGroup) {
-      const currentIndex = store.months.indexOf(store.topIntersectingMonthGroup);
-      if (currentIndex > 0) {
-        if (index < currentIndex) {
-          store.scrollCompensation = {
-            heightDelta,
-            scrollTop: undefined,
-            monthGroup: this,
-          };
-        } else if (percent > 0) {
-          const top = this.top + height * percent;
-          store.scrollCompensation = {
-            heightDelta: undefined,
-            scrollTop: top,
-            monthGroup: this,
-          };
-        }
-      }
+
+    if (needsIntersectionUpdate) {
+      timelineManager.updateIntersections();
     }
   }
 

--- a/web/src/lib/managers/photostream-manager/TestHooks.svelte.ts
+++ b/web/src/lib/managers/photostream-manager/TestHooks.svelte.ts
@@ -1,0 +1,11 @@
+import type { PhotostreamSegment } from '$lib/managers/photostream-manager/PhotostreamSegment.svelte';
+
+let testHooks: { hookSegment: (segment: PhotostreamSegment) => void } | undefined = undefined;
+
+export function setTestHook(hooks: { hookSegment: (segment: PhotostreamSegment) => void }) {
+  testHooks = hooks;
+}
+
+export function getTestHook() {
+  return testHooks;
+}

--- a/web/src/lib/managers/timeline-manager/internal/intersection-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/intersection-support.svelte.ts
@@ -51,7 +51,7 @@ export function calculateSegmentIntersecting(
 }
 
 /**
- * Calculate intersection for viewer assets with additional parameters like header height and scroll compensation
+ * Calculate intersection for viewer assets with additional parameters like header height
  */
 export function calculateViewerAssetIntersecting(
   timelineManager: PhotostreamManager,
@@ -60,13 +60,8 @@ export function calculateViewerAssetIntersecting(
   expandTop: number = INTERSECTION_EXPAND_TOP,
   expandBottom: number = INTERSECTION_EXPAND_BOTTOM,
 ) {
-  const scrollCompensationHeightDelta = timelineManager.scrollCompensation?.heightDelta ?? 0;
-
-  const topWindow =
-    timelineManager.visibleWindow.top - timelineManager.headerHeight - expandTop + scrollCompensationHeightDelta;
-  const bottomWindow =
-    timelineManager.visibleWindow.bottom + timelineManager.headerHeight + expandBottom + scrollCompensationHeightDelta;
-
+  const topWindow = timelineManager.visibleWindow.top - timelineManager.headerHeight - expandTop;
+  const bottomWindow = timelineManager.visibleWindow.bottom + timelineManager.headerHeight + expandBottom;
   const positionBottom = positionTop + positionHeight;
 
   return isIntersecting(positionTop, positionBottom, topWindow, bottomWindow);

--- a/web/src/lib/managers/timeline-manager/month-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/month-group.svelte.ts
@@ -73,6 +73,10 @@ export class MonthGroup extends PhotostreamSegment {
     return loadFromTimeBuckets(this.timelineManager, this, this.timelineManager.options, signal);
   }
 
+  layout(noDefer?: boolean) {
+    layoutMonthGroup(this.timelineManager, this, noDefer);
+  }
+
   get lastDayGroup() {
     return this.dayGroups.at(-1);
   }
@@ -304,10 +308,6 @@ export class MonthGroup extends PhotostreamSegment {
 
   cancel() {
     this.loader?.cancel();
-  }
-
-  layout(noDefer?: boolean) {
-    layoutMonthGroup(this.timelineManager, this, noDefer);
   }
 
   #clearDeferredLayout() {


### PR DESCRIPTION
stacked pr

### Summary
- Removed complex scroll compensation mechanism that was causing unnecessary re-renders and performance issues
- Simplified segment rendering by removing `onScrollCompensationMonthInDOM` callback
- Fixed intersection updates to prevent recursive calls during layout changes

### Impact
This refactoring improves performance by eliminating complex scroll compensation logic, and reduces overall complexity of the code. 