### PR TITLE
feat: lazy load thumbnails on people and place list

### DIFF
--- a/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/image-thumbnail.svelte
@@ -20,6 +20,7 @@
     hiddenIconClass?: string;
     class?: ClassValue;
     brokenAssetClass?: ClassValue;
+    preload?: boolean;
     onComplete?: ((errored: boolean) => void) | undefined;
   }
 
@@ -38,6 +39,7 @@
     onComplete = undefined,
     class: imageClass = '',
     brokenAssetClass = '',
+    preload = true,
   }: Props = $props();
 
   let loaded = $state(false);
@@ -92,6 +94,7 @@
     {title}
     class={['object-cover', optionalClasses, imageClass]}
     draggable="false"
+    loading={preload ? 'eager' : 'lazy'}
   />
 {/if}
 

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -157,6 +157,7 @@
           altText={person.name}
           widthStyle="100%"
           hiddenIconClass="text-white group-hover:text-black transition-colors"
+          preload={false}
         />
         {#if person.name}
           <span class="absolute bottom-2 start-0 w-full select-text px-1 text-center font-medium text-white">

--- a/web/src/lib/components/faces-page/people-card.svelte
+++ b/web/src/lib/components/faces-page/people-card.svelte
@@ -52,6 +52,7 @@
         title={person.name}
         widthStyle="100%"
         circle
+        preload={false}
       />
       {#if person.isFavorite}
         <div class="absolute top-4 start-4">

--- a/web/src/lib/components/places-page/places-card-group.svelte
+++ b/web/src/lib/components/places-page/places-card-group.svelte
@@ -49,6 +49,7 @@
               src={getAssetThumbnailUrl({ id: item.id, size: AssetMediaSize.Thumbnail })}
               alt={city}
               class="object-cover w-39 h-39"
+              loading="lazy"
             />
           </div>
           <span


### PR DESCRIPTION
## Description

Fixes #23681 

Adds lazy image loading to:

- list of people
- list of people visibility change
- list of places

Initial requests for the people list with 355 people is reduced from ~256 to ~34.

Of course a "timeline-like" implementation with proper blur effects would be nicer, but this is a good start IMHO.

## How Has This Been Tested?

Open `/people` or `/places` and scroll down to see lazy thumbnail-loading.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.