### PR TITLE
fix(docs): link to immich docs does not lead correctly to docs

### DIFF
--- a/web/src/lib/modals/HelpAndFeedbackModal.svelte
+++ b/web/src/lib/modals/HelpAndFeedbackModal.svelte
@@ -18,7 +18,7 @@
     <p>{$t('official_immich_resources')}</p>
     <div class="flex flex-col sm:grid sm:grid-cols-2 gap-2 mt-5">
       <div>
-        <a href="https://{info.version}.archive.docs.immich.app/overview/introduction" target="_blank" rel="noreferrer">
+        <a href="https://docs.{info.version}.archive.immich.app/overview/introduction" target="_blank" rel="noreferrer">
           <Icon icon={mdiInformationOutline} size="1.5em" class="inline-block" />
           <p class="font-medium text-primary text-sm underline inline-block" id="documentation-label">
             {$t('documentation')}


### PR DESCRIPTION
## Description
Fixes #22686

## How Has This Been Tested?
Not tested since this seems a relatively small fix.
Let me know if this should be manually tested.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
N/A
