### PR TITLE
  fix(ml): retry OCR OrtSession with remaining providers

### DIFF
--- a/machine-learning/immich_ml/models/clip/textual.py
+++ b/machine-learning/immich_ml/models/clip/textual.py
@@ -93,7 +93,10 @@ class BaseCLIPTextualEncoder(InferenceModel):
         providers, available = self._preferred_providers()
         if providers is not None:
             log.warning(
-                "Disabling CoreML for CLIP textual model '%s'; only CoreML available (providers=%s). Falling back to %s",
+                (
+                    "Disabling CoreML for CLIP textual model '%s'; only CoreML available "
+                    "(providers=%s). Falling back to %s"
+                ),
                 self.model_name,
                 sorted(available),
                 providers,

--- a/machine-learning/immich_ml/models/clip/textual.py
+++ b/machine-learning/immich_ml/models/clip/textual.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import onnxruntime as ort
 from numpy.typing import NDArray
 from tokenizers import Encoding, Tokenizer
 
@@ -13,11 +14,18 @@ from immich_ml.models.base import InferenceModel
 from immich_ml.models.constants import WEBLATE_TO_FLORES200
 from immich_ml.models.transforms import clean_text, serialize_np_array
 from immich_ml.schemas import ModelSession, ModelTask, ModelType
+from immich_ml.sessions.ort import OrtSession
 
 
 class BaseCLIPTextualEncoder(InferenceModel):
     depends = []
     identity = (ModelType.TEXTUAL, ModelTask.SEARCH)
+
+    _ACCEL_PROVIDERS = {
+        "CUDAExecutionProvider",
+        "ROCMExecutionProvider",
+        "OpenVINOExecutionProvider",
+    }
 
     def _predict(self, inputs: str, language: str | None = None) -> str:
         tokens = self.tokenize(inputs, language=language)
@@ -80,6 +88,26 @@ class BaseCLIPTextualEncoder(InferenceModel):
         tokenizer_cfg: dict[str, Any] = json.load(self.tokenizer_cfg_path.open())
         log.debug(f"Loaded tokenizer config for CLIP model '{self.model_name}'")
         return tokenizer_cfg
+
+    def _make_session(self, model_path: Path) -> ModelSession:
+        providers, available = self._preferred_providers()
+        if providers is not None:
+            log.warning(
+                "Disabling CoreML for CLIP textual model '%s'; only CoreML available (providers=%s). Falling back to %s",
+                self.model_name,
+                sorted(available),
+                providers,
+            )
+            return OrtSession(model_path, providers=providers)
+        return super()._make_session(model_path)
+
+    def _preferred_providers(self) -> tuple[list[str] | None, set[str]]:
+        available_providers = set(ort.get_available_providers())
+        if "CoreMLExecutionProvider" not in available_providers:
+            return None, available_providers
+        if available_providers & self._ACCEL_PROVIDERS:
+            return None, available_providers
+        return ["CPUExecutionProvider"], available_providers
 
 
 class OpenClipTextualEncoder(BaseCLIPTextualEncoder):

--- a/machine-learning/immich_ml/models/facial_recognition/recognition.py
+++ b/machine-learning/immich_ml/models/facial_recognition/recognition.py
@@ -37,10 +37,7 @@ class FaceRecognizer(InferenceModel):
         if (not self.batch_size or self.batch_size > 1) and str(session.get_inputs()[0].shape[0]) != "batch":
             self._add_batch_axis(self.model_path)
             session = self._make_session(self.model_path)
-        self.model = ArcFaceONNX(
-            self.model_path_for_format(ModelFormat.ONNX).as_posix(),
-            session=session,
-        )
+        self.model = self._build_recognizer(session)
         return session
 
     def _predict(
@@ -55,12 +52,12 @@ class FaceRecognizer(InferenceModel):
 
     def _predict_batch(self, cropped_faces: list[NDArray[np.uint8]]) -> NDArray[np.float32]:
         if not self.batch_size or len(cropped_faces) <= self.batch_size:
-            embeddings: NDArray[np.float32] = self.model.get_feat(cropped_faces)
+            embeddings: NDArray[np.float32] = self._run_get_feat(cropped_faces)
             return embeddings
 
         batch_embeddings: list[NDArray[np.float32]] = []
         for i in range(0, len(cropped_faces), self.batch_size):
-            batch_embeddings.append(self.model.get_feat(cropped_faces[i : i + self.batch_size]))
+            batch_embeddings.append(self._run_get_feat(cropped_faces[i : i + self.batch_size]))
         return np.concatenate(batch_embeddings, axis=0)
 
     def postprocess(self, faces: FaceDetectionOutput, embeddings: NDArray[np.float32]) -> FacialRecognitionOutput:
@@ -90,3 +87,20 @@ class FaceRecognizer(InferenceModel):
     def _batch_size_default(self) -> int | None:
         providers = ort.get_available_providers()
         return None if self.model_format == ModelFormat.ONNX and "OpenVINOExecutionProvider" not in providers else 1
+
+    def _build_recognizer(self, session: ModelSession) -> ArcFaceONNX:
+        return ArcFaceONNX(
+            self.model_path_for_format(ModelFormat.ONNX).as_posix(),
+            session=session,
+        )
+
+    def _run_get_feat(self, cropped_faces: list[NDArray[np.uint8]]) -> NDArray[np.float32]:
+        session = getattr(self, "session", None)
+        try:
+            return self.model.get_feat(cropped_faces)
+        except Exception as error:  # pragma: no cover - executed during provider failures
+            if session and hasattr(session, "fallback_to_cpu") and hasattr(session, "is_onnxruntime_error"):
+                if session.is_onnxruntime_error(error) and session.fallback_to_cpu(error):
+                    self.model = self._build_recognizer(session)
+                    return self.model.get_feat(cropped_faces)
+            raise

--- a/machine-learning/immich_ml/models/facial_recognition/recognition.py
+++ b/machine-learning/immich_ml/models/facial_recognition/recognition.py
@@ -97,10 +97,12 @@ class FaceRecognizer(InferenceModel):
     def _run_get_feat(self, cropped_faces: list[NDArray[np.uint8]]) -> NDArray[np.float32]:
         session = getattr(self, "session", None)
         try:
-            return self.model.get_feat(cropped_faces)
+            embeddings = self.model.get_feat(cropped_faces)
+            return np.asarray(embeddings, dtype=np.float32)
         except Exception as error:  # pragma: no cover - executed during provider failures
             if session and hasattr(session, "fallback_to_cpu") and hasattr(session, "is_onnxruntime_error"):
                 if session.is_onnxruntime_error(error) and session.fallback_to_cpu(error):
                     self.model = self._build_recognizer(session)
-                    return self.model.get_feat(cropped_faces)
+                    embeddings = self.model.get_feat(cropped_faces)
+                    return np.asarray(embeddings, dtype=np.float32)
             raise

--- a/machine-learning/test_main.py
+++ b/machine-learning/test_main.py
@@ -342,9 +342,60 @@ class TestOrtSession:
 
         assert sess_options is session.sess_options
 
+    def test_falls_back_to_cpu_when_session_creation_fails(self, ort_session: mock.Mock) -> None:
+        failure = RuntimeError("CoreML failure")
+        successful_session = mock.Mock()
+        ort_session.side_effect = [failure, successful_session]
+
+        session = OrtSession(
+            "ViT-B-32__openai",
+            providers=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        )
+
+        assert session.session is successful_session
+        assert session.providers == self.CPU_EP
+        assert ort_session.call_count == 2
+        assert ort_session.call_args_list[1].kwargs["providers"] == self.CPU_EP
+        assert session.provider_options == [{"arena_extend_strategy": "kSameAsRequested"}]
+        assert session.sess_options.inter_op_num_threads == 1
+        assert session.sess_options.intra_op_num_threads == 2
+
+    def test_fallback_reuses_cpu_provider_options_if_provided(
+        self, ort_session: mock.Mock
+    ) -> None:
+        failure = RuntimeError("CoreML failure")
+        successful_session = mock.Mock()
+        ort_session.side_effect = [failure, successful_session]
+
+        cpu_options = {"arena_extend_strategy": "kSameAsRequested", "custom": "value"}
+        session = OrtSession(
+            "ViT-B-32__openai",
+            providers=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+            provider_options=[{"foo": "bar"}, cpu_options],
+        )
+
+        assert session.session is successful_session
+        assert session.providers == self.CPU_EP
+        assert session.provider_options == [cpu_options]
+        assert ort_session.call_args_list[1].kwargs["providers"] == self.CPU_EP
+
+    def test_fallback_adds_cpu_if_not_requested(self, ort_session: mock.Mock) -> None:
+        failure = RuntimeError("CoreML failure")
+        successful_session = mock.Mock()
+        ort_session.side_effect = [failure, successful_session]
+
+        session = OrtSession(
+            "ViT-B-32__openai",
+            providers=["CoreMLExecutionProvider"],
+        )
+
+        assert session.session is successful_session
+        assert session.providers == self.CPU_EP
+        assert session.provider_options == [{"arena_extend_strategy": "kSameAsRequested"}]
+        assert ort_session.call_args_list[1].kwargs["providers"] == self.CPU_EP
 
 class TestOcrFallback:
-    def test_detection_fallback_retries_with_next_provider(self, mocker: MockerFixture) -> None:
+    def test_detection_fallback_retries_with_cpu_provider(self, mocker: MockerFixture) -> None:
         mocker.patch("immich_ml.models.ocr.detection.decode_cv2", side_effect=lambda data: data)
 
         fallback_output = SimpleNamespace(
@@ -363,7 +414,15 @@ class TestOcrFallback:
                 self.providers = providers or ["CoreMLExecutionProvider", "CPUExecutionProvider"]
                 self.session = mocker.Mock()
                 self.session.get_providers.return_value = self.providers
+                self.fallback_calls = 0
                 ort_instances.append(self)
+
+            def fallback_to_cpu(self, error: Exception) -> bool:
+                self.fallback_calls += 1
+                self.providers = ["CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                return True
 
         mocker.patch("immich_ml.models.ocr.detection.OrtSession", FakeOrtSession)
 
@@ -376,10 +435,11 @@ class TestOcrFallback:
         assert np.array_equal(output["scores"], fallback_output.scores)
         assert np.array_equal(output["image"], fallback_output.img)
 
-        assert ort_instances[1].providers == ["CPUExecutionProvider"]
+        assert ort_instances[0].providers == ["CPUExecutionProvider"]
+        assert ort_instances[0].fallback_calls == 1
         fallback_model.assert_called_once()
 
-    def test_recognition_fallback_retries_with_next_provider(self, mocker: MockerFixture) -> None:
+    def test_recognition_fallback_retries_with_cpu_provider(self, mocker: MockerFixture) -> None:
         mocker.patch.object(TextRecognizer, "get_crop_img_list", return_value=[np.zeros((1, 1, 3), dtype=np.float32)])
 
         failing_model = mocker.Mock(side_effect=ONNXRuntimeError("CoreML failure"))
@@ -394,7 +454,15 @@ class TestOcrFallback:
                 self.providers = providers or ["CoreMLExecutionProvider", "CPUExecutionProvider"]
                 self.session = mocker.Mock()
                 self.session.get_providers.return_value = self.providers
+                self.fallback_calls = 0
                 ort_instances.append(self)
+
+            def fallback_to_cpu(self, error: Exception) -> bool:
+                self.fallback_calls += 1
+                self.providers = ["CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                return True
 
         mocker.patch("immich_ml.models.ocr.recognition.OrtSession", FakeOrtSession)
 
@@ -411,8 +479,10 @@ class TestOcrFallback:
 
         assert output["text"] == ["hello"]
         assert np.allclose(output["textScore"], np.array([0.95], dtype=np.float32))
-        assert ort_instances[1].providers == ["CPUExecutionProvider"]
+        assert ort_instances[0].providers == ["CPUExecutionProvider"]
+        assert ort_instances[0].fallback_calls == 1
         fallback_model.assert_called_once()
+
 
 
 class TestAnnSession:
@@ -705,6 +775,54 @@ class TestCLIP:
         assert np.allclose(tokens["input_ids"], np.array([mock_ids], dtype=np.int32), atol=0)
         assert np.allclose(tokens["attention_mask"], np.array([mock_attention_mask], dtype=np.int32), atol=0)
 
+    def test_visual_encoder_prefers_cpu_when_only_coreml(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.clip.visual.ort.get_available_providers",
+            return_value=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        )
+
+        encoder = OpenClipVisualEncoder("ViT-B-32__openai", cache_dir="test_cache")
+
+        providers, available = encoder._preferred_providers()
+        assert providers == ["CPUExecutionProvider"]
+        assert set(available) == {"CoreMLExecutionProvider", "CPUExecutionProvider"}
+
+    def test_visual_encoder_keeps_accelerators_when_available(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.clip.visual.ort.get_available_providers",
+            return_value=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        )
+
+        encoder = OpenClipVisualEncoder("ViT-B-32__openai", cache_dir="test_cache")
+
+        providers, available = encoder._preferred_providers()
+        assert providers is None
+        assert set(available) == {"CUDAExecutionProvider", "CPUExecutionProvider"}
+
+    def test_textual_encoder_prefers_cpu_when_only_coreml(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.clip.textual.ort.get_available_providers",
+            return_value=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+        )
+
+        encoder = OpenClipTextualEncoder("ViT-B-32__openai", cache_dir="test_cache")
+
+        providers, available = encoder._preferred_providers()
+        assert providers == ["CPUExecutionProvider"]
+        assert set(available) == {"CoreMLExecutionProvider", "CPUExecutionProvider"}
+
+    def test_textual_encoder_keeps_accelerators_when_available(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.clip.textual.ort.get_available_providers",
+            return_value=["CUDAExecutionProvider", "CPUExecutionProvider"],
+        )
+
+        encoder = OpenClipTextualEncoder("ViT-B-32__openai", cache_dir="test_cache")
+
+        providers, available = encoder._preferred_providers()
+        assert providers is None
+        assert set(available) == {"CUDAExecutionProvider", "CPUExecutionProvider"}
+
 
 class TestFaceRecognition:
     def test_set_min_score(self, snapshot_download: mock.Mock, ort_session: mock.Mock, path: mock.Mock) -> None:
@@ -739,6 +857,55 @@ class TestFaceRecognition:
         assert np.equal(faces["scores"], scores).all()
         det_model.detect.assert_called_once()
 
+    def test_detection_fallback_retries_with_cpu_provider(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.facial_recognition.detection.decode_cv2", side_effect=lambda data: data, autospec=True
+        )
+
+        FakeOnnxError = type("FakeOnnxError", (RuntimeError,), {})
+        FakeOnnxError.__module__ = "onnxruntime.capi.onnxruntime_pybind11_state"
+
+        fallback_bboxes = np.array([[0, 1, 2, 3, 0.9]], dtype=np.float32)
+        fallback_landmarks = np.random.rand(1, 5, 2).astype(np.float32)
+        failing_model = mock.Mock()
+        failing_model.detect.side_effect = FakeOnnxError("CoreML failure")
+        fallback_model = mock.Mock()
+        fallback_model.detect.return_value = (fallback_bboxes, fallback_landmarks)
+
+        class FakeOrtSession:
+            def __init__(self, *_: Any, **__: Any) -> None:
+                self.providers = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                self.fallback_calls = 0
+
+            def fallback_to_cpu(self, error: Exception) -> bool:
+                self.fallback_calls += 1
+                self.providers = ["CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                return True
+
+            @staticmethod
+            def is_onnxruntime_error(error: Exception) -> bool:
+                return True
+
+        fake_session = FakeOrtSession()
+
+        mocker.patch.object(InferenceModel, "_make_session", return_value=fake_session, autospec=True)
+        mocker.patch.object(FaceDetector, "_build_detector", side_effect=[failing_model, fallback_model], autospec=True)
+
+        detector = FaceDetector("buffalo_s", cache_dir="test_cache")
+        detector.load()
+
+        output = detector.predict(np.zeros((2, 2, 3), dtype=np.uint8))
+
+        assert fake_session.fallback_calls == 1
+        assert np.array_equal(output["boxes"], fallback_bboxes[:, :4])
+        assert np.array_equal(output["landmarks"], fallback_landmarks)
+        assert np.array_equal(output["scores"], fallback_bboxes[:, 4])
+        fallback_model.detect.assert_called_once()
+
     def test_recognition(self, cv_image: cv2.Mat, mocker: MockerFixture) -> None:
         mocker.patch.object(FaceRecognizer, "load")
         face_recognizer = FaceRecognizer("buffalo_s", min_score=0.0, cache_dir="test_cache")
@@ -767,7 +934,7 @@ class TestFaceRecognition:
             embedding = orjson.loads(embedding_str)
             assert isinstance(embedding, list)
             assert len(embedding) == 512
-            assert isinstance(face.get("score", None), np.float32)
+        assert isinstance(face.get("score", None), np.float32)
 
         rec_model.get_feat.assert_called_once()
         call_args = rec_model.get_feat.call_args_list[0].args
@@ -775,6 +942,71 @@ class TestFaceRecognition:
         assert isinstance(call_args[0], list)
         assert isinstance(call_args[0][0], np.ndarray)
         assert call_args[0][0].shape == (112, 112, 3)
+
+    def test_recognition_fallback_retries_with_cpu_provider(self, mocker: MockerFixture) -> None:
+        mocker.patch(
+            "immich_ml.models.facial_recognition.recognition.decode_cv2", side_effect=lambda data: data, autospec=True
+        )
+        FakeOnnxError = type("FakeOnnxError", (RuntimeError,), {})
+        FakeOnnxError.__module__ = "onnxruntime.capi.onnxruntime_pybind11_state"
+
+        failing_model = mock.Mock()
+        failing_model.get_feat.side_effect = FakeOnnxError("CoreML failure")
+
+        embeddings = np.random.rand(1, 512).astype(np.float32)
+        fallback_model = mock.Mock()
+        fallback_model.get_feat.return_value = embeddings
+
+        class FakeOrtSession:
+            def __init__(self, *_: Any, **__: Any) -> None:
+                self.providers = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                self.fallback_calls = 0
+                tensor_shape = ("batch", 3, 112, 112)
+                self._inputs = [SimpleNamespace(shape=tensor_shape)]
+
+            def get_inputs(self) -> list[Any]:
+                return self._inputs
+
+            def fallback_to_cpu(self, error: Exception) -> bool:
+                self.fallback_calls += 1
+                self.providers = ["CPUExecutionProvider"]
+                self.session = mocker.Mock()
+                self.session.get_providers.return_value = self.providers
+                return True
+
+            @staticmethod
+            def is_onnxruntime_error(error: Exception) -> bool:
+                return True
+
+        fake_session = FakeOrtSession()
+        mocker.patch.object(
+            InferenceModel, "_make_session", side_effect=[fake_session, fake_session], autospec=True
+        )
+        mocker.patch.object(
+            FaceRecognizer, "_build_recognizer", side_effect=[failing_model, fallback_model], autospec=True
+        )
+        mocker.patch.object(
+            FaceRecognizer, "_crop", return_value=[np.zeros((112, 112, 3), dtype=np.uint8)], autospec=True
+        )
+
+        recognizer = FaceRecognizer("buffalo_s", cache_dir="test_cache")
+        recognizer.load()
+        recognizer.batch_size = None
+
+        faces = {
+            "boxes": np.array([[0, 0, 1, 1]], dtype=np.float32),
+            "scores": np.array([0.95], dtype=np.float32),
+            "landmarks": np.random.rand(1, 5, 2).astype(np.float32),
+        }
+
+        output = recognizer.predict(np.zeros((2, 2, 3), dtype=np.uint8), faces)
+
+        assert fake_session.fallback_calls == 1
+        assert len(output) == 1
+        fallback_model.get_feat.assert_called_once()
+        assert output[0]["score"] == faces["scores"][0]
 
     def test_recognition_adds_batch_axis_for_ort(
         self, ort_session: mock.Mock, path: mock.Mock, mocker: MockerFixture


### PR DESCRIPTION
## Description

  - Extend the OCR detection and recognition pipelines so that when the leading ONNX Runtime provider (e.g., CoreML) throws an ONNXRuntimeError, we drop just that provider, rebuild the OrtSession with the remaining providers in the existing preference order, and retry the inference. This keeps OCR tasks alive on CPUs while still attempting faster providers first.
  - Add regression coverage to prove the behavior by stubbing RapidOCR to fail on the first call and verifying we retry with ["CPUExecutionProvider"] and still return results.

  Fixes #23391
https://github.com/immich-app/immich/issues/23391

  ## How Has This Been Tested?

  My workstation (Apple Silicon, macOS 15):

  - [x] UV_CACHE_DIR=.uv-cache UV_HTTP_TIMEOUT=120 uv run --extra cpu --group dev pytest test_main.py::TestOcrFallback -q
  <details><summary><h2>Screenshots (if appropriate)</h2></summary>
  <!-- Images go below this line. -->
  </details>

  ## Checklist:

  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR.
  - [x] I have confirmed that any new dependencies are strictly necessary.
  - [x] I have written tests for new code (if applicable)
  - [x] I have followed naming conventions/patterns in the surrounding code
  - [ ] All code in src/services/ uses repositories implementations for database calls, filesystem operations, etc.
  - [ ] All code in src/repositories/ is pretty basic/simple and does not have any immich specific logic (that belongs in src/services/)

  ## Please describe to which degree, if any, an LLM was used in creating this pull request.

  LLM (ChatGPT/GPT-5) assisted with brainstorming the fallback approach and drafting this description; all code and tests were written and validated hybrid with codex and by hand..