### PR TITLE
fix(web): broken asset urls if shared link has photos in name

### DIFF
--- a/web/src/lib/utils/navigation.ts
+++ b/web/src/lib/utils/navigation.ts
@@ -47,7 +47,7 @@ export function currentUrlReplaceAssetId(assetId: string) {
   // off / instead of a subpath, unlike every other asset-containing route.
   return isPhotosRoute($page.route.id)
     ? `${AppRoute.PHOTOS}/${assetId}${searchparams}`
-    : `${$page.url.pathname.replace(/(\/photos.*)$/, '')}/photos/${assetId}${searchparams}`;
+    : `${$page.url.pathname.replace(/\/photos\/[^/]+$/, '')}/photos/${assetId}${searchparams}`;
 }
 
 function replaceScrollTarget(url: string, searchParams?: AssetGridRouteSearchParams | null) {


### PR DESCRIPTION
## Description

Fixes #23526

## How Has This Been Tested?

- [x] Create an album
- [x] Share it with a custom URL which contains "photos" in the name
- [x] Click on any asset, it loads

## Please describe to which degree, if any, an LLM was used in creating this pull request.
AI was used to correct the Regex.