### PR TITLE
feat(web): animate gifs on hover

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ProjectionType } from '$lib/constants';
   import { locale, playVideoThumbnailOnHover } from '$lib/stores/preferences.store';
-  import { getAssetPlaybackUrl, getAssetThumbnailUrl } from '$lib/utils';
+  import { getAssetOriginalUrl, getAssetPlaybackUrl, getAssetThumbnailUrl } from '$lib/utils';
   import { timeToSeconds } from '$lib/utils/date-time';
   import { getAltText } from '$lib/utils/thumbnail-util';
   import { AssetMediaSize, AssetVisibility } from '@immich/sdk';
@@ -9,6 +9,7 @@
     mdiArchiveArrowDownOutline,
     mdiCameraBurst,
     mdiCheckCircle,
+    mdiFileGifBox,
     mdiHeart,
     mdiMotionPauseOutline,
     mdiMotionPlayOutline,
@@ -281,6 +282,14 @@
           </div>
         {/if}
 
+        {#if asset.isImage && asset.duration}
+          <div class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
+            <span class="pe-2 pt-2">
+              <Icon icon={mdiFileGifBox} size="24" />
+            </span>
+          </div>
+        {/if}
+
         <!-- Stacked asset -->
         {#if asset.stack && showStackedIcon}
           <div
@@ -341,6 +350,25 @@
             curve={selected}
             playbackOnIconHover={!$playVideoThumbnailOnHover}
           />
+        </div>
+      {:else if asset.isImage && asset.duration && mouseOver}
+        <!-- GIF -->
+        <div class="absolute top-0 h-full w-full pointer-events-none">
+          <div class="absolute h-full w-full bg-linear-to-b from-black/25 via-[transparent_25%]"></div>
+          <ImageThumbnail
+            class={imageClass}
+            {brokenAssetClass}
+            url={getAssetOriginalUrl({ id: asset.id, cacheKey: asset.thumbhash })}
+            altText={$getAltText(asset)}
+            widthStyle="{width}px"
+            heightStyle="{height}px"
+            curve={selected}
+          />
+          <div class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
+            <span class="pe-2 pt-2">
+              <Icon icon={mdiMotionPauseOutline} size="24" />
+            </span>
+          </div>
         </div>
       {/if}
 


### PR DESCRIPTION
## Description

Animate/play gifs and animated webp files when hovering over their thumbnail, like videos. These are now also marked as such with the "animation" icon. I can see how that might be confused for stacks; another option is the gif file icon, but there's no "playing" variant for that one.

Since gifs are typically short/small files, I don't see the need for transcoding and playing a transcoded file instead of the original.

## How Has This Been Tested?

Upload gif -> observe it's still showing as a thumbnail -> hover -> observe it's now playing the original file.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="1629" height="663" alt="image" src="https://github.com/user-attachments/assets/4a176f62-327a-4339-b36a-d02dd166fc86" />

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
