### PR TITLE
fix: unarchive action doesn't update archive page

### DIFF
--- a/e2e/src/web/specs/timeline/timeline.parallel-e2e-spec.ts
+++ b/e2e/src/web/specs/timeline/timeline.parallel-e2e-spec.ts
@@ -607,8 +607,7 @@ test.describe('Timeline', () => {
         visibility: 'timeline',
         ids: [assetToArchive.id],
       });
-      console.log('Skipping assertion - TODO - fix bug with not removing asset from timeline-manager after unarchive');
-      // await expect(thumbnail.withAssetId(page, assetToArchive.id)).toHaveCount(0);
+      await expect(thumbnailUtils.withAssetId(page, assetToArchive.id)).toHaveCount(0);
       await page.getByText('Photos', { exact: true }).click();
       await thumbnailUtils.expectInViewport(page, assetToArchive.id);
     });

--- a/web/src/lib/components/timeline/actions/ArchiveAction.svelte
+++ b/web/src/lib/components/timeline/actions/ArchiveAction.svelte
@@ -24,12 +24,12 @@
   const { clearSelect, getOwnedAssets } = getAssetControlContext();
 
   const handleArchive = async () => {
-    const isArchived = unarchive ? AssetVisibility.Timeline : AssetVisibility.Archive;
-    const assets = [...getOwnedAssets()].filter((asset) => asset.visibility !== isArchived);
+    const visibility = unarchive ? AssetVisibility.Timeline : AssetVisibility.Archive;
+    const assets = [...getOwnedAssets()].filter((asset) => asset.visibility !== visibility);
     loading = true;
-    const ids = await archiveAssets(assets, isArchived as AssetVisibility);
+    const ids = await archiveAssets(assets, visibility as AssetVisibility);
     if (ids) {
-      onArchive?.(ids, isArchived ? AssetVisibility.Archive : AssetVisibility.Timeline);
+      onArchive?.(ids, visibility);
       clearSelect();
     }
     loading = false;


### PR DESCRIPTION
Note: Hidden most of the time, since websocket event will also take care of this - disable websocket to reproduce. 