### PR TITLE
fix: blank page on assetviewer to timeline (regression)

### DIFF
--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -154,6 +154,9 @@
 
     // If the asset is already visible, then don't scroll.
     if (assetIsVisible(height)) {
+      // need to update window positions/intersections because since the <Portal>
+      // went from invisible to visible
+      timelineManager.updateSlidingWindow();
       return true;
     }
 


### PR DESCRIPTION
Regression from #23017 