### PR TITLE
fix(mobile): remove weird zooming behaviour on videos and play/pause button delay

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -599,6 +599,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
       filterQuality: FilterQuality.high,
       maxScale: 1.0,
       basePosition: Alignment.center,
+      disableScaleGestures: true,
       child: SizedBox(
         width: ctx.width,
         height: ctx.height,


### PR DESCRIPTION
## Description

This fixes the weird behaviour when zooming into videos (which is currently unsupported), and the double tap recognition delay on the play/pause button. 

This is a more or less temporary fix until video zooming is implemented in #22036

## How Has This Been Tested?

- [x] Try zooming and play/pausing the asset viewer on android. 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before:

https://github.com/user-attachments/assets/22671e2b-6ff8-4f55-9a17-ec9c35f96d2b


After:

https://github.com/user-attachments/assets/69ec4098-6ed4-4547-8f84-6880999856e8



</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Not used.
