### PR TITLE
fix: remove postgres exclude datasource match

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,6 @@
       ]
     },
     {
-      "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/immich-app/postgres"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
Apparently that's about where it used, not what type of thing it is :thinking:
