### PR TITLE
fix: detection of WebM container

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -756,7 +756,13 @@ export class MediaService extends BaseService {
       return false;
     }
 
-    const name = formatLongName === 'QuickTime / MOV' ? VideoContainer.Mov : (formatName as VideoContainer);
+    const formatLongNameMapping: Record<string, VideoContainer> = {
+      'QuickTime / MOV': VideoContainer.Mov,
+      'Matroska / WebM': VideoContainer.Webm,
+    };
+
+    const name = (formatLongName ? formatLongNameMapping[formatLongName] : undefined) ?? (formatName as VideoContainer);
+
     return name !== VideoContainer.Mp4 && !ffmpegConfig.acceptedContainers.includes(name);
   }
 


### PR DESCRIPTION
## Description

Immich can fail to detect WebM containers as the name string doesn't exactly match that in the `enum` for WebM, which can cause these files to be incorrectly transcoded and/or remuxed when the transcode policy specifies that WebM is an accepted container format.

I added a check for WebM / Matroska.

## How Has This Been Tested?

- Set WebM as an accepted format in transcode policy.
- Set transcode policy to "Only videos not in an accepted format".
- Upload a WebM container file with an accepted codec video and audio stream.
- Verify the transcode status.

Before: video file is remuxed to MP4 even though it shouldn't be.
After: video file is not remuxed.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs or other AI/ML was used in creating this pull request.