### PR TITLE
fix(server): people count doesn't match array

### DIFF
--- a/e2e/src/api/specs/person.e2e-spec.ts
+++ b/e2e/src/api/specs/person.e2e-spec.ts
@@ -144,7 +144,7 @@ describe('/people', () => {
 
       expect(status).toBe(200);
       expect(body.hasNextPage).toBe(false);
-      expect(body.total).toBe(10); // All persons
+      expect(body.total).toBe(10); // All people
       expect(body.hidden).toBe(1); // 'hidden_person'
 
       const people = body.people as PersonResponseDto[];

--- a/e2e/src/api/specs/person.e2e-spec.ts
+++ b/e2e/src/api/specs/person.e2e-spec.ts
@@ -122,7 +122,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: false,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [
           expect.objectContaining({ name: 'Freddy' }),
@@ -144,7 +144,7 @@ describe('/people', () => {
 
       expect(status).toBe(200);
       expect(body.hasNextPage).toBe(false);
-      expect(body.total).toBe(11); // All persons
+      expect(body.total).toBe(10); // All persons
       expect(body.hidden).toBe(1); // 'hidden_person'
 
       const people = body.people as PersonResponseDto[];
@@ -170,7 +170,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: false,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [
           expect.objectContaining({ name: 'Freddy' }),
@@ -195,7 +195,7 @@ describe('/people', () => {
       expect(status).toBe(200);
       expect(body).toEqual({
         hasNextPage: true,
-        total: 11,
+        total: 10,
         hidden: 1,
         people: [expect.objectContaining({ name: 'Alice' })],
       });

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -259,8 +259,13 @@ where
           and "asset"."visibility" = 'timeline'
           and "asset"."deletedAt" is null
       )
+    having
+      (
+        "person"."name" != $2
+        or count("asset_face"."assetId") >= $3
+      )
   )
-  and "person"."ownerId" = $2
+  and "person"."ownerId" = $4
 
 -- PersonRepository.refreshFaces
 with

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -23,38 +23,6 @@ where
 limit
   3
 
--- PersonRepository.getAllForUser
-select
-  "person".*
-from
-  "person"
-  inner join "asset_face" on "asset_face"."personId" = "person"."id"
-  inner join "asset" on "asset_face"."assetId" = "asset"."id"
-  and "asset"."visibility" = 'timeline'
-  and "asset"."deletedAt" is null
-where
-  "person"."ownerId" = $1
-  and "asset_face"."deletedAt" is null
-  and "person"."isHidden" = $2
-group by
-  "person"."id"
-having
-  (
-    "person"."name" != $3
-    or count("asset_face"."assetId") >= $4
-  )
-order by
-  "person"."isHidden" asc,
-  "person"."isFavorite" desc,
-  NULLIF(person.name, '') is null asc,
-  count("asset_face"."assetId") desc,
-  NULLIF(person.name, '') asc nulls last,
-  "person"."createdAt"
-limit
-  $5
-offset
-  $6
-
 -- PersonRepository.getAllWithoutFaces
 select
   "person".*
@@ -229,43 +197,6 @@ from
   and "asset"."deletedAt" is null
 where
   "asset_face"."deletedAt" is null
-
--- PersonRepository.getNumberOfPeople
-select
-  coalesce(count(*), 0) as "total",
-  coalesce(
-    count(*) filter (
-      where
-        "isHidden" = $1
-    ),
-    0
-  ) as "hidden"
-from
-  "person"
-where
-  exists (
-    select
-    from
-      "asset_face"
-    where
-      "asset_face"."personId" = "person"."id"
-      and "asset_face"."deletedAt" is null
-      and exists (
-        select
-        from
-          "asset"
-        where
-          "asset"."id" = "asset_face"."assetId"
-          and "asset"."visibility" = 'timeline'
-          and "asset"."deletedAt" is null
-      )
-    having
-      (
-        "person"."name" != $2
-        or count("asset_face"."assetId") >= $3
-      )
-  )
-  and "person"."ownerId" = $4
 
 -- PersonRepository.refreshFaces
 with

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -70,11 +70,28 @@ describe(PersonService.name, () => {
 
   describe('getAll', () => {
     it('should get all hidden and visible people with thumbnails', async () => {
+      // Updated stubs with the required aggregated fields
+      const personWithCounts = {
+        ...personStub.withName,
+        faceCount: 3,
+        totalCount: 2,
+        hiddenCount: 1,
+      };
+
+      const hiddenPersonWithCounts = {
+        ...personStub.hidden,
+        faceCount: 1,
+        totalCount: 2,
+        hiddenCount: 1,
+      };
+
       mocks.person.getAllForUser.mockResolvedValue({
-        items: [personStub.withName, personStub.hidden],
+        items: [personWithCounts, hiddenPersonWithCounts],
         hasNextPage: false,
+        total: 2,
+        hidden: 1,
       });
-      mocks.person.getNumberOfPeople.mockResolvedValue({ total: 2, hidden: 1 });
+
       await expect(sut.getAll(authStub.admin, { withHidden: true, page: 1, size: 10 })).resolves.toEqual({
         hasNextPage: false,
         total: 2,
@@ -93,18 +110,36 @@ describe(PersonService.name, () => {
           },
         ],
       });
+
       expect(mocks.person.getAllForUser).toHaveBeenCalledWith({ skip: 0, take: 10 }, authStub.admin.user.id, {
         minimumFaceCount: 3,
         withHidden: true,
+        closestFaceAssetId: undefined,
       });
     });
 
     it('should get all visible people and favorites should be first in the array', async () => {
+      const favoritePersonWithCounts = {
+        ...personStub.isFavorite,
+        faceCount: 3,
+        totalCount: 2,
+        hiddenCount: 1,
+      };
+
+      const namedPersonWithCounts = {
+        ...personStub.withName,
+        faceCount: 3,
+        totalCount: 2,
+        hiddenCount: 1,
+      };
+
       mocks.person.getAllForUser.mockResolvedValue({
-        items: [personStub.isFavorite, personStub.withName],
+        items: [favoritePersonWithCounts, namedPersonWithCounts],
         hasNextPage: false,
+        total: 2,
+        hidden: 1,
       });
-      mocks.person.getNumberOfPeople.mockResolvedValue({ total: 2, hidden: 1 });
+
       await expect(sut.getAll(authStub.admin, { withHidden: false, page: 1, size: 10 })).resolves.toEqual({
         hasNextPage: false,
         total: 2,
@@ -123,9 +158,11 @@ describe(PersonService.name, () => {
           responseDto,
         ],
       });
+
       expect(mocks.person.getAllForUser).toHaveBeenCalledWith({ skip: 0, take: 10 }, authStub.admin.user.id, {
         minimumFaceCount: 3,
         withHidden: false,
+        closestFaceAssetId: undefined,
       });
     });
   });

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -67,7 +67,10 @@ export class PersonService extends BaseService {
       withHidden,
       closestFaceAssetId,
     });
-    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id);
+    const { total, hidden } = await this.personRepository.getNumberOfPeople(auth.user.id, {
+      minimumFaceCount: machineLearning.facialRecognition.minFaces,
+      withHidden,
+    });
 
     return {
       people: items.map((person) => mapPerson(person)),


### PR DESCRIPTION
## Description
Server-side fix for #24434

The total and hidden count in the `people` endpoint was inconsistent with the actual array, as people who were automatically "hidden" because of a lack of assets still counted (I assume this was unintentional and not the desired behavior).

**Potentially breaking change**

_Not sure if this is the preferred fix, feel free to suggest better solutions :)_

## How Has This Been Tested?

- [x] Upload photos to the server, let it do ML for faces, and make sure that at least one of the faces doesn't have enough assets
- [x] Call the `people` endpoint, manually check the number of people returned in the array, and the counts below