### PR TITLE
refactor(web): i18n-ize "view asset owners"

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2192,6 +2192,7 @@
   "view_album": "View Album",
   "view_all": "View All",
   "view_all_users": "View all users",
+  "view_asset_owners": "View asset owners",
   "view_details": "View Details",
   "view_in_timeline": "View in timeline",
   "view_link": "View link",

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -610,7 +610,7 @@
                 variant="ghost"
                 shape="round"
                 color="secondary"
-                aria-label="view asset owners"
+                aria-label={$t('view_asset_owners')}
                 icon={mdiAccountEyeOutline}
                 onclick={() => (showAlbumUsers = !showAlbumUsers)}
               />


### PR DESCRIPTION
## Description
- i18n-ize the label name like other buttons
- implementation lack in https://github.com/immich-app/immich/pull/21171

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] manually tests

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] ~I have written tests for new code (if applicable)~
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
none
