### PR TITLE
feat(server): add storage-at-rest encryption columns and official migration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,80 +1,96 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "label": "Fix Permissions, Install Dependencies",
-      "type": "shell",
-      "command": "[ -f /immich-devcontainer/container-start.sh ] && /immich-devcontainer/container-start.sh || exit 0",
-      "isBackground": true,
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "dedicated",
-        "showReuseMessage": true,
-        "clear": false,
-        "group": "Devcontainer tasks",
-        "close": true
-      },
-      "runOptions": {
-        "runOn": "default"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Immich API Server (Nest)",
-      "dependsOn": ["Fix Permissions, Install Dependencies"],
-      "type": "shell",
-      "command": "[ -f /immich-devcontainer/container-start-backend.sh ] && /immich-devcontainer/container-start-backend.sh || exit 0",
-      "isBackground": true,
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "dedicated",
-        "showReuseMessage": true,
-        "clear": false,
-        "group": "Devcontainer tasks",
-        "close": true
-      },
-      "runOptions": {
-        "runOn": "default"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Immich Web Server (Vite)",
-      "dependsOn": ["Fix Permissions, Install Dependencies"],
-      "type": "shell",
-      "command": "[ -f /immich-devcontainer/container-start-frontend.sh ] && /immich-devcontainer/container-start-frontend.sh || exit 0",
-      "isBackground": true,
-      "presentation": {
-        "echo": true,
-        "reveal": "always",
-        "focus": false,
-        "panel": "dedicated",
-        "showReuseMessage": true,
-        "clear": false,
-        "group": "Devcontainer tasks",
-        "close": true
-      },
-      "runOptions": {
-        "runOn": "default"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Immich Server and Web",
-      "dependsOn": ["Immich Web Server (Vite)", "Immich API Server (Nest)"],
-      "runOptions": {
-        "runOn": "folderOpen"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Build Immich CLI",
-      "type": "shell",
-      "command": "pnpm --filter cli build:dev"
-    }
-  ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Fix Permissions, Install Dependencies",
+			"type": "shell",
+			"command": "[ -f /immich-devcontainer/container-start.sh ] && /immich-devcontainer/container-start.sh || exit 0",
+			"isBackground": true,
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": true,
+				"clear": false,
+				"group": "Devcontainer tasks",
+				"close": true
+			},
+			"runOptions": {
+				"runOn": "default"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "Immich API Server (Nest)",
+			"dependsOn": [
+				"Fix Permissions, Install Dependencies"
+			],
+			"type": "shell",
+			"command": "[ -f /immich-devcontainer/container-start-backend.sh ] && /immich-devcontainer/container-start-backend.sh || exit 0",
+			"isBackground": true,
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": true,
+				"clear": false,
+				"group": "Devcontainer tasks",
+				"close": true
+			},
+			"runOptions": {
+				"runOn": "default"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "Immich Web Server (Vite)",
+			"dependsOn": [
+				"Fix Permissions, Install Dependencies"
+			],
+			"type": "shell",
+			"command": "[ -f /immich-devcontainer/container-start-frontend.sh ] && /immich-devcontainer/container-start-frontend.sh || exit 0",
+			"isBackground": true,
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
+				"focus": false,
+				"panel": "dedicated",
+				"showReuseMessage": true,
+				"clear": false,
+				"group": "Devcontainer tasks",
+				"close": true
+			},
+			"runOptions": {
+				"runOn": "default"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "Immich Server and Web",
+			"dependsOn": [
+				"Immich Web Server (Vite)",
+				"Immich API Server (Nest)"
+			],
+			"runOptions": {
+				"runOn": "folderOpen"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "Build Immich CLI",
+			"type": "shell",
+			"command": "pnpm --filter cli build:dev"
+		},
+		{
+			"label": "Run Server Build and Tests",
+			"type": "shell",
+			"command": "pnpm --filter server build && pnpm --filter server test",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		}
+	]
 }

--- a/docs/architecture/storage-encryption.md
+++ b/docs/architecture/storage-encryption.md
@@ -1,0 +1,109 @@
+# Immich Storage Encryption (At-Rest)
+
+This document outlines a phased approach to encrypt assets (photos/videos and derived files) at rest in Immich.
+
+## Goals
+- Protect media bytes on disk or object storage via authenticated encryption.
+- Minimize disruption: reuse existing upload/serve paths through storage abstractions.
+- Preserve server features (thumbnails, previews, metadata extraction, ML) with transparent decrypt on read.
+- Support future key rotation and optional per-user keys without rearchitecting core flows.
+
+## Scope
+- Originals, sidecars, thumbnails, previews, encoded videos.
+- Local filesystem; future-ready for object storage.
+- Server-Side Encryption (SSE) using envelope encryption in Phase 1; optional per-user keys later.
+
+## Architecture Overview
+
+- Crypto: AES-256-GCM per file, random IV, authentication tag for integrity.
+- Keys:
+  - Data Encryption Key (DEK): randomly generated per file.
+  - Key Encryption Key (KEK): master server key (local secret or KMS-managed).
+  - Envelope: store `encryptedDek` (DEK wrapped by KEK) alongside file metadata.
+
+- Metadata: track encryption status and parameters per file record:
+  - `encrypted: boolean`
+  - `encryptionAlgo: 'AES-256-GCM'`
+  - `encryptionIv: base64`
+  - `encryptedDek: base64`
+  - `encryptionTag: base64` (if not embedded in file stream)
+  - `encryptionVersion: number`
+
+- Storage Repository additions:
+  - Streaming encrypt on write: `createEncryptedWriteStream(path, params)`.
+  - Streaming decrypt on read: `createDecryptedReadStream(path, params)`.
+  - Branch existing `createReadStream`/`createWriteStream` when file is marked encrypted.
+
+- Config additions:
+  - `storageEncryption.enabled: boolean`
+  - `storageEncryption.mode: 'sse' | 'per-user'` (future)
+  - `storageEncryption.algorithm: 'AES-256-GCM'`
+  - `storageEncryption.kek`: `{ type: 'local' | 'kms', secret?: string, provider?: 'aws'|'gcp'|'azure', keyId?: string }`
+
+## Data Flow Changes
+
+1) Upload
+- Compute plaintext checksum before encryption for dedupe.
+- Generate DEK + IV.
+- Stream-encrypt upload temp file into final location.
+- Store encryption metadata (encryptedDek, IV, algo, version) with asset file record; store plaintext checksum.
+
+2) Serve (Download/Playback/Thumbnails)
+- Storage layer transparently decrypts when reading encrypted files.
+- Existing controllers/services continue to call repository methods; no API changes.
+
+3) Derived Assets
+- Generators read decrypted streams, process, and write encrypted outputs.
+- Ensure all file IO goes through `StorageRepository`.
+
+4) Verification & Dedupe
+- Size checks unaffected.
+- Checksum comparisons use stored plaintext checksum captured at upload.
+
+## Key Management
+
+Phase 1 (SSE): single KEK
+- Local: KEK from env/secret; rotate by rewrapping DEKs and updating metadata.
+- KMS: use provider’s key to wrap/unwrap DEKs; audit and rotation via KMS.
+
+Phase 2+: Per-user KEKs
+- Each user has a KEK; DEKs wrapped to user KEK.
+- Sharing: rewrap DEKs to recipient KEKs or use group KEK.
+
+## Migration Strategy
+
+1) Schema migration: add encryption columns to `asset_file` table and possibly `asset` for originals.
+2) Config defaults: encryption disabled.
+3) Backfill: optional job to re-encrypt existing files in batches and update metadata.
+4) Rollback: decrypt and clear metadata if needed.
+
+## Risks & Considerations
+
+- Performance: AES-GCM is fast; expect modest CPU overhead.
+- Recovery: backups require KEK availability; document ops procedures.
+- Integrity: GCM tag verification on reads; fail closed on mismatch.
+- Direct FS access: audit and replace with repository methods.
+- Object storage SSE: avoid double-encrypt unless mandated; allow mode selection per backend.
+
+## Phased Implementation
+
+Phase 1 (baseline, 2–3 weeks)
+- Add config and crypto helpers.
+- Implement streaming encrypt/decrypt helpers.
+- Wire upload and read paths to use helpers via `StorageRepository`.
+- Store plaintext checksums in DB; adapt duplicate checks to use DB value.
+
+Phase 2 (derived assets, 1–2 weeks)
+- Encrypt thumbnails/previews/encoded videos.
+- Ensure jobs/services read via repository.
+
+Phase 3 (KMS & rotation, ~2 weeks)
+- Add KMS integration; implement DEK rewrap jobs and admin controls.
+
+Phase 4 (per-user keys, 3–4+ weeks)
+- Introduce per-user KEKs; implement sharing rewrap and UI.
+
+## Minimal Scaffold (this PR)
+
+- `server/src/utils/encryption.ts`: streaming AES-GCM encrypt/decrypt helpers and envelope routines.
+- No behavior changes by default; ready to be integrated in `StorageRepository`.

--- a/server/migrations/20251130_storage_encryption.sql
+++ b/server/migrations/20251130_storage_encryption.sql
@@ -1,0 +1,63 @@
+-- Storage encryption columns for originals and derived files
+-- Up migration
+
+BEGIN;
+
+-- asset: originals encryption metadata
+ALTER TABLE IF EXISTS "asset"
+  ADD COLUMN IF NOT EXISTS "encrypted" boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "encryptionAlgo" varchar NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionIv" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptedDek" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionTag" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionVersion" integer NULL,
+  ADD COLUMN IF NOT EXISTS "plaintextChecksum" bytea NULL;
+
+-- Ensure default applied to existing rows
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'asset') THEN
+    UPDATE "asset" SET "encrypted" = COALESCE("encrypted", false) WHERE TRUE;
+  END IF;
+END $$;
+
+-- asset_file: derived files encryption metadata
+ALTER TABLE IF EXISTS "asset_file"
+  ADD COLUMN IF NOT EXISTS "encrypted" boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "encryptionAlgo" varchar NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionIv" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptedDek" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionTag" bytea NULL,
+  ADD COLUMN IF NOT EXISTS "encryptionVersion" integer NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'asset_file') THEN
+    UPDATE "asset_file" SET "encrypted" = COALESCE("encrypted", false) WHERE TRUE;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- Down migration (rollback)
+-- Note: dropping columns will remove encryption metadata
+-- Execute manually if your tooling does not support down migrations
+--
+-- BEGIN;
+-- ALTER TABLE "asset" 
+--   DROP COLUMN IF EXISTS "plaintextChecksum",
+--   DROP COLUMN IF EXISTS "encryptionVersion",
+--   DROP COLUMN IF EXISTS "encryptionTag",
+--   DROP COLUMN IF EXISTS "encryptedDek",
+--   DROP COLUMN IF EXISTS "encryptionIv",
+--   DROP COLUMN IF EXISTS "encryptionAlgo",
+--   DROP COLUMN IF EXISTS "encrypted";
+--
+-- ALTER TABLE "asset_file"
+--   DROP COLUMN IF EXISTS "encryptionVersion",
+--   DROP COLUMN IF EXISTS "encryptionTag",
+--   DROP COLUMN IF EXISTS "encryptedDek",
+--   DROP COLUMN IF EXISTS "encryptionIv",
+--   DROP COLUMN IF EXISTS "encryptionAlgo",
+--   DROP COLUMN IF EXISTS "encrypted";
+-- COMMIT;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,17 +1,17 @@
 import { CronExpression } from '@nestjs/schedule';
 import {
-  AudioCodec,
-  Colorspace,
-  CQMode,
-  ImageFormat,
-  LogLevel,
-  OAuthTokenEndpointAuthMethod,
-  QueueName,
-  ToneMapping,
-  TranscodeHardwareAcceleration,
-  TranscodePolicy,
-  VideoCodec,
-  VideoContainer,
+    AudioCodec,
+    Colorspace,
+    CQMode,
+    ImageFormat,
+    LogLevel,
+    OAuthTokenEndpointAuthMethod,
+    QueueName,
+    ToneMapping,
+    TranscodeHardwareAcceleration,
+    TranscodePolicy,
+    VideoCodec,
+    VideoContainer,
 } from 'src/enum';
 import { ConcurrentQueueName, FullsizeImageOptions, ImageOptions } from 'src/types';
 
@@ -186,6 +186,19 @@ export interface SystemConfig {
   };
   user: {
     deleteDelay: number;
+  };
+
+  // Storage encryption (at-rest) configuration
+  storageEncryption?: {
+    enabled: boolean;
+    algorithm: 'AES-256-GCM';
+    mode: 'sse' | 'per-user';
+    kek: {
+      type: 'local' | 'kms';
+      secret?: string; // for local
+      provider?: 'aws' | 'gcp' | 'azure';
+      keyId?: string; // for KMS
+    };
   };
 }
 

--- a/server/src/schema/migrations/1764556323636-storage_encryption_columns.ts
+++ b/server/src/schema/migrations/1764556323636-storage_encryption_columns.ts
@@ -1,0 +1,43 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "asset" 
+    ADD COLUMN IF NOT EXISTS "encrypted" boolean DEFAULT false,
+    ADD COLUMN IF NOT EXISTS "encryptionAlgo" varchar NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionIv" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptedDek" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionTag" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionVersion" integer NULL,
+    ADD COLUMN IF NOT EXISTS "plaintextChecksum" bytea NULL;`.execute(db);
+
+  await sql`UPDATE "asset" SET "encrypted" = COALESCE("encrypted", false);`.execute(db);
+
+  await sql`ALTER TABLE "asset_file"
+    ADD COLUMN IF NOT EXISTS "encrypted" boolean DEFAULT false,
+    ADD COLUMN IF NOT EXISTS "encryptionAlgo" varchar NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionIv" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptedDek" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionTag" bytea NULL,
+    ADD COLUMN IF NOT EXISTS "encryptionVersion" integer NULL;`.execute(db);
+
+  await sql`UPDATE "asset_file" SET "encrypted" = COALESCE("encrypted", false);`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "asset" 
+    DROP COLUMN IF EXISTS "plaintextChecksum",
+    DROP COLUMN IF EXISTS "encryptionVersion",
+    DROP COLUMN IF EXISTS "encryptionTag",
+    DROP COLUMN IF EXISTS "encryptedDek",
+    DROP COLUMN IF EXISTS "encryptionIv",
+    DROP COLUMN IF EXISTS "encryptionAlgo",
+    DROP COLUMN IF EXISTS "encrypted";`.execute(db);
+
+  await sql`ALTER TABLE "asset_file"
+    DROP COLUMN IF EXISTS "encryptionVersion",
+    DROP COLUMN IF EXISTS "encryptionTag",
+    DROP COLUMN IF EXISTS "encryptedDek",
+    DROP COLUMN IF EXISTS "encryptionIv",
+    DROP COLUMN IF EXISTS "encryptionAlgo",
+    DROP COLUMN IF EXISTS "encrypted";`.execute(db);
+}

--- a/server/src/schema/tables/asset-file.table.ts
+++ b/server/src/schema/tables/asset-file.table.ts
@@ -2,15 +2,15 @@ import { UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
 import { AssetFileType } from 'src/enum';
 import { AssetTable } from 'src/schema/tables/asset.table';
 import {
-  Column,
-  CreateDateColumn,
-  ForeignKeyColumn,
-  Generated,
-  PrimaryGeneratedColumn,
-  Table,
-  Timestamp,
-  Unique,
-  UpdateDateColumn,
+    Column,
+    CreateDateColumn,
+    ForeignKeyColumn,
+    Generated,
+    PrimaryGeneratedColumn,
+    Table,
+    Timestamp,
+    Unique,
+    UpdateDateColumn,
 } from 'src/sql-tools';
 
 @Table('asset_file')
@@ -34,6 +34,25 @@ export class AssetFileTable {
 
   @Column()
   path!: string;
+
+  // Encryption metadata (nullable when not encrypted)
+  @Column({ type: 'boolean', default: false })
+  encrypted!: Generated<boolean>;
+
+  @Column({ type: 'character varying', nullable: true })
+  encryptionAlgo!: string | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptionIv!: Buffer | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptedDek!: Buffer | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptionTag!: Buffer | null;
+
+  @Column({ type: 'integer', nullable: true })
+  encryptionVersion!: number | null;
 
   @UpdateIdColumn({ index: true })
   updateId!: Generated<string>;

--- a/server/src/schema/tables/asset.table.ts
+++ b/server/src/schema/tables/asset.table.ts
@@ -6,17 +6,17 @@ import { LibraryTable } from 'src/schema/tables/library.table';
 import { StackTable } from 'src/schema/tables/stack.table';
 import { UserTable } from 'src/schema/tables/user.table';
 import {
-  AfterDeleteTrigger,
-  Column,
-  CreateDateColumn,
-  DeleteDateColumn,
-  ForeignKeyColumn,
-  Generated,
-  Index,
-  PrimaryGeneratedColumn,
-  Table,
-  Timestamp,
-  UpdateDateColumn,
+    AfterDeleteTrigger,
+    Column,
+    CreateDateColumn,
+    DeleteDateColumn,
+    ForeignKeyColumn,
+    Generated,
+    Index,
+    PrimaryGeneratedColumn,
+    Table,
+    Timestamp,
+    UpdateDateColumn,
 } from 'src/sql-tools';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
 
@@ -74,6 +74,29 @@ export class AssetTable {
 
   @Column()
   originalPath!: string;
+
+  // Encryption metadata for original asset file (nullable when not encrypted)
+  @Column({ type: 'boolean', default: false })
+  encrypted!: Generated<boolean>;
+
+  @Column({ type: 'character varying', nullable: true })
+  encryptionAlgo!: string | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptionIv!: Buffer | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptedDek!: Buffer | null;
+
+  @Column({ type: 'bytea', nullable: true })
+  encryptionTag!: Buffer | null;
+
+  @Column({ type: 'integer', nullable: true })
+  encryptionVersion!: number | null;
+
+  // Plaintext checksum stored for dedupe/verification when encrypted at rest
+  @Column({ type: 'bytea', nullable: true })
+  plaintextChecksum!: Buffer | null;
 
   @Column({ type: 'timestamp with time zone', index: true })
   fileCreatedAt!: Timestamp;

--- a/server/src/utils/encryption.ts
+++ b/server/src/utils/encryption.ts
@@ -1,0 +1,138 @@
+import { CipherGCMTypes, createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { Readable, Transform, TransformCallback, Writable } from 'node:stream';
+
+export type EncryptionAlgo = 'AES-256-GCM';
+
+export interface EnvelopeParams {
+  algo: EncryptionAlgo;
+  iv: Buffer;
+  encryptedDek: Buffer; // DEK wrapped by KEK
+  version: number;
+}
+
+export interface EncryptParams {
+  algo: EncryptionAlgo;
+  iv: Buffer;
+  dek: Buffer; // plaintext DEK
+}
+
+export interface DecryptParams {
+  algo: EncryptionAlgo;
+  iv: Buffer;
+  dek: Buffer; // plaintext DEK
+  authTag?: Buffer; // optional external tag if not embedded
+}
+
+export function generateIv(length = 12): Buffer {
+  // GCM standard 12-byte IV
+  return randomBytes(length);
+}
+
+export function generateDek(length = 32): Buffer {
+  // 32 bytes for AES-256
+  return randomBytes(length);
+}
+
+export function createEncryptStream(params: EncryptParams): {
+  cipher: ReturnType<typeof createCipheriv>;
+  stream: Transform;
+  getAuthTag: () => Buffer;
+} {
+  const { algo, iv, dek } = params;
+  const nodeAlgo: CipherGCMTypes = algo === 'AES-256-GCM' ? 'aes-256-gcm' : 'aes-256-gcm';
+  const cipher = createCipheriv(nodeAlgo, dek, iv, { authTagLength: 16 });
+
+  const stream = new Transform({
+    transform(chunk: Buffer, _enc: BufferEncoding, cb: TransformCallback) {
+      try {
+        const encrypted = cipher.update(chunk);
+        cb(null, encrypted);
+      } catch (e) {
+        cb(e as Error);
+      }
+    },
+    flush(cb: TransformCallback) {
+      try {
+        const final = cipher.final();
+        if (final.length) this.push(final);
+        cb();
+      } catch (e) {
+        cb(e as Error);
+      }
+    },
+  });
+
+  const getAuthTag = () => cipher.getAuthTag();
+  return { cipher, stream, getAuthTag };
+}
+
+export function createDecryptStream(params: DecryptParams): {
+  decipher: ReturnType<typeof createDecipheriv>;
+  stream: Transform;
+} {
+  const { algo, iv, dek, authTag } = params;
+  const nodeAlgo: CipherGCMTypes = algo === 'AES-256-GCM' ? 'aes-256-gcm' : 'aes-256-gcm';
+  const decipher = createDecipheriv(nodeAlgo, dek, iv);
+  if (authTag) {
+    decipher.setAuthTag(authTag);
+  }
+
+  const stream = new Transform({
+    transform(chunk: Buffer, _enc: BufferEncoding, cb: TransformCallback) {
+      try {
+        const decrypted = decipher.update(chunk);
+        cb(null, decrypted);
+      } catch (e) {
+        cb(e as Error);
+      }
+    },
+    flush(cb: TransformCallback) {
+      try {
+        const final = decipher.final();
+        if (final.length) this.push(final);
+        cb();
+      } catch (e) {
+        cb(e as Error);
+      }
+    },
+  });
+
+  return { decipher, stream };
+}
+
+// Helper to pipe read->encrypt->write and return authTag
+export async function encryptFileStream(
+  input: Readable,
+  output: Writable,
+  params: EncryptParams,
+): Promise<Buffer> {
+  const { stream, getAuthTag } = createEncryptStream(params);
+  await new Promise<void>((resolve, reject) => {
+    input
+      .on('error', reject)
+      .pipe(stream)
+      .on('error', reject)
+      .pipe(output)
+      .on('error', reject)
+      .on('finish', () => resolve());
+  });
+  return getAuthTag();
+}
+
+// Helper to pipe read->decrypt->write
+export async function decryptFileStream(
+  input: Readable,
+  output: Writable,
+  params: DecryptParams,
+): Promise<void> {
+  const { stream } = createDecryptStream(params);
+  await new Promise<void>((resolve, reject) => {
+    input
+      .on('error', reject)
+      .pipe(stream)
+      .on('error', reject)
+      .pipe(output)
+      .on('error', reject)
+      .on('finish', () => resolve());
+  });
+}

--- a/server/test/repositories/crypto.repository.mock.ts
+++ b/server/test/repositories/crypto.repository.mock.ts
@@ -15,5 +15,9 @@ export const newCryptoRepositoryMock = (): Mocked<RepositoryInterface<CryptoRepo
     randomBytesAsText: vitest.fn().mockReturnValue(Buffer.from('random-bytes').toString('base64')),
     signJwt: vitest.fn().mockReturnValue('mock-jwt-token'),
     verifyJwt: vitest.fn().mockImplementation((token) => ({ verified: true, token })),
+    // storage encryption helpers (no-op defaults)
+    deriveKek: vitest.fn().mockImplementation((secret: string) => Buffer.from(secret)),
+    wrapDek: vitest.fn().mockImplementation((kek: Buffer, dek: Buffer) => Buffer.from(`${kek.toString('hex')}:${dek.toString('hex')}`)),
+    unwrapDek: vitest.fn().mockImplementation((kek: Buffer, wrapped: Buffer) => Buffer.from('dek')),
   };
 };


### PR DESCRIPTION
- Add columns on asset/asset_file: encrypted, encryptionAlgo, encryptionIv, encryptedDek, encryptionTag, encryptionVersion; asset also plaintextChecksum
- Place TS migration under server/src/schema/migrations; provide down migration
- Validate against full schema via migrations.js on Postgres 17 + pgvector
- All server tests pass (93 files); remove temporary baseline stub SQL
