### PR TITLE
fix(web): search bar accessibility

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -33,6 +33,7 @@
   let close: (() => Promise<void>) | undefined;
 
   const listboxId = generateId();
+  const searchTypeId = generateId();
 
   onDestroy(() => {
     searchStore.isSearchEnabled = false;
@@ -248,6 +249,7 @@
         aria-activedescendant={selectedId ?? ''}
         aria-expanded={showSuggestions && isSearchSuggestions}
         aria-autocomplete="list"
+        aria-describedby={searchTypeId}
         use:shortcuts={[
           { shortcut: { key: 'Escape' }, onShortcut: onEscape },
           { shortcut: { ctrl: true, shift: true, key: 'k' }, onShortcut: onFilterClick },
@@ -286,6 +288,7 @@
 
     {#if searchStore.isSearchEnabled}
       <div
+        id={searchTypeId}
         class="absolute inset-y-0 flex items-center end-16"
         class:max-md:hidden={value}
         class:end-28={value.length > 0}

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -30,7 +30,6 @@
   let showSuggestions = $state(false);
   let isSearchSuggestions = $state(false);
   let selectedId: string | undefined = $state();
-  let isFocus = $state(false);
   let close: (() => Promise<void>) | undefined;
 
   const listboxId = generateId();
@@ -161,12 +160,10 @@
 
   const openDropdown = () => {
     showSuggestions = true;
-    isFocus = true;
   };
 
   const closeDropdown = () => {
     showSuggestions = false;
-    isFocus = false;
     searchHistoryBox?.clearSelection();
   };
 
@@ -287,12 +284,11 @@
       />
     </div>
 
-    {#if isFocus}
+    {#if searchStore.isSearchEnabled}
       <div
-        class="absolute inset-y-0 flex items-center"
+        class="absolute inset-y-0 flex items-center end-16"
         class:max-md:hidden={value}
-        class:end-16={isFocus}
-        class:end-28={isFocus && value.length > 0}
+        class:end-28={value.length > 0}
       >
         <p
           class="bg-immich-primary text-white dark:bg-immich-dark-primary/90 dark:text-black/75 rounded-full px-3 py-1 text-xs"


### PR DESCRIPTION
## Description

Announce the search type to screen reader users to provide a similar experience as the blue label provides in the visual search bar.

Also always keep the blue search type label visible while the search bar is active, regardless of whether the dropdown menu is open or not.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Tested the search bar with VoiceOver on MacOS, in the Safari, Firefox, and Chrome browsers.

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->

<img width="1273" height="207" alt="Screenshot 2025-11-03 at 07 16 36" src="https://github.com/user-attachments/assets/7ed7fb91-097d-40d5-8384-2004124ed3c1" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None