### PR TITLE
fix: show in timeline from search page

### DIFF
--- a/mobile/lib/pages/common/tab_shell.page.dart
+++ b/mobile/lib/pages/common/tab_shell.page.dart
@@ -14,7 +14,6 @@ import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
-import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/search/search_input_focus.provider.dart';
 import 'package:immich_mobile/providers/tab.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -108,8 +107,6 @@ class _TabShellPageState extends ConsumerState<TabShellPage> {
 }
 
 void _onNavigationSelected(TabsRouter router, int index, WidgetRef ref) {
-  ref.read(currentTabIndexProvider.notifier).state = index;
-
   // On Photos page menu tapped
   if (router.activeIndex == kPhotoTabIndex && index == kPhotoTabIndex) {
     EventStream.shared.emit(const ScrollToTopEvent());

--- a/mobile/lib/presentation/pages/search/drift_search.page.dart
+++ b/mobile/lib/presentation/pages/search/drift_search.page.dart
@@ -73,26 +73,28 @@ class DriftSearchPage extends HookConsumerWidget {
       );
     }
 
-    search() async {
-      if (filter.value.isEmpty) {
+    searchFilter(SearchFilter filter) async {
+      if (filter.isEmpty) {
         return;
       }
 
-      if (preFilter == null && filter.value == previousFilter.value) {
+      if (preFilter == null && filter == previousFilter.value) {
         return;
       }
 
       isSearching.value = true;
       ref.watch(paginatedSearchProvider.notifier).clear();
-      final hasResult = await ref.watch(paginatedSearchProvider.notifier).search(filter.value);
+      final hasResult = await ref.watch(paginatedSearchProvider.notifier).search(filter);
 
       if (!hasResult) {
         context.showSnackBar(searchInfoSnackBar('search_no_result'.t(context: context)));
       }
 
-      previousFilter.value = filter.value;
+      previousFilter.value = filter;
       isSearching.value = false;
     }
+
+    search() => searchFilter(filter.value);
 
     loadMoreSearchResult() async {
       isSearching.value = true;
@@ -108,7 +110,7 @@ class DriftSearchPage extends HookConsumerWidget {
     searchPreFilter() {
       if (preFilter != null) {
         Future.delayed(Duration.zero, () {
-          search();
+          searchFilter(preFilter);
 
           if (preFilter.location.city != null) {
             locationCurrentFilterWidget.value = Text(preFilter.location.city!, style: context.textTheme.labelLarge);
@@ -122,7 +124,7 @@ class DriftSearchPage extends HookConsumerWidget {
       searchPreFilter();
 
       return null;
-    }, []);
+    }, [preFilter]);
 
     showPeoplePicker() {
       handleOnSelect(Set<PersonDto> value) {

--- a/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/similar_photos_action_button.widget.dart
@@ -3,14 +3,12 @@ import 'dart:async';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/pages/search/paginated_search.provider.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
-import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class SimilarPhotosActionButton extends ConsumerWidget {
@@ -38,20 +36,7 @@ class SimilarPhotosActionButton extends ConsumerWidget {
           ),
         );
 
-    /// Using and currentTabIndex to make sure we are using the correct
-    /// navigation behavior. We want to be able to navigate back to the
-    /// main timline using View In Timeline button without the need of
-    /// waiting for the timeline to be rebuild. At the same time, we want
-    /// to refresh the search page when tapping the Similar Photos button
-    /// while already in the Search tab.
-    final currentTabIndex = (ref.read(currentTabIndexProvider.notifier).state);
-
-    if (currentTabIndex != kSearchTabIndex) {
-      unawaited(context.router.navigate(const DriftSearchRoute()));
-      ref.read(currentTabIndexProvider.notifier).state = kSearchTabIndex;
-    } else {
-      unawaited(context.router.popAndPush(const DriftSearchRoute()));
-    }
+    unawaited(context.navigateTo(const DriftSearchRoute()));
   }
 
   @override

--- a/mobile/lib/providers/routes.provider.dart
+++ b/mobile/lib/providers/routes.provider.dart
@@ -5,4 +5,3 @@ final inLockedViewProvider = StateProvider<bool>((ref) => false);
 final currentRouteNameProvider = StateProvider<String?>((ref) => null);
 final previousRouteNameProvider = StateProvider<String?>((ref) => null);
 final previousRouteDataProvider = StateProvider<RouteSettings?>((ref) => null);
-final currentTabIndexProvider = StateProvider<int>((ref) => 0);


### PR DESCRIPTION
## Description

The current handling on main only fixes the show in timeline action for the very first navigation to the search page. Further navigation would still result in the action not working but instead, just redirecting the user to the main timeline. It is now handled by always navigating to the search page.

### How has this been tested
- Search works. Search filters works
- Show similar images action works for any number of levels
- Show in timeline works when used in an asset viewer from the search page
