### PR TITLE
fix: button condition rendering

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
@@ -141,14 +141,28 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
   }
 
   Widget _buildAppearsInList(WidgetRef ref, BuildContext context) {
-    final isRemote = ref.watch(currentAssetNotifier)?.hasRemote ?? false;
-    if (!isRemote) {
+    final aseet = ref.watch(currentAssetNotifier);
+    if (aseet == null) {
       return const SizedBox.shrink();
     }
 
-    final remoteAsset = ref.watch(currentAssetNotifier) as RemoteAsset;
+    if (!aseet.hasRemote) {
+      return const SizedBox.shrink();
+    }
+
+    String? remoteAssetId;
+    if (aseet is RemoteAsset) {
+      remoteAssetId = aseet.id;
+    } else if (aseet is LocalAsset) {
+      remoteAssetId = aseet.remoteAssetId;
+    }
+
+    if (remoteAssetId == null) {
+      return const SizedBox.shrink();
+    }
+
     final userId = ref.watch(currentUserProvider)?.id;
-    final assetAlbums = ref.watch(albumsContainingAssetProvider(remoteAsset.id));
+    final assetAlbums = ref.watch(albumsContainingAssetProvider(remoteAssetId));
 
     return assetAlbums.when(
       data: (albums) {

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -127,7 +127,7 @@ enum ActionButtonType {
             context.currentAlbum!.isShared,
       ActionButtonType.similarPhotos =>
         !context.isInLockedView && //
-            context.asset.hasRemote,
+            context.asset is RemoteAsset,
     };
   }
 


### PR DESCRIPTION
Fixes an issue where opening the detail panel in On this device view of an asset that is merged triggers an error.

@shenlong-tanwen @bwees FYI, when an `asset.hasRemote` is true the type can either be `RemoteAsset` or `LocalAsset`, each type has different remote ID property, `remoteAsset.id` and `localAsset.remoteAssetId`, so if we check for hasRemote condition, we have to further check for the type to correctly get the remote asset id for the corresponding case.

I think this will need to be simplified somehow because checking getter value then checking type is getting confusing easily and error prone