### PR TITLE
refactor(web): rename DayGroup/MonthGroup to TimelineDay/TimelineMonth

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -6,7 +6,7 @@
   import SelectAllAssets from '$lib/components/timeline/actions/SelectAllAction.svelte';
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { dragAndDropFilesStore } from '$lib/stores/drag-and-drop-files.store';

--- a/web/src/lib/components/timeline/Scrubber.svelte
+++ b/web/src/lib/components/timeline/Scrubber.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { ScrubberMonth, ViewportTopMonth } from '$lib/managers/timeline-manager/types';
   import { mobileDevice } from '$lib/stores/mobile-device.svelte';
   import { getTabbable } from '$lib/utils/focus-util';
@@ -91,7 +91,7 @@
     scrubberWidth = usingMobileDevice ? MOBILE_WIDTH : DESKTOP_WIDTH;
   });
 
-  const toScrollFromMonthGroupPercentage = (
+  const toScrollFromMonthPercentage = (
     scrubberMonth: ViewportTopMonth,
     scrubberMonthPercent: number,
     scrubOverallPercent: number,
@@ -124,7 +124,7 @@
     }
   };
   const scrollY = $derived(
-    toScrollFromMonthGroupPercentage(viewportTopMonth, viewportTopMonthScrollPercent, timelineScrollPercent),
+    toScrollFromMonthPercentage(viewportTopMonth, viewportTopMonthScrollPercent, timelineScrollPercent),
   );
   const timelineFullHeight = $derived(timelineManager.scrubberTimelineHeight);
   const relativeTopOffset = $derived(toScrollY(timelineTopOffset / timelineFullHeight));
@@ -280,12 +280,12 @@
       const boundingClientRect = bestElement.boundingClientRect;
       const sy = boundingClientRect.y;
       const relativeY = y - sy;
-      const monthGroupPercentY = relativeY / boundingClientRect.height;
+      const monthPercentY = relativeY / boundingClientRect.height;
       return {
         isOnPaddingTop: false,
         isOnPaddingBottom: false,
         segment,
-        monthGroupPercentY,
+        monthPercentY,
       };
     }
 
@@ -308,7 +308,7 @@
       isOnPaddingTop,
       isOnPaddingBottom,
       segment: undefined,
-      monthGroupPercentY: 0,
+      monthPercentY: 0,
     };
   };
 
@@ -327,7 +327,7 @@
     const upper = rect?.height - (PADDING_TOP + PADDING_BOTTOM);
     hoverY = clamp(clientY - rect?.top - PADDING_TOP, lower, upper);
     const x = rect!.left + rect!.width / 2;
-    const { segment, monthGroupPercentY, isOnPaddingTop, isOnPaddingBottom } = getActive(x, clientY);
+    const { segment, monthPercentY, isOnPaddingTop, isOnPaddingBottom } = getActive(x, clientY);
     activeSegment = segment;
     isHoverOnPaddingTop = isOnPaddingTop;
     isHoverOnPaddingBottom = isOnPaddingBottom;
@@ -335,7 +335,7 @@
     const scrubData = {
       scrubberMonth: segmentDate,
       overallScrollPercent: toTimelineY(hoverY),
-      scrubberMonthScrollPercent: monthGroupPercentY,
+      scrubberMonthScrollPercent: monthPercentY,
     };
     if (wasDragging === false && isDragging) {
       void startScrub?.(scrubData);

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -2,7 +2,7 @@
   import type { Action } from '$lib/components/asset-viewer/actions/action';
   import { AssetAction } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { updateStackedAssetInTimeline, updateUnstackedAssetInTimeline } from '$lib/utils/actions';
   import { navigate } from '$lib/utils/navigation';

--- a/web/src/lib/components/timeline/TimelineDateGroup.svelte
+++ b/web/src/lib/components/timeline/TimelineDateGroup.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
   import Thumbnail from '$lib/components/assets/thumbnail/thumbnail.svelte';
-  import type { DayGroup } from '$lib/managers/timeline-manager/day-group.svelte';
-  import type { MonthGroup } from '$lib/managers/timeline-manager/month-group.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineDay } from '$lib/managers/timeline-manager/TimelineDay.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
+  import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { assetSnapshot, assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
   import type { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { isSelectingAllAssets } from '$lib/stores/assets-store.svelte';
   import { uploadAssetsStore } from '$lib/stores/upload';
   import { navigate } from '$lib/utils/navigation';
-
-  import { mdiCheckCircle, mdiCircleOutline } from '@mdi/js';
-
   import { fromTimelinePlainDate, getDateLocaleString } from '$lib/utils/timeline-util';
   import { Icon } from '@immich/ui';
+  import { mdiCheckCircle, mdiCircleOutline } from '@mdi/js';
   import { type Snippet } from 'svelte';
   import { flip } from 'svelte/animate';
   import { scale } from 'svelte/transition';
@@ -25,7 +23,7 @@
     singleSelect: boolean;
     withStacked: boolean;
     showArchiveIcon: boolean;
-    monthGroup: MonthGroup;
+    month: TimelineMonth;
     timelineManager: TimelineManager;
     assetInteraction: AssetInteraction;
     customLayout?: Snippet<[TimelineAsset]>;
@@ -36,11 +34,11 @@
     onThumbnailClick?: (
       asset: TimelineAsset,
       timelineManager: TimelineManager,
-      dayGroup: DayGroup,
+      day: TimelineDay,
       onClick: (
         timelineManager: TimelineManager,
         assets: TimelineAsset[],
-        groupTitle: string,
+        dayTitle: string,
         asset: TimelineAsset,
       ) => void,
     ) => void;
@@ -51,7 +49,7 @@
     singleSelect,
     withStacked,
     showArchiveIcon,
-    monthGroup = $bindable(),
+    month = $bindable(),
     assetInteraction,
     timelineManager,
     customLayout,
@@ -63,20 +61,18 @@
   }: Props = $props();
 
   let isMouseOverGroup = $state(false);
-  let hoveredDayGroup = $state();
+  let hoveredDay = $state();
 
-  const transitionDuration = $derived.by(() =>
-    monthGroup.timelineManager.suspendTransitions && !$isUploading ? 0 : 150,
-  );
+  const transitionDuration = $derived.by(() => (month.timelineManager.suspendTransitions && !$isUploading ? 0 : 150));
   const scaleDuration = $derived(transitionDuration === 0 ? 0 : transitionDuration + 100);
   const _onClick = (
     timelineManager: TimelineManager,
     assets: TimelineAsset[],
-    groupTitle: string,
+    dayTitle: string,
     asset: TimelineAsset,
   ) => {
     if (isSelectionMode || assetInteraction.selectionActive) {
-      assetSelectHandler(timelineManager, asset, assets, groupTitle);
+      assetSelectHandler(timelineManager, asset, assets, dayTitle);
       return;
     }
     void navigate({ targetRoute: 'current', assetId: asset.id });
@@ -87,21 +83,19 @@
   const assetSelectHandler = (
     timelineManager: TimelineManager,
     asset: TimelineAsset,
-    assetsInDayGroup: TimelineAsset[],
-    groupTitle: string,
+    assetsInDay: TimelineAsset[],
+    dayTitle: string,
   ) => {
     onSelectAssets(asset);
 
     // Check if all assets are selected in a group to toggle the group selection's icon
-    let selectedAssetsInGroupCount = assetsInDayGroup.filter((asset) =>
-      assetInteraction.hasSelectedAsset(asset.id),
-    ).length;
+    let selectedAssetsInDayCount = assetsInDay.filter((asset) => assetInteraction.hasSelectedAsset(asset.id)).length;
 
     // if all assets are selected in a group, add the group to selected group
-    if (selectedAssetsInGroupCount == assetsInDayGroup.length) {
-      assetInteraction.addGroupToMultiselectGroup(groupTitle);
+    if (selectedAssetsInDayCount == assetsInDay.length) {
+      assetInteraction.addGroupToMultiselectGroup(dayTitle);
     } else {
-      assetInteraction.removeGroupFromMultiselectGroup(groupTitle);
+      assetInteraction.removeGroupFromMultiselectGroup(dayTitle);
     }
 
     if (timelineManager.assetCount == assetInteraction.selectedAssets.length) {
@@ -111,9 +105,9 @@
     }
   };
 
-  const assetMouseEventHandler = (groupTitle: string, asset: TimelineAsset | null) => {
+  const assetMouseEventHandler = (dayTitle: string, asset: TimelineAsset | null) => {
     // Show multi select icon on hover on date group
-    hoveredDayGroup = groupTitle;
+    hoveredDay = dayTitle;
 
     if (assetInteraction.selectionActive) {
       onSelectAssetCandidates(asset);
@@ -124,52 +118,52 @@
     return intersectable.filter((int) => int.intersecting);
   }
 
-  const getDayGroupFullDate = (dayGroup: DayGroup): string => {
-    const { month, year } = dayGroup.monthGroup.yearMonth;
+  const getDayFullDate = (day: TimelineDay): string => {
+    const { month, year } = day.month.yearMonth;
     const date = fromTimelinePlainDate({
       year,
       month,
-      day: dayGroup.day,
+      day: day.day,
     });
     return getDateLocaleString(date);
   };
 </script>
 
-{#each filterIntersecting(monthGroup.dayGroups) as dayGroup, groupIndex (dayGroup.day)}
-  {@const absoluteWidth = dayGroup.left}
+{#each filterIntersecting(month.days) as day, groupIndex (day.day)}
+  {@const absoluteWidth = day.left}
 
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <section
     class={[
-      { 'transition-all': !monthGroup.timelineManager.suspendTransitions },
-      !monthGroup.timelineManager.suspendTransitions && `delay-${transitionDuration}`,
+      { 'transition-all': !month.timelineManager.suspendTransitions },
+      !month.timelineManager.suspendTransitions && `delay-${transitionDuration}`,
     ]}
     data-group
     style:position="absolute"
-    style:transform={`translate3d(${absoluteWidth}px,${dayGroup.top}px,0)`}
+    style:transform={`translate3d(${absoluteWidth}px,${day.top}px,0)`}
     onmouseenter={() => {
       isMouseOverGroup = true;
-      assetMouseEventHandler(dayGroup.groupTitle, null);
+      assetMouseEventHandler(day.dayTitle, null);
     }}
     onmouseleave={() => {
       isMouseOverGroup = false;
-      assetMouseEventHandler(dayGroup.groupTitle, null);
+      assetMouseEventHandler(day.dayTitle, null);
     }}
   >
     <!-- Date group title -->
     <div
       class="flex pt-7 pb-5 max-md:pt-5 max-md:pb-3 h-6 place-items-center text-xs font-medium text-immich-fg dark:text-immich-dark-fg md:text-sm"
-      style:width={dayGroup.width + 'px'}
+      style:width={day.width + 'px'}
     >
       {#if !singleSelect}
         <div
           class="hover:cursor-pointer transition-all duration-200 ease-out overflow-hidden w-0"
-          class:w-8={(hoveredDayGroup === dayGroup.groupTitle && isMouseOverGroup) ||
-            assetInteraction.selectedGroup.has(dayGroup.groupTitle)}
-          onclick={() => handleSelectGroup(dayGroup.groupTitle, assetsSnapshot(dayGroup.getAssets()))}
-          onkeydown={() => handleSelectGroup(dayGroup.groupTitle, assetsSnapshot(dayGroup.getAssets()))}
+          class:w-8={(hoveredDay === day.dayTitle && isMouseOverGroup) ||
+            assetInteraction.selectedGroup.has(day.dayTitle)}
+          onclick={() => handleSelectGroup(day.dayTitle, assetsSnapshot(day.getAssets()))}
+          onkeydown={() => handleSelectGroup(day.dayTitle, assetsSnapshot(day.getAssets()))}
         >
-          {#if assetInteraction.selectedGroup.has(dayGroup.groupTitle)}
+          {#if assetInteraction.selectedGroup.has(day.dayTitle)}
             <Icon icon={mdiCheckCircle} size="24" class="text-primary" />
           {:else}
             <Icon icon={mdiCircleOutline} size="24" color="#757575" />
@@ -177,19 +171,14 @@
         </div>
       {/if}
 
-      <span class="w-full truncate first-letter:capitalize" title={getDayGroupFullDate(dayGroup)}>
-        {dayGroup.groupTitle}
+      <span class="w-full truncate first-letter:capitalize" title={getDayFullDate(day)}>
+        {day.dayTitle}
       </span>
     </div>
 
     <!-- Image grid -->
-    <div
-      data-image-grid
-      class="relative overflow-clip"
-      style:height={dayGroup.height + 'px'}
-      style:width={dayGroup.width + 'px'}
-    >
-      {#each filterIntersecting(dayGroup.viewerAssets) as viewerAsset (viewerAsset.id)}
+    <div data-image-grid class="relative overflow-clip" style:height={day.height + 'px'} style:width={day.width + 'px'}>
+      {#each filterIntersecting(day.viewerAssets) as viewerAsset (viewerAsset.id)}
         {@const position = viewerAsset.position!}
         {@const asset = viewerAsset.asset!}
 
@@ -212,17 +201,17 @@
             {groupIndex}
             onClick={(asset) => {
               if (typeof onThumbnailClick === 'function') {
-                onThumbnailClick(asset, timelineManager, dayGroup, _onClick);
+                onThumbnailClick(asset, timelineManager, day, _onClick);
               } else {
-                _onClick(timelineManager, dayGroup.getAssets(), dayGroup.groupTitle, asset);
+                _onClick(timelineManager, day.getAssets(), day.dayTitle, asset);
               }
             }}
-            onSelect={(asset) => assetSelectHandler(timelineManager, asset, dayGroup.getAssets(), dayGroup.groupTitle)}
-            onMouseEvent={() => assetMouseEventHandler(dayGroup.groupTitle, assetSnapshot(asset))}
+            onSelect={(asset) => assetSelectHandler(timelineManager, asset, day.getAssets(), day.dayTitle)}
+            onMouseEvent={() => assetMouseEventHandler(day.dayTitle, assetSnapshot(asset))}
             selected={assetInteraction.hasSelectedAsset(asset.id) ||
-              dayGroup.monthGroup.timelineManager.albumAssets.has(asset.id)}
+              day.month.timelineManager.albumAssets.has(asset.id)}
             selectionCandidate={assetInteraction.hasSelectionCandidate(asset.id)}
-            disabled={dayGroup.monthGroup.timelineManager.albumAssets.has(asset.id)}
+            disabled={day.month.timelineManager.albumAssets.has(asset.id)}
             thumbnailWidth={position.width}
             thumbnailHeight={position.height}
           />

--- a/web/src/lib/components/timeline/actions/SelectAllAction.svelte
+++ b/web/src/lib/components/timeline/actions/SelectAllAction.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { isSelectingAllAssets } from '$lib/stores/assets-store.svelte';
   import { cancelMultiselect, selectAllAssets } from '$lib/utils/asset-utils';

--- a/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
+++ b/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
@@ -7,7 +7,7 @@
     setFocusTo as setFocusToInit,
   } from '$lib/components/timeline/actions/focus-actions';
   import { AppRoute } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import NavigateToDateModal from '$lib/modals/NavigateToDateModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';

--- a/web/src/lib/components/timeline/actions/focus-actions.ts
+++ b/web/src/lib/components/timeline/actions/focus-actions.ts
@@ -1,4 +1,4 @@
-import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { moveFocus } from '$lib/utils/focus-util';
 import { InvocationTracker } from '$lib/utils/invocationTracker';

--- a/web/src/lib/managers/VirtualScrollManager/ScrollSegment.svelte.ts
+++ b/web/src/lib/managers/VirtualScrollManager/ScrollSegment.svelte.ts
@@ -1,0 +1,1 @@
+export class ScrollSegment {}

--- a/web/src/lib/managers/timeline-manager/TimelineDay.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/TimelineDay.svelte.ts
@@ -1,18 +1,16 @@
-import { AssetOrder } from '@immich/sdk';
-
+import { onCreateDay } from '$lib/managers/timeline-manager/internal/TestHooks.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
+import type { AssetOperation, Direction, TimelineAsset } from '$lib/managers/timeline-manager/types';
+import { ViewerAsset } from '$lib/managers/timeline-manager/viewer-asset.svelte';
 import type { CommonLayoutOptions } from '$lib/utils/layout-utils';
 import { getJustifiedLayoutFromAssets } from '$lib/utils/layout-utils';
 import { plainDateTimeCompare } from '$lib/utils/timeline-util';
+import { AssetOrder } from '@immich/sdk';
 
-import { onCreateDayGroup } from '$lib/managers/timeline-manager/internal/TestHooks.svelte';
-import type { MonthGroup } from './month-group.svelte';
-import type { AssetOperation, Direction, TimelineAsset } from './types';
-import { ViewerAsset } from './viewer-asset.svelte';
-
-export class DayGroup {
-  readonly monthGroup: MonthGroup;
+export class TimelineDay {
+  readonly month: TimelineMonth;
   readonly index: number;
-  readonly groupTitle: string;
+  readonly dayTitle: string;
   readonly day: number;
   viewerAssets: ViewerAsset[] = $state([]);
 
@@ -26,13 +24,13 @@ export class DayGroup {
   #col = $state(0);
   #deferredLayout = false;
 
-  constructor(monthGroup: MonthGroup, index: number, day: number, groupTitle: string) {
+  constructor(month: TimelineMonth, index: number, day: number, dayTitle: string) {
     this.index = index;
-    this.monthGroup = monthGroup;
+    this.month = month;
     this.day = day;
-    this.groupTitle = groupTitle;
+    this.dayTitle = dayTitle;
     if (import.meta.env.DEV) {
-      onCreateDayGroup(this);
+      onCreateDay(this);
     }
   }
 
@@ -144,7 +142,7 @@ export class DayGroup {
       }
       unprocessedIds.delete(assetId);
       processedIds.add(assetId);
-      if (remove || this.monthGroup.timelineManager.isExcluded(asset)) {
+      if (remove || this.month.timelineManager.isExcluded(asset)) {
         this.viewerAssets.splice(index, 1);
         changedGeometry = true;
       }
@@ -153,7 +151,7 @@ export class DayGroup {
   }
 
   layout(options: CommonLayoutOptions, noDefer: boolean) {
-    if (!noDefer && !this.monthGroup.intersecting) {
+    if (!noDefer && !this.month.intersecting) {
       this.#deferredLayout = true;
       return;
     }
@@ -167,7 +165,7 @@ export class DayGroup {
     }
   }
 
-  get absoluteDayGroupTop() {
-    return this.monthGroup.top + this.#top;
+  get absoluteTop() {
+    return this.month.top + this.#top;
   }
 }

--- a/web/src/lib/managers/timeline-manager/group-insertion-cache.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/group-insertion-cache.svelte.ts
@@ -1,64 +1,64 @@
+import { TimelineDay } from '$lib/managers/timeline-manager/TimelineDay.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
+import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { setDifference, type TimelineDate } from '$lib/utils/timeline-util';
 import { AssetOrder } from '@immich/sdk';
-import type { DayGroup } from './day-group.svelte';
-import type { MonthGroup } from './month-group.svelte';
-import type { TimelineAsset } from './types';
 
 export class GroupInsertionCache {
   #lookupCache: {
-    [year: number]: { [month: number]: { [day: number]: DayGroup } };
+    [year: number]: { [month: number]: { [day: number]: TimelineDay } };
   } = {};
   unprocessedAssets: TimelineAsset[] = [];
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
-  changedDayGroups = new Set<DayGroup>();
+  changedDays = new Set<TimelineDay>();
   // eslint-disable-next-line svelte/prefer-svelte-reactivity
-  newDayGroups = new Set<DayGroup>();
+  newDays = new Set<TimelineDay>();
 
-  getDayGroup({ year, month, day }: TimelineDate): DayGroup | undefined {
+  getDay({ year, month, day }: TimelineDate): TimelineDay | undefined {
     return this.#lookupCache[year]?.[month]?.[day];
   }
 
-  setDayGroup(dayGroup: DayGroup, { year, month, day }: TimelineDate) {
+  setDay(day: TimelineDay, { year, month, day: dayNumber }: TimelineDate) {
     if (!this.#lookupCache[year]) {
       this.#lookupCache[year] = {};
     }
     if (!this.#lookupCache[year][month]) {
       this.#lookupCache[year][month] = {};
     }
-    this.#lookupCache[year][month][day] = dayGroup;
+    this.#lookupCache[year][month][dayNumber] = day;
   }
 
-  get existingDayGroups() {
-    return setDifference(this.changedDayGroups, this.newDayGroups);
+  get existingDays() {
+    return setDifference(this.changedDays, this.newDays);
   }
 
-  get updatedBuckets() {
+  get updatedMonths() {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const updated = new Set<MonthGroup>();
-    for (const group of this.changedDayGroups) {
-      updated.add(group.monthGroup);
+    const months = new Set<TimelineMonth>();
+    for (const day of this.changedDays) {
+      months.add(day.month);
     }
-    return updated;
+    return months;
   }
 
-  get bucketsWithNewDayGroups() {
+  get monthsWithNewDays() {
     // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const updated = new Set<MonthGroup>();
-    for (const group of this.newDayGroups) {
-      updated.add(group.monthGroup);
+    const months = new Set<TimelineMonth>();
+    for (const day of this.newDays) {
+      months.add(day.month);
     }
-    return updated;
+    return months;
   }
 
-  sort(monthGroup: MonthGroup, sortOrder: AssetOrder = AssetOrder.Desc) {
-    for (const group of this.changedDayGroups) {
-      group.sortAssets(sortOrder);
+  sort(month: TimelineMonth, sortOrder: AssetOrder = AssetOrder.Desc) {
+    for (const day of this.changedDays) {
+      day.sortAssets(sortOrder);
     }
-    for (const group of this.newDayGroups) {
-      group.sortAssets(sortOrder);
+    for (const day of this.newDays) {
+      day.sortAssets(sortOrder);
     }
-    if (this.newDayGroups.size > 0) {
-      monthGroup.sortDayGroups();
+    if (this.newDays.size > 0) {
+      month.sortDays();
     }
   }
 }

--- a/web/src/lib/managers/timeline-manager/internal/TestHooks.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/TestHooks.svelte.ts
@@ -1,16 +1,16 @@
-import type { DayGroup } from '$lib/managers/timeline-manager/day-group.svelte';
-import type { MonthGroup } from '$lib/managers/timeline-manager/month-group.svelte';
+import { TimelineDay } from '$lib/managers/timeline-manager/TimelineDay.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
 
 let testHooks: TestHooks | undefined = undefined;
 
 export type TestHooks = {
-  onCreateMonthGroup(monthGroup: MonthGroup): unknown;
-  onCreateDayGroup(dayGroup: DayGroup): unknown;
+  onCreateMonth(month: TimelineMonth): unknown;
+  onCreateDay(day: TimelineDay): unknown;
 };
 
 export const setTestHooks = (hooks: TestHooks) => {
   testHooks = hooks;
 };
 
-export const onCreateMonthGroup = (monthGroup: MonthGroup) => testHooks?.onCreateMonthGroup(monthGroup);
-export const onCreateDayGroup = (dayGroup: DayGroup) => testHooks?.onCreateDayGroup(dayGroup);
+export const onCreateMonth = (month: TimelineMonth) => testHooks?.onCreateMonth(month);
+export const onCreateDay = (day: TimelineDay) => testHooks?.onCreateDay(day);

--- a/web/src/lib/managers/timeline-manager/internal/intersection-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/intersection-support.svelte.ts
@@ -1,16 +1,16 @@
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
 import { TUNABLES } from '$lib/utils/tunables';
-import type { MonthGroup } from '../month-group.svelte';
-import { TimelineManager } from '../timeline-manager.svelte';
 
 const {
   TIMELINE: { INTERSECTION_EXPAND_TOP, INTERSECTION_EXPAND_BOTTOM },
 } = TUNABLES;
 
-export function updateIntersectionMonthGroup(timelineManager: TimelineManager, month: MonthGroup) {
-  const actuallyIntersecting = calculateMonthGroupIntersecting(timelineManager, month, 0, 0);
+export function updateIntersectionMonth(timelineManager: TimelineManager, month: TimelineMonth) {
+  const actuallyIntersecting = calculateMonthIntersecting(timelineManager, month, 0, 0);
   let preIntersecting = false;
   if (!actuallyIntersecting) {
-    preIntersecting = calculateMonthGroupIntersecting(
+    preIntersecting = calculateMonthIntersecting(
       timelineManager,
       month,
       INTERSECTION_EXPAND_TOP,
@@ -40,18 +40,18 @@ export function isIntersecting(regionTop: number, regionBottom: number, windowTo
   );
 }
 
-export function calculateMonthGroupIntersecting(
+export function calculateMonthIntersecting(
   timelineManager: TimelineManager,
-  monthGroup: MonthGroup,
+  month: TimelineMonth,
   expandTop: number,
   expandBottom: number,
 ) {
-  const monthGroupTop = monthGroup.top;
-  const monthGroupBottom = monthGroupTop + monthGroup.height;
+  const monthTop = month.top;
+  const monthBottom = monthTop + month.height;
   const topWindow = timelineManager.visibleWindow.top - expandTop;
   const bottomWindow = timelineManager.visibleWindow.bottom + expandBottom;
 
-  return isIntersecting(monthGroupTop, monthGroupBottom, topWindow, bottomWindow);
+  return isIntersecting(monthTop, monthBottom, topWindow, bottomWindow);
 }
 
 /**

--- a/web/src/lib/managers/timeline-manager/internal/layout-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/layout-support.svelte.ts
@@ -1,8 +1,8 @@
-import type { MonthGroup } from '../month-group.svelte';
-import { TimelineManager } from '../timeline-manager.svelte';
-import type { UpdateGeometryOptions } from '../types';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
+import type { UpdateGeometryOptions } from '$lib/managers/timeline-manager/types';
 
-export function updateGeometry(timelineManager: TimelineManager, month: MonthGroup, options: UpdateGeometryOptions) {
+export function updateGeometry(timelineManager: TimelineManager, month: TimelineMonth, options: UpdateGeometryOptions) {
   const { invalidateHeight, noDefer = false } = options;
   if (invalidateHeight) {
     month.isHeightActual = false;
@@ -17,49 +17,49 @@ export function updateGeometry(timelineManager: TimelineManager, month: MonthGro
     }
     return;
   }
-  layoutMonthGroup(timelineManager, month, noDefer);
+  layoutMonth(timelineManager, month, noDefer);
 }
 
-export function layoutMonthGroup(timelineManager: TimelineManager, month: MonthGroup, noDefer: boolean = false) {
+export function layoutMonth(timelineManager: TimelineManager, month: TimelineMonth, noDefer: boolean = false) {
   let cumulativeHeight = 0;
   let cumulativeWidth = 0;
   let currentRowHeight = 0;
 
-  let dayGroupRow = 0;
-  let dayGroupCol = 0;
+  let dayRow = 0;
+  let dayCol = 0;
 
   const options = timelineManager.justifiedLayoutOptions;
-  for (const dayGroup of month.dayGroups) {
-    dayGroup.layout(options, noDefer);
+  for (const day of month.days) {
+    day.layout(options, noDefer);
 
     // Calculate space needed for this item (including gap if not first in row)
-    const spaceNeeded = dayGroup.width + (dayGroupCol > 0 ? timelineManager.gap : 0);
+    const spaceNeeded = day.width + (dayCol > 0 ? timelineManager.gap : 0);
     const fitsInCurrentRow = cumulativeWidth + spaceNeeded <= timelineManager.viewportWidth;
 
     if (fitsInCurrentRow) {
-      dayGroup.row = dayGroupRow;
-      dayGroup.col = dayGroupCol++;
-      dayGroup.left = cumulativeWidth;
-      dayGroup.top = cumulativeHeight;
+      day.row = dayRow;
+      day.col = dayCol++;
+      day.left = cumulativeWidth;
+      day.top = cumulativeHeight;
 
-      cumulativeWidth += dayGroup.width + timelineManager.gap;
+      cumulativeWidth += day.width + timelineManager.gap;
     } else {
       // Move to next row
       cumulativeHeight += currentRowHeight;
       cumulativeWidth = 0;
-      dayGroupRow++;
-      dayGroupCol = 0;
+      dayRow++;
+      dayCol = 0;
 
       // Position at start of new row
-      dayGroup.row = dayGroupRow;
-      dayGroup.col = dayGroupCol;
-      dayGroup.left = 0;
-      dayGroup.top = cumulativeHeight;
+      day.row = dayRow;
+      day.col = dayCol;
+      day.left = 0;
+      day.top = cumulativeHeight;
 
-      dayGroupCol++;
-      cumulativeWidth += dayGroup.width + timelineManager.gap;
+      dayCol++;
+      cumulativeWidth += day.width + timelineManager.gap;
     }
-    currentRowHeight = dayGroup.height + timelineManager.headerHeight;
+    currentRowHeight = day.height + timelineManager.headerHeight;
   }
 
   // Add the height of the final row

--- a/web/src/lib/managers/timeline-manager/internal/load-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/load-support.svelte.ts
@@ -1,21 +1,21 @@
 import { authManager } from '$lib/managers/auth-manager.svelte';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
+import type { TimelineManagerOptions } from '$lib/managers/timeline-manager/types';
 import { toISOYearMonthUTC } from '$lib/utils/timeline-util';
 import { getTimeBucket } from '@immich/sdk';
-import type { MonthGroup } from '../month-group.svelte';
-import { TimelineManager } from '../timeline-manager.svelte';
-import type { TimelineManagerOptions } from '../types';
 
 export async function loadFromTimeBuckets(
   timelineManager: TimelineManager,
-  monthGroup: MonthGroup,
+  month: TimelineMonth,
   options: TimelineManagerOptions,
   signal: AbortSignal,
 ): Promise<void> {
-  if (monthGroup.getFirstAsset()) {
+  if (month.getFirstAsset()) {
     return;
   }
 
-  const timeBucket = toISOYearMonthUTC(monthGroup.yearMonth);
+  const timeBucket = toISOYearMonthUTC(month.yearMonth);
   const bucketResponse = await getTimeBucket(
     {
       ...authManager.params,
@@ -43,10 +43,10 @@ export async function loadFromTimeBuckets(
     }
   }
 
-  const unprocessedAssets = monthGroup.addAssets(bucketResponse, true);
+  const unprocessedAssets = month.addAssets(bucketResponse, true);
   if (unprocessedAssets.length > 0) {
     console.error(
-      `Warning: getTimeBucket API returning assets not in requested month: ${monthGroup.yearMonth.month}, ${JSON.stringify(
+      `Warning: getTimeBucket API returning assets not in requested month: ${month.yearMonth.month}, ${JSON.stringify(
         unprocessedAssets.map((unprocessed) => ({
           id: unprocessed.id,
           localDateTime: unprocessed.localDateTime,

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.spec.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.spec.ts
@@ -1,11 +1,11 @@
+import { findClosestGroupForDate } from '$lib/managers/timeline-manager/internal/search-support.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
 import { describe, expect, it } from 'vitest';
-import type { MonthGroup } from '../month-group.svelte';
-import { findClosestGroupForDate } from './search-support.svelte';
 
-function createMockMonthGroup(year: number, month: number): MonthGroup {
+function createMockMonth(year: number, month: number): TimelineMonth {
   return {
     yearMonth: { year, month },
-  } as MonthGroup;
+  } as TimelineMonth;
 }
 
 describe('findClosestGroupForDate', () => {
@@ -15,25 +15,25 @@ describe('findClosestGroupForDate', () => {
   });
 
   it('should return the only month when there is only one month', () => {
-    const months = [createMockMonthGroup(2024, 6)];
+    const months = [createMockMonth(2024, 6)];
     const result = findClosestGroupForDate(months, { year: 2025, month: 1 });
     expect(result?.yearMonth).toEqual({ year: 2024, month: 6 });
   });
 
   it('should return exact match when available', () => {
-    const months = [createMockMonthGroup(2024, 1), createMockMonthGroup(2024, 6), createMockMonthGroup(2024, 12)];
+    const months = [createMockMonth(2024, 1), createMockMonth(2024, 6), createMockMonth(2024, 12)];
     const result = findClosestGroupForDate(months, { year: 2024, month: 6 });
     expect(result?.yearMonth).toEqual({ year: 2024, month: 6 });
   });
 
   it('should find closest month when target is between two months', () => {
-    const months = [createMockMonthGroup(2024, 1), createMockMonthGroup(2024, 6), createMockMonthGroup(2024, 12)];
+    const months = [createMockMonth(2024, 1), createMockMonth(2024, 6), createMockMonth(2024, 12)];
     const result = findClosestGroupForDate(months, { year: 2024, month: 4 });
     expect(result?.yearMonth).toEqual({ year: 2024, month: 6 });
   });
 
   it('should handle year boundaries correctly (2023-12 vs 2024-01)', () => {
-    const months = [createMockMonthGroup(2023, 12), createMockMonthGroup(2024, 2)];
+    const months = [createMockMonth(2023, 12), createMockMonth(2024, 2)];
     const result = findClosestGroupForDate(months, { year: 2024, month: 1 });
     // 2024-01 is 1 month from 2023-12 and 1 month from 2024-02
     // Should return first encountered with min distance (2023-12)
@@ -41,33 +41,33 @@ describe('findClosestGroupForDate', () => {
   });
 
   it('should correctly calculate distance across years', () => {
-    const months = [createMockMonthGroup(2022, 6), createMockMonthGroup(2024, 6)];
+    const months = [createMockMonth(2022, 6), createMockMonth(2024, 6)];
     const result = findClosestGroupForDate(months, { year: 2023, month: 6 });
     // Both are exactly 12 months away, should return first encountered
     expect(result?.yearMonth).toEqual({ year: 2022, month: 6 });
   });
 
   it('should handle target before all months', () => {
-    const months = [createMockMonthGroup(2024, 6), createMockMonthGroup(2024, 12)];
+    const months = [createMockMonth(2024, 6), createMockMonth(2024, 12)];
     const result = findClosestGroupForDate(months, { year: 2024, month: 1 });
     expect(result?.yearMonth).toEqual({ year: 2024, month: 6 });
   });
 
   it('should handle target after all months', () => {
-    const months = [createMockMonthGroup(2024, 1), createMockMonthGroup(2024, 6)];
+    const months = [createMockMonth(2024, 1), createMockMonth(2024, 6)];
     const result = findClosestGroupForDate(months, { year: 2025, month: 1 });
     expect(result?.yearMonth).toEqual({ year: 2024, month: 6 });
   });
 
   it('should handle multiple years correctly', () => {
-    const months = [createMockMonthGroup(2020, 1), createMockMonthGroup(2022, 1), createMockMonthGroup(2024, 1)];
+    const months = [createMockMonth(2020, 1), createMockMonth(2022, 1), createMockMonth(2024, 1)];
     const result = findClosestGroupForDate(months, { year: 2023, month: 1 });
     // 2023-01 is 12 months from 2022-01 and 12 months from 2024-01
     expect(result?.yearMonth).toEqual({ year: 2022, month: 1 });
   });
 
   it('should prefer closer month when one is clearly closer', () => {
-    const months = [createMockMonthGroup(2024, 1), createMockMonthGroup(2024, 10)];
+    const months = [createMockMonth(2024, 1), createMockMonth(2024, 10)];
     const result = findClosestGroupForDate(months, { year: 2024, month: 11 });
     // 2024-11 is 1 month from 2024-10 and 10 months from 2024-01
     expect(result?.yearMonth).toEqual({ year: 2024, month: 10 });

--- a/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/search-support.svelte.ts
@@ -1,9 +1,9 @@
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
+import { TimelineMonth } from '$lib/managers/timeline-manager/TimelineMonth.svelte';
+import type { AssetDescriptor, Direction, TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { plainDateTimeCompare, type TimelineYearMonth } from '$lib/utils/timeline-util';
 import { AssetOrder } from '@immich/sdk';
 import { DateTime } from 'luxon';
-import type { MonthGroup } from '../month-group.svelte';
-import { TimelineManager } from '../timeline-manager.svelte';
-import type { AssetDescriptor, Direction, TimelineAsset } from '../types';
 
 export async function getAssetWithOffset(
   timelineManager: TimelineManager,
@@ -11,40 +11,40 @@ export async function getAssetWithOffset(
   interval: 'asset' | 'day' | 'month' | 'year' = 'asset',
   direction: Direction,
 ): Promise<TimelineAsset | undefined> {
-  const { asset, monthGroup } = findMonthGroupForAsset(timelineManager, assetDescriptor.id) ?? {};
-  if (!monthGroup || !asset) {
+  const { asset, month } = findMonthForAsset(timelineManager, assetDescriptor.id) ?? {};
+  if (!month || !asset) {
     return;
   }
 
   switch (interval) {
     case 'asset': {
-      return getAssetByAssetOffset(timelineManager, asset, monthGroup, direction);
+      return getAssetByAssetOffset(timelineManager, asset, month, direction);
     }
     case 'day': {
-      return getAssetByDayOffset(timelineManager, asset, monthGroup, direction);
+      return getAssetByDayOffset(timelineManager, asset, month, direction);
     }
     case 'month': {
-      return getAssetByMonthOffset(timelineManager, monthGroup, direction);
+      return getAssetByMonthOffset(timelineManager, month, direction);
     }
     case 'year': {
-      return getAssetByYearOffset(timelineManager, monthGroup, direction);
+      return getAssetByYearOffset(timelineManager, month, direction);
     }
   }
 }
 
-export function findMonthGroupForAsset(timelineManager: TimelineManager, id: string) {
+export function findMonthForAsset(timelineManager: TimelineManager, id: string) {
   for (const month of timelineManager.months) {
     const asset = month.findAssetById({ id });
     if (asset) {
-      return { monthGroup: month, asset };
+      return { month, asset };
     }
   }
 }
 
-export function getMonthGroupByDate(
+export function getMonthByDate(
   timelineManager: TimelineManager,
   targetYearMonth: TimelineYearMonth,
-): MonthGroup | undefined {
+): TimelineMonth | undefined {
   return timelineManager.months.find(
     (month) => month.yearMonth.year === targetYearMonth.year && month.yearMonth.month === targetYearMonth.month,
   );
@@ -53,13 +53,13 @@ export function getMonthGroupByDate(
 async function getAssetByAssetOffset(
   timelineManager: TimelineManager,
   asset: TimelineAsset,
-  monthGroup: MonthGroup,
+  month: TimelineMonth,
   direction: Direction,
 ) {
-  const dayGroup = monthGroup.findDayGroupForAsset(asset);
+  const day = month.findDayForAsset(asset);
   for await (const targetAsset of timelineManager.assetsIterator({
-    startMonthGroup: monthGroup,
-    startDayGroup: dayGroup,
+    startMonth: month,
+    startDay: day,
     startAsset: asset,
     direction,
   })) {
@@ -72,13 +72,13 @@ async function getAssetByAssetOffset(
 async function getAssetByDayOffset(
   timelineManager: TimelineManager,
   asset: TimelineAsset,
-  monthGroup: MonthGroup,
+  month: TimelineMonth,
   direction: Direction,
 ) {
-  const dayGroup = monthGroup.findDayGroupForAsset(asset);
+  const day = month.findDayForAsset(asset);
   for await (const targetAsset of timelineManager.assetsIterator({
-    startMonthGroup: monthGroup,
-    startDayGroup: dayGroup,
+    startMonth: month,
+    startDay: day,
     startAsset: asset,
     direction,
   })) {
@@ -88,44 +88,44 @@ async function getAssetByDayOffset(
   }
 }
 
-async function getAssetByMonthOffset(timelineManager: TimelineManager, month: MonthGroup, direction: Direction) {
-  for (const targetMonth of timelineManager.monthGroupIterator({ startMonthGroup: month, direction })) {
+async function getAssetByMonthOffset(timelineManager: TimelineManager, month: TimelineMonth, direction: Direction) {
+  for (const targetMonth of timelineManager.monthIterator({ startMonth: month, direction })) {
     if (targetMonth.yearMonth.month !== month.yearMonth.month) {
-      const { value, done } = await timelineManager.assetsIterator({ startMonthGroup: targetMonth, direction }).next();
+      const { value, done } = await timelineManager.assetsIterator({ startMonth: targetMonth, direction }).next();
       return done ? undefined : value;
     }
   }
 }
 
-async function getAssetByYearOffset(timelineManager: TimelineManager, month: MonthGroup, direction: Direction) {
-  for (const targetMonth of timelineManager.monthGroupIterator({ startMonthGroup: month, direction })) {
+async function getAssetByYearOffset(timelineManager: TimelineManager, month: TimelineMonth, direction: Direction) {
+  for (const targetMonth of timelineManager.monthIterator({ startMonth: month, direction })) {
     if (targetMonth.yearMonth.year !== month.yearMonth.year) {
-      const { value, done } = await timelineManager.assetsIterator({ startMonthGroup: targetMonth, direction }).next();
+      const { value, done } = await timelineManager.assetsIterator({ startMonth: targetMonth, direction }).next();
       return done ? undefined : value;
     }
   }
 }
 
 export async function retrieveRange(timelineManager: TimelineManager, start: AssetDescriptor, end: AssetDescriptor) {
-  let { asset: startAsset, monthGroup: startMonthGroup } = findMonthGroupForAsset(timelineManager, start.id) ?? {};
-  if (!startMonthGroup || !startAsset) {
+  let { asset: startAsset, month: startMonth } = findMonthForAsset(timelineManager, start.id) ?? {};
+  if (!startMonth || !startAsset) {
     return [];
   }
-  let { asset: endAsset, monthGroup: endMonthGroup } = findMonthGroupForAsset(timelineManager, end.id) ?? {};
-  if (!endMonthGroup || !endAsset) {
+  let { asset: endAsset, month: endMonth } = findMonthForAsset(timelineManager, end.id) ?? {};
+  if (!endMonth || !endAsset) {
     return [];
   }
   const assetOrder: AssetOrder = timelineManager.getAssetOrder();
   if (plainDateTimeCompare(assetOrder === AssetOrder.Desc, startAsset.localDateTime, endAsset.localDateTime) < 0) {
     [startAsset, endAsset] = [endAsset, startAsset];
-    [startMonthGroup, endMonthGroup] = [endMonthGroup, startMonthGroup];
+    [startMonth, endMonth] = [endMonth, startMonth];
   }
 
   const range: TimelineAsset[] = [];
-  const startDayGroup = startMonthGroup.findDayGroupForAsset(startAsset);
+  const startDay = startMonth.findDayForAsset(startAsset);
   for await (const targetAsset of timelineManager.assetsIterator({
-    startMonthGroup,
-    startDayGroup,
+    startMonth,
+    startDay,
     startAsset,
   })) {
     range.push(targetAsset);
@@ -136,7 +136,7 @@ export async function retrieveRange(timelineManager: TimelineManager, start: Ass
   return range;
 }
 
-export function findMonthGroupForDate(timelineManager: TimelineManager, targetYearMonth: TimelineYearMonth) {
+export function findMonthForDate(timelineManager: TimelineManager, targetYearMonth: TimelineYearMonth) {
   for (const month of timelineManager.months) {
     const { year, month: monthNum } = month.yearMonth;
     if (monthNum === targetYearMonth.month && year === targetYearMonth.year) {
@@ -145,10 +145,10 @@ export function findMonthGroupForDate(timelineManager: TimelineManager, targetYe
   }
 }
 
-export function findClosestGroupForDate(months: MonthGroup[], targetYearMonth: TimelineYearMonth) {
+export function findClosestGroupForDate(months: TimelineMonth[], targetYearMonth: TimelineYearMonth) {
   const targetDate = DateTime.fromObject({ year: targetYearMonth.year, month: targetYearMonth.month });
 
-  let closestMonth: MonthGroup | undefined;
+  let closestMonth: TimelineMonth | undefined;
   let minDifference = Number.MAX_SAFE_INTEGER;
 
   for (const month of months) {

--- a/web/src/lib/managers/timeline-manager/internal/websocket-support.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/internal/websocket-support.svelte.ts
@@ -1,4 +1,4 @@
-import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
 import type { PendingChange, TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { websocketEvents } from '$lib/stores/websocket';
 import { toTimelineAsset } from '$lib/utils/timeline-util';

--- a/web/src/lib/managers/timeline-manager/utils.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/utils.svelte.ts
@@ -1,4 +1,4 @@
-import type { TimelineAsset } from './types';
+import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 
 export const assetSnapshot = (asset: TimelineAsset): TimelineAsset => $state.snapshot(asset);
 export const assetsSnapshot = (assets: TimelineAsset[]) => assets.map((asset) => $state.snapshot(asset));

--- a/web/src/lib/managers/timeline-manager/viewer-asset.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/viewer-asset.svelte.ts
@@ -1,19 +1,18 @@
+import { calculateViewerAssetIntersecting } from '$lib/managers/timeline-manager/internal/intersection-support.svelte';
+import { TimelineDay } from '$lib/managers/timeline-manager/TimelineDay.svelte';
+import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import type { CommonPosition } from '$lib/utils/layout-utils';
 
-import type { DayGroup } from './day-group.svelte';
-import { calculateViewerAssetIntersecting } from './internal/intersection-support.svelte';
-import type { TimelineAsset } from './types';
-
 export class ViewerAsset {
-  readonly #group: DayGroup;
+  readonly #day: TimelineDay;
 
   intersecting = $derived.by(() => {
     if (!this.position) {
       return false;
     }
 
-    const store = this.#group.monthGroup.timelineManager;
-    const positionTop = this.#group.absoluteDayGroupTop + this.position.top;
+    const store = this.#day.month.timelineManager;
+    const positionTop = this.#day.absoluteTop + this.position.top;
 
     return calculateViewerAssetIntersecting(store, positionTop, this.position.height);
   });
@@ -22,8 +21,8 @@ export class ViewerAsset {
   asset: TimelineAsset = <TimelineAsset>$state();
   id: string = $derived(this.asset.id);
 
-  constructor(group: DayGroup, asset: TimelineAsset) {
-    this.#group = group;
+  constructor(day: TimelineDay, asset: TimelineAsset) {
+    this.#day = day;
     this.asset = asset;
   }
 }

--- a/web/src/lib/modals/NavigateToDateModal.svelte
+++ b/web/src/lib/modals/NavigateToDateModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import DateInput from '$lib/elements/DateInput.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import { getPreferredTimeZone, getTimezones, toDatetime, type ZoneOption } from '$lib/modals/timezone-utils';
   import { Button, HStack, Modal, ModalBody, ModalFooter, VStack } from '@immich/ui';

--- a/web/src/lib/utils/actions.ts
+++ b/web/src/lib/utils/actions.ts
@@ -1,5 +1,5 @@
 import ToastAction from '$lib/components/ToastAction.svelte';
-import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import type { StackResponse } from '$lib/utils/asset-utils';
 import { AssetVisibility, deleteAssets as deleteBulk, restoreAssets } from '@immich/sdk';

--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -3,7 +3,7 @@ import ToastAction from '$lib/components/ToastAction.svelte';
 import { AppRoute } from '$lib/constants';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { downloadManager } from '$lib/managers/download-manager.svelte';
-import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
 import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
 import { assetsSnapshot } from '$lib/managers/timeline-manager/utils.svelte';
 import type { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
@@ -490,17 +490,17 @@ export const selectAllAssets = async (timelineManager: TimelineManager, assetInt
   isSelectingAllAssets.set(true);
 
   try {
-    for (const monthGroup of timelineManager.months) {
-      await timelineManager.loadMonthGroup(monthGroup.yearMonth);
+    for (const month of timelineManager.months) {
+      await timelineManager.loadMonth(month.yearMonth);
 
       if (!get(isSelectingAllAssets)) {
         assetInteraction.clearMultiselect();
         break; // Cancelled
       }
-      assetInteraction.selectAssets(assetsSnapshot([...monthGroup.assetsIterator()]));
+      assetInteraction.selectAssets(assetsSnapshot([...month.assetsIterator()]));
 
-      for (const dateGroup of monthGroup.dayGroups) {
-        assetInteraction.addGroupToMultiselectGroup(dateGroup.groupTitle);
+      for (const dateGroup of month.days) {
+        assetInteraction.addGroupToMultiselectGroup(dateGroup.dayTitle);
       }
     }
   } catch (error) {

--- a/web/src/lib/utils/timeline-util.spec.ts
+++ b/web/src/lib/utils/timeline-util.spec.ts
@@ -1,9 +1,9 @@
 import { locale } from '$lib/stores/preferences.store';
 import { parseUtcDate } from '$lib/utils/date-time';
-import { formatGroupTitle, toISOYearMonthUTC } from '$lib/utils/timeline-util';
+import { formatDayTitle, toISOYearMonthUTC } from '$lib/utils/timeline-util';
 import { DateTime } from 'luxon';
 
-describe('formatGroupTitle', () => {
+describe('formatDayTitle', () => {
   beforeAll(() => {
     vi.useFakeTimers();
     process.env.TZ = 'UTC';
@@ -18,63 +18,63 @@ describe('formatGroupTitle', () => {
   it('formats today', () => {
     const date = parseUtcDate('2024-07-27T01:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('today');
+    expect(formatDayTitle(date)).toBe('today');
     locale.set('es');
-    expect(formatGroupTitle(date)).toBe('hoy');
+    expect(formatDayTitle(date)).toBe('hoy');
   });
 
   it('formats yesterday', () => {
     const date = parseUtcDate('2024-07-26T23:59:59Z');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('yesterday');
+    expect(formatDayTitle(date)).toBe('yesterday');
     locale.set('fr');
-    expect(formatGroupTitle(date)).toBe('hier');
+    expect(formatDayTitle(date)).toBe('hier');
   });
 
   it('formats last week', () => {
     const date = parseUtcDate('2024-07-21T00:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('Sunday');
+    expect(formatDayTitle(date)).toBe('Sunday');
     locale.set('ar-SA');
-    expect(formatGroupTitle(date)).toBe('الأحد');
+    expect(formatDayTitle(date)).toBe('الأحد');
   });
 
   it('formats date 7 days ago', () => {
     const date = parseUtcDate('2024-07-20T00:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('Sat, Jul 20');
+    expect(formatDayTitle(date)).toBe('Sat, Jul 20');
     locale.set('de');
-    expect(formatGroupTitle(date)).toBe('Sa., 20. Juli');
+    expect(formatDayTitle(date)).toBe('Sa., 20. Juli');
   });
 
   it('formats date this year', () => {
     const date = parseUtcDate('2020-01-01T00:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('Wed, Jan 1, 2020');
+    expect(formatDayTitle(date)).toBe('Wed, Jan 1, 2020');
     locale.set('ja');
-    expect(formatGroupTitle(date)).toBe('2020年1月1日(水)');
+    expect(formatDayTitle(date)).toBe('2020年1月1日(水)');
   });
 
   it('formats future date', () => {
     const tomorrow = parseUtcDate('2024-07-28T00:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(tomorrow)).toBe('Sun, Jul 28');
+    expect(formatDayTitle(tomorrow)).toBe('Sun, Jul 28');
 
     const nextMonth = parseUtcDate('2024-08-28T00:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(nextMonth)).toBe('Wed, Aug 28');
+    expect(formatDayTitle(nextMonth)).toBe('Wed, Aug 28');
 
     const nextYear = parseUtcDate('2025-01-10T12:00:00Z');
     locale.set('en');
-    expect(formatGroupTitle(nextYear)).toBe('Fri, Jan 10, 2025');
+    expect(formatDayTitle(nextYear)).toBe('Fri, Jan 10, 2025');
   });
 
   it('returns "Invalid DateTime" when date is invalid', () => {
     const date = DateTime.invalid('test');
     locale.set('en');
-    expect(formatGroupTitle(date)).toBe('Invalid DateTime');
+    expect(formatDayTitle(date)).toBe('Invalid DateTime');
     locale.set('es');
-    expect(formatGroupTitle(date)).toBe('Invalid DateTime');
+    expect(formatDayTitle(date)).toBe('Invalid DateTime');
   });
 });
 

--- a/web/src/lib/utils/timeline-util.ts
+++ b/web/src/lib/utils/timeline-util.ts
@@ -99,7 +99,7 @@ export const toISOYearMonthUTC = ({ year, month }: TimelineYearMonth): string =>
   return `${yearFull}-${monthFull}-01T00:00:00.000Z`;
 };
 
-export function formatMonthGroupTitle(_date: DateTime): string {
+export function formatMonthTitle(_date: DateTime): string {
   if (!_date.isValid) {
     return _date.toString();
   }
@@ -113,7 +113,7 @@ export function formatMonthGroupTitle(_date: DateTime): string {
   );
 }
 
-export function formatGroupTitle(_date: DateTime): string {
+export function formatDayTitle(_date: DateTime): string {
   if (!_date.isValid) {
     return _date.toString();
   }

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -29,7 +29,7 @@
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AlbumPageViewMode, AppRoute } from '$lib/constants';
   import { activityManager } from '$lib/managers/activity-manager.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import AlbumOptionsModal from '$lib/modals/AlbumOptionsModal.svelte';
   import AlbumShareModal from '$lib/modals/AlbumShareModal.svelte';
@@ -141,7 +141,7 @@
     const asset =
       $slideshowNavigation === SlideshowNavigation.Shuffle
         ? await timelineManager.getRandomAsset()
-        : timelineManager.months[0]?.dayGroups[0]?.viewerAssets[0]?.asset;
+        : timelineManager.months[0]?.days[0]?.viewerAssets[0]?.asset;
     if (asset) {
       handlePromiseError(setAssetId(asset.id).then(() => ($slideshowState = SlideshowState.PlaySlideshow)));
     }

--- a/web/src/routes/(user)/archive/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/archive/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -14,7 +14,7 @@
   import { AssetAction } from '$lib/constants';
 
   import SetVisibilityAction from '$lib/components/timeline/actions/SetVisibilityAction.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { AssetVisibility } from '@immich/sdk';
   import { mdiDotsVertical, mdiPlus } from '@mdi/js';

--- a/web/src/routes/(user)/favorites/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/favorites/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -17,7 +17,7 @@
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AssetAction } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { preferences } from '$lib/stores/user.store';
   import { mdiDotsVertical, mdiPlus } from '@mdi/js';

--- a/web/src/routes/(user)/locked/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/locked/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -12,7 +12,7 @@
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AppRoute, AssetAction } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { AssetVisibility, lockAuthSession } from '@immich/sdk';
   import { Button } from '@immich/ui';

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -26,7 +26,7 @@
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AppRoute, PersonPageViewMode, QueryParameter, SessionStorageKey } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
   import PersonMergeSuggestionModal from '$lib/modals/PersonMergeSuggestionModal.svelte';

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -22,7 +22,7 @@
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AssetAction } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';

--- a/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/tags/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -8,7 +8,7 @@
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AppRoute, AssetAction, QueryParameter } from '$lib/constants';
   import SkipLink from '$lib/elements/SkipLink.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import TagCreateModal from '$lib/modals/TagCreateModal.svelte';
   import TagEditModal from '$lib/modals/TagEditModal.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';

--- a/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -9,7 +9,7 @@
   import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AppRoute } from '$lib/constants';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
   import { featureFlags, serverConfig } from '$lib/stores/server-config.store';
   import { handlePromiseError } from '$lib/utils';

--- a/web/src/routes/(user)/utilities/geolocation/+page.svelte
+++ b/web/src/routes/(user)/utilities/geolocation/+page.svelte
@@ -5,8 +5,8 @@
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { AssetAction } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
-  import type { DayGroup } from '$lib/managers/timeline-manager/day-group.svelte';
-  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { TimelineDay } from '$lib/managers/timeline-manager/TimelineDay.svelte';
+  import { TimelineManager } from '$lib/managers/timeline-manager/TimelineManager.svelte';
   import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
   import GeolocationUpdateConfirmModal from '$lib/modals/GeolocationUpdateConfirmModal.svelte';
   import { AssetInteraction } from '$lib/stores/asset-interaction.svelte';
@@ -113,11 +113,11 @@
   const handleThumbnailClick = (
     asset: TimelineAsset,
     timelineManager: TimelineManager,
-    dayGroup: DayGroup,
+    day: TimelineDay,
     onClick: (
       timelineManager: TimelineManager,
       assets: TimelineAsset[],
-      groupTitle: string,
+      dayTitle: string,
       asset: TimelineAsset,
     ) => void,
   ) => {
@@ -129,7 +129,7 @@
       location = { latitude: asset.latitude!, longitude: asset.longitude! };
       void setQueryValue('at', asset.id);
     } else {
-      onClick(timelineManager, dayGroup.getAssets(), dayGroup.groupTitle, asset);
+      onClick(timelineManager, day.getAssets(), day.dayTitle, asset);
     }
   };
 </script>


### PR DESCRIPTION
- Rename classes: DayGroup → TimelineDay, MonthGroup → TimelineMonth
- Use short variable names: dayGroup → day, monthGroup → month
- Update all method names and properties for consistency
- Convert relative imports to $lib alias convention

No functional changes.

Previous PR: #23139 
Next PR: #23309