### PR TITLE
fix(mobile): buttons inside AddActionButton color is the same as background color

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
@@ -22,7 +22,9 @@ import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_shee
 enum AddToMenuItem { album, archive, unarchive, lockedFolder }
 
 class AddActionButton extends ConsumerStatefulWidget {
-  const AddActionButton({super.key});
+  const AddActionButton({super.key, this.originalTheme});
+
+  final ThemeData? originalTheme;
 
   @override
   ConsumerState<AddActionButton> createState() => _AddActionButtonState();
@@ -166,16 +168,25 @@ class _AddActionButtonState extends ConsumerState<AddActionButton> {
       return const SizedBox.shrink();
     }
 
+    final themeData = widget.originalTheme ?? context.themeData;
+
     return MenuAnchor(
       consumeOutsideTap: true,
       style: MenuStyle(
-        backgroundColor: WidgetStatePropertyAll(context.themeData.scaffoldBackgroundColor),
+        backgroundColor: WidgetStatePropertyAll(themeData.scaffoldBackgroundColor),
         elevation: const WidgetStatePropertyAll(4),
         shape: const WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
         ),
       ),
-      menuChildren: _buildMenuChildren(),
+      menuChildren: widget.originalTheme != null
+          ? [
+              Theme(
+                data: widget.originalTheme!,
+                child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: _buildMenuChildren()),
+              ),
+            ]
+          : _buildMenuChildren(),
       builder: (context, controller, child) {
         return BaseActionButton(
           iconData: Icons.add,

--- a/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
@@ -73,7 +73,7 @@ class _AddActionButtonState extends ConsumerState<AddActionButton> {
       ),
 
       if (isOwner) ...[
-        const PopupMenuDivider(),
+        const Divider(),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text("move_to".tr(), style: context.textTheme.labelMedium),

--- a/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart
@@ -38,11 +38,13 @@ class ViewerBottomBar extends ConsumerWidget {
       opacity = 0;
     }
 
+    final originalTheme = context.themeData;
+
     final actions = <Widget>[
       const ShareActionButton(source: ActionSource.viewer),
       if (asset.isLocalOnly) const UploadActionButton(source: ActionSource.viewer),
       if (asset.type == AssetType.image) const EditImageActionButton(),
-      if (asset.hasRemote) const AddActionButton(),
+      if (asset.hasRemote) AddActionButton(originalTheme: originalTheme),
 
       if (isOwner) ...[
         asset.isLocalOnly


### PR DESCRIPTION
## Description
- Fix [this issue](https://github.com/immich-app/immich/pull/24387#issuecomment-3620826554)
  - cause: theme was customized specifically under the bottom bar
    - https://github.com/immich-app/immich/blob/main/mobile/lib/presentation/widgets/asset_viewer/bottom_bar.widget.dart#L64-L67
  - fix to use original theme inside the AddActionButton
  - Details: `Screenshots` section
- other minor fix: use Divider instead of PopupMenuDivider

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### Manual visual testing on iOS Simulator
- [x] Automatic theme
- [x] Dark mode

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
| Before | After(default theme) | After(dark mode) |
|--------|--------|--------|
| ![iPhone_16](https://github.com/user-attachments/assets/b0e48104-aa1a-458d-8b5c-14f7ed9cf2fe) |![iPhone_16e](https://github.com/user-attachments/assets/26d75acc-10c3-425f-84f5-1ccaadd04dcc)|![iPhone_16e1](https://github.com/user-attachments/assets/a8d181cb-32f9-454e-b067-bb1ec966eb22)|
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
initial implementation
