### PR TITLE
fix: remove assets from shared link

### DIFF
--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -31,6 +31,7 @@ import { ProcessRepository } from 'src/repositories/process.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { ServerInfoRepository } from 'src/repositories/server-info.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
+import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -79,6 +80,7 @@ export const repositories = [
   SessionRepository,
   ServerInfoRepository,
   SharedLinkRepository,
+  SharedLinkAssetRepository,
   StackRepository,
   StorageRepository,
   SyncRepository,

--- a/server/src/repositories/shared-link-asset.repository.ts
+++ b/server/src/repositories/shared-link-asset.repository.ts
@@ -1,0 +1,18 @@
+import { Kysely } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+import { DB } from 'src/schema';
+
+export class SharedLinkAssetRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  async remove(sharedLinkId: string, assetsId: string[]) {
+    const deleted = await this.db
+      .deleteFrom('shared_link_asset')
+      .where('shared_link_asset.sharedLinksId', '=', sharedLinkId)
+      .where('shared_link_asset.assetsId', 'in', assetsId)
+      .returning('assetsId')
+      .execute();
+
+    return deleted.map((row) => row.assetsId);
+  }
+}

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -90,6 +90,7 @@ export const BASE_SERVICE_DEPENDENCIES = [
   ServerInfoRepository,
   SessionRepository,
   SharedLinkRepository,
+  SharedLinkAssetRepository,
   StackRepository,
   StorageRepository,
   SyncRepository,

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -38,6 +38,7 @@ import { ProcessRepository } from 'src/repositories/process.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { ServerInfoRepository } from 'src/repositories/server-info.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
+import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -141,6 +142,7 @@ export class BaseService {
     protected serverInfoRepository: ServerInfoRepository,
     protected sessionRepository: SessionRepository,
     protected sharedLinkRepository: SharedLinkRepository,
+    protected sharedLinkAssetRepository: SharedLinkAssetRepository,
     protected stackRepository: StackRepository,
     protected storageRepository: StorageRepository,
     protected syncRepository: SyncRepository,

--- a/server/src/services/shared-link.service.spec.ts
+++ b/server/src/services/shared-link.service.spec.ts
@@ -300,6 +300,7 @@ describe(SharedLinkService.name, () => {
       mocks.sharedLink.get.mockResolvedValue(_.cloneDeep(sharedLinkStub.individual));
       mocks.sharedLink.create.mockResolvedValue(sharedLinkStub.individual);
       mocks.sharedLink.update.mockResolvedValue(sharedLinkStub.individual);
+      mocks.sharedLinkAsset.remove.mockResolvedValue([assetStub.image.id]);
 
       await expect(
         sut.removeAssets(authStub.admin, 'link-1', { assetIds: [assetStub.image.id, 'asset-2'] }),
@@ -308,6 +309,7 @@ describe(SharedLinkService.name, () => {
         { assetId: 'asset-2', success: false, error: AssetIdErrorReason.NOT_FOUND },
       ]);
 
+      expect(mocks.sharedLinkAsset.remove).toHaveBeenCalledWith('link-1', [assetStub.image.id, 'asset-2']);
       expect(mocks.sharedLink.update).toHaveBeenCalledWith({ ...sharedLinkStub.individual, assets: [] });
     });
   });

--- a/server/src/services/shared-link.service.ts
+++ b/server/src/services/shared-link.service.ts
@@ -179,8 +179,8 @@ export class SharedLinkService extends BaseService {
 
     const results: AssetIdsResponseDto[] = [];
     for (const assetId of dto.assetIds) {
-      const hasAsset = removedAssetIds.find((id) => id === assetId);
-      if (!hasAsset) {
+      const wasRemoved = removedAssetIds.find((id) => id === assetId);
+      if (!wasRemoved) {
         results.push({ assetId, success: false, error: AssetIdErrorReason.NOT_FOUND });
         continue;
       }

--- a/server/src/services/shared-link.service.ts
+++ b/server/src/services/shared-link.service.ts
@@ -175,9 +175,11 @@ export class SharedLinkService extends BaseService {
       throw new BadRequestException('Invalid shared link type');
     }
 
+    const removedAssetIds = await this.sharedLinkAssetRepository.remove(id, dto.assetIds);
+
     const results: AssetIdsResponseDto[] = [];
     for (const assetId of dto.assetIds) {
-      const hasAsset = sharedLink.assets.find((asset) => asset.id === assetId);
+      const hasAsset = removedAssetIds.find((id) => id === assetId);
       if (!hasAsset) {
         results.push({ assetId, success: false, error: AssetIdErrorReason.NOT_FOUND });
         continue;

--- a/server/test/medium.factory.ts
+++ b/server/test/medium.factory.ts
@@ -33,6 +33,7 @@ import { PartnerRepository } from 'src/repositories/partner.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
+import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -296,6 +297,7 @@ const newRealRepository = <T>(key: ClassConstructor<T>, db: Kysely<DB>): T => {
     case SearchRepository:
     case SessionRepository:
     case SharedLinkRepository:
+    case SharedLinkAssetRepository:
     case StackRepository:
     case SyncRepository:
     case SyncCheckpointRepository:

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -47,6 +47,7 @@ import { ProcessRepository } from 'src/repositories/process.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { ServerInfoRepository } from 'src/repositories/server-info.repository';
 import { SessionRepository } from 'src/repositories/session.repository';
+import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -236,6 +237,7 @@ export type ServiceOverrides = {
   serverInfo: ServerInfoRepository;
   session: SessionRepository;
   sharedLink: SharedLinkRepository;
+  sharedLinkAsset: SharedLinkAssetRepository;
   stack: StackRepository;
   storage: StorageRepository;
   sync: SyncRepository;
@@ -307,6 +309,7 @@ export const newTestService = <T extends BaseService>(
     serverInfo: automock(ServerInfoRepository, { args: [, loggerMock], strict: false }),
     session: automock(SessionRepository),
     sharedLink: automock(SharedLinkRepository),
+    sharedLinkAsset: automock(SharedLinkAssetRepository),
     stack: automock(StackRepository),
     storage: newStorageRepositoryMock(),
     sync: automock(SyncRepository),
@@ -357,6 +360,7 @@ export const newTestService = <T extends BaseService>(
     overrides.serverInfo || (mocks.serverInfo as As<ServerInfoRepository>),
     overrides.session || (mocks.session as As<SessionRepository>),
     overrides.sharedLink || (mocks.sharedLink as As<SharedLinkRepository>),
+    overrides.sharedLinkAsset || (mocks.sharedLinkAsset as As<SharedLinkAssetRepository>),
     overrides.stack || (mocks.stack as As<StackRepository>),
     overrides.storage || (mocks.storage as As<StorageRepository>),
     overrides.sync || (mocks.sync as As<SyncRepository>),


### PR DESCRIPTION
## Description

Looking into this issue #22124 , I realized that the `DELETE /shared-links/:id/assets` endpoint was not deleting the assets from the `shared_link_asset` table, and returning `success: true`


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #22105

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] With a few existing assetsIds
- [x] With a few existing assetsIds and a few that does not exists
- [x] (New) Should share individually assets
- [x] (New) Should remove individually shared asset

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation if applicable~~
- [x] I have no unrelated changes in the PR.
- [ ] ~~I have confirmed that any new dependencies are strictly necessary.~~
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
