### PR TITLE
fix(web): fix support & feedback modal wrapping

### DIFF
--- a/web/src/lib/modals/HelpAndFeedbackModal.svelte
+++ b/web/src/lib/modals/HelpAndFeedbackModal.svelte
@@ -13,94 +13,57 @@
   let { onClose, info }: Props = $props();
 </script>
 
+{#snippet link(url: string, icon: string | SimpleIcon, text: string)}
+  <div>
+    <a href={url} target="_blank" rel="noreferrer">
+      <Icon {icon} size="1.5em" class="inline-block" />
+      <p class="font-medium text-primary text-sm underline inline-block">
+        {text}
+      </p>
+    </a>
+  </div>
+{/snippet}
+
 <Modal title={$t('support_and_feedback')} {onClose} size="small">
   <ModalBody>
     <p>{$t('official_immich_resources')}</p>
-    <div class="flex flex-col sm:grid sm:grid-cols-2 gap-2 mt-5">
-      <div>
-        <a href="https://docs.{info.version}.archive.immich.app/overview/introduction" target="_blank" rel="noreferrer">
-          <Icon icon={mdiInformationOutline} size="1.5em" class="inline-block" />
-          <p class="font-medium text-primary text-sm underline inline-block" id="documentation-label">
-            {$t('documentation')}
-          </p>
-        </a>
-      </div>
+    <div class="flex flex-col gap-2 mt-5">
+      {@render link(
+        `https://docs.${info.version}.archive.immich.app/overview/introduction`,
+        mdiInformationOutline,
+        $t('documentation'),
+      )}
 
-      <div>
-        <a href="https://github.com/immich-app/immich/" target="_blank" rel="noreferrer">
-          <Icon icon={mdiGithub} size="1.5em" class="inline-block" />
-          <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-            {$t('source')}
-          </p>
-        </a>
-      </div>
+      {@render link('https://github.com/immich-app/immich/', mdiGithub, $t('source'))}
 
-      <div>
-        <a href="https://discord.immich.app" target="_blank" rel="noreferrer">
-          <Icon icon={siDiscord} class="inline-block" size="1.5em" />
-          <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-            {$t('discord')}
-          </p>
-        </a>
-      </div>
+      {@render link('https://discord.immich.app', siDiscord, $t('discord'))}
 
-      <div>
-        <a href="https://github.com/immich-app/immich/issues/new/choose" target="_blank" rel="noreferrer">
-          <Icon icon={mdiBugOutline} size="1.5em" class="inline-block" />
-          <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-            {$t('bugs_and_feature_requests')}
-          </p>
-        </a>
-      </div>
+      {@render link(
+        'https://github.com/immich-app/immich/issues/new/choose',
+        mdiBugOutline,
+        $t('bugs_and_feature_requests'),
+      )}
     </div>
     {#if info.thirdPartyBugFeatureUrl || info.thirdPartySourceUrl || info.thirdPartyDocumentationUrl || info.thirdPartySupportUrl}
       <p class="mt-5">{$t('third_party_resources')}</p>
       <p class="text-sm mt-1">
         {$t('support_third_party_description')}
       </p>
-      <div class="flex flex-col sm:grid sm:grid-cols-2 gap-2 mt-5">
+      <div class="flex flex-col gap-2 mt-5">
         {#if info.thirdPartyDocumentationUrl}
-          <div>
-            <a href={info.thirdPartyDocumentationUrl} target="_blank" rel="noreferrer">
-              <Icon icon={mdiInformationOutline} size="1.5em" class="inline-block" />
-              <p class="font-medium text-primary text-sm underline inline-block" id="documentation-label">
-                {$t('documentation')}
-              </p>
-            </a>
-          </div>
+          {@render link(info.thirdPartyDocumentationUrl, mdiInformationOutline, $t('documentation'))}
         {/if}
 
         {#if info.thirdPartySourceUrl}
-          <div>
-            <a href={info.thirdPartySourceUrl} target="_blank" rel="noreferrer">
-              <Icon icon={mdiGit} size="1.5em" class="inline-block" />
-              <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-                {$t('source')}
-              </p>
-            </a>
-          </div>
+          {@render link(info.thirdPartySourceUrl, mdiGit, $t('source'))}
         {/if}
 
         {#if info.thirdPartySupportUrl}
-          <div>
-            <a href={info.thirdPartySupportUrl} target="_blank" rel="noreferrer">
-              <Icon icon={mdiFaceAgent} class="inline-block" size="1.5em" />
-              <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-                {$t('support')}
-              </p>
-            </a>
-          </div>
+          {@render link(info.thirdPartySupportUrl, mdiFaceAgent, $t('support'))}
         {/if}
 
         {#if info.thirdPartyBugFeatureUrl}
-          <div>
-            <a href={info.thirdPartyBugFeatureUrl} target="_blank" rel="noreferrer">
-              <Icon icon={mdiBugOutline} size="1.5em" class="inline-block" />
-              <p class="font-medium text-primary text-sm underline inline-block" id="github-label">
-                {$t('bugs_and_feature_requests')}
-              </p>
-            </a>
-          </div>
+          {@render link(info.thirdPartyBugFeatureUrl, mdiBugOutline, $t('bugs_and_feature_requests'))}
         {/if}
       </div>
     {/if}

--- a/web/src/lib/modals/HelpAndFeedbackModal.svelte
+++ b/web/src/lib/modals/HelpAndFeedbackModal.svelte
@@ -2,7 +2,7 @@
   import { type ServerAboutResponseDto } from '@immich/sdk';
   import { Icon, Modal, ModalBody } from '@immich/ui';
   import { mdiBugOutline, mdiFaceAgent, mdiGit, mdiGithub, mdiInformationOutline } from '@mdi/js';
-  import { siDiscord } from 'simple-icons';
+  import { type SimpleIcon, siDiscord } from 'simple-icons';
   import { t } from 'svelte-i18n';
 
   interface Props {


### PR DESCRIPTION
## Description
The text text wrapping in the Support & Feedback modal caused icons and text to not be aligned. Links are now a single column. Also removed element `id`s as they were duplicated and seemingly unused.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested with/without third-party features at various breakpoints

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

| Before | After |
| --- | --- |
| <img width="436" height="468" alt="image" src="https://github.com/user-attachments/assets/64fd9971-e32e-4331-a9a1-7d3867bb1f14" /> | <img width="427" height="550" alt="image" src="https://github.com/user-attachments/assets/921e2f7d-9054-4cdb-8b76-a93a1455eb9d" /> |
| <img width="429" height="239" alt="image" src="https://github.com/user-attachments/assets/8d9720c9-4189-40c3-aee3-1ae378b15b5d" /> | <img width="427" height="275" alt="image" src="https://github.com/user-attachments/assets/96562de6-9b60-4ef7-aee0-9dc16b1b7b38" /> |


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
