### PR TITLE
fix: Use correct app store link

### DIFF
--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -50,7 +50,7 @@ const double kUploadStatusCanceled = -2.0;
 
 const int kMinMonthsToEnableScrubberSnap = 12;
 
-const String kImmichAppStoreLink = "https://apps.apple.com/app/immich/id6449244941";
+const String kImmichAppStoreLink = "https://apps.apple.com/app/immich/id1613945652";
 const String kImmichPlayStoreLink = "https://play.google.com/store/apps/details?id=app.alextran.immich";
 const String kImmichLatestRelease = "https://github.com/immich-app/immich/releases/latest";
 


### PR DESCRIPTION
The Apple App store link used has a completely wrong ID for whatever reason.

## How Has This Been Tested?

I checked the URLs used.
