### PR TITLE
fix(mobile): docs link

### DIFF
--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_dialog.dart
@@ -193,7 +193,7 @@ class ImmichAppBarDialog extends HookConsumerWidget {
             InkWell(
               onTap: () {
                 context.pop();
-                launchUrl(Uri.parse('https://immich.app'), mode: LaunchMode.externalApplication);
+                launchUrl(Uri.parse('https://docs.immich.app'), mode: LaunchMode.externalApplication);
               },
               child: Text("documentation", style: context.textTheme.bodySmall).tr(),
             ),


### PR DESCRIPTION
The button is labelled as Documentation but goes to the homepage.