### PR TITLE
feat: android periodic work manager task

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundEngineLock.kt
@@ -43,8 +43,8 @@ class BackgroundEngineLock(context: Context) : BackgroundWorkerLockApi, ImmichPl
 
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     super.onAttachedToEngine(binding)
-    checkAndEnforceBackgroundLock(binding.applicationContext)
     engineCount.incrementAndGet()
+    checkAndEnforceBackgroundLock(binding.applicationContext)
     Log.i(TAG, "Flutter engine attached. Attached Engines count: $engineCount")
   }
 

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/PeriodicWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/PeriodicWorker.kt
@@ -1,0 +1,16 @@
+package app.alextran.immich.background
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+
+class PeriodicWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+  private val ctx: Context = context.applicationContext
+
+  override fun doWork(): Result {
+    Log.i("PeriodicWorker", "Periodic worker triggered, starting background worker")
+    BackgroundWorkerApiImpl.enqueueBackgroundWorker(ctx)
+    return Result.success()
+  }
+}


### PR DESCRIPTION
## Description

- Introduces a periodic work manager tasks that runs every 45-60mins and executes the background worker loop: local sync -> remote sync -> hash followed by queuing assets for uploads