### PR TITLE
fix(mobile): first video memory on page doesn't play

### DIFF
--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -24,7 +24,7 @@ class DriftMemoryPage extends HookConsumerWidget {
 
   const DriftMemoryPage({required this.memories, required this.memoryIndex, super.key});
 
-  static void setCurrentAsset(WidgetRef ref, BaseAsset asset) {
+  static void setMemory(WidgetRef ref, BaseAsset asset) {
     ref.read(currentAssetNotifier.notifier).setAsset(asset);
 
     if (asset.isVideo) {
@@ -212,8 +212,10 @@ class DriftMemoryPage extends HookConsumerWidget {
                 currentMemory.value = memories[pageNumber];
 
                 WidgetsBinding.instance.addPostFrameCallback((_) {
-                  final firstAsset = memories[pageNumber].assets.first;
-                  DriftMemoryPage.setCurrentAsset(ref, firstAsset);
+                  if (memories[pageNumber].assets.isNotEmpty) {
+                    final firstAsset = memories[pageNumber].assets.first;
+                    DriftMemoryPage.setMemory(ref, firstAsset);
+                  }
                 });
               }
 

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -27,10 +27,10 @@ class DriftMemoryPage extends HookConsumerWidget {
   static void setMemory(WidgetRef ref, DriftMemory memory) {
     if (memory.assets.isNotEmpty) {
       ref.read(currentAssetNotifier.notifier).setAsset(memory.assets.first);
-    }
 
-    if (memory.assets.first.isVideo) {
-      ref.read(videoPlaybackValueProvider.notifier).reset();
+      if (memory.assets.first.isVideo) {
+        ref.read(videoPlaybackValueProvider.notifier).reset();
+      }
     }
   }
 

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -24,6 +24,14 @@ class DriftMemoryPage extends HookConsumerWidget {
 
   const DriftMemoryPage({required this.memories, required this.memoryIndex, super.key});
 
+  static void setCurrentAsset(WidgetRef ref, BaseAsset asset) {
+    ref.read(currentAssetNotifier.notifier).setAsset(asset);
+
+    if (asset.isVideo) {
+      ref.read(videoPlaybackValueProvider.notifier).reset();
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentMemory = useState(memories[memoryIndex]);
@@ -205,8 +213,7 @@ class DriftMemoryPage extends HookConsumerWidget {
 
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   final firstAsset = memories[pageNumber].assets.first;
-                  currentAsset.value = firstAsset;
-                  ref.read(currentAssetNotifier.notifier).setAsset(firstAsset);
+                  DriftMemoryPage.setCurrentAsset(ref, firstAsset);
                 });
               }
 

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -202,6 +202,12 @@ class DriftMemoryPage extends HookConsumerWidget {
               if (pageNumber < memories.length) {
                 currentMemoryIndex.value = pageNumber;
                 currentMemory.value = memories[pageNumber];
+
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  final firstAsset = memories[pageNumber].assets.first;
+                  currentAsset.value = firstAsset;
+                  ref.read(currentAssetNotifier.notifier).setAsset(firstAsset);
+                });
               }
 
               currentAssetPage.value = 0;

--- a/mobile/lib/presentation/pages/drift_memory.page.dart
+++ b/mobile/lib/presentation/pages/drift_memory.page.dart
@@ -24,10 +24,12 @@ class DriftMemoryPage extends HookConsumerWidget {
 
   const DriftMemoryPage({required this.memories, required this.memoryIndex, super.key});
 
-  static void setMemory(WidgetRef ref, BaseAsset asset) {
-    ref.read(currentAssetNotifier.notifier).setAsset(asset);
+  static void setMemory(WidgetRef ref, DriftMemory memory) {
+    if (memory.assets.isNotEmpty) {
+      ref.read(currentAssetNotifier.notifier).setAsset(memory.assets.first);
+    }
 
-    if (asset.isVideo) {
+    if (memory.assets.first.isVideo) {
       ref.read(videoPlaybackValueProvider.notifier).reset();
     }
   }
@@ -212,10 +214,7 @@ class DriftMemoryPage extends HookConsumerWidget {
                 currentMemory.value = memories[pageNumber];
 
                 WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (memories[pageNumber].assets.isNotEmpty) {
-                    final firstAsset = memories[pageNumber].assets.first;
-                    DriftMemoryPage.setMemory(ref, firstAsset);
-                  }
+                  DriftMemoryPage.setMemory(ref, memories[pageNumber]);
                 });
               }
 

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -3,10 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/pages/drift_memory.page.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
-import 'package:immich_mobile/providers/asset_viewer/video_player_value_provider.dart';
-import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
@@ -30,17 +28,8 @@ class DriftMemoryLane extends ConsumerWidget {
         backgroundColor: Colors.black,
         overlayColor: WidgetStateProperty.all(Colors.white.withValues(alpha: 0.1)),
         onTap: (index) {
-          ref.read(hapticFeedbackProvider.notifier).heavyImpact();
-
-          if (memories[index].assets.isNotEmpty) {
-            final asset = memories[index].assets[0];
-            ref.read(currentAssetNotifier.notifier).setAsset(asset);
-
-            if (asset.isVideo) {
-              ref.read(videoPlaybackValueProvider.notifier).reset();
-            }
-          }
-
+          final asset = memories[index].assets[0];
+          DriftMemoryPage.setCurrentAsset(ref, asset);
           context.pushRoute(DriftMemoryRoute(memories: memories, memoryIndex: index));
         },
         children: memories

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -31,8 +31,7 @@ class DriftMemoryLane extends ConsumerWidget {
         onTap: (index) {
           ref.read(hapticFeedbackProvider.notifier).heavyImpact();
           if (memories[index].assets.isNotEmpty) {
-            final asset = memories[index].assets.first;
-            DriftMemoryPage.setMemory(ref, asset);
+            DriftMemoryPage.setMemory(ref, memories[index]);
           }
           context.pushRoute(DriftMemoryRoute(memories: memories, memoryIndex: index));
         },

--- a/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_lane.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/pages/drift_memory.page.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
@@ -28,8 +29,11 @@ class DriftMemoryLane extends ConsumerWidget {
         backgroundColor: Colors.black,
         overlayColor: WidgetStateProperty.all(Colors.white.withValues(alpha: 0.1)),
         onTap: (index) {
-          final asset = memories[index].assets[0];
-          DriftMemoryPage.setCurrentAsset(ref, asset);
+          ref.read(hapticFeedbackProvider.notifier).heavyImpact();
+          if (memories[index].assets.isNotEmpty) {
+            final asset = memories[index].assets.first;
+            DriftMemoryPage.setMemory(ref, asset);
+          }
           context.pushRoute(DriftMemoryRoute(memories: memories, memoryIndex: index));
         },
         children: memories


### PR DESCRIPTION
## Description

Fixes #23722

## How Has This Been Tested?

- [x] Looked through memories, after switching to the next page (the one that starts with a video) the video plays correctly

## Please describe to which degree, if any, an LLM was used in creating this pull request.
GitHub Copilot (Claude) was used to analyze the problem, adjusted the output afterwards.
