### PR TITLE
feat(ml): multilingual ocr

### DIFF
--- a/machine-learning/immich_ml/models/constants.py
+++ b/machine-learning/immich_ml/models/constants.py
@@ -78,6 +78,14 @@ _INSIGHTFACE_MODELS = {
 _PADDLE_MODELS = {
     "PP-OCRv5_server",
     "PP-OCRv5_mobile",
+    "CH__PP-OCRv5_server",
+    "CH__PP-OCRv5_mobile",
+    "EL__PP-OCRv5_mobile",
+    "EN__PP-OCRv5_mobile",
+    "ESLAV__PP-OCRv5_mobile",
+    "KOREAN__PP-OCRv5_mobile",
+    "LATIN__PP-OCRv5_mobile",
+    "TH__PP-OCRv5_mobile",
 }
 
 SUPPORTED_PROVIDERS = [

--- a/machine-learning/immich_ml/models/ocr/detection.py
+++ b/machine-learning/immich_ml/models/ocr/detection.py
@@ -23,7 +23,7 @@ class TextDetector(InferenceModel):
     identity = (ModelType.DETECTION, ModelTask.OCR)
 
     def __init__(self, model_name: str, **model_kwargs: Any) -> None:
-        super().__init__(model_name, **model_kwargs, model_format=ModelFormat.ONNX)
+        super().__init__(model_name.split("__")[-1], **model_kwargs, model_format=ModelFormat.ONNX)
         self.max_resolution = 736
         self.mean = np.array([0.5, 0.5, 0.5], dtype=np.float32)
         self.std_inv = np.float32(1.0) / (np.array([0.5, 0.5, 0.5], dtype=np.float32) * 255.0)

--- a/machine-learning/immich_ml/models/ocr/recognition.py
+++ b/machine-learning/immich_ml/models/ocr/recognition.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 import numpy as np

--- a/machine-learning/immich_ml/models/ocr/recognition.py
+++ b/machine-learning/immich_ml/models/ocr/recognition.py
@@ -37,13 +37,6 @@ class TextRecognizer(InferenceModel):
         VisRes.__init__ = lambda self, **kwargs: None  # pyright: ignore[reportAttributeAccessIssue]
         super().__init__(model_name, **model_kwargs, model_format=ModelFormat.ONNX)
 
-    @property
-    def model_path(self) -> Path:
-        path = super().model_path
-        if self.language == LangRec.CH:
-            return path
-        return path.parent / self.language.value / path.name
-
     def _download(self) -> None:
         model_info = InferSession.get_model_url(
             FileInfo(

--- a/machine-learning/immich_ml/models/ocr/schemas.py
+++ b/machine-learning/immich_ml/models/ocr/schemas.py
@@ -20,8 +20,8 @@ class TextRecognitionOutput(TypedDict):
 
 # RapidOCR expects `engine_type`, `lang_type`, and `font_path` to be attributes
 class OcrOptions(dict[str, Any]):
-    def __init__(self, **options: Any) -> None:
+    def __init__(self, lang_type: LangRec | None = None, **options: Any) -> None:
         super().__init__(**options)
         self.engine_type = EngineType.ONNXRUNTIME
-        self.lang_type = LangRec.CH
+        self.lang_type = lang_type
         self.font_path = None

--- a/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
+++ b/web/src/lib/components/admin-settings/MachineLearningSettings.svelte
@@ -275,8 +275,14 @@
             name="ocr-model"
             bind:value={config.machineLearning.ocr.modelName}
             options={[
-              { value: 'PP-OCRv5_server', text: 'PP-OCRv5_server' },
-              { value: 'PP-OCRv5_mobile', text: 'PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_server (Chinese, Japanese and English)', value: 'PP-OCRv5_server' },
+              { text: 'PP-OCRv5_mobile (Chinese, Japanese and English)', value: 'PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (English-only)', value: 'EN__PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (Greek and English)', value: 'EL__PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (Korean and English)', value: 'KOREAN__PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (Latin script languages)', value: 'LATIN__PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (Russian, Belarusian, Ukrainian and English)', value: 'ESLAV__PP-OCRv5_mobile' },
+              { text: 'PP-OCRv5_mobile (Thai and English)', value: 'TH__PP-OCRv5_mobile' },
             ]}
             disabled={disabled || !config.machineLearning.enabled || !config.machineLearning.ocr.enabled}
             isEdited={config.machineLearning.ocr.modelName !== savedConfig.machineLearning.ocr.modelName}


### PR DESCRIPTION
## Description

This PR adds language-specific OCR variants, extending support to Greek, Korean, Russian, Belarusian, Ukrainian, Thai and languages using Latin script. All variants support English as well.

The change is backwards compatible as it only adds new model variants, with the default being the same and still accepted by the ML server.

Notably, the server model only comes in one flavor; all the language-specific models are mobile size.

## How Has This Been Tested?

Tested with Chinese, Greek, English and Korean variants, confirming that different recognition models are dowloaded for each and the outputs are more accurate for the respective languages.