### PR TITLE
fix: missing email button padding

### DIFF
--- a/server/src/emails/album-update.email.tsx
+++ b/server/src/emails/album-update.email.tsx
@@ -29,8 +29,8 @@ export const AlbumUpdateEmail = ({
       </Text>
 
       <Text>
-        New media has been added to <strong>{albumName}</strong>,
-        <br /> check it out!
+        New media has been added to <strong>{albumName}</strong>.
+        <br /> Check it out!
       </Text>
     </>
   );

--- a/server/src/emails/components/button.component.tsx
+++ b/server/src/emails/components/button.component.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { Button, ButtonProps } from '@react-email/components';
+import { Button, ButtonProps, Text } from '@react-email/components';
 
 export const ImmichButton = ({ children, ...props }: ButtonProps) => (
   <Button
     {...props}
-    className="py-3 px-8 border bg-immich-primary rounded-full no-underline hover:no-underline text-white hover:text-gray-50 font-bold uppercase"
+    className="border bg-immich-primary rounded-full no-underline hover:no-underline text-white hover:text-gray-50 font-bold uppercase"
   >
-    {children}
+    <Text className="my-3 mx-8">{children}</Text>
   </Button>
 );


### PR DESCRIPTION
## Description

The `py-*` and `px-*` classes don't work in the `Button` element - email buttons are rendered without padding.

The text is still slightly misaligned vertically owing to the spacing reserved for letter descendants, which are not present in uppercase text.

This commit also fixes a small syntactic error in the punctuation of the email message.

## How Has This Been Tested?

With `npm run email:dev`.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->


Before:
﻿
<img width="369" height="342" alt="image" src="https://github.com/user-attachments/assets/2e315848-3afb-4a89-b752-786b7b10345e" />

After:

<img width="369" height="368" alt="image" src="https://github.com/user-attachments/assets/48c05b05-55e1-4ad3-a8c1-cb8b819c734f" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Code changes and PR were exclusively generated by organic-based intelligence.