### PR TITLE
chore(dep): bump ioredis to 5.8.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^7.6.0
         version: 7.14.0
       ioredis:
-        specifier: ^5.3.2
-        version: 5.8.1
+        specifier: ^5.8.2
+        version: 5.8.2
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -7302,8 +7302,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ioredis@5.8.1:
-    resolution: {integrity: sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==}
+  ioredis@5.8.2:
+    resolution: {integrity: sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==}
     engines: {node: '>=12.22.0'}
 
   ip-address@10.0.1:
@@ -17212,7 +17212,7 @@ snapshots:
   bullmq@5.61.0:
     dependencies:
       cron-parser: 4.9.0
-      ioredis: 5.8.1
+      ioredis: 5.8.2
       msgpackr: 1.11.5
       node-abort-controller: 3.1.1
       semver: 7.7.3
@@ -19600,7 +19600,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ioredis@5.8.1:
+  ioredis@5.8.2:
     dependencies:
       '@ioredis/commands': 1.4.0
       cluster-key-slot: 1.1.2

--- a/server/package.json
+++ b/server/package.json
@@ -75,7 +75,7 @@
     "geo-tz": "^8.0.0",
     "handlebars": "^4.7.8",
     "i18n-iso-countries": "^7.6.0",
-    "ioredis": "^5.3.2",
+    "ioredis": "^5.8.2",
     "js-yaml": "^4.1.0",
     "kysely": "0.28.2",
     "kysely-postgres-js": "^3.0.0",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follows up on #22863. ioredis has now resolved https://github.com/redis/ioredis/issues/2026 which means that there are no workarounds required to run immich <-> redis on IPv6-only network.

This effectively bumps ioredis one patch version from `5.8.1` to `5.8.2` (when building with lockfile in place).

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

All manual.