### PR TITLE
feat(cli): change progress bar to display file size

### DIFF
--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -181,18 +181,52 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
   }
 
   let multiBar: MultiBar | undefined;
+  let totalSize = 0;
+  const statsMap = new Map<string, Stats>();
+
+  // Calculate total size first
+  for (const filepath of files) {
+    const stats = await stat(filepath);
+    statsMap.set(filepath, stats);
+    totalSize += stats.size;
+  }
+
+  let processedBytes = 0;
+  let checkedBytes = 0;
 
   if (progress) {
     multiBar = new MultiBar(
-      { format: '{message} | {bar} | {percentage}% | ETA: {eta}s | {value}/{total} assets' },
+      {
+        format: '{message} | {bar} | {percentage}% | ETA: {eta_formatted} | {value}/{total}',
+        formatValue: (v: number, options, type) => {
+          // Don't format percentage
+          if (type === 'percentage') {
+            return v.toString();
+          }
+          return byteSize(v).toString();
+        },
+        etaBuffer: 100, // Increase samples for ETA calculation
+      },
       Presets.shades_classic,
     );
+
+    // Ensure we restore cursor on interrupt
+    process.on('SIGINT', () => {
+      if (multiBar) {
+        multiBar.stop();
+      }
+      process.exit(0);
+    });
   } else {
-    console.log(`Received ${files.length} files, hashing...`);
+    console.log(`Received ${files.length} files (${byteSize(totalSize)}), hashing...`);
   }
 
-  const hashProgressBar = multiBar?.create(files.length, 0, { message: 'Hashing files          ' });
-  const checkProgressBar = multiBar?.create(files.length, 0, { message: 'Checking for duplicates' });
+  const hashProgressBar = multiBar?.create(totalSize, 0, {
+    message: 'Hashing files          ',
+  });
+  const checkProgressBar = multiBar?.create(totalSize, 0, {
+    message: 'Checking for duplicates',
+  });
 
   const newFiles: string[] = [];
   const duplicates: Asset[] = [];
@@ -212,7 +246,16 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
         }
       }
 
-      checkProgressBar?.increment(assets.length);
+      // Update progress based on total size of processed files
+      let processedSize = 0;
+      for (const asset of assets) {
+        const stats = statsMap.get(asset.id);
+        processedSize += stats?.size || 0;
+      }
+      processedBytes += processedSize;
+      // hashProgressBar?.increment(processedSize);
+      checkedBytes += processedSize;
+      checkProgressBar?.increment(processedSize);
     },
     { concurrency, retry: 3 },
   );
@@ -222,6 +265,10 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
 
   const queue = new Queue<string, AssetBulkUploadCheckItem[]>(
     async (filepath: string): Promise<AssetBulkUploadCheckItem[]> => {
+      const stats = statsMap.get(filepath);
+      if (!stats) {
+        throw new Error(`Stats not found for ${filepath}`);
+      }
       const dto = { id: filepath, checksum: await sha1(filepath) };
 
       results.push(dto);
@@ -232,7 +279,7 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
         void checkBulkUploadQueue.push(batch);
       }
 
-      hashProgressBar?.increment();
+      hashProgressBar?.increment(stats.size);
       return results;
     },
     { concurrency, retry: 3 },

--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -191,9 +191,6 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
     totalSize += stats.size;
   }
 
-  let processedBytes = 0;
-  let checkedBytes = 0;
-
   if (progress) {
     multiBar = new MultiBar(
       {
@@ -252,9 +249,6 @@ export const checkForDuplicates = async (files: string[], { concurrency, skipHas
         const stats = statsMap.get(asset.id);
         processedSize += stats?.size || 0;
       }
-      processedBytes += processedSize;
-      // hashProgressBar?.increment(processedSize);
-      checkedBytes += processedSize;
       checkProgressBar?.increment(processedSize);
     },
     { concurrency, retry: 3 },


### PR DESCRIPTION
## Description

Progress bar has been adapted to display file size instead of assets (which were hardly readable and usable for large uploads).

Moved from  #19855

## How Has This Been Tested?

Tested on a large real photo library.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
