### PR TITLE
fix(server): improve user agent detection for Immich app

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -309,7 +309,14 @@ export const columns = {
   assetFiles: ['asset_file.id', 'asset_file.path', 'asset_file.type'],
   authUser: ['user.id', 'user.name', 'user.email', 'user.isAdmin', 'user.quotaUsageInBytes', 'user.quotaSizeInBytes'],
   authApiKey: ['api_key.id', 'api_key.permissions'],
-  authSession: ['session.id', 'session.updatedAt', 'session.pinExpiresAt', 'session.appVersion'],
+  authSession: [
+    'session.id',
+    'session.updatedAt',
+    'session.pinExpiresAt',
+    'session.appVersion',
+    'session.deviceOS',
+    'session.deviceType',
+  ],
   authSharedLink: [
     'shared_link.id',
     'shared_link.userId',

--- a/server/src/queries/session.repository.sql
+++ b/server/src/queries/session.repository.sql
@@ -24,6 +24,8 @@ select
   "session"."updatedAt",
   "session"."pinExpiresAt",
   "session"."appVersion",
+  "session"."deviceOS",
+  "session"."deviceType",
   (
     select
       to_json(obj)

--- a/server/src/services/auth.service.spec.ts
+++ b/server/src/services/auth.service.spec.ts
@@ -269,6 +269,8 @@ describe(AuthService.name, () => {
         user: factory.authUser(),
         pinExpiresAt: null,
         appVersion: null,
+        deviceOS: '',
+        deviceType: '',
       };
 
       mocks.session.getByToken.mockResolvedValue(sessionWithToken);
@@ -435,6 +437,8 @@ describe(AuthService.name, () => {
         user: factory.authUser(),
         pinExpiresAt: null,
         appVersion: null,
+        deviceOS: '',
+        deviceType: '',
       };
 
       mocks.session.getByToken.mockResolvedValue(sessionWithToken);
@@ -463,6 +467,8 @@ describe(AuthService.name, () => {
         isPendingSyncReset: false,
         pinExpiresAt: null,
         appVersion: null,
+        deviceOS: '',
+        deviceType: '',
       };
 
       mocks.session.getByToken.mockResolvedValue(sessionWithToken);
@@ -485,6 +491,8 @@ describe(AuthService.name, () => {
         isPendingSyncReset: false,
         pinExpiresAt: null,
         appVersion: null,
+        deviceOS: '',
+        deviceType: '',
       };
 
       mocks.session.getByToken.mockResolvedValue(sessionWithToken);

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -484,8 +484,8 @@ export class AuthService extends BaseService {
           id: session.id,
           updatedAt: new Date(),
           appVersion: appVersion ?? session.appVersion,
-          deviceOS,
-          deviceType,
+          deviceOS: deviceOS || session.deviceOS,
+          deviceType: deviceType || session.deviceType,
         });
       }
 

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -480,13 +480,21 @@ export class AuthService extends BaseService {
       const updatedAt = DateTime.fromJSDate(session.updatedAt);
       const diff = now.diff(updatedAt, ['hours']);
       if (diff.hours > 1 || appVersion != session.appVersion) {
-        await this.sessionRepository.update(session.id, {
-          id: session.id,
+        const updates: Record<string, any> = {
           updatedAt: new Date(),
-          appVersion: appVersion ?? session.appVersion,
-          deviceOS: deviceOS || session.deviceOS,
-          deviceType: deviceType || session.deviceType,
-        });
+        };
+
+        if (appVersion && appVersion !== session.appVersion) {
+          updates.appVersion = appVersion;
+        }
+        if (deviceOS && deviceOS !== session.deviceOS) {
+          updates.deviceOS = deviceOS;
+        }
+        if (deviceType && deviceType !== session.deviceType) {
+          updates.deviceType = deviceType;
+        }
+
+        await this.sessionRepository.update(session.id, updates);
       }
 
       // Pin check

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -483,7 +483,7 @@ export class AuthService extends BaseService {
         await this.sessionRepository.update(session.id, {
           id: session.id,
           updatedAt: new Date(),
-          appVersion,
+          appVersion: appVersion ?? session.appVersion,
           deviceOS,
           deviceType,
         });

--- a/server/src/utils/request.ts
+++ b/server/src/utils/request.ts
@@ -11,7 +11,14 @@ const getAppVersionFromUA = (ua: string) =>
   ua.match(/^Immich_(?:Android|iOS)_(?<appVersion>.+)$/)?.groups?.appVersion ?? null;
 
 const isImmichUserAgent = (ua: string) => {
-  const immichPatterns = [/^Mobile$/, /^Dart\//, /^immich_mobile/, /^AppleCoreMedia/, /^Dalvik\//];
+  const immichPatterns = [
+    /^Mobile$/,
+    /^Dart\//,
+    /^immich_mobile/,
+    /^AppleCoreMedia/,
+    /^Dalvik\//,
+    /^Immich_(?:Android|iOS)_/,
+  ];
 
   return immichPatterns.some((pattern) => pattern.test(ua));
 };

--- a/server/src/utils/request.ts
+++ b/server/src/utils/request.ts
@@ -10,12 +10,21 @@ export const fromMaybeArray = <T>(param: T | T[]) => (Array.isArray(param) ? par
 const getAppVersionFromUA = (ua: string) =>
   ua.match(/^Immich_(?:Android|iOS)_(?<appVersion>.+)$/)?.groups?.appVersion ?? null;
 
+const isImmichUserAgent = (ua: string) => {
+  const immichPatterns = [/^Mobile$/, /^Dart\//, /^immich_mobile/, /^AppleCoreMedia/, /^Dalvik\//];
+
+  return immichPatterns.some((pattern) => pattern.test(ua));
+};
+
 export const getUserAgentDetails = (headers: IncomingHttpHeaders) => {
   const userAgent = UAParser(headers['user-agent']);
   const appVersion = getAppVersionFromUA(headers['user-agent'] ?? '');
+  const isImmichApp = appVersion !== null || isImmichUserAgent(headers['user-agent'] ?? '');
 
   return {
-    deviceType: userAgent.browser.name || userAgent.device.type || (headers['devicemodel'] as string) || '',
+    deviceType: isImmichApp
+      ? 'Immich app'
+      : userAgent.browser.name || userAgent.device.type || (headers['devicemodel'] as string) || '',
     deviceOS: userAgent.os.name || (headers['devicetype'] as string) || '',
     appVersion,
   };

--- a/web/src/lib/components/user-settings-page/device-card.svelte
+++ b/web/src/lib/components/user-settings-page/device-card.svelte
@@ -57,9 +57,8 @@
       <span class="text-sm">
         {#if session.deviceType || session.deviceOS}
           <span
-            >{session.deviceOS || $t('unknown')} • {session.deviceType || $t('unknown')}{session.appVersion
-              ? `(v${session.appVersion})`
-              : ''}</span
+            >{session.deviceOS || $t('unknown')} • {session.deviceType || $t('unknown')}
+            {session.appVersion ? `(v${session.appVersion})` : ''}</span
           >
         {:else}
           <span>{$t('unknown')}</span>


### PR DESCRIPTION
This PR addresses several issues with the new option added in #21345:

1. Sometimes the app doesn't send a UA with a version number but only another UA like

^Mobile$/, /^Dart\//, /^immich_mobile/, /^AppleCoreMedia/, /^Dalvik\/

From now on we keep the last version number received until a new one is received with the UA

2. Because the app's UA is inconsistent it could sometimes appear as mobile without the app version (due to issue .1 I mentioned) and sometimes as "unknown", to solve this I perform a test using isImmichApp to check if it is an immich app sending the UA or not.
The test is robust enough because it checks 2 things

1. Is a version number included in the UA?

2. Does it contain other UAs sent by the app but not containing the original UA we expect?

If so, it will be considered an Immich app in the UI along with the version number.

