### PR TITLE
fix: include current shared link expiry date as default select option

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1799,6 +1799,7 @@
   "select_keep_all": "Select keep all",
   "select_library_owner": "Select library owner",
   "select_new_face": "Select new face",
+  "select_option_unchanged": "{label} (unchanged)",
   "select_person_to_tag": "Select a person to tag",
   "select_photos": "Select photos",
   "select_trash_all": "Select trash all",

--- a/web/src/lib/components/sharedlinks-page/shared-link-card.svelte
+++ b/web/src/lib/components/sharedlinks-page/shared-link-card.svelte
@@ -6,10 +6,10 @@
   import ShareCover from '$lib/components/sharedlinks-page/covers/share-cover.svelte';
   import { AppRoute } from '$lib/constants';
   import Badge from '$lib/elements/Badge.svelte';
-  import { locale } from '$lib/stores/preferences.store';
+  import { getCountDownExpirationDate } from '$lib/utils/shared-links';
   import { SharedLinkType, type SharedLinkResponseDto } from '@immich/sdk';
   import { mdiDotsVertical } from '@mdi/js';
-  import { DateTime, type ToRelativeUnit } from 'luxon';
+  import { DateTime } from 'luxon';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -22,18 +22,6 @@
   let now = DateTime.now();
   let expiresAt = $derived(link.expiresAt ? DateTime.fromISO(link.expiresAt) : undefined);
   let isExpired = $derived(expiresAt ? now > expiresAt : false);
-
-  const getCountDownExpirationDate = (expiresAtDate: DateTime, now: DateTime) => {
-    const relativeUnits: ToRelativeUnit[] = ['days', 'hours', 'minutes', 'seconds'];
-    const expirationCountdown = expiresAtDate.diff(now, relativeUnits).toObject();
-
-    for (const unit of relativeUnits) {
-      const value = expirationCountdown[unit];
-      if (value && value > 0) {
-        return expiresAtDate.toRelativeCalendar({ base: now, locale: $locale, unit });
-      }
-    }
-  };
 </script>
 
 <div

--- a/web/src/lib/utils/shared-links.ts
+++ b/web/src/lib/utils/shared-links.ts
@@ -1,8 +1,11 @@
+import { locale } from '$lib/stores/preferences.store';
 import { getAssetThumbnailUrl, setSharedLink } from '$lib/utils';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import { getAssetInfoFromParam } from '$lib/utils/navigation';
 import { getMySharedLink, isHttpError } from '@immich/sdk';
+import { DateTime, type ToRelativeUnit } from 'luxon';
+import { get } from 'svelte/store';
 
 export const asQueryString = ({ slug, key }: { slug?: string; key?: string }) => {
   const params = new URLSearchParams();
@@ -60,5 +63,17 @@ export const loadSharedLink = async ({
     }
 
     throw error;
+  }
+};
+
+export const getCountDownExpirationDate = (expiresAtDate: DateTime, now: DateTime) => {
+  const relativeUnits: ToRelativeUnit[] = ['days', 'hours', 'minutes', 'seconds'];
+  const expirationCountdown = expiresAtDate.diff(now, relativeUnits).toObject();
+
+  for (const unit of relativeUnits) {
+    const value = expirationCountdown[unit];
+    if (value && value > 0) {
+      return expiresAtDate.toRelativeCalendar({ base: now, locale: get(locale), unit });
+    }
   }
 };


### PR DESCRIPTION
## Description

When editing a shared link with an expiry date of e.g. 'in 7 days', the 'Expire after' dropdown is disabled and shows 'never', instead of 'in 7 days'. The ux for changing that date, or not, is not so intuitive with the switch to enable changing the date. I added the current expiry date, if it's not 'never', to the option list and set it as selected. That way, it's clear to the user nothing would be changed per se, but it's also easy to change it when you want to do so.

If you agree with these changes I'll try to port them to mobile as well.

Not 100% happy about the solution for overwriting the `expiryOption` state; I got a svelte warning about that, but not sure how to best handle.

Fixes #22147

## How Has This Been Tested?
- Create a new shared link; nothing unusual happens. Normal select options. Select a not-never expiry date.
- Go to shared links and see 'Expires in 29 minutes' at the shared link info card.
- Edit the shared link. The selected default is 'in 29 minutes (unchanged)', and all other options are there, as well.
- Verify all combinations of changing 'unchanged', 'never', 'in x minutes' to something else works as expected.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="591" height="406" alt="image" src="https://github.com/user-attachments/assets/bd4f22d8-77b4-4037-bb5e-1be42c46ed4c" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
