### PR TITLE
fix(server): Sort stacked assets by creation date

### DIFF
--- a/server/src/queries/stack.repository.sql
+++ b/server/src/queries/stack.repository.sql
@@ -54,6 +54,8 @@ select
           "asset"."deletedAt" is null
           and "asset"."stackId" = "stack"."id"
           and "asset"."visibility" in ('archive', 'timeline')
+        order by
+          "asset"."fileCreatedAt" asc
       ) as agg
   ) as "assets"
 from
@@ -139,6 +141,8 @@ select
           "asset"."deletedAt" is null
           and "asset"."stackId" = "stack"."id"
           and "asset"."visibility" in ('archive', 'timeline')
+        order by
+          "asset"."fileCreatedAt" asc
       ) as agg
   ) as "assets"
 from

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -565,6 +565,7 @@ export class AssetRepository {
                     .whereRef('stacked.id', '!=', 'stack.primaryAssetId')
                     .where('stacked.deletedAt', 'is', null)
                     .where('stacked.visibility', '=', AssetVisibility.Timeline)
+                    .orderBy('stacked.fileCreatedAt', 'asc')
                     .groupBy('stack.id')
                     .as('stacked_assets'),
                 (join) => join.on('stack.id', 'is not', null),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -6,7 +6,6 @@ import {
   NotNull,
   Selectable,
   SelectQueryBuilder,
-  ShallowDehydrateObject,
   sql,
   Updateable,
   UpdateResult,
@@ -556,16 +555,13 @@ export class AssetRepository {
                   eb
                     .selectFrom('asset as stacked')
                     .selectAll('stack')
-                    .select((eb) =>
-                      eb
-                        .fn<ShallowDehydrateObject<Selectable<AssetTable>>>('array_agg', [eb.table('stacked')])
-                        .as('assets'),
+                    .select(
+                      sql<unknown[]>`array_agg(to_json(stacked) ORDER BY stacked."fileCreatedAt" ASC)`.as('assets'),
                     )
                     .whereRef('stacked.stackId', '=', 'stack.id')
                     .whereRef('stacked.id', '!=', 'stack.primaryAssetId')
                     .where('stacked.deletedAt', 'is', null)
                     .where('stacked.visibility', '=', AssetVisibility.Timeline)
-                    .orderBy('stacked.fileCreatedAt', 'asc')
                     .groupBy('stack.id')
                     .as('stacked_assets'),
                 (join) => join.on('stack.id', 'is not', null),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -603,6 +603,7 @@ export class AssetRepository {
                     .whereRef('stacked.id', '!=', 'stack.primaryAssetId')
                     .where('stacked.deletedAt', 'is', null)
                     .where('stacked.visibility', '=', AssetVisibility.Timeline)
+                    .orderBy('stacked.fileCreatedAt', 'asc')
                     .groupBy('stack.id')
                     .as('stacked_assets'),
                 (join) => join.on('stack.id', 'is not', null),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -6,7 +6,6 @@ import {
   NotNull,
   Selectable,
   SelectQueryBuilder,
-  ShallowDehydrateObject,
   sql,
   Updateable,
   UpdateResult,
@@ -594,16 +593,13 @@ export class AssetRepository {
                   eb
                     .selectFrom('asset as stacked')
                     .selectAll('stack')
-                    .select((eb) =>
-                      eb
-                        .fn<ShallowDehydrateObject<Selectable<AssetTable>>>('array_agg', [eb.table('stacked')])
-                        .as('assets'),
+                    .select(
+                      sql<unknown[]>`array_agg(to_json(stacked) ORDER BY stacked."fileCreatedAt" ASC)`.as('assets'),
                     )
                     .whereRef('stacked.stackId', '=', 'stack.id')
                     .whereRef('stacked.id', '!=', 'stack.primaryAssetId')
                     .where('stacked.deletedAt', 'is', null)
                     .where('stacked.visibility', '=', AssetVisibility.Timeline)
-                    .orderBy('stacked.fileCreatedAt', 'asc')
                     .groupBy('stack.id')
                     .as('stacked_assets'),
                 (join) => join.on('stack.id', 'is not', null),

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -6,6 +6,7 @@ import {
   NotNull,
   Selectable,
   SelectQueryBuilder,
+  ShallowDehydrateObject,
   sql,
   Updateable,
   UpdateResult,
@@ -594,7 +595,9 @@ export class AssetRepository {
                     .selectFrom('asset as stacked')
                     .selectAll('stack')
                     .select(
-                      sql<unknown[]>`array_agg(to_json(stacked) ORDER BY stacked."fileCreatedAt" ASC)`.as('assets'),
+                      sql<
+                        ShallowDehydrateObject<Selectable<AssetTable>>[]
+                      >`array_agg(to_json(stacked) ORDER BY stacked."fileCreatedAt" ASC)`.as('assets'),
                     )
                     .whereRef('stacked.stackId', '=', 'stack.id')
                     .whereRef('stacked.id', '!=', 'stack.primaryAssetId')

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -41,7 +41,8 @@ const withAssets = (eb: ExpressionBuilder<DB, 'stack'>, withTags = false) => {
       .select((eb) => eb.fn.toJson('exifInfo').as('exifInfo'))
       .where('asset.deletedAt', 'is', null)
       .whereRef('asset.stackId', '=', 'stack.id')
-      .$call(withDefaultVisibility),
+      .$call(withDefaultVisibility)
+      .orderBy('asset.fileCreatedAt', 'asc'),
   ).as('assets');
 };
 


### PR DESCRIPTION
## Description

This PR fixes the ordering of assets within manually created stacks. Previously, stacked assets (burst photos) were displayed in an arbitrary order based on their UUID values, which didn't match either the capture date or the selection order.

**Changes:**
- Added `ORDER BY asset.fileCreatedAt ASC` to the `withAssets` helper in `StackRepository`
- Added `ORDER BY stacked.fileCreatedAt ASC` to the asset stack query in `AssetRepository.getById`

**Behavior:**
- The primary asset (user's chosen cover photo) remains at position 0
- All other assets in the stack are now ordered chronologically by their capture timestamp (oldest to newest)
- This provides a natural viewing experience for burst photos where photos appear in the order they were taken

Fixes # (issue)

## How Has This Been Tested?

- [x] Created a manual stack from multiple burst photos taken at different times
- [x] Verified that after refreshing, photos appear in chronological order (excluding the primary which stays first)
- [x] Tested that changing the primary asset still works correctly
- [x] Verified stack creation, viewing, and updating operations display correct order

<!-- API endpoint changes (if relevant)
## API Changes

No API endpoint changes. The response structure remains the same - only the ordering of assets within the `assets` array has changed to be chronological.
-->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules
