### PR TITLE
feat: (mobile) open asset viewer from album activity page

### DIFF
--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -33,6 +33,7 @@ enum TimelineOrigin {
   map,
   search,
   deepLink,
+  albumActivities,
 }
 
 class TimelineFactory {

--- a/mobile/lib/presentation/pages/drift_activities.page.dart
+++ b/mobile/lib/presentation/pages/drift_activities.page.dart
@@ -23,7 +23,7 @@ class DriftActivitiesPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final album = ref.watch(currentRemoteAlbumProvider)!;
-    final asset = ref.watch(currentAssetNotifier) as RemoteAsset?;
+    final asset = ref.read(currentAssetNotifier) as RemoteAsset?;
     final user = ref.watch(currentUserProvider);
 
     final activityNotifier = ref.read(albumActivityProvider(album.id, asset?.id).notifier);

--- a/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
+++ b/mobile/lib/presentation/widgets/album/drift_activity_text_field.dart
@@ -36,10 +36,6 @@ class _DriftActivityTextFieldState extends ConsumerState<DriftActivityTextField>
     inputController = TextEditingController();
     inputFocusNode = FocusNode();
 
-    if (!widget.isBottomSheet) {
-      inputFocusNode.requestFocus();
-    }
-
     inputFocusNode.addListener(() {
       if (inputFocusNode.hasFocus) {
         widget.onKeyboardFocus?.call();

--- a/mobile/lib/providers/activity_service.provider.dart
+++ b/mobile/lib/providers/activity_service.provider.dart
@@ -1,4 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/repositories/activity_api.repository.dart';
 import 'package:immich_mobile/services/activity.service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -6,4 +8,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'activity_service.provider.g.dart';
 
 @riverpod
-ActivityService activityService(Ref ref) => ActivityService(ref.watch(activityApiRepositoryProvider));
+ActivityService activityService(Ref ref) => ActivityService(
+  ref.watch(activityApiRepositoryProvider),
+  ref.watch(timelineFactoryProvider),
+  ref.watch(assetServiceProvider),
+);

--- a/mobile/lib/providers/activity_service.provider.g.dart
+++ b/mobile/lib/providers/activity_service.provider.g.dart
@@ -6,7 +6,7 @@ part of 'activity_service.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$activityServiceHash() => r'ce775779787588defe1e76406e09a9c109470310';
+String _$activityServiceHash() => r'3ce0eb33948138057cc63f07a7598047b99e7599';
 
 /// See also [activityService].
 @ProviderFor(activityService)

--- a/mobile/lib/services/activity.service.dart
+++ b/mobile/lib/services/activity.service.dart
@@ -1,16 +1,24 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/errors.dart';
+import 'package:immich_mobile/domain/services/asset.service.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/mixins/error_logger.mixin.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
 import 'package:immich_mobile/repositories/activity_api.repository.dart';
+import 'package:immich_mobile/routing/router.dart';
 import 'package:logging/logging.dart';
+import 'package:immich_mobile/entities/store.entity.dart' as immich_store;
 
 class ActivityService with ErrorLoggerMixin {
   final ActivityApiRepository _activityApiRepository;
+  final TimelineFactory _timelineFactory;
+  final AssetService _assetService;
 
   @override
   final Logger logger = Logger("ActivityService");
 
-  ActivityService(this._activityApiRepository);
+  ActivityService(this._activityApiRepository, this._timelineFactory, this._assetService);
 
   Future<List<Activity>> getAllActivities(String albumId, {String? assetId}) async {
     return logError(
@@ -48,5 +56,22 @@ class ActivityService with ErrorLoggerMixin {
       () => _activityApiRepository.create(albumId, type, assetId: assetId, comment: comment),
       errorMessage: "Failed to create $type for album $albumId",
     );
+  }
+
+  Future<AssetViewerRoute?> buildAssetViewerRoute(String assetId, WidgetRef ref) async {
+    if (immich_store.Store.isBetaTimelineEnabled) {
+      final asset = await _assetService.getRemoteAsset(assetId);
+      if (asset == null) {
+        return null;
+      }
+
+      AssetViewer.setAsset(ref, asset);
+      return AssetViewerRoute(
+        initialIndex: 0,
+        timelineService: _timelineFactory.fromAssets([asset], TimelineOrigin.albumActivities),
+      );
+    }
+
+    return null;
   }
 }

--- a/mobile/lib/widgets/activities/activity_tile.dart
+++ b/mobile/lib/widgets/activities/activity_tile.dart
@@ -1,8 +1,10 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/datetime_extensions.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
+import 'package:immich_mobile/providers/activity_service.provider.dart';
 import 'package:immich_mobile/providers/image/immich_remote_thumbnail_provider.dart';
 import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/widgets/common/user_circle_avatar.dart';
@@ -20,6 +22,14 @@ class ActivityTile extends HookConsumerWidget {
     // Asset thumbnail is displayed when we are accessing activities from the album page
     // currentAssetProvider will not be set until we open the gallery viewer
     final showAssetThumbnail = asset == null && activity.assetId != null && !isBottomSheet;
+
+    onTap() async {
+      final activityService = ref.read(activityServiceProvider);
+      final route = await activityService.buildAssetViewerRoute(activity.assetId!, ref);
+      if (route != null) {
+        await context.pushRoute(route);
+      }
+    }
 
     return ListTile(
       minVerticalPadding: 15,
@@ -39,7 +49,7 @@ class ActivityTile extends HookConsumerWidget {
       ),
       // No subtitle for like, so center title
       titleAlignment: !isLike ? ListTileTitleAlignment.top : ListTileTitleAlignment.center,
-      trailing: showAssetThumbnail ? _ActivityAssetThumbnail(activity.assetId!) : null,
+      trailing: showAssetThumbnail ? _ActivityAssetThumbnail(activity.assetId!, onTap) : null,
       subtitle: !isLike ? Text(activity.comment!) : null,
     );
   }
@@ -78,22 +88,26 @@ class _ActivityTitle extends StatelessWidget {
 
 class _ActivityAssetThumbnail extends StatelessWidget {
   final String assetId;
+  final GestureTapCallback? onTap;
 
-  const _ActivityAssetThumbnail(this.assetId);
+  const _ActivityAssetThumbnail(this.assetId, this.onTap);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 40,
-      height: 30,
-      decoration: BoxDecoration(
-        borderRadius: const BorderRadius.all(Radius.circular(4)),
-        image: DecorationImage(
-          image: ImmichRemoteThumbnailProvider(assetId: assetId),
-          fit: BoxFit.cover,
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 40,
+        height: 30,
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(4)),
+          image: DecorationImage(
+            image: ImmichRemoteThumbnailProvider(assetId: assetId),
+            fit: BoxFit.cover,
+          ),
         ),
+        child: const SizedBox.shrink(),
       ),
-      child: const SizedBox.shrink(),
     );
   }
 }


### PR DESCRIPTION
## Description
- Click thumbnail in album activity page, then navigate to the asset viewer.
- Web has this behavior, but not yet on mobile.
- Note: needed "Enable New Timeline"
- [Discord | "feat(mobile) : open asset viewer from album activity list" | Immich](https://discord.com/channels/979116623879368755/1430247761269358763)

Fixes # (issue)
- N/A

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### Manually tests on Simulator (iPhone 16e)
- [x] Round-trip operation tests - between the activity page and the asset viewer for several thumbnails
- [x] Basic feature tests for the asset viewer
- [x] Tests for several albums

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

https://github.com/user-attachments/assets/a37a24c8-fa1b-4cb0-bed9-c8457c0dc228

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- Investegation
