### PR TITLE
chore: do not remote sync twice in backup page

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -599,7 +599,7 @@
   "backup_controller_page_turn_on": "Turn on foreground backup",
   "backup_controller_page_uploading_file_info": "Uploading file info",
   "backup_err_only_album": "Cannot remove the only album",
-  "backup_error_sync_failed": "Sync failed. Cannot start backup.",
+  "backup_error_sync_failed": "Sync failed. Cannot process backup.",
   "backup_info_card_assets": "assets",
   "backup_manual_cancelled": "Cancelled",
   "backup_manual_in_progress": "Upload already in progress. Try after sometime",

--- a/mobile/lib/presentation/widgets/backup/backup_toggle_button.widget.dart
+++ b/mobile/lib/presentation/widgets/backup/backup_toggle_button.widget.dart
@@ -65,7 +65,9 @@ class BackupToggleButtonState extends ConsumerState<BackupToggleButton> with Sin
 
     final uploadTasks = ref.watch(driftBackupProvider.select((state) => state.uploadItems));
 
-    final isUploading = uploadTasks.isNotEmpty;
+    final isSyncing = ref.watch(driftBackupProvider.select((state) => state.isSyncing));
+
+    final isProcessing = uploadTasks.isNotEmpty || isSyncing;
 
     return AnimatedBuilder(
       animation: _animationController,
@@ -129,7 +131,7 @@ class BackupToggleButtonState extends ConsumerState<BackupToggleButton> with Sin
                             ],
                           ),
                         ),
-                        child: isUploading
+                        child: isProcessing
                             ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2))
                             : Icon(Icons.cloud_upload_outlined, color: context.primaryColor, size: 24),
                       ),

--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -102,6 +102,7 @@ class DriftBackupState {
   final int enqueueCount;
   final int enqueueTotalCount;
 
+  final bool isSyncing;
   final bool isCanceling;
   final BackupError error;
 
@@ -115,6 +116,7 @@ class DriftBackupState {
     required this.enqueueCount,
     required this.enqueueTotalCount,
     required this.isCanceling,
+    required this.isSyncing,
     required this.uploadItems,
     this.error = BackupError.none,
   });
@@ -127,6 +129,7 @@ class DriftBackupState {
     int? enqueueCount,
     int? enqueueTotalCount,
     bool? isCanceling,
+    bool? isSyncing,
     Map<String, DriftUploadStatus>? uploadItems,
     BackupError? error,
   }) {
@@ -138,6 +141,7 @@ class DriftBackupState {
       enqueueCount: enqueueCount ?? this.enqueueCount,
       enqueueTotalCount: enqueueTotalCount ?? this.enqueueTotalCount,
       isCanceling: isCanceling ?? this.isCanceling,
+      isSyncing: isSyncing ?? this.isSyncing,
       uploadItems: uploadItems ?? this.uploadItems,
       error: error ?? this.error,
     );
@@ -145,7 +149,7 @@ class DriftBackupState {
 
   @override
   String toString() {
-    return 'DriftBackupState(totalCount: $totalCount, backupCount: $backupCount, remainderCount: $remainderCount, processingCount: $processingCount, enqueueCount: $enqueueCount, enqueueTotalCount: $enqueueTotalCount, isCanceling: $isCanceling, uploadItems: $uploadItems, error: $error)';
+    return 'DriftBackupState(totalCount: $totalCount, backupCount: $backupCount, remainderCount: $remainderCount, processingCount: $processingCount, enqueueCount: $enqueueCount, enqueueTotalCount: $enqueueTotalCount, isCanceling: $isCanceling, isSyncing: $isSyncing, uploadItems: $uploadItems, error: $error)';
   }
 
   @override
@@ -160,6 +164,7 @@ class DriftBackupState {
         other.enqueueCount == enqueueCount &&
         other.enqueueTotalCount == enqueueTotalCount &&
         other.isCanceling == isCanceling &&
+        other.isSyncing == isSyncing &&
         mapEquals(other.uploadItems, uploadItems) &&
         other.error == error;
   }
@@ -173,6 +178,7 @@ class DriftBackupState {
         enqueueCount.hashCode ^
         enqueueTotalCount.hashCode ^
         isCanceling.hashCode ^
+        isSyncing.hashCode ^
         uploadItems.hashCode ^
         error.hashCode;
   }
@@ -193,6 +199,7 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
           enqueueCount: 0,
           enqueueTotalCount: 0,
           isCanceling: false,
+          isSyncing: false,
           uploadItems: {},
           error: BackupError.none,
         ),
@@ -312,8 +319,12 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
     );
   }
 
-  Future<void> updateError(BackupError error) async {
+  void updateError(BackupError error) async {
     state = state.copyWith(error: error);
+  }
+
+  void updateSyncing(bool isSyncing) async {
+    state = state.copyWith(isSyncing: isSyncing);
   }
 
   Future<void> startBackup(String userId) {


### PR DESCRIPTION
## Description

Updated the backup page to reuse the result of the initial sync to display the error. However, a user might see the error and toggle the backup button to restart the process. So the handling is actually updated as follows:

- If the remote sync failed and the user just enables backup, we reuse the error message
- If the remote sync failed and the user already has backup enabled, toggling it off and then back on will trigger a new remote sync and processes the backups based on the new result

But this also means that we run a remote sync whenever the user toggles the backup button, which is fine and should be fast as we already do a sync when the user enters the page