### PR TITLE
feat(ml): Offer environment variables to set the listener host and port

### DIFF
--- a/machine-learning/immich_ml/config.py
+++ b/machine-learning/immich_ml/config.py
@@ -88,8 +88,8 @@ class Settings(BaseSettings):
 class NonPrefixedSettings(BaseSettings):
     model_config = SettingsConfigDict(case_sensitive=False)
 
-    immich_host: str = "[::]"
-    immich_port: int = 3003
+    immich_host: str = os.getenv("MACHINE_LEARNING_HOST", "[::]")
+    immich_port: int = int(os.getenv("MACHINE_LEARNING_PORT", "3003"))
     immich_log_level: str = "info"
     no_color: bool = False
 


### PR DESCRIPTION
## Description

The machine-learning server listens hard coded on 0.0.0.0 and port 3003. There are currently no options to define listener host or port. I propose to introduce environment variables `MACHINE_LEARNING_HOST` and `MACHINE_LEARNING_PORT` to offer such configuration. If those variables are not set, the previously existing default apply.

The environment variable names were chosen for consistency. All/Most ML specific environment variable start with `MACHINE_LEARNING_`, all/most main server specifics start with `IMMICH_`

This is useful for packaged builds and especially for installations on the same machine, where the machine-learning server can be set to localhost.

Any server should have a configuration to set the listener address.

No documentation has been modified as there is no mention needed for the official docker compose build (defaults stay the same). There are also other environment variables not documented which are also not relevant for the docker compose build.

There could be a documentation section for a complete list of available environment variables focused per service, but this is out of the scope for this PR.

I'm currently using this exact change as a patch in my downstream packaging.

Fixes no reported issue

## How Has This Been Tested?

- manually by setting and not setting the environment variables

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I've used an LLM to suggest me the change as a shortcut since I'm not familiar with python. I've verified the changes manually.
