### PR TITLE
fix(docs): build `cli` for e2e tests

### DIFF
--- a/docs/docs/developer/testing.md
+++ b/docs/docs/developer/testing.md
@@ -18,6 +18,7 @@ make e2e
 Before you can run the tests, you need to run the following commands _once_:
 
 - `pnpm install` (in `e2e/`)
+- `pnpm run build` (in `cli/`)
 - `make open-api` (in the project root `/`)
 
 Once the test environment is running, the e2e tests can be run via:


### PR DESCRIPTION
Description
-----------

To make sure that my setup is working properly I want to have all tests green, including e2e. I follow the docs and run into the following:
```
 FAIL  src/cli/specs/upload.e2e-spec.ts > immich upload > immich upload --ignore <pattern> > should have accurate dry run
AssertionError: expected 'node:internal/modules/esm/resolve:274…' to contain '{message}'

- Expected
+ Received

- {message}
+ node:internal/modules/esm/resolve:274
+     throw new ERR_MODULE_NOT_FOUND(
+           ^
+
+ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/robert/Development/immich/cli/dist/index.js' imported from /home/robert/Development/immich/cli/bin/immich
+     at finalizeResolution (node:internal/modules/esm/resolve:274:11)
+     at moduleResolve (node:internal/modules/esm/resolve:864:10)
+     at defaultResolve (node:internal/modules/esm/resolve:990:11)
+     at #cachedDefaultResolve (node:internal/modules/esm/loader:737:20)
+     at ModuleLoader.resolve (node:internal/modules/esm/loader:714:38)
+     at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:293:38)
+     at #link (node:internal/modules/esm/module_job:208:49) {
+   code: 'ERR_MODULE_NOT_FOUND',
+   url: 'file:///home/robert/Development/immich/cli/dist/index.js'
+ }
+
+ Node.js v24.11.1
```

How Has This Been Tested?
-------------------------

1. Freshly clone the repo and follow the documentation for [setup](https://docs.immich.app/developer/setup) and [testing](https://docs.immich.app/developer/testing)
2. Run `pnpm run test` from `./e2e`:
3. See the error above
4. Run `pnpm run build` in `./cli`
5. Repeat step 2, tests pass

Checklist:
----------

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

