### PR TITLE
chore(deps): cache pnpm dependencies in prod build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,35 +1,50 @@
 FROM ghcr.io/immich-app/base-server-dev:202509210934@sha256:b5ce2d7eaf379d4cf15efd4bab180d8afc8a80d20b36c9800f4091aca6ae267e AS builder
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   CI=1 \
-  COREPACK_HOME=/tmp
+  COREPACK_HOME=/tmp \
+  PNPM_HOME=/pnpm \
+  PATH="/pnpm:$PATH"
 
 RUN npm install --global corepack@latest && \
-  corepack enable pnpm
+  corepack enable pnpm && \
+  pnpm config set store-dir "$PNPM_HOME"
 
 FROM builder AS server
 
 WORKDIR /usr/src/app
-COPY ./package* ./pnpm* .pnpmfile.cjs ./
 COPY ./server ./server/
-RUN SHARP_IGNORE_GLOBAL_LIBVIPS=true pnpm --filter immich --frozen-lockfile build && \
+RUN --mount=type=cache,id=pnpm-server,target=/pnpm \
+  --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
+  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+  --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
+  SHARP_IGNORE_GLOBAL_LIBVIPS=true pnpm --filter immich --frozen-lockfile build && \
   SHARP_FORCE_GLOBAL_LIBVIPS=true pnpm --filter immich --frozen-lockfile --prod --no-optional deploy /output/server-pruned
 
 FROM builder AS web
 
 WORKDIR /usr/src/app
-COPY ./package* ./pnpm* .pnpmfile.cjs ./
 COPY ./web ./web/
 COPY ./i18n ./i18n/
 COPY ./open-api ./open-api/
-RUN SHARP_IGNORE_GLOBAL_LIBVIPS=true pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install && \
+RUN --mount=type=cache,id=pnpm-web,target=/pnpm \
+  --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
+  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+  --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
+  SHARP_IGNORE_GLOBAL_LIBVIPS=true pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install && \
   pnpm --filter @immich/sdk --filter immich-web build
 
 FROM builder AS cli
 
-COPY ./package* ./pnpm* .pnpmfile.cjs ./
 COPY ./cli ./cli/
 COPY ./open-api ./open-api/
-RUN pnpm --filter @immich/sdk --filter @immich/cli --frozen-lockfile install && \
+RUN --mount=type=cache,id=pnpm-cli,target=/pnpm \
+  --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
+  --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+  --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
+  pnpm --filter @immich/sdk --filter @immich/cli --frozen-lockfile install && \
   pnpm --filter @immich/sdk --filter @immich/cli build && \
   pnpm --filter @immich/cli --prod --no-optional deploy /output/cli-pruned
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,8 +2,8 @@ FROM ghcr.io/immich-app/base-server-dev:202509210934@sha256:b5ce2d7eaf379d4cf15e
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   CI=1 \
   COREPACK_HOME=/tmp \
-  PNPM_HOME=/pnpm \
-  PATH="/pnpm:$PATH"
+  PNPM_HOME=/buildcache/pnpm-store \
+  PATH="/buildcache/pnpm-store:$PATH"
 
 RUN npm install --global corepack@latest && \
   corepack enable pnpm && \
@@ -13,7 +13,7 @@ FROM builder AS server
 
 WORKDIR /usr/src/app
 COPY ./server ./server/
-RUN --mount=type=cache,id=pnpm-server,target=/pnpm \
+RUN --mount=type=cache,id=pnpm-server,target=/buildcache/pnpm-store \
   --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
@@ -27,7 +27,7 @@ WORKDIR /usr/src/app
 COPY ./web ./web/
 COPY ./i18n ./i18n/
 COPY ./open-api ./open-api/
-RUN --mount=type=cache,id=pnpm-web,target=/pnpm \
+RUN --mount=type=cache,id=pnpm-web,target=/buildcache/pnpm-store \
   --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
@@ -39,7 +39,7 @@ FROM builder AS cli
 
 COPY ./cli ./cli/
 COPY ./open-api ./open-api/
-RUN --mount=type=cache,id=pnpm-cli,target=/pnpm \
+RUN --mount=type=cache,id=pnpm-cli,target=/buildcache/pnpm-store \
   --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \


### PR DESCRIPTION
## Description

This PR makes prod builds reuse dependencies across builds using a cache mount, including when there are source or dependency changes.