### PR TITLE
fix: deep link to last asset

### DIFF
--- a/web/src/lib/managers/timeline-manager/day-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/day-group.svelte.ts
@@ -140,7 +140,7 @@ export class DayGroup {
   }
 
   layout(options: CommonLayoutOptions, noDefer: boolean) {
-    if (!noDefer && !this.monthGroup.intersecting) {
+    if (!noDefer && !this.monthGroup.intersecting && !this.monthGroup.timelineManager.isScrollingOnLoad) {
       this.#deferredLayout = true;
       return;
     }

--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -61,6 +61,7 @@ export class TimelineManager extends VirtualScrollManager {
   });
 
   isInitialized = $state(false);
+  isScrollingOnLoad = false;
   months: MonthGroup[] = $state([]);
   albumAssets: Set<string> = new SvelteSet();
   scrubberMonths: ScrubberMonth[] = $state([]);


### PR DESCRIPTION
Found during #23895 

Fixes deep linking to asset - due to issue with defer layout. 

Defer layout is used to delay layout of loading off-screen months - only the on-screen assets will have a layout performed on them. 

Bug: 
When deep linking to the last asset, that asset is offscreen - which defers the layout. Then the scroll is performed, and is completed BEFORE the new scrollHeight has been reflected into the DOM. You can not scroll an element beyond its scrollHeight, so the position is no longer accurate. 

Fix: 
Special case this timing issue that only affects deep linking to one of the assets at the end of the timeline. Just avoid deferring layouts during the scrollOnLoad routine. 
