### PR TITLE
fix: Update module name for rapidocr DownloadFile

### DIFF
--- a/machine-learning/immich_ml/models/ocr/detection.py
+++ b/machine-learning/immich_ml/models/ocr/detection.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 from PIL import Image
 from rapidocr.ch_ppocr_det.utils import DBPostProcess
 from rapidocr.inference_engine.base import FileInfo, InferSession
-from rapidocr.utils import DownloadFile, DownloadFileInput
+from rapidocr.utils.download_file import DownloadFile, DownloadFileInput
 from rapidocr.utils.typings import EngineType, LangDet, OCRVersion, TaskType
 from rapidocr.utils.typings import ModelType as RapidModelType
 

--- a/machine-learning/immich_ml/models/ocr/recognition.py
+++ b/machine-learning/immich_ml/models/ocr/recognition.py
@@ -6,7 +6,7 @@ from PIL import Image
 from rapidocr.ch_ppocr_rec import TextRecInput
 from rapidocr.ch_ppocr_rec import TextRecognizer as RapidTextRecognizer
 from rapidocr.inference_engine.base import FileInfo, InferSession
-from rapidocr.utils import DownloadFile, DownloadFileInput
+from rapidocr.utils.download_file import DownloadFile, DownloadFileInput
 from rapidocr.utils.typings import EngineType, LangRec, OCRVersion, TaskType
 from rapidocr.utils.typings import ModelType as RapidModelType
 from rapidocr.utils.vis_res import VisRes


### PR DESCRIPTION
## Description

Since rapidocr 3.4.2 the convinient reexport of `DonwloadFile` and `DownloadFileInput` from `rapidocr.utils` was removed (it was removed in https://github.com/RapidAI/RapidOCR/commit/32dad48ebbfa76e51b54693fab6dfa686e04a66d) and we need to use `rapidorc.utils.download_file`.

## How Has This Been Tested?

This fixes this import error:

```
ImportError: cannot import name 'DownloadFile' from 'rapidocr.utils'
```
when using `rapidocr-3.4.2`.

With this changes no import error occurs and the ocr job is working.


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used to create this pull request.