### PR TITLE
feat(server): exclude syncthing folders from external libraries

### DIFF
--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -223,7 +223,14 @@ export class LibraryService extends BaseService {
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**', '**/.stversions/**', '**/.stfolder/**'],
+      exclusionPatterns: dto.exclusionPatterns ?? [
+        '**/@eaDir/**',
+        '**/._*',
+        '**/#recycle/**',
+        '**/#snapshot/**',
+        '**/.stversions/**',
+        '**/.stfolder/**',
+      ],
     });
     return mapLibrary(library);
   }

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -223,7 +223,7 @@ export class LibraryService extends BaseService {
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**'],
+      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**', '**/.stversion/**', '**/.stfolder/**'],
     });
     return mapLibrary(library);
   }

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -223,7 +223,7 @@ export class LibraryService extends BaseService {
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
-      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**', '**/.stversion/**', '**/.stfolder/**'],
+      exclusionPatterns: dto.exclusionPatterns ?? ['**/@eaDir/**', '**/._*', '**/#recycle/**', '**/#snapshot/**', '**/.stversions/**', '**/.stfolder/**'],
     });
     return mapLibrary(library);
   }


### PR DESCRIPTION
## Description

SyncThing is a popular library for syncing files (like pictures) between systems. It can really mess up your library if an external library, which is also used by SyncThing, is added and these folders are not excluded.