### PR TITLE
chore: change usage of `pnpx` to `pnpm dlx`

### DIFF
--- a/open-api/bin/generate-open-api.sh
+++ b/open-api/bin/generate-open-api.sh
@@ -15,7 +15,7 @@ function dart {
   patch --no-backup-if-mismatch -u api.mustache <api.mustache.patch
 
   cd ../../
-  pnpx @openapitools/openapi-generator-cli generate -g dart -i ./immich-openapi-specs.json -o ../mobile/openapi -t ./templates/mobile
+  pnpm dlx @openapitools/openapi-generator-cli generate -g dart -i ./immich-openapi-specs.json -o ../mobile/openapi -t ./templates/mobile
 
   # Post generate patches
   patch --no-backup-if-mismatch -u ../mobile/openapi/lib/api_client.dart <./patch/api_client.dart.patch
@@ -27,7 +27,7 @@ function dart {
 }
 
 function typescript {
-  pnpx oazapfts --optimistic --argumentStyle=object --useEnumType immich-openapi-specs.json typescript-sdk/src/fetch-client.ts
+  pnpm dlx oazapfts --optimistic --argumentStyle=object --useEnumType immich-openapi-specs.json typescript-sdk/src/fetch-client.ts
   pnpm --filter @immich/sdk install --frozen-lockfile
   pnpm --filter @immich/sdk build
 }

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --check .",
     "format:fix": "prettier --write . && npm run format:i18n",
-    "format:i18n": "pnpx sort-json ../i18n/*.json",
+    "format:i18n": "pnpm dlx sort-json ../i18n/*.json",
     "test": "vitest --run",
     "test:cov": "vitest --coverage",
     "test:watch": "vitest dev",


### PR DESCRIPTION
See https://pnpm.io/cli/dlx

pnpx is an alias to pnpm dlx. However in some situations, the alias might not be preset in the current terminal session. We should use pnpm dlx directly instead of relying on the alias which might not work.