### PR TITLE
fix(web): make sliding window cover all visible space to show small number of assets

### DIFF
--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -99,7 +99,7 @@
   let scrollTop = $state(0);
   let slidingWindow = $derived.by(() => {
     const top = (scrollTop || 0) - slidingWindowOffset;
-    const bottom = top + viewport.height;
+    const bottom = top + viewport.height + slidingWindowOffset;
     return {
       top,
       bottom,


### PR DESCRIPTION
## Description
This fixes #23479 by extending the size of the sliding window. I think this is the correct way to calculate the sliding window top&bottom, by not only offsetting the window towards the top, but also extending the height so that the bottom doesn't cut off too early. Either way, it cannot really hurt to make the window bigger, except it could hurt performance a little bit if you make it way too big.

## How Has This Been Tested?
- Search for a file type, name, etc. of which you only have a few (issue says <4), see them appear
- Switch to responsive design mode in your browser's devtools, see that the assets have disappeared.
- With this fix, the assets stay visible.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None