### PR TITLE
fix(web): enable similar search on partner-shared assets

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer-nav-bar.svelte
@@ -183,15 +183,26 @@
 
     {#if isOwner}
       <DeleteAction {asset} {onAction} {preAction} />
+    {/if}
 
-      <ButtonContextMenu direction="left" align="top-right" color="secondary" title={$t('more')} icon={mdiDotsVertical}>
-        {#if showSlideshow && !isLocked}
-          <MenuOption icon={mdiPresentationPlay} text={$t('slideshow')} onClick={onPlaySlideshow} />
-        {/if}
-        {#if showDownloadButton}
-          <DownloadAction asset={toTimelineAsset(asset)} menuItem />
-        {/if}
+    <ButtonContextMenu direction="left" align="top-right" color="secondary" title={$t('more')} icon={mdiDotsVertical}>
+      {#if isOwner && showSlideshow && !isLocked}
+        <MenuOption icon={mdiPresentationPlay} text={$t('slideshow')} onClick={onPlaySlideshow} />
+      {/if}
+      {#if showDownloadButton}
+        <DownloadAction asset={toTimelineAsset(asset)} menuItem />
+      {/if}
 
+      {#if !isLocked && !asset.isArchived && !asset.isTrashed && smartSearchEnabled}
+        <MenuOption
+          icon={mdiCompare}
+          onClick={() =>
+            goto(resolve(`${AppRoute.SEARCH}?query={"queryAssetId":"${stack?.primaryAssetId ?? asset.id}"}`))}
+          text={$t('view_similar_photos')}
+        />
+      {/if}
+
+      {#if isOwner}
         {#if !isLocked}
           {#if asset.isTrashed}
             <RestoreAction {asset} {onAction} />
@@ -201,89 +212,79 @@
           {/if}
         {/if}
 
-        {#if isOwner}
-          <AddToStackAction {asset} {stack} {onAction} />
-          {#if stack}
-            <UnstackAction {stack} {onAction} />
-            <KeepThisDeleteOthersAction {stack} {asset} {onAction} />
-            {#if stack?.primaryAssetId !== asset.id}
-              <SetStackPrimaryAsset {stack} {asset} {onAction} />
-              {#if stack?.assets?.length > 2}
-                <RemoveAssetFromStack {asset} {stack} {onAction} />
-              {/if}
+        <AddToStackAction {asset} {stack} {onAction} />
+        {#if stack}
+          <UnstackAction {stack} {onAction} />
+          <KeepThisDeleteOthersAction {stack} {asset} {onAction} />
+          {#if stack?.primaryAssetId !== asset.id}
+            <SetStackPrimaryAsset {stack} {asset} {onAction} />
+            {#if stack?.assets?.length > 2}
+              <RemoveAssetFromStack {asset} {stack} {onAction} />
             {/if}
           {/if}
-          {#if album}
-            <SetAlbumCoverAction {asset} {album} />
-          {/if}
-          {#if person}
-            <SetFeaturedPhotoAction {asset} {person} {onAction} />
-          {/if}
-          {#if asset.type === AssetTypeEnum.Image && !isLocked}
-            <SetProfilePictureAction {asset} />
-          {/if}
+        {/if}
+        {#if album}
+          <SetAlbumCoverAction {asset} {album} />
+        {/if}
+        {#if person}
+          <SetFeaturedPhotoAction {asset} {person} {onAction} />
+        {/if}
+        {#if asset.type === AssetTypeEnum.Image && !isLocked}
+          <SetProfilePictureAction {asset} />
+        {/if}
 
-          {#if !isLocked}
-            <ArchiveAction {asset} {onAction} {preAction} />
-            <MenuOption
-              icon={mdiUpload}
-              onClick={() => openFileUploadDialog({ multiple: false, assetId: asset.id })}
-              text={$t('replace_with_upload')}
-            />
-            {#if !asset.isArchived && !asset.isTrashed}
-              <MenuOption
-                icon={mdiImageSearch}
-                onClick={() => goto(resolve(`${AppRoute.PHOTOS}?at=${stack?.primaryAssetId ?? asset.id}`))}
-                text={$t('view_in_timeline')}
-              />
-            {/if}
-            {#if !asset.isArchived && !asset.isTrashed && smartSearchEnabled}
-              <MenuOption
-                icon={mdiCompare}
-                onClick={() =>
-                  goto(resolve(`${AppRoute.SEARCH}?query={"queryAssetId":"${stack?.primaryAssetId ?? asset.id}"}`))}
-                text={$t('view_similar_photos')}
-              />
-            {/if}
-          {/if}
-
-          {#if !asset.isTrashed}
-            <SetVisibilityAction asset={toTimelineAsset(asset)} {onAction} {preAction} />
-          {/if}
-
-          {#if asset.type === AssetTypeEnum.Video}
-            <MenuOption
-              icon={mdiVideoOutline}
-              onClick={() => setPlayOriginalVideo(!playOriginalVideo)}
-              text={playOriginalVideo ? $t('play_transcoded_video') : $t('play_original_video')}
-            />
-          {/if}
-
-          <hr />
+        {#if !isLocked}
+          <ArchiveAction {asset} {onAction} {preAction} />
           <MenuOption
-            icon={mdiHeadSyncOutline}
-            onClick={() => onRunJob(AssetJobName.RefreshFaces)}
-            text={$getAssetJobName(AssetJobName.RefreshFaces)}
+            icon={mdiUpload}
+            onClick={() => openFileUploadDialog({ multiple: false, assetId: asset.id })}
+            text={$t('replace_with_upload')}
           />
-          <MenuOption
-            icon={mdiDatabaseRefreshOutline}
-            onClick={() => onRunJob(AssetJobName.RefreshMetadata)}
-            text={$getAssetJobName(AssetJobName.RefreshMetadata)}
-          />
-          <MenuOption
-            icon={mdiImageRefreshOutline}
-            onClick={() => onRunJob(AssetJobName.RegenerateThumbnail)}
-            text={$getAssetJobName(AssetJobName.RegenerateThumbnail)}
-          />
-          {#if asset.type === AssetTypeEnum.Video}
+          {#if !asset.isArchived && !asset.isTrashed}
             <MenuOption
-              icon={mdiCogRefreshOutline}
-              onClick={() => onRunJob(AssetJobName.TranscodeVideo)}
-              text={$getAssetJobName(AssetJobName.TranscodeVideo)}
+              icon={mdiImageSearch}
+              onClick={() => goto(resolve(`${AppRoute.PHOTOS}?at=${stack?.primaryAssetId ?? asset.id}`))}
+              text={$t('view_in_timeline')}
             />
           {/if}
         {/if}
-      </ButtonContextMenu>
-    {/if}
+
+        {#if !asset.isTrashed}
+          <SetVisibilityAction asset={toTimelineAsset(asset)} {onAction} {preAction} />
+        {/if}
+
+        {#if asset.type === AssetTypeEnum.Video}
+          <MenuOption
+            icon={mdiVideoOutline}
+            onClick={() => setPlayOriginalVideo(!playOriginalVideo)}
+            text={playOriginalVideo ? $t('play_transcoded_video') : $t('play_original_video')}
+          />
+        {/if}
+
+        <hr />
+        <MenuOption
+          icon={mdiHeadSyncOutline}
+          onClick={() => onRunJob(AssetJobName.RefreshFaces)}
+          text={$getAssetJobName(AssetJobName.RefreshFaces)}
+        />
+        <MenuOption
+          icon={mdiDatabaseRefreshOutline}
+          onClick={() => onRunJob(AssetJobName.RefreshMetadata)}
+          text={$getAssetJobName(AssetJobName.RefreshMetadata)}
+        />
+        <MenuOption
+          icon={mdiImageRefreshOutline}
+          onClick={() => onRunJob(AssetJobName.RegenerateThumbnail)}
+          text={$getAssetJobName(AssetJobName.RegenerateThumbnail)}
+        />
+        {#if asset.type === AssetTypeEnum.Video}
+          <MenuOption
+            icon={mdiCogRefreshOutline}
+            onClick={() => onRunJob(AssetJobName.TranscodeVideo)}
+            text={$getAssetJobName(AssetJobName.TranscodeVideo)}
+          />
+        {/if}
+      {/if}
+    </ButtonContextMenu>
   </div>
 </div>


### PR DESCRIPTION
## Description

Fixes #21855

Previously, the 'View similar photos' option was only available when viewing your own assets due to the `isOwner` check. This prevented users from initiating similar search on partner-shared assets they already have view access to.

## Changes

- Moved `ButtonContextMenu` outside the `isOwner` restriction
- Relocated the 'View similar photos' menu option to be accessible for all viewable assets
- Similar search now appears when asset is not locked, archived, or trashed, and smart search is enabled
- Maintains all owner-only restrictions for other menu options (delete, archive, etc.)

## Alignment

This change aligns web UI behavior with the mobile app, which already allows similar search on partner-shared assets without ownership restrictions.

## Testing

- ✅ Set up bidirectional partner sharing between admin and non-admin user
- ✅ Verified admin can initiate similar search on non-admin's shared assets
- ✅ Verified non-admin can initiate similar search on admin's shared assets  
- ✅ Confirmed all type checks pass (`pnpm check:svelte`, `pnpm check:typescript`)
- ✅ Confirmed linting passes (`pnpm lint`)
- ✅ Confirmed web build succeeds