### PR TITLE
fix(web): consistently use mdiMotionPauseOutline icon

### DIFF
--- a/web/src/lib/components/asset-viewer/actions/motion-photo-action.svelte
+++ b/web/src/lib/components/asset-viewer/actions/motion-photo-action.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IconButton } from '@immich/ui';
-  import { mdiMotionPauseOutline, mdiPlaySpeed } from '@mdi/js';
+  import { mdiMotionPauseOutline, mdiMotionPlayOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -15,7 +15,7 @@
   color="secondary"
   variant="ghost"
   shape="round"
-  icon={isPlaying ? mdiMotionPauseOutline : mdiPlaySpeed}
+  icon={isPlaying ? mdiMotionPauseOutline : mdiMotionPlayOutline}
   aria-label={isPlaying ? $t('stop_motion_photo') : $t('play_motion_photo')}
   onclick={() => onClick(!isPlaying)}
 />


### PR DESCRIPTION
The asset viewer navbar erroneously used `mdiPlaySpeed`.

## Description
`mdiMotionPauseOutline` is used everywhere and corresponds to the play icon used here, too.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.
