### PR TITLE
fix: build iOS fastlane installation

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -222,19 +222,13 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+          bundler-cache: true
           working-directory: ./mobile/ios
 
       - name: Install CocoaPods dependencies
         working-directory: ./mobile/ios
         run: |
           pod install
-
-      - name: Install Fastlane
-        working-directory: ./mobile/ios
-        run: |
-          gem install bundler
-          bundle config set --local path 'vendor/bundle'
-          bundle install
 
       - name: Create API Key
         env:


### PR DESCRIPTION
Recommended by setup ruby action to install bundle and cache them automatically https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#single-job