### PR TITLE
fix: Show correct photo name in buttom sheet and backup details page

### DIFF
--- a/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 @RoutePage()
@@ -30,53 +31,60 @@ class DriftBackupAssetDetailPage extends ConsumerWidget {
             itemBuilder: (context, index) {
               final asset = candidates[index];
               final albumsAsyncValue = ref.watch(driftCandidateBackupAlbumInfoProvider(asset.id));
-              return LargeLeadingTile(
-                title: Text(
-                  asset.name,
-                  style: context.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w500, fontSize: 16),
-                ),
-                subtitle: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      asset.createdAt.toString(),
-                      style: TextStyle(fontSize: 13.0, color: context.colorScheme.onSurfaceSecondary),
+              final assetMediaRepository = ref.watch(assetMediaRepositoryProvider);
+              return FutureBuilder<String?>(
+                future: assetMediaRepository.getOriginalFilename(asset.id),
+                builder: (context, snapshot) {
+                  final displayName = snapshot.data ?? asset.name;
+                  return LargeLeadingTile(
+                    title: Text(
+                      displayName,
+                      style: context.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w500, fontSize: 16),
                     ),
-                    Text(
-                      asset.checksum ?? "N/A",
-                      style: TextStyle(fontSize: 13.0, color: context.colorScheme.onSurfaceSecondary),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    albumsAsyncValue.when(
-                      data: (albums) {
-                        if (albums.isEmpty) {
-                          return const SizedBox.shrink();
-                        }
-                        return Text(
-                          albums.map((a) => a.name).join(', '),
-                          style: context.textTheme.labelLarge?.copyWith(color: context.primaryColor),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          asset.createdAt.toString(),
+                          style: TextStyle(fontSize: 13.0, color: context.colorScheme.onSurfaceSecondary),
+                        ),
+                        Text(
+                          asset.checksum ?? "N/A",
+                          style: TextStyle(fontSize: 13.0, color: context.colorScheme.onSurfaceSecondary),
                           overflow: TextOverflow.ellipsis,
-                        );
-                      },
-                      error: (error, stackTrace) =>
-                          Text('Error: $error', style: TextStyle(color: context.colorScheme.error)),
-                      loading: () => const SizedBox(height: 16, width: 16, child: CircularProgressIndicator.adaptive()),
+                        ),
+                        albumsAsyncValue.when(
+                          data: (albums) {
+                            if (albums.isEmpty) {
+                              return const SizedBox.shrink();
+                            }
+                            return Text(
+                              albums.map((a) => a.name).join(', '),
+                              style: context.textTheme.labelLarge?.copyWith(color: context.primaryColor),
+                              overflow: TextOverflow.ellipsis,
+                            );
+                          },
+                          error: (error, stackTrace) =>
+                              Text('Error: $error', style: TextStyle(color: context.colorScheme.error)),
+                          loading: () => const SizedBox(height: 16, width: 16, child: CircularProgressIndicator.adaptive()),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                leading: ClipRRect(
-                  borderRadius: const BorderRadius.all(Radius.circular(12)),
-                  child: SizedBox(
-                    width: 64,
-                    height: 64,
-                    child: Thumbnail.fromAsset(asset: asset, size: const Size(64, 64), fit: BoxFit.cover),
-                  ),
-                ),
-                trailing: const Padding(padding: EdgeInsets.only(right: 24, left: 8), child: Icon(Icons.image_search)),
-                onTap: () async {
-                  await context.maybePop();
-                  await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-                  EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
+                    leading: ClipRRect(
+                      borderRadius: const BorderRadius.all(Radius.circular(12)),
+                      child: SizedBox(
+                        width: 64,
+                        height: 64,
+                        child: Thumbnail.fromAsset(asset: asset, size: const Size(64, 64), fit: BoxFit.cover),
+                      ),
+                    ),
+                    trailing: const Padding(padding: EdgeInsets.only(right: 24, left: 8), child: Icon(Icons.image_search)),
+                    onTap: () async {
+                      await context.maybePop();
+                      await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+                      EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
+                    },
+                  );
                 },
               );
             },


### PR DESCRIPTION
## Description

This is a follow-up PR to https://github.com/immich-app/immich/pull/21877. The goal is to use the same approach to fix an issue where the file names of some assets in the photo bottom sheet and backup details pages are displayed in UUID format instead of the correct file name.

Fixes https://github.com/immich-app/immich/issues/20630

## How Has This Been Tested?

I've tried to compile the app and installed it on my iPhone, and all photos display the correct name now

| Before             |  After |
:-------------------------:|:-------------------------:
![Image](https://github.com/user-attachments/assets/3879e287-5cdc-44f1-99c0-9cc25c1aa829)  |  ![Image](https://github.com/user-attachments/assets/b385991f-dbd6-4be3-b828-e85e3ef3a275)


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

![Image](https://github.com/user-attachments/assets/b385991f-dbd6-4be3-b828-e85e3ef3a275)

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

`mobile/lib/pages/backup/drift_backup_asset_detail.page.dart` was manually written, and `mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart` was processed by an LLM following the same modification approach. I believe the changes made are reasonable.
