### PR TITLE
fix: Fix issue fail to download iOS live photos

### DIFF
--- a/mobile/lib/repositories/download.repository.dart
+++ b/mobile/lib/repositories/download.repository.dart
@@ -88,6 +88,7 @@ class DownloadRepository {
       final id = asset.id;
       final livePhotoVideoId = asset.livePhotoVideoId;
       final isVideo = asset.isVideo;
+      final url = getOriginalUrlForRemoteId(id);
 
       // on iOS it cannot link the image, check if the filename has .MP extension
       // to avoid downloading the video part
@@ -96,7 +97,7 @@ class DownloadRepository {
       if (Platform.isAndroid || livePhotoVideoId == null || isVideo || isAndroidMotionPhoto) {
         tasks[taskIndex++] = DownloadTask(
           taskId: id,
-          url: getOriginalUrlForRemoteId(id),
+          url: url,
           headers: headers,
           filename: asset.name,
           updates: Updates.statusAndProgress,
@@ -109,7 +110,7 @@ class DownloadRepository {
       _dummyMetadata['id'] = id;
       tasks[taskIndex++] = DownloadTask(
         taskId: id,
-        url: getOriginalUrlForRemoteId(id),
+        url: url,
         headers: headers,
         filename: asset.name,
         updates: Updates.statusAndProgress,

--- a/mobile/lib/repositories/download.repository.dart
+++ b/mobile/lib/repositories/download.repository.dart
@@ -88,7 +88,6 @@ class DownloadRepository {
       final id = asset.id;
       final livePhotoVideoId = asset.livePhotoVideoId;
       final isVideo = asset.isVideo;
-      final url = getOriginalUrlForRemoteId(id);
 
       // on iOS it cannot link the image, check if the filename has .MP extension
       // to avoid downloading the video part
@@ -97,7 +96,7 @@ class DownloadRepository {
       if (Platform.isAndroid || livePhotoVideoId == null || isVideo || isAndroidMotionPhoto) {
         tasks[taskIndex++] = DownloadTask(
           taskId: id,
-          url: url,
+          url: getOriginalUrlForRemoteId(id),
           headers: headers,
           filename: asset.name,
           updates: Updates.statusAndProgress,
@@ -110,7 +109,7 @@ class DownloadRepository {
       _dummyMetadata['id'] = id;
       tasks[taskIndex++] = DownloadTask(
         taskId: id,
-        url: url,
+        url: getOriginalUrlForRemoteId(id),
         headers: headers,
         filename: asset.name,
         updates: Updates.statusAndProgress,
@@ -121,7 +120,7 @@ class DownloadRepository {
       _dummyMetadata['part'] = LivePhotosPart.video.index;
       tasks[taskIndex++] = DownloadTask(
         taskId: livePhotoVideoId,
-        url: url,
+        url: getOriginalUrlForRemoteId(livePhotoVideoId),
         headers: headers,
         filename: asset.name.toUpperCase().replaceAll(RegExp(r"\.(JPG|HEIC)$"), '.MOV'),
         updates: Updates.statusAndProgress,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fixed the issue where the URL of the photo part was mistakenly used to download the video part when downloading iOS Live Photos. This caused the video part to fail decoding and prevented it from being saved to the photo library.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #22651 #20506 #22030 #22354 #22481 #15805 
## How Has This Been Tested?

Just tested downloading a Live Photo that didn’t exist in the device’s photo library. The Live Photo was successfully downloaded, and the Live functionality works correctly.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
