### PR TITLE
fix(server): properly handle HEAD requests to SSR paths

### DIFF
--- a/server/src/services/api.service.ts
+++ b/server/src/services/api.service.ts
@@ -65,9 +65,10 @@ export class ApiService {
     }
 
     return async (request: Request, res: Response, next: NextFunction) => {
+      const method = request.method.toLowerCase();
       if (
         request.url.startsWith('/api') ||
-        request.method.toLowerCase() !== 'get' ||
+        (method !== 'get' && method !== 'head') ||
         excludePaths.some((item) => request.url.startsWith(item))
       ) {
         return next();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixes the HTTP HEAD method not working for paths that are handled by ApiService.ssr.
<!--- Why is this change required? What problem does it solve? -->
The HEAD method is supposed to return the same metadata as a GET request but without the body (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/HEAD).
Previously this didn't happen because the `ApiService.ssr` checked if the method is GET and otherwise forwards the request to the api handlers which would result in a 404. Now `ApiService.ssr` also checks if the method is HEAD and handles the request. The html is still passed to res.send so that express can determine the proper Content-Length.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I manually tested the status and headers (besides Date) being the same for GET and HEAD requests. I didn't write a unit test as `ApiService`, unlike all the other services, doesn't have a spec file and isn't able to use `newTestService` because it doesn't extend `BaseService`.
I also ran `pnpm test` and it didn't show any regressions.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No AI used.
