### PR TITLE
fix: respect storage indicator setting

### DIFF
--- a/mobile/lib/pages/common/settings.page.dart
+++ b/mobile/lib/pages/common/settings.page.dart
@@ -141,14 +141,9 @@ class SettingsSubPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.locale;
-    return SafeArea(
-      bottom: true,
-      top: false,
-      right: true,
-      child: Scaffold(
-        appBar: AppBar(centerTitle: false, title: Text(section.title).tr()),
-        body: section.widget,
-      ),
+    return Scaffold(
+      appBar: AppBar(centerTitle: false, title: Text(section.title).tr()),
+      body: section.widget,
     );
   }
 }

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -16,7 +16,7 @@ class ThumbnailTile extends ConsumerWidget {
     this.asset, {
     this.size = kThumbnailResolution,
     this.fit = BoxFit.cover,
-    this.showStorageIndicator,
+    this.showStorageIndicator = false,
     this.lockSelection = false,
     this.heroOffset,
     super.key,
@@ -25,7 +25,7 @@ class ThumbnailTile extends ConsumerWidget {
   final BaseAsset? asset;
   final Size size;
   final BoxFit fit;
-  final bool? showStorageIndicator;
+  final bool showStorageIndicator;
   final bool lockSelection;
   final int? heroOffset;
 
@@ -55,7 +55,7 @@ class ThumbnailTile extends ConsumerWidget {
         : const BoxDecoration();
 
     final bool storageIndicator =
-        showStorageIndicator ?? ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator)));
+        ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator))) && showStorageIndicator;
 
     return Stack(
       children: [

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -14,7 +14,7 @@ class TimelineArgs {
   final double maxHeight;
   final double spacing;
   final int columnCount;
-  final bool? showStorageIndicator;
+  final bool showStorageIndicator;
   final bool withStack;
   final GroupAssetsBy? groupBy;
 
@@ -23,7 +23,7 @@ class TimelineArgs {
     required this.maxHeight,
     this.spacing = kTimelineSpacing,
     this.columnCount = kTimelineColumnCount,
-    this.showStorageIndicator,
+    this.showStorageIndicator = false,
     this.withStack = false,
     this.groupBy,
   });


### PR DESCRIPTION
Fixes #22366

Changing the indicator setting is causing the timeline to reload and resets the scroll state to the beginning of the timeline. This will be fixed in a followup PR as changing this setting is not a common action