### PR TITLE
chore: mark VSCode tasks as background tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,7 @@
       "label": "Fix Permissions, Install Dependencies",
       "type": "shell",
       "command": "[ -f /immich-devcontainer/container-start.sh ] && /immich-devcontainer/container-start.sh || exit 0",
+      "isBackground": true,
       "presentation": {
         "echo": true,
         "reveal": "always",
@@ -25,6 +26,7 @@
       "dependsOn": ["Fix Permissions, Install Dependencies"],
       "type": "shell",
       "command": "[ -f /immich-devcontainer/container-start-backend.sh ] && /immich-devcontainer/container-start-backend.sh || exit 0",
+      "isBackground": true,
       "presentation": {
         "echo": true,
         "reveal": "always",
@@ -45,6 +47,7 @@
       "dependsOn": ["Fix Permissions, Install Dependencies"],
       "type": "shell",
       "command": "[ -f /immich-devcontainer/container-start-frontend.sh ] && /immich-devcontainer/container-start-frontend.sh || exit 0",
+      "isBackground": true,
       "presentation": {
         "echo": true,
         "reveal": "always",


### PR DESCRIPTION
## Description

VSCode expects tasks that aren't marked as background tasks to finish eventually. That's not how a dev-server is supposed to work. We expect it to run for basically infinite time.

By marking those tasks as background tasks, VSCode stops showing the infinite loading spinner on those processes.
Documentation: https://code.visualstudio.com/docs/reference/tasks-appendix

<img width="530" height="373" alt="image" src="https://github.com/user-attachments/assets/db340787-0ab9-40d6-8930-c58094cfd4a8" />

~Fixes # (issue)~

## How Has This Been Tested?

I restarted the tasks in my devcontainer and confirmed the spinners are gone. I also did the same change at work projects a while ago, so I am very confident in this change.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="523" height="692" alt="image" src="https://github.com/user-attachments/assets/a3e3b6e8-2b13-4aef-8c3c-8f8ce2f5694c" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None