### PR TITLE
feat(web): last session information in admin user management 

### DIFF
--- a/e2e/src/api/specs/user-admin.e2e-spec.ts
+++ b/e2e/src/api/specs/user-admin.e2e-spec.ts
@@ -3,6 +3,7 @@ import {
   createStack,
   deleteUserAdmin,
   getMyUser,
+  getSessions,
   getUserAdmin,
   getUserPreferencesAdmin,
   login,
@@ -59,6 +60,7 @@ describe('/admin/users', () => {
     });
 
     it('should hide deleted users by default', async () => {
+      const expectedSessions = await getSessions({ headers: asBearerAuth(admin.accessToken) });
       const { status, body } = await request(app)
         .get(`/admin/users`)
         .set('Authorization', `Bearer ${admin.accessToken}`);
@@ -71,8 +73,11 @@ describe('/admin/users', () => {
           expect.objectContaining({ email: userToDelete.userEmail }),
         ]),
       );
+
       expect(body.find((u: any) => u.id === admin.userId)?.latestSession).toBeDefined();
-      expect(body.find((u: any) => u.id === admin.userId)?.latestSession.updatedAt).toBeInstanceOf(Date);
+      expect(body.find((u: any) => u.id === admin.userId)?.latestSession.updatedAt).toEqual(
+        expectedSessions[0].updatedAt,
+      );
     });
 
     it('should include deleted users', async () => {

--- a/e2e/src/api/specs/user-admin.e2e-spec.ts
+++ b/e2e/src/api/specs/user-admin.e2e-spec.ts
@@ -71,6 +71,8 @@ describe('/admin/users', () => {
           expect.objectContaining({ email: userToDelete.userEmail }),
         ]),
       );
+      expect(body.find((u: any) => u.id === admin.userId)?.latestSession).toBeDefined();
+      expect(body.find((u: any) => u.id === admin.userId)?.latestSession.updatedAt).toBeInstanceOf(Date);
     });
 
     it('should include deleted users', async () => {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1210,6 +1210,7 @@
   "large_files": "Large Files",
   "last": "Last",
   "last_seen": "Last seen",
+  "last_session": "Last session",
   "latest_version": "Latest Version",
   "latitude": "Latitude",
   "leave": "Leave",

--- a/mobile/openapi/lib/model/user_admin_response_dto.dart
+++ b/mobile/openapi/lib/model/user_admin_response_dto.dart
@@ -19,6 +19,7 @@ class UserAdminResponseDto {
     required this.email,
     required this.id,
     required this.isAdmin,
+    this.latestSession,
     required this.license,
     required this.name,
     required this.oauthId,
@@ -43,6 +44,14 @@ class UserAdminResponseDto {
   String id;
 
   bool isAdmin;
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  SessionResponseDto? latestSession;
 
   UserLicense? license;
 
@@ -74,6 +83,7 @@ class UserAdminResponseDto {
     other.email == email &&
     other.id == id &&
     other.isAdmin == isAdmin &&
+    other.latestSession == latestSession &&
     other.license == license &&
     other.name == name &&
     other.oauthId == oauthId &&
@@ -95,6 +105,7 @@ class UserAdminResponseDto {
     (email.hashCode) +
     (id.hashCode) +
     (isAdmin.hashCode) +
+    (latestSession == null ? 0 : latestSession!.hashCode) +
     (license == null ? 0 : license!.hashCode) +
     (name.hashCode) +
     (oauthId.hashCode) +
@@ -108,7 +119,7 @@ class UserAdminResponseDto {
     (updatedAt.hashCode);
 
   @override
-  String toString() => 'UserAdminResponseDto[avatarColor=$avatarColor, createdAt=$createdAt, deletedAt=$deletedAt, email=$email, id=$id, isAdmin=$isAdmin, license=$license, name=$name, oauthId=$oauthId, profileChangedAt=$profileChangedAt, profileImagePath=$profileImagePath, quotaSizeInBytes=$quotaSizeInBytes, quotaUsageInBytes=$quotaUsageInBytes, shouldChangePassword=$shouldChangePassword, status=$status, storageLabel=$storageLabel, updatedAt=$updatedAt]';
+  String toString() => 'UserAdminResponseDto[avatarColor=$avatarColor, createdAt=$createdAt, deletedAt=$deletedAt, email=$email, id=$id, isAdmin=$isAdmin, latestSession=$latestSession, license=$license, name=$name, oauthId=$oauthId, profileChangedAt=$profileChangedAt, profileImagePath=$profileImagePath, quotaSizeInBytes=$quotaSizeInBytes, quotaUsageInBytes=$quotaUsageInBytes, shouldChangePassword=$shouldChangePassword, status=$status, storageLabel=$storageLabel, updatedAt=$updatedAt]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -122,6 +133,11 @@ class UserAdminResponseDto {
       json[r'email'] = this.email;
       json[r'id'] = this.id;
       json[r'isAdmin'] = this.isAdmin;
+    if (this.latestSession != null) {
+      json[r'latestSession'] = this.latestSession;
+    } else {
+    //  json[r'latestSession'] = null;
+    }
     if (this.license != null) {
       json[r'license'] = this.license;
     } else {
@@ -167,6 +183,7 @@ class UserAdminResponseDto {
         email: mapValueOfType<String>(json, r'email')!,
         id: mapValueOfType<String>(json, r'id')!,
         isAdmin: mapValueOfType<bool>(json, r'isAdmin')!,
+        latestSession: SessionResponseDto.fromJson(json[r'latestSession']),
         license: UserLicense.fromJson(json[r'license']),
         name: mapValueOfType<String>(json, r'name')!,
         oauthId: mapValueOfType<String>(json, r'oauthId')!,

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -17492,6 +17492,9 @@
           "isAdmin": {
             "type": "boolean"
           },
+          "latestSession": {
+            "$ref": "#/components/schemas/SessionResponseDto"
+          },
           "license": {
             "allOf": [
               {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -82,6 +82,16 @@ export type SystemConfigSmtpDto = {
 export type TestEmailResponseDto = {
     messageId: string;
 };
+export type SessionResponseDto = {
+    createdAt: string;
+    current: boolean;
+    deviceOS: string;
+    deviceType: string;
+    expiresAt?: string;
+    id: string;
+    isPendingSyncReset: boolean;
+    updatedAt: string;
+};
 export type UserLicense = {
     activatedAt: string;
     activationKey: string;
@@ -94,6 +104,7 @@ export type UserAdminResponseDto = {
     email: string;
     id: string;
     isAdmin: boolean;
+    latestSession?: SessionResponseDto;
     license: (UserLicense) | null;
     name: string;
     oauthId: string;
@@ -1185,16 +1196,6 @@ export type ServerVersionHistoryResponseDto = {
     createdAt: string;
     id: string;
     version: string;
-};
-export type SessionResponseDto = {
-    createdAt: string;
-    current: boolean;
-    deviceOS: string;
-    deviceType: string;
-    expiresAt?: string;
-    id: string;
-    isPendingSyncReset: boolean;
-    updatedAt: string;
 };
 export type SessionCreateDto = {
     deviceOS?: string;

--- a/server/src/dtos/user.dto.ts
+++ b/server/src/dtos/user.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsEmail, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 import { User, UserAdmin } from 'src/database';
+import { SessionResponseDto } from 'src/dtos/session.dto';
 import { UserAvatarColor, UserMetadataKey, UserStatus } from 'src/enum';
 import { UserMetadataItem } from 'src/types';
 import { Optional, PinCode, ValidateBoolean, ValidateEnum, ValidateUUID, toEmail, toSanitized } from 'src/validation';
@@ -166,6 +167,7 @@ export class UserAdminResponseDto extends UserResponseDto {
   @ValidateEnum({ enum: UserStatus, name: 'UserStatus' })
   status!: string;
   license!: UserLicense | null;
+  latestSession?: SessionResponseDto;
 }
 
 export function mapUserAdmin(entity: UserAdmin): UserAdminResponseDto {

--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -68,6 +68,19 @@ order by
   "session"."updatedAt" desc,
   "session"."createdAt" desc
 
+-- SessionRepository.getLatestByUserId
+select
+  "session".*
+from
+  "session"
+where
+  "session"."userId" = $1
+order by
+  "session"."updatedAt" desc,
+  "session"."createdAt" desc
+limit
+  $2
+
 -- SessionRepository.delete
 delete from "session"
 where

--- a/server/src/repositories/session.repository.ts
+++ b/server/src/repositories/session.repository.ts
@@ -83,6 +83,18 @@ export class SessionRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getLatestByUserId(userId: string) {
+    return this.db
+      .selectFrom('session')
+      .selectAll('session')
+      .where('session.userId', '=', userId)
+      .orderBy('session.updatedAt', 'desc')
+      .orderBy('session.createdAt', 'desc')
+      .limit(1)
+      .executeTakeFirst();
+  }
+
   create(dto: Insertable<SessionTable>) {
     return this.db.insertInto('session').values(dto).returningAll().executeTakeFirstOrThrow();
   }

--- a/server/src/services/user-admin.service.spec.ts
+++ b/server/src/services/user-admin.service.spec.ts
@@ -25,12 +25,14 @@ describe(UserAdminService.name, () => {
     it('should set latestSession for each user', async () => {
       const { user1, admin } = userStub;
       const users = [admin, user1];
-      // Session型にuserIdを含める
       const session = { ...factory.session(), userId: user1.id };
       mocks.user.getList.mockResolvedValue(users);
-      mocks.session.getLatestByUserId.mockImplementation(async (userId) => {
-        if (userId === user1.id) return session;
-        return undefined;
+      mocks.session.getLatestByUserId.mockImplementation((userId) => {
+        if (userId === user1.id) {
+          return Promise.resolve(session);
+        }
+        // eslint-disable-next-line unicorn/no-useless-undefined
+        return Promise.resolve(undefined);
       });
       const mapSessionSpy = vitest.spyOn(sessionDto, 'mapSession');
 


### PR DESCRIPTION
## Description
### Feature
- added session information into `admin/users` setting page
  - add "Last Session" Column
  - information : "session UpdatedAt datetime" (relative format) and "device type and device os"
    - note: `updateAt` is not be updated immediately, upon each access (ref. [codebase](https://github.com/immich-app/immich/blob/main/server/src/services/auth.service.ts#L473-L475))
  - show "-", if no session

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### API Changes (`GET /admin/users`)
- added `latestSession` field, if session exists

### Fixes # (issue)
- N/A

## How Has This Been Tested?
### Manually
- [x] never logged in user : session info is `-`
- [x] shows session info even if deleted user

### Unit Test
- added latestSesion test

### E2E Test
- added latestSesion test

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="934" height="530" alt="User_Management_-_Immich" src="https://github.com/user-attachments/assets/c033e303-21e1-4f02-a24d-d9831d6a2f78" />

<!-- Images go below this line. -->

</details>

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- server: mainly initial test implementation and more...
- web: initial implementation and more
...
