### PR TITLE
feat(mobile): shared albums in Home screen widget

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
@@ -109,7 +109,7 @@ class ImmichAPI(cfg: ServerConfig) {
   }
 
   suspend fun fetchAlbums(): List<Album> = withContext(Dispatchers.IO) {
-    val url = buildRequestURL("/albums", listOf(Pair("shared","true")))
+    val url = buildRequestURL("/albums", listOf("shared" to "true"))
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "GET"
       applyCustomHeaders()

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/widget/ImmichAPI.kt
@@ -109,7 +109,7 @@ class ImmichAPI(cfg: ServerConfig) {
   }
 
   suspend fun fetchAlbums(): List<Album> = withContext(Dispatchers.IO) {
-    val url = buildRequestURL("/albums")
+    val url = buildRequestURL("/albums", listOf(Pair("shared","true")))
     val connection = (url.openConnection() as HttpURLConnection).apply {
       requestMethod = "GET"
       applyCustomHeaders()

--- a/mobile/ios/WidgetExtension/ImmichAPI.swift
+++ b/mobile/ios/WidgetExtension/ImmichAPI.swift
@@ -267,7 +267,8 @@ class ImmichAPI {
     guard
       let searchURL = buildRequestURL(
         serverConfig: serverConfig,
-        endpoint: "/albums"
+        endpoint: "/albums",
+        params: [URLQueryItem(name: "shared", value: "true")]
       )
     else {
       throw URLError(.badURL)


### PR DESCRIPTION
## Description

This PR lets the user select albums shared with them but not owned by them for the Home Screen widget in iOS and Android. It adds the URL query parameter "shared=true" to the API call getAllAlbums.

Fixes #23028
Implements Feature Request https://github.com/immich-app/immich/discussions/20229

## How Has This Been Tested?

- iOS Simulator iPhone17
- Android Medium Phone API 35

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I'm neither a Kotlin nor a Swift developer, so after diagnosing the problem I consulted several LLMs for the correct syntax for each language. I then checked the official documentation for both languages if the LLM suggestions were correct and then implemented them manually before progressing to testing.
...
