### PR TITLE
fix: devcontainer server not starting due to missing plugins mount

### DIFF
--- a/.devcontainer/server/container-compose-overrides.yml
+++ b/.devcontainer/server/container-compose-overrides.yml
@@ -21,6 +21,7 @@ services:
       - app-node_modules:/usr/src/app/node_modules
       - sveltekit:/usr/src/app/web/.svelte-kit
       - coverage:/usr/src/app/web/coverage
+      - ../plugins:/build/corePlugin
   immich-web:
     env_file: !reset []
   immich-machine-learning:


### PR DESCRIPTION
docker-compose.dev.yml had this volume added: (4dcc04946584b7822faba82644cf8644d4d7da8d)
```diff
+       - ../plugins:/build/corePlugin
```
But this is not present in `.devcontainer/server/container-compose-overrides.yml` which makes the API server fail to start trying to load the plugins code.