### PR TITLE
fix(mobile): regression - not displayed activity button in top bar

### DIFF
--- a/mobile/lib/services/activity.service.dart
+++ b/mobile/lib/services/activity.service.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/mixins/error_logger.mixin.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.page.dart';
+import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/repositories/activity_api.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:logging/logging.dart';
@@ -69,6 +70,7 @@ class ActivityService with ErrorLoggerMixin {
       return AssetViewerRoute(
         initialIndex: 0,
         timelineService: _timelineFactory.fromAssets([asset], TimelineOrigin.albumActivities),
+        currentAlbum: ref.read(currentRemoteAlbumProvider),
       );
     }
 


### PR DESCRIPTION
## Description
- not displayed activity button in asset viewer top bar, when navigated from album activity page
- side effected by https://github.com/immich-app/immich/pull/21925
  - https://github.com/immich-app/immich/pull/21925/files#diff-8d080186255d2486c7e534f0a061a7ce21839a536cd223e01cf4caa88217fa44R51

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] fixed it by manually on Simulator

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] ~I have followed naming conventions/patterns in the surrounding code~
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- investigation
