### PR TITLE
fix(ml): do not upscale preview

### DIFF
--- a/machine-learning/immich_ml/models/ocr/detection.py
+++ b/machine-learning/immich_ml/models/ocr/detection.py
@@ -82,6 +82,7 @@ class TextDetector(InferenceModel):
             ratio = float(self.max_resolution) / img.height
         else:
             ratio = float(self.max_resolution) / img.width
+        ratio = min(ratio, 1.0)
 
         resize_h = int(img.height * ratio)
         resize_w = int(img.width * ratio)


### PR DESCRIPTION
## Description

The current behavior upscales images if the max_resolution is higher than the preview. This PR caps it to the original resolution.