### PR TITLE
fix(web): handle non-square user profile images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ vite.config.js.timestamp-*
 .pnpm-store
 .devcontainer/library
 .devcontainer/.env*
-.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ vite.config.js.timestamp-*
 .pnpm-store
 .devcontainer/library
 .devcontainer/.env*
+.vs/

--- a/web/src/lib/components/shared-components/user-avatar.svelte
+++ b/web/src/lib/components/shared-components/user-avatar.svelte
@@ -86,7 +86,7 @@
       bind:this={img}
       src={getProfileImageUrl(user)}
       alt={$t('profile_image_of_user', { values: { user: title } })}
-      class="h-full w-full object-cover"
+      class="h-full w-full object-cover aspect-square"
       class:hidden={showFallback}
       draggable="false"
     />


### PR DESCRIPTION
## Description

This PR enforces a 1:1 aspect ratio for user avatars by adding the "aspect-square" class in "user-avatar.svelte" This fixes the issue that would occur when non square images were selected as a user avatar, in which they would be displayed inconsistently. 

Fixes #20097 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Uploaded portrait (150x300) and landscape (300 x 150) images that now display as squares

<img width="458" height="465" alt="image" src="https://github.com/user-attachments/assets/a77f338d-9c79-4d3f-a254-7d3e0083e68b" />
<img width="466" height="480" alt="image" src="https://github.com/user-attachments/assets/556f3a9a-d617-408a-beff-6611db8984e2" />

## Checklist:

- [ X ] I have performed a self-review of my own code
- [ X ] I have made corresponding changes to the documentation if applicable
- [ X ] I have no unrelated changes in the PR.
- [ X ] I have confirmed that any new dependencies are strictly necessary.
- [ X ] I have written tests for new code (if applicable)
- [ X ] I have followed naming conventions/patterns in the surrounding code
- [ X ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ X ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
LLM was used to refine description and debug
