### PR TITLE
Detect exact duplicates via filename/thumbhash

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -492,6 +492,20 @@ export class AssetRepository {
       .execute();
   }
 
+  @GenerateSql({ params: [{ ownerId: DummyValue.UUID, assetId: DummyValue.UUID, fileName: DummyValue.STRING, thumbHash: DummyValue.BUFFER }] })
+  async getDuplicatesByFileNameAndThumbHash(ownerId: string, assetId: string, fileName: string, thumbHash: Buffer): Promise<string[]> {
+    const assets = await this.db
+      .selectFrom('asset')
+      .select('id')
+      .where('ownerId', '=', asUuid(ownerId))
+      .where('id', '!=', asUuid(assetId))
+      .where('asset.originalFileName', '=', fileName)
+      .where('asset.thumbhash', '=', thumbHash)
+      .execute();
+
+    return assets.map((asset) => asset.id);
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.BUFFER] })
   async getUploadAssetIdByChecksum(ownerId: string, checksum: Buffer): Promise<string | undefined> {
     const asset = await this.db

--- a/web/src/lib/components/jobs/JobsPanel.svelte
+++ b/web/src/lib/components/jobs/JobsPanel.svelte
@@ -103,7 +103,6 @@
       subtitle: $t('admin.duplicate_detection_job_description'),
       allText: $t('all'),
       missingText: $t('missing'),
-      disabled: !$featureFlags.duplicateDetection,
     },
     [JobName.FaceDetection]: {
       icon: mdiFaceRecognition,


### PR DESCRIPTION
## Description

This adds support for detecting duplicate assets with the same original file name and content hash, such as when an asset has its metadata changed and is then reuploaded.

When machine learning and its duplicate detection is enabled, the smart search flow runs instead (as any exact content matches should also be found by the visual similarity checks).

Fixes #23205/#23206.

## How Has This Been Tested?

This is a work in progress -- currently I can see `duplicateId` being assigned to assets as I'd expect (two duplicates listing each other's IDs), though I'm presumably doing something wrong here as the Duplicates utility still comes up empty.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No use of LLMs.
