### PR TITLE
fix: semver parser grab everything before hyphen

### DIFF
--- a/mobile/lib/utils/semver.dart
+++ b/mobile/lib/utils/semver.dart
@@ -15,7 +15,7 @@ class SemVer {
   }
 
   factory SemVer.fromString(String version) {
-    final parts = version.split('.');
+    final parts = version.split("-")[0].split('.');
     return SemVer(major: int.parse(parts[0]), minor: int.parse(parts[1]), patch: int.parse(parts[2]));
   }
 


### PR DESCRIPTION
used for versions like 2.1.0-DEBUG
