### PR TITLE
fix: ios skip posting hash response after detached from engine

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -131,10 +131,13 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		B231F52D2E93A44A00BC45D1 /* Core */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Core;
+			sourceTree = "<group>";
+		};
 		B2CF7F8C2DDE4EBB00744BF6 /* Sync */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Sync;
 			sourceTree = "<group>";
 		};
@@ -247,6 +250,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				B231F52D2E93A44A00BC45D1 /* Core */,
 				B25D37792E72CA15008B6CA7 /* Connectivity */,
 				B21E34A62E5AF9760031FDB9 /* Background */,
 				B2CF7F8C2DDE4EBB00744BF6 /* Sync */,
@@ -331,6 +335,7 @@
 				F0B57D482DF764BE00DC5BCC /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				B231F52D2E93A44A00BC45D1 /* Core */,
 				B2CF7F8C2DDE4EBB00744BF6 /* Sync */,
 			);
 			name = Runner;
@@ -521,9 +526,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -553,9 +562,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -20,7 +20,7 @@ import UIKit
 
     GeneratedPluginRegistrant.register(with: self)
     let controller: FlutterViewController = window?.rootViewController as! FlutterViewController
-    AppDelegate.registerPlugins(binaryMessenger: controller.binaryMessenger)
+    AppDelegate.registerPlugins(with: controller.engine)
     BackgroundServicePlugin.register(with: self.registrar(forPlugin: "BackgroundServicePlugin")!)
 
     BackgroundServicePlugin.registerBackgroundProcessing()
@@ -51,9 +51,11 @@ import UIKit
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
   
-  public static func registerPlugins(binaryMessenger: FlutterBinaryMessenger) {
-    NativeSyncApiSetup.setUp(binaryMessenger: binaryMessenger, api: NativeSyncApiImpl())
-    ThumbnailApiSetup.setUp(binaryMessenger: binaryMessenger, api: ThumbnailApiImpl())
-    BackgroundWorkerFgHostApiSetup.setUp(binaryMessenger: binaryMessenger, api: BackgroundWorkerApiImpl())
+  public static func registerPlugins(with engine: FlutterEngine) {
+    if !engine.hasPlugin("NativeSyncApi") {
+      NativeSyncApiImpl.register(with: engine.registrar(forPlugin: "NativeSyncApi")!)
+    }
+    ThumbnailApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: ThumbnailApiImpl())
+    BackgroundWorkerFgHostApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: BackgroundWorkerApiImpl())
   }
 }

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -56,4 +56,8 @@ import UIKit
     ThumbnailApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: ThumbnailApiImpl())
     BackgroundWorkerFgHostApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: BackgroundWorkerApiImpl())
   }
+  
+  public static func cancelPlugins(with engine: FlutterEngine) {
+    (engine.valuePublished(byPlugin: NativeSyncApiImpl.name) as? NativeSyncApiImpl)?.detachFromEngine()
+  }
 }

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -52,9 +52,7 @@ import UIKit
   }
   
   public static func registerPlugins(with engine: FlutterEngine) {
-    if !engine.hasPlugin("NativeSyncApi") {
-      NativeSyncApiImpl.register(with: engine.registrar(forPlugin: "NativeSyncApi")!)
-    }
+    NativeSyncApiImpl.register(with: engine.registrar(forPlugin: NativeSyncApiImpl.name)!)
     ThumbnailApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: ThumbnailApiImpl())
     BackgroundWorkerFgHostApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: BackgroundWorkerApiImpl())
   }

--- a/mobile/ios/Runner/Background/BackgroundWorker.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.swift
@@ -95,7 +95,7 @@ class BackgroundWorker: BackgroundWorkerBgHostApi {
     // Register plugins in the new engine
     GeneratedPluginRegistrant.register(with: engine)
     // Register custom plugins
-    AppDelegate.registerPlugins(binaryMessenger: engine.binaryMessenger)
+    AppDelegate.registerPlugins(with: engine)
     flutterApi = BackgroundWorkerFlutterApi(binaryMessenger: engine.binaryMessenger)
     BackgroundWorkerBgHostApiSetup.setUp(binaryMessenger: engine.binaryMessenger, api: self)
     

--- a/mobile/ios/Runner/Background/BackgroundWorker.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.swift
@@ -168,6 +168,7 @@ class BackgroundWorker: BackgroundWorkerBgHostApi {
     }
     
     isComplete = true
+    AppDelegate.cancelPlugins(with: engine)
     engine.destroyContext()
     flutterApi = nil
     completionHandler(success)

--- a/mobile/ios/Runner/Core/ImmichPlugin.swift
+++ b/mobile/ios/Runner/Core/ImmichPlugin.swift
@@ -1,0 +1,17 @@
+class ImmichPlugin: NSObject {
+  var detached: Bool
+  
+  override init() {
+    detached = false
+    super.init()
+  }
+  
+  func detachFromEngine() {
+    self.detached = true
+  }
+  
+  func completeWhenActive<T>(for completion: @escaping (T) -> Void, with value: T) {
+    guard !self.detached else { return }
+    completion(value)
+  }
+}

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -33,7 +33,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
   private let albumTypes: [PHAssetCollectionType] = [.album, .smartAlbum]
   private let recoveredAlbumSubType = 1000000219
   
-  private var hashTask: Task<Void, Error>?
+  private var hashTask: Task<Void?, Error>?
   private static let hashCancelledCode = "HASH_CANCELLED"
   private static let hashCancelled = Result<[HashResult], Error>.failure(PigeonError(code: hashCancelledCode, message: "Hashing cancelled", details: nil))
   
@@ -282,8 +282,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
       }
       
       if Task.isCancelled {
-        self?.completeWhenActive(for: completion, with: Self.hashCancelled)
-        return
+        return self?.completeWhenActive(for: completion, with: Self.hashCancelled)
       }
       
       await withTaskGroup(of: HashResult?.self) { taskGroup in
@@ -291,8 +290,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
         results.reserveCapacity(assets.count)
         for asset in assets {
           if Task.isCancelled {
-            self?.completeWhenActive(for: completion, with: Self.hashCancelled)
-            return
+            return self?.completeWhenActive(for: completion, with: Self.hashCancelled)
           }
           taskGroup.addTask {
             guard let self = self else { return nil }
@@ -302,8 +300,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
         
         for await result in taskGroup {
           guard let result = result else {
-            self?.completeWhenActive(for: completion, with: Self.hashCancelled)
-            return
+            return self?.completeWhenActive(for: completion, with: Self.hashCancelled)
           }
           results.append(result)
         }
@@ -312,8 +309,7 @@ class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
           results.append(HashResult(assetId: missing, error: "Asset not found in library", hash: nil))
         }
         
-        self?.completeWhenActive(for: completion, with: .success(results))
-        return
+        return self?.completeWhenActive(for: completion, with: .success(results))
       }
     }
   }

--- a/mobile/ios/Runner/Sync/MessagesImpl.swift
+++ b/mobile/ios/Runner/Sync/MessagesImpl.swift
@@ -18,6 +18,8 @@ struct AssetWrapper: Hashable, Equatable {
 }
 
 class NativeSyncApiImpl: ImmichPlugin, NativeSyncApi, FlutterPlugin {
+  static let name = "NativeSyncApi"
+  
   static func register(with registrar: any FlutterPluginRegistrar) {
     let instance = NativeSyncApiImpl()
     NativeSyncApiSetup.setUp(binaryMessenger: registrar.messenger(), api: instance)

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -192,6 +192,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       _cancellationToken.cancel();
       _logger.info("Cleaning up background worker");
       final cleanupFutures = [
+        nativeSyncApi?.cancelHashing(),
         workerManager.dispose().catchError((_) async {
           // Discard any errors on the dispose call
           return;
@@ -201,7 +202,6 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
         _drift.close(),
         _driftLogger.close(),
         backgroundSyncManager?.cancel(),
-        nativeSyncApi?.cancelHashing(),
       ];
 
       if (_isar.isOpen) {


### PR DESCRIPTION
## Description

The NativeSyncApi class now extends `FlutterPlugin` to receive detached callbacks when the background engine is destroyed to stop ourself from sending responses back to the now dead background engine

## How has this been tested

Confirmed that the `detachFromEngine` method is called when the background engine's context is destroyed