### PR TITLE
fix: correct edited shared link expiration time

### DIFF
--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -49,9 +49,9 @@
   ]);
 
 	const expiresAt = DateTime.fromISO(editingLink?.expiresAt);
+	const createdAt = DateTime.fromISO(editingLink?.createdAt);
 
-	const now = DateTime.now();
-	const remainingMs = expiresAt.toMillis() - now.toMillis();
+	const remainingMs = expiresAt.toMillis() - createdAt.toMillis();
 	let selectedOption = expiredDateOptions[0];
 
 	for (const option of expiredDateOptions) {

--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -49,7 +49,6 @@
   ]);
 
 	const expiresAt = DateTime.fromISO(editingLink?.expiresAt);
-	console.log(editingLink?.expiresAt);
 
 	const now = DateTime.now();
 	const remainingMs = expiresAt.toMillis() - now.toMillis();
@@ -60,9 +59,6 @@
 			selectedOption = option;
 		}
 	}
-
-	console.log(expiredDateOptions);
-
 
   let shareType = $derived(albumId ? SharedLinkType.Album : SharedLinkType.Individual);
 

--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -48,6 +48,22 @@
     })),
   ]);
 
+	const expiresAt = DateTime.fromISO(editingLink?.expiresAt);
+	console.log(editingLink?.expiresAt);
+
+	const now = DateTime.now();
+	const remainingMs = expiresAt.toMillis() - now.toMillis();
+	let selectedOption = expiredDateOptions[0];
+
+	for (const option of expiredDateOptions) {
+		if (option.value <= remainingMs) {
+			selectedOption = option;
+		}
+	}
+
+	console.log(expiredDateOptions);
+
+
   let shareType = $derived(albumId ? SharedLinkType.Album : SharedLinkType.Individual);
 
   $effect(() => {
@@ -182,7 +198,7 @@
 
       <div class="mt-2">
         <SettingSelect
-          bind:value={expirationOption}
+					bind:value={selectedOption.value}
           options={expiredDateOptions}
           label={$t('expire_after')}
           disabled={editingLink && !shouldChangeExpirationTime}


### PR DESCRIPTION
## Description

When user wants to create a shared link and sets the link to expire in 1 day (for example), it wouldn't work when user wants to visit the `/shared-links` page.

Fixes # ([issue](https://github.com/immich-app/immich/issues/22147))

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Open a photo
- [ ] Create share link
- [ ] Set `expire after` some time
- [ ] Go to `/shared-links`
- [ ] Open the shared link details
- [ ] You should see `Expire in` now

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
