### PR TITLE
fix(web): people count showing incorrectly

### DIFF
--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -231,7 +231,7 @@
 
   let people = $derived(data.people.people);
   let visiblePeople = $derived(people.filter((people) => !people.isHidden));
-  let countVisiblePeople = $derived(searchName ? searchedPeopleLocal.length : data.people.total - data.people.hidden);
+  let countVisiblePeople = $derived(searchName ? searchedPeopleLocal.length : visiblePeople.length);
   let showPeople = $derived(searchName ? searchedPeopleLocal : visiblePeople);
 
   const onNameChangeInputFocus = (person: PersonResponseDto) => {


### PR DESCRIPTION
## Description

Fixes the people counter not reporting correctly on the people page.

**EDIT:** While this fix works, the main issue is server-side; the counts for `total` and `hidden` are reported incorrectly.