### PR TITLE
chore: use hosted isar flutter libs

### DIFF
--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -64,7 +64,7 @@ PODS:
     - Flutter
   - integration_test (0.0.1):
     - Flutter
-  - isar_flutter_libs (1.0.0):
+  - isar_community_flutter_libs (1.0.0):
     - Flutter
   - local_auth_darwin (0.0.1):
     - Flutter
@@ -149,7 +149,7 @@ DEPENDENCIES:
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - isar_flutter_libs (from `.symlinks/plugins/isar_flutter_libs/ios`)
+  - isar_community_flutter_libs (from `.symlinks/plugins/isar_community_flutter_libs/ios`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - maplibre_gl (from `.symlinks/plugins/maplibre_gl/ios`)
   - native_video_player (from `.symlinks/plugins/native_video_player/ios`)
@@ -210,8 +210,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
-  isar_flutter_libs:
-    :path: ".symlinks/plugins/isar_flutter_libs/ios"
+  isar_community_flutter_libs:
+    :path: ".symlinks/plugins/isar_community_flutter_libs/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   maplibre_gl:
@@ -264,7 +264,7 @@ SPEC CHECKSUMS:
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  isar_flutter_libs: bc909e72c3d756c2759f14c8776c13b5b0556e26
+  isar_community_flutter_libs: bede843185a61a05ff364a05c9b23209523f7e0d
   local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
   MapLibre: 69e572367f4ef6287e18246cfafc39c80cdcabcd
   maplibre_gl: 3c924e44725147b03dda33430ad216005b40555f

--- a/mobile/lib/entities/album.entity.g.dart
+++ b/mobile/lib/entities/album.entity.g.dart
@@ -132,7 +132,7 @@ const AlbumSchema = CollectionSchema(
   getId: _albumGetId,
   getLinks: _albumGetLinks,
   attach: _albumAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _albumEstimateSize(

--- a/mobile/lib/entities/android_device_asset.entity.g.dart
+++ b/mobile/lib/entities/android_device_asset.entity.g.dart
@@ -47,7 +47,7 @@ const AndroidDeviceAssetSchema = CollectionSchema(
   getId: _androidDeviceAssetGetId,
   getLinks: _androidDeviceAssetGetLinks,
   attach: _androidDeviceAssetAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _androidDeviceAssetEstimateSize(

--- a/mobile/lib/entities/asset.entity.g.dart
+++ b/mobile/lib/entities/asset.entity.g.dart
@@ -168,7 +168,7 @@ const AssetSchema = CollectionSchema(
   getId: _assetGetId,
   getLinks: _assetGetLinks,
   attach: _assetAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _assetEstimateSize(

--- a/mobile/lib/entities/backup_album.entity.g.dart
+++ b/mobile/lib/entities/backup_album.entity.g.dart
@@ -43,7 +43,7 @@ const BackupAlbumSchema = CollectionSchema(
   getId: _backupAlbumGetId,
   getLinks: _backupAlbumGetLinks,
   attach: _backupAlbumAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _backupAlbumEstimateSize(

--- a/mobile/lib/entities/duplicated_asset.entity.g.dart
+++ b/mobile/lib/entities/duplicated_asset.entity.g.dart
@@ -32,7 +32,7 @@ const DuplicatedAssetSchema = CollectionSchema(
   getId: _duplicatedAssetGetId,
   getLinks: _duplicatedAssetGetLinks,
   attach: _duplicatedAssetAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _duplicatedAssetEstimateSize(

--- a/mobile/lib/entities/etag.entity.g.dart
+++ b/mobile/lib/entities/etag.entity.g.dart
@@ -52,7 +52,7 @@ const ETagSchema = CollectionSchema(
   getId: _eTagGetId,
   getLinks: _eTagGetLinks,
   attach: _eTagAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _eTagEstimateSize(

--- a/mobile/lib/entities/ios_device_asset.entity.g.dart
+++ b/mobile/lib/entities/ios_device_asset.entity.g.dart
@@ -60,7 +60,7 @@ const IOSDeviceAssetSchema = CollectionSchema(
   getId: _iOSDeviceAssetGetId,
   getLinks: _iOSDeviceAssetGetLinks,
   attach: _iOSDeviceAssetAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _iOSDeviceAssetEstimateSize(

--- a/mobile/lib/infrastructure/entities/device_asset.entity.g.dart
+++ b/mobile/lib/infrastructure/entities/device_asset.entity.g.dart
@@ -65,7 +65,7 @@ const DeviceAssetEntitySchema = CollectionSchema(
   getId: _deviceAssetEntityGetId,
   getLinks: _deviceAssetEntityGetLinks,
   attach: _deviceAssetEntityAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _deviceAssetEntityEstimateSize(

--- a/mobile/lib/infrastructure/entities/exif.entity.g.dart
+++ b/mobile/lib/infrastructure/entities/exif.entity.g.dart
@@ -68,7 +68,7 @@ const ExifInfoSchema = CollectionSchema(
   getId: _exifInfoGetId,
   getLinks: _exifInfoGetLinks,
   attach: _exifInfoAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _exifInfoEstimateSize(

--- a/mobile/lib/infrastructure/entities/store.entity.g.dart
+++ b/mobile/lib/infrastructure/entities/store.entity.g.dart
@@ -37,7 +37,7 @@ const StoreValueSchema = CollectionSchema(
   getId: _storeValueGetId,
   getLinks: _storeValueGetLinks,
   attach: _storeValueAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _storeValueEstimateSize(

--- a/mobile/lib/infrastructure/entities/user.entity.g.dart
+++ b/mobile/lib/infrastructure/entities/user.entity.g.dart
@@ -95,7 +95,7 @@ const UserSchema = CollectionSchema(
   getId: _userGetId,
   getLinks: _userGetLinks,
   attach: _userAttach,
-  version: '3.1.8',
+  version: '3.3.0-dev.3',
 );
 
 int _userEstimateSize(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -317,10 +317,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -1023,26 +1023,33 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/isar"
-      ref: "3561848fe7f5811743b880ddd96bb18dede27306"
-      resolved-ref: "3561848fe7f5811743b880ddd96bb18dede27306"
+      ref: bb1dca40fe87a001122e5d43bc6254718cb49f3a
+      resolved-ref: bb1dca40fe87a001122e5d43bc6254718cb49f3a
       url: "https://github.com/immich-app/isar"
     source: git
     version: "3.1.8"
-  isar_flutter_libs:
+  isar_community:
+    dependency: transitive
+    description:
+      name: isar_community
+      sha256: "28f59e54636c45ba0bb1b3b7f2656f1c50325f740cea6efcd101900be3fba546"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0-dev.3"
+  isar_community_flutter_libs:
     dependency: "direct main"
     description:
-      path: "packages/isar_flutter_libs"
-      ref: "3561848fe7f5811743b880ddd96bb18dede27306"
-      resolved-ref: "3561848fe7f5811743b880ddd96bb18dede27306"
-      url: "https://github.com/immich-app/isar"
-    source: git
-    version: "3.1.8"
+      name: isar_community_flutter_libs
+      sha256: c2934fe755bb3181cb67602fd5df0d080b3d3eb52799f98623aa4fc5acbea010
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0-dev.3"
   isar_generator:
     dependency: "direct dev"
     description:
       path: "packages/isar_generator"
-      ref: "3561848fe7f5811743b880ddd96bb18dede27306"
-      resolved-ref: "3561848fe7f5811743b880ddd96bb18dede27306"
+      ref: bb1dca40fe87a001122e5d43bc6254718cb49f3a
+      resolved-ref: bb1dca40fe87a001122e5d43bc6254718cb49f3a
       url: "https://github.com/immich-app/isar"
     source: git
     version: "3.1.8"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   cancellation_token_http: ^2.1.0
   cast: ^2.1.0
   collection: ^1.18.0
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^6.1.3
   crop_image: ^1.0.16
   crypto: ^3.0.6
   device_info_plus: ^12.0.0
@@ -81,13 +81,9 @@ dependencies:
   isar:
     git:
       url: https://github.com/immich-app/isar
-      ref: '3561848fe7f5811743b880ddd96bb18dede27306'
+      ref: 'bb1dca40fe87a001122e5d43bc6254718cb49f3a'
       path: packages/isar/
-  isar_flutter_libs:
-    git:
-      url: https://github.com/immich-app/isar
-      ref: '3561848fe7f5811743b880ddd96bb18dede27306'
-      path: packages/isar_flutter_libs/
+  isar_community_flutter_libs: 3.3.0-dev.3
   # DB
   drift: ^2.23.1
   drift_flutter: ^0.2.4
@@ -103,7 +99,7 @@ dev_dependencies:
   isar_generator:
     git:
       url: https://github.com/immich-app/isar
-      ref: '3561848fe7f5811743b880ddd96bb18dede27306'
+      ref: 'bb1dca40fe87a001122e5d43bc6254718cb49f3a'
       path: packages/isar_generator/
   integration_test:
     sdk: flutter


### PR DESCRIPTION
## Description

Isar core was not initializing properly with isar_flutter_libs from a git reference. Updated it to use the hosted community libs instead. Verified this by confirming that the app builds and runs properly on the Android emulator and the iOS Simulator