### PR TITLE
fix(ml): Upgrade ONNX Runtime to v1.22.1 to fix ROCm build failures

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -25,7 +25,7 @@ FROM builder-cpu AS builder-rknn
 FROM rocm/dev-ubuntu-22.04:6.4.3-complete@sha256:1f7e92ca7e3a3785680473329ed1091fc99db3e90fcb3a1688f2933e870ed76b AS builder-rocm
 
 # renovate: datasource=github-releases depName=Microsoft/onnxruntime
-ARG ONNXRUNTIME_VERSION="v1.21.0"
+ARG ONNXRUNTIME_VERSION="v1.22.1"
 WORKDIR /code
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget git python3.10-venv

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -25,7 +25,7 @@ FROM builder-cpu AS builder-rknn
 FROM rocm/dev-ubuntu-22.04:6.4.3-complete@sha256:1f7e92ca7e3a3785680473329ed1091fc99db3e90fcb3a1688f2933e870ed76b AS builder-rocm
 
 # renovate: datasource=github-releases depName=Microsoft/onnxruntime
-ARG ONNXRUNTIME_VERSION="v1.20.1"
+ARG ONNXRUNTIME_VERSION="v1.21.0"
 WORKDIR /code
 
 RUN apt-get update && apt-get install -y --no-install-recommends wget git python3.10-venv

--- a/machine-learning/patches/0002-target-gfx900-gfx1102.patch
+++ b/machine-learning/patches/0002-target-gfx900-gfx1102.patch
@@ -1,13 +1,13 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index d90a2a355..bb1a7de12 100644
+index 2714e6f59..a69da76b4 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -295,7 +295,7 @@ if (onnxruntime_USE_ROCM)
+@@ -338,7 +338,7 @@ if (onnxruntime_USE_ROCM)
+     if (ROCM_VERSION_DEV VERSION_LESS "6.2")
+       message(FATAL_ERROR "CMAKE_HIP_ARCHITECTURES is not set when ROCm version < 6.2")
+     else()
+-      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx940;gfx941;gfx942;gfx1200;gfx1201")
++      set(CMAKE_HIP_ARCHITECTURES "gfx900;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102;gfx940;gfx941;gfx942;gfx1200;gfx1201")
+     endif()
    endif()
-
-   if (NOT CMAKE_HIP_ARCHITECTURES)
--    set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx940;gfx941;gfx942;gfx1200;gfx1201")
-+    set(CMAKE_HIP_ARCHITECTURES "gfx900;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102;gfx940;gfx941;gfx942;gfx1200;gfx1201")
-   endif()
-
-   file(GLOB rocm_cmake_components ${onnxruntime_ROCM_HOME}/lib/cmake/*)
+ 


### PR DESCRIPTION
## Description

Fixes machine learning ROCm Docker image build failures in v2.3.0 and v2.3.1 by upgrading ONNX Runtime from v1.20.1 to v1.21.0.

### Problem

The ROCm-enabled machine learning images (`-rocm` tag) fail to build due to an Eigen library SHA1 hash mismatch in ONNX Runtime v1.20.1. This is caused by changes in GitLab's archive generation, which is documented in these ONNX Runtime issues:
- microsoft/onnxruntime#18286
- microsoft/onnxruntime#25098
- microsoft/onnxruntime#25206

ONNX Runtime v1.21.0 includes updated Eigen dependency hashes that resolve this issue.

### Changes

- Updated `ONNXRUNTIME_VERSION` from `v1.20.1` to `v1.21.0` in `machine-learning/Dockerfile`



Fixes #24029

## How Has This Been Tested?

- Verified ONNX Runtime v1.21.0 still includes ROCm execution provider support
- Confirmed Python 3.11 compatibility (Immich uses 3.11, v1.21.0 requires 3.8+)
- Reviewed release notes - no breaking changes affecting Immich
- Verified Eigen dependency uses correct hash in v1.21.0


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude code was used as a helper to research the issue, scrape the changelogs and figure out compatibilities
