### PR TITLE
fix: redirect user to AUTH_CHANGE_PASSWORD if shouldChangePassword

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -23,6 +23,7 @@ export type AuthUser = {
   email: string;
   quotaUsageInBytes: number;
   quotaSizeInBytes: number | null;
+  shouldChangePassword: boolean;
 };
 
 export type AlbumUser = {
@@ -306,7 +307,7 @@ export const columns = {
     'asset.type',
   ],
   assetFiles: ['asset_file.id', 'asset_file.path', 'asset_file.type'],
-  authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes'],
+  authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes', 'user.shouldChangePassword'],
   authApiKey: ['api_key.id', 'api_key.permissions'],
   authSession: ['session.id', 'session.updatedAt', 'session.pinExpiresAt'],
   authSharedLink: [

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -184,7 +184,11 @@ export class AuthService extends BaseService {
       throw new ForbiddenException('Forbidden');
     }
 
-    if (authDto.user.shouldChangePassword) {
+    if (
+      authDto.user.shouldChangePassword &&
+      typeof requestedPermission === 'string' &&
+      ![Permission.UserUpdate, Permission.UserRead, Permission.UserPreferenceRead, Permission.ServerAbout].includes(requestedPermission)
+    ) {
       this.logger.warn(`Denied access, user should change their password`);
       throw new ForbiddenException('Change your password');
     }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -184,6 +184,11 @@ export class AuthService extends BaseService {
       throw new ForbiddenException('Forbidden');
     }
 
+    if (authDto.user.shouldChangePassword) {
+      this.logger.warn(`Denied access, user should change their password`);
+      throw new ForbiddenException('Change your password');
+    }
+
     if (authDto.sharedLink && !sharedLinkRoute) {
       this.logger.warn(`Denied access to non-shared route: ${uri}`);
       throw new ForbiddenException('Forbidden');

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -168,6 +168,7 @@ export class AuthService extends BaseService {
       name: dto.name,
       password: dto.password,
       storageLabel: 'admin',
+      shouldChangePassword: false
     });
 
     return mapUserAdmin(admin);

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -62,6 +62,10 @@ export const authenticate = async (url: URL, options?: AuthOptions) => {
     redirect(302, `${AppRoute.AUTH_LOGIN}?continue=${encodeURIComponent(url.pathname + url.search)}`);
   }
 
+  if (user.shouldChangePassword && url.pathname !== AppRoute.AUTH_CHANGE_PASSWORD) {
+    redirect(302, AppRoute.AUTH_CHANGE_PASSWORD)
+  }
+
   if (adminRoute && !user.isAdmin) {
     redirect(302, AppRoute.PHOTOS);
   }

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -62,10 +62,6 @@ export const authenticate = async (url: URL, options?: AuthOptions) => {
     redirect(302, `${AppRoute.AUTH_LOGIN}?continue=${encodeURIComponent(url.pathname + url.search)}`);
   }
 
-  if (user.shouldChangePassword && url.pathname !== AppRoute.AUTH_CHANGE_PASSWORD) {
-    redirect(302, AppRoute.AUTH_CHANGE_PASSWORD)
-  }
-
   if (adminRoute && !user.isAdmin) {
     redirect(302, AppRoute.PHOTOS);
   }

--- a/web/src/routes/auth/login/+page.svelte
+++ b/web/src/routes/auth/login/+page.svelte
@@ -30,7 +30,7 @@
     eventManager.emit('auth.login', user);
   };
 
-  const onFirstLogin = () => goto(AppRoute.AUTH_CHANGE_PASSWORD);
+  const onChangePassword = () => goto(AppRoute.AUTH_CHANGE_PASSWORD);
   const onOnboarding = () => goto(AppRoute.AUTH_ONBOARDING);
 
   onMount(async () => {
@@ -85,9 +85,8 @@
         return;
       }
 
-      // change the user password before we onboard them
-      if (!user.isAdmin && user.shouldChangePassword) {
-        await onFirstLogin();
+      if (user.shouldChangePassword) {
+        await onChangePassword();
         return;
       }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Now the user only can make actions with UserUpdate, UserRead, UserPreferenceRead or ServerAbout permissions, needed in the change-password page.

Added a check in the authenticate method to redirect the user if has a pending password change.

Fixes #11146
## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Reset user password -> login with that user -> on the /auth/change-password  change the url and go directly to /photos, /albums or any other route
- [x] When the user finally change the password, can go to /photos, /albums etc.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

