### PR TITLE
fix(mobile): Add fade-in to asset viewer transition

### DIFF
--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -313,6 +313,7 @@ class AppRouter extends RootStackRouter {
           settings: page,
           pageBuilder: (_, __, ___) => child,
           opaque: false,
+          transitionsBuilder: TransitionsBuilders.fadeIn,
         ),
       ),
     ),


### PR DESCRIPTION
## Description

Added a fade-in animation to the asset viewer opening/closing transition to fix the asset viewer background (and controls) just popping in and out instantly.

Fixes #20570

## How Has This Been Tested?

- [x] Opened and closed an asset using the back button in the top left and the android system back button.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Before: 

https://github.com/user-attachments/assets/14754bef-acb9-4764-9569-e9b411284bfc

After:

https://github.com/user-attachments/assets/cab641c2-2a30-41ab-a41c-10241fbb0043

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

(Removed N/A checks)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Not used.
