### PR TITLE
fix(web): #21171

### DIFF
--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -426,7 +426,7 @@
         enableRouting={viewMode === AlbumPageViewMode.SELECT_ASSETS ? false : true}
         {album}
         {albumUsers}
-        {timelineManager}
+        bind:timelineManager
         {options}
         assetInteraction={currentAssetIntersection}
         {isShared}


### PR DESCRIPTION
## Description
- Fixed the cause of the e2e tests failure of https://github.com/immich-app/immich/pull/21171
- The cause was that the add_photos button was not functioning due to the following:
  - By reverting {timelineManager} to bind:timelineManager, the Timeline component can correctly return the timelineManager instance to the parent component
