### PR TITLE
feat(mobile): move top bar buttons into kebabu menu in AssetViewer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1511,7 +1511,6 @@
   "online": "Online",
   "only_favorites": "Only favorites",
   "open": "Open",
-  "open_asset_info": "About",
   "open_in_map_view": "Open in map view",
   "open_in_openstreetmap": "Open in OpenStreetMap",
   "open_the_search_filters": "Open the search filters",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1511,6 +1511,7 @@
   "online": "Online",
   "only_favorites": "Only favorites",
   "open": "Open",
+  "open_asset_info": "About",
   "open_in_map_view": "Open in map view",
   "open_in_openstreetmap": "Open in OpenStreetMap",
   "open_the_search_filters": "Open the search filters",

--- a/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/add_action_button.widget.dart
@@ -174,10 +174,12 @@ class _AddActionButtonState extends ConsumerState<AddActionButton> {
       consumeOutsideTap: true,
       style: MenuStyle(
         backgroundColor: WidgetStatePropertyAll(themeData.scaffoldBackgroundColor),
+        surfaceTintColor: const WidgetStatePropertyAll(Colors.grey),
         elevation: const WidgetStatePropertyAll(4),
         shape: const WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
         ),
+        padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 6)),
       ),
       menuChildren: widget.originalTheme != null
           ? [

--- a/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 
-class BaseActionButton extends StatelessWidget {
+class BaseActionButton extends ConsumerWidget {
   const BaseActionButton({
     super.key,
     required this.label,
@@ -30,7 +31,7 @@ class BaseActionButton extends StatelessWidget {
   final void Function()? onLongPressed;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final miniWidth = minWidth ?? (context.isMobile ? context.width / 4.5 : 75.0);
     final iconTheme = IconTheme.of(context);
     final iconSize = iconTheme.size ?? 24.0;

--- a/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/base_action_button.widget.dart
@@ -47,14 +47,13 @@ class BaseActionButton extends ConsumerWidget {
 
     if (menuItem) {
       final theme = context.themeData;
-      final effectiveStyle = theme.textTheme.labelLarge;
       final effectiveIconColor = iconColor ?? theme.iconTheme.color ?? theme.colorScheme.onSurfaceVariant;
 
       return MenuItemButton(
-        style: MenuItemButton.styleFrom(padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12)),
-        leadingIcon: Icon(iconData, color: effectiveIconColor, size: 20),
+        style: MenuItemButton.styleFrom(alignment: Alignment.centerLeft, padding: const EdgeInsets.all(16)),
+        leadingIcon: Icon(iconData, color: effectiveIconColor),
         onPressed: onPressed,
-        child: Text(label, style: effectiveStyle),
+        child: Text(label, style: theme.textTheme.labelLarge?.copyWith(fontSize: 16)),
       );
     }
 

--- a/mobile/lib/presentation/widgets/action_buttons/cast_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/cast_action_button.widget.dart
@@ -7,7 +7,7 @@ import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/widgets/asset_viewer/cast_dialog.dart';
 
 class CastActionButton extends ConsumerWidget {
-  const CastActionButton({super.key, this.iconOnly = true, this.menuItem = false});
+  const CastActionButton({super.key, this.iconOnly = false, this.menuItem = false});
 
   final bool iconOnly;
   final bool menuItem;

--- a/mobile/lib/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart
@@ -5,7 +5,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_bu
 import 'package:immich_mobile/providers/asset_viewer/is_motion_video_playing.provider.dart';
 
 class MotionPhotoActionButton extends ConsumerWidget {
-  const MotionPhotoActionButton({super.key, this.iconOnly = true, this.menuItem = false});
+  const MotionPhotoActionButton({super.key, this.iconOnly = false, this.menuItem = false});
 
   final bool iconOnly;
   final bool menuItem;

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -4,26 +4,18 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
-import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
-import 'package:immich_mobile/extensions/translate_extensions.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/cast_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/favorite_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart';
 import 'package:immich_mobile/providers/activity.provider.dart';
-import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/current_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
-import 'package:immich_mobile/routing/router.dart';
 
 class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
   const ViewerTopAppBar({super.key});
@@ -42,15 +34,6 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final isInLockedView = ref.watch(inLockedViewProvider);
     final isReadonlyModeEnabled = ref.watch(readonlyModeProvider);
 
-    final timelineOrigin = ref.read(timelineServiceProvider).origin;
-    final showViewInTimelineButton =
-        timelineOrigin != TimelineOrigin.main &&
-        timelineOrigin != TimelineOrigin.deepLink &&
-        timelineOrigin != TimelineOrigin.trash &&
-        timelineOrigin != TimelineOrigin.archive &&
-        timelineOrigin != TimelineOrigin.localAlbum &&
-        isOwner;
-
     final isShowingSheet = ref.watch(assetViewerProvider.select((state) => state.showingBottomSheet));
     int opacity = ref.watch(assetViewerProvider.select((state) => state.backgroundOpacity));
     final showControls = ref.watch(assetViewerProvider.select((s) => s.showingControls));
@@ -63,11 +46,7 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
       opacity = 0;
     }
 
-    final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
-
     final actions = <Widget>[
-      if (asset.isRemoteOnly) const DownloadActionButton(source: ActionSource.viewer, iconOnly: true),
-      if (isCasting || (asset.hasRemote)) const CastActionButton(iconOnly: true),
       if (album != null && album.isActivityEnabled && album.isShared)
         IconButton(
           icon: const Icon(Icons.chat_outlined),
@@ -75,28 +54,14 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
             EventStream.shared.emit(const ViewerOpenBottomSheetEvent(activitiesMode: true));
           },
         ),
-      if (showViewInTimelineButton)
-        IconButton(
-          onPressed: () async {
-            await context.maybePop();
-            await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-            EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
-          },
-          icon: const Icon(Icons.image_search),
-          tooltip: 'view_in_timeline'.t(context: context),
-        ),
       if (asset.hasRemote && isOwner && !asset.isFavorite)
         const FavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
       if (asset.hasRemote && isOwner && asset.isFavorite)
         const UnFavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
-      if (asset.isMotionPhoto) const MotionPhotoActionButton(iconOnly: true),
       const ViewerKebabMenu(),
     ];
 
-    final lockedViewActions = <Widget>[
-      if (isCasting || (asset.hasRemote)) const CastActionButton(iconOnly: true),
-      const ViewerKebabMenu(),
-    ];
+    final lockedViewActions = <Widget>[const ViewerKebabMenu()];
 
     return IgnorePointer(
       ignoring: opacity < 255,

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/favorite_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unfavorite_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart';
@@ -49,6 +50,7 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final originalTheme = context.themeData;
 
     final actions = <Widget>[
+      if (asset.isMotionPhoto) const MotionPhotoActionButton(iconOnly: true),
       if (album != null && album.isActivityEnabled && album.isShared)
         IconButton(
           icon: const Icon(Icons.chat_outlined),
@@ -56,10 +58,12 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
             EventStream.shared.emit(const ViewerOpenBottomSheetEvent(activitiesMode: true));
           },
         ),
+
       if (asset.hasRemote && isOwner && !asset.isFavorite)
         const FavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
       if (asset.hasRemote && isOwner && asset.isFavorite)
         const UnFavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
+
       ViewerKebabMenu(originalTheme: originalTheme),
     ];
 

--- a/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/top_app_bar.widget.dart
@@ -46,6 +46,8 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
       opacity = 0;
     }
 
+    final originalTheme = context.themeData;
+
     final actions = <Widget>[
       if (album != null && album.isActivityEnabled && album.isShared)
         IconButton(
@@ -58,10 +60,10 @@ class ViewerTopAppBar extends ConsumerWidget implements PreferredSizeWidget {
         const FavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
       if (asset.hasRemote && isOwner && asset.isFavorite)
         const UnFavoriteActionButton(source: ActionSource.viewer, iconOnly: true),
-      const ViewerKebabMenu(),
+      ViewerKebabMenu(originalTheme: originalTheme),
     ];
 
-    final lockedViewActions = <Widget>[const ViewerKebabMenu()];
+    final lockedViewActions = <Widget>[ViewerKebabMenu(originalTheme: originalTheme)];
 
     return IgnorePointer(
       ignoring: opacity < 255,

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -1,11 +1,23 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/cast_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
+import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
+import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
 
 class ViewerKebabMenu extends ConsumerWidget {
   const ViewerKebabMenu({super.key});
@@ -17,6 +29,19 @@ class ViewerKebabMenu extends ConsumerWidget {
       return const SizedBox.shrink();
     }
 
+    final user = ref.watch(currentUserProvider);
+    final isOwner = asset is RemoteAsset && asset.ownerId == user?.id;
+    final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
+
+    final timelineOrigin = ref.read(timelineServiceProvider).origin;
+    final showViewInTimelineButton =
+        timelineOrigin != TimelineOrigin.main &&
+        timelineOrigin != TimelineOrigin.deepLink &&
+        timelineOrigin != TimelineOrigin.trash &&
+        timelineOrigin != TimelineOrigin.archive &&
+        timelineOrigin != TimelineOrigin.localAlbum &&
+        isOwner;
+
     final menuChildren = <Widget>[
       BaseActionButton(
         label: 'open_asset_info'.tr(),
@@ -25,6 +50,37 @@ class ViewerKebabMenu extends ConsumerWidget {
         onPressed: () => EventStream.shared.emit(const ViewerOpenBottomSheetEvent()),
       ),
     ];
+
+    // Add motion photo button
+    if (asset.isMotionPhoto) {
+      menuChildren.add(const MotionPhotoActionButton(menuItem: true));
+    }
+
+    // Add view in timeline button
+    if (showViewInTimelineButton) {
+      menuChildren.add(
+        BaseActionButton(
+          label: 'view_in_timeline'.t(context: context),
+          iconData: Icons.image_search,
+          menuItem: true,
+          onPressed: () async {
+            await context.maybePop();
+            await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
+            EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
+          },
+        ),
+      );
+    }
+
+    // Add cast button if casting or has remote
+    if (isCasting || asset.hasRemote) {
+      menuChildren.add(const CastActionButton(menuItem: true));
+    }
+
+    // Add download button if remote only
+    if (asset.isRemoteOnly) {
+      menuChildren.add(const DownloadActionButton(source: ActionSource.viewer, menuItem: true));
+    }
 
     return MenuAnchor(
       consumeOutsideTap: true,

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -30,7 +30,7 @@ class ViewerKebabMenu extends ConsumerWidget {
       timelineOrigin: timelineOrigin,
     );
 
-    final menuChildren = ViewerKebabMenuButtonBuilder.build(kebabContext, context);
+    final menuChildren = ViewerKebabMenuButtonBuilder.build(kebabContext, context, ref);
 
     return MenuAnchor(
       consumeOutsideTap: true,

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -19,7 +19,7 @@ class ViewerKebabMenu extends ConsumerWidget {
 
     final menuChildren = <Widget>[
       BaseActionButton(
-        label: 'about'.tr(),
+        label: 'open_asset_info'.tr(),
         iconData: Icons.info_outline,
         menuItem: true,
         onPressed: () => EventStream.shared.emit(const ViewerOpenBottomSheetEvent()),

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -39,13 +39,23 @@ class ViewerKebabMenu extends ConsumerWidget {
       consumeOutsideTap: true,
       style: MenuStyle(
         backgroundColor: WidgetStatePropertyAll(context.themeData.scaffoldBackgroundColor),
+        surfaceTintColor: const WidgetStatePropertyAll(Colors.grey),
         elevation: const WidgetStatePropertyAll(4),
         shape: const WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
         ),
-        padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 2)),
+        padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 6)),
       ),
-      menuChildren: menuChildren,
+      menuChildren: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 150),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: menuChildren,
+          ),
+        ),
+      ],
       builder: (context, controller, child) {
         return IconButton(
           icon: const Icon(Icons.more_vert_rounded),

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -9,7 +9,9 @@ import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/utils/action_button.utils.dart';
 
 class ViewerKebabMenu extends ConsumerWidget {
-  const ViewerKebabMenu({super.key});
+  const ViewerKebabMenu({super.key, this.originalTheme});
+
+  final ThemeData? originalTheme;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -28,6 +30,7 @@ class ViewerKebabMenu extends ConsumerWidget {
       isOwner: isOwner,
       isCasting: isCasting,
       timelineOrigin: timelineOrigin,
+      originalTheme: originalTheme,
     );
 
     final menuChildren = ViewerKebabMenuButtonBuilder.build(kebabContext, context, ref);

--- a/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/viewer_kebab_menu.widget.dart
@@ -1,23 +1,12 @@
-import 'package:auto_route/auto_route.dart';
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/domain/models/events.model.dart';
-import 'package:immich_mobile/domain/services/timeline.service.dart';
-import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
-import 'package:immich_mobile/extensions/translate_extensions.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/base_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/cast_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/providers/cast.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/current_asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
-import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/action_button.utils.dart';
 
 class ViewerKebabMenu extends ConsumerWidget {
   const ViewerKebabMenu({super.key});
@@ -32,55 +21,16 @@ class ViewerKebabMenu extends ConsumerWidget {
     final user = ref.watch(currentUserProvider);
     final isOwner = asset is RemoteAsset && asset.ownerId == user?.id;
     final isCasting = ref.watch(castProvider.select((c) => c.isCasting));
-
     final timelineOrigin = ref.read(timelineServiceProvider).origin;
-    final showViewInTimelineButton =
-        timelineOrigin != TimelineOrigin.main &&
-        timelineOrigin != TimelineOrigin.deepLink &&
-        timelineOrigin != TimelineOrigin.trash &&
-        timelineOrigin != TimelineOrigin.archive &&
-        timelineOrigin != TimelineOrigin.localAlbum &&
-        isOwner;
 
-    final menuChildren = <Widget>[
-      BaseActionButton(
-        label: 'open_asset_info'.tr(),
-        iconData: Icons.info_outline,
-        menuItem: true,
-        onPressed: () => EventStream.shared.emit(const ViewerOpenBottomSheetEvent()),
-      ),
-    ];
+    final kebabContext = ViewerKebabMenuButtonContext(
+      asset: asset,
+      isOwner: isOwner,
+      isCasting: isCasting,
+      timelineOrigin: timelineOrigin,
+    );
 
-    // Add motion photo button
-    if (asset.isMotionPhoto) {
-      menuChildren.add(const MotionPhotoActionButton(menuItem: true));
-    }
-
-    // Add view in timeline button
-    if (showViewInTimelineButton) {
-      menuChildren.add(
-        BaseActionButton(
-          label: 'view_in_timeline'.t(context: context),
-          iconData: Icons.image_search,
-          menuItem: true,
-          onPressed: () async {
-            await context.maybePop();
-            await context.navigateTo(const TabShellRoute(children: [MainTimelineRoute()]));
-            EventStream.shared.emit(ScrollToDateEvent(asset.createdAt));
-          },
-        ),
-      );
-    }
-
-    // Add cast button if casting or has remote
-    if (isCasting || asset.hasRemote) {
-      menuChildren.add(const CastActionButton(menuItem: true));
-    }
-
-    // Add download button if remote only
-    if (asset.isRemoteOnly) {
-      menuChildren.add(const DownloadActionButton(source: ActionSource.viewer, menuItem: true));
-    }
+    final menuChildren = ViewerKebabMenuButtonBuilder.build(kebabContext, context);
 
     return MenuAnchor(
       consumeOutsideTap: true,
@@ -90,6 +40,7 @@ class ViewerKebabMenu extends ConsumerWidget {
         shape: const WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
         ),
+        padding: const WidgetStatePropertyAll(EdgeInsets.symmetric(vertical: 2)),
       ),
       menuChildren: menuChildren,
       builder: (context, controller, child) {

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -18,7 +18,6 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/delete_local_a
 import 'package:immich_mobile/presentation/widgets/action_buttons/delete_permanent_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/like_activity_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/action_buttons/motion_photo_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/move_to_lock_folder_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_album_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_lock_folder_action_button.widget.dart';

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -212,7 +213,7 @@ enum ViewerKebabMenuButtonType {
     };
   }
 
-  Widget buildButton(ViewerKebabMenuButtonContext context, BuildContext buildContext) {
+  ConsumerWidget buildButton(ViewerKebabMenuButtonContext context, BuildContext buildContext) {
     return switch (this) {
       ViewerKebabMenuButtonType.openInfo => BaseActionButton(
         label: 'open_asset_info'.tr(),
@@ -240,10 +241,10 @@ enum ViewerKebabMenuButtonType {
 class ViewerKebabMenuButtonBuilder {
   static const List<ViewerKebabMenuButtonType> _buttonTypes = ViewerKebabMenuButtonType.values;
 
-  static List<Widget> build(ViewerKebabMenuButtonContext context, BuildContext buildContext) {
+  static List<Widget> build(ViewerKebabMenuButtonContext context, BuildContext buildContext, WidgetRef ref) {
     return _buttonTypes
         .where((type) => type.shouldShow(context))
-        .map((type) => type.buildButton(context, buildContext))
+        .map((type) => type.buildButton(context, buildContext).build(buildContext, ref))
         .expand((action) => [const Divider(height: 0), action])
         .skip(1) // to remove the first divider
         .toList();

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -181,12 +181,14 @@ class ViewerKebabMenuButtonContext {
   final bool isOwner;
   final bool isCasting;
   final TimelineOrigin timelineOrigin;
+  final ThemeData? originalTheme;
 
   const ViewerKebabMenuButtonContext({
     required this.asset,
     required this.isOwner,
     required this.isCasting,
     required this.timelineOrigin,
+    this.originalTheme,
   });
 }
 
@@ -218,6 +220,7 @@ enum ViewerKebabMenuButtonType {
       ViewerKebabMenuButtonType.openInfo => BaseActionButton(
         label: 'open_asset_info'.tr(),
         iconData: Icons.info_outline,
+        iconColor: context.originalTheme?.iconTheme.color,
         menuItem: true,
         onPressed: () => EventStream.shared.emit(const ViewerOpenBottomSheetEvent()),
       ),
@@ -225,6 +228,7 @@ enum ViewerKebabMenuButtonType {
       ViewerKebabMenuButtonType.viewInTimeline => BaseActionButton(
         label: 'view_in_timeline'.t(context: buildContext),
         iconData: Icons.image_search,
+        iconColor: context.originalTheme?.iconTheme.color,
         menuItem: true,
         onPressed: () async {
           await buildContext.maybePop();


### PR DESCRIPTION
## Description
- next step of #24387 
  - move buttons other than Favorites and Activity to the kebamu menu (same as gphotos)
  - details: `ScreenShots` section
- other minor fix
  - i18n: "About"

### Next Step
- show datetime & location in top bar
- #23635 


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

### Manual tests on iOS Simulator
- [x] Visual regression tests
- [x] Basic regression tests of button features

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![iPhone_16e](https://github.com/user-attachments/assets/70858e45-d56f-499a-996f-ec639bfd36db)


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~
- [ ] ~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
initial implementation and refactoring
