### PR TITLE
fix(server): include the previous year in memories for January 1, 2, 3

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -64,7 +64,7 @@ with
               from
                 asset
             ),
-            date_part('year', current_date)::int - 1
+            $3
           ) as "year"
       )
     select
@@ -81,21 +81,21 @@ with
         where
           "asset_job_status"."previewAt" is not null
           and (asset."localDateTime" at time zone 'UTC')::date = today.date
-          and "asset"."ownerId" = any ($3::uuid[])
-          and "asset"."visibility" = $4
+          and "asset"."ownerId" = any ($4::uuid[])
+          and "asset"."visibility" = $5
           and exists (
             select
             from
               "asset_file"
             where
               "assetId" = "asset"."id"
-              and "asset_file"."type" = $5
+              and "asset_file"."type" = $6
           )
           and "asset"."deletedAt" is null
         order by
           (asset."localDateTime" at time zone 'UTC')::date desc
         limit
-          $6
+          $7
       ) as "a" on true
       inner join "asset_exif" on "a"."id" = "asset_exif"."assetId"
   )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -73,9 +73,10 @@ export interface TimeBucketItem {
   count: number;
 }
 
-export interface MonthDay {
+export interface YearMonthDay {
   day: number;
   month: number;
+  year: number;
 }
 
 interface AssetExploreFieldOptions {
@@ -259,8 +260,8 @@ export class AssetRepository {
     return this.db.insertInto('asset').values(assets).returningAll().execute();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, { day: 1, month: 1 }] })
-  getByDayOfYear(ownerIds: string[], { day, month }: MonthDay) {
+  @GenerateSql({ params: [DummyValue.UUID, { year: 2000, day: 1, month: 1 }] })
+  getByDayOfYear(ownerIds: string[], { year, day, month }: YearMonthDay) {
     return this.db
       .with('res', (qb) =>
         qb
@@ -270,7 +271,7 @@ export class AssetRepository {
                 eb
                   .fn('generate_series', [
                     sql`(select date_part('year', min(("localDateTime" at time zone 'UTC')::date))::int from asset)`,
-                    sql`date_part('year', current_date)::int - 1`,
+                    sql`${year - 1}`,
                   ])
                   .as('year'),
               )


### PR DESCRIPTION
## Description

This PR fixes an edge case of creating memories in advance when target year is different from the current year. The PR uses target year instead of the current year when fetching/filtering assets during memory generation. (Is there a better solution than passing the year to `getByDayOfYear` in addition to month-day?)

Example issue: memories targeting Jan 1, 2, 3 (2026) won't show photos of the previous year (2025) on these days.
By default, Immich creates memories 3 days in advance. At the end of December 2025 it will generate memories for the beginning of January 2026.
Assume the job runs on 2025-12-31 (current year is 2025) and creates memories to be shown on 2026-01-01 (target year is 2026). 
- If using _current_ year in calculation then the range of years is capped at (2025 - 1 = 2024) thus excluding 2025-01-01 from memories.
- With _target_ year it becomes (2026 - 1 = 2025), so 2025-01-01 will be included in memories.

Fixes #19596 (section about January 1/2/3)

## How Has This Been Tested?

### Medium test
Added a medium test (copied an existing one) with _target_ date in the future: 
- It fails on the current code: zero memories returned
- It passes ok with the fix.

### Check for regression
To quickly check for regression I generated memories on my personal Immich instance and compared version 2.2.3 vs this fix.

Result: JSONs returned from the memory search API are identical (except for a few volatile fields `id`, `createdAt`, `updatedAt` as expected).
<details><summary>Regression check</summary>

Begin with v2.2.3
1. Cleanup: `docker exec immich_postgres psql -U postgres -d immich -c "delete from system_metadata where key like 'memories-state'" -c "truncate table memory cascade"`
2. Trigger the "memory-create" job from UI
3. When done, fetch generated memories at https://my.immich.app/api/memories

Apply the fix and repeat
1. Cleanup
2. Trigger the job
3. Fetch generated memories (json)

Then compare
```sh
diff <(jq '.[] | del(.id, .createdAt, .updatedAt)' memories.orig.json) \
     <(jq '.[] | del(.id, .createdAt, .updatedAt)' memories.fix.json)
```
</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.

## Out of scope
Possible issue with generating memories targeting Feb 29, such as for the next leap year 2028-02-29. 
Caused by the `make_date()` invocation in the generated series that includes non-leap years: make_date would error out `date field value out of range: 2027-02-29`.
I believe the memories code will be rewritten before 2028 anyway :)