### PR TITLE
fix(metadata): add retry logic for cloud storage

### DIFF
--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -269,7 +269,7 @@ export class MetadataRepository {
           await this.recreateExifTool();
         }
 
-        return await this.exiftool.read(path, args);
+        return (await this.exiftool.read(path, args)) as ImmichTags;
       } catch (error) {
         lastError = error;
 

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -76,50 +76,135 @@ export interface ImmichTags extends Omit<Tags, TagsWithWrongTypes> {
 
 @Injectable()
 export class MetadataRepository {
-  private exiftool = new ExifTool({
-    defaultVideosToUTC: true,
-    backfillTimezones: true,
-    inferTimezoneFromDatestamps: true,
-    inferTimezoneFromTimeStamp: true,
-    useMWG: true,
-    numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength', 'FileSize'],
-    /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
-    geoTz: (lat, lon) => geotz.find(lat, lon)[0],
-    geolocation: true,
-    // Enable exiftool LFS to parse metadata for files larger than 2GB.
-    readArgs: ['-api', 'largefilesupport=1'],
-    writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
-  });
+  private exiftool: ExifTool;
+  private maxConcurrency: number | null = null;
+  private isShuttingDown = false;
+  private recreateLock = false;
 
   constructor(private logger: LoggingRepository) {
     this.logger.setContext(MetadataRepository.name);
+    this.exiftool = this.createExifTool();
+  }
+
+  private createExifTool(): ExifTool {
+    return new ExifTool({
+      defaultVideosToUTC: true,
+      backfillTimezones: true,
+      inferTimezoneFromDatestamps: true,
+      inferTimezoneFromTimeStamp: true,
+      useMWG: true,
+      numericTags: [...DefaultReadTaskOptions.numericTags, 'FocalLength', 'FileSize'],
+      /* eslint unicorn/no-array-callback-reference: off, unicorn/no-array-method-this-argument: off */
+      geoTz: (lat, lon) => geotz.find(lat, lon)[0],
+      geolocation: true,
+      // Enable exiftool LFS to parse metadata for files larger than 2GB.
+      readArgs: ['-api', 'largefilesupport=1'],
+      writeArgs: ['-api', 'largefilesupport=1', '-overwrite_original'],
+    });
+  }
+
+  private async recreateExifTool(): Promise<void> {
+    if (this.isShuttingDown || this.recreateLock) {
+      return;
+    }
+
+    this.recreateLock = true;
+    try {
+      this.logger.warn('BatchCluster has ended, recreating ExifTool instance');
+      try {
+        // Пытаемся корректно завершить старый экземпляр, если это возможно
+        await this.exiftool.end();
+      } catch {
+        // Игнорируем ошибки при завершении старого экземпляра
+      }
+
+      // Создаем новый экземпляр
+      this.exiftool = this.createExifTool();
+
+      // Восстанавливаем настройку concurrency, если она была установлена
+      if (this.maxConcurrency !== null) {
+        this.exiftool.batchCluster.setMaxProcs(this.maxConcurrency);
+      }
+    } finally {
+      this.recreateLock = false;
+    }
+  }
+
+  private isBatchClusterError(error: any): boolean {
+    const message = error?.message || String(error);
+    return (
+      typeof message === 'string' &&
+      (message.includes('BatchCluster has ended') || message.includes('cannot enqueue'))
+    );
   }
 
   setMaxConcurrency(concurrency: number) {
-    this.exiftool.batchCluster.setMaxProcs(concurrency);
+    this.maxConcurrency = concurrency;
+    try {
+      this.exiftool.batchCluster.setMaxProcs(concurrency);
+    } catch (error) {
+      if (this.isBatchClusterError(error)) {
+        // Если BatchCluster завершен, просто сохраняем значение для следующего пересоздания
+        return;
+      }
+      this.logger.warn(`Failed to set max concurrency: ${error}`);
+    }
   }
 
   async teardown() {
-    await this.exiftool.end();
+    this.isShuttingDown = true;
+    try {
+      await this.exiftool.end();
+    } catch (error) {
+      this.logger.warn(`Error during ExifTool teardown: ${error}`);
+    }
   }
 
-  readTags(path: string): Promise<ImmichTags> {
+  async readTags(path: string): Promise<ImmichTags> {
     const args = mimeTypes.isVideo(path) ? ['-ee'] : [];
-    return this.exiftool.read(path, args).catch((error) => {
-      this.logger.warn(`Error reading exif data (${path}): ${error}\n${error?.stack}`);
+    try {
+      return await this.exiftool.read(path, args);
+    } catch (error) {
+      // Если ошибка связана с завершенным BatchCluster, пересоздаем и повторяем попытку один раз
+      if (this.isBatchClusterError(error)) {
+        await this.recreateExifTool();
+        try {
+          return await this.exiftool.read(path, args);
+        } catch (retryError) {
+          this.logger.warn(`Error reading exif data after retry (${path}): ${retryError}`);
+          return {};
+        }
+      }
+      this.logger.warn(`Error reading exif data (${path}): ${error}`);
       return {};
-    }) as Promise<ImmichTags>;
+    }
   }
 
-  extractBinaryTag(path: string, tagName: string): Promise<Buffer> {
-    return this.exiftool.extractBinaryTagToBuffer(tagName, path);
+  async extractBinaryTag(path: string, tagName: string): Promise<Buffer> {
+    try {
+      return await this.exiftool.extractBinaryTagToBuffer(tagName, path);
+    } catch (error) {
+      // Если ошибка связана с завершенным BatchCluster, пересоздаем и повторяем попытку один раз
+      if (this.isBatchClusterError(error)) {
+        await this.recreateExifTool();
+        return await this.exiftool.extractBinaryTagToBuffer(tagName, path);
+      }
+      throw error;
+    }
   }
 
   async writeTags(path: string, tags: Partial<Tags>): Promise<void> {
     try {
       await this.exiftool.write(path, tags);
     } catch (error) {
+      // Если ошибка связана с завершенным BatchCluster, пересоздаем и повторяем попытку один раз
+      if (this.isBatchClusterError(error)) {
+        await this.recreateExifTool();
+        await this.exiftool.write(path, tags);
+        return;
+      }
       this.logger.warn(`Error writing exif data (${path}): ${error}`);
+      throw error;
     }
   }
 }

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -80,8 +80,9 @@ export class MetadataRepository {
   private maxConcurrency: number | null = null;
   private isShuttingDown = false;
   private recreateLock = false;
-  private readonly MAX_RETRIES = 3;
+  private readonly MAX_RETRIES = 4;
   private readonly INITIAL_RETRY_DELAY_MS = 500;
+  private readonly FINAL_RETRY_DELAY_MS = 10000;
 
   constructor(private logger: LoggingRepository) {
     this.logger.setContext(MetadataRepository.name);
@@ -226,8 +227,11 @@ export class MetadataRepository {
           return {};
         }
 
-        // Вычисляем задержку с экспоненциальным backoff
-        const delayMs = this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        // Вычисляем задержку с экспоненциальным backoff, последняя попытка - 10 секунд
+        const delayMs =
+          attempt === this.MAX_RETRIES - 1
+            ? this.FINAL_RETRY_DELAY_MS
+            : this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
         this.logger.debug(
           `Retrying readTags for ${path} (attempt ${attempt + 1}/${this.MAX_RETRIES}) after ${delayMs}ms`,
         );
@@ -264,8 +268,11 @@ export class MetadataRepository {
           throw error;
         }
 
-        // Вычисляем задержку с экспоненциальным backoff
-        const delayMs = this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        // Вычисляем задержку с экспоненциальным backoff, последняя попытка - 10 секунд
+        const delayMs =
+          attempt === this.MAX_RETRIES - 1
+            ? this.FINAL_RETRY_DELAY_MS
+            : this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
         this.logger.debug(
           `Retrying extractBinaryTag for ${path} (attempt ${attempt + 1}/${this.MAX_RETRIES}) after ${delayMs}ms`,
         );
@@ -303,8 +310,11 @@ export class MetadataRepository {
           throw error;
         }
 
-        // Вычисляем задержку с экспоненциальным backoff
-        const delayMs = this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        // Вычисляем задержку с экспоненциальным backoff, последняя попытка - 10 секунд
+        const delayMs =
+          attempt === this.MAX_RETRIES - 1
+            ? this.FINAL_RETRY_DELAY_MS
+            : this.INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
         this.logger.debug(
           `Retrying writeTags for ${path} (attempt ${attempt + 1}/${this.MAX_RETRIES}) after ${delayMs}ms`,
         );

--- a/server/src/repositories/metadata.repository.ts
+++ b/server/src/repositories/metadata.repository.ts
@@ -82,7 +82,7 @@ export class MetadataRepository {
   private recreateLock = false;
   private readonly MAX_RETRIES = 4;
   private readonly INITIAL_RETRY_DELAY_MS = 500;
-  private readonly FINAL_RETRY_DELAY_MS = 10000;
+  private readonly FINAL_RETRY_DELAY_MS = 10_000;
 
   constructor(private logger: LoggingRepository) {
     this.logger.setContext(MetadataRepository.name);
@@ -231,8 +231,7 @@ export class MetadataRepository {
   private isBatchClusterError(error: any): boolean {
     const message = error?.message || String(error);
     return (
-      typeof message === 'string' &&
-      (message.includes('BatchCluster has ended') || message.includes('cannot enqueue'))
+      typeof message === 'string' && (message.includes('BatchCluster has ended') || message.includes('cannot enqueue'))
     );
   }
 
@@ -276,9 +275,7 @@ export class MetadataRepository {
         // Если это последняя попытка или ошибка не требует повторной попытки
         if (attempt === this.MAX_RETRIES || !this.isRetryableError(error)) {
           if (attempt > 0) {
-            this.logger.warn(
-              `Error reading exif data after ${attempt} retries (${path}): ${error}`,
-            );
+            this.logger.warn(`Error reading exif data after ${attempt} retries (${path}): ${error}`);
           } else {
             this.logger.warn(`Error reading exif data (${path}): ${error}`);
           }
@@ -317,9 +314,7 @@ export class MetadataRepository {
         // Если это последняя попытка или ошибка не требует повторной попытки
         if (attempt === this.MAX_RETRIES || !this.isRetryableError(error)) {
           if (attempt > 0) {
-            this.logger.warn(
-              `Error extracting binary tag after ${attempt} retries (${path}, ${tagName}): ${error}`,
-            );
+            this.logger.warn(`Error extracting binary tag after ${attempt} retries (${path}, ${tagName}): ${error}`);
           } else {
             this.logger.warn(`Error extracting binary tag (${path}, ${tagName}): ${error}`);
           }
@@ -359,9 +354,7 @@ export class MetadataRepository {
         // Если это последняя попытка или ошибка не требует повторной попытки
         if (attempt === this.MAX_RETRIES || !this.isRetryableError(error)) {
           if (attempt > 0) {
-            this.logger.warn(
-              `Error writing exif data after ${attempt} retries (${path}): ${error}`,
-            );
+            this.logger.warn(`Error writing exif data after ${attempt} retries (${path}): ${error}`);
           } else {
             this.logger.warn(`Error writing exif data (${path}): ${error}`);
           }


### PR DESCRIPTION
## Description

This PR addresses issues where metadata operations (reading, extracting, writing) cause container crashes and spam `BatchCluster has ended, cannot enqueue` errors, particularly when interacting with cloud drives or experiencing temporary file unavailability.

The changes implement:
*   **Retry logic with exponential backoff:** Metadata operations (`readTags`, `extractBinaryTag`, `writeTags`) now include up to 3 retries with increasing delays (500ms, 1000ms, 2000ms) to handle temporary network issues or file unavailability.
*   **Automatic ExifTool instance recreation:** If an `ExifTool` operation fails with a "BatchCluster has ended" error, the `ExifTool` instance is automatically recreated to restore functionality without crashing the container.
*   **Improved error handling:** Specific file system errors (`ENOENT`, `ETIMEDOUT`, `ECONNRESET`, `EACCES`) and messages indicating temporary file unavailability are now considered retryable.

This significantly improves the robustness and stability of metadata processing, especially in environments with potentially unreliable file access.

Fixes # (issue)

## How Has This Been Tested?

- [ ] Manual testing with cloud drive storage to simulate temporary file unavailability and `BatchCluster` errors.
- [ ] Unit tests for retry logic and `ExifTool` recreation (if applicable).

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This pull request was created with the help of an AI assistant, which assisted in identifying the root cause, suggesting solutions, and generating the code changes based on the problem description and user feedback.

