### PR TITLE
feat: use browser download manager for archive downloads

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4448,6 +4448,83 @@
         "x-immich-state": "Stable"
       }
     },
+    "/download/archive/{id}": {
+      "get": {
+        "description": "Download a ZIP archive corresponding to the given download request. The download request needs to be created first.",
+        "operationId": "downloadRequestArchive",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slug",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Download asset archive from download request",
+        "tags": [
+          "Download"
+        ],
+        "x-immich-history": [
+          {
+            "version": "v1",
+            "state": "Added"
+          },
+          {
+            "version": "v1",
+            "state": "Beta"
+          },
+          {
+            "version": "v2",
+            "state": "Stable"
+          }
+        ],
+        "x-immich-permission": "asset.download",
+        "x-immich-state": "Stable"
+      }
+    },
     "/download/info": {
       "post": {
         "description": "Retrieve information about how to request a download for the specified assets or album. The response includes groups of assets that can be downloaded together.",
@@ -4515,6 +4592,79 @@
           {
             "version": "v1",
             "state": "Beta"
+          },
+          {
+            "version": "v2",
+            "state": "Stable"
+          }
+        ],
+        "x-immich-permission": "asset.download",
+        "x-immich-state": "Stable"
+      }
+    },
+    "/download/request": {
+      "post": {
+        "description": "Create a download request for the specified assets or album. The response includes one or more tokens that can be used to download groups of assets.",
+        "operationId": "prepareDownload",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slug",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadInfoDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrepareDownloadResponseDto"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Prepare download archive",
+        "tags": [
+          "Download"
+        ],
+        "x-immich-history": [
+          {
+            "version": "v2",
+            "state": "Added"
           },
           {
             "version": "v2",
@@ -18028,6 +18178,39 @@
           "PersonRecognized"
         ],
         "type": "string"
+      },
+      "PrepareDownloadArchiveInfo": {
+        "properties": {
+          "downloadRequestId": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "downloadRequestId",
+          "size"
+        ],
+        "type": "object"
+      },
+      "PrepareDownloadResponseDto": {
+        "properties": {
+          "archives": {
+            "items": {
+              "$ref": "#/components/schemas/PrepareDownloadArchiveInfo"
+            },
+            "type": "array"
+          },
+          "totalSize": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "archives",
+          "totalSize"
+        ],
+        "type": "object"
       },
       "PurchaseResponse": {
         "properties": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2818,6 +2818,24 @@ export function downloadArchive({ key, slug, assetIdsDto }: {
     })));
 }
 /**
+ * Download asset archive from download request
+ */
+export function downloadRequestArchive({ id, key, slug }: {
+    id: string;
+    key?: string;
+    slug?: string;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchBlob<{
+        status: 200;
+        data: Blob;
+    }>(`/download/archive/${encodeURIComponent(id)}${QS.query(QS.explode({
+        key,
+        slug
+    }))}`, {
+        ...opts
+    }));
+}
+/**
  * Retrieve download information
  */
 export function getDownloadInfo({ key, slug, downloadInfoDto }: {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -667,6 +667,14 @@ export type DownloadResponseDto = {
     archives: DownloadArchiveInfo[];
     totalSize: number;
 };
+export type PrepareDownloadArchiveInfo = {
+    downloadRequestId: string;
+    size: number;
+};
+export type PrepareDownloadResponseDto = {
+    archives: PrepareDownloadArchiveInfo[];
+    totalSize: number;
+};
 export type DuplicateResponseDto = {
     assets: AssetResponseDto[];
     duplicateId: string;
@@ -2821,6 +2829,26 @@ export function getDownloadInfo({ key, slug, downloadInfoDto }: {
         status: 201;
         data: DownloadResponseDto;
     }>(`/download/info${QS.query(QS.explode({
+        key,
+        slug
+    }))}`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: downloadInfoDto
+    })));
+}
+/**
+ * Prepare download archive
+ */
+export function prepareDownload({ key, slug, downloadInfoDto }: {
+    key?: string;
+    slug?: string;
+    downloadInfoDto: DownloadInfoDto;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 201;
+        data: PrepareDownloadResponseDto;
+    }>(`/download/request${QS.query(QS.explode({
         key,
         slug
     }))}`, oazapfts.json({

--- a/server/src/controllers/download.controller.ts
+++ b/server/src/controllers/download.controller.ts
@@ -1,13 +1,14 @@
-import { Body, Controller, HttpCode, HttpStatus, Post, StreamableFile } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, StreamableFile } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import { AssetIdsDto } from 'src/dtos/asset.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { DownloadInfoDto, DownloadResponseDto } from 'src/dtos/download.dto';
+import { DownloadInfoDto, DownloadResponseDto, PrepareDownloadResponseDto } from 'src/dtos/download.dto';
 import { ApiTag, Permission } from 'src/enum';
 import { Auth, Authenticated, FileResponse } from 'src/middleware/auth.guard';
 import { DownloadService } from 'src/services/download.service';
 import { asStreamableFile } from 'src/utils/file';
+import { UUIDParamDto } from 'src/validation';
 
 @ApiTags(ApiTag.Download)
 @Controller('download')
@@ -26,6 +27,18 @@ export class DownloadController {
     return this.service.getDownloadInfo(auth, dto);
   }
 
+  @Post('request')
+  @Authenticated({ permission: Permission.AssetDownload, sharedLink: true })
+  @Endpoint({
+    summary: 'Prepare download archive',
+    description:
+      'Create a download request for the specified assets or album. The response includes one or more tokens that can be used to download groups of assets.',
+    history: new HistoryBuilder().added('v2').stable('v2'),
+  })
+  prepareDownload(@Auth() auth: AuthDto, @Body() dto: DownloadInfoDto): Promise<PrepareDownloadResponseDto> {
+    return this.service.prepareDownload(auth, dto);
+  }
+
   @Post('archive')
   @Authenticated({ permission: Permission.AssetDownload, sharedLink: true })
   @FileResponse()
@@ -38,5 +51,19 @@ export class DownloadController {
   })
   downloadArchive(@Auth() auth: AuthDto, @Body() dto: AssetIdsDto): Promise<StreamableFile> {
     return this.service.downloadArchive(auth, dto).then(asStreamableFile);
+  }
+
+  @Get('archive/:id')
+  @Authenticated({ permission: Permission.AssetDownload, sharedLink: true })
+  @FileResponse()
+  @HttpCode(HttpStatus.OK)
+  @Endpoint({
+    summary: 'Download asset archive from download request',
+    description:
+      'Download a ZIP archive corresponding to the given download request. The download request needs to be created first.',
+    history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
+  })
+  downloadRequestArchive(@Auth() auth: AuthDto, @Param() { id }: UUIDParamDto): Promise<StreamableFile> {
+    return this.service.downloadRequestArchive(auth, id).then(asStreamableFile);
   }
 }

--- a/server/src/dtos/download.dto.ts
+++ b/server/src/dtos/download.dto.ts
@@ -30,3 +30,15 @@ export class DownloadArchiveInfo {
   size!: number;
   assetIds!: string[];
 }
+
+export class PrepareDownloadResponseDto {
+  @ApiProperty({ type: 'integer' })
+  totalSize!: number;
+  archives!: PrepareDownloadArchiveInfo[];
+}
+
+export class PrepareDownloadArchiveInfo {
+  @ApiProperty({ type: 'integer' })
+  size!: number;
+  downloadRequestId!: string;
+}

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -564,6 +564,8 @@ export enum JobName {
 
   DatabaseBackup = 'DatabaseBackup',
 
+  DownloadRequestCleanup = 'DownloadRequestCleanup',
+
   FacialRecognitionQueueAll = 'FacialRecognitionQueueAll',
   FacialRecognition = 'FacialRecognition',
 

--- a/server/src/repositories/download-request.repository.ts
+++ b/server/src/repositories/download-request.repository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { Insertable, Kysely, sql } from 'kysely';
+import _ from 'lodash';
+import { InjectKysely } from 'nestjs-kysely';
+import { DummyValue, GenerateSql } from 'src/decorators';
+import { DB } from 'src/schema';
+import { DownloadRequestTable } from 'src/schema/tables/download-request.table';
+
+@Injectable()
+export class DownloadRequestRepository {
+  constructor(@InjectKysely() private db: Kysely<DB>) {}
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  get(id: string) {
+    return this.db
+      .selectFrom('download_request')
+      .selectAll('download_request')
+      .where('download_request.id', '=', id)
+      .leftJoin('download_request_asset', 'download_request_asset.downloadRequestId', 'download_request.id')
+      .select((eb) =>
+        eb.fn
+          .coalesce(eb.fn.jsonAgg('download_request_asset.assetId'), sql`'[]'`)
+          .$castTo<string[]>()
+          .as('assetIds'),
+      )
+      .groupBy('download_request.id')
+      .executeTakeFirstOrThrow();
+  }
+
+  async create(entity: Insertable<DownloadRequestTable> & { assetIds?: string[] }) {
+    const { id } = await this.db
+      .insertInto('download_request')
+      .values(_.omit(entity, 'assetIds'))
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    if (entity.assetIds && entity.assetIds.length > 0) {
+      await this.db
+        .insertInto('download_request_asset')
+        .values(entity.assetIds!.map((assetId) => ({ assetId, downloadRequestId: id })))
+        .execute();
+    }
+
+    return this.getDownloadRequest(id);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.db.deleteFrom('download_request').where('download_request.id', '=', id).execute();
+  }
+
+  private getDownloadRequest(id: string) {
+    return this.db
+      .selectFrom('download_request')
+      .selectAll('download_request')
+      .where('download_request.id', '=', id)
+      .executeTakeFirstOrThrow();
+  }
+}

--- a/server/src/repositories/index.ts
+++ b/server/src/repositories/index.ts
@@ -11,6 +11,7 @@ import { ConfigRepository } from 'src/repositories/config.repository';
 import { CronRepository } from 'src/repositories/cron.repository';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
+import { DownloadRequestRepository } from 'src/repositories/download-request.repository';
 import { DownloadRepository } from 'src/repositories/download.repository';
 import { DuplicateRepository } from 'src/repositories/duplicate.repository';
 import { EmailRepository } from 'src/repositories/email.repository';
@@ -65,6 +66,7 @@ export const repositories = [
   CryptoRepository,
   DatabaseRepository,
   DownloadRepository,
+  DownloadRequestRepository,
   DuplicateRepository,
   EmailRepository,
   EventRepository,

--- a/server/src/schema/index.ts
+++ b/server/src/schema/index.ts
@@ -38,6 +38,8 @@ import { AssetMetadataTable } from 'src/schema/tables/asset-metadata.table';
 import { AssetOcrTable } from 'src/schema/tables/asset-ocr.table';
 import { AssetTable } from 'src/schema/tables/asset.table';
 import { AuditTable } from 'src/schema/tables/audit.table';
+import { DownloadRequestAssetTable } from 'src/schema/tables/download-request-asset.table';
+import { DownloadRequestTable } from 'src/schema/tables/download-request.table';
 import { FaceSearchTable } from 'src/schema/tables/face-search.table';
 import { GeodataPlacesTable } from 'src/schema/tables/geodata-places.table';
 import { LibraryTable } from 'src/schema/tables/library.table';
@@ -96,6 +98,8 @@ export class ImmichDatabase {
     AssetFileTable,
     AuditTable,
     AssetExifTable,
+    DownloadRequestAssetTable,
+    DownloadRequestTable,
     FaceSearchTable,
     GeodataPlacesTable,
     LibraryTable,
@@ -190,6 +194,9 @@ export interface DB {
   ocr_search: OcrSearchTable;
 
   audit: AuditTable;
+
+  download_request_asset: DownloadRequestAssetTable;
+  download_request: DownloadRequestTable;
 
   face_search: FaceSearchTable;
 

--- a/server/src/schema/migrations/1763915568967-AddDownloadRequestTables.ts
+++ b/server/src/schema/migrations/1763915568967-AddDownloadRequestTables.ts
@@ -1,0 +1,23 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE TABLE "download_request" (
+  "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+  "expiresAt" timestamp with time zone NOT NULL,
+  CONSTRAINT "download_request_pkey" PRIMARY KEY ("id")
+);`.execute(db);
+  await sql`CREATE TABLE "download_request_asset" (
+  "assetId" uuid NOT NULL,
+  "downloadRequestId" uuid NOT NULL,
+  CONSTRAINT "download_request_asset_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "asset" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT "download_request_asset_downloadRequestId_fkey" FOREIGN KEY ("downloadRequestId") REFERENCES "download_request" ("id") ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT "download_request_asset_pkey" PRIMARY KEY ("assetId", "downloadRequestId")
+);`.execute(db);
+  await sql`CREATE INDEX "download_request_asset_assetId_idx" ON "download_request_asset" ("assetId");`.execute(db);
+  await sql`CREATE INDEX "download_request_asset_downloadRequestId_idx" ON "download_request_asset" ("downloadRequestId");`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP TABLE "download_request_asset";`.execute(db);
+  await sql`DROP TABLE "download_request";`.execute(db);
+}

--- a/server/src/schema/tables/download-request-asset.table.ts
+++ b/server/src/schema/tables/download-request-asset.table.ts
@@ -1,0 +1,12 @@
+import { AssetTable } from 'src/schema/tables/asset.table';
+import { DownloadRequestTable } from 'src/schema/tables/download-request.table';
+import { ForeignKeyColumn, Table } from 'src/sql-tools';
+
+@Table('download_request_asset')
+export class DownloadRequestAssetTable {
+  @ForeignKeyColumn(() => AssetTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE', primary: true })
+  assetId!: string;
+
+  @ForeignKeyColumn(() => DownloadRequestTable, { onUpdate: 'CASCADE', onDelete: 'CASCADE', primary: true })
+  downloadRequestId!: string;
+}

--- a/server/src/schema/tables/download-request.table.ts
+++ b/server/src/schema/tables/download-request.table.ts
@@ -1,0 +1,10 @@
+import { Column, Generated, PrimaryGeneratedColumn, Table, Timestamp } from 'src/sql-tools';
+
+@Table('download_request')
+export class DownloadRequestTable {
+  @PrimaryGeneratedColumn()
+  id!: Generated<string>;
+
+  @Column({ type: 'timestamp with time zone' })
+  expiresAt!: Timestamp;
+}

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -18,6 +18,7 @@ import { ConfigRepository } from 'src/repositories/config.repository';
 import { CronRepository } from 'src/repositories/cron.repository';
 import { CryptoRepository } from 'src/repositories/crypto.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
+import { DownloadRequestRepository } from 'src/repositories/download-request.repository';
 import { DownloadRepository } from 'src/repositories/download.repository';
 import { DuplicateRepository } from 'src/repositories/duplicate.repository';
 import { EmailRepository } from 'src/repositories/email.repository';
@@ -76,6 +77,7 @@ export const BASE_SERVICE_DEPENDENCIES = [
   CryptoRepository,
   DatabaseRepository,
   DownloadRepository,
+  DownloadRequestRepository,
   DuplicateRepository,
   EmailRepository,
   EventRepository,
@@ -134,6 +136,7 @@ export class BaseService {
     protected cryptoRepository: CryptoRepository,
     protected databaseRepository: DatabaseRepository,
     protected downloadRepository: DownloadRepository,
+    protected downloadRequestRepository: DownloadRequestRepository,
     protected duplicateRepository: DuplicateRepository,
     protected emailRepository: EmailRepository,
     protected eventRepository: EventRepository,

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -226,6 +226,7 @@ export class QueueService extends BaseService {
         { name: JobName.SessionCleanup },
         { name: JobName.AuditTableCleanup },
         { name: JobName.AuditLogCleanup },
+        { name: JobName.DownloadRequestCleanup },
       );
     }
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -362,6 +362,7 @@ export type JobItem =
 
   // Cleanup
   | { name: JobName.AuditLogCleanup; data?: IBaseJob }
+  | { name: JobName.DownloadRequestCleanup; data?: IBaseJob }
   | { name: JobName.SessionCleanup; data?: IBaseJob }
 
   // Tags


### PR DESCRIPTION
## TODO
Note: very WIP

- [x] Add cron job to delete expired download requests
- [ ] Cleanup/polish code a bit
- [ ] Tests
- [ ] Decide on final name; is "download request" good? Perhaps "download bundle"?
- [ ] Handle asset in download request being deleted

Potentially on a separate PR
- [ ] Calculate exact archive size
- [ ] Support [resuming downloads](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests)

## Description

Currently, when downloading more than one asset at a time (i.e., an archive), the contents of the archive are buffered in memory. This does not scale to big archives, causing browsers to fail.

In this PR, we are introducing new API endpoints that instead create a "download request" (essentially a mapping between a key and a list of assets) that allow requests to be made via a GET requests.
This would pave the way for resumable downloads and accurate download progress in the browser itself (see https://github.com/immich-app/immich/issues/14725#issuecomment-3394151394).

Fixes #14725

## How Has This Been Tested?

For now, just manual testing has been done by creating an album and downloading its entire contents.

E2E Tests WIP

## API Changes
Two new endpoints:

- `POST /download/request`
- `GET /download/archive/:id`

## Security Concerns

This would allow any user having access to a shared link to increase the database size in a potentially unbounded way by just creating "download requests" in rapid succession. Not sure if this is something we should worry about.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM has or will be used for this PR, just me and my trusty neovim :)
