### PR TITLE
feat(server): implement trusted header authentication

### DIFF
--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -70,7 +70,10 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
     @Auth() auth: AuthDto,
   ): Promise<LogoutResponseDto> {
-    const authType = (request.cookies || {})[ImmichCookie.AuthType];
+    let authType = (request.cookies || {})[ImmichCookie.AuthType];
+    if (request.headers["remote-email"]) {
+      authType = AuthType.TrustedHeader;
+    }
 
     const body = await this.service.logout(auth, authType);
     return respondWithoutCookie(res, body, [

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -1,6 +1,7 @@
 export enum AuthType {
   Password = 'password',
   OAuth = 'oauth',
+  TrustedHeader = 'trustedheader',
 }
 
 export enum ImmichCookie {

--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -19,7 +19,7 @@ export const loadUser = async () => {
     let preferences = get(preferences$);
     let serverInfo;
 
-    if ((!user || !preferences) && hasAuthCookie()) {
+    if ((!user || !preferences)) {
       [user, preferences, serverInfo] = await Promise.all([getMyUser(), getMyPreferences(), getAboutInfo()]);
       user$.set(user);
       preferences$.set(preferences);


### PR DESCRIPTION
## Description

Draft to implement trusted header authentication.
Some users may secure their immich server behind authentication services like authelia. In such a setup you already need to log in with that service before even reaching immich. Currently you would have to log in to immich separately. With this PR immich reads headers set by the reverse proxy to determine which user is logged in, avoiding multiple log in steps, and allowing single sign-on between different services on the same server. Compared to OAuth, this is in my opinion easier to set up and more convenient to use.

Right now I have implemented a minimal version that I am personally using. If this is a change you would consider merging I'd want to clean up the code, flesh out the feature, and add options to properly configure the setup.
In that case some things left to consider are:
- Should it be possible to set user quotas and admin users automatically, similar to how OAuth handles it?
- What's the best way to handle mobile login? Maybe Basic auth using the Authorization header?
- What happens if a user changes their email? The OAuth code seems to be using some kind of id, is something similar possible?
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

I just tested it on my personal immich instance so far.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Nope
