### PR TITLE
chore: perform full local sync on cold start

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -64,7 +64,7 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
             if (Store.isBetaTimelineEnabled) {
               bool syncSuccess = false;
               await Future.wait([
-                backgroundManager.syncLocal(),
+                backgroundManager.syncLocal(full: true),
                 backgroundManager.syncRemote().then((success) => syncSuccess = success),
               ]);
 


### PR DESCRIPTION
## Description

We currently do not do a full local sync unless the user manually presses the sync local button in the Sync status page. If something is missed during the delta sync, it will not be processed due to the checkpoint always fetching changes after that. A full sync resets the checkpoint and is as fast as the delta sync, so performing it on app startup acts as housekeeping
