### PR TITLE
fix(mobile): cannot create album while name field is focused

### DIFF
--- a/mobile/lib/presentation/pages/drift_create_album.page.dart
+++ b/mobile/lib/presentation/pages/drift_create_album.page.dart
@@ -28,7 +28,18 @@ class _DriftCreateAlbumPageState extends ConsumerState<DriftCreateAlbumPage> {
   Set<BaseAsset> selectedAssets = {};
 
   @override
+  void initState() {
+    super.initState();
+    albumTitleController.addListener(_onTitleChanged);
+  }
+
+  void _onTitleChanged() {
+    setState(() {});
+  }
+
+  @override
   void dispose() {
+    albumTitleController.removeListener(_onTitleChanged);
     albumTitleController.dispose();
     albumDescriptionController.dispose();
     albumTitleTextFieldFocusNode.dispose();


### PR DESCRIPTION
## Description

Fixes #22620

## How Has This Been Tested?

- [x] Go to new album page
- [x] Focus on the name field, start typing
- [x] The "Create" button becomes active when the text field is not empty