### PR TITLE
feat(server): support IPv6 Redis instances

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -101,15 +101,16 @@ When `DB_URL` is defined, the `DB_HOSTNAME`, `DB_PORT`, `DB_USERNAME`, `DB_PASSW
 
 ## Redis
 
-| Variable         | Description    | Default | Containers |
-| :--------------- | :------------- | :-----: | :--------- |
-| `REDIS_URL`      | Redis URL      |         | server     |
-| `REDIS_SOCKET`   | Redis socket   |         | server     |
-| `REDIS_HOSTNAME` | Redis host     | `redis` | server     |
-| `REDIS_PORT`     | Redis port     | `6379`  | server     |
-| `REDIS_USERNAME` | Redis username |         | server     |
-| `REDIS_PASSWORD` | Redis password |         | server     |
-| `REDIS_DBINDEX`  | Redis DB index |   `0`   | server     |
+| Variable          | Description     | Default | Containers |
+| :---------------- | :-------------- | :-----: | :--------- |
+| `REDIS_URL`       | Redis URL       |         | server     |
+| `REDIS_SOCKET`    | Redis socket    |         | server     |
+| `REDIS_HOSTNAME`  | Redis host      | `redis` | server     |
+| `REDIS_PORT`      | Redis port      | `6379`  | server     |
+| `REDIS_USERNAME`  | Redis username  |         | server     |
+| `REDIS_PASSWORD`  | Redis password  |         | server     |
+| `REDIS_DBINDEX`   | Redis DB index  |   `0`   | server     |
+| `REDIS_IP_FAMILY` | Redis IP family |   `0`   | server     |
 
 :::info
 All `REDIS_` variables must be provided to all Immich workers, including `api` and `microservices`.
@@ -117,7 +118,7 @@ All `REDIS_` variables must be provided to all Immich workers, including `api` a
 `REDIS_URL` must start with `ioredis://` and then include a `base64` encoded JSON string for the configuration.
 More information can be found in the upstream [ioredis] documentation.
 
-When `REDIS_URL` or `REDIS_SOCKET` are defined, the `REDIS_HOSTNAME`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, and `REDIS_DBINDEX` variables are ignored.
+When `REDIS_URL` or `REDIS_SOCKET` are defined, the `REDIS_HOSTNAME`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD`, `REDIS_IP_FAMILY`, and `REDIS_DBINDEX` variables are ignored.
 :::
 
 Redis (Sentinel) URL example JSON before encoding:

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -1,5 +1,5 @@
 import { Transform, Type } from 'class-transformer';
-import { IsEnum, IsInt, IsString, Matches } from 'class-validator';
+import { IsEnum, IsIn, IsInt, IsString, Matches } from 'class-validator';
 import { DatabaseSslMode, ImmichEnvironment, LogLevel } from 'src/enum';
 import { IsIPRange, Optional, ValidateBoolean } from 'src/validation';
 
@@ -195,4 +195,9 @@ export class EnvDto {
   @IsString()
   @Optional()
   REDIS_URL?: string;
+
+  @IsIn([0, 4, 6])
+  @Optional()
+  @Type(() => Number)
+  REDIS_IP_FAMILY?: 0 | 4 | 6;
 }

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -35,6 +35,7 @@ const resetEnv = () => {
     'REDIS_PASSWORD',
     'REDIS_SOCKET',
     'REDIS_URL',
+    'REDIS_IP_FAMILY',
 
     'NO_COLOR',
   ]) {
@@ -138,6 +139,7 @@ describe('getEnv', () => {
         username: undefined,
         password: undefined,
         path: undefined,
+        family: 0,
       });
     });
 

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -163,6 +163,7 @@ const getEnv = (): EnvData => {
     username: dto.REDIS_USERNAME || undefined,
     password: dto.REDIS_PASSWORD || undefined,
     path: dto.REDIS_SOCKET || undefined,
+    family: dto.REDIS_IP_FAMILY || 0,
   };
 
   const redisUrl = dto.REDIS_URL;


### PR DESCRIPTION
## Description

This enables automatic family affinity by using `0`, which overwrites ioredis' default set to `4`. With this change, Immich will be able to connect to Redis exposed only via IPv6.

Users will still be able to overwrite the default with `REDIS_IP_FAMILY` or by adding `?family=4` to `REDIS_URL`.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Running `make dev` with `immich-server` container configured with `REDIS_IP_FAMILY` to all possible values.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
~- [ ] I have confirmed that any new dependencies are strictly necessary.~
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
~- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
~- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs, just manual grunt work.
