### PR TITLE
fix(web): render context overlays over the scrollbar

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/context-menu.svelte
+++ b/web/src/lib/components/shared-components/context-menu/context-menu.svelte
@@ -61,7 +61,7 @@
 
 <div
   bind:clientHeight={height}
-  class="fixed min-w-[200px] w-max max-w-[300px] overflow-hidden rounded-lg shadow-lg"
+  class="fixed min-w-[200px] w-max max-w-[300px] overflow-hidden rounded-lg shadow-lg z-1"
   style:left="{left}px"
   style:top="{top}px"
   transition:slide={{ duration: 250, easing: quintOut }}


### PR DESCRIPTION
## Description

Small bugfix to move the button overlays over the scrollbar in the album view and others. 

Opening a context menu is an intentional action, so should take focus over components underneath.

## How Has This Been Tested?

See screenshots for UI view

Recreate by:
- open the album view
- select a picture to open up the asset manager
- select the '+' button
- Note how the date scrollbar is overlaid over the context menu, making the rightmost section unable to be pressed (see picture)

<details><summary><h2>Screenshots</h2></summary>

Without z-index, scrollbar visible:
<img width="293" height="151" alt="image" src="https://github.com/user-attachments/assets/19068a33-c84f-4fb6-a85e-93f31f18ada4" />

WITH z-index, scrollbar is under the popup:
<img width="280" height="154" alt="image" src="https://github.com/user-attachments/assets/6e480fec-58b6-4ec0-9d82-2762fbf876e5" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
