### PR TITLE
refactor: sync width & height to remote asset entity

### DIFF
--- a/mobile/lib/domain/models/exif.model.dart
+++ b/mobile/lib/domain/models/exif.model.dart
@@ -3,8 +3,6 @@ class ExifInfo {
   final int? fileSize;
   final String? description;
   final bool isFlipped;
-  final double? width;
-  final double? height;
   final String? orientation;
   final String? timeZone;
   final DateTime? dateTimeOriginal;
@@ -46,8 +44,6 @@ class ExifInfo {
     this.fileSize,
     this.description,
     this.orientation,
-    this.width,
-    this.height,
     this.timeZone,
     this.dateTimeOriginal,
     this.isFlipped = false,
@@ -72,8 +68,6 @@ class ExifInfo {
     return other.fileSize == fileSize &&
         other.description == description &&
         other.isFlipped == isFlipped &&
-        other.width == width &&
-        other.height == height &&
         other.orientation == orientation &&
         other.timeZone == timeZone &&
         other.dateTimeOriginal == dateTimeOriginal &&
@@ -98,8 +92,6 @@ class ExifInfo {
         description.hashCode ^
         orientation.hashCode ^
         isFlipped.hashCode ^
-        width.hashCode ^
-        height.hashCode ^
         timeZone.hashCode ^
         dateTimeOriginal.hashCode ^
         latitude.hashCode ^
@@ -123,8 +115,6 @@ class ExifInfo {
 fileSize: ${fileSize ?? 'NA'},
 description: ${description ?? 'NA'},
 orientation: ${orientation ?? 'NA'},
-width: ${width ?? 'NA'},
-height: ${height ?? 'NA'},
 isFlipped: $isFlipped,
 timeZone: ${timeZone ?? 'NA'},
 dateTimeOriginal: ${dateTimeOriginal ?? 'NA'},

--- a/mobile/lib/domain/services/asset.service.dart
+++ b/mobile/lib/domain/services/asset.service.dart
@@ -65,8 +65,8 @@ class AssetService {
     if (asset.hasRemote) {
       final exif = await getExif(asset);
       isFlipped = ExifDtoConverter.isOrientationFlipped(exif?.orientation);
-      width = exif?.width ?? asset.width?.toDouble();
-      height = exif?.height ?? asset.height?.toDouble();
+      width = asset.width?.toDouble();
+      height = asset.height?.toDouble();
     } else if (asset is LocalAsset) {
       isFlipped = CurrentPlatform.isAndroid && (asset.orientation == 90 || asset.orientation == 270);
       width = asset.width?.toDouble();

--- a/mobile/lib/infrastructure/entities/exif.entity.dart
+++ b/mobile/lib/infrastructure/entities/exif.entity.dart
@@ -165,8 +165,6 @@ extension RemoteExifEntityDataDomainEx on RemoteExifEntityData {
     f: fNumber?.toDouble(),
     mm: focalLength?.toDouble(),
     lens: lens,
-    width: width?.toDouble(),
-    height: height?.toDouble(),
     isFlipped: ExifDtoConverter.isOrientationFlipped(orientation),
   );
 }

--- a/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
@@ -219,8 +219,6 @@ class SyncStreamRepository extends DriftDatabaseRepository {
             country: Value(exif.country),
             dateTimeOriginal: Value(exif.dateTimeOriginal),
             description: Value(exif.description),
-            height: Value(exif.exifImageHeight),
-            width: Value(exif.exifImageWidth),
             exposureTime: Value(exif.exposureTime),
             fNumber: Value(exif.fNumber),
             fileSize: Value(exif.fileSizeInByte),
@@ -241,6 +239,16 @@ class SyncStreamRepository extends DriftDatabaseRepository {
             _db.remoteExifEntity,
             companion.copyWith(assetId: Value(exif.assetId)),
             onConflict: DoUpdate((_) => companion),
+          );
+        }
+      });
+
+      await _db.batch((batch) {
+        for (final exif in data) {
+          batch.update(
+            _db.remoteAssetEntity,
+            RemoteAssetEntityCompanion(width: Value(exif.exifImageWidth), height: Value(exif.exifImageHeight)),
+            where: (row) => row.id.equals(exif.assetId),
           );
         }
       });

--- a/mobile/lib/presentation/pages/drift_asset_troubleshoot.page.dart
+++ b/mobile/lib/presentation/pages/drift_asset_troubleshoot.page.dart
@@ -161,8 +161,6 @@ class _AssetPropertiesSectionState extends ConsumerState<_AssetPropertiesSection
         value: exif.fileSize != null ? '${(exif.fileSize! / 1024 / 1024).toStringAsFixed(2)} MB' : null,
       ),
       _PropertyItem(label: 'Description', value: exif.description),
-      _PropertyItem(label: 'EXIF Width', value: exif.width?.toString()),
-      _PropertyItem(label: 'EXIF Height', value: exif.height?.toString()),
       _PropertyItem(label: 'Date Taken', value: exif.dateTimeOriginal?.toString()),
       _PropertyItem(label: 'Time Zone', value: exif.timeZone),
       _PropertyItem(label: 'Camera Make', value: exif.make),

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_sheet.widget.dart
@@ -97,8 +97,8 @@ class _AssetDetailBottomSheet extends ConsumerWidget {
   }
 
   String _getFileInfo(BaseAsset asset, ExifInfo? exifInfo) {
-    final height = asset.height ?? exifInfo?.height;
-    final width = asset.width ?? exifInfo?.width;
+    final height = asset.height;
+    final width = asset.width;
     final resolution = (width != null && height != null) ? "${width.toInt()} x ${height.toInt()}" : null;
     final fileSize = exifInfo?.fileSize != null ? formatBytes(exifInfo!.fileSize!) : null;
 


### PR DESCRIPTION
## Description

Updates the remote sync repo to write the width and height of assets to the remote asset entity instead of the remote exif entity. This will make it easier for queries to fetch those properties without joining on the exif table.

Follows #23969, as that resets the remote sync, truncating all remote tables, allowing us to migrate the width and height easily, instead of us manually migrating them