### PR TITLE
fix: back/forward navigation won't reset scroll in timeline

### DIFF
--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -107,7 +107,7 @@ export class StorageRepository {
     const file = await fs.open(filepath);
     try {
       const { buffer } = await file.read(options);
-      return buffer;
+      return buffer as Buffer;
     } finally {
       await file.close();
     }

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -139,6 +139,10 @@
       return;
     }
 
+    // Need to update window positions/intersections because <Portal> may have
+    // gone from invisible to visible.
+    timelineManager.updateSlidingWindow();
+
     const assetTop = position.top;
     const assetBottom = position.top + position.height;
     const visibleTop = timelineManager.visibleWindow.top;
@@ -146,10 +150,6 @@
 
     // Check if the asset is already at least partially visible in the viewport
     if (isIntersecting(assetTop, assetBottom, visibleTop, visibleBottom)) {
-      // Asset is already visible, no scroll needed but need to update window
-      // positions/intersections because since the <Portal> went from invisible
-      // to visible
-      timelineManager.updateSlidingWindow();
       return;
     }
 

--- a/web/src/lib/managers/timeline-manager/month-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/month-group.svelte.ts
@@ -311,12 +311,14 @@ export class MonthGroup {
       if (viewerAsset) {
         if (!viewerAsset.position) {
           console.warn('No position for asset');
-          break;
+          return;
         }
-        return this.top + group.top + viewerAsset.position.top + this.timelineManager.headerHeight;
+        return {
+          top: this.top + group.top + viewerAsset.position.top + this.timelineManager.headerHeight,
+          height: viewerAsset.position.height,
+        };
       }
     }
-    return -1;
   }
 
   *assetsIterator(options?: { startDayGroup?: DayGroup; startAsset?: TimelineAsset; direction?: Direction }) {

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -234,7 +234,6 @@ export class TimelineManager extends VirtualScrollManager {
     await this.initTask.reset();
     await this.#init(options);
     this.updateViewportGeometry(false);
-    this.#createScrubberMonths();
   }
 
   async #init(options: TimelineManagerOptions) {


### PR DESCRIPTION
Fixes a bug where navigating to/from the asser-viewer from timeline causes the scroll position to be reset.
