### PR TITLE
feat(mobile): Clear search button

### DIFF
--- a/mobile/lib/models/search/search_filter.model.dart
+++ b/mobile/lib/models/search/search_filter.model.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/entities/asset.entity.dart';
 
@@ -268,7 +269,7 @@ class SearchFilter {
         other.language == language &&
         other.ocr == ocr &&
         other.assetId == assetId &&
-        other.people == people &&
+        setEquals(other.people, people) &&
         other.location == location &&
         other.camera == camera &&
         other.date == date &&


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Show clear search button to reset search page to empty state.

Users can clear each filter individually on their own bottom sheets (e.g. Location chip opens "Select location" bottom sheet with "Clear button" which clears only the location).

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Case 1:
- Open "Search" tab
- Select any filter (e.g. Location)
- The clear icon is displayed as suffix icon for the search text field

Case 2:
- Open "Photos" tab
- Select any photo
- Scroll down (or click on menu icon) to open bottom sheet
- Click on "View similar photos" action
- The clear icon is displayed as suffix icon for the search text field

<details><summary><h2>Screenshots</h2></summary>


https://github.com/user-attachments/assets/29370520-3513-4b03-8c80-c6acaa7983fb



</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM
