### PR TITLE
chore: clean auth-user entity on reset

### DIFF
--- a/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
@@ -51,6 +51,7 @@ class SyncStreamRepository extends DriftDatabaseRepository {
           await _db.remoteAssetEntity.deleteAll();
           await _db.remoteExifEntity.deleteAll();
           await _db.stackEntity.deleteAll();
+          await _db.authUserEntity.deleteAll();
           await _db.userEntity.deleteAll();
           await _db.userMetadataEntity.deleteAll();
         });


### PR DESCRIPTION
## Description

Auth User entity was missed from the reset handling. This adds the auth user entity to be cleaned up on logout as well as when receiving a `SyncResetV1` event from the server