### PR TITLE
feat(web): allow navigating the map with arrow keys

### DIFF
--- a/web/src/lib/actions/shortcut.ts
+++ b/web/src/lib/actions/shortcut.ts
@@ -39,13 +39,17 @@ export const shortcutLabel = (shortcut: Shortcut) => {
 /** Determines whether an event should be ignored. The event will be ignored if:
  *  - The element dispatching the event is not the same as the element which the event listener is attached to
  *  - The element dispatching the event is an input field
+ *  - The element dispatching the event is a map canvas
  */
 export const shouldIgnoreEvent = (event: KeyboardEvent | ClipboardEvent): boolean => {
   if (event.target === event.currentTarget) {
     return false;
   }
   const type = (event.target as HTMLInputElement).type;
-  return ['textarea', 'text', 'date', 'datetime-local', 'email', 'password'].includes(type);
+  return (
+    ['textarea', 'text', 'date', 'datetime-local', 'email', 'password'].includes(type) ||
+    (event.target instanceof HTMLCanvasElement && event.target.classList.contains('maplibregl-canvas'))
+  );
 };
 
 export const matchesShortcut = (event: KeyboardEvent, shortcut: Shortcut) => {


### PR DESCRIPTION
## Description

Ignore keyboard shortcuts when focused on map in sidebar or popup. This allows navigating the map with arrow keys. 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Manually in Firefox

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

|before|after|
|------|-----|
|[Kooha-2025-11-21-17-57-04.webm](https://github.com/user-attachments/assets/eb74b0a4-6dcd-4960-8a13-1464d6e57b37)|[Kooha-2025-11-21-17-54-43.webm](https://github.com/user-attachments/assets/c451d92a-4e91-44ff-a28b-4c726bceeff3)|
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.