### PR TITLE
fix(mobile): hide locate asset on local assets

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -44,7 +44,8 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final showViewInTimelineButton =
         (previousRouteName != TabShellRoute.name || tabRoute == TabEnum.search) &&
         previousRouteName != AssetViewerRoute.name &&
-        previousRouteName != null;
+        previousRouteName != null &&
+        !asset.isLocalOnly;
 
     final isShowingSheet = ref.watch(assetViewerProvider.select((state) => state.showingBottomSheet));
     int opacity = ref.watch(assetViewerProvider.select((state) => state.backgroundOpacity));


### PR DESCRIPTION
## Description

Hides the "locate in timeline" button on assets that are local-only (can be accessed by going into Library -> On this device), because they're not in the timeline, so clicking that button will lead to that date on the timeline, but that asset won't be there.