### PR TITLE
fix: word wrap on custom link preview

### DIFF
--- a/web/src/lib/modals/SharedLinkCreateModal.svelte
+++ b/web/src/lib/modals/SharedLinkCreateModal.svelte
@@ -68,7 +68,7 @@
           <Input bind:value={slug} autocomplete="off" />
         </Field>
         {#if slug}
-          <Text size="tiny" color="muted" class="pt-2">/s/{encodeURIComponent(slug)}</Text>
+          <Text size="tiny" color="muted" class="pt-2 break-all">/s/{encodeURIComponent(slug)}</Text>
         {/if}
       </div>
 


### PR DESCRIPTION
The PR adds the "break-all" style to the slug text under the custom link input text box on the web front.

## Description
In the create custom link modal box, the small gray text doesn't have a word wrap style causing the UI elements to move outside of the popup boundary. This is especially prominent when the url preview contains specially encoded characters(for example cyrillic characters or a space " " in the url).

## How Has This Been Tested?
I've ran it locally with the change.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
<img width="1241" height="740" alt="Immich long custom link example 1 - old" src="https://github.com/user-attachments/assets/7c5550c8-d6d1-40f9-8e20-c8033566c5a9" />
<img width="1241" height="740" alt="Immich long custom link example 1 - new" src="https://github.com/user-attachments/assets/935e42c9-7f4b-4766-85b4-6f99d4aaca36" />

<img width="1241" height="739" alt="immich long custom link example 2 - old" src="https://github.com/user-attachments/assets/fa9fd284-1bb2-438b-ba89-6b4b144085eb" />
<img width="1242" height="740" alt="immich long custom link example 2 - new" src="https://github.com/user-attachments/assets/6aaf1f19-7b2a-42f4-85fc-bff25177bc39" />
</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
It's a single class, I don't think it is relevant