### PR TITLE
fix: prevent OOM on nginx reverse proxy servers

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -21,6 +21,9 @@ server {
     # allow large file uploads
     client_max_body_size 50000M;
 
+    # disable buffering uploads to prevent OOM on reverse proxy server and make uploads twice as fast (no pause)
+    proxy_request_buffering off;
+
     # Set headers
     proxy_set_header Host              $host;
     proxy_set_header X-Real-IP         $remote_addr;


### PR DESCRIPTION
Added configuration to disable buffering for uploads.

## Description

Adds configuration to disable `proxy_request_buffering` for nginx because the default of it on results in files uploading to the reverse proxy server and then once it is fully uploaded there it is then uploaded to Immich. It takes twice as long  and has the potential to cause OOM on the reverse proxy server (as happened to me).

Fixes https://discord.com/channels/979116623879368755/994044917355663450/1445533330270326835

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Nginx on my OpenWrt router pointed at Immich on my TrueNAS server

<!--<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. - ->

</details> -->

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
N/A
...
