### PR TITLE
chore(docker-compose): update default pg image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.5.3@sha256:dd4d8939bc6a49feb3d3ed7914e1da2f680d1193f3430340641f17a20d99aa36
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}


### PR DESCRIPTION
## Description

The versions that included pgvecto.rs are no longer built/updated since https://github.com/immich-app/base-images/pull/279 , and now that immich is in 2.x I think we can assume most users have migrated or will heed the bump in major versions indicating a breaking change.

## How Has This Been Tested?

- [x] https://docs.immich.app/install/docker-compose/ in a codespace (seemingly works)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
  - seems N/A
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
naw
...
