### PR TITLE
fix(web): keep album timeline when selecting cover

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -298,9 +298,6 @@
 
   let timelineManager = $state<TimelineManager>() as TimelineManager;
   const options = $derived.by(() => {
-    if (viewMode === AlbumPageViewMode.VIEW) {
-      return { albumId, order: albumOrder };
-    }
     if (viewMode === AlbumPageViewMode.SELECT_ASSETS) {
       return {
         visibility: AssetVisibility.Timeline,
@@ -308,7 +305,7 @@
         timelineAlbumId: albumId,
       };
     }
-    return {};
+    return { albumId, order: albumOrder };
   });
 
   const isShared = $derived(viewMode === AlbumPageViewMode.SELECT_ASSETS ? false : album.albumUsers.length > 0);


### PR DESCRIPTION
## Description

  Fixes #23415

  - Keep the album timeline scoped to the current album while the cover chooser is open so the UI doesn’t jump to All Photos
  - Reuse the same album-scoped options when closing the cover chooser to prevent the album grid from clearing out

  ## How Has This Been Tested?

  - [x] `npm run test` (all 35 Vitest files / 279 tests passed)

  <details><summary><h2>Screenshots (if appropriate)</h2></summary>

[Screencast_20251111_233150.webm](https://github.com/user-attachments/assets/988bae86-581e-46f7-aeb4-e20cdf68b60a)

  </details>

  ## Checklist:

  - [x] I have performed a self-review of my own code
  - [ ] I have made corresponding changes to the documentation if applicable
  - [x] I have no unrelated changes in the PR.
  - [x] I have confirmed that any new dependencies are strictly necessary.
  - [ ] I have written tests for new code (if applicable)
  - [x] I have followed naming conventions/patterns in the surrounding code
  - [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
  - [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

  ## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM (GPT-5 Codex High) helped brainstorm the fallback approach; coding and test validation were done collaboratively with Codex and by hand.
