### PR TITLE
chore: show leading zero week in storage template

### DIFF
--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -11,7 +11,7 @@
   let { options }: Props = $props();
 
   const getLuxonExample = (format: string) => {
-    return DateTime.fromISO('2022-09-04T20:03:05.250Z', { locale: $locale }).toFormat(format);
+    return DateTime.fromISO('2022-02-03T20:03:05.250Z', { locale: $locale }).toFormat(format);
   };
 </script>
 

--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -11,7 +11,7 @@
   let { options }: Props = $props();
 
   const getLuxonExample = (format: string) => {
-    return DateTime.fromISO('2022-02-03T20:03:05.250Z', { locale: $locale }).toFormat(format);
+    return DateTime.fromISO('2022-02-15T20:03:05.250Z', { locale: $locale }).toFormat(format);
   };
 </script>
 

--- a/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
+++ b/web/src/lib/components/admin-settings/SupportedDatetimePanel.svelte
@@ -23,7 +23,7 @@
 <div class="mt-2 rounded-lg bg-gray-200 p-4 text-xs dark:bg-gray-700 dark:text-immich-dark-fg">
   <div class="mb-2 text-gray-600 dark:text-immich-dark-fg">
     <p>{$t('admin.storage_template_date_time_description')}</p>
-    <p>{$t('admin.storage_template_date_time_sample', { values: { date: '2022-09-04T20:03:05.250' } })}</p>
+    <p>{$t('admin.storage_template_date_time_sample', { values: { date: '2022-02-03T20:03:05.250' } })}</p>
   </div>
   <div class="flex gap-[40px]">
     <div>


### PR DESCRIPTION
## Description

W and WW show the same thing in sample as opposed to the intended leading zero. Decided to use the date of the immich first commit, hence changing day as well as month

## How Has This Been Tested?

I have not tested this as I presumed this change is minimal enough to not be an issue

<details><summary><h2>Screenshots (current view)</h2></summary>

<!-- Images go below this line. -->
<img width="360" height="110" alt="image" src="https://github.com/user-attachments/assets/be384a32-4ddd-4f0c-b1a6-de538bd99ff5" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.