### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - model-cache:/cache
     env_file:
       - .env
+    ports:
+      - '3003:3003'
     restart: always
     healthcheck:
       disable: false


### PR DESCRIPTION
The ports for immich-machine-learning were missing.

## Description

For some reason port 3003 wasn't exposed in this version. Which broke connection to machinelearning. 
This fixes the problem for me.

Fixes # (issue)

## How Has This Been Tested?

Machinelearning worked again on my server.


## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
not
...
