### PR TITLE
fix(server): count videos extracted from motion photos towards photo usage

### DIFF
--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -265,7 +265,15 @@ export class UserRepository {
             eb.fn
               .sum<number>('asset_exif.fileSizeInByte')
               .filterWhere((eb) =>
-                eb.and([eb('asset.libraryId', 'is', null), eb('asset.type', '=', sql.lit(AssetType.Image))]),
+                eb.and([
+                  eb('asset.libraryId', 'is', null),
+                  eb.or([
+                    eb('asset.type', '=', sql.lit(AssetType.Image)),
+                    eb.exists(
+                      eb.selectFrom('asset as a').select('a.id').whereRef('a.livePhotoVideoId', '=', 'asset.id'),
+                    ),
+                  ]),
+                ]),
               ),
             eb.lit(0),
           )
@@ -275,7 +283,15 @@ export class UserRepository {
             eb.fn
               .sum<number>('asset_exif.fileSizeInByte')
               .filterWhere((eb) =>
-                eb.and([eb('asset.libraryId', 'is', null), eb('asset.type', '=', sql.lit(AssetType.Video))]),
+                eb.and([
+                  eb('asset.libraryId', 'is', null),
+                  eb('asset.type', '=', sql.lit(AssetType.Video)),
+                  eb.not(
+                    eb.exists(
+                      eb.selectFrom('asset as a').select('a.id').whereRef('a.livePhotoVideoId', '=', 'asset.id'),
+                    ),
+                  ),
+                ]),
               ),
             eb.lit(0),
           )


### PR DESCRIPTION
## Description

The `getUserStats` query simply sums all the videos' file sizes, and all the photo's file sizes. This can be confusing when you upload a bunch of live/motion photos, but no videos, and see there is a lot of storage used for videos.

The PR adds checks to the query to exclude live photo videos from the video usage, and count it towards photo usage instead.

Personally, I'd argue that the extracted motion photos' videos should not count towards the user's quota usage (incremented on metadata & motion photo extraction [here](https://github.com/immich-app/immich/blob/c666dc6c67cec2358233e57c7ac863b44af14bc6/server/src/services/metadata.service.ts#L620-L622)), since that's a limitation/result of the Immich backend processes. But that could be a bit harder to exclude, without also excluding the apple live photo videos, which are two files by default and not extracted by Immich. (What's also interesting to note, is that the extracted motion video _does_ count towards quota usage when it's an internal library motion photo, but it _doesn't_ when it's in an external library. Even though the extracted video is stored in the same place.)

## How Has This Been Tested?

Go to https://my.immich.app/admin/server-status
The two numbers still add up to the same total storage usage, but with the 'correct' distribution between photos and videos.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
