### PR TITLE
feat: logout sessions on password change 

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -669,6 +669,8 @@
   "change_password_description": "This is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
   "change_password_form_confirm_password": "Confirm Password",
   "change_password_form_description": "Hi {name},\n\nThis is either the first time you are signing into the system or a request has been made to change your password. Please enter the new password below.",
+  "change_password_form_log_out": "Log out all other devices",
+  "change_password_form_log_out_description": "It is recommended to log out of all other devices",
   "change_password_form_new_password": "New Password",
   "change_password_form_password_mismatch": "Passwords do not match",
   "change_password_form_reenter_new_password": "Re-enter New Password",

--- a/mobile/openapi/lib/model/change_password_dto.dart
+++ b/mobile/openapi/lib/model/change_password_dto.dart
@@ -13,18 +13,12 @@ part of openapi.api;
 class ChangePasswordDto {
   /// Returns a new [ChangePasswordDto] instance.
   ChangePasswordDto({
-    this.invalidateSessions,
+    this.invalidateSessions = false,
     required this.newPassword,
     required this.password,
   });
 
-  ///
-  /// Please note: This property should have been non-nullable! Since the specification file
-  /// does not include a default value (using the "default:" property), however, the generated
-  /// source code must fall back to having a nullable type.
-  /// Consider adding a "default:" property in the specification file to hide this note.
-  ///
-  bool? invalidateSessions;
+  bool invalidateSessions;
 
   String newPassword;
 
@@ -39,7 +33,7 @@ class ChangePasswordDto {
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (invalidateSessions == null ? 0 : invalidateSessions!.hashCode) +
+    (invalidateSessions.hashCode) +
     (newPassword.hashCode) +
     (password.hashCode);
 
@@ -48,11 +42,7 @@ class ChangePasswordDto {
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-    if (this.invalidateSessions != null) {
       json[r'invalidateSessions'] = this.invalidateSessions;
-    } else {
-    //  json[r'invalidateSessions'] = null;
-    }
       json[r'newPassword'] = this.newPassword;
       json[r'password'] = this.password;
     return json;
@@ -67,7 +57,7 @@ class ChangePasswordDto {
       final json = value.cast<String, dynamic>();
 
       return ChangePasswordDto(
-        invalidateSessions: mapValueOfType<bool>(json, r'invalidateSessions'),
+        invalidateSessions: mapValueOfType<bool>(json, r'invalidateSessions') ?? false,
         newPassword: mapValueOfType<String>(json, r'newPassword')!,
         password: mapValueOfType<String>(json, r'password')!,
       );

--- a/mobile/openapi/lib/model/change_password_dto.dart
+++ b/mobile/openapi/lib/model/change_password_dto.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ChangePasswordDto {
   /// Returns a new [ChangePasswordDto] instance.
   ChangePasswordDto({
-    this.logOutOtherSessions,
+    this.invalidateSessions,
     required this.newPassword,
     required this.password,
   });
@@ -24,7 +24,7 @@ class ChangePasswordDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
-  bool? logOutOtherSessions;
+  bool? invalidateSessions;
 
   String newPassword;
 
@@ -32,26 +32,26 @@ class ChangePasswordDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ChangePasswordDto &&
-    other.logOutOtherSessions == logOutOtherSessions &&
+    other.invalidateSessions == invalidateSessions &&
     other.newPassword == newPassword &&
     other.password == password;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (logOutOtherSessions == null ? 0 : logOutOtherSessions!.hashCode) +
+    (invalidateSessions == null ? 0 : invalidateSessions!.hashCode) +
     (newPassword.hashCode) +
     (password.hashCode);
 
   @override
-  String toString() => 'ChangePasswordDto[logOutOtherSessions=$logOutOtherSessions, newPassword=$newPassword, password=$password]';
+  String toString() => 'ChangePasswordDto[invalidateSessions=$invalidateSessions, newPassword=$newPassword, password=$password]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-    if (this.logOutOtherSessions != null) {
-      json[r'logOutOtherSessions'] = this.logOutOtherSessions;
+    if (this.invalidateSessions != null) {
+      json[r'invalidateSessions'] = this.invalidateSessions;
     } else {
-    //  json[r'logOutOtherSessions'] = null;
+    //  json[r'invalidateSessions'] = null;
     }
       json[r'newPassword'] = this.newPassword;
       json[r'password'] = this.password;
@@ -67,7 +67,7 @@ class ChangePasswordDto {
       final json = value.cast<String, dynamic>();
 
       return ChangePasswordDto(
-        logOutOtherSessions: mapValueOfType<bool>(json, r'logOutOtherSessions'),
+        invalidateSessions: mapValueOfType<bool>(json, r'invalidateSessions'),
         newPassword: mapValueOfType<String>(json, r'newPassword')!,
         password: mapValueOfType<String>(json, r'password')!,
       );

--- a/mobile/openapi/lib/model/change_password_dto.dart
+++ b/mobile/openapi/lib/model/change_password_dto.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ChangePasswordDto {
   /// Returns a new [ChangePasswordDto] instance.
   ChangePasswordDto({
-    this.logOutOhterSessions,
+    this.logOutOtherSessions,
     required this.newPassword,
     required this.password,
   });
@@ -24,7 +24,7 @@ class ChangePasswordDto {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
-  bool? logOutOhterSessions;
+  bool? logOutOtherSessions;
 
   String newPassword;
 
@@ -32,26 +32,26 @@ class ChangePasswordDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ChangePasswordDto &&
-    other.logOutOhterSessions == logOutOhterSessions &&
+    other.logOutOtherSessions == logOutOtherSessions &&
     other.newPassword == newPassword &&
     other.password == password;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (logOutOhterSessions == null ? 0 : logOutOhterSessions!.hashCode) +
+    (logOutOtherSessions == null ? 0 : logOutOtherSessions!.hashCode) +
     (newPassword.hashCode) +
     (password.hashCode);
 
   @override
-  String toString() => 'ChangePasswordDto[logOutOhterSessions=$logOutOhterSessions, newPassword=$newPassword, password=$password]';
+  String toString() => 'ChangePasswordDto[logOutOtherSessions=$logOutOtherSessions, newPassword=$newPassword, password=$password]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-    if (this.logOutOhterSessions != null) {
-      json[r'logOutOhterSessions'] = this.logOutOhterSessions;
+    if (this.logOutOtherSessions != null) {
+      json[r'logOutOtherSessions'] = this.logOutOtherSessions;
     } else {
-    //  json[r'logOutOhterSessions'] = null;
+    //  json[r'logOutOtherSessions'] = null;
     }
       json[r'newPassword'] = this.newPassword;
       json[r'password'] = this.password;
@@ -67,7 +67,7 @@ class ChangePasswordDto {
       final json = value.cast<String, dynamic>();
 
       return ChangePasswordDto(
-        logOutOhterSessions: mapValueOfType<bool>(json, r'logOutOhterSessions'),
+        logOutOtherSessions: mapValueOfType<bool>(json, r'logOutOtherSessions'),
         newPassword: mapValueOfType<String>(json, r'newPassword')!,
         password: mapValueOfType<String>(json, r'password')!,
       );

--- a/mobile/openapi/lib/model/change_password_dto.dart
+++ b/mobile/openapi/lib/model/change_password_dto.dart
@@ -13,9 +13,18 @@ part of openapi.api;
 class ChangePasswordDto {
   /// Returns a new [ChangePasswordDto] instance.
   ChangePasswordDto({
+    this.logOutOhterSessions,
     required this.newPassword,
     required this.password,
   });
+
+  ///
+  /// Please note: This property should have been non-nullable! Since the specification file
+  /// does not include a default value (using the "default:" property), however, the generated
+  /// source code must fall back to having a nullable type.
+  /// Consider adding a "default:" property in the specification file to hide this note.
+  ///
+  bool? logOutOhterSessions;
 
   String newPassword;
 
@@ -23,20 +32,27 @@ class ChangePasswordDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is ChangePasswordDto &&
+    other.logOutOhterSessions == logOutOhterSessions &&
     other.newPassword == newPassword &&
     other.password == password;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (logOutOhterSessions == null ? 0 : logOutOhterSessions!.hashCode) +
     (newPassword.hashCode) +
     (password.hashCode);
 
   @override
-  String toString() => 'ChangePasswordDto[newPassword=$newPassword, password=$password]';
+  String toString() => 'ChangePasswordDto[logOutOhterSessions=$logOutOhterSessions, newPassword=$newPassword, password=$password]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+    if (this.logOutOhterSessions != null) {
+      json[r'logOutOhterSessions'] = this.logOutOhterSessions;
+    } else {
+    //  json[r'logOutOhterSessions'] = null;
+    }
       json[r'newPassword'] = this.newPassword;
       json[r'password'] = this.password;
     return json;
@@ -51,6 +67,7 @@ class ChangePasswordDto {
       final json = value.cast<String, dynamic>();
 
       return ChangePasswordDto(
+        logOutOhterSessions: mapValueOfType<bool>(json, r'logOutOhterSessions'),
         newPassword: mapValueOfType<String>(json, r'newPassword')!,
         password: mapValueOfType<String>(json, r'password')!,
       );

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11470,6 +11470,7 @@
       "ChangePasswordDto": {
         "properties": {
           "invalidateSessions": {
+            "default": false,
             "type": "boolean"
           },
           "newPassword": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11469,8 +11469,7 @@
       },
       "ChangePasswordDto": {
         "properties": {
-          "logOutOtherSessions": {
-            "example": true,
+          "invalidateSessions": {
             "type": "boolean"
           },
           "newPassword": {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11469,7 +11469,7 @@
       },
       "ChangePasswordDto": {
         "properties": {
-          "logOutOhterSessions": {
+          "logOutOtherSessions": {
             "example": true,
             "type": "boolean"
           },

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11469,6 +11469,10 @@
       },
       "ChangePasswordDto": {
         "properties": {
+          "logOutOhterSessions": {
+            "example": true,
+            "type": "boolean"
+          },
           "newPassword": {
             "example": "password",
             "minLength": 8,

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -561,7 +561,7 @@ export type SignUpDto = {
     password: string;
 };
 export type ChangePasswordDto = {
-    logOutOtherSessions?: boolean;
+    invalidateSessions?: boolean;
     newPassword: string;
     password: string;
 };

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -561,6 +561,7 @@ export type SignUpDto = {
     password: string;
 };
 export type ChangePasswordDto = {
+    logOutOhterSessions?: boolean;
     newPassword: string;
     password: string;
 };

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -561,7 +561,7 @@ export type SignUpDto = {
     password: string;
 };
 export type ChangePasswordDto = {
-    logOutOhterSessions?: boolean;
+    logOutOtherSessions?: boolean;
     newPassword: string;
     password: string;
 };

--- a/server/src/controllers/auth.controller.spec.ts
+++ b/server/src/controllers/auth.controller.spec.ts
@@ -183,7 +183,7 @@ describe(AuthController.name, () => {
     it('should be an authenticated route', async () => {
       await request(ctx.getHttpServer())
         .post('/auth/change-password')
-        .send({ password: 'password', newPassword: 'Password1234', logOutOtherSessions: false });
+        .send({ password: 'password', newPassword: 'Password1234', invalidateSessions: false });
       expect(ctx.authenticate).toHaveBeenCalled();
     });
   });

--- a/server/src/controllers/auth.controller.spec.ts
+++ b/server/src/controllers/auth.controller.spec.ts
@@ -183,7 +183,7 @@ describe(AuthController.name, () => {
     it('should be an authenticated route', async () => {
       await request(ctx.getHttpServer())
         .post('/auth/change-password')
-        .send({ password: 'password', newPassword: 'Password1234', logOutOhterSessions: false });
+        .send({ password: 'password', newPassword: 'Password1234', logOutOtherSessions: false });
       expect(ctx.authenticate).toHaveBeenCalled();
     });
   });

--- a/server/src/controllers/auth.controller.spec.ts
+++ b/server/src/controllers/auth.controller.spec.ts
@@ -183,7 +183,7 @@ describe(AuthController.name, () => {
     it('should be an authenticated route', async () => {
       await request(ctx.getHttpServer())
         .post('/auth/change-password')
-        .send({ password: 'password', newPassword: 'Password1234' });
+        .send({ password: 'password', newPassword: 'Password1234', logOutOhterSessions: false });
       expect(ctx.authenticate).toHaveBeenCalled();
     });
   });

--- a/server/src/controllers/session.controller.ts
+++ b/server/src/controllers/session.controller.ts
@@ -28,7 +28,7 @@ export class SessionController {
   @Authenticated({ permission: Permission.SessionDelete })
   @HttpCode(HttpStatus.NO_CONTENT)
   deleteAllSessions(@Auth() auth: AuthDto): Promise<void> {
-    return this.service.deleteAll(auth.user.id, auth.session?.id);
+    return this.service.deleteAll(auth);
   }
 
   @Put(':id')

--- a/server/src/controllers/session.controller.ts
+++ b/server/src/controllers/session.controller.ts
@@ -28,7 +28,7 @@ export class SessionController {
   @Authenticated({ permission: Permission.SessionDelete })
   @HttpCode(HttpStatus.NO_CONTENT)
   deleteAllSessions(@Auth() auth: AuthDto): Promise<void> {
-    return this.service.deleteAll(auth);
+    return this.service.deleteAll(auth.user.id);
   }
 
   @Put(':id')

--- a/server/src/controllers/session.controller.ts
+++ b/server/src/controllers/session.controller.ts
@@ -28,7 +28,7 @@ export class SessionController {
   @Authenticated({ permission: Permission.SessionDelete })
   @HttpCode(HttpStatus.NO_CONTENT)
   deleteAllSessions(@Auth() auth: AuthDto): Promise<void> {
-    return this.service.deleteAll(auth.user.id);
+    return this.service.deleteAll(auth.user.id, auth.session?.id);
   }
 
   @Put(':id')

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -85,7 +85,7 @@ export class ChangePasswordDto {
   newPassword!: string;
 
   @ValidateBoolean({ optional: true })
-  logOutOtherSessions?: boolean;
+  invalidateSessions?: boolean;
 }
 
 export class PinCodeSetupDto {

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -84,7 +84,7 @@ export class ChangePasswordDto {
   @ApiProperty({ example: 'password' })
   newPassword!: string;
 
-  @ValidateBoolean({ optional: true })
+  @ValidateBoolean({ optional: true, default: false })
   invalidateSessions?: boolean;
 }
 

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -85,8 +85,6 @@ export class ChangePasswordDto {
   newPassword!: string;
 
   @ValidateBoolean({ optional: true })
-  @Optional()
-  @ApiProperty({ example: true })
   logOutOtherSessions?: boolean;
 }
 

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 import { AuthApiKey, AuthSession, AuthSharedLink, AuthUser, UserAdmin } from 'src/database';
 import { ImmichCookie, UserMetadataKey } from 'src/enum';
 import { UserMetadataItem } from 'src/types';
-import { Optional, PinCode, toEmail } from 'src/validation';
+import { Optional, PinCode, toEmail, ValidateBoolean } from 'src/validation';
 
 export type CookieResponse = {
   isSecure: boolean;
@@ -84,7 +84,7 @@ export class ChangePasswordDto {
   @ApiProperty({ example: 'password' })
   newPassword!: string;
 
-  @IsBoolean()
+  @ValidateBoolean({ optional: true })
   @Optional()
   @ApiProperty({ example: true })
   logOutOtherSessions?: boolean;

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { IsBoolean, IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 import { AuthApiKey, AuthSession, AuthSharedLink, AuthUser, UserAdmin } from 'src/database';
 import { ImmichCookie, UserMetadataKey } from 'src/enum';
 import { UserMetadataItem } from 'src/types';
@@ -83,6 +83,11 @@ export class ChangePasswordDto {
   @MinLength(8)
   @ApiProperty({ example: 'password' })
   newPassword!: string;
+
+  @IsBoolean()
+  @Optional()
+  @ApiProperty({ example: true })
+  logOutOhterSessions?: boolean;
 }
 
 export class PinCodeSetupDto {

--- a/server/src/dtos/auth.dto.ts
+++ b/server/src/dtos/auth.dto.ts
@@ -87,7 +87,7 @@ export class ChangePasswordDto {
   @IsBoolean()
   @Optional()
   @ApiProperty({ example: true })
-  logOutOhterSessions?: boolean;
+  logOutOtherSessions?: boolean;
 }
 
 export class PinCodeSetupDto {

--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -74,6 +74,12 @@ delete from "session"
 where
   "id" = $1::uuid
 
+-- SessionRepository.invalidate
+delete from "session"
+where
+  "userId" = $1
+  and "id" != $2
+
 -- SessionRepository.lockAll
 update "session"
 set

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -99,7 +99,8 @@ type EventMap = {
   /** user is permanently deleted */
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
-  UserPasswordChange: [{ userId: string; currentSessionId?: string; shouldLogoutSessions?: boolean }];
+
+  AuthChangePassword: [{ userId: string; currentSessionId?: string; shouldLogoutSessions?: boolean }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -100,7 +100,7 @@ type EventMap = {
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
 
-  AuthChangePassword: [{ userId: string; currentSessionId?: string; shouldLogoutSessions?: boolean }];
+  AuthChangePassword: [{ userId: string; currentSessionId?: string; invalidateSessions?: boolean }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -99,7 +99,7 @@ type EventMap = {
   /** user is permanently deleted */
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
-  UserLogoutOtherSessions: [{ userId: string; currentSessionId?: string }];
+  UserPasswordChange: [{ userId: string; currentSessionId?: string; shouldLogoutSessions?: boolean }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -99,6 +99,7 @@ type EventMap = {
   /** user is permanently deleted */
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
+  UserChangePassword: [{ userId: string; currentSessionId?: string }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/repositories/event.repository.ts
+++ b/server/src/repositories/event.repository.ts
@@ -99,7 +99,7 @@ type EventMap = {
   /** user is permanently deleted */
   UserDelete: [UserEvent];
   UserRestore: [UserEvent];
-  UserChangePassword: [{ userId: string; currentSessionId?: string }];
+  UserLogoutOtherSessions: [{ userId: string; currentSessionId?: string }];
 
   // websocket events
   WebsocketConnect: [{ userId: string }];

--- a/server/src/repositories/session.repository.ts
+++ b/server/src/repositories/session.repository.ts
@@ -101,6 +101,15 @@ export class SessionRepository {
     await this.db.deleteFrom('session').where('id', '=', asUuid(id)).execute();
   }
 
+  @GenerateSql({ params: [{ userId: DummyValue.UUID, excludeId: DummyValue.UUID }] })
+  async invalidate({ userId, excludeId }: { userId: string; excludeId?: string }) {
+    await this.db
+      .deleteFrom('session')
+      .where('userId', '=', userId)
+      .$if(!!excludeId, (qb) => qb.where('id', '!=', excludeId!))
+      .execute();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   async lockAll(userId: string) {
     await this.db.updateTable('session').set({ pinExpiresAt: null }).where('userId', '=', userId).execute();

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -167,8 +167,8 @@ describe(AuthService.name, () => {
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
       expect(mocks.event.emit).toHaveBeenCalledWith('AuthChangePassword', {
         userId: user.id,
+        invalidateSessions: true,
         currentSessionId: auth.session?.id,
-        shouldLogoutSessions: true,
       });
     });
   });

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -124,7 +124,7 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.getForChangePassword).toHaveBeenCalledWith(user.id);
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
-      expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AuthChangePassword', {
         userId: user.id,
         currentSessionId: auth.session?.id,
         shouldLogoutSessions: undefined,
@@ -156,7 +156,7 @@ describe(AuthService.name, () => {
     it('should change the password and logout other sessions', async () => {
       const user = factory.userAdmin();
       const auth = factory.auth({ user });
-      const dto = { password: 'old-password', newPassword: 'new-password', logOutOtherSessions: true };
+      const dto = { password: 'old-password', newPassword: 'new-password', invalidateSessions: true };
 
       mocks.user.getForChangePassword.mockResolvedValue({ id: user.id, password: 'hash-password' });
       mocks.user.update.mockResolvedValue(user);
@@ -165,7 +165,7 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.getForChangePassword).toHaveBeenCalledWith(user.id);
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
-      expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('AuthChangePassword', {
         userId: user.id,
         currentSessionId: auth.session?.id,
         shouldLogoutSessions: true,

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -124,6 +124,11 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.getForChangePassword).toHaveBeenCalledWith(user.id);
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
+      expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
+        userId: user.id,
+        currentSessionId: auth.session?.id,
+        shouldLogoutSessions: false
+      });
     });
 
     it('should throw when password does not match existing password', async () => {
@@ -148,7 +153,7 @@ describe(AuthService.name, () => {
       await expect(sut.changePassword(auth, dto)).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('should change the password and emmit UserLogoutOtherSessions', async () => {
+    it('should change the password and logout other sessions', async () => {
       const user = factory.userAdmin();
       const auth = factory.auth({ user });
       const dto = { password: 'old-password', newPassword: 'new-password', logOutOtherSessions: true };
@@ -160,9 +165,10 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.getForChangePassword).toHaveBeenCalledWith(user.id);
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
-      expect(mocks.event.emit).toHaveBeenCalledWith('UserLogoutOtherSessions', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
         userId: user.id,
         currentSessionId: auth.session?.id,
+        shouldLogoutSessions: true
       });
     });
   });

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -148,7 +148,7 @@ describe(AuthService.name, () => {
       await expect(sut.changePassword(auth, dto)).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('should change the password and emmit UserChangePassword', async () => {
+    it('should change the password and emmit UserLogoutOtherSessions', async () => {
       const user = factory.userAdmin();
       const auth = factory.auth({ user });
       const dto = { password: 'old-password', newPassword: 'new-password', logOutOhterSessions: true };
@@ -160,7 +160,7 @@ describe(AuthService.name, () => {
 
       expect(mocks.user.getForChangePassword).toHaveBeenCalledWith(user.id);
       expect(mocks.crypto.compareBcrypt).toHaveBeenCalledWith('old-password', 'hash-password');
-      expect(mocks.event.emit).toHaveBeenCalledWith('UserChangePassword', {
+      expect(mocks.event.emit).toHaveBeenCalledWith('UserLogoutOtherSessions', {
         userId: user.id,
         currentSessionId: auth.session?.id,
       });

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -127,7 +127,7 @@ describe(AuthService.name, () => {
       expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
         userId: user.id,
         currentSessionId: auth.session?.id,
-        shouldLogoutSessions: false
+        shouldLogoutSessions: undefined
       });
     });
 

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -127,7 +127,7 @@ describe(AuthService.name, () => {
       expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
         userId: user.id,
         currentSessionId: auth.session?.id,
-        shouldLogoutSessions: undefined
+        shouldLogoutSessions: undefined,
       });
     });
 
@@ -168,7 +168,7 @@ describe(AuthService.name, () => {
       expect(mocks.event.emit).toHaveBeenCalledWith('UserPasswordChange', {
         userId: user.id,
         currentSessionId: auth.session?.id,
-        shouldLogoutSessions: true
+        shouldLogoutSessions: true,
       });
     });
   });

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -151,7 +151,7 @@ describe(AuthService.name, () => {
     it('should change the password and emmit UserLogoutOtherSessions', async () => {
       const user = factory.userAdmin();
       const auth = factory.auth({ user });
-      const dto = { password: 'old-password', newPassword: 'new-password', logOutOhterSessions: true };
+      const dto = { password: 'old-password', newPassword: 'new-password', logOutOtherSessions: true };
 
       mocks.user.getForChangePassword.mockResolvedValue({ id: user.id, password: 'hash-password' });
       mocks.user.update.mockResolvedValue(user);

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -105,9 +105,9 @@ export class AuthService extends BaseService {
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
     await this.eventRepository.emit('AuthChangePassword', {
-      userId: auth.user.id,
+      userId: user.id,
       currentSessionId: auth.session?.id,
-      shouldLogoutSessions: dto.invalidateSessions,
+      invalidateSessions: dto.invalidateSessions,
     });
 
     return mapUserAdmin(updatedUser);

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -104,10 +104,10 @@ export class AuthService extends BaseService {
 
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
-    await this.eventRepository.emit('UserPasswordChange', {
+    await this.eventRepository.emit('AuthChangePassword', {
       userId: auth.user.id,
       currentSessionId: auth.session?.id,
-      shouldLogoutSessions: dto.logOutOtherSessions,
+      shouldLogoutSessions: dto.invalidateSessions,
     });
 
     return mapUserAdmin(updatedUser);

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -104,7 +104,7 @@ export class AuthService extends BaseService {
 
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
-    if (dto.logOutOhterSessions) {
+    if (dto.logOutOtherSessions) {
       await this.eventRepository.emit('UserLogoutOtherSessions', {
         userId: auth.user.id,
         currentSessionId: auth.session?.id,

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -104,6 +104,13 @@ export class AuthService extends BaseService {
 
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
+    if (dto.logOutOhterSessions) {
+      await this.eventRepository.emit('UserChangePassword', {
+        userId: auth.user.id,
+        currentSessionId: auth.session?.id,
+      });
+    }
+
     return mapUserAdmin(updatedUser);
   }
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -104,12 +104,11 @@ export class AuthService extends BaseService {
 
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
-    if (dto.logOutOtherSessions) {
-      await this.eventRepository.emit('UserLogoutOtherSessions', {
-        userId: auth.user.id,
-        currentSessionId: auth.session?.id,
-      });
-    }
+    await this.eventRepository.emit('UserPasswordChange', {
+      userId: auth.user.id,
+      currentSessionId: auth.session?.id,
+      shouldLogoutSessions: dto.logOutOtherSessions
+    });
 
     return mapUserAdmin(updatedUser);
   }

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -105,7 +105,7 @@ export class AuthService extends BaseService {
     const updatedUser = await this.userRepository.update(user.id, { password: hashedPassword });
 
     if (dto.logOutOhterSessions) {
-      await this.eventRepository.emit('UserChangePassword', {
+      await this.eventRepository.emit('UserLogoutOtherSessions', {
         userId: auth.user.id,
         currentSessionId: auth.session?.id,
       });

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -107,7 +107,7 @@ export class AuthService extends BaseService {
     await this.eventRepository.emit('UserPasswordChange', {
       userId: auth.user.id,
       currentSessionId: auth.session?.id,
-      shouldLogoutSessions: dto.logOutOtherSessions
+      shouldLogoutSessions: dto.logOutOtherSessions,
     });
 
     return mapUserAdmin(updatedUser);

--- a/server/src/services/session.service.spec.ts
+++ b/server/src/services/session.service.spec.ts
@@ -43,17 +43,13 @@ describe('SessionService', () => {
   describe('logoutDevices', () => {
     it('should logout all devices', async () => {
       const currentSession = factory.session();
-      const otherSession = factory.session();
       const auth = factory.auth({ session: currentSession });
 
-      mocks.session.getByUserId.mockResolvedValue([currentSession, otherSession]);
-      mocks.session.delete.mockResolvedValue();
+      mocks.session.invalidate.mockResolvedValue();
 
-      await sut.deleteAll(auth.user.id, auth.session?.id);
+      await sut.deleteAll(auth);
 
-      expect(mocks.session.getByUserId).toHaveBeenCalledWith(auth.user.id);
-      expect(mocks.session.delete).toHaveBeenCalledWith(otherSession.id);
-      expect(mocks.session.delete).not.toHaveBeenCalledWith(currentSession.id);
+      expect(mocks.session.invalidate).toHaveBeenCalledWith({ userId: auth.user.id, excludeId: currentSession.id });
     });
   });
 

--- a/server/src/services/session.service.spec.ts
+++ b/server/src/services/session.service.spec.ts
@@ -49,7 +49,7 @@ describe('SessionService', () => {
       mocks.session.getByUserId.mockResolvedValue([currentSession, otherSession]);
       mocks.session.delete.mockResolvedValue();
 
-      await sut.deleteAll(auth);
+      await sut.deleteAll(auth.user.id, auth.session?.id);
 
       expect(mocks.session.getByUserId).toHaveBeenCalledWith(auth.user.id);
       expect(mocks.session.delete).toHaveBeenCalledWith(otherSession.id);

--- a/server/src/services/session.service.ts
+++ b/server/src/services/session.service.ts
@@ -75,8 +75,8 @@ export class SessionService extends BaseService {
     await this.sessionRepository.update(id, { pinExpiresAt: null });
   }
 
-  @OnEvent({ name: 'UserPasswordChange' })
-  async handleUserPasswordChange({ userId, currentSessionId }: ArgOf<'UserPasswordChange'>): Promise<void> {
+  @OnEvent({ name: 'AuthChangePassword' })
+  async onEventAuthChangePassword({ userId, currentSessionId }: ArgOf<'AuthChangePassword'>): Promise<void> {
     await this.deleteAll(userId, currentSessionId);
   }
 

--- a/server/src/services/session.service.ts
+++ b/server/src/services/session.service.ts
@@ -75,16 +75,12 @@ export class SessionService extends BaseService {
     await this.sessionRepository.update(id, { pinExpiresAt: null });
   }
 
-  @OnEvent({ name: 'UserLogoutOtherSessions' })
-  async handleUserLogoutOtherSessions({ userId, currentSessionId }: ArgOf<'UserLogoutOtherSessions'>): Promise<void> {
-    await this.deleteAllSessionsForUser(userId, currentSessionId);
+  @OnEvent({ name: 'UserPasswordChange' })
+  async handleUserPasswordChange({ userId, currentSessionId }: ArgOf<'UserPasswordChange'>): Promise<void> {
+    await this.deleteAll(userId, currentSessionId);
   }
 
-  async deleteAll(auth: AuthDto): Promise<void> {
-    await this.deleteAllSessionsForUser(auth.user.id, auth.session?.id);
-  }
-
-  private async deleteAllSessionsForUser(userId: string, excludeSessionId?: string): Promise<void> {
+  async deleteAll(userId: string, excludeSessionId?: string): Promise<void> {
     const sessions = await this.sessionRepository.getByUserId(userId);
     for (const session of sessions) {
       if (session.id === excludeSessionId) {

--- a/server/src/services/session.service.ts
+++ b/server/src/services/session.service.ts
@@ -75,8 +75,8 @@ export class SessionService extends BaseService {
     await this.sessionRepository.update(id, { pinExpiresAt: null });
   }
 
-  @OnEvent({ name: 'UserChangePassword' })
-  async handleUserChangePassword({ userId, currentSessionId }: ArgOf<'UserChangePassword'>): Promise<void> {
+  @OnEvent({ name: 'UserLogoutOtherSessions' })
+  async handleUserLogoutOtherSessions({ userId, currentSessionId }: ArgOf<'UserLogoutOtherSessions'>): Promise<void> {
     await this.deleteAllSessionsForUser(userId, currentSessionId);
   }
 

--- a/server/test/medium/specs/services/auth.service.spec.ts
+++ b/server/test/medium/specs/services/auth.service.spec.ts
@@ -131,6 +131,7 @@ describe(AuthService.name, () => {
   describe('changePassword', () => {
     it('should change the password and login with it', async () => {
       const { sut, ctx } = setup();
+      ctx.getMock(EventRepository).emit.mockResolvedValue();
       const dto = { password: 'password', newPassword: 'new-password' };
       const passwordHashed = await hash(dto.password, 10);
       const { user } = await ctx.newUser({ password: passwordHashed });

--- a/web/src/lib/components/user-settings-page/change-password-settings.svelte
+++ b/web/src/lib/components/user-settings-page/change-password-settings.svelte
@@ -15,11 +15,11 @@
   let password = $state('');
   let newPassword = $state('');
   let confirmPassword = $state('');
-  let logOutOtherSessions = $state(false);
+  let invalidateSessions = $state(false);
 
   const handleChangePassword = async () => {
     try {
-      await changePassword({ changePasswordDto: { password, newPassword, logOutOtherSessions } });
+      await changePassword({ changePasswordDto: { password, newPassword, invalidateSessions } });
 
       notificationController.show({
         message: $t('updated_password'),
@@ -74,7 +74,7 @@
         <SettingSwitch
           title={$t('log_out_all_devices')}
           subtitle={$t('change_password_form_log_out_description')}
-          bind:checked={logOutOtherSessions}
+          bind:checked={invalidateSessions}
         />
 
         <div class="flex justify-end">

--- a/web/src/lib/components/user-settings-page/change-password-settings.svelte
+++ b/web/src/lib/components/user-settings-page/change-password-settings.svelte
@@ -72,8 +72,8 @@
         />
 
         <SettingSwitch
-          title="Cerrar sesion de todos los dispositivos"
-          subtitle="Se cerrara la sesion de todos los dispositivos autorizados menos el actual"
+          title={$t('log_out_all_devices')}
+          subtitle={$t('change_password_form_log_out_description')}
           bind:checked={logOutOhterSessions}
         />
 

--- a/web/src/lib/components/user-settings-page/change-password-settings.svelte
+++ b/web/src/lib/components/user-settings-page/change-password-settings.svelte
@@ -15,11 +15,11 @@
   let password = $state('');
   let newPassword = $state('');
   let confirmPassword = $state('');
-  let logOutOhterSessions = $state(false);
+  let logOutOtherSessions = $state(false);
 
   const handleChangePassword = async () => {
     try {
-      await changePassword({ changePasswordDto: { password, newPassword, logOutOhterSessions } });
+      await changePassword({ changePasswordDto: { password, newPassword, logOutOtherSessions } });
 
       notificationController.show({
         message: $t('updated_password'),
@@ -74,7 +74,7 @@
         <SettingSwitch
           title={$t('log_out_all_devices')}
           subtitle={$t('change_password_form_log_out_description')}
-          bind:checked={logOutOhterSessions}
+          bind:checked={logOutOtherSessions}
         />
 
         <div class="flex justify-end">

--- a/web/src/lib/components/user-settings-page/change-password-settings.svelte
+++ b/web/src/lib/components/user-settings-page/change-password-settings.svelte
@@ -4,6 +4,7 @@
     NotificationType,
   } from '$lib/components/shared-components/notification/notification';
   import SettingInputField from '$lib/components/shared-components/settings/setting-input-field.svelte';
+  import SettingSwitch from '$lib/components/shared-components/settings/setting-switch.svelte';
   import { SettingInputFieldType } from '$lib/constants';
   import { changePassword } from '@immich/sdk';
   import { Button } from '@immich/ui';
@@ -14,10 +15,11 @@
   let password = $state('');
   let newPassword = $state('');
   let confirmPassword = $state('');
+  let logOutOhterSessions = $state(false);
 
   const handleChangePassword = async () => {
     try {
-      await changePassword({ changePasswordDto: { password, newPassword } });
+      await changePassword({ changePasswordDto: { password, newPassword, logOutOhterSessions } });
 
       notificationController.show({
         message: $t('updated_password'),
@@ -67,6 +69,12 @@
           bind:value={confirmPassword}
           required={true}
           passwordAutocomplete="new-password"
+        />
+
+        <SettingSwitch
+          title="Cerrar sesion de todos los dispositivos"
+          subtitle="Se cerrara la sesion de todos los dispositivos autorizados menos el actual"
+          bind:checked={logOutOhterSessions}
         />
 
         <div class="flex justify-end">


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds a option to log out from all other devices when a user change their password.

Fixes #19620

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] should change the password and emmit UserLogoutOtherSessions
- [x] Change password from UI

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] ~~I have confirmed that any new dependencies are strictly necessary.~~
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
