### PR TITLE
fix(ml): pin cudnn version

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -93,7 +93,8 @@ ENV LD_PRELOAD=/usr/lib/libmimalloc.so.2 \
     MACHINE_LEARNING_MODEL_ARENA=false
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -yqq libcudnn9-cuda-12 && \
+    # Pascal support was dropped in 9.11
+    apt-get install --no-install-recommends -yqq libcudnn9-cuda-12=9.10.2.21-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Immich 2.0.1 installed cuDNN 9.8, while 2.1.0 installs 9.14. It seems Pascal and Maxwell cards are no longer supported as of cuDNN 9.11 (see [9.10](https://docs.nvidia.com/deeplearning/cudnn/backend/v9.10.0/reference/support-matrix.html) vs [9.11](https://docs.nvidia.com/deeplearning/cudnn/backend/v9.11.0/reference/support-matrix.html)), which explains why everyone with the issue has a Pascal or Maxwell GPU. The solution will be to pin to 9.10, and probably add a new CUDA 13 image variant so newer GPUs can continue to receive updates.

Fixes #22982