### PR TITLE
fix(mobile): Hide download button in asset viewer "immersive mode"

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -663,7 +663,6 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
         appBar: const ViewerTopAppBar(),
         extendBody: true,
         extendBodyBehindAppBar: true,
-        // floatingActionButton: const DownloadStatusFloatingButton(),
         floatingActionButton: IgnorePointer(
           ignoring: !showingControls, // avoid invisible fab being tappable
           child: AnimatedOpacity(

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -664,7 +664,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
         extendBody: true,
         extendBodyBehindAppBar: true,
         floatingActionButton: IgnorePointer(
-          ignoring: !showingControls, // avoid invisible fab being tappable
+          ignoring: !showingControls,
           child: AnimatedOpacity(
             opacity: showingControls ? 1.0 : 0.0,
             duration: Durations.short2,

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -627,10 +627,10 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
     // Rebuild the widget when the asset viewer state changes
     // Using multiple selectors to avoid unnecessary rebuilds for other state changes
     ref.watch(assetViewerProvider.select((s) => s.showingBottomSheet));
-    ref.watch(assetViewerProvider.select((s) => s.showingControls));
     ref.watch(assetViewerProvider.select((s) => s.backgroundOpacity));
     ref.watch(assetViewerProvider.select((s) => s.stackIndex));
     ref.watch(isPlayingMotionVideoProvider);
+    final showingControls = ref.watch(assetViewerProvider.select((s) => s.showingControls));
 
     // Listen for casting changes and send initial asset to the cast provider
     ref.listen(castProvider.select((value) => value.isCasting), (_, isCasting) async {
@@ -663,7 +663,15 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
         appBar: const ViewerTopAppBar(),
         extendBody: true,
         extendBodyBehindAppBar: true,
-        floatingActionButton: const DownloadStatusFloatingButton(),
+        // floatingActionButton: const DownloadStatusFloatingButton(),
+        floatingActionButton: IgnorePointer(
+          ignoring: !showingControls, // avoid invisible fab being tappable
+          child: AnimatedOpacity(
+            opacity: showingControls ? 1.0 : 0.0,
+            duration: Durations.short2,
+            child: const DownloadStatusFloatingButton(),
+          ),
+        ),
         body: Stack(
           children: [
             PhotoViewGallery.builder(


### PR DESCRIPTION
## Description

Currently when the asset viewer controls are hidden (a state which I like to call immersive mode), the download button still remains, usually covering part of the image/video. This PR simply makes the button disappear/reappear together with the controls.

## How Has This Been Tested?

- [x] Show and hide controls in asset viewer. Confirm that download button shows/hides along with it.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Before:

https://github.com/user-attachments/assets/7e5759f0-86d9-445c-bbbc-b45144d89b15

After:

https://github.com/user-attachments/assets/02220d52-e080-4976-9757-cac1fc358571

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

(Removed N/A checks)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Not used.