### PR TITLE
fix(mobile): delete from device warning shows incorrectly

### DIFF
--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -264,9 +264,8 @@ class ActionNotifier extends Notifier<void> {
   }
 
   Future<ActionResult?> deleteLocal(ActionSource source, BuildContext context) async {
-    // Always perform the operation if there is only one merged asset
     final assets = _getAssets(source);
-    bool? backedUpOnly = assets.length == 1 && assets.first.storage == AssetState.merged
+    bool? backedUpOnly = assets.every((asset) => asset.storage == AssetState.merged)
         ? true
         : await showDialog<bool>(
             context: context,


### PR DESCRIPTION
## Description

Fixes #23742

## How Has This Been Tested?

- [x] Try to delete multiple assets which are synced: prompt doesn't appear
- [x] Try to delete multiple assets, one of them not synced: prompt appears
