### PR TITLE
fix: prefer filename from body over path in mime validation

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -269,7 +269,7 @@ describe(AssetMediaService.name, () => {
       const pathFilename = 'invalid-file-name';
       const body = { filename: 'video.mov' };
       expect(() => sut.canUploadFile(uploadFile.filename(UploadFieldName.ASSET_DATA, pathFilename))).toThrowError(
-        BadRequestException
+        BadRequestException,
       );
       expect(sut.canUploadFile(uploadFile.filename(UploadFieldName.ASSET_DATA, pathFilename, body))).toEqual(true);
     });

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -12,6 +12,7 @@ import { MapAsset } from 'src/dtos/asset-response.dto';
 import { AssetFileType, AssetStatus, AssetType, AssetVisibility, CacheControl, JobName } from 'src/enum';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
+import { UploadBody } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
 import { ImmichFileResponse } from 'src/utils/file';
 import { assetStub } from 'test/fixtures/asset.stub';
@@ -35,10 +36,10 @@ const uploadFile = {
       size: 1000,
     },
   },
-  filename: (fieldName: UploadFieldName, filename: string) => {
+  filename: (fieldName: UploadFieldName, filename: string, body?: UploadBody) => {
     return {
       auth: authStub.admin,
-      body: {},
+      body: body || {},
       fieldName,
       file: {
         uuid: 'random-uuid',
@@ -263,6 +264,15 @@ describe(AssetMediaService.name, () => {
         });
       });
     }
+
+    it('should prefer filename from body over name from path', () => {
+      const pathFilename = 'invalid-file-name';
+      const body = { filename: 'video.mov' };
+      expect(() => sut.canUploadFile(uploadFile.filename(UploadFieldName.ASSET_DATA, pathFilename))).toThrowError(
+        BadRequestException
+      );
+      expect(sut.canUploadFile(uploadFile.filename(UploadFieldName.ASSET_DATA, pathFilename, body))).toEqual(true);
+    });
   });
 
   describe('getUploadFilename', () => {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -51,10 +51,10 @@ export class AssetMediaService extends BaseService {
     return { id: assetId, status: AssetMediaStatus.DUPLICATE };
   }
 
-  canUploadFile({ auth, fieldName, file }: UploadRequest): true {
+  canUploadFile({ auth, fieldName, file, body }: UploadRequest): true {
     requireUploadAccess(auth);
 
-    const filename = file.originalName;
+    const filename = body.filename || file.originalName;
 
     switch (fieldName) {
       case UploadFieldName.ASSET_DATA: {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -419,14 +419,16 @@ export interface UploadFile {
   size: number;
 }
 
+export interface UploadBody {
+  filename?: string;
+  [key: string]: unknown;
+}
+
 export type UploadRequest = {
   auth: AuthDto | null;
   fieldName: UploadFieldName;
   file: UploadFile;
-  body: {
-    filename?: string;
-    [key: string]: unknown;
-  };
+  body: UploadBody;
 };
 
 export interface UploadFiles {


### PR DESCRIPTION
### Description

The file filter now prefers the filename from the DTO over the one from the file path for validation

Fixes #22600 