### PR TITLE
feat(server): support running medium tests in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,12 @@
       ]
     }
   },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      // https://github.com/devcontainers/features/issues/1466
+      "moby": false
+    }
+  },
   "forwardPorts": [3000, 9231, 9230, 2283],
   "portsAttributes": {
     "3000": {

--- a/docs/docs/developer/devcontainers.md
+++ b/docs/docs/developer/devcontainers.md
@@ -274,6 +274,7 @@ make test-medium-dev    # End-to-end tests
 # Server tests
 cd /workspaces/immich/server
 pnpm test                # Run all tests
+pnpm run test:medium    # Medium tests (integration tests)
 pnpm run test:watch     # Watch mode
 pnpm run test:cov       # Coverage report
 

--- a/docs/docs/developer/devcontainers.md
+++ b/docs/docs/developer/devcontainers.md
@@ -268,7 +268,7 @@ make test-all           # Runs tests for all components
 make test-medium-dev    # End-to-end tests
 ```
 
-#### Using NPM Directly
+#### Using PNPM Directly
 
 ```bash
 # Server tests
@@ -308,7 +308,7 @@ make check-web          # Type check web
 make check-all          # Check all components
 
 # Complete hygiene check
-make hygiene-all        # Runs lint, format, check, SQL sync, and audit
+make hygiene-all        # Run lint, format, check, SQL sync, and audit
 ```
 
 ### Additional Make Commands

--- a/docs/docs/developer/devcontainers.md
+++ b/docs/docs/developer/devcontainers.md
@@ -256,7 +256,7 @@ The Dev Container supports multiple ways to run tests:
 
 ```bash
 # Run tests for specific components
-make test-server         # Server unit tests
+make test-server        # Server unit tests
 make test-web           # Web unit tests
 make test-e2e           # End-to-end tests
 make test-cli           # CLI tests
@@ -273,7 +273,7 @@ make test-medium-dev    # End-to-end tests
 ```bash
 # Server tests
 cd /workspaces/immich/server
-pnpm test                # Run all tests
+pnpm test               # Run all tests
 pnpm run test:medium    # Medium tests (integration tests)
 pnpm run test:watch     # Watch mode
 pnpm run test:cov       # Coverage report
@@ -294,21 +294,21 @@ pnpm run test:web       # Run web UI tests
 ```bash
 # Linting
 make lint-server        # Lint server code
-make lint-web          # Lint web code
-make lint-all          # Lint all components
+make lint-web           # Lint web code
+make lint-all           # Lint all components
 
 # Formatting
 make format-server      # Format server code
-make format-web        # Format web code
-make format-all        # Format all code
+make format-web         # Format web code
+make format-all         # Format all code
 
 # Type checking
 make check-server       # Type check server
-make check-web         # Type check web
-make check-all         # Check all components
+make check-web          # Type check web
+make check-all          # Check all components
 
 # Complete hygiene check
-make hygiene-all       # Runs lint, format, check, SQL sync, and audit
+make hygiene-all        # Runs lint, format, check, SQL sync, and audit
 ```
 
 ### Additional Make Commands
@@ -316,21 +316,21 @@ make hygiene-all       # Runs lint, format, check, SQL sync, and audit
 ```bash
 # Build commands
 make build-server       # Build server
-make build-web         # Build web app
-make build-all         # Build everything
+make build-web          # Build web app
+make build-all          # Build everything
 
 # API generation
-make open-api          # Generate OpenAPI specs
+make open-api           # Generate OpenAPI specs
 make open-api-typescript # Generate TypeScript SDK
-make open-api-dart     # Generate Dart SDK
+make open-api-dart      # Generate Dart SDK
 
 # Database
-make sql               # Sync database schema
+make sql                # Sync database schema
 
 # Dependencies
-make install-server    # Install server dependencies
-make install-web      # Install web dependencies
-make install-all      # Install all dependencies
+make install-server     # Install server dependencies
+make install-web        # Install web dependencies
+make install-all        # Install all dependencies
 ```
 
 ### Debugging


### PR DESCRIPTION
## Description

Add the "docker-in-docker" feature to devcontainer to allow running medium tests in devcontainer.

Currently, medium tests in devcontainer cannot run due to `Error: Could not find a working container runtime strategy` because testcontainers attempt to start Postgres from devcontainer.

Initially discussed several months ago in #contributing on Discord [Does anyone run server medium tests inside devcontainer? Does it work for you?](https://discord.com/channels/979116623879368755/1071165397228855327/1392017535972544512)

Related devcontainers issues (explain the delay in implementation)
- https://github.com/devcontainers/features/issues/1059
- https://github.com/devcontainers/features/issues/1466

## Alternatives
Another solution/option: docker-outside-of-docker.
It would be more efficient than docker-in-docker.
On the other hand, to support dood we have to modify existing test setup / scripts. Currently, tests are simply targeting 127.0.0.1. This works with dind, but fails with dood: tests in devcontainer cannot reach Postgres if it is started outside devcontainer.

## How Has This Been Tested?
Inside devcontainer:
- running medium tests
```sh
node@immich-dev:/workspaces/immich/server$ pnpm run test:medium

# before
Error: Could not find a working container runtime strategy

# after (this PR)
 Test Files  42 passed (42)
      Tests  207 passed (207)
   Duration  23.54s (transform 2.04s, setup 0ms, collect 116.18s, tests 10.02s, environment 4ms, prepare 3.22s)
```

- Postgres is started by testcontainers
```sh
root@immich-dev:/workspaces/immich# docker ps -a
CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS                   PORTS                                           NAMES
a76c6816b6e1   ghcr.io/immich-app/postgres:14-vectorchord0.4.3   "/usr/local/bin/immi…"   6 seconds ago   Up 6 seconds (healthy)   0.0.0.0:32771->5432/tcp, [::]:32771->5432/tcp   admiring_maxwell
cd7165fd0a79   testcontainers/ryuk:0.14.0                        "/bin/ryuk"              6 seconds ago   Up 6 seconds             0.0.0.0:32770->8080/tcp, [::]:32770->8080/tcp   testcontainers-ryuk-4b1be69cd3de
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.