### PR TITLE
feat(mobile): keyboard shortcuts in asset viewer

### DIFF
--- a/mobile/lib/presentation/widgets/action_buttons/delete_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/delete_action_button.widget.dart
@@ -20,7 +20,7 @@ class DeleteActionButton extends ConsumerWidget {
   final bool showConfirmation;
   const DeleteActionButton({super.key, required this.source, this.showConfirmation = false});
 
-  void _onTap(BuildContext context, WidgetRef ref) async {
+  static void deleteAsset(BuildContext context, WidgetRef ref, bool showConfirmation, ActionSource source) async {
     if (!context.mounted) {
       return;
     }
@@ -74,7 +74,7 @@ class DeleteActionButton extends ConsumerWidget {
       maxWidth: 110.0,
       iconData: Icons.delete_sweep_outlined,
       label: "delete".t(context: context),
-      onPressed: () => _onTap(context, ref),
+      onPressed: () => deleteAsset(context, ref, showConfirmation, source),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/action_buttons/download_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/download_action_button.widget.dart
@@ -14,7 +14,12 @@ class DownloadActionButton extends ConsumerWidget {
   final bool menuItem;
   const DownloadActionButton({super.key, required this.source, this.iconOnly = false, this.menuItem = false});
 
-  void _onTap(BuildContext context, WidgetRef ref, BackgroundSyncManager backgroundSyncManager) async {
+  static void onDownload(
+    BuildContext context,
+    WidgetRef ref,
+    ActionSource source,
+    BackgroundSyncManager backgroundSyncManager,
+  ) async {
     if (!context.mounted) {
       return;
     }
@@ -41,7 +46,7 @@ class DownloadActionButton extends ConsumerWidget {
       label: "download".t(context: context),
       iconOnly: iconOnly,
       menuItem: menuItem,
-      onPressed: () => _onTap(context, ref, backgroundManager),
+      onPressed: () => onDownload(context, ref, source, backgroundManager),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/action_buttons/favorite_action_button.widget.dart
+++ b/mobile/lib/presentation/widgets/action_buttons/favorite_action_button.widget.dart
@@ -15,7 +15,7 @@ class FavoriteActionButton extends ConsumerWidget {
 
   const FavoriteActionButton({super.key, required this.source, this.iconOnly = false, this.menuItem = false});
 
-  void _onTap(BuildContext context, WidgetRef ref) async {
+  static void favoriteAsset(BuildContext context, WidgetRef ref, ActionSource source) async {
     if (!context.mounted) {
       return;
     }
@@ -47,7 +47,7 @@ class FavoriteActionButton extends ConsumerWidget {
       label: "favorite".t(context: context),
       iconOnly: iconOnly,
       menuItem: menuItem,
-      onPressed: () => _onTap(context, ref),
+      onPressed: () => favoriteAsset(context, ref, source),
     );
   }
 }


### PR DESCRIPTION
## Description
Implements #7665

<table>
<tr>
 <td><b>Shortcut</b>
 <td><b>Action</b>
<tr>
 <td>Arrow keys
 <td>Navigate between assets
<tr>
 <td><code>F</code>
 <td>Favorite/Unfavorite
<tr>
 <td><code>Shift</code> + <code>D</code>
 <td>Download
<tr>
 <td><code>Del</code>
 <td>Delete
<tr>
 <td><code>L</code>
 <td>Add to album
</table>

## How Has This Been Tested?
Tested on my phone using scrcpy on PC to act as an external keyboard.
**Not tested on iOS/iPadOS**

<details><summary><h2>Video demo</h2></summary>

https://github.com/user-attachments/assets/cf56a8fd-cf8a-43bc-baa1-c55be60c2695



</details>