### PR TITLE
refactor: user delete

### DIFF
--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -94,6 +94,9 @@ type EventMap = {
   // user events
   UserSignup: [{ notify: boolean; id: string; password?: string }];
   UserCreate: [UserEvent];
+  /** user is soft deleted */
+  UserTrash: [UserEvent];
+  /** user is permanently deleted */
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
 

--- a/server/src/services/job.service.ts
+++ b/server/src/services/job.service.ts
@@ -421,11 +421,6 @@ export class JobService extends BaseService {
         }
         break;
       }
-
-      case JobName.UserDelete: {
-        this.eventRepository.clientBroadcast('on_user_delete', item.data.id);
-        break;
-      }
     }
   }
 }

--- a/server/src/services/notification.service.ts
+++ b/server/src/services/notification.service.ts
@@ -202,6 +202,11 @@ export class NotificationService extends BaseService {
     }
   }
 
+  @OnEvent({ name: 'UserDelete' })
+  onUserDelete({ id }: ArgOf<'UserDelete'>) {
+    this.eventRepository.clientBroadcast('on_user_delete', id);
+  }
+
   @OnEvent({ name: 'AlbumUpdate' })
   async onAlbumUpdate({ id, recipientId }: ArgOf<'AlbumUpdate'>) {
     await this.jobRepository.removeJob(JobName.NotifyAlbumUpdate, `${id}/${recipientId}`);

--- a/server/src/services/telemetry.service.ts
+++ b/server/src/services/telemetry.service.ts
@@ -16,8 +16,8 @@ export class TelemetryService extends BaseService {
     this.telemetryRepository.api.addToGauge(`immich.users.total`, 1);
   }
 
-  @OnEvent({ name: 'UserDelete' })
-  onUserDelete() {
+  @OnEvent({ name: 'UserTrash' })
+  onUserTrash() {
     this.telemetryRepository.api.addToGauge(`immich.users.total`, -1);
   }
 

--- a/server/src/services/user-admin.service.ts
+++ b/server/src/services/user-admin.service.ts
@@ -104,7 +104,7 @@ export class UserAdminService extends BaseService {
     const status = force ? UserStatus.Removing : UserStatus.Deleted;
     const user = await this.userRepository.update(id, { status, deletedAt: new Date() });
 
-    await this.eventRepository.emit('UserDelete', user);
+    await this.eventRepository.emit('UserTrash', user);
 
     if (force) {
       await this.jobRepository.queue({ name: JobName.UserDelete, data: { id: user.id, force } });


### PR DESCRIPTION
- Prefer events instead of success/skip/fail job status return codes (how `JobService.onDone` currently works)
- Rename `UserDelete` to `UserRemove` (triggered when a user is soft deleted)
- Add `UserDelete` (triggered when a user is permanently deleted from the system)