### PR TITLE
feat(web): Added Content-Signal to robots.txt

### DIFF
--- a/web/static/robots.txt
+++ b/web/static/robots.txt
@@ -1,5 +1,6 @@
 # Allow social media access og Tags
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=no # https://contentsignals.org/
 Allow: /share/
 Allow: /api/assets/
 


### PR DESCRIPTION
## Description

Added Content-Signal (by Cloudflare) to indicate that the allowed URLs should not be used for AI training or input.

I am not sure on how effective this indicator is. But considering it is from Cloudflare and they do have provisions to detect and block bot traffic from some AI bots, I thought this could be a nice addition for people using Cloudflare tunnels for their home servers.

Ref: https://contentsignals.org/

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.