### PR TITLE
fix(web): disable picture-in-picture on video viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/video-native-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/video-native-viewer.svelte
@@ -140,6 +140,7 @@
         autoplay={$autoPlayVideo}
         playsinline
         controls
+        disablePictureInPicture
         class="h-full object-contain"
         {...useSwipe(onSwipe)}
         oncanplay={(e) => handleCanPlay(e.currentTarget)}


### PR DESCRIPTION
## Description

This PR fixes a bug where the video player would show the picture-in-picture (PiP) button on top of the player. The PiP button could overlay the return button and sometimes trigger picture-in-picture mode instead of returning to the overview.

The fix ensures that the `video` HTML element has the `disablepictureinpicture` attribute set, preventing this behavior.

## How Has This Been Tested?

The changes were tested locally:

- Verified that the `video` element now includes the `disablepictureinpicture` attribute.
- Confirmed that the PiP button no longer appears over the return button.
- Manually navigated through the video player to ensure normal playback and navigation behavior.

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->
Before: <img width="960" height="760" alt="Screenshot 2025-10-28 at 12 21 38 PM" src="https://github.com/user-attachments/assets/28b661a8-37a0-4a84-a3a7-95f8c4e9e05e" />

After: <img width="960" height="760" alt="Screenshot 2025-10-28 at 12 17 05 PM" src="https://github.com/user-attachments/assets/8fe4df66-2f05-41e9-ad09-ab25321d51a8" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
No API changes were made.
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (ChatGPT) was used to help word the pull request description.
