### PR TITLE
chore: correct hosted isar paths in fdroid_build_isar.sh

### DIFF
--- a/mobile/scripts/fdroid_build_isar.sh
+++ b/mobile/scripts/fdroid_build_isar.sh
@@ -8,11 +8,11 @@ bash tool/build_android.sh x64
 bash tool/build_android.sh armv7
 bash tool/build_android.sh arm64
 mv libisar_android_arm64.so libisar.so
-mv libisar.so ../.pub-cache/hosted/pub.isar-community.dev/isar_flutter_libs-*/android/src/main/jniLibs/arm64-v8a/
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_community_flutter_libs-*/android/src/main/jniLibs/arm64-v8a/
 mv libisar_android_armv7.so libisar.so
-mv libisar.so ../.pub-cache/hosted/pub.isar-community.dev/isar_flutter_libs-*/android/src/main/jniLibs/armeabi-v7a/
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_community_flutter_libs-*/android/src/main/jniLibs/armeabi-v7a/
 mv libisar_android_x64.so libisar.so
-mv libisar.so ../.pub-cache/hosted/pub.isar-community.dev/isar_flutter_libs-*/android/src/main/jniLibs/x86_64/
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_community_flutter_libs-*/android/src/main/jniLibs/x86_64/
 mv libisar_android_x86.so libisar.so
-mv libisar.so ../.pub-cache/hosted/pub.isar-community.dev/isar_flutter_libs-*/android/src/main/jniLibs/x86/
+mv libisar.so ../.pub-cache/hosted/pub.dev/isar_community_flutter_libs-*/android/src/main/jniLibs/x86/
 )


### PR DESCRIPTION
## Description

Following the suggestion in https://github.com/immich-app/immich/pull/22757#issuecomment-3404516987, adjust the F-Droid script to point at the new isar paths.

This should hopefully unblock F-Droid builds, which are currently stuck on version 2.0.1; see https://gitlab.com/fdroid/fdroiddata/-/merge_requests/28208 which is currently marked `waiting-for-upstream`.

## How Has This Been Tested?

This has not been tested. (Apologies; I don't have a setup for testing nor know the F-Droid process well enough to be confident in verifying the results.)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~~I have made corresponding changes to the documentation if applicable~~ N/A
- [x] I have no unrelated changes in the PR.
- [x] ~~I have confirmed that any new dependencies are strictly necessary.~~ N/A
- [x] ~~I have written tests for new code (if applicable)~~ N/A
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] ~~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~ N/A
- [x] ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~ N/A

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used in creating this pull request.