### PR TITLE
fix: theme switcher

### DIFF
--- a/web/src/lib/managers/theme-manager.svelte.ts
+++ b/web/src/lib/managers/theme-manager.svelte.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import { Theme } from '$lib/constants';
 import { eventManager } from '$lib/managers/event-manager.svelte';
 import { PersistedLocalStorage } from '$lib/utils/persisted';
+import { theme as uiTheme, type Theme as UiTheme } from '@immich/ui';
 
 export interface ThemeSetting {
   value: Theme;
@@ -70,6 +71,8 @@ class ThemeManager {
     document.documentElement.classList.toggle('dark', !(theme.value === Theme.LIGHT));
 
     this.#theme.current = theme;
+
+    uiTheme.value = theme.value as unknown as UiTheme;
 
     eventManager.emit('ThemeChange', theme);
   }


### PR DESCRIPTION
If the theme was switched in a way outside of the button the UI lib internal theme state would not be updated.