### PR TITLE
feat(server): Option to configure SMTPS transport

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -211,6 +211,7 @@
     "notification_email_ignore_certificate_errors_description": "Ignore TLS certificate validation errors (not recommended)",
     "notification_email_password_description": "Password to use when authenticating with the email server",
     "notification_email_port_description": "Port of the email server (e.g 25, 465, or 587)",
+    "notification_email_secure_description": "Use SMTPS (SMTP over TLS)",
     "notification_email_sent_test_email_button": "Send test email and save",
     "notification_email_setting_description": "Settings for sending email notifications",
     "notification_email_test_email": "Send test email",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -211,6 +211,7 @@
     "notification_email_ignore_certificate_errors_description": "Ignore TLS certificate validation errors (not recommended)",
     "notification_email_password_description": "Password to use when authenticating with the email server",
     "notification_email_port_description": "Port of the email server (e.g 25, 465, or 587)",
+    "notification_email_secure": "SMTPS",
     "notification_email_secure_description": "Use SMTPS (SMTP over TLS)",
     "notification_email_sent_test_email_button": "Send test email and save",
     "notification_email_setting_description": "Settings for sending email notifications",

--- a/mobile/openapi/lib/model/system_config_smtp_transport_dto.dart
+++ b/mobile/openapi/lib/model/system_config_smtp_transport_dto.dart
@@ -17,6 +17,7 @@ class SystemConfigSmtpTransportDto {
     required this.ignoreCert,
     required this.password,
     required this.port,
+    required this.secure,
     required this.username,
   });
 
@@ -30,6 +31,8 @@ class SystemConfigSmtpTransportDto {
   /// Maximum value: 65535
   num port;
 
+  bool secure;
+
   String username;
 
   @override
@@ -38,6 +41,7 @@ class SystemConfigSmtpTransportDto {
     other.ignoreCert == ignoreCert &&
     other.password == password &&
     other.port == port &&
+    other.secure == secure &&
     other.username == username;
 
   @override
@@ -47,10 +51,11 @@ class SystemConfigSmtpTransportDto {
     (ignoreCert.hashCode) +
     (password.hashCode) +
     (port.hashCode) +
+    (secure.hashCode) +
     (username.hashCode);
 
   @override
-  String toString() => 'SystemConfigSmtpTransportDto[host=$host, ignoreCert=$ignoreCert, password=$password, port=$port, username=$username]';
+  String toString() => 'SystemConfigSmtpTransportDto[host=$host, ignoreCert=$ignoreCert, password=$password, port=$port, secure=$secure, username=$username]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -58,6 +63,7 @@ class SystemConfigSmtpTransportDto {
       json[r'ignoreCert'] = this.ignoreCert;
       json[r'password'] = this.password;
       json[r'port'] = this.port;
+      json[r'secure'] = this.secure;
       json[r'username'] = this.username;
     return json;
   }
@@ -75,6 +81,7 @@ class SystemConfigSmtpTransportDto {
         ignoreCert: mapValueOfType<bool>(json, r'ignoreCert')!,
         password: mapValueOfType<String>(json, r'password')!,
         port: num.parse('${json[r'port']}'),
+        secure: mapValueOfType<bool>(json, r'secure')!,
         username: mapValueOfType<String>(json, r'username')!,
       );
     }
@@ -127,6 +134,7 @@ class SystemConfigSmtpTransportDto {
     'ignoreCert',
     'password',
     'port',
+    'secure',
     'username',
   };
 }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16726,6 +16726,9 @@
             "minimum": 0,
             "type": "number"
           },
+          "secure": {
+            "type": "boolean"
+          },
           "username": {
             "type": "string"
           }
@@ -16735,6 +16738,7 @@
           "ignoreCert",
           "password",
           "port",
+          "secure",
           "username"
         ],
         "type": "object"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -71,6 +71,7 @@ export type SystemConfigSmtpTransportDto = {
     ignoreCert: boolean;
     password: string;
     port: number;
+    secure: boolean;
     username: string;
 };
 export type SystemConfigSmtpDto = {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -159,6 +159,7 @@ export interface SystemConfig {
         ignoreCert: boolean;
         host: string;
         port: number;
+        secure: boolean;
         username: string;
         password: string;
       };
@@ -356,6 +357,7 @@ export const defaults = Object.freeze<SystemConfig>({
         ignoreCert: false,
         host: '',
         port: 587,
+        secure: false,
         username: '',
         password: '',
       },

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -463,6 +463,9 @@ class SystemConfigSmtpTransportDto {
   @Max(65_535)
   port!: number;
 
+  @ValidateBoolean()
+  secure!: boolean;
+
   @IsString()
   username!: string;
 

--- a/server/src/repositories/email.repository.ts
+++ b/server/src/repositories/email.repository.ts
@@ -23,6 +23,7 @@ export type SendEmailOptions = {
 export type SmtpOptions = {
   host: string;
   port?: number;
+  secure?: boolean;
   username?: string;
   password?: string;
   ignoreCert?: boolean;

--- a/server/src/services/notification-admin.service.spec.ts
+++ b/server/src/services/notification-admin.service.spec.ts
@@ -14,6 +14,7 @@ const smtpTransport = Object.freeze<SystemConfig>({
         ignoreCert: false,
         host: 'localhost',
         port: 587,
+        secure: false,
         username: 'test',
         password: 'test',
       },

--- a/server/src/services/notification.service.spec.ts
+++ b/server/src/services/notification.service.spec.ts
@@ -40,6 +40,7 @@ const configs = {
           ignoreCert: false,
           host: 'localhost',
           port: 587,
+          secure: false,
           username: 'test',
           password: 'test',
         },

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -197,6 +197,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
       transport: {
         host: '',
         port: 587,
+        secure: false,
         username: '',
         password: '',
         ignoreCert: false,

--- a/web/src/lib/components/admin-settings/NotificationSettings.svelte
+++ b/web/src/lib/components/admin-settings/NotificationSettings.svelte
@@ -110,16 +110,6 @@
             />
 
             <SettingInputField
-              inputType={SettingInputFieldType.BOOL}
-              required
-              label={$t('secure')}
-              description={$t('admin.notification_email_secure_description')}
-              disabled={disabled || !config.notifications.smtp.enabled}
-              bind:value={config.notifications.smtp.transport.secure}
-              isEdited={config.notifications.smtp.transport.secure !== savedConfig.notifications.smtp.transport.secure}
-            />
-
-            <SettingInputField
               inputType={SettingInputFieldType.TEXT}
               label={$t('username')}
               description={$t('admin.notification_email_username_description')}
@@ -137,6 +127,13 @@
               bind:value={config.notifications.smtp.transport.password}
               isEdited={config.notifications.smtp.transport.password !==
                 savedConfig.notifications.smtp.transport.password}
+            />
+
+            <SettingSwitch
+              title={$t('admin.notification_email_secure')}
+              subtitle={$t('admin.notification_email_secure_description')}
+              disabled={disabled || !config.notifications.smtp.enabled}
+              bind:checked={config.notifications.smtp.transport.secure}
             />
 
             <SettingSwitch

--- a/web/src/lib/components/admin-settings/NotificationSettings.svelte
+++ b/web/src/lib/components/admin-settings/NotificationSettings.svelte
@@ -45,6 +45,7 @@
           transport: {
             host: config.notifications.smtp.transport.host,
             port: config.notifications.smtp.transport.port,
+            secure: config.notifications.smtp.transport.secure,
             username: config.notifications.smtp.transport.username,
             password: config.notifications.smtp.transport.password,
             ignoreCert: config.notifications.smtp.transport.ignoreCert,
@@ -106,6 +107,16 @@
               disabled={disabled || !config.notifications.smtp.enabled}
               bind:value={config.notifications.smtp.transport.port}
               isEdited={config.notifications.smtp.transport.port !== savedConfig.notifications.smtp.transport.port}
+            />
+
+            <SettingInputField
+              inputType={SettingInputFieldType.BOOL}
+              required
+              label={$t('secure')}
+              description={$t('admin.notification_email_secure_description')}
+              disabled={disabled || !config.notifications.smtp.enabled}
+              bind:value={config.notifications.smtp.transport.secure}
+              isEdited={config.notifications.smtp.transport.secure !== savedConfig.notifications.smtp.transport.secure}
             />
 
             <SettingInputField


### PR DESCRIPTION
## Description

This commit adds a boolean option in the SMTP transport configuration to enable the so-called "secure" mode. What it does is use SMTP over TLS instead of relying on the more common STARTTLS option over plain SMTP.

Fixes #22832 22832


## How Has This Been Tested?
Unit tests are passing, configured the use of SMTPS, sent a test email and received it.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.

