### PR TITLE
fix(mobile): enable backup text overflows

### DIFF
--- a/mobile/lib/presentation/widgets/backup/backup_toggle_button.widget.dart
+++ b/mobile/lib/presentation/widgets/backup/backup_toggle_button.widget.dart
@@ -143,11 +143,13 @@ class BackupToggleButtonState extends ConsumerState<BackupToggleButton> with Sin
                             Row(
                               crossAxisAlignment: CrossAxisAlignment.center,
                               children: [
-                                Text(
-                                  "enable_backup".t(context: context),
-                                  style: context.textTheme.titleMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                    color: context.primaryColor,
+                                Flexible(
+                                  child: Text(
+                                    "enable_backup".t(context: context),
+                                    style: context.textTheme.titleMedium?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                      color: context.primaryColor,
+                                    ),
                                   ),
                                 ),
                               ],


### PR DESCRIPTION
## Description
Fixes #24207
In some languages, the "Enable backup" text would overflow instead of wrapping properly.

## How Has This Been Tested?

- [x] Tested the layout with Swedish, the language in which the original bug report was made.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/0f5dce1b-afd7-4a4c-9a75-8009ff127a4a" />

</details>

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No AI was used for this PR.
