### PR TITLE
docs(caddy): add request_body max_size to the caddy example

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -55,6 +55,9 @@ As an alternative to nginx, you can also use [Caddy](https://caddyserver.com/) a
 
 ```
 immich.example.org {
+    request_body {
+	    max_size 50000MB
+    }
     reverse_proxy http://<snip>:2283
 }
 ```


### PR DESCRIPTION
## Description

This PR updates the reverse proxy docs (Caddy section) to include an explicit `request_body` limit:

```caddyfile
request_body {
  max_size 50000MB
}
```

### Why
- Nginx example already has equivalent config param in the example configuration
- Without this change, Immich app gets stuck while uploading - see https://github.com/immich-app/immich/issues/5067#issuecomment-2885237904

> Other components in the path (CDNs...) may still impose their own limits and should be adjusted as needed.

Issue https://github.com/immich-app/immich/issues/22101 may be related.

## How Has This Been Tested?

Immich app failed to upload my iOS photo library before this fix. After this change I had to toggle the Immich upload switch off and on again to unstuck the upload.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in ---src/services/--- uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in ---src/repositories/--- is pretty basic/simple and does not have any immich specific logic (that belongs in ---src/services/---)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM was not used.