### PR TITLE
fix: limit android background worker duration

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.g.kt
@@ -416,12 +416,12 @@ class BackgroundWorkerFlutterApi(private val binaryMessenger: BinaryMessenger, p
       } 
     }
   }
-  fun onAndroidUpload(callback: (Result<Unit>) -> Unit)
+  fun onAndroidUpload(maxMinutesArg: Long?, callback: (Result<Unit>) -> Unit)
 {
     val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
     val channelName = "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onAndroidUpload$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(null) {
+    channel.send(listOf(maxMinutesArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/background/BackgroundWorker.kt
@@ -107,7 +107,7 @@ class BackgroundWorker(context: Context, params: WorkerParameters) :
    * This method acts as a bridge between the native Android background task system and Flutter.
    */
   override fun onInitialized() {
-    flutterApi?.onAndroidUpload { handleHostResult(it) }
+    flutterApi?.onAndroidUpload(maxMinutesArg = 20) { handleHostResult(it) }
   }
 
   // TODO: Move this to a separate NotificationManager class

--- a/mobile/ios/Runner/Background/BackgroundWorker.g.swift
+++ b/mobile/ios/Runner/Background/BackgroundWorker.g.swift
@@ -348,7 +348,7 @@ class BackgroundWorkerBgHostApiSetup {
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol BackgroundWorkerFlutterApiProtocol {
   func onIosUpload(isRefresh isRefreshArg: Bool, maxSeconds maxSecondsArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void)
-  func onAndroidUpload(completion: @escaping (Result<Void, PigeonError>) -> Void)
+  func onAndroidUpload(maxMinutes maxMinutesArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void)
   func cancel(completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class BackgroundWorkerFlutterApi: BackgroundWorkerFlutterApiProtocol {
@@ -379,10 +379,10 @@ class BackgroundWorkerFlutterApi: BackgroundWorkerFlutterApiProtocol {
       }
     }
   }
-  func onAndroidUpload(completion: @escaping (Result<Void, PigeonError>) -> Void) {
+  func onAndroidUpload(maxMinutes maxMinutesArg: Int64?, completion: @escaping (Result<Void, PigeonError>) -> Void) {
     let channelName: String = "dev.flutter.pigeon.immich_mobile.BackgroundWorkerFlutterApi.onAndroidUpload\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage(nil) { response in
+    channel.sendMessage([maxMinutesArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -105,46 +105,56 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   }
 
   @override
-  Future<void> onAndroidUpload() async {
-    _logger.info('Android background processing started');
-    final sw = Stopwatch()..start();
-    try {
-      if (!await _syncAssets(hashTimeout: Duration(minutes: _isBackupEnabled ? 3 : 6))) {
-        _logger.warning("Remote sync did not complete successfully, skipping backup");
-        return;
-      }
-      await _handleBackup();
-    } catch (error, stack) {
-      _logger.severe("Failed to complete Android background processing", error, stack);
-    } finally {
-      sw.stop();
-      _logger.info("Android background processing completed in ${sw.elapsed.inSeconds}s");
-      await _cleanup();
-    }
+  Future<void> onAndroidUpload(int? maxMinutes) async {
+    final hashTimeout = Duration(minutes: _isBackupEnabled ? 3 : 6);
+    final backupTimeout = maxMinutes != null ? Duration(minutes: maxMinutes - 1) : null;
+    await _backgroundLoop(
+      hashTimeout: hashTimeout,
+      backupTimeout: backupTimeout,
+      debugLabel: 'Android background upload',
+    );
   }
 
   @override
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds) async {
-    _logger.info('iOS background upload started with maxSeconds: ${maxSeconds}s');
+    final hashTimeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
+    final backupTimeout = maxSeconds != null ? Duration(seconds: maxSeconds - 1) : null;
+    await _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
+  }
+
+  Future<void> _backgroundLoop({
+    required Duration hashTimeout,
+    required Duration? backupTimeout,
+    required String debugLabel,
+  }) async {
+    _logger.info(
+      '$debugLabel started hashTimeout: ${hashTimeout.inSeconds}s, backupTimeout: ${backupTimeout?.inMinutes ?? '~'}m',
+    );
     final sw = Stopwatch()..start();
     try {
-      final timeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
-      if (!await _syncAssets(hashTimeout: timeout)) {
+      if (!await _syncAssets(hashTimeout: hashTimeout)) {
         _logger.warning("Remote sync did not complete successfully, skipping backup");
         return;
       }
 
       final backupFuture = _handleBackup();
-      if (maxSeconds != null) {
-        await backupFuture.timeout(Duration(seconds: maxSeconds - 1), onTimeout: () {});
+      if (backupTimeout != null) {
+        await backupFuture.timeout(
+          backupTimeout,
+          onTimeout: () {
+            if (!_cancellationToken.isCompleted) {
+              _cancellationToken.complete();
+            }
+          },
+        );
       } else {
         await backupFuture;
       }
     } catch (error, stack) {
-      _logger.severe("Failed to complete iOS background upload", error, stack);
+      _logger.severe("Failed to complete $debugLabel", error, stack);
     } finally {
       sw.stop();
-      _logger.info("iOS background upload completed in ${sw.elapsed.inSeconds}s");
+      _logger.info("$debugLabel completed in ${sw.elapsed.inSeconds}s");
       await _cleanup();
     }
   }

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -108,7 +108,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   Future<void> onAndroidUpload(int? maxMinutes) async {
     final hashTimeout = Duration(minutes: _isBackupEnabled ? 3 : 6);
     final backupTimeout = maxMinutes != null ? Duration(minutes: maxMinutes - 1) : null;
-    await _backgroundLoop(
+    return _backgroundLoop(
       hashTimeout: hashTimeout,
       backupTimeout: backupTimeout,
       debugLabel: 'Android background upload',
@@ -119,7 +119,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds) async {
     final hashTimeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
     final backupTimeout = maxSeconds != null ? Duration(seconds: maxSeconds - 1) : null;
-    await _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
+    return _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
   }
 
   Future<void> _backgroundLoop({
@@ -138,17 +138,19 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       }
 
       final backupFuture = _handleBackup();
+      Timer? cancelTimer;
       if (backupTimeout != null) {
-        await backupFuture.timeout(
-          backupTimeout,
-          onTimeout: () {
-            if (!_cancellationToken.isCompleted) {
-              _cancellationToken.complete();
-            }
-          },
-        );
-      } else {
+        cancelTimer = Timer(backupTimeout, () {
+          if (!_cancellationToken.isCompleted) {
+            _logger.warning("$debugLabel timed out after ${backupTimeout.inMinutes}m, cancelling backup");
+            _cancellationToken.complete();
+          }
+        });
+      }
+      try {
         await backupFuture;
+      } finally {
+        cancelTimer?.cancel();
       }
     } catch (error, stack) {
       _logger.severe("Failed to complete $debugLabel", error, stack);
@@ -187,7 +189,9 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       final nativeSyncApi = _ref?.read(nativeSyncApiProvider);
 
       _logger.info("Cleaning up background worker");
-      _cancellationToken.complete();
+      if (!_cancellationToken.isCompleted) {
+        _cancellationToken.complete();
+      }
       final cleanupFutures = [
         nativeSyncApi?.cancelHashing(),
         workerManagerPatch.dispose().catchError((_) async {

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -105,46 +105,56 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   }
 
   @override
-  Future<void> onAndroidUpload() async {
-    _logger.info('Android background processing started');
-    final sw = Stopwatch()..start();
-    try {
-      if (!await _syncAssets(hashTimeout: Duration(minutes: _isBackupEnabled ? 3 : 6))) {
-        _logger.warning("Remote sync did not complete successfully, skipping backup");
-        return;
-      }
-      await _handleBackup();
-    } catch (error, stack) {
-      _logger.severe("Failed to complete Android background processing", error, stack);
-    } finally {
-      sw.stop();
-      _logger.info("Android background processing completed in ${sw.elapsed.inSeconds}s");
-      await _cleanup();
-    }
+  Future<void> onAndroidUpload(int? maxMinutes) async {
+    final hashTimeout = Duration(minutes: _isBackupEnabled ? 3 : 6);
+    final backupTimeout = maxMinutes != null ? Duration(minutes: maxMinutes - 1) : null;
+    await _backgroundLoop(
+      hashTimeout: hashTimeout,
+      backupTimeout: backupTimeout,
+      debugLabel: 'Android background upload',
+    );
   }
 
   @override
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds) async {
-    _logger.info('iOS background upload started with maxSeconds: ${maxSeconds}s');
+    final hashTimeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
+    final backupTimeout = maxSeconds != null ? Duration(seconds: maxSeconds - 1) : null;
+    await _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
+  }
+
+  Future<void> _backgroundLoop({
+    required Duration hashTimeout,
+    required Duration? backupTimeout,
+    required String debugLabel,
+  }) async {
+    _logger.info(
+      '$debugLabel started hashTimeout: ${hashTimeout.inSeconds}s, backupTimeout: ${backupTimeout?.inMinutes ?? '~'}m',
+    );
     final sw = Stopwatch()..start();
     try {
-      final timeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
-      if (!await _syncAssets(hashTimeout: timeout)) {
+      if (!await _syncAssets(hashTimeout: hashTimeout)) {
         _logger.warning("Remote sync did not complete successfully, skipping backup");
         return;
       }
 
       final backupFuture = _handleBackup();
-      if (maxSeconds != null) {
-        await backupFuture.timeout(Duration(seconds: maxSeconds - 1), onTimeout: () {});
+      if (backupTimeout != null) {
+        await backupFuture.timeout(
+          backupTimeout,
+          onTimeout: () {
+            if (!_cancellationToken.isCompleted) {
+              _cancellationToken.complete();
+            }
+          },
+        );
       } else {
         await backupFuture;
       }
     } catch (error, stack) {
-      _logger.severe("Failed to complete iOS background upload", error, stack);
+      _logger.severe("Failed to complete $debugLabel", error, stack);
     } finally {
       sw.stop();
-      _logger.info("iOS background upload completed in ${sw.elapsed.inSeconds}s");
+      _logger.info("$debugLabel completed in ${sw.elapsed.inSeconds}s");
       await _cleanup();
     }
   }
@@ -182,7 +192,9 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       _ref?.dispose();
       _ref = null;
 
-      _cancellationToken.complete();
+      if (!_cancellationToken.isCompleted) {
+        _cancellationToken.complete();
+      }
       _logger.info("Cleaning up background worker");
 
       final cleanupFutures = [

--- a/mobile/lib/domain/services/background_worker.service.dart
+++ b/mobile/lib/domain/services/background_worker.service.dart
@@ -108,7 +108,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   Future<void> onAndroidUpload(int? maxMinutes) async {
     final hashTimeout = Duration(minutes: _isBackupEnabled ? 3 : 6);
     final backupTimeout = maxMinutes != null ? Duration(minutes: maxMinutes - 1) : null;
-    await _backgroundLoop(
+    return _backgroundLoop(
       hashTimeout: hashTimeout,
       backupTimeout: backupTimeout,
       debugLabel: 'Android background upload',
@@ -119,7 +119,7 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds) async {
     final hashTimeout = isRefresh ? const Duration(seconds: 5) : Duration(minutes: _isBackupEnabled ? 3 : 6);
     final backupTimeout = maxSeconds != null ? Duration(seconds: maxSeconds - 1) : null;
-    await _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
+    return _backgroundLoop(hashTimeout: hashTimeout, backupTimeout: backupTimeout, debugLabel: 'iOS background upload');
   }
 
   Future<void> _backgroundLoop({
@@ -138,17 +138,19 @@ class BackgroundWorkerBgService extends BackgroundWorkerFlutterApi {
       }
 
       final backupFuture = _handleBackup();
+      Timer? cancelTimer;
       if (backupTimeout != null) {
-        await backupFuture.timeout(
-          backupTimeout,
-          onTimeout: () {
-            if (!_cancellationToken.isCompleted) {
-              _cancellationToken.complete();
-            }
-          },
-        );
-      } else {
+        cancelTimer = Timer(backupTimeout, () {
+          if (!_cancellationToken.isCompleted) {
+            _logger.warning("$debugLabel timed out after ${backupTimeout.inMinutes}m, cancelling backup");
+            _cancellationToken.complete();
+          }
+        });
+      }
+      try {
         await backupFuture;
+      } finally {
+        cancelTimer?.cancel();
       }
     } catch (error, stack) {
       _logger.severe("Failed to complete $debugLabel", error, stack);

--- a/mobile/lib/platform/background_worker_api.g.dart
+++ b/mobile/lib/platform/background_worker_api.g.dart
@@ -277,7 +277,7 @@ abstract class BackgroundWorkerFlutterApi {
 
   Future<void> onIosUpload(bool isRefresh, int? maxSeconds);
 
-  Future<void> onAndroidUpload();
+  Future<void> onAndroidUpload(int? maxMinutes);
 
   Future<void> cancel();
 
@@ -323,8 +323,10 @@ abstract class BackgroundWorkerFlutterApi {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final int? arg_maxMinutes = args[0] as int?;
           try {
-            await api.onAndroidUpload();
+            await api.onAndroidUpload(arg_maxMinutes);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/mobile/pigeon/background_worker_api.dart
+++ b/mobile/pigeon/background_worker_api.dart
@@ -47,7 +47,7 @@ abstract class BackgroundWorkerFlutterApi {
 
   // Android Only: Called when the Android background upload is triggered
   @async
-  void onAndroidUpload();
+  void onAndroidUpload(int? maxMinutes);
 
   @async
   void cancel();


### PR DESCRIPTION
Android background upload now also has a periodic worker so each work manager invocation is restricted to a maximum of 20 minutes to prevent the entire foreground service time of the app exceeding 6 hours for the dataSync task