### PR TITLE
feat(web): disable searching by disabled features

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-text-section.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-text-section.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import RadioButton from '$lib/elements/RadioButton.svelte';
+  import { featureFlags } from '$lib/stores/server-config.store';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -13,7 +14,9 @@
 <fieldset>
   <legend class="immich-form-label">{$t('search_type')}</legend>
   <div class="flex flex-wrap gap-x-5 gap-y-2 mt-1 mb-2">
-    <RadioButton name="query-type" id="context-radio" label={$t('context')} bind:group={queryType} value="smart" />
+    {#if $featureFlags.loaded && $featureFlags.smartSearch}
+      <RadioButton name="query-type" id="context-radio" label={$t('context')} bind:group={queryType} value="smart" />
+    {/if}
     <RadioButton
       name="query-type"
       id="file-name-radio"
@@ -28,7 +31,9 @@
       bind:group={queryType}
       value="description"
     />
-    <RadioButton name="query-type" id="ocr-radio" label={$t('ocr')} bind:group={queryType} value="ocr" />
+    {#if $featureFlags.loaded && $featureFlags.ocr}
+      <RadioButton name="query-type" id="ocr-radio" label={$t('ocr')} bind:group={queryType} value="ocr" />
+    {/if}
   </div>
 </fieldset>
 


### PR DESCRIPTION
## Description
Disable/disallow search types if their corresponding ML features are turned off (smart search and OCR). Not sure if this is actually a good idea for OCR, since you can of course run OCR on all assets, then turn off the OCR feature, but you'd still be able to search for the results stored in the db. For smart search its a smart idea either way.

Fixes #23412 

## How Has This Been Tested?

Enable/disable OCR and smart search features in /admin/settings and check that the radio button (dis)appears from the search filter modal.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
