### PR TITLE
Fix(server): Change PostgreSQL volume mount to parent directory for v18 upgrade

### DIFF
--- a/.devcontainer/mobile/container-compose-overrides.yml
+++ b/.devcontainer/mobile/container-compose-overrides.yml
@@ -32,7 +32,7 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
       POSTGRES_HOST_AUTH_METHOD: md5
     volumes:
-      - ${UPLOAD_LOCATION:-postgres-devcontainer-volume}${UPLOAD_LOCATION:+/postgres}:/var/lib/postgresql/data
+      - ${UPLOAD_LOCATION:-postgres-devcontainer-volume}${UPLOAD_LOCATION:+/postgres}:/var/lib/postgresql
   redis:
     env_file: !reset []
 volumes:

--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -34,7 +34,7 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
       POSTGRES_HOST_AUTH_METHOD: md5
     volumes:
-      - ${UPLOAD_LOCATION:-postgres-devcontainer-volume}${UPLOAD_LOCATION:+/postgres}:/var/lib/postgresql/data
+      - ${UPLOAD_LOCATION:-postgres-devcontainer-volume}${UPLOAD_LOCATION:+/postgres}:/var/lib/postgresql
   redis:
     env_file: !reset []
 volumes:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -149,7 +149,7 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
-      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
+      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql
     ports:
       - 5432:5432
     shm_size: 128mb

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -72,7 +72,7 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
-      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
+      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql
     ports:
       - 5432:5432
     shm_size: 128mb

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       # DB_STORAGE_TYPE: 'HDD'
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
-      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql
     shm_size: 128mb
     restart: always
 

--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -472,7 +472,7 @@ If it mentions SIGILL (note the lack of a K) or error code 132, it most likely m
 
 ### Why am I getting database ownership errors?
 
-If you get database errors such as `FATAL:  data directory "/var/lib/postgresql/data" has wrong ownership` upon database startup, this is likely due to an issue with your filesystem.
+If you get database errors such as `FATAL:  data directory "/var/lib/postgresql" has wrong ownership` upon database startup, this is likely due to an issue with your filesystem.
 NTFS and ex/FAT/32 filesystems are not supported. See [here](/install/requirements#special-requirements-for-windows-users) for more details.
 
 ### How can I verify the integrity of my database?

--- a/docs/docs/developer/devcontainers.md
+++ b/docs/docs/developer/devcontainers.md
@@ -142,7 +142,7 @@ The `UPLOAD_LOCATION` environment variable controls where files are stored:
 ```yaml
 # From .devcontainer/server/container-compose-overrides.yml
 - ${UPLOAD_LOCATION-./Library}/photos:/workspaces/immich/server/upload
-- ${UPLOAD_LOCATION-./Library}/postgres:/var/lib/postgresql/data
+- ${UPLOAD_LOCATION-./Library}/postgres:/var/lib/postgresql
 ```
 
 ### Database Configuration

--- a/docs/docs/install/upgrading.md
+++ b/docs/docs/install/upgrading.md
@@ -58,7 +58,7 @@ After making a backup, please modify your `docker-compose.yml` file with the fol
 +     # DB_STORAGE_TYPE: 'HDD'
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
-      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql
 -   healthcheck:
 -     test: >-
 -       pg_isready --dbname="$${POSTGRES_DB}" --username="$${POSTGRES_USER}" || exit 1;


### PR DESCRIPTION
## Description

### Background

When upgrading the PostgreSQL image from:

- (14) `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf6335719`
- to 
- (18) `ghcr.io/immich-app/postgres:18-vectorchord0.5.3-pgvector0.8.1@sha256:64103c0f43` 

A mount error occurred during container startup.

### Problem

When changing the database image definition in the distributed docker-compose.yml to version 18, the following error occurs:

```
Error response from daemon: failed to create task for container: failed to create shim task: 
OCI runtime create failed: runc create failed: unable to start container process: 
error during container init: error mounting "/mnt/hdd_toshiba1/immich-app/postgres" to rootfs 
at "/var/lib/postgresql/data": change mount propagation through procfd: 
open o_path procfd: open /home/nvme/docker-persistent-data/overlay2/.../merged/var/lib/postgresql/data: 
no such file or directory: unknown
```

Note: The host directory was empty (after running `rm -rf ./postgres`) when starting with `docker compose up`, so the test was performed with no existing data.

### Root Cause

PostgreSQL 14 and 18 have different default values for the `PGDATA` environment variable in the `pgvector/pgvector` base image:

- **PostgreSQL 14**: `PGDATA=/var/lib/postgresql/data`
- **PostgreSQL 18**: `PGDATA=/var/lib/postgresql/18/docker`

Additionally, the VOLUME definition has changed:

- **PostgreSQL 14**: `VOLUME /var/lib/postgresql/data`
- **PostgreSQL 18**: `VOLUME /var/lib/postgresql`

### Solution

Modified the volume mount path for the database service in `docker-compose.yml`:

```diff
  volumes:
-   - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+   - ${DB_DATA_LOCATION}:/var/lib/postgresql
```

With this change, PostgreSQL 18 will automatically store data in `/var/lib/postgresql/18/docker`.
By mounting to the parent directory, data will be preserved when upgrading from version 14 to 18.

### Files Not Modified

The following files were intentionally left unchanged to maintain test environment stability:

#### `e2e/docker-compose.yml`
```yaml
database:
  image: ghcr.io/immich-app/postgres:14-vectorchord0.3.0
  command: -c fsync=off -c shared_preload_libraries=vchord.so -c config_file=/var/lib/postgresql/data/postgresql.conf
```
This database service uses PostgreSQL 14-vectorchord0.3.0 with specific command settings for E2E testing. Changing this configuration could affect test stability.

#### `server/test/medium/globalSetup.ts`
```typescript
const postgresContainer = await new GenericContainer('ghcr.io/immich-app/postgres:14-vectorchord0.4.3')
  .withCommand([
    'postgres',
    '-c',
    'config_file=/var/lib/postgresql/data/postgresql.conf',
  ])
```
This file contains detailed PostgreSQL settings optimized for integration test performance and data integrity. Changes could impact existing tests.

These files are test environment-specific configurations and do not affect the production environment mount path changes.

### Related Commits

- base-images repository commit: [1f83981](https://github.com/immich-app/base-images/commit/1f83981) (Added PGDATA variable support)
- base-images repository commit: [aee9606](https://github.com/immich-app/base-images/commit/aee9606) (Moved configuration template)

Fixes #(issue)

## How Has This Been Tested?

- [x] Verified `docker compose up` starts successfully with an empty data directory
- [x] Verified PostgreSQL container initializes the database properly
- [x] Verified Immich application operates normally

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

N/A

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Breaking Changes

Existing PostgreSQL 14 users upgrading to PostgreSQL 18 should be aware:

1. Apply this mount path change
2. Data migration is required (`pg_upgrade` or dump→restore)

Alternatively, you can maintain the existing path by explicitly setting the PGDATA environment variable:

```yaml
environment:
  PGDATA: /var/lib/postgresql/data
volumes:
  - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
```

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM (Claude) was used for code suggestions and documentation.
