### PR TITLE
fix(web): prevent photo-only memories showing mute button

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -403,16 +403,18 @@
           </p>
         </div>
 
-        <div class="w-[50px] dark">
-          <IconButton
-            shape="round"
-            variant="ghost"
-            color="secondary"
-            aria-label={$videoViewerMuted ? $t('unmute_memories') : $t('mute_memories')}
-            icon={$videoViewerMuted ? mdiVolumeOff : mdiVolumeHigh}
-            onclick={() => ($videoViewerMuted = !$videoViewerMuted)}
-          />
-        </div>
+        {#if currentTimelineAssets.some(({ isVideo }) => isVideo)}
+          <div class="w-[50px] dark">
+            <IconButton
+              shape="round"
+              variant="ghost"
+              color="secondary"
+              aria-label={$videoViewerMuted ? $t('unmute_memories') : $t('mute_memories')}
+              icon={$videoViewerMuted ? mdiVolumeOff : mdiVolumeHigh}
+              onclick={() => ($videoViewerMuted = !$videoViewerMuted)}
+            />
+          </div>
+        {/if}
       </div>
     </ControlAppBar>
 


### PR DESCRIPTION
## Description

Currently, the mute button in the memories slideshow is always shown. This doesn't make sense when there aren't any videos. This commit changes the mute button to be only visible if a memory contains at least one video. Other memories aren't taken in consideration; if the current memory is photo-only, the mute button is hidden, and it reappears when viewing the next memory (that contains a video).

Fixes #21355

## How Has This Been Tested?

Not sure how to test this, except manually

- [x] Upload photos of today, 2 years ago. Upload at least one video and if you want, photos, dated today, 1 year ago. Regenerate memories (can be tricky) and verify the mute button is hidden on the 2 years ago memory, and shown on the 1 year ago memory.

<details><summary><h2>Screenshots</h2></summary>

with mute button, as memory contains video
<img width="1369" height="195" alt="image" src="https://github.com/user-attachments/assets/d7a23c61-6b2e-4f0f-94ad-5d6e332b6705" />

without mute button, as memory contains only photos
<img width="1369" height="195" alt="image" src="https://github.com/user-attachments/assets/34ba75e0-f83f-4539-ad4d-4ed9fb39164e" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
