### PR TITLE
fix(web): use full tag path when creating nested subtags

### DIFF
--- a/web/src/lib/modals/TagCreateModal.svelte
+++ b/web/src/lib/modals/TagCreateModal.svelte
@@ -14,7 +14,7 @@
 
   const { onClose, baseTag }: Props = $props();
 
-  let tagValue = $state(baseTag?.value ? `${baseTag.value}/` : '');
+  let tagValue = $state(baseTag?.path ? `${baseTag.path}/` : '');
 
   const createTag = async () => {
     const [tag] = await upsertTags({ tagUpsertDto: { tags: [tagValue] } });


### PR DESCRIPTION
## Description

This PR fixes a bug in the tag creation where only the immediate tag name was prefilled instead of the full tag path when creating nested subtags.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] I started the application using `make dev` and created a nested subtag.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="1193" height="571" alt="image" src="https://github.com/user-attachments/assets/4ee36394-473a-4307-b343-183eb2d6c6a6" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Cursor to find the part in the code that needs fixing.
