### PR TITLE
feat: show location & date on duplicate asset comparison overview

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -29,6 +29,8 @@
   let isFromExternalLibrary = $derived(!!asset.libraryId);
   let assetData = $derived(JSON.stringify(asset, null, 2));
 
+  let locationParts = $derived([asset.exifInfo?.city, asset.exifInfo?.state, asset.exifInfo?.country].filter(Boolean));
+
   let timeZone = $derived(asset.exifInfo?.timeZone);
   let dateTime = $derived(
     timeZone && asset.exifInfo?.dateTimeOriginal
@@ -143,16 +145,8 @@
 
     <div class="flex items-start gap-x-1">
       <Icon icon={mdiMapMarkerOutline} size="16" />
-      {#if asset.exifInfo?.city || asset.exifInfo?.state || asset.exifInfo?.country}
-        {#if asset.exifInfo?.city}
-          {asset.exifInfo.city}
-        {/if}
-        {#if asset.exifInfo?.state}
-          {asset.exifInfo.state}
-        {/if}
-        {#if asset.exifInfo?.country}
-          {asset.exifInfo.country}
-        {/if}
+      {#if locationParts.length > 0}
+        {locationParts.join(', ')}
       {:else}
         {$t('unknown')}
       {/if}

--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
+  import { locale } from '$lib/stores/preferences.store';
   import { getAssetThumbnailUrl } from '$lib/utils';
   import { getAssetResolution, getFileSize } from '$lib/utils/asset-utils';
   import { getAltText } from '$lib/utils/thumbnail-util';
-  import { toTimelineAsset } from '$lib/utils/timeline-util';
+  import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
   import { type AssetResponseDto, getAllAlbums } from '@immich/sdk';
   import { Icon } from '@immich/ui';
-  import { mdiHeart, mdiImageMultipleOutline, mdiMagnifyPlus } from '@mdi/js';
+  import {
+    mdiBookmarkOutline,
+    mdiCalendar,
+    mdiHeart,
+    mdiImageMultipleOutline,
+    mdiImageOutline,
+    mdiMagnifyPlus,
+    mdiMapMarkerOutline,
+  } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -19,6 +28,13 @@
 
   let isFromExternalLibrary = $derived(!!asset.libraryId);
   let assetData = $derived(JSON.stringify(asset, null, 2));
+
+  let timeZone = $derived(asset.exifInfo?.timeZone);
+  let dateTime = $derived(
+    timeZone && asset.exifInfo?.dateTimeOriginal
+      ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
+      : fromISODateTimeUTC(asset.localDateTime),
+  );
 </script>
 
 <div
@@ -88,13 +104,61 @@
   </div>
 
   <div
-    class="grid place-items-center gap-y-2 py-2 text-xs transition-colors {isSelected
+    class="grid place-items-start gap-y-2 py-2 text-xs transition-colors {isSelected
       ? 'text-white dark:text-black'
       : 'dark:text-white'}"
   >
-    <span class="break-all text-center">{asset.originalFileName}</span>
-    <span>{getAssetResolution(asset)} - {getFileSize(asset)}</span>
-    <span>
+    <div class="flex items-start gap-x-1">
+      <Icon icon={mdiImageOutline} size="16" />
+      <div>
+        <span class="break-all text-center">{asset.originalFileName}</span><br />
+        {getAssetResolution(asset)} - {getFileSize(asset)}
+      </div>
+    </div>
+    <div class="flex items-start gap-x-1">
+      <Icon icon={mdiCalendar} size="16" />
+      {#if dateTime}
+        {dateTime.toLocaleString(
+          {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          },
+          { locale: $locale },
+        )}
+
+        {dateTime.toLocaleString(
+          {
+            // weekday: 'short',
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: timeZone ? 'shortOffset' : undefined,
+          },
+          { locale: $locale },
+        )}
+      {:else}
+        {$t('unknown')}
+      {/if}
+    </div>
+
+    <div class="flex items-start gap-x-1">
+      <Icon icon={mdiMapMarkerOutline} size="16" />
+      {#if asset.exifInfo?.city || asset.exifInfo?.state || asset.exifInfo?.country}
+        {#if asset.exifInfo?.city}
+          {asset.exifInfo.city}
+        {/if}
+        {#if asset.exifInfo?.state}
+          {asset.exifInfo.state}
+        {/if}
+        {#if asset.exifInfo?.country}
+          {asset.exifInfo.country}
+        {/if}
+      {:else}
+        {$t('unknown')}
+      {/if}
+    </div>
+    <div class="flex items-start gap-x-1">
+      <Icon icon={mdiBookmarkOutline} size="16" />
       {#await getAllAlbums({ assetId: asset.id })}
         {$t('scanning_for_album')}
       {:then albums}
@@ -104,6 +168,6 @@
           {$t('in_albums', { values: { count: albums.length } })}
         {/if}
       {/await}
-    </span>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Description

Adding some metadata to the duplicate asset comparison view, to make it faster to decide which asset to keep. 
To keep everything scannable, I changed the alignment to left-align and added some icons.

Discord Thread: https://discord.com/channels/979116623879368755/1071165397228855327/1423964140220711075

## How Has This Been Tested?

Created some duplicate files, by scaling them with the MacOS preview conversion tool and removed some metadata. I then checked them in the duplicate finder UI (see screenshot)
I also made sure to keep all conditions from the existing details view of the assets, so there shouldn't be a new issue.

<details><summary><h2>Screenshots</h2></summary>

<img width="1790" height="1108" alt="image" src="https://github.com/user-attachments/assets/c1a0ec55-8ea5-443b-acd6-fa679f28b575" />

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
   - not sure about that one. I think the alignment & icon changes are necessary to keep the UI usable, but I can extract them into a separate preparation PR if you want to.
- [x] ~I have confirmed that any new dependencies are strictly necessary.~
- [x] ~I have written tests for new code (if applicable)~
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [x] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
