### PR TITLE
fix(server): copy relevant panorama tags to preview image

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -121,6 +121,23 @@ export class MediaRepository {
     }
   }
 
+  async copyTagGroup(tagGroup: string, source: string, target: string): Promise<boolean> {
+    try {
+      await exiftool.write(
+        target,
+        {},
+        {
+          ignoreMinorErrors: true,
+          writeArgs: ['-TagsFromFile', source, `-${tagGroup}:all>${tagGroup}:all`, '-overwrite_original'],
+        },
+      );
+      return true;
+    } catch (error: any) {
+      this.logger.warn(`Could not copy tag data to image: ${error.message}`);
+      return false;
+    }
+  }
+
   decodeImage(input: string | Buffer, options: DecodeToBufferOptions) {
     return this.getImageDecodingPipeline(input, options).raw().toBuffer({ resolveWithObject: true });
   }

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -865,6 +865,7 @@ describe(MediaService.name, () => {
       mocks.systemMetadata.get.mockResolvedValue({ image: { fullsize: { enabled: false } } });
       mocks.media.extract.mockResolvedValue({ buffer: extractedBuffer, format: RawExtractedFormat.Jpeg });
       mocks.media.getImageDimensions.mockResolvedValue({ width: 3840, height: 2160 });
+      mocks.media.copyTagGroup.mockResolvedValue(true);
 
       mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(assetStub.panoramaTif);
 
@@ -888,6 +889,13 @@ describe(MediaService.name, () => {
           processInvalidImages: false,
           raw: rawInfo,
         },
+        expect.any(String),
+      );
+
+      expect(mocks.media.copyTagGroup).toHaveBeenCalledTimes(2);
+      expect(mocks.media.copyTagGroup).toHaveBeenCalledWith(
+        'XMP-GPano',
+        assetStub.panoramaTif.originalPath,
         expect.any(String),
       );
     });

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -316,6 +316,16 @@ export class MediaService extends BaseService {
 
     const outputs = await Promise.all(promises);
 
+    if (asset.exifInfo.projectionType === 'EQUIRECTANGULAR') {
+      const promises = [
+        this.mediaRepository.copyTagGroup('XMP-GPano', asset.originalPath, previewPath),
+        fullsizePath
+          ? this.mediaRepository.copyTagGroup('XMP-GPano', asset.originalPath, fullsizePath)
+          : Promise.resolve(),
+      ];
+      await Promise.all(promises);
+    }
+
     return { previewPath, thumbnailPath, fullsizePath, thumbhash: outputs[0] as Buffer };
   }
 

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -6,6 +6,7 @@ export const newMediaRepositoryMock = (): Mocked<RepositoryInterface<MediaReposi
   return {
     generateThumbnail: vitest.fn().mockImplementation(() => Promise.resolve()),
     writeExif: vitest.fn().mockImplementation(() => Promise.resolve()),
+    copyTagGroup: vitest.fn().mockImplementation(() => Promise.resolve()),
     generateThumbhash: vitest.fn().mockResolvedValue(Buffer.from('')),
     decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {} }),
     extract: vitest.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Description
Copy all `XMP-GPano` tags over to the preview image of panorama images. These are required to correctly display:
- The initial heading, roll, pitch, etc. (example image https://commons.wikimedia.org/wiki/File:Alte_Schachtschleuse_Waltrop_Panorama.jpg )
- Cropped panoramas that do not have a full 360/180 degree image (example image https://photo-sphere-viewer-data.netlify.app/assets/sphere-cropped.jpg )

All these tags are necessary for correct display in the photo sphere viewer (relevant [docs](https://photo-sphere-viewer.js.org/guide/adapters/equirectangular.html)).

Fixes #10917

## How Has This Been Tested?
(maybe we should add some more tests for this behavior? e2e? not sure how that would work though)


Upload images linked above;

Before, the Alte Schachtschleuse panorama would start out looking into the building (0 degree heading) and when you zoom in and the original loads, it would change over to the 129.5 degree heading stored in the original file. Unfortunately if you have moved around so to say, it does reset to that stored heading again... but that's another issue, at least initial display is correct.

Before, the cropped panorama would be stretched and stitched together wrongly. Now, the missing part is correctly 'shown' as a black spot. See screenshots.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
Cropped before:
<img width="1322" height="1793" alt="image" src="https://github.com/user-attachments/assets/5833df66-ad5f-4041-bc9b-2b800bc132b4" />
Cropped after:
<img width="2377" height="1793" alt="image" src="https://github.com/user-attachments/assets/c16c6aa9-30e1-4b4d-91e7-3983eab70ba0" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [...] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
