### PR TITLE
fix(web): "select all" button in trash and permanently deleted count

### DIFF
--- a/web/src/lib/utils/actions.ts
+++ b/web/src/lib/utils/actions.ts
@@ -38,7 +38,7 @@ export const deleteAssets = async (
         props: {
           title: $t('success'),
           description: force
-            ? $t('assets_permanently_deleted_count')
+            ? $t('assets_permanently_deleted_count', { values: { count: ids.length } })
             : $t('assets_trashed_count', { values: { count: ids.length } }),
           color: 'success',
           button:

--- a/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/trash/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -103,7 +103,7 @@
       </HStack>
     {/snippet}
 
-    <Timeline enableRouting={true} {options} {assetInteraction} onEscape={handleEscape}>
+    <Timeline enableRouting={true} bind:timelineManager {options} {assetInteraction} onEscape={handleEscape}>
       <p class="font-medium text-gray-500/60 dark:text-gray-300/60 p-4">
         {$t('trashed_items_will_be_permanently_deleted_after', { values: { days: $serverConfig.trashDays } })}
       </p>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Changed the parameters passed to the Timeline Component call (passing the already instantiated timeline manager object).
Changed the parameters passed to the popup to add the deleted elements count.

Fixes #23537 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Tested by deleting elements in trash on my own instance

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code