### PR TITLE
fix(mobile): fix overflow text in backup card

### DIFF
--- a/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 
-class EntitiyCountTile extends StatelessWidget {
+class EntityCountTile extends StatelessWidget {
   final int count;
   final String label;
   final IconData icon;
 
-  const EntitiyCountTile({super.key, required this.count, required this.label, required this.icon});
+  const EntityCountTile({super.key, required this.count, required this.label, required this.icon});
 
   String zeroPadding(int number, int targetWidth) {
     final numStr = number.toString();

--- a/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
@@ -38,9 +38,11 @@ class EntitiyCountTile extends StatelessWidget {
             children: [
               Icon(icon, color: context.primaryColor),
               const SizedBox(width: 8),
-              Text(
-                label,
-                style: TextStyle(color: context.primaryColor, fontWeight: FontWeight.bold, fontSize: 16),
+              Flexible(
+                child: Text(
+                  label,
+                  style: TextStyle(color: context.primaryColor, fontWeight: FontWeight.bold, fontSize: 16),
+                ),
               ),
             ],
           ),

--- a/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/entity_count_tile.dart
@@ -14,14 +14,15 @@ class EntitiyCountTile extends StatelessWidget {
     return numStr.length < targetWidth ? "0" * (targetWidth - numStr.length) : "";
   }
 
-  int calculateMaxDigits(double availableWidth) {
-    const double charWidth = 11.0;
-    return (availableWidth / charWidth).floor().clamp(1, 8);
-  }
-
   @override
   Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final availableWidth = (screenWidth - 32 - 8) / 2;
+    const double charWidth = 11.0;
+    final maxDigits = ((availableWidth - 32) / charWidth).floor().clamp(1, 8);
+
     return Container(
+      height: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: context.colorScheme.surfaceContainerLow,
@@ -29,7 +30,6 @@ class EntitiyCountTile extends StatelessWidget {
         border: Border.all(width: 0.5, color: context.colorScheme.outline.withAlpha(25)),
       ),
       child: Column(
-        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           // Icon and Label
@@ -46,27 +46,22 @@ class EntitiyCountTile extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 12),
           // Number
-          LayoutBuilder(
-            builder: (context, constraints) {
-              final maxDigits = calculateMaxDigits(constraints.maxWidth);
-              return RichText(
-                text: TextSpan(
-                  style: const TextStyle(fontSize: 18, fontFamily: 'OverpassMono', fontWeight: FontWeight.w600),
-                  children: [
-                    TextSpan(
-                      text: zeroPadding(count, maxDigits),
-                      style: TextStyle(color: context.colorScheme.onSurfaceSecondary.withAlpha(75)),
-                    ),
-                    TextSpan(
-                      text: count.toString(),
-                      style: TextStyle(color: context.primaryColor),
-                    ),
-                  ],
+          const Spacer(),
+          RichText(
+            text: TextSpan(
+              style: const TextStyle(fontSize: 18, fontFamily: 'OverpassMono', fontWeight: FontWeight.w600),
+              children: [
+                TextSpan(
+                  text: zeroPadding(count, maxDigits),
+                  style: TextStyle(color: context.colorScheme.onSurfaceSecondary.withAlpha(75)),
                 ),
-              );
-            },
+                TextSpan(
+                  text: count.toString(),
+                  style: TextStyle(color: context.primaryColor),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
@@ -282,76 +282,87 @@ class _SyncStatsCounts extends ConsumerWidget {
             _SectionHeaderText(text: "assets".t(context: context)),
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-              child: Flex(
-                direction: Axis.horizontal,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                spacing: 8.0,
-                children: [
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "local".t(context: context),
-                      count: localAssetCount,
-                      icon: Icons.smartphone,
+              // 1. Wrap in IntrinsicHeight
+              child: IntrinsicHeight(
+                child: Flex(
+                  direction: Axis.horizontal,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  // 2. Stretch children vertically to fill the IntrinsicHeight
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  spacing: 8.0,
+                  children: [
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "local".t(context: context),
+                        count: localAssetCount,
+                        icon: Icons.smartphone,
+                      ),
                     ),
-                  ),
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "remote".t(context: context),
-                      count: remoteAssetCount,
-                      icon: Icons.cloud,
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "remote".t(context: context),
+                        count: remoteAssetCount,
+                        icon: Icons.cloud,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
             _SectionHeaderText(text: "albums".t(context: context)),
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-              child: Flex(
-                direction: Axis.horizontal,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                spacing: 8.0,
-                children: [
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "local".t(context: context),
-                      count: localAlbumCount,
-                      icon: Icons.smartphone,
+              child: IntrinsicHeight(
+                child: Flex(
+                  direction: Axis.horizontal,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.stretch, // Added
+                  spacing: 8.0,
+                  children: [
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "local".t(context: context),
+                        count: localAlbumCount,
+                        icon: Icons.smartphone,
+                      ),
                     ),
-                  ),
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "remote".t(context: context),
-                      count: remoteAlbumCount,
-                      icon: Icons.cloud,
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "remote".t(context: context),
+                        count: remoteAlbumCount,
+                        icon: Icons.cloud,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
             _SectionHeaderText(text: "other".t(context: context)),
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-              child: Flex(
-                direction: Axis.horizontal,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                spacing: 8.0,
-                children: [
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "memories".t(context: context),
-                      count: memoryCount,
-                      icon: Icons.calendar_today,
+              child: IntrinsicHeight(
+                child: Flex(
+                  direction: Axis.horizontal,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.stretch, // Added
+                  spacing: 8.0,
+                  children: [
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "memories".t(context: context),
+                        count: memoryCount,
+                        icon: Icons.calendar_today,
+                      ),
                     ),
-                  ),
-                  Expanded(
-                    child: EntitiyCountTile(
-                      label: "hashed_assets".t(context: context),
-                      count: localHashedCount,
-                      icon: Icons.tag,
+                    Expanded(
+                      child: EntitiyCountTile(
+                        label: "hashed_assets".t(context: context),
+                        count: localHashedCount,
+                        icon: Icons.tag,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
             // To be removed once the experimental feature is stable
@@ -364,26 +375,29 @@ class _SyncStatsCounts extends ConsumerWidget {
                   return counts.when(
                     data: (c) => Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                      child: Flex(
-                        direction: Axis.horizontal,
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        spacing: 8.0,
-                        children: [
-                          Expanded(
-                            child: EntitiyCountTile(
-                              label: "local".t(context: context),
-                              count: c.total,
-                              icon: Icons.delete_outline,
+                      child: IntrinsicHeight(
+                        child: Flex(
+                          direction: Axis.horizontal,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.stretch, // Added
+                          spacing: 8.0,
+                          children: [
+                            Expanded(
+                              child: EntitiyCountTile(
+                                label: "local".t(context: context),
+                                count: c.total,
+                                icon: Icons.delete_outline,
+                              ),
                             ),
-                          ),
-                          Expanded(
-                            child: EntitiyCountTile(
-                              label: "hashed_assets".t(context: context),
-                              count: c.hashed,
-                              icon: Icons.tag,
+                            Expanded(
+                              child: EntitiyCountTile(
+                                label: "hashed_assets".t(context: context),
+                                count: c.hashed,
+                                icon: Icons.tag,
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                     loading: () => const CircularProgressIndicator(),

--- a/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
+++ b/mobile/lib/widgets/settings/beta_sync_settings/sync_status_and_actions.dart
@@ -292,14 +292,14 @@ class _SyncStatsCounts extends ConsumerWidget {
                   spacing: 8.0,
                   children: [
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "local".t(context: context),
                         count: localAssetCount,
                         icon: Icons.smartphone,
                       ),
                     ),
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "remote".t(context: context),
                         count: remoteAssetCount,
                         icon: Icons.cloud,
@@ -320,14 +320,14 @@ class _SyncStatsCounts extends ConsumerWidget {
                   spacing: 8.0,
                   children: [
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "local".t(context: context),
                         count: localAlbumCount,
                         icon: Icons.smartphone,
                       ),
                     ),
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "remote".t(context: context),
                         count: remoteAlbumCount,
                         icon: Icons.cloud,
@@ -348,14 +348,14 @@ class _SyncStatsCounts extends ConsumerWidget {
                   spacing: 8.0,
                   children: [
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "memories".t(context: context),
                         count: memoryCount,
                         icon: Icons.calendar_today,
                       ),
                     ),
                     Expanded(
-                      child: EntitiyCountTile(
+                      child: EntityCountTile(
                         label: "hashed_assets".t(context: context),
                         count: localHashedCount,
                         icon: Icons.tag,
@@ -383,14 +383,14 @@ class _SyncStatsCounts extends ConsumerWidget {
                           spacing: 8.0,
                           children: [
                             Expanded(
-                              child: EntitiyCountTile(
+                              child: EntityCountTile(
                                 label: "local".t(context: context),
                                 count: c.total,
                                 icon: Icons.delete_outline,
                               ),
                             ),
                             Expanded(
-                              child: EntitiyCountTile(
+                              child: EntityCountTile(
                                 label: "hashed_assets".t(context: context),
                                 count: c.hashed,
                                 icon: Icons.tag,


### PR DESCRIPTION
## Description
Fixes #23343

Not sure if one tile being larger is desirable (see screenshot), but I'm not sure what other solution there is without modifying the translation to be shorter.

Also fixes the spelling of the `EntityCountTile` class

_Note: For the Spanish translation, I would translate it as "Archivos hasheados" instead, which is much shorter but still understandable._

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="350" alt="image" src="https://github.com/user-attachments/assets/92153f1e-e7dd-4e95-b2bc-7ec756a55bb3" />


</details>
