### PR TITLE
fix(mobile): empty album description does not save

### DIFF
--- a/mobile/lib/presentation/pages/drift_remote_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_remote_album.page.dart
@@ -300,7 +300,7 @@ class _EditAlbumDialogState extends ConsumerState<_EditAlbumDialog> {
 
       await ref
           .read(remoteAlbumProvider.notifier)
-          .updateAlbum(widget.album.id, name: newTitle, description: newDescription.isEmpty ? null : newDescription);
+          .updateAlbum(widget.album.id, name: newTitle, description: newDescription);
 
       if (mounted) {
         Navigator.of(


### PR DESCRIPTION
## Description

Made it possible to assign an empty description for an album on mobile (same as it is possible on web).