### PR TITLE
refactor: asset description modal

### DIFF
--- a/web/src/lib/modals/AssetUpdateDescriptionConfirmModal.svelte
+++ b/web/src/lib/modals/AssetUpdateDescriptionConfirmModal.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-  import { ConfirmModal, Input } from '@immich/ui';
+  import { ConfirmModal, Field, Textarea } from '@immich/ui';
   import { mdiText } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
-  interface Props {
+  type Props = {
     onClose: (description?: string) => void;
-  }
+  };
 
   let { onClose }: Props = $props();
-
   let description = $state('');
 </script>
 
@@ -20,11 +19,8 @@
   onClose={(confirmed) => (confirmed ? onClose(description) : onClose())}
 >
   {#snippet promptSnippet()}
-    <div class="flex flex-col text-start gap-2">
-      <div class="flex flex-col">
-        <label for="description">{$t('description')}</label>
-        <Input class="immich-form-input" id="description" bind:value={description} />
-      </div>
-    </div>
+    <Field label={$t('description')}>
+      <Textarea bind:value={description} grow />
+    </Field>
   {/snippet}
 </ConfirmModal>


### PR DESCRIPTION
Prefer an auto-growing text area component, over a single line input field

| Before | After |
| - | - |
| <img width="594" height="370" alt="image" src="https://github.com/user-attachments/assets/2b157651-0ead-4543-a4f5-c860272c5c68" /> | <img width="594" height="370" alt="image" src="https://github.com/user-attachments/assets/97467fbf-fdb4-4b13-bce0-5b64e768f9b0" /> |