### PR TITLE
fix(server): fix chunking Postgres query parameters

### DIFF
--- a/server/src/decorators.ts
+++ b/server/src/decorators.ts
@@ -103,7 +103,7 @@ export function ChunkedArray(options?: { paramIndex?: number }): MethodDecorator
 }
 
 export function ChunkedSet(options?: { paramIndex?: number }): MethodDecorator {
-  return Chunked({ ...options, mergeFn: setUnion });
+  return Chunked({ ...options, mergeFn: (args: Set<any>[]) => setUnion(...args) });
 }
 
 const UUID = '00000000-0000-4000-a000-000000000000';

--- a/server/src/decorators.ts
+++ b/server/src/decorators.ts
@@ -86,13 +86,13 @@ export function Chunked(
       }
 
       return Promise.all(
-        chunks(argument, chunkSize).map(async (chunk) =>
-          Reflect.apply(originalMethod, this, [
+        chunks(argument, chunkSize).map(async (chunk) => {
+          return await Reflect.apply(originalMethod, this, [
             ...arguments_.slice(0, parameterIndex),
             chunk,
             ...arguments_.slice(parameterIndex + 1),
-          ]),
-        ),
+          ]);
+        }),
       ).then((results) => (options.mergeFn ? options.mergeFn(results) : results));
     };
   };

--- a/server/src/decorators.ts
+++ b/server/src/decorators.ts
@@ -86,13 +86,13 @@ export function Chunked(
       }
 
       return Promise.all(
-        chunks(argument, chunkSize).map(async (chunk) => {
-          await Reflect.apply(originalMethod, this, [
+        chunks(argument, chunkSize).map(async (chunk) =>
+          Reflect.apply(originalMethod, this, [
             ...arguments_.slice(0, parameterIndex),
             chunk,
             ...arguments_.slice(parameterIndex + 1),
-          ]);
-        }),
+          ]),
+        ),
       ).then((results) => (options.mergeFn ? options.mergeFn(results) : results));
     };
   };


### PR DESCRIPTION
## Description

This PR fixes the `Chunked` decorator used for SQL parameter chunking.

Currently it seems to be broken. When chunking is invoked (on a large list of parameters), Immich returns HTTP 400 "Not found or no asset.download access".
There are basically two bugs.
- During chunk processing. Each chunk call produces `undefined` result because the map callback does not return anything.
- When done with chunks. It processes/merges results as _one set of sets of IDs_ instead of _sets of IDs_ due to passing an array to setUnion: `setUnion([result1, result2, ...])` vs `setUnion(result1, result2, ...)`

## How Has This Been Tested?

To reproduce / test I've used two approaches.

### Test 1. Manual (with artificially low chunk size)
1. Modify `decorators.ts` to use smaller chunk size: `DATABASE_PARAMETER_CHUNK_SIZE = 3`.
2. Do bulk actions with N assets and compare outcomes when N=3 (ok) vs N=4 (fails).
   - Add 4 assets to an album: `Added 0 assets`.
   - Download 4 assets: `HttpException(400): {"message":"Not found or no asset.download access","error":"Bad Request","statusCode":400}`

**Upon applying the fix:** bulk actions complete successfully.

### Test 2. Scripted (testing default chunk size)

The script below connects to an existing Immich stack, generates synthetic asset data (150K assets), then calls `getDownloadInfo` for 140K assets.
<details><summary>api.sh</summary>

```sh
#!/usr/bin/env bash

# WARNING Run this script against a dev/throwaway Immich stack. Its data will be altered.

api_asset_count=${1:-140000} # number of assets in a single API call
total_asset_count=150000
api_url="http://localhost:2283/api"
api_key="1Gnc8KORH9Nbx5l0ZBguTkpmwhb7e9RMJ9oNhOpxqM"
api_key_hash="1mJobDYdj93Xy+YK0Tx40joJMZ1p3JFVso3hdXW4s80="
user_email="user@local"
user_password_hash='$2b$10$j4ONLwyNajHo2caTKdRyOe2AsccSjaensvRVt7qXkwUwuKUYvsnhu' # "password"
immich_container=immich_server
db_container=immich_postgres

query_create_dataset=$(cat <<'EOF'
-- user
DELETE FROM "user" WHERE email = :'user_email';
INSERT INTO "user" (email, password, "isAdmin") VALUES (:'user_email', :'user_password_hash', true);
-- api_key
INSERT INTO api_key ("name", "key", "userId", "permissions") SELECT 'user-api-key', :'api_key_hash', id, '{all}' FROM "user" WHERE email = :'user_email';
-- asset
INSERT INTO asset ("ownerId", "originalPath", "originalFileName", "deviceAssetId", "deviceId", checksum, type, "fileCreatedAt", "fileModifiedAt", "localDateTime")
SELECT 
    (SELECT id FROM "user" WHERE email = :'user_email'),
    '/data/library/user/' || n,
    'img' || n,
    'img' || n,
    'user',
    ('user' || n)::bytea,
    'IMAGE',
    now(), now(), now()
FROM generate_series(1, :total_asset_count) n;
-- asset_exif
INSERT INTO asset_exif ("assetId", "fileSizeInByte") SELECT asset.id, 1 FROM asset JOIN "user" ON "user".id = asset."ownerId" WHERE email = :'user_email';
EOF
)

psql_cmd() {
  docker exec -i "$db_container" psql --tuples-only -U postgres -d immich "$@"
}

create_dataset() {
  echo "[*] create dataset"
  psql_cmd -v user_email="$user_email" -v user_password_hash="$user_password_hash" -v api_key_hash="$api_key_hash" \
    -v total_asset_count="$total_asset_count" <<<"$query_create_dataset"
}

gen_asset_json() {
  echo "[*] generate json file with asset IDs"
  asset_file="assets.${api_asset_count}.json"
  query_asset_csv=$(cat <<'EOF'
    SELECT '{"assetIds": [' || string_agg('"' || id::text || '"', ', ') || ']}' 
    FROM (SELECT asset.id FROM asset JOIN "user" ON "user".id = asset."ownerId" WHERE email = :'user_email' LIMIT (:api_asset_count)) t
EOF
  )
  psql_cmd -Aq -v api_asset_count="$api_asset_count" -v user_email="$user_email" <<<"$query_asset_csv" >"$asset_file"
}

call_api_getDownloadInfo() {
  echo "[*] call api: getDownloadInfo with $api_asset_count IDs"
  local url="$api_url/download/info"
  <"$asset_file" docker exec -i $immich_container \
    curl -sSL -X POST --json @- -H "x-api-key: $api_key" "$url" | cut -c-5000
}

create_dataset
gen_asset_json
call_api_getDownloadInfo
```
</details>

Save and run it as `bash api.sh`.
Script output:
```
[*] create dataset
<...>
[*] generate json file with asset IDs
[*] call api: getDownloadInfo with 140000 IDs
{"message":"Not found or no asset.download access","error":"Bad Request","statusCode":400,"correlationId":"w9nj6hew"}
```
Immich log:
```
  DEBUG [Api:LoggingInterceptor~w9nj6hew] POST /api/download/info 201 1215.22ms ::ffff:127.0.0.1
VERBOSE [Api:LoggingInterceptor~w9nj6hew] {"assetIds":["fb4d6087-4f3a-49a5-8b8e-a7216483d032","20bfb990-9e8b-4010-ab6e-9a85cfdc518f",<...>,"98e3fea9-85c0-4b47-bd73-633c3947db80","...and 139900 more"]}
  DEBUG [Api:GlobalExceptionFilter~w9nj6hew] HttpException(400): {"message":"Not found or no asset.download access","error":"Bad Request","statusCode":400}
```

**Upon applying the fix:** the api call is successful; getDownloadInfo returns `{"totalSize":140000,"archives":[{"size":140000,"assetIds":["4650957e-4e65-4627-87c6-8a6c80d47668",<...>`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
It was used to understand existing code and explore options to fix it.
