### PR TITLE
fix(web): i18n for admin>users>sessions

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1421,6 +1421,7 @@
   "no_cast_devices_found": "No cast devices found",
   "no_checksum_local": "No checksum available - cannot fetch local assets",
   "no_checksum_remote": "No checksum available - cannot fetch remote asset",
+  "no_devices": "No authorized devices",
   "no_duplicates_found": "No duplicates were found.",
   "no_exif_info_available": "No exif info available",
   "no_explore_results_message": "Upload more photos to explore your collection.",

--- a/web/src/routes/admin/users/[id]/+page.svelte
+++ b/web/src/routes/admin/users/[id]/+page.svelte
@@ -34,12 +34,12 @@
   } from '@immich/ui';
   import {
     mdiAccountOutline,
-    mdiAppsBox,
     mdiCameraIris,
     mdiChartPie,
     mdiChartPieOutline,
     mdiCheckCircle,
     mdiDeleteRestore,
+    mdiDevices,
     mdiFeatureSearchOutline,
     mdiLockSmart,
     mdiOnepassword,
@@ -350,8 +350,8 @@
         <Card color="secondary">
           <CardHeader>
             <div class="flex items-center gap-2 px-4 py-2 text-primary">
-              <Icon icon={mdiAppsBox} size="1.5rem" />
-              <CardTitle>Sessions</CardTitle>
+              <Icon icon={mdiDevices} size="1.5rem" />
+              <CardTitle>{$t('authorized_devices')}</CardTitle>
             </div>
           </CardHeader>
           <CardBody>
@@ -360,7 +360,7 @@
                 {#each userSessions as session (session.id)}
                   <DeviceCard {session} />
                 {:else}
-                  <span class="text-dark">No mobile devices</span>
+                  <span class="text-dark">{$t('no_devices')}</span>
                 {/each}
               </Stack>
             </div>


### PR DESCRIPTION
## Description
Add missing i18n for the 'Sessions' block in the admin/users/[id] page. I reused the 'devices' type string and icon to be more consistent with /user-settings?isOpen=authorized-devices and added a no_devices strinbg.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
