### PR TITLE
fix(web): open onboarding documentation link in new tab

### DIFF
--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -9,7 +9,7 @@
   <p>
     <FormatMessage key="admin.storage_template_onboarding_description_v2">
       {#snippet children({ message })}
-        <Link isExternal href="https://docs.immich.app/administration/storage-template">{message}</Link>
+        <Link href="https://docs.immich.app/administration/storage-template">{message}</Link>
       {/snippet}
     </FormatMessage>
   </p>

--- a/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
+++ b/web/src/lib/components/onboarding-page/onboarding-storage-template.svelte
@@ -2,13 +2,14 @@
   import StorageTemplateSettings from '$lib/components/admin-settings/StorageTemplateSettings.svelte';
   import FormatMessage from '$lib/elements/FormatMessage.svelte';
   import { user } from '$lib/stores/user.store';
+  import { Link } from '@immich/ui';
 </script>
 
 <div class="flex flex-col">
   <p>
     <FormatMessage key="admin.storage_template_onboarding_description_v2">
       {#snippet children({ message })}
-        <a class="underline" href="https://docs.immich.app/administration/storage-template">{message}</a>
+        <Link isExternal href="https://docs.immich.app/administration/storage-template">{message}</Link>
       {/snippet}
     </FormatMessage>
   </p>


### PR DESCRIPTION
Fix documentation link breaking onboarding flow

## Description

Clicking the documentation link in the storage template step navigated away from the onboarding page. This adds `target="_blank"` to open it in a new tab, preserving the onboarding flow.

## How Has This Been Tested?

- [x] Manually verified the link opens in a new tab.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Full execution.