### PR TITLE
fix(mobile): Add timeout for missing video file

### DIFF
--- a/mobile/lib/infrastructure/repositories/storage.repository.dart
+++ b/mobile/lib/infrastructure/repositories/storage.repository.dart
@@ -36,7 +36,8 @@ class StorageRepository {
 
     try {
       final entity = await AssetEntity.fromId(asset.id);
-      file = await entity?.originFileWithSubtype;
+      // Use a timeout to avoid hanging on Live Photos whose paired video is unavailable (e.g., shared albums)
+      file = await entity?.originFileWithSubtype.timeout(const Duration(seconds: 5));
       if (file == null) {
         log.warning(
           "Cannot get motion file for asset ${asset.id}, name: ${asset.name}, created on: ${asset.createdAt}",


### PR DESCRIPTION
## Description

Background uploads on iOS could stall “halfway” when an album contained Live Photos whose paired motion video was unavailable (common in shared/cloud albums, older formats, or when iCloud hadn’t downloaded the video yet). In the iOS background path, we attempted to upload the motion video first and only then the still photo. If the motion video could not be retrieved, the task never proceeded and the asset stayed in the “remainder,” making the backup appear stuck.

This change:
- Adds a fallback in `UploadService._getUploadTask` to upload the still photo as a normal image when the motion video is missing.
- Adds a 5s timeout in `StorageRepository.getMotionFileForAsset` when awaiting `originFileWithSubtype` so the fallback triggers promptly (instead of hanging).

Why required:
- Prevents iOS background backup from stalling on Live Photos with missing/undownloaded motion videos.
- Aligns background behavior with the manual/HTTP path, which already tolerated missing motion video by uploading the still only.

Fixes #22601

## How Has This Been Tested?

- Local iOS testing with albums containing Live Photos that do not expose the motion video (e.g., shared album or cloud-only):
  - Start background backup.
  - Observe logs for the early timeout and fallback:
    - `StorageRepository` warns about missing/timeout on motion file.
    - `UploadService` logs: “Live Photo motion file missing … uploading still image only.”
  - Verify the backup continues and “remainder” decreases to completion instead of stalling.

- Verified that albums with normal Live Photos still upload motion video first, then enqueue the still photo linked via `livePhotoVideoId`.

- Confirmed no linter errors in:
  - `lib/services/upload.service.dart`
  - `lib/infrastructure/repositories/storage.repository.dart`

- [ ] Built and tested locally, able to reproduce fallback behavior and complete backup
- [ ] Test B

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->

<img height="800" alt="IMG_1749" src="https://github.com/user-attachments/assets/c964d708-a16b-4e8b-9b06-92257258ad76" />
<img height="800" alt="IMG_1747" src="https://github.com/user-attachments/assets/f2d45bcf-f962-4d00-8147-27e5abf352de" />


</details>

As you can see, in the first image you can see a corrupt live photo where the video is unable to be played in the photos app. In the second image, just the still image was successfully uploaded to immich.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (None added)
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `lib/services/` uses repository implementations for filesystem/Photos access (e.g., `StorageRepository`)
- [x] All code in `lib/infrastructure/repositories/` remains simple and focused on platform/data access

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I diagnosed the underlying issue myself and then used AI to help write the fallback/timeout changes as I have no flutter experience. All code changes were reviewed and validated locally.

## Final Note

I can refactor the code if it is not following best practices according to the codebase and the language. I am a flutter n00b.
