### PR TITLE
fix: label 'for' attributes in user-api-key-grid

### DIFF
--- a/web/src/lib/components/user-settings-page/user-api-key-grid.svelte
+++ b/web/src/lib/components/user-settings-page/user-api-key-grid.svelte
@@ -39,7 +39,7 @@
       checked={selectAllSubItems}
       onCheckedChange={handleSelectAllSubItems}
     />
-    <Label label={title} for={title} class="font-mono text-primary text-lg" />
+    <Label label={title} for="permission-{title}" class="font-mono text-primary text-lg" />
   </div>
   <div class="mx-6 mt-3 grid grid-cols-3 gap-2">
     {#each subItems as item (item)}
@@ -50,7 +50,7 @@
           checked={selectedItems.includes(item)}
           onCheckedChange={() => handleToggleItem(item)}
         />
-        <Label label={item} for={item} class="text-sm font-mono" />
+        <Label label={item} for="permission-{item}" class="text-sm font-mono" />
       </div>
     {/each}
   </div>


### PR DESCRIPTION
## Description

The `for` attributes on the `label` elements in the `user-api-key-grid` component are incorrect. They are `{title}` and `{item}` respectively, when the `checkbox` elements they are labels for actually use IDs `permission-{title}` and `permission-{item}`.
That means It's not possible to click the labels to toggle the checkboxes and may also confuse screen readers and other assistive technology.

## How Has This Been Tested?

Not tested. There seem to be no tests in the test suite for these API key components. However, the changes are trivial.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Code changes made with Claude Code. Pull request description lovingly hand crafted. ❤️