### PR TITLE
fix(web): [album table view] long album title overflows table row

### DIFF
--- a/web/src/lib/components/album-page/albums-table-row.svelte
+++ b/web/src/lib/components/album-page/albums-table-row.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <tr
-  class="flex h-12 w-full place-items-center border-3 border-transparent p-2 text-center even:bg-subtle/20 odd:bg-subtle/80 hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75 md:p-5"
+  class="flex w-full place-items-center border-3 border-transparent p-2 text-center even:bg-subtle/20 odd:bg-subtle/80 hover:cursor-pointer hover:border-immich-primary/75 odd:dark:bg-immich-dark-gray/75 even:dark:bg-immich-dark-gray/50 dark:hover:border-immich-dark-primary/75 md:px-5 md:py-2"
   onclick={() => goto(resolve(`${AppRoute.ALBUMS}/${album.id}`))}
   {oncontextmenu}
 >


### PR DESCRIPTION
## Description

In the album page table view, rows with long album titles overflow on the y-axis, which makes the titles unreadable on smaller viewports.

This happens because the table rows have a fixed height (h-12) applied. [See here.](https://github.com/immich-app/immich/blob/1e1cf0d1feb914fb260b473c862d38127440d0ff/web/src/lib/components/album-page/albums-table-row.svelte#L35)

I remove the fixed height constraint and adjusted the paddings so that the layout looks identical with short album titles but also supports longer album names.

Fixes #24447

## How Has This Been Tested?

Visually by comparing the main branch vs. the fix branch:

1. install fresh immich instance
2. add some albums with long title names, for example This is a really long title for a album and I'm very sure that this album 3. title will overflow in table view
4. switch to album page table view
5. decrease viewport width
6. table rows adjust the hight depending on the length of the album title

Before implementing the fix:
<img width="1328" height="677" alt="Bildschirmfoto 2025-12-08 um 09 51 37" src="https://github.com/user-attachments/assets/0bd95f07-bec1-4e53-beee-e1dc73921a4e" />

After implementing the fix:
<img width="1840" height="679" alt="Bildschirmfoto 2025-12-08 um 11 02 41" src="https://github.com/user-attachments/assets/c19a9a8b-ae80-4775-a7a1-f33382c61694" />
<img width="957" height="814" alt="Bildschirmfoto 2025-12-08 um 11 02 50" src="https://github.com/user-attachments/assets/0898993d-d2b7-4b6a-add6-4d2f2ce6a91f" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
