### PR TITLE
fix: don't get OCR data in shared link

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -399,7 +399,9 @@
   $effect(() => {
     handlePromiseError(handleGetAllAlbums());
     ocrManager.clear();
-    handlePromiseError(ocrManager.getAssetOcr(asset.id));
+    if (!sharedLink) {
+      handlePromiseError(ocrManager.getAssetOcr(asset.id));
+    }
   });
 </script>
 


### PR DESCRIPTION
Fixes #24145
