### PR TITLE
feat(mobile): Change the UI of asset activity list to bottom sheet

### DIFF
--- a/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
+++ b/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
@@ -36,7 +36,9 @@ class _DriftActivityTextFieldState extends ConsumerState<DriftActivityTextField>
     inputController = TextEditingController();
     inputFocusNode = FocusNode();
 
-    if (!widget.isBottomSheet) inputFocusNode.requestFocus();
+    if (!widget.isBottomSheet) {
+      inputFocusNode.requestFocus();
+    }
 
     inputFocusNode.addListener(() {
       if (inputFocusNode.hasFocus) {

--- a/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
+++ b/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
 
 class DriftActivityTextField extends ConsumerStatefulWidget {
   final bool isEnabled;
+  final bool isBottomSheet;
   final String? likeId;
   final Function(String) onSubmit;
   final Function()? onKeyboardFocus;
@@ -16,6 +17,7 @@ class DriftActivityTextField extends ConsumerStatefulWidget {
     this.isEnabled = true,
     this.likeId,
     this.onKeyboardFocus,
+    this.isBottomSheet = false,
     super.key,
   });
 
@@ -34,7 +36,7 @@ class _DriftActivityTextFieldState extends ConsumerState<DriftActivityTextField>
     inputController = TextEditingController();
     inputFocusNode = FocusNode();
 
-    inputFocusNode.requestFocus();
+    if (!widget.isBottomSheet) inputFocusNode.requestFocus();
 
     inputFocusNode.addListener(() {
       if (inputFocusNode.hasFocus) {
@@ -72,7 +74,7 @@ class _DriftActivityTextFieldState extends ConsumerState<DriftActivityTextField>
     }
 
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10),
+      padding: EdgeInsets.symmetric(vertical: widget.isBottomSheet ? 0 : 10),
       child: TextField(
         controller: inputController,
         enabled: widget.isEnabled,

--- a/mobile/lib/presentation/widgets/asset_viewer/activities_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/activities_bottom_sheet.widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/album/drift_activity_text_field.dart';
@@ -36,7 +35,6 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
 
     Future<void> onAddComment(String comment) async {
       await activityNotifier.addComment(comment);
-      EventStream.shared.emit(const ScrollToBottomEvent());
     }
 
     Widget buildActivitiesSliver() {
@@ -46,7 +44,6 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
           return SliverList(
             delegate: SliverChildBuilderDelegate((context, index) {
               if (index == data.length) {
-                // return const SizedBox(height: 5);
                 return const SizedBox.shrink();
               }
               final activity = data[data.length - 1 - index];
@@ -55,7 +52,7 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
                 padding: const EdgeInsets.symmetric(vertical: 1),
                 child: DismissibleActivity(
                   activity.id,
-                  ActivityTile(activity),
+                  ActivityTile(activity, isBottomSheet: true),
                   onDismiss: canDelete
                       ? (activityId) async => await activityNotifier.removeActivity(activity.id)
                       : null,
@@ -92,7 +89,6 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
       expand: false,
       shouldCloseOnMinExtent: false,
       resizeOnScroll: false,
-      listenScrollToBottomEvents: false,
       backgroundColor: context.isDarkTheme ? Colors.black : Colors.white,
     );
   }

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -20,7 +20,7 @@ import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_bar.widge
 import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/top_app_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/video_viewer.widget.dart';
-import 'package:immich_mobile/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/activities_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/is_motion_video_playing.provider.dart';

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -20,6 +20,7 @@ import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_bar.widge
 import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/top_app_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/video_viewer.widget.dart';
+import 'package:immich_mobile/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/images/image_provider.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/is_motion_video_playing.provider.dart';
@@ -418,7 +419,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
     if (event is ViewerOpenBottomSheetEvent) {
       final extent = _kBottomSheetMinimumExtent + 0.3;
-      _openBottomSheet(scaffoldContext!, extent: extent);
+      _openBottomSheet(scaffoldContext!, extent: extent, activitiesMode: event.activitiesMode);
       final offset = _getVerticalOffsetForBottomSheet(extent);
       viewController?.position = Offset(0, -offset);
       return;
@@ -460,7 +461,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     });
   }
 
-  void _openBottomSheet(BuildContext ctx, {double extent = _kBottomSheetMinimumExtent}) {
+  void _openBottomSheet(BuildContext ctx, {double extent = _kBottomSheetMinimumExtent, bool activitiesMode = false}) {
     ref.read(assetViewerProvider.notifier).setBottomSheet(true);
     initialScale = viewController?.scale;
     // viewController?.updateMultiple(scale: (viewController?.scale ?? 1.0) + 0.01);
@@ -474,7 +475,9 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       builder: (_) {
         return NotificationListener<Notification>(
           onNotification: _onNotification,
-          child: AssetDetailBottomSheet(controller: bottomSheetController, initialChildSize: extent),
+          child: activitiesMode
+              ? ActivitiesBottomSheet(controller: bottomSheetController, initialChildSize: extent)
+              : AssetDetailBottomSheet(controller: bottomSheetController, initialChildSize: extent),
         );
       },
     );

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.state.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.state.dart
@@ -4,7 +4,8 @@ import 'package:immich_mobile/providers/asset_viewer/video_player_controls_provi
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 class ViewerOpenBottomSheetEvent extends Event {
-  const ViewerOpenBottomSheetEvent();
+  final bool activitiesMode;
+  const ViewerOpenBottomSheetEvent({this.activitiesMode = false});
 }
 
 class ViewerReloadAssetEvent extends Event {

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -72,43 +72,6 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
           icon: const Icon(Icons.chat_outlined),
           onPressed: () {
             EventStream.shared.emit(const ViewerOpenBottomSheetEvent(activitiesMode: true));
-            // showModalBottomSheet(
-            //   // backgroundColor: context.colorScheme.surface,
-            //   context: context,
-            //   useSafeArea: true,
-            //   isScrollControlled: true,
-
-            //   builder: (context) => Padding(
-            //     padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
-            //     child: const ActivitiesBottomSheet(),
-            //   ),
-            // );
-
-            // showModalBottomSheet(
-            //   shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0))),
-            //   barrierColor: Colors.transparent,
-            //   isScrollControlled: true,
-            //   showDragHandle: true,
-            //   enableDrag: true,
-            //   context: context,
-            //   useSafeArea: true,
-            //   builder: (context) {
-            //     return DraggableScrollableSheet(
-            //       minChildSize: 0.2,
-            //       maxChildSize: 0.8,
-            //       initialChildSize: 0.2,
-            //       expand: false,
-            //       snap: true,
-            //       snapSizes: const [0.2, 0.4, 0.6],
-            //       builder: (context, scrollController) {
-            //         return Padding(
-            //           padding: EdgeInsets.only(bottom: context.viewInsets.bottom),
-            //           child: ActivitiesBottomSheet(scrollController: scrollController),
-            //         );
-            //       },
-            //     );
-            //   },
-            // );
           },
         ),
       if (showViewInTimelineButton)

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -14,6 +14,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/favorite_actio
 import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
+import 'package:immich_mobile/providers/activity.provider.dart';
 import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
@@ -53,6 +54,10 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     int opacity = ref.watch(assetViewerProvider.select((state) => state.backgroundOpacity));
     final showControls = ref.watch(assetViewerProvider.select((s) => s.showingControls));
 
+    if (album != null && album.isActivityEnabled && album.isShared && asset is RemoteAsset) {
+      ref.watch(albumActivityProvider(album.id, asset.id));
+    }
+
     if (!showControls) {
       opacity = 0;
     }
@@ -66,7 +71,44 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
         IconButton(
           icon: const Icon(Icons.chat_outlined),
           onPressed: () {
-            context.navigateTo(const DriftActivitiesRoute());
+            EventStream.shared.emit(const ViewerOpenBottomSheetEvent(activitiesMode: true));
+            // showModalBottomSheet(
+            //   // backgroundColor: context.colorScheme.surface,
+            //   context: context,
+            //   useSafeArea: true,
+            //   isScrollControlled: true,
+
+            //   builder: (context) => Padding(
+            //     padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+            //     child: const ActivitiesBottomSheet(),
+            //   ),
+            // );
+
+            // showModalBottomSheet(
+            //   shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(15.0))),
+            //   barrierColor: Colors.transparent,
+            //   isScrollControlled: true,
+            //   showDragHandle: true,
+            //   enableDrag: true,
+            //   context: context,
+            //   useSafeArea: true,
+            //   builder: (context) {
+            //     return DraggableScrollableSheet(
+            //       minChildSize: 0.2,
+            //       maxChildSize: 0.8,
+            //       initialChildSize: 0.2,
+            //       expand: false,
+            //       snap: true,
+            //       snapSizes: const [0.2, 0.4, 0.6],
+            //       builder: (context, scrollController) {
+            //         return Padding(
+            //           padding: EdgeInsets.only(bottom: context.viewInsets.bottom),
+            //           child: ActivitiesBottomSheet(scrollController: scrollController),
+            //         );
+            //       },
+            //     );
+            //   },
+            // );
           },
         ),
       if (showViewInTimelineButton)

--- a/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
+import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/album/drift_activity_text_field.dart';
+import 'package:immich_mobile/providers/activity.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/widgets/activities/activity_tile.dart';
+import 'package:immich_mobile/widgets/activities/dismissible_activity.dart';
+import 'base_bottom_sheet.widget.dart';
+
+class ActivitiesBottomSheet extends HookConsumerWidget {
+  final DraggableScrollableController controller;
+  final double initialChildSize;
+  final bool scrollToBottomInitially;
+
+  const ActivitiesBottomSheet({
+    required this.controller,
+    this.initialChildSize = 0.35,
+    this.scrollToBottomInitially = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final album = ref.watch(currentRemoteAlbumProvider)!;
+    final asset = ref.watch(currentAssetNotifier) as RemoteAsset?;
+    final user = ref.watch(currentUserProvider);
+
+    final activityNotifier = ref.read(albumActivityProvider(album.id, asset?.id).notifier);
+    final activities = ref.watch(albumActivityProvider(album.id, asset?.id));
+
+    Future<void> onAddComment(String comment) async {
+      await activityNotifier.addComment(comment);
+      EventStream.shared.emit(const ScrollToBottomEvent());
+    }
+
+    Widget buildActivitiesSliver() {
+      return activities.widgetWhen(
+        onLoading: () => const SliverToBoxAdapter(child: SizedBox.shrink()),
+        onData: (data) {
+          return SliverList(
+            delegate: SliverChildBuilderDelegate((context, index) {
+              if (index == data.length) {
+                // return const SizedBox(height: 5);
+                return const SizedBox.shrink();
+              }
+              final activity = data[index];
+              final canDelete = activity.user.id == user?.id || album.ownerId == user?.id;
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 1),
+                child: DismissibleActivity(
+                  activity.id,
+                  ActivityTile(activity),
+                  onDismiss: canDelete
+                      ? (activityId) async => await activityNotifier.removeActivity(activity.id)
+                      : null,
+                ),
+              );
+            }, childCount: data.length + 1),
+          );
+        },
+      );
+    }
+
+    return BaseBottomSheet(
+      actions: [],
+      slivers: [buildActivitiesSliver()],
+      footer: Column(
+        children: [
+          const Divider(indent: 16, endIndent: 16),
+          DriftActivityTextField(
+            isEnabled: album.isActivityEnabled,
+            isBottomSheet: true,
+            // likeId: likedId,
+            onSubmit: onAddComment,
+          ),
+        ],
+      ),
+      controller: controller,
+      initialChildSize: initialChildSize,
+      minChildSize: 0.1,
+      maxChildSize: 0.88,
+      expand: false,
+      shouldCloseOnMinExtent: false,
+      resizeOnScroll: false,
+      listenScrollToBottomEvents: true,
+      backgroundColor: context.isDarkTheme ? Colors.black : Colors.white,
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
@@ -49,7 +49,7 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
                 // return const SizedBox(height: 5);
                 return const SizedBox.shrink();
               }
-              final activity = data[index];
+              final activity = data[data.length - 1 - index];
               final canDelete = activity.user.id == user?.id || album.ownerId == user?.id;
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 1),
@@ -70,16 +70,20 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
     return BaseBottomSheet(
       actions: [],
       slivers: [buildActivitiesSliver()],
-      footer: Column(
-        children: [
-          const Divider(indent: 16, endIndent: 16),
-          DriftActivityTextField(
-            isEnabled: album.isActivityEnabled,
-            isBottomSheet: true,
-            // likeId: likedId,
-            onSubmit: onAddComment,
-          ),
-        ],
+      footer: Padding(
+        // TODO: avoid fixed padding, use context.padding.bottom
+        padding: const EdgeInsets.only(bottom: 32),
+        child: Column(
+          children: [
+            const Divider(indent: 16, endIndent: 16),
+            DriftActivityTextField(
+              isEnabled: album.isActivityEnabled,
+              isBottomSheet: true,
+              // likeId: likedId,
+              onSubmit: onAddComment,
+            ),
+          ],
+        ),
       ),
       controller: controller,
       initialChildSize: initialChildSize,
@@ -88,7 +92,7 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
       expand: false,
       shouldCloseOnMinExtent: false,
       resizeOnScroll: false,
-      listenScrollToBottomEvents: true,
+      listenScrollToBottomEvents: false,
       backgroundColor: context.isDarkTheme ? Colors.black : Colors.white,
     );
   }

--- a/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart
@@ -4,13 +4,13 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/album/drift_activity_text_field.dart';
-import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/activity.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/activities/activity_tile.dart';
 import 'package:immich_mobile/widgets/activities/dismissible_activity.dart';
+import 'base_bottom_sheet.widget.dart';
 
 class ActivitiesBottomSheet extends HookConsumerWidget {
   final DraggableScrollableController controller;
@@ -44,15 +44,16 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
           return SliverList(
             delegate: SliverChildBuilderDelegate((context, index) {
               if (index == data.length) {
+                // return const SizedBox(height: 5);
                 return const SizedBox.shrink();
               }
-              final activity = data[data.length - 1 - index];
+              final activity = data[index];
               final canDelete = activity.user.id == user?.id || album.ownerId == user?.id;
               return Padding(
                 padding: const EdgeInsets.symmetric(vertical: 1),
                 child: DismissibleActivity(
                   activity.id,
-                  ActivityTile(activity, isBottomSheet: true),
+                  ActivityTile(activity),
                   onDismiss: canDelete
                       ? (activityId) async => await activityNotifier.removeActivity(activity.id)
                       : null,
@@ -67,20 +68,16 @@ class ActivitiesBottomSheet extends HookConsumerWidget {
     return BaseBottomSheet(
       actions: [],
       slivers: [buildActivitiesSliver()],
-      footer: Padding(
-        // TODO: avoid fixed padding, use context.padding.bottom
-        padding: const EdgeInsets.only(bottom: 32),
-        child: Column(
-          children: [
-            const Divider(indent: 16, endIndent: 16),
-            DriftActivityTextField(
-              isEnabled: album.isActivityEnabled,
-              isBottomSheet: true,
-              // likeId: likedId,
-              onSubmit: onAddComment,
-            ),
-          ],
-        ),
+      footer: Column(
+        children: [
+          const Divider(indent: 16, endIndent: 16),
+          DriftActivityTextField(
+            isEnabled: album.isActivityEnabled,
+            isBottomSheet: true,
+            // likeId: likedId,
+            onSubmit: onAddComment,
+          ),
+        ],
       ),
       controller: controller,
       initialChildSize: initialChildSize,

--- a/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
@@ -38,7 +38,6 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
 
 class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> {
   late DraggableScrollableController _controller;
-  ScrollController? _innerScrollController;
 
   @override
   void initState() {
@@ -71,7 +70,6 @@ class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> 
       expand: widget.expand,
       shouldCloseOnMinExtent: widget.shouldCloseOnMinExtent,
       builder: (BuildContext context, ScrollController scrollController) {
-        _innerScrollController ??= scrollController;
         return Card(
           color: widget.backgroundColor ?? context.colorScheme.surfaceContainer,
           elevation: 3.0,

--- a/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
@@ -1,13 +1,22 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
+
+class ScrollToBottomEvent extends Event {
+  const ScrollToBottomEvent();
+}
 
 class BaseBottomSheet extends ConsumerStatefulWidget {
   final List<Widget> actions;
   final DraggableScrollableController? controller;
   final List<Widget>? slivers;
+  final Widget? footer;
+  // ScrollToBottomEventを監視して内部スクロール末尾スクロールを有効化するか
+  final bool listenScrollToBottomEvents;
   final double initialChildSize;
   final double minChildSize;
   final double maxChildSize;
@@ -20,6 +29,7 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
     super.key,
     required this.actions,
     this.slivers,
+    this.footer,
     this.controller,
     this.initialChildSize = 0.35,
     double? minChildSize,
@@ -28,6 +38,7 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
     this.shouldCloseOnMinExtent = true,
     this.resizeOnScroll = true,
     this.backgroundColor,
+    this.listenScrollToBottomEvents = false,
   }) : minChildSize = minChildSize ?? 0.15;
 
   @override
@@ -36,11 +47,43 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
 
 class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> {
   late DraggableScrollableController _controller;
+  StreamSubscription<ScrollToBottomEvent>? _scrollToBottomSub;
+  ScrollController? _innerScrollController;
 
   @override
   void initState() {
     super.initState();
     _controller = widget.controller ?? DraggableScrollableController();
+    if (widget.listenScrollToBottomEvents) {
+      _scrollToBottomSub = EventStream.shared.listen<ScrollToBottomEvent>(_onScrollToBottomEvent);
+      // ここで初期スクロールを発火
+      EventStream.shared.emit(const ScrollToBottomEvent());
+    }
+  }
+
+  void _onScrollToBottomEvent(ScrollToBottomEvent event) async {
+    final scrollController = _innerScrollController;
+    if (scrollController == null || !scrollController.hasClients) return;
+    // レイアウト確定後に実行（再ビルド直後などmaxScrollExtentが0の場合に対応）
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!scrollController.hasClients) return;
+      final maxExtent = scrollController.position.maxScrollExtent;
+      if ((maxExtent - scrollController.offset).abs() > 4) {
+        // scrollController.jumpTo(maxExtent);
+
+        await scrollController.animateTo(
+          maxExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.fastOutSlowIn,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollToBottomSub?.cancel();
+    super.dispose();
   }
 
   @override
@@ -68,29 +111,43 @@ class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> 
       expand: widget.expand,
       shouldCloseOnMinExtent: widget.shouldCloseOnMinExtent,
       builder: (BuildContext context, ScrollController scrollController) {
+        _innerScrollController ??= scrollController;
         return Card(
           color: widget.backgroundColor ?? context.colorScheme.surfaceContainer,
           elevation: 3.0,
           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(18))),
           margin: const EdgeInsets.symmetric(horizontal: 0),
-          child: CustomScrollView(
-            controller: scrollController,
-            slivers: [
-              const SliverPersistentHeader(delegate: _DragHandleDelegate(), pinned: true),
-              if (widget.actions.isNotEmpty)
-                SliverToBoxAdapter(
-                  child: Column(
-                    children: [
-                      SizedBox(
-                        height: 115,
-                        child: ListView(shrinkWrap: true, scrollDirection: Axis.horizontal, children: widget.actions),
+          child: Column(
+            children: [
+              Expanded(
+                child: CustomScrollView(
+                  controller: scrollController,
+                  // // builder内のcontrollerをStateに保持
+                  // key: ValueKey(widget.slivers?.length ?? 0),
+                  slivers: [
+                    const SliverPersistentHeader(delegate: _DragHandleDelegate(), pinned: true),
+                    if (widget.actions.isNotEmpty)
+                      SliverToBoxAdapter(
+                        child: Column(
+                          children: [
+                            SizedBox(
+                              height: 115,
+                              child: ListView(
+                                shrinkWrap: true,
+                                scrollDirection: Axis.horizontal,
+                                children: widget.actions,
+                              ),
+                            ),
+                            const Divider(indent: 16, endIndent: 16),
+                            const SizedBox(height: 16),
+                          ],
+                        ),
                       ),
-                      const Divider(indent: 16, endIndent: 16),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
+                    if (widget.slivers != null) ...widget.slivers!,
+                  ],
                 ),
-              if (widget.slivers != null) ...widget.slivers!,
+              ),
+              if (widget.footer != null) widget.footer!,
             ],
           ),
         );

--- a/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart
@@ -1,22 +1,14 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
-
-class ScrollToBottomEvent extends Event {
-  const ScrollToBottomEvent();
-}
 
 class BaseBottomSheet extends ConsumerStatefulWidget {
   final List<Widget> actions;
   final DraggableScrollableController? controller;
   final List<Widget>? slivers;
   final Widget? footer;
-  // ScrollToBottomEventを監視して内部スクロール末尾スクロールを有効化するか
-  final bool listenScrollToBottomEvents;
   final double initialChildSize;
   final double minChildSize;
   final double maxChildSize;
@@ -38,7 +30,6 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
     this.shouldCloseOnMinExtent = true,
     this.resizeOnScroll = true,
     this.backgroundColor,
-    this.listenScrollToBottomEvents = false,
   }) : minChildSize = minChildSize ?? 0.15;
 
   @override
@@ -47,43 +38,12 @@ class BaseBottomSheet extends ConsumerStatefulWidget {
 
 class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> {
   late DraggableScrollableController _controller;
-  StreamSubscription<ScrollToBottomEvent>? _scrollToBottomSub;
   ScrollController? _innerScrollController;
 
   @override
   void initState() {
     super.initState();
     _controller = widget.controller ?? DraggableScrollableController();
-    if (widget.listenScrollToBottomEvents) {
-      _scrollToBottomSub = EventStream.shared.listen<ScrollToBottomEvent>(_onScrollToBottomEvent);
-      // ここで初期スクロールを発火
-      EventStream.shared.emit(const ScrollToBottomEvent());
-    }
-  }
-
-  void _onScrollToBottomEvent(ScrollToBottomEvent event) async {
-    final scrollController = _innerScrollController;
-    if (scrollController == null || !scrollController.hasClients) return;
-    // レイアウト確定後に実行（再ビルド直後などmaxScrollExtentが0の場合に対応）
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!scrollController.hasClients) return;
-      final maxExtent = scrollController.position.maxScrollExtent;
-      if ((maxExtent - scrollController.offset).abs() > 4) {
-        // scrollController.jumpTo(maxExtent);
-
-        await scrollController.animateTo(
-          maxExtent,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.fastOutSlowIn,
-        );
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _scrollToBottomSub?.cancel();
-    super.dispose();
   }
 
   @override
@@ -122,8 +82,6 @@ class _BaseDraggableScrollableSheetState extends ConsumerState<BaseBottomSheet> 
               Expanded(
                 child: CustomScrollView(
                   controller: scrollController,
-                  // // builder内のcontrollerをStateに保持
-                  // key: ValueKey(widget.slivers?.length ?? 0),
                   slivers: [
                     const SliverPersistentHeader(delegate: _DragHandleDelegate(), pinned: true),
                     if (widget.actions.isNotEmpty)

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
+import 'package:immich_mobile/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
@@ -14,25 +15,28 @@ class ActivityTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final bool isBottomSheet = context.findAncestorWidgetOfExactType<ActivitiesBottomSheet>() != null;
     final asset = ref.watch(currentAssetProvider);
     final isLike = activity.type == ActivityType.like;
     // Asset thumbnail is displayed when we are accessing activities from the album page
     // currentAssetProvider will not be set until we open the gallery viewer
-    final showAssetThumbnail = asset == null && activity.assetId != null;
+    final showAssetThumbnail = asset == null && activity.assetId != null && !isBottomSheet;
 
     return ListTile(
       minVerticalPadding: 15,
       leading: isLike
           ? Container(
-              width: 44,
+              width: isBottomSheet ? 30 : 44,
               alignment: Alignment.center,
               child: Icon(Icons.favorite_rounded, color: Colors.red[700]),
             )
+          : isBottomSheet
+          ? UserCircleAvatar(user: activity.user, size: 30, radius: 15)
           : UserCircleAvatar(user: activity.user),
       title: _ActivityTitle(
         userName: activity.user.name,
         createdAt: activity.createdAt.timeAgo(),
-        leftAlign: isLike || showAssetThumbnail,
+        leftAlign: isBottomSheet ? false : (isLike || showAssetThumbnail),
       ),
       // No subtitle for like, so center title
       titleAlignment: !isLike ? ListTileTitleAlignment.top : ListTileTitleAlignment.center,

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -3,19 +3,18 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
-import 'package:immich_mobile/presentation/widgets/bottom_sheet/activities_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
 
 class ActivityTile extends HookConsumerWidget {
   final Activity activity;
+  final bool isBottomSheet;
 
-  const ActivityTile(this.activity, {super.key});
+  const ActivityTile(this.activity, {super.key, this.isBottomSheet = false});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final bool isBottomSheet = context.findAncestorWidgetOfExactType<ActivitiesBottomSheet>() != null;
     final asset = ref.watch(currentAssetProvider);
     final isLike = activity.type == ActivityType.like;
     // Asset thumbnail is displayed when we are accessing activities from the album page


### PR DESCRIPTION
## Description
- I think being able to view and comment on activities while viewing asset, would be more convenient.
So, changed the asset activity list UI to use the same UI components as the bottom sheet (displayed by swiping from the bottom) that displays asset details.

Note: Confirmed the positive relaction from Alex regarding this changes. 
[• Discord | "mobile: display asset activities in a Bottom Sheet of Asset Viewer" | Immich](https://discord.com/channels/979116623879368755/1428734401650364497)

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)
- N/A

## How Has This Been Tested?
- Tests Manually on Simulator (iPhone 16e)
  - [x] UI operation & display : empty list,  add comment, remove likes/comment, scrolling the bottom sheet (e.g. 10+ comments or likes)
  - [x] No side effect the existing UI : asset activity detail bottom sheet, album activity list
 
<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/054bcfba-1f20-411a-9afc-83525053504d


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- investigate / prototyping
