### PR TITLE
fix(mobile): inconsistent query for people

### DIFF
--- a/mobile/lib/infrastructure/repositories/people.repository.dart
+++ b/mobile/lib/infrastructure/repositories/people.repository.dart
@@ -2,7 +2,6 @@ import 'package:drift/drift.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/infrastructure/entities/person.entity.drift.dart';
-import 'package:immich_mobile/infrastructure/entities/remote_asset.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 
 class DriftPeopleRepository extends DriftDatabaseRepository {
@@ -24,17 +23,11 @@ class DriftPeopleRepository extends DriftDatabaseRepository {
     final query =
         _db.select(_db.personEntity).join([
             innerJoin(_db.assetFaceEntity, _db.assetFaceEntity.personId.equalsExp(_db.personEntity.id)),
-            innerJoin(
-              _db.remoteAssetEntity,
-              _db.remoteAssetEntity.id.equalsExp(_db.assetFaceEntity.assetId) &
-                  _db.remoteAssetEntity.visibility.equals(
-                    $RemoteAssetEntityTable.$convertervisibility.toSql(AssetVisibility.timeline),
-                  ) &
-                  _db.remoteAssetEntity.deletedAt.isNull(),
-            ),
+            innerJoin(_db.remoteAssetEntity, _db.remoteAssetEntity.id.equalsExp(_db.assetFaceEntity.assetId)),
           ])
           ..where(_db.personEntity.isHidden.equals(false))
           ..where(_db.remoteAssetEntity.deletedAt.isNull())
+          ..where(_db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline))
           ..groupBy(
             [_db.personEntity.id],
             having: Expression.or([


### PR DESCRIPTION
## Description
The `drift` query for people in the mobile app was not consistent with the server, leading the mobile app to show people that should have been hidden.

Fixes #21222
Fixes #22169

_Note: the mobile version still doesn't fetch the `minimumFaceCount` from the server, so there still could be inconsistencies. This could be improved further._