### PR TITLE
feat: statically hostable frontend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -789,6 +789,9 @@ importers:
       '@koddsson/eslint-plugin-tscompat':
         specifier: ^0.2.0
         version: 0.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@rollup/plugin-replace':
+        specifier: ^6.0.2
+        version: 6.0.2(rollup@4.52.5)
       '@socket.io/component-emitter':
         specifier: ^3.1.0
         version: 3.1.2
@@ -3680,6 +3683,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@rollup/plugin-replace@6.0.2':
+    resolution: {integrity: sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -15289,6 +15301,13 @@ snapshots:
   '@react-email/text@0.1.5(react@19.2.0)':
     dependencies:
       react: 19.2.0
+
+  '@rollup/plugin-replace@6.0.2(rollup@4.52.5)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      magic-string: 0.30.19
+    optionalDependencies:
+      rollup: 4.52.5
 
   '@rollup/pluginutils@5.3.0(rollup@4.52.5)':
     dependencies:

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -195,4 +195,10 @@ export class EnvDto {
   @IsString()
   @Optional()
   REDIS_URL?: string;
+
+  @ValidateBoolean({ optional: true })
+  IMMICH_DEV_CORS_ALL_ORIGINS?: boolean;
+
+  @ValidateBoolean({ optional: true })
+  IMMICH_DEV_CORS_CREDENTIALS?: boolean;
 }

--- a/server/src/workers/api.ts
+++ b/server/src/workers/api.ts
@@ -34,7 +34,17 @@ async function bootstrap() {
   app.use(cookieParser());
   app.use(json({ limit: '10mb' }));
   if (configRepository.isDev()) {
-    app.enableCors();
+    const options = configRepository.getCorsOptions();
+    if (options) {
+      logger.warn(`Enabling CORS: ${JSON.stringify(configRepository.getEnv().dev.cors)}`);
+      logger.warn(
+        'NOTE: to properly support a fully statically hosted frontend you MUST configure the frontend/backend to be on the same site. i.e. frontend=https://localhost:1234 and backend=http://localhost:2283 or configure TLS',
+      );
+      app.enableCors(options);
+    } else {
+      logger.warn('Enabling CORS');
+      app.enableCors();
+    }
   }
   app.useWebSocketAdapter(new WebSocketAdapter(app));
   useSwagger(app, { write: configRepository.isDev() });

--- a/web/package.json
+++ b/web/package.json
@@ -65,6 +65,7 @@
     "@eslint/js": "^9.36.0",
     "@faker-js/faker": "^10.0.0",
     "@koddsson/eslint-plugin-tscompat": "^0.2.0",
+    "@rollup/plugin-replace": "^6.0.2",
     "@socket.io/component-emitter": "^3.1.0",
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/enhanced-img": "^0.8.0",

--- a/web/src/lib/utils/server.ts
+++ b/web/src/lib/utils/server.ts
@@ -1,15 +1,48 @@
 import { retrieveServerConfig } from '$lib/stores/server-config.store';
-import { initLanguage } from '$lib/utils';
+import { AbortError, initLanguage, sleep } from '$lib/utils';
 import { defaults } from '@immich/sdk';
 import { memoize } from 'lodash-es';
 
 type Fetch = typeof fetch;
+
+const api_server: string = '@IMMICH_API_SERVER@';
+
+const tryServers = async (fetchFn: typeof fetch) => {
+  const servers = api_server
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+  if (servers.length === 0) {
+    return true;
+  }
+  // servers are in priority order, try in parallel, use first success
+  const fetchers = servers.map(async (url: string) => {
+    const response = await fetchFn(url + '/server/config');
+    if (response.ok) {
+      return url;
+    }
+    throw new AbortError();
+  });
+  try {
+    const urlWinner = await Promise.any(fetchers);
+    defaults.baseUrl = urlWinner;
+    defaults.fetch = (url, options) => fetchFn(url, { credentials: 'include', ...options });
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+};
 
 async function _init(fetch: Fetch) {
   // set event.fetch on the fetch-client used by @immich/sdk
   // https://kit.svelte.dev/docs/load#making-fetch-requests
   // https://github.com/oazapfts/oazapfts/blob/main/README.md#fetch-options
   defaults.fetch = fetch;
+  try {
+    await Promise.race([tryServers(fetch), sleep(5000)]);
+  } catch {
+    throw 'Could not connect to any server';
+  }
   await initLanguage();
   await retrieveServerConfig();
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+import replace from '@rollup/plugin-replace';
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
@@ -39,6 +40,16 @@ export default defineConfig({
     enhancedImages(),
     tailwindcss(),
     sveltekit(),
+    replace({
+      preventAssignment: true,
+      include: ['**/server.ts'],
+      sourceMap: true,
+      objectGuards: false,
+      delimiters: ['@', '@'],
+      values: {
+        IMMICH_API_SERVER: process.env.IMMICH_API_SERVER ?? '',
+      },
+    }),
     process.env.BUILD_STATS === 'true'
       ? visualizer({
           emitFile: true,


### PR DESCRIPTION
Add the ability to statically serve the frontend, with important restrictions. 

It is desirable to be able to deploy/build/test the web frontend separately from the backend - for CI, simplified testing, and many other reasons. 

The frontend talks to the backend over `fetch`. Normally, the frontend/backend are hosted by the same server, and have identical domains and ports. 

There are two ways to have the frontend/backend on different servers.
1. two servers, non-TLS - but domain between frontend/backend must match (i.e. localhost) 
  a. different ports on the same domain are considered 'same-site'
3. two servers, different sites, TLS required on both

In order for fetch to work across sites, you must specify the option `{credentials: 'include'}`. The web frontend has been modified to check if `process.env.IMMICH_API_SERVER` is not null, it will configure the 'baseUrl' of the `@immich/sdk` to use that server. 

To compile the web code statically using this `baseUrl` override, and start a simple static http server, use the commands:

```sh
cd web
IMMICH_API_SERVER=http://localhost:2283/api pnpm run build
cd build
# the -s flag enables SPA support, redirecting all paths to index.html
pnpm dlx serve -s 
```

If this env variable is not specified, the old behavior (using `/api`) as the `baseUrl` will work as before. 

When the server is launched in development environments, it turns on CORS. However, when the incoming fetch specifies `credentials: include` - you MUST specify a non-* (wildcard) origin AND specify `Access-Control-Allow-Credentials` in the response headers. 

You can do this with 2 new env variables. Put these in your `.env` file in the `/docker` directory:
```sh
IMMICH_DEV_CORS_ALL_ORIGINS=true
IMMICH_DEV_CORS_CREDENTIALS=true
```

## Limitations: 
- Websockets don't work on a static host
- Cross site (cross-domain) without TLS

## Security:
- No changes to any default configuration
- CORS changes are opt in, and only work in dev mode
- Web changes rely on rollup plugin which only runs when env variable is present

## Changes
- Add `IMMICH_API_SERVER` environment variable to configure comma-separated list of API endpoints
- Implement api server discovery with fallback to first available server  
- Add `IMMICH_DEV_CORS_ALL_ORIGINS` and `IMMICH_DEV_CORS_CREDENTIALS` env vars for dev CORS control
- Use `@rollup/plugin-replace` to inject API server config at build time
- Enable credentials in fetch requests when custom servers are configured
- Add warning logs when dev CORS options are enabled
