### PR TITLE
fix(ml): ocr failing with rootless docker

### DIFF
--- a/machine-learning/immich_ml/models/ocr/recognition.py
+++ b/machine-learning/immich_ml/models/ocr/recognition.py
@@ -10,6 +10,7 @@ from rapidocr.inference_engine.base import FileInfo, InferSession
 from rapidocr.utils import DownloadFile, DownloadFileInput
 from rapidocr.utils.typings import EngineType, LangRec, OCRVersion, TaskType
 from rapidocr.utils.typings import ModelType as RapidModelType
+from rapidocr.utils.vis_res import VisRes
 
 from immich_ml.config import log, settings
 from immich_ml.models.base import InferenceModel
@@ -31,6 +32,7 @@ class TextRecognizer(InferenceModel):
             "text": [],
             "textScore": np.empty(0, dtype=np.float32),
         }
+        VisRes.__init__ = lambda self, **kwargs: None  # pyright: ignore[reportAttributeAccessIssue]
         super().__init__(model_name, **model_kwargs, model_format=ModelFormat.ONNX)
 
     def _download(self) -> None:


### PR DESCRIPTION
## Description

Apparently the library checks and downloads the font when initializing an VisRes instance at the end of text recognition. The workaround is to make this init a no-op as it isn't actually used for anything.

The upstream issue is [here](https://github.com/RapidAI/RapidOCR/issues/585), which should hopefully lead to a better fix without monkeypatching.

Fixes #23393