### PR TITLE
chore: show error message in upload details route

### DIFF
--- a/mobile/lib/extensions/string_extensions.dart
+++ b/mobile/lib/extensions/string_extensions.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 extension StringExtension on String {
   String capitalize() {
     return split(" ").map((str) => str.isEmpty ? str : str[0].toUpperCase() + str.substring(1)).join(" ");
@@ -21,5 +23,13 @@ extension DurationExtension on String {
 
   int toInt() {
     return int.parse(this);
+  }
+}
+
+Map<String, dynamic>? tryJsonDecode(dynamic json) {
+  try {
+    return jsonDecode(json) as Map<String, dynamic>;
+  } catch (e) {
+    return null;
   }
 }

--- a/mobile/lib/pages/backup/drift_upload_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_upload_detail.page.dart
@@ -1,12 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
-import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
-import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/utils/bytes_units.dart';
 import 'package:path/path.dart' as path;
 
@@ -82,6 +82,7 @@ class DriftUploadDetailPage extends ConsumerWidget {
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
+                      spacing: 4,
                       children: [
                         Text(
                           path.basename(item.filename),
@@ -89,7 +90,13 @@ class DriftUploadDetailPage extends ConsumerWidget {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
-                        const SizedBox(height: 4),
+                        if (item.error != null)
+                          Text(
+                            item.error!,
+                            style: context.textTheme.bodySmall?.copyWith(
+                              color: context.colorScheme.onErrorContainer.withValues(alpha: 0.6),
+                            ),
+                          ),
                         Text(
                           'Tap for more details',
                           style: context.textTheme.bodySmall?.copyWith(

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -35,6 +35,7 @@ class DriftUploadStatus {
   final int fileSize;
   final String networkSpeedAsString;
   final bool? isFailed;
+  final String? error;
 
   const DriftUploadStatus({
     required this.taskId,
@@ -43,6 +44,7 @@ class DriftUploadStatus {
     required this.fileSize,
     required this.networkSpeedAsString,
     this.isFailed,
+    this.error,
   });
 
   DriftUploadStatus copyWith({
@@ -52,6 +54,7 @@ class DriftUploadStatus {
     int? fileSize,
     String? networkSpeedAsString,
     bool? isFailed,
+    String? error,
   }) {
     return DriftUploadStatus(
       taskId: taskId ?? this.taskId,
@@ -60,12 +63,13 @@ class DriftUploadStatus {
       fileSize: fileSize ?? this.fileSize,
       networkSpeedAsString: networkSpeedAsString ?? this.networkSpeedAsString,
       isFailed: isFailed ?? this.isFailed,
+      error: error ?? this.error,
     );
   }
 
   @override
   String toString() {
-    return 'DriftUploadStatus(taskId: $taskId, filename: $filename, progress: $progress, fileSize: $fileSize, networkSpeedAsString: $networkSpeedAsString, isFailed: $isFailed)';
+    return 'DriftUploadStatus(taskId: $taskId, filename: $filename, progress: $progress, fileSize: $fileSize, networkSpeedAsString: $networkSpeedAsString, isFailed: $isFailed, error: $error)';
   }
 
   @override
@@ -77,7 +81,8 @@ class DriftUploadStatus {
         other.progress == progress &&
         other.fileSize == fileSize &&
         other.networkSpeedAsString == networkSpeedAsString &&
-        other.isFailed == isFailed;
+        other.isFailed == isFailed &&
+        other.error == error;
   }
 
   @override
@@ -87,7 +92,8 @@ class DriftUploadStatus {
         progress.hashCode ^
         fileSize.hashCode ^
         networkSpeedAsString.hashCode ^
-        isFailed.hashCode;
+        isFailed.hashCode ^
+        error.hashCode;
   }
 }
 
@@ -238,7 +244,12 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
           return;
         }
 
-        state = state.copyWith(uploadItems: {...state.uploadItems, taskId: currentItem.copyWith(isFailed: true)});
+        state = state.copyWith(
+          uploadItems: {
+            ...state.uploadItems,
+            taskId: currentItem.copyWith(isFailed: true, error: update.exception?.toString()),
+          },
+        );
         _logger.fine("Upload failed for taskId: $taskId, exception: ${update.exception}");
         break;
 


### PR DESCRIPTION
## Description

Errors from the uploads are now displayed in the upload details page

<img width="335" height="170" alt="image" src="https://github.com/user-attachments/assets/0aeff9a4-2956-4349-90bc-7834f2ac04a2" />