### PR TITLE
fix(web): add URLs to results in large files utility

### DIFF
--- a/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -8,6 +8,7 @@
   import { navigate } from '$lib/utils/navigation';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
+  import type { AssetResponseDto } from '@immich/sdk';
 
   interface Props {
     data: PageData;
@@ -16,35 +17,42 @@
   let { data }: Props = $props();
 
   let assets = $derived(data.assets);
+  let asset = $derived(data.asset);
   const { isViewing: showAssetViewer, asset: viewingAsset, setAsset } = assetViewingStore;
   const getAssetIndex = (id: string) => assets.findIndex((asset) => asset.id === id);
 
-  const onNext = () => {
+  $effect(() => {
+    if (asset) {
+      setAsset(asset);
+    }
+  });
+
+  const onNext = async () => {
     const index = getAssetIndex($viewingAsset.id) + 1;
     if (index >= assets.length) {
-      return Promise.resolve(false);
+      return false;
     }
-    setAsset(assets[index]);
-    return Promise.resolve(true);
+    await onViewAsset(assets[index]);
+    return true;
   };
 
-  const onPrevious = () => {
+  const onPrevious = async () => {
     const index = getAssetIndex($viewingAsset.id) - 1;
     if (index < 0) {
-      return Promise.resolve(false);
+      return false;
     }
-    setAsset(assets[index]);
-    return Promise.resolve(true);
+    await onViewAsset(assets[index]);
+    return true;
   };
 
-  const onRandom = () => {
+  const onRandom = async () => {
     if (assets.length <= 0) {
-      return Promise.resolve(undefined);
+      return undefined;
     }
     const index = Math.floor(Math.random() * assets.length);
     const asset = assets[index];
-    setAsset(asset);
-    return Promise.resolve(asset);
+    await onViewAsset(asset);
+    return asset;
   };
 
   const onAction = (payload: Action) => {
@@ -53,13 +61,17 @@
       $showAssetViewer = false;
     }
   };
+
+  const onViewAsset = async (asset: AssetResponseDto) => {
+    await navigate({ targetRoute: 'current', assetId: asset.id });
+  };
 </script>
 
 <UserPageLayout title={data.meta.title} scrollbar={true}>
   <div class="grid gap-2 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
     {#if assets && data.assets.length > 0}
       {#each assets as asset (asset.id)}
-        <LargeAssetData {asset} onViewAsset={(asset) => setAsset(asset)} />
+        <LargeAssetData {asset} {onViewAsset} />
       {/each}
     {:else}
       <p class="text-center text-lg dark:text-white flex place-items-center place-content-center">

--- a/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.ts
+++ b/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.ts
@@ -1,15 +1,17 @@
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
+import { getAssetInfoFromParam } from '$lib/utils/navigation';
 import { searchLargeAssets } from '@immich/sdk';
 import type { PageLoad } from './$types';
 
-export const load = (async ({ url }) => {
+export const load = (async ({ params, url }) => {
   await authenticate(url);
-  const assets = await searchLargeAssets({ minFileSize: 0 });
+  const [assets, asset] = await Promise.all([searchLargeAssets({ minFileSize: 0 }), getAssetInfoFromParam(params)]);
   const $t = await getFormatter();
 
   return {
     assets,
+    asset,
     meta: {
       title: $t('large_files'),
     },


### PR DESCRIPTION
## Description
Add a route for individual assets in the Large Files utility. This allows opening assets while still in the context of the utility in new tabs and adds browser history when navigating between assets, among other things.

Fixes #23614

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested middle clicking on assets in the Large Files utility
- [x] Tested navigating between assets in the utility to make sure the URL updates

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

100% hand-crafted.
