### PR TITLE
refactor(web): improve date labels in scrubber  

### DIFF
--- a/web/src/lib/components/timeline/Scrubber.svelte
+++ b/web/src/lib/components/timeline/Scrubber.svelte
@@ -141,14 +141,18 @@
   };
 
   const calculateSegments = (months: ScrubberMonth[]) => {
-    let height = 0;
-    let dotHeight = 0;
+    let verticalSpanWithoutLabel = 0;
+    let verticalSpanWithoutDot = 0;
 
     let segments: Segment[] = [];
     let previousLabeledSegment: Segment | undefined;
 
     let top = 0;
-    for (const [i, scrubMonth] of months.entries()) {
+
+    // Process months in reverse order to pick labels, then reverse for display
+    const reversed = [...months].reverse();
+
+    for (const scrubMonth of reversed) {
       const scrollBarPercentage = scrubMonth.height / timelineFullHeight;
 
       const segment = {
@@ -162,25 +166,26 @@
         hasDot: false,
       };
       top += segment.height;
-      if (i === 0) {
-        segment.hasDot = true;
-        segment.hasLabel = true;
-        previousLabeledSegment = segment;
-      } else {
-        if (previousLabeledSegment?.year !== segment.year && height > MIN_YEAR_LABEL_DISTANCE) {
-          height = 0;
+      if (previousLabeledSegment) {
+        if (previousLabeledSegment.year !== segment.year && verticalSpanWithoutLabel > MIN_YEAR_LABEL_DISTANCE) {
+          verticalSpanWithoutLabel = 0;
           segment.hasLabel = true;
           previousLabeledSegment = segment;
         }
-        if (segment.height > 5 && dotHeight > MIN_DOT_DISTANCE) {
+        if (segment.height > 5 && verticalSpanWithoutDot > MIN_DOT_DISTANCE) {
           segment.hasDot = true;
-          dotHeight = 0;
+          verticalSpanWithoutDot = 0;
         }
-        height += segment.height;
+      } else {
+        segment.hasDot = true;
+        segment.hasLabel = true;
+        previousLabeledSegment = segment;
       }
-      dotHeight += segment.height;
+      verticalSpanWithoutLabel += segment.height;
+      verticalSpanWithoutDot += segment.height;
       segments.push(segment);
     }
+    segments.reverse();
 
     return segments;
   };
@@ -576,7 +581,7 @@
     >
       {#if !usingMobileDevice}
         {#if segment.hasLabel}
-          <div class="absolute end-5 top-[-16px] text-[12px] dark:text-immich-dark-fg font-immich-mono">
+          <div class="absolute end-5 text-[12px] dark:text-immich-dark-fg font-immich-mono bottom-0">
             {segment.year}
           </div>
         {/if}

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -234,6 +234,7 @@ export class TimelineManager extends VirtualScrollManager {
     await this.initTask.reset();
     await this.#init(options);
     this.updateViewportGeometry(false);
+    this.#createScrubberMonths();
   }
 
   async #init(options: TimelineManagerOptions) {


### PR DESCRIPTION
## Summary

- Add year label to top padding area - always show
- Add year label to last segment - will always show
- You should now "read" the labels from bottom to top. That is, starting at the bottom, all photos will be in the labeled year, until after you see another year label, and then all photos are after that last year. 
- Refactor timeline scrubber segment calculation for better readability and maintainability
- Improve label positioning logic to prevent duplicate year labels
- Rename variables to be more descriptive (`height` → `verticalSpanWithoutLabel`, `dotHeight` → `verticalSpanWithoutDot`)
- Remove unnecessary use of `.entries()` iterator in favor of simpler iteration
- Adjust label positioning from top-aligned to bottom-aligned within segments
- Fix scrubber month recalculation on timeline reset

## Changes

**Scrubber.svelte:**
- Process months in reverse order, then reverse the array for display (makes label selection logic more intuitive)
- Remove duplicate first label when it matches the top segment (already shown in padding area)
- Display year label in the top padding area
- Move segment labels from top-aligned to bottom-aligned positioning
- Use more descriptive variable names for tracking vertical spans

**timeline-manager.svelte.ts:**
- Call `createScrubberMonths()` on reset to ensure scrubber updates correctly
