### PR TITLE
fix(docs): server and machine-learning use IMMICH_HOST and IMMICH_PORT

### DIFF
--- a/docs/docs/install/environment-variables.md
+++ b/docs/docs/install/environment-variables.md
@@ -62,10 +62,10 @@ Information on the current workers can be found [here](/administration/jobs-work
 
 ## Ports
 
-| Variable      | Description    |                  Default                   |
-| :------------ | :------------- | :----------------------------------------: |
-| `IMMICH_HOST` | Listening host |                 `0.0.0.0`                  |
-| `IMMICH_PORT` | Listening port | `2283` (server), `3003` (machine learning) |
+| Variable      | Description    |                  Default                   | Containers               |
+| :------------ | :------------- | :----------------------------------------: | :----------------------- |
+| `IMMICH_HOST` | Listening host |                 `0.0.0.0`                  | server, machine learning |
+| `IMMICH_PORT` | Listening port | `2283` (server), `3003` (machine learning) | server, machine learning |
 
 ## Database
 


### PR DESCRIPTION
## Description

It was not clear which environment variables the machine-learning server uses to build its listener address.

Followup of #24304

## How Has This Been Tested?

-

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none