### PR TITLE
fix(server): use bigrams for cjk

### DIFF
--- a/server/src/repositories/ocr.repository.ts
+++ b/server/src/repositories/ocr.repository.ts
@@ -45,6 +45,7 @@ export class OcrRepository {
           textScore: DummyValue.NUMBER,
         },
       ],
+      DummyValue.STRING,
     ],
   })
   upsert(assetId: string, ocrDataList: Insertable<AssetOcrTable>[], searchText: string) {

--- a/server/src/repositories/ocr.repository.ts
+++ b/server/src/repositories/ocr.repository.ts
@@ -47,10 +47,9 @@ export class OcrRepository {
       ],
     ],
   })
-  upsert(assetId: string, ocrDataList: Insertable<AssetOcrTable>[]) {
+  upsert(assetId: string, ocrDataList: Insertable<AssetOcrTable>[], searchText: string) {
     let query = this.db.with('deleted_ocr', (db) => db.deleteFrom('asset_ocr').where('assetId', '=', assetId));
     if (ocrDataList.length > 0) {
-      const searchText = ocrDataList.map((item) => item.text.trim()).join(' ');
       (query as any) = query
         .with('inserted_ocr', (db) => db.insertInto('asset_ocr').values(ocrDataList))
         .with('inserted_search', (db) =>

--- a/server/src/schema/migrations/1764483051488-OCRBigramsForCJK.ts
+++ b/server/src/schema/migrations/1764483051488-OCRBigramsForCJK.ts
@@ -16,4 +16,4 @@ export async function up(db: Kysely<any>): Promise<void> {
   }
 }
 
-export async function down(db: Kysely<any>): Promise<void> {}
+export async function down(): Promise<void> {}

--- a/server/src/schema/migrations/1764483051488-OCRBigramsForCJK.ts
+++ b/server/src/schema/migrations/1764483051488-OCRBigramsForCJK.ts
@@ -1,10 +1,15 @@
 import { Kysely, sql } from 'kysely';
+import { tokenizeForSearch } from 'src/utils/database';
 
 export async function up(db: Kysely<any>): Promise<void> {
   await sql`truncate ${sql.table('ocr_search')}`.execute(db);
   const batch = [];
-  for await (const { assetId, text } of db.selectFrom('asset_ocr').select(['assetId', 'text']).stream()) {
-    batch.push({ assetId, text });
+  for await (const { assetId, text } of db
+    .selectFrom('asset_ocr')
+    .select(['assetId', sql<string>`string_agg(text, ' ')`.as('text')])
+    .groupBy('assetId')
+    .stream()) {
+    batch.push({ assetId, text: tokenizeForSearch(text) });
     if (batch.length >= 5000) {
       await db.insertInto('ocr_search').values(batch).execute();
       batch.length = 0;

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -183,7 +183,7 @@ describe(OcrService.name, () => {
       expect(mocks.ocr.upsert).not.toHaveBeenCalled();
     });
 
-    describe('searchText generation', () => {
+    describe('search tokenization', () => {
       it('should generate bigrams for Chinese text', async () => {
         mockOcrResult('機器學習');
 

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -252,12 +252,12 @@ describe(OcrService.name, () => {
         expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'Hello World');
       });
 
-      it('should skip single CJK characters', async () => {
+      it('should keep single CJK characters', async () => {
         mockOcrResult('A', '中', 'B');
 
         await sut.handleOcr({ id: assetStub.image.id });
 
-        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'A B');
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'A 中 B');
       });
     });
   });

--- a/server/src/services/ocr.service.spec.ts
+++ b/server/src/services/ocr.service.spec.ts
@@ -12,7 +12,20 @@ describe(OcrService.name, () => {
     ({ sut, mocks } = newTestService(OcrService));
 
     mocks.config.getWorker.mockReturnValue(ImmichWorker.Microservices);
+    mocks.assetJob.getForOcr.mockResolvedValue({
+      visibility: AssetVisibility.Timeline,
+      previewFile: assetStub.image.files[1].path,
+    });
   });
+
+  const mockOcrResult = (...texts: string[]) => {
+    mocks.machineLearning.ocr.mockResolvedValue({
+      box: texts.flatMap((_, i) => Array.from({ length: 8 }, (_, j) => i * 10 + j)),
+      boxScore: texts.map(() => 0.9),
+      text: texts,
+      textScore: texts.map(() => 0.95),
+    });
+  };
 
   it('should work', () => {
     expect(sut).toBeDefined();
@@ -72,10 +85,6 @@ describe(OcrService.name, () => {
         text: ['One Two Three', 'Four Five'],
         textScore: [0.95, 0.85],
       });
-      mocks.assetJob.getForOcr.mockResolvedValue({
-        visibility: AssetVisibility.Timeline,
-        previewFile: assetStub.image.files[1].path,
-      });
 
       expect(await sut.handleOcr({ id: assetStub.image.id })).toEqual(JobStatus.Success);
 
@@ -88,36 +97,40 @@ describe(OcrService.name, () => {
           maxResolution: 736,
         }),
       );
-      expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, [
-        {
-          assetId: assetStub.image.id,
-          boxScore: 0.9,
-          text: 'One Two Three',
-          textScore: 0.95,
-          x1: 10,
-          y1: 20,
-          x2: 30,
-          y2: 40,
-          x3: 50,
-          y3: 60,
-          x4: 70,
-          y4: 80,
-        },
-        {
-          assetId: assetStub.image.id,
-          boxScore: 0.8,
-          text: 'Four Five',
-          textScore: 0.85,
-          x1: 90,
-          y1: 100,
-          x2: 110,
-          y2: 120,
-          x3: 130,
-          y3: 140,
-          x4: 150,
-          y4: 160,
-        },
-      ]);
+      expect(mocks.ocr.upsert).toHaveBeenCalledWith(
+        assetStub.image.id,
+        [
+          {
+            assetId: assetStub.image.id,
+            boxScore: 0.9,
+            text: 'One Two Three',
+            textScore: 0.95,
+            x1: 10,
+            y1: 20,
+            x2: 30,
+            y2: 40,
+            x3: 50,
+            y3: 60,
+            x4: 70,
+            y4: 80,
+          },
+          {
+            assetId: assetStub.image.id,
+            boxScore: 0.8,
+            text: 'Four Five',
+            textScore: 0.85,
+            x1: 90,
+            y1: 100,
+            x2: 110,
+            y2: 120,
+            x3: 130,
+            y3: 140,
+            x4: 150,
+            y4: 160,
+          },
+        ],
+        'One Two Three Four Five',
+      );
     });
 
     it('should apply config settings', async () => {
@@ -133,11 +146,7 @@ describe(OcrService.name, () => {
           },
         },
       });
-      mocks.machineLearning.ocr.mockResolvedValue({ box: [], boxScore: [], text: [], textScore: [] });
-      mocks.assetJob.getForOcr.mockResolvedValue({
-        visibility: AssetVisibility.Timeline,
-        previewFile: assetStub.image.files[1].path,
-      });
+      mockOcrResult();
 
       expect(await sut.handleOcr({ id: assetStub.image.id })).toEqual(JobStatus.Success);
 
@@ -150,7 +159,7 @@ describe(OcrService.name, () => {
           maxResolution: 1500,
         }),
       );
-      expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, []);
+      expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, [], '');
     });
 
     it('should skip invisible assets', async () => {
@@ -172,6 +181,84 @@ describe(OcrService.name, () => {
 
       expect(mocks.machineLearning.ocr).not.toHaveBeenCalled();
       expect(mocks.ocr.upsert).not.toHaveBeenCalled();
+    });
+
+    describe('searchText generation', () => {
+      it('should generate bigrams for Chinese text', async () => {
+        mockOcrResult('機器學習');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), '機器 器學 學習');
+      });
+
+      it('should generate bigrams for Japanese text', async () => {
+        mockOcrResult('テスト');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'テス スト');
+      });
+
+      it('should generate bigrams for Korean text', async () => {
+        mockOcrResult('한국어');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), '한국 국어');
+      });
+
+      it('should pass through Latin text unchanged', async () => {
+        mockOcrResult('Hello World');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'Hello World');
+      });
+
+      it('should handle mixed CJK and Latin text', async () => {
+        mockOcrResult('機器學習Model');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), '機器 器學 學習 Model');
+      });
+
+      it('should handle year followed by CJK', async () => {
+        mockOcrResult('2024年レポート');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(
+          assetStub.image.id,
+          expect.any(Array),
+          '2024 年レ レポ ポー ート',
+        );
+      });
+
+      it('should join multiple OCR boxes', async () => {
+        mockOcrResult('機器', 'Learning');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), '機器 Learning');
+      });
+
+      it('should normalize whitespace', async () => {
+        mockOcrResult('  Hello   World  ');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'Hello World');
+      });
+
+      it('should skip single CJK characters', async () => {
+        mockOcrResult('A', '中', 'B');
+
+        await sut.handleOcr({ id: assetStub.image.id });
+
+        expect(mocks.ocr.upsert).toHaveBeenCalledWith(assetStub.image.id, expect.any(Array), 'A B');
+      });
     });
   });
 });

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -63,7 +63,7 @@ export class OcrService extends BaseService {
     return JobStatus.Success;
   }
 
-  parseOcrResults(id: string, { box, boxScore, text, textScore }: OCR) {
+  private parseOcrResults(id: string, { box, boxScore, text, textScore }: OCR) {
     const ocrDataList = [];
     const searchTokens = [];
     for (let i = 0; i < text.length; i++) {

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -65,7 +65,7 @@ export class OcrService extends BaseService {
 
   parseOcrResults(id: string, { box, boxScore, text, textScore }: OCR) {
     const ocrDataList = [];
-    let searchText = '';
+    const searchTokens = [];
     for (let i = 0; i < text.length; i++) {
       const rawText = text[i];
       const boxOffset = i * 8;
@@ -83,15 +83,9 @@ export class OcrService extends BaseService {
         textScore: textScore[i],
         text: rawText,
       });
-      const tokens = tokenizeForSearch(rawText);
-      if (tokens) {
-        if (searchText) {
-          searchText += ' ';
-        }
-        searchText += tokens;
-      }
+      searchTokens.push(...tokenizeForSearch(rawText));
     }
 
-    return { ocrDataList, searchText };
+    return { ocrDataList, searchText: searchTokens.join(' ') };
   }
 }

--- a/server/src/services/ocr.service.ts
+++ b/server/src/services/ocr.service.ts
@@ -85,7 +85,9 @@ export class OcrService extends BaseService {
       });
       const tokens = tokenizeForSearch(rawText);
       if (tokens) {
-        if (searchText) searchText += ' ';
+        if (searchText) {
+          searchText += ' ';
+        }
         searchText += tokens;
       }
     }

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -306,6 +306,44 @@ export function withTagId<O>(qb: SelectQueryBuilder<DB, 'asset', O>, tagId: stri
   );
 }
 
+const isCJK = (c: number): boolean =>
+  (c >= 0x4e_00 && c <= 0x9f_ff) ||
+  (c >= 0xac_00 && c <= 0xd7_af) ||
+  (c >= 0x30_40 && c <= 0x30_9f) ||
+  (c >= 0x30_a0 && c <= 0x30_ff) ||
+  (c >= 0x34_00 && c <= 0x4d_bf);
+
+export const tokenizeForSearch = (text: string): string => {
+  /* eslint-disable unicorn/prefer-code-point */
+  let result = '';
+  let i = 0;
+  while (i < text.length) {
+    const c = text.charCodeAt(i);
+    if (c <= 32) {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    if (isCJK(c)) {
+      while (i < text.length && isCJK(text.charCodeAt(i))) {
+        i++;
+      }
+      for (let k = start; k < i - 1; k++) {
+        if (result) result += ' ';
+        result += text[k] + text[k + 1];
+      }
+    } else {
+      while (i < text.length && text.charCodeAt(i) > 32 && !isCJK(text.charCodeAt(i))) {
+        i++;
+      }
+      if (result) result += ' ';
+      result += text.slice(start, i);
+    }
+  }
+  return result;
+};
+
 const joinDeduplicationPlugin = new DeduplicateJoinsPlugin();
 /** TODO: This should only be used for search-related queries, not as a general purpose query builder */
 
@@ -391,7 +429,7 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
     .$if(!!options.ocr, (qb) =>
       qb
         .innerJoin('ocr_search', 'asset.id', 'ocr_search.assetId')
-        .where(() => sql`f_unaccent(ocr_search.text) %>> f_unaccent(${options.ocr!})`),
+        .where(() => sql`f_unaccent(ocr_search.text) %>> f_unaccent(${tokenizeForSearch(options.ocr!)})`),
     )
     .$if(!!options.type, (qb) => qb.where('asset.type', '=', options.type!))
     .$if(options.isFavorite !== undefined, (qb) => qb.where('asset.isFavorite', '=', options.isFavorite!))

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -329,11 +329,18 @@ export const tokenizeForSearch = (text: string): string => {
       while (i < text.length && isCJK(text.charCodeAt(i))) {
         i++;
       }
-      for (let k = start; k < i - 1; k++) {
+      if (i - start === 1) {
         if (result) {
           result += ' ';
         }
-        result += text[k] + text[k + 1];
+        result += text[start];
+      } else {
+        for (let k = start; k < i - 1; k++) {
+          if (result) {
+            result += ' ';
+          }
+          result += text[k] + text[k + 1];
+        }
       }
     } else {
       while (i < text.length && text.charCodeAt(i) > 32 && !isCJK(text.charCodeAt(i))) {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -330,14 +330,18 @@ export const tokenizeForSearch = (text: string): string => {
         i++;
       }
       for (let k = start; k < i - 1; k++) {
-        if (result) result += ' ';
+        if (result) {
+          result += ' ';
+        }
         result += text[k] + text[k + 1];
       }
     } else {
       while (i < text.length && text.charCodeAt(i) > 32 && !isCJK(text.charCodeAt(i))) {
         i++;
       }
-      if (result) result += ' ';
+      if (result) {
+        result += ' ';
+      }
       result += text.slice(start, i);
     }
   }


### PR DESCRIPTION
## Description

OCR search currently doesn't work very well for CJK scripts. This is in large part due to a trigram in these scripts having much higher semantic density than Latin script. Preprocessing this text into bigrams results in higher recall without lowering accuracy or impacting other languages, as lowering the score threshold would do.

Text: 中关村延庆

| Query       | Before (raw)     | After (bigrams) |
  |-------------|------------------|-----------------|
  | 中           | 0.143 (excluded) | 0.25 (excluded) |
  | 中关          | 0.286 (excluded) | 1.0 (included)  |
  | 中关村 (tokenized to 中关 关村) | 0.429 (excluded) | 1.0 (included)  |

As this PR includes a migration, re-running OCR is not necessary.

Fixes #23507