### PR TITLE
fix(server): building docker image for different platforms on the same host

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -50,13 +50,15 @@ RUN --mount=type=cache,id=pnpm-cli,target=/buildcache/pnpm-store \
 
 FROM builder AS plugins
 
+ARG TARGETPLATFORM
+
 COPY --from=ghcr.io/jdx/mise:2025.11.3@sha256:ac26f5978c0e2783f3e68e58ce75eddb83e41b89bf8747c503bac2aa9baf22c5 /usr/local/bin/mise /usr/local/bin/mise
 
 WORKDIR /usr/src/app
 COPY ./plugins/mise.toml ./plugins/
 ENV MISE_TRUSTED_CONFIG_PATHS=/usr/src/app/plugins/mise.toml
 ENV MISE_DATA_DIR=/buildcache/mise
-RUN --mount=type=cache,id=mise-tools,target=/buildcache/mise \
+RUN --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
   mise install --cd plugins
 
 COPY ./plugins ./plugins/
@@ -66,7 +68,7 @@ RUN --mount=type=cache,id=pnpm-plugins,target=/buildcache/pnpm-store \
   --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs \
   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
   --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml \
-  --mount=type=cache,id=mise-tools,target=/buildcache/mise \
+  --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
   cd plugins && mise run build
 
 FROM ghcr.io/immich-app/base-server-prod:202511261514@sha256:c04c1c38dd90e53455b180aedf93c3c63474c8d20ffe2c6d7a3a61a2181e6d29


### PR DESCRIPTION
## Description

Use per-platform mise cache in the server dockerfile to avoid `sh: 1: extism-js: not found`.
This happens due to re-using cached installed binary for another platform. 
E.g. on apple silicon I build a server image for the default aarch64 successfully, later I specify `--platform linux/amd64`, and it fails.
<details><summary>Build error log</summary>

```log
 > [plugins 6/6] RUN --mount=type=cache,id=pnpm-plugins,target=/buildcache/pnpm-store   --mount=type=bind,source=package.json,target=package.json   --mount=type=bind,source=.pnpmfile.cjs,target=.pnpmfile.cjs   --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml   --mount=type=bind,source=pnpm-workspace.yaml,target=pnpm-workspace.yaml   --mount=type=cache,id=mise-tools,target=/buildcache/mise   cd plugins && mise run build:
0.490 [install] $ pnpm install --frozen-lockfile
1.206 Scope: all 2 workspace projects
1.554 ..                                       | Progress: resolved 1, reused 0, downloaded 0, added 0
1.574 ..                                       |   +5 +
2.265 ..                                       | Progress: resolved 5, reused 5, downloaded 0, added 5, done
2.351 
2.351 devDependencies:
2.351 + @extism/js-pdk 1.1.1
2.351 + esbuild 0.27.0
2.351 + typescript 5.9.3
2.351 
2.403 Done in 1.5s using pnpm v10.24.0
2.424 [build] $ pnpm run build
3.117 
3.117 > plugins@1.0.0 build /usr/src/app/plugins
3.117 > pnpm build:tsc && pnpm build:wasm
3.117 
3.785 
3.785 > plugins@1.0.0 build:tsc /usr/src/app/plugins
3.785 > tsc --noEmit && node esbuild.js
3.785 
5.682 
5.682 > plugins@1.0.0 build:wasm /usr/src/app/plugins
5.682 > extism-js dist/index.js -i src/index.d.ts -o dist/plugin.wasm
5.682 
5.706 sh: 1: extism-js: not found
5.723  ELIFECYCLE  Command failed.
5.780  ELIFECYCLE  Command failed with exit code 1.
```
</details>

This PR adds `${TARGETPLATFORM}` to the cache id - [docker docs](https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope).

Other possible workarounds:
- build with `--no-cache`
- build with `--no-cache-filter plugins` (less drastic then full `--no-cache`)
- explicitly set platform for every build invocation, do not rely on defaults

Brought up in #contributing on Discord: [If I try to set the platform to "linux/amd64" it fails saying it can't find "extism-js"](https://discord.com/channels/979116623879368755/1071165397228855327/1441128919414866165)

## How Has This Been Tested?

On apple silicon: alternating runs of
```sh
docker build --progress plain -t immich-server:my -f server/Dockerfile .
docker build --progress plain -t immich-server:amd64 -f server/Dockerfile . --platform linux/amd64
```
- fail on main
- successful with this PR

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.