### PR TITLE
feat(server): log all thumbnail generation attempts at verbose level

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -174,8 +174,10 @@ export class MediaService extends BaseService {
       thumbhash: Buffer;
     };
     if (asset.type === AssetType.Video || asset.originalFileName.toLowerCase().endsWith('.gif')) {
+      this.logger.verbose(`Thumbnail generation for video ${id} ${asset.originalPath}`);
       generated = await this.generateVideoThumbnails(asset);
     } else if (asset.type === AssetType.Image) {
+      this.logger.verbose(`Thumbnail generation for image ${id} ${asset.originalPath}`);
       generated = await this.generateImageThumbnails(asset);
     } else {
       this.logger.warn(`Skipping thumbnail generation for asset ${id}: ${asset.type} is not an image or video`);


### PR DESCRIPTION
## Description

Add logging of the asset ID and file path right before executing `generateImageThumbnails` and `generateVideoThumbnails`.
This would be useful when Immich crashes in native code during thumbnail generation.

Currently, right before the crash, there are either no traces in log or red herrings such as "Unable to run job handler (AssetGenerateThumbnails): Error: VipsJpeg: premature end of JPEG image".

A couple of workarounds used so far to pinpoint offending assets:
- manually bisect through the library
- patch media.service.js in immich_server to add logging

Example tickets: thumbnail generation is crashing or stuck without hints in logs
- https://github.com/immich-app/immich/issues/21883
- Discord [Crash on "Generate Thumbnails" - Missing/Corrupted files](https://discord.com/channels/979116623879368755/1435774629896523847)
- https://github.com/immich-app/immich/issues/20516

## How Has This Been Tested?

Set "Verbose" log level.
Run "Refresh thumbnails".
Check logs:
```
... VERBOSE [Microservices:MediaService] Thumbnail generation for image 7118ff8e-4df6-4799-a63b-3e17a4fa72fe /data/library/admin/2024/2024-07/Friends.2024.jpg
... VERBOSE [Microservices:MediaService] Thumbnail generation for video eba60de8-4484-41cd-a2db-87f44d5ec6f0 /data/library/admin/2024/2024-07/2024.07.21 08.42.10 Movie 003.mov
...   DEBUG [Microservices:MediaRepository] ffmpeg -n 10 /usr/bin/ffmpeg -skip_frame nointra -sws_flags accurate_rnd+full_chroma_int -i /data/library/admin/2024/2024-07/2024.07.21 08.42.10 Movie 003.mov -y -fps_mode vfr -frames:v 1 -update 1 -v verbose -vf fps=12:start_time=0:eof_action=pass:round=down,thumbnail=12,select=gt(scene\,0.1)-eq(prev_selected_n\,n)+isnan(prev_selected_n)+gt(n\,20),trim=end_frame=2,reverse /data/thumbs/ff5e354e-34fa-4d25-9093-ac372ff14a43/eb/a6/eba60de8-4484-41cd-a2db-87f44d5ec6f0-preview.jpeg
```

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.