### PR TITLE
fix: handle null bucketId or name in android local sync

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -101,9 +101,15 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
 
         while (c.moveToNext()) {
           val id = c.getLong(idColumn).toString()
+          val name = c.getStringOrNull(nameColumn)
+          val bucketId = c.getStringOrNull(bucketIdColumn)
+          val path = c.getStringOrNull(dataColumn)
 
-          val path = c.getString(dataColumn)
-          if (path.isNullOrBlank() || !File(path).exists()) {
+          // Skip assets with invalid metadata
+          if (
+            name.isNullOrBlank() || bucketId.isNullOrBlank() ||
+            path.isNullOrBlank() || !File(path).exists()
+          ) {
             yield(AssetResult.InvalidAsset(id))
             continue
           }
@@ -113,7 +119,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
             MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> 2
             else -> 0
           }
-          val name = c.getString(nameColumn)
           // Date taken is milliseconds since epoch, Date added is seconds since epoch
           val createdAt = (c.getLong(dateTakenColumn).takeIf { it > 0 }?.div(1000))
             ?: c.getLong(dateAddedColumn)
@@ -124,7 +129,6 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
           // Duration is milliseconds
           val duration = if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) 0
           else c.getLong(durationColumn) / 1000
-          val bucketId = c.getString(bucketIdColumn)
           val orientation = c.getInt(orientationColumn)
           val isFavorite = if (favoriteColumn == -1) false else c.getInt(favoriteColumn) != 0
 


### PR DESCRIPTION
## Description

Fixes #23216

I cannot reproduce the issue, but these can in theory be null when the store is corrupted and we need to handle them anyways

#### Has was this tested

The user who reported the issue tested the fix from this PR and confirmed that the new timeline can see all albums now