### PR TITLE
Update transcoding without tonemapping (VAAPI)

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -18,6 +18,7 @@ import {
   QueueName,
   RawExtractedFormat,
   StorageFolder,
+  ToneMapping,
   TranscodeHardwareAcceleration,
   TranscodePolicy,
   TranscodeTarget,
@@ -424,8 +425,16 @@ export class MediaService extends BaseService {
     }
     const mainAudioStream = this.getMainStream(audioStreams);
 
-    const previewConfig = ThumbnailConfig.create({ ...ffmpeg, targetResolution: image.preview.size.toString() });
-    const thumbnailConfig = ThumbnailConfig.create({ ...ffmpeg, targetResolution: image.thumbnail.size.toString() });
+    const previewConfig = ThumbnailConfig.create({
+      ...ffmpeg,
+      targetResolution: image.preview.size.toString(),
+      tonemap: ToneMapping.Hable,
+    });
+    const thumbnailConfig = ThumbnailConfig.create({
+      ...ffmpeg,
+      targetResolution: image.thumbnail.size.toString(),
+      tonemap: ToneMapping.Hable,
+    });
     const previewOptions = previewConfig.getCommand(TranscodeTarget.Video, mainVideoStream, mainAudioStream, format);
     const thumbnailOptions = thumbnailConfig.getCommand(
       TranscodeTarget.Video,

--- a/server/src/utils/media.ts
+++ b/server/src/utils/media.ts
@@ -801,10 +801,13 @@ export class VaapiSwDecodeConfig extends BaseHWConfig {
   }
 
   getFilterOptions(videoStream: VideoStreamInfo) {
-    const options = this.getToneMapping(videoStream);
-    options.push('hwupload=extra_hw_frames=64');
+    const tonemapOptions = this.getToneMapping(videoStream);
+    const options = [...tonemapOptions, 'hwupload=extra_hw_frames=64'];
+    const format = videoStream.isHDR && tonemapOptions.length === 0 ? 'p010' : 'nv12';
     if (this.shouldScale(videoStream)) {
-      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:out_range=pc:format=nv12`);
+      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:format=${format}`);
+    } else {
+      options.push(`scale_vaapi=format=${format}`);
     }
 
     return options;
@@ -867,10 +870,8 @@ export class VaapiHwDecodeConfig extends VaapiSwDecodeConfig {
   getFilterOptions(videoStream: VideoStreamInfo) {
     const options = [];
     const tonemapOptions = this.getToneMapping(videoStream);
-    if (tonemapOptions.length === 0 && !videoStream.pixelFormat.endsWith('420p')) {
-      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:out_range=pc:format=nv12`);
-    } else if (this.shouldScale(videoStream)) {
-      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq:out_range=pc`);
+    if (this.shouldScale(videoStream)) {
+      options.push(`scale_vaapi=${this.getScaling(videoStream)}:mode=hq`);
     }
     options.push(...tonemapOptions);
     return options;


### PR DESCRIPTION
## Description

As described in issue #23631:
- Fixed incorrect colors after transcoding HEVC -> HEVC with no tonemapping by removing `out_range=pc`. Looks like ffmpeg is able to figure it out automatically and doing it better
- Fixed preview and thumbnail images for HDR videos transcoded without tonemapping by force adding tonemapping to image generation
- Fixed transcoding params without scaling
  - VaapiSwDecodeConfig: fixed transcoding from h264 by adding `scale_vaapi=format=...` (#18111)
  - VaapiHwDecodeConfig: do not add `scale_vaapi` if scaling is not required. There _might_ be a possibility that same `scale_vaapi=format=...` is needed on some hardware but I can't verify it. On my hardware it works without it

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #23631

## How Has This Been Tested?

Tested several transcoding options with several videos

**AMD Ryzen 5 5600G**
- Source=h264, Target=HEVC/h264
  - [x] SW decoder
  - [x] HW decoder
- Source=HEVC, Target=HEVC
  - [x] SW decoder
  - [x] SW decoder + scaling
  - [x] SW decoder + tonemapping
  - [x] SW decoder + scaling + tonemapping
  - [x] HW decoder
  - [x] HW decoder + scaling

HW tonemapping doesn't work on this machine so I can't test it

**Intel(R) Core(TM) i5-8265U**
- Source=h264, Target=h264
  - [x] SW decoder
  - [x] SW decoder + scaling
  - [x] HW decoder + scaling
- Source=HEVC, Target=h264
  - [x] SW decoder + scaling + tonemapping
  - [x] SW decoder + tonemapping
  - [x] HW decoder + tonemapping (works but wrong colors)
  - [x] HW decoder + scaling + tonemapping (works but wrong colors)
</details>

Note: "wrong colors" issue also present with hw tonemapping in main branch so there is no regression
## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none