### PR TITLE
fix(web): Add minimum content size to logo for consistent visual on small screens

### DIFF
--- a/web/src/lib/components/album-page/album-viewer.svelte
+++ b/web/src/lib/components/album-page/album-viewer.svelte
@@ -98,7 +98,7 @@
     <ControlAppBar showBackButton={false}>
       {#snippet leading()}
         <a data-sveltekit-preload-data="hover" class="ms-4" href="/">
-          <Logo variant="inline" />
+          <Logo variant="inline" class="min-w-min" />
         </a>
       {/snippet}
 


### PR DESCRIPTION
This adds a style class to the logo in the snippet shown for album share to address this issue on smaller screens: 

Fixes #24102