### PR TITLE
feat(mobile): display error on app init fail

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:immich_mobile/theme/theme_data.dart';
 import 'package:immich_mobile/utils/bootstrap.dart';
 import 'package:immich_mobile/utils/cache/widgets_binding.dart';
 import 'package:immich_mobile/utils/debug_print.dart';
+import 'package:immich_mobile/utils/http_ssl_options.dart';
 import 'package:immich_mobile/utils/licenses.dart';
 import 'package:immich_mobile/utils/migration.dart';
 import 'package:immich_mobile/pages/common/error_display_screen.dart';
@@ -55,6 +56,7 @@ void main() async {
     // Warm-up isolate pool for worker manager
     await workerManager.init(dynamicSpawning: true);
     await migrateDatabaseIfNeeded(isar, drift);
+    HttpSSLOptions.apply();
 
     runApp(
       ProviderScope(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -80,10 +80,6 @@ void main() async {
           stackTrace: stackTrace.toString(),
         ),
         debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          brightness: Brightness.dark,
-          primarySwatch: Colors.red,
-        ),
       ),
     );
   }

--- a/mobile/lib/pages/common/error_display_screen.dart
+++ b/mobile/lib/pages/common/error_display_screen.dart
@@ -16,6 +16,8 @@ class ErrorDisplayScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    
     return Scaffold(
       body: Center(
         child: Padding(
@@ -37,13 +39,13 @@ class ErrorDisplayScreen extends StatelessWidget {
                     child: Container(
                       width: 24,
                       height: 24,
-                      decoration: const BoxDecoration(
-                        color: Colors.red,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.error,
                         shape: BoxShape.circle,
                       ),
-                      child: const Icon(
+                      child: Icon(
                         Icons.error,
-                        color: Colors.white,
+                        color: theme.colorScheme.onError,
                         size: 16,
                       ),
                     ),
@@ -53,22 +55,22 @@ class ErrorDisplayScreen extends StatelessWidget {
               const SizedBox(height: 24),
               
               // Error title
-              const Text(
+              Text(
                 'Initialization Failed',
                 style: TextStyle(
-                  color: Colors.white,
                   fontSize: 28,
                   fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.onSurface,
                 ),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
               
               // Error message
-              const Text(
+              Text(
                 'Failed to start due to an error during initialization.',
                 style: TextStyle(
-                  color: Colors.grey,
+                  color: theme.colorScheme.onSurfaceVariant,
                   fontSize: 16,
                 ),
                 textAlign: TextAlign.center,
@@ -80,9 +82,9 @@ class ErrorDisplayScreen extends StatelessWidget {
                 width: double.infinity,
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.grey[900],
+                  color: theme.colorScheme.surfaceContainer,
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+                  border: Border.all(color: theme.colorScheme.error),
                 ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -90,44 +92,38 @@ class ErrorDisplayScreen extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
+                        Text(
                           'Error Details:',
                           style: TextStyle(
-                            color: Colors.red,
+                            color: theme.colorScheme.error,
                             fontSize: 14,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
                         IconButton(
                           onPressed: () async {
+                            String errorDetails;
                             try {
                               final packageInfo = await PackageInfo.fromPlatform();
                               final appVersion = '${packageInfo.version} build.${packageInfo.buildNumber}';
-                              final errorDetails = 'App Version: $appVersion\n\nError: $error\n\nStack Trace:\n$stackTrace';
-                              Clipboard.setData(ClipboardData(text: errorDetails)).then((_) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Error details copied to clipboard'),
-                                    backgroundColor: Colors.green,
-                                  ),
-                                );
-                              });
+                              errorDetails = 'App Version: $appVersion\n\nError: $error\n\nStack Trace:\n$stackTrace';
                             } catch (e) {
                               // Fallback if package info fails
-                              final errorDetails = 'Error: $error\n\nStack Trace:\n$stackTrace';
-                              Clipboard.setData(ClipboardData(text: errorDetails)).then((_) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('Error details copied to clipboard'),
-                                    backgroundColor: Colors.green,
-                                  ),
-                                );
-                              });
+                              errorDetails = 'Error: $error\n\nStack Trace:\n$stackTrace';
                             }
+
+                            Clipboard.setData(ClipboardData(text: errorDetails)).then((_) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: const Text('Error details copied to clipboard'),
+                                  backgroundColor: theme.colorScheme.primary,
+                                ),
+                              );
+                            });
                           },
-                          icon: const Icon(
+                          icon: Icon(
                             Icons.copy,
-                            color: Colors.grey,
+                            color: theme.colorScheme.onSurfaceVariant,
                             size: 18,
                           ),
                           padding: EdgeInsets.zero,
@@ -138,35 +134,37 @@ class ErrorDisplayScreen extends StatelessWidget {
                     const SizedBox(height: 8),
                     Text(
                       error,
-                      style: const TextStyle(
-                        color: Colors.white,
+                      style: TextStyle(
+                        color: theme.colorScheme.onSurface,
                         fontSize: 12,
                         fontFamily: 'monospace',
                       ),
                     ),
                     const SizedBox(height: 16),
                     ExpansionTile(
-                      title: const Text(
+                      title: Text(
                         'Stack Trace',
                         style: TextStyle(
-                          color: Colors.orange,
+                          color: theme.colorScheme.tertiary,
                           fontSize: 12,
                         ),
                       ),
                       tilePadding: EdgeInsets.zero,
+                      iconColor: theme.colorScheme.onSurfaceVariant,
+                      collapsedIconColor: theme.colorScheme.onSurfaceVariant,
                       children: [
                         Container(
                           width: double.infinity,
                           padding: const EdgeInsets.all(8),
                           decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.5),
+                            color: theme.colorScheme.surfaceContainerHighest,
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: SingleChildScrollView(
                             child: Text(
                               stackTrace,
-                              style: const TextStyle(
-                                color: Colors.white,
+                              style: TextStyle(
+                                color: theme.colorScheme.onSurface,
                                 fontSize: 10,
                                 fontFamily: 'monospace',
                               ),
@@ -188,11 +186,11 @@ class ErrorDisplayScreen extends StatelessWidget {
                     exit(0);
                   }
                 },
-                icon: const Icon(Icons.refresh),
-                label: const Text('Restart App'),
+                icon: const Icon(Icons.close),
+                label: const Text('Close App'),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.red,
-                  foregroundColor: Colors.white,
+                  backgroundColor: theme.colorScheme.error,
+                  foregroundColor: theme.colorScheme.onError,
                   padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
                 ),
               ),

--- a/mobile/lib/pages/common/error_display_screen.dart
+++ b/mobile/lib/pages/common/error_display_screen.dart
@@ -1,0 +1,205 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class ErrorDisplayScreen extends StatelessWidget {
+  final String error;
+  final String stackTrace;
+
+  const ErrorDisplayScreen({
+    super.key,
+    required this.error,
+    required this.stackTrace,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // App logo with error indicator
+              Stack(
+                children: [
+                  Image.asset(
+                    'assets/immich-logo.png',
+                    width: 80,
+                    height: 80,
+                  ),
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: Container(
+                      width: 24,
+                      height: 24,
+                      decoration: const BoxDecoration(
+                        color: Colors.red,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.error,
+                        color: Colors.white,
+                        size: 16,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              
+              // Error title
+              const Text(
+                'Initialization Failed',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 28,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              
+              // Error message
+              const Text(
+                'Failed to start due to an error during initialization.',
+                style: TextStyle(
+                  color: Colors.grey,
+                  fontSize: 16,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              
+              // Expandable error details
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Colors.grey[900],
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          'Error Details:',
+                          style: TextStyle(
+                            color: Colors.red,
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        IconButton(
+                          onPressed: () async {
+                            try {
+                              final packageInfo = await PackageInfo.fromPlatform();
+                              final appVersion = '${packageInfo.version} build.${packageInfo.buildNumber}';
+                              final errorDetails = 'App Version: $appVersion\n\nError: $error\n\nStack Trace:\n$stackTrace';
+                              Clipboard.setData(ClipboardData(text: errorDetails)).then((_) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Error details copied to clipboard'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              });
+                            } catch (e) {
+                              // Fallback if package info fails
+                              final errorDetails = 'Error: $error\n\nStack Trace:\n$stackTrace';
+                              Clipboard.setData(ClipboardData(text: errorDetails)).then((_) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Error details copied to clipboard'),
+                                    backgroundColor: Colors.green,
+                                  ),
+                                );
+                              });
+                            }
+                          },
+                          icon: const Icon(
+                            Icons.copy,
+                            color: Colors.grey,
+                            size: 18,
+                          ),
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints(),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      error,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    ExpansionTile(
+                      title: const Text(
+                        'Stack Trace',
+                        style: TextStyle(
+                          color: Colors.orange,
+                          fontSize: 12,
+                        ),
+                      ),
+                      tilePadding: EdgeInsets.zero,
+                      children: [
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: SingleChildScrollView(
+                            child: Text(
+                              stackTrace,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                                fontFamily: 'monospace',
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+              
+              // Restart button
+              ElevatedButton.icon(
+                onPressed: () {
+                  // Attempt to restart the app
+                  if (Platform.isAndroid || Platform.isIOS) {
+                    exit(0);
+                  }
+                },
+                icon: const Icon(Icons.refresh),
+                label: const Text('Restart App'),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

Before this change, the application, in case of error, was silently failing.

In my case, the missing `IsarCore` library caused the app to be constantly restarted (result = stuck at the Immich logo forever) without any message on screen or on the console.

This fixes a similar behavior like #1815 and #2005 - in that case the user was not able to report an additional information due to the missing error handling. Ironically, in that case the cause of failure was the same as mine - but it wasn't immediately clear to me (actually, it took me several hours to debug) on what was causing it.

With this PR, we now have a proper error handling in case of init failures.

TL;DR: 

<p align="center">
<img height="800" alt="image" src="https://github.com/user-attachments/assets/ef702f25-0eab-4f29-8eb5-2f983403a421" />
</p>


## How Has This Been Tested?

Runned the app in debug mode on my device.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<p align="center">
<img height="800" alt="image" src="https://github.com/user-attachments/assets/ef702f25-0eab-4f29-8eb5-2f983403a421" />
</p>

</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Pretty much all done with [Z.AI's GLM-4.6](https://z.ai/blog/glm-4.6) - minor corrections here and there.