### PR TITLE
fix(mobile): sync album and asset activity state when add/remove asset level activity

### DIFF
--- a/mobile/lib/providers/activity.provider.dart
+++ b/mobile/lib/providers/activity.provider.dart
@@ -76,14 +76,14 @@ class AlbumActivity extends _$AlbumActivity {
     if (activities == null) {
       return null;
     }
-    final index = activities.indexWhere((a) => a.id == id);
-    if (index == -1) {
+    final activity = activities.firstWhereOrNull((a) => a.id == id);
+    if (activity == null) {
       return null;
     }
-    final updated = [...activities]..removeAt(index);
-    final removed = activities[index];
+
+    final updated = [...activities]..remove(activity);
     state = AsyncData(updated);
-    return removed;
+    return activity;
   }
 }
 

--- a/mobile/lib/providers/activity.provider.dart
+++ b/mobile/lib/providers/activity.provider.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:immich_mobile/models/activities/activity.model.dart';
 import 'package:immich_mobile/providers/activity_service.provider.dart';
 import 'package:immich_mobile/providers/activity_statistics.provider.dart';

--- a/mobile/lib/providers/activity.provider.g.dart
+++ b/mobile/lib/providers/activity.provider.g.dart
@@ -6,7 +6,7 @@ part of 'activity.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$albumActivityHash() => r'5011cc0b7f948a804d48ef280c9743896801964e';
+String _$albumActivityHash() => r'80497c975e57af1321645ec315552093d7758e42';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/mobile/lib/providers/activity.provider.g.dart
+++ b/mobile/lib/providers/activity.provider.g.dart
@@ -6,7 +6,7 @@ part of 'activity.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$albumActivityHash() => r'80497c975e57af1321645ec315552093d7758e42';
+String _$albumActivityHash() => r'154e8ae98da3efc142369eae46d4005468fd67da';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/mobile/lib/providers/activity.provider.g.dart
+++ b/mobile/lib/providers/activity.provider.g.dart
@@ -6,7 +6,7 @@ part of 'activity.provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$albumActivityHash() => r'3b0d7acee4d41c84b3f220784c3b904c83f836e6';
+String _$albumActivityHash() => r'5011cc0b7f948a804d48ef280c9743896801964e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/mobile/test/modules/activity/activity_provider_test.dart
+++ b/mobile/test/modules/activity/activity_provider_test.dart
@@ -33,6 +33,7 @@ final _activities = [
 void main() {
   late ActivityServiceMock activityMock;
   late ActivityStatisticsMock activityStatisticsMock;
+  late ActivityStatisticsMock albumActivityStatisticsMock;
   late ProviderContainer container;
   late AlbumActivityProvider provider;
   late ListenerMock<AsyncValue<List<Activity>>> listener;
@@ -44,14 +45,19 @@ void main() {
   setUp(() async {
     activityMock = ActivityServiceMock();
     activityStatisticsMock = ActivityStatisticsMock();
+    albumActivityStatisticsMock = ActivityStatisticsMock();
+
     container = TestUtils.createContainer(
       overrides: [
         activityServiceProvider.overrideWith((ref) => activityMock),
         activityStatisticsProvider('test-album', 'test-asset').overrideWith(() => activityStatisticsMock),
+        activityStatisticsProvider('test-album').overrideWith(() => albumActivityStatisticsMock),
       ],
     );
 
     // Mock values
+    when(() => activityStatisticsMock.build(any(), any())).thenReturn(0);
+    when(() => albumActivityStatisticsMock.build(any())).thenReturn(0);
     when(
       () => activityMock.getAllActivities('test-album', assetId: 'test-asset'),
     ).thenAnswer((_) async => [..._activities]);
@@ -99,6 +105,7 @@ void main() {
 
       // Never bump activity count for new likes
       verifyNever(() => activityStatisticsMock.addActivity());
+      verifyNever(() => albumActivityStatisticsMock.addActivity());
     });
 
     test('Like failed', () async {
@@ -114,6 +121,8 @@ void main() {
       final activities = await container.read(provider.future);
       expect(activities, hasLength(4));
       expect(activities, isNot(contains(like)));
+
+      verifyNever(() => albumActivityStatisticsMock.addActivity());
     });
   });
 
@@ -130,6 +139,7 @@ void main() {
       expect(activities, isNot(anyElement(predicate((Activity a) => a.id == '3'))));
 
       verifyNever(() => activityStatisticsMock.removeActivity());
+      verifyNever(() => albumActivityStatisticsMock.removeActivity());
     });
 
     test('Remove Like failed', () async {
@@ -140,6 +150,9 @@ void main() {
       final activities = await container.read(provider.future);
       expect(activities, hasLength(4));
       expect(activities, anyElement(predicate((Activity a) => a.id == '3')));
+
+      verifyNever(() => activityStatisticsMock.removeActivity());
+      verifyNever(() => albumActivityStatisticsMock.removeActivity());
     });
 
     test('Comment successfully removed', () async {
@@ -151,14 +164,38 @@ void main() {
       expect(activities, isNot(anyElement(predicate((Activity a) => a.id == '1'))));
 
       verify(() => activityStatisticsMock.removeActivity());
+      verify(() => albumActivityStatisticsMock.removeActivity());
+    });
+
+    test('Removes activity from album state when asset scoped', () async {
+      when(() => activityMock.removeActivity('3')).thenAnswer((_) async => true);
+      when(() => activityMock.getAllActivities('test-album')).thenAnswer((_) async => [..._activities]);
+
+      final albumProvider = albumActivityProvider('test-album');
+      container.read(albumProvider.notifier);
+      await container.read(albumProvider.future);
+
+      await container.read(provider.notifier).removeActivity('3');
+
+      final assetActivities = container.read(provider).requireValue;
+      final albumActivities = container.read(albumProvider).requireValue;
+
+      expect(assetActivities, hasLength(3));
+      expect(assetActivities, isNot(anyElement(predicate((Activity a) => a.id == '3'))));
+
+      expect(albumActivities, hasLength(3));
+      expect(albumActivities, isNot(anyElement(predicate((Activity a) => a.id == '3'))));
+
+      verify(() => activityMock.removeActivity('3'));
+      verifyNever(() => activityStatisticsMock.removeActivity());
+      verifyNever(() => albumActivityStatisticsMock.removeActivity());
     });
   });
 
   group('addComment()', () {
-    late ActivityStatisticsMock albumActivityStatisticsMock;
-
     setUp(() {
       albumActivityStatisticsMock = ActivityStatisticsMock();
+      // when(() => albumActivityStatisticsMock.build(any())).thenReturn(0);
       container = TestUtils.createContainer(
         overrides: [
           activityServiceProvider.overrideWith((ref) => activityMock),


### PR DESCRIPTION
## Description
- when add/remove asset level activity, sync them to album level activity

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)
- i don't know

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] modify / add unit tests
- [x] When delete an asset activity in asset activity view, it is deleted in the album activity view (e2e manually test on Simulator)
  - [x] same as adding asset likes, adding asset comment too

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- consideration / initial implementation
