### PR TITLE
feat(docs): add one-click install docs page

### DIFF
--- a/docs/docs/install/one-click.md
+++ b/docs/docs/install/one-click.md
@@ -5,7 +5,7 @@ sidebar_position: 65
 # One-Click [Cloud Service]
 
 :::note
-This version of Immich is provided via cloud service provider's one-click marketplaces.  Hosting costs are set by the cloud service providers.
+This version of Immich is provided via cloud service provider's one-click marketplaces. Hosting costs are set by the cloud service providers.
 Support for these are provided by the individual cloud service providers.
 
 **Please report issues to the corresponding [Github Repository][github].**

--- a/docs/docs/install/one-click.md
+++ b/docs/docs/install/one-click.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 65
+---
+
+# One-Click [Cloud Service]
+
+:::note
+This version is of Immich is provided via cloud service provider's one-click marketplaces.  Hosting costs are set by the cloud service providers.
+Support for these are provided by the individual cloud service providers.
+
+**Please report issues to the corresponding [Github Repository][github].**
+:::
+
+## Installation
+
+Simply goto the providers marketplace and choose Immich, then follow the provided instructions.
+
+## One-Click Immich marketplace providers
+
+### DigitalOcean
+
+https://marketplace.digitalocean.com/apps/immich
+
+### Vultr
+
+https://www.vultr.com/marketplace/apps/immich
+
+## Issues
+
+For issues, open an issue on the associated [GitHub Repository][github].
+
+[github]: https://github.com/imagegenius/docker-immich/

--- a/docs/docs/install/one-click.md
+++ b/docs/docs/install/one-click.md
@@ -5,7 +5,7 @@ sidebar_position: 65
 # One-Click [Cloud Service]
 
 :::note
-This version is of Immich is provided via cloud service provider's one-click marketplaces.  Hosting costs are set by the cloud service providers.
+This version of Immich is provided via cloud service provider's one-click marketplaces.  Hosting costs are set by the cloud service providers.
 Support for these are provided by the individual cloud service providers.
 
 **Please report issues to the corresponding [Github Repository][github].**


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
    Adding one-click docs page, for instructions on one-click installs.
<!--- Why is this change required? What problem does it solve? -->
   Provides instructions for how to set up immich using a one-click market place. 
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
