### PR TITLE
fix: unit overlapses value in server stats card

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -29,7 +29,7 @@
   <div class="relative mx-auto font-mono text-2xl font-semibold">
     <span class="text-gray-400 dark:text-gray-600">{zeros()}</span><span>{value}</span>
     {#if unit}
-      <Code color="muted" class="absolute -top-5 end-1 font-light">{unit}</Code>
+      <Code color="muted" class="absolute -top-5 end-1 font-light p-0">{unit}</Code>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
Fixes #22967, regression from https://github.com/immich-app/ui/commit/871cacacdd9c98b51d452bbe4cf191eae8f20612#diff-a22d7d541de60d5205265c5a0e47999afdca9b6758193c13d3eb4cb605840291R26
