### PR TITLE
feat(mobile): location edit from asset viewer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1440,6 +1440,7 @@
   "no_favorites_message": "Add favorites to quickly find your best pictures and videos",
   "no_libraries_message": "Create an external library to view your photos and videos",
   "no_local_assets_found": "No local assets found with this checksum",
+  "no_location_set": "No location set",
   "no_locked_photos_message": "Photos and videos in the locked folder are hidden and won't show up as you browse or search your library.",
   "no_name": "No Name",
   "no_notifications": "No notifications",

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
@@ -4,7 +4,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -16,8 +15,8 @@ import 'package:immich_mobile/presentation/widgets/album/album_tile.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/bottom_sheet/sheet_people_details.widget.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/sheet_tile.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
-import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
@@ -181,7 +180,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
           spacing: 12,
           children: [
             if (albums.isNotEmpty)
-              _SheetTile(
+              SheetTile(
                 title: 'appears_in'.t(context: context).toUpperCase(),
                 titleStyle: context.textTheme.labelMedium?.copyWith(
                   color: context.textTheme.labelMedium?.color?.withAlpha(200),
@@ -233,7 +232,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
           future: assetMediaRepository.getOriginalFilename(asset.id),
           builder: (context, snapshot) {
             final displayName = snapshot.data ?? asset.name;
-            return _SheetTile(
+            return SheetTile(
               title: displayName,
               titleStyle: context.textTheme.labelLarge,
               leading: Icon(
@@ -250,7 +249,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
         );
       } else {
         // For remote assets, use the name directly
-        return _SheetTile(
+        return SheetTile(
           title: asset.name,
           titleStyle: context.textTheme.labelLarge,
           leading: Icon(
@@ -269,7 +268,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
     return SliverList.list(
       children: [
         // Asset Date and Time
-        _SheetTile(
+        SheetTile(
           title: _getDateTime(context, asset),
           titleStyle: context.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
           trailing: asset.hasRemote && isOwner ? const Icon(Icons.edit, size: 18) : null,
@@ -279,7 +278,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
         const SheetPeopleDetails(),
         const SheetLocationDetails(),
         // Details header
-        _SheetTile(
+        SheetTile(
           title: 'exif_bottom_sheet_details'.t(context: context),
           titleStyle: context.textTheme.labelMedium?.copyWith(
             color: context.textTheme.labelMedium?.color?.withAlpha(200),
@@ -290,7 +289,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
         buildFileInfoTile(),
         // Camera info
         if (cameraTitle != null)
-          _SheetTile(
+          SheetTile(
             title: cameraTitle,
             titleStyle: context.textTheme.labelLarge,
             leading: Icon(Icons.camera_alt_outlined, size: 24, color: context.textTheme.labelLarge?.color),
@@ -301,7 +300,7 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
           ),
         // Lens info
         if (lensTitle != null)
-          _SheetTile(
+          SheetTile(
             title: lensTitle,
             titleStyle: context.textTheme.labelLarge,
             leading: Icon(Icons.camera_outlined, size: 24, color: context.textTheme.labelLarge?.color),
@@ -315,77 +314,6 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
         // padding at the bottom to avoid cut-off
         const SizedBox(height: 100),
       ],
-    );
-  }
-}
-
-class _SheetTile extends ConsumerWidget {
-  final String title;
-  final Widget? leading;
-  final Widget? trailing;
-  final String? subtitle;
-  final TextStyle? titleStyle;
-  final TextStyle? subtitleStyle;
-  final VoidCallback? onTap;
-
-  const _SheetTile({
-    required this.title,
-    this.titleStyle,
-    this.leading,
-    this.subtitle,
-    this.subtitleStyle,
-    this.trailing,
-    this.onTap,
-  });
-
-  void copyTitle(BuildContext context, WidgetRef ref) {
-    Clipboard.setData(ClipboardData(text: title));
-    ImmichToast.show(
-      context: context,
-      msg: 'copied_to_clipboard'.t(context: context),
-      toastType: ToastType.info,
-    );
-    ref.read(hapticFeedbackProvider.notifier).selectionClick();
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final Widget titleWidget;
-    if (leading == null) {
-      titleWidget = LimitedBox(
-        maxWidth: double.infinity,
-        child: Text(title, style: titleStyle),
-      );
-    } else {
-      titleWidget = Container(
-        width: double.infinity,
-        padding: const EdgeInsets.only(left: 15),
-        child: Text(title, style: titleStyle),
-      );
-    }
-
-    final Widget? subtitleWidget;
-    if (leading == null && subtitle != null) {
-      subtitleWidget = Text(subtitle!, style: subtitleStyle);
-    } else if (leading != null && subtitle != null) {
-      subtitleWidget = Padding(
-        padding: const EdgeInsets.only(left: 15),
-        child: Text(subtitle!, style: subtitleStyle),
-      );
-    } else {
-      subtitleWidget = null;
-    }
-
-    return ListTile(
-      dense: true,
-      visualDensity: VisualDensity.compact,
-      title: GestureDetector(onLongPress: () => copyTitle(context, ref), child: titleWidget),
-      titleAlignment: ListTileTitleAlignment.center,
-      leading: leading,
-      trailing: trailing,
-      contentPadding: leading == null ? null : const EdgeInsets.only(left: 25),
-      subtitle: subtitleWidget,
-      onTap: onTap,
     );
   }
 }

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
@@ -67,7 +67,7 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
     }
 
     // Guard local assets
-    if (asset is! RemoteAsset) {
+    if (asset != null && asset is LocalAsset && asset!.hasRemote) {
       return const SizedBox.shrink();
     }
 

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
@@ -59,7 +59,6 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
 
   @override
   Widget build(BuildContext context) {
-    // Watch the providers to ensure widget rebuilds when data changes
     final asset = ref.watch(currentAssetNotifier);
     final exifInfo = ref.watch(currentAssetExifProvider).valueOrNull;
     final hasCoordinates = exifInfo?.hasCoordinates ?? false;

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
@@ -87,23 +87,14 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: EdgeInsets.symmetric(horizontal: context.isMobile ? 16.0 : 56.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  "exif_bottom_sheet_location".t(context: context),
-                  style: context.textTheme.labelMedium?.copyWith(
-                    color: context.textTheme.labelMedium?.color?.withAlpha(200),
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                if (hasCoordinates)
-                  IconButton(onPressed: editLocation, icon: const Icon(Icons.edit_location_alt), iconSize: 20),
-              ],
+          SheetTile(
+            title: 'exif_bottom_sheet_location'.t(context: context),
+            titleStyle: context.textTheme.labelMedium?.copyWith(
+              color: context.textTheme.labelMedium?.color?.withAlpha(200),
+              fontWeight: FontWeight.w600,
             ),
+            trailing: hasCoordinates ? const Icon(Icons.edit_location_alt, size: 20) : null,
+            onTap: editLocation,
           ),
           if (hasCoordinates)
             Padding(
@@ -112,7 +103,7 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   ExifMap(exifInfo: exifInfo!, markerId: remoteId, onMapCreated: _onMapCreated),
-                  const SizedBox(height: 15),
+                  const SizedBox(height: 16),
                   if (locationName != null)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 4.0),
@@ -128,17 +119,14 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
               ),
             ),
           if (!hasCoordinates)
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: SheetTile(
-                title: "add_a_location".t(context: context),
-                titleStyle: context.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: context.primaryColor,
-                ),
-                leading: const Icon(Icons.location_off),
-                onTap: editLocation,
+            SheetTile(
+              title: "add_a_location".t(context: context),
+              titleStyle: context.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: context.primaryColor,
               ),
+              leading: const Icon(Icons.location_off),
+              onTap: editLocation,
             ),
         ],
       ),

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet/sheet_location_details.widget.dart
@@ -40,19 +40,10 @@ class _SheetLocationDetailsState extends ConsumerState<SheetLocationDetails> {
   }
 
   void _onExifChanged(AsyncValue<ExifInfo?>? previous, AsyncValue<ExifInfo?> current) {
-    final prevExif = previous?.valueOrNull;
     final currentExif = current.valueOrNull;
 
-    // Update map camera if coordinates changed
     if (currentExif != null && currentExif.hasCoordinates) {
-      final prevLat = prevExif?.latitude;
-      final prevLon = prevExif?.longitude;
-      final currentLat = currentExif.latitude;
-      final currentLon = currentExif.longitude;
-
-      if (prevLat != currentLat || prevLon != currentLon) {
-        _mapController?.moveCamera(CameraUpdate.newLatLng(LatLng(currentLat!, currentLon!)));
-      }
+      _mapController?.moveCamera(CameraUpdate.newLatLng(LatLng(currentExif.latitude!, currentExif.longitude!)));
     }
   }
 

--- a/mobile/lib/presentation/widgets/asset_viewer/sheet_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/sheet_tile.widget.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
+
+class SheetTile extends ConsumerWidget {
+  final String title;
+  final Widget? leading;
+  final Widget? trailing;
+  final String? subtitle;
+  final TextStyle? titleStyle;
+  final TextStyle? subtitleStyle;
+  final VoidCallback? onTap;
+
+  const SheetTile({
+    super.key,
+    required this.title,
+    this.titleStyle,
+    this.leading,
+    this.subtitle,
+    this.subtitleStyle,
+    this.trailing,
+    this.onTap,
+  });
+
+  void copyTitle(BuildContext context, WidgetRef ref) {
+    Clipboard.setData(ClipboardData(text: title));
+    ImmichToast.show(
+      context: context,
+      msg: 'copied_to_clipboard'.t(context: context),
+      toastType: ToastType.info,
+    );
+    ref.read(hapticFeedbackProvider.notifier).selectionClick();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Widget titleWidget;
+    if (leading == null) {
+      titleWidget = LimitedBox(
+        maxWidth: double.infinity,
+        child: Text(title, style: titleStyle),
+      );
+    } else {
+      titleWidget = Container(
+        width: double.infinity,
+        padding: const EdgeInsets.only(left: 15),
+        child: Text(title, style: titleStyle),
+      );
+    }
+
+    final Widget? subtitleWidget;
+    if (leading == null && subtitle != null) {
+      subtitleWidget = Text(subtitle!, style: subtitleStyle);
+    } else if (leading != null && subtitle != null) {
+      subtitleWidget = Padding(
+        padding: const EdgeInsets.only(left: 15),
+        child: Text(subtitle!, style: subtitleStyle),
+      );
+    } else {
+      subtitleWidget = null;
+    }
+
+    return ListTile(
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      title: GestureDetector(onLongPress: () => copyTitle(context, ref), child: titleWidget),
+      titleAlignment: ListTileTitleAlignment.center,
+      leading: leading,
+      trailing: trailing,
+      contentPadding: leading == null ? null : const EdgeInsets.only(left: 25),
+      subtitle: subtitleWidget,
+      onTap: onTap,
+    );
+  }
+}

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -302,6 +302,13 @@ class ActionNotifier extends Notifier<void> {
         return null;
       }
 
+      // This must be called since editing location
+      // does not update the currentAsset which means
+      // the exif provider will not be refreshed automatically
+      if (source == ActionSource.viewer) {
+        ref.invalidate(currentAssetExifProvider);
+      }
+
       return ActionResult(count: ids.length, success: true);
     } catch (error, stack) {
       _logger.severe('Failed to edit location for assets', error, stack);


### PR DESCRIPTION
## Description

Adds location editing to the asset viewer on new timeline.

Location picker was also modified to be simpler and easier to use.

Fixes #23638

## How Has This Been Tested?

Tested on assets with both location and no location. Local assets do not show location data unless they are on server.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="388" height="243" alt="image" src="https://github.com/user-attachments/assets/d687ccf6-c97c-40f5-9bd4-87922cfd4cb7" />

<img width="404" height="434" alt="image" src="https://github.com/user-attachments/assets/c1840b16-6c44-4f44-a3d9-5c8bba771a56" />

# Location Picker Changes

<img width="272" height="344" alt="image" src="https://github.com/user-attachments/assets/0997e61a-a015-45a4-82af-ead43b9c52af" />

Tapping on "Choose on map" takes directly to map picker

<img width="406" height="876" alt="image" src="https://github.com/user-attachments/assets/1b9ccc4d-08fa-43ff-9580-61609469a5ca" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
