### PR TITLE
fix: clear temp cache on iOS before uploads

### DIFF
--- a/mobile/lib/infrastructure/repositories/storage.repository.dart
+++ b/mobile/lib/infrastructure/repositories/storage.repository.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -88,6 +89,18 @@ class StorageRepository {
       await PhotoManager.clearFileCache();
     } catch (error, stackTrace) {
       log.warning("Error clearing cache", error, stackTrace);
+    }
+
+    if (!CurrentPlatform.isIOS) {
+      return;
+    }
+
+    try {
+      if (await Directory.systemTemp.exists()) {
+        await Directory.systemTemp.delete(recursive: true);
+      }
+    } catch (error, stackTrace) {
+      log.warning("Error deleting temporary directory", error, stackTrace);
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #22574

The `background_downloader` library stores the multipart data under `/tmp` which isn't cleaned up properly when the uploads are interrupted. We now clean it as part of our routine calls before and after backups. Thanks @skatsubo for the analysis in https://github.com/immich-app/immich/issues/22574#issuecomment-3441429808