### PR TITLE
fix(web): two scrollbars in folder view

### DIFF
--- a/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/folders/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -96,7 +96,7 @@
 
   <Breadcrumbs node={data.tree} icon={mdiFolderHome} title={$t('folders')} getLink={getLinkForPath} />
 
-  <section class="mt-2 h-[calc(100%-(--spacing(20)))] overflow-auto immich-scrollbar">
+  <section class="mt-2 h-[calc(100%-(--spacing(25)))] overflow-auto immich-scrollbar">
     <TreeItemThumbnails items={data.tree.children} icon={mdiFolder} onClick={handleNavigateToFolder} />
 
     <!-- Assets -->


### PR DESCRIPTION
## Description

Fixes #22860

| Before | After |
|---------|--------|
| <img height="500" alt="Before image" src="https://github.com/user-attachments/assets/40289a3c-34d0-4a61-8d87-e8a370ddfe90" /> | <img height="500" alt="After image" src="https://github.com/user-attachments/assets/47aee580-5cbc-4e5c-87a4-d824358c5053" /> |

