### PR TITLE
fix(docs): cli upload json format example

### DIFF
--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -182,7 +182,7 @@ For example to get a list of files that would be uploaded for further
 processing:
 
 ```bash
-immich upload --dry-run . | tail -n +4 | jq .newFiles[]
+immich upload --dry-run . | tail -n +6 | jq .newFiles[]
 ```
 
 ### Obtain the API Key


### PR DESCRIPTION
## Description

The docs about how to handle the json output of the cli upload seem to be outdated, at least during my testing I had to use `+6` instead of `+4`.

The cli command I did run:

```
docker run -it -v /XXX:/import:ro -e IMMICH_INSTANCE_URL=https://immich.XXX.dev/api -e IMMICH_API_KEY=XXX ghcr.io/immich-app/immich-cli:latest  upload --dry-run  --recursive /import -j  | tail -n +6 | jq .newFiles[].filepath
```
