### PR TITLE
fix(web): folder view sort oder

### DIFF
--- a/web/src/lib/utils/tree-utils.ts
+++ b/web/src/lib/utils/tree-utils.ts
@@ -62,8 +62,16 @@ export class TreeNode extends Map<string, TreeNode> {
       const child = this.values().next().value!;
       child.value = joinPaths(this.value, child.value);
       child.parent = this.parent;
-      this.parent.delete(this.value);
-      this.parent.set(child.value, child);
+
+      const entries = Array.from(this.parent.entries());
+      this.parent.clear();
+      for (const [key, value] of entries) {
+        if (key === this.value) {
+          this.parent.set(child.value, child);
+        } else {
+          this.parent.set(key, value);
+        }
+      }
     }
 
     for (const child of this.values()) {


### PR DESCRIPTION
There is an issue in the folder view where folders are sorted incorrectly when seeing varying path depts, see this screenshot:

<img width="220" height="246" alt="image" src="https://github.com/user-attachments/assets/e3b4a6a0-04e0-4557-baa9-c508d7976a83" />

This PR fixes it and gives the correct sort:

<img width="242" height="247" alt="image" src="https://github.com/user-attachments/assets/23694ec4-4a91-451b-ae86-25e8ef30851b" />

It appears that the core issue is that the underlying Map data type respect insertion order and not sort order. I've reworked some of the logic in collapse() to fix the issue