### PR TITLE
fix: make hitbox on app bar dialog bigger

### DIFF
--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -46,19 +46,24 @@ class ImmichAppBarDialog extends HookConsumerWidget {
     }, []);
 
     buildTopRow() {
-      return Stack(
-        children: [
-          Align(
-            alignment: Alignment.topLeft,
-            child: InkWell(onTap: () => context.pop(), child: const Icon(Icons.close, size: 20)),
-          ),
-          Center(
-            child: Image.asset(
-              context.isDarkTheme ? 'assets/immich-text-dark.png' : 'assets/immich-text-light.png',
-              height: 16,
+      return SizedBox(
+        height: 56,
+        child: Stack(
+          alignment: Alignment.centerLeft,
+          children: [
+            IconButton(onPressed: () => context.pop(), icon: const Icon(Icons.close, size: 20)),
+            Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Image.asset(
+                  context.isDarkTheme ? 'assets/immich-text-dark.png' : 'assets/immich-text-light.png',
+                  height: 16,
+                ),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       );
     }
 
@@ -260,7 +265,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Container(padding: const EdgeInsets.all(20), child: buildTopRow()),
+                Container(padding: const EdgeInsets.symmetric(horizontal: 8), child: buildTopRow()),
                 const AppBarProfileInfoBox(),
                 buildStorageInformation(),
                 const AppBarServerInfo(),


### PR DESCRIPTION
## Description

Makes the hitbox bigger for the close button

<img width="346" height="492" alt="Screenshot 2025-10-27 at 11 36 14 PM" src="https://github.com/user-attachments/assets/086def95-6bac-417f-9057-79664c8ae59e" />
