### PR TITLE
fix(mobile): timeline bottom padding on selection

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -324,7 +324,11 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
           final topPadding = context.padding.top + (widget.appBar == null ? 0 : kToolbarHeight) + 10;
 
           const scrubberBottomPadding = 100.0;
-          final bottomPadding = context.padding.bottom + (widget.appBar == null ? 0 : scrubberBottomPadding);
+          const bottomSheetOpenModifier = 120.0;
+          final bottomPadding =
+              context.padding.bottom +
+              (widget.appBar == null ? 0 : scrubberBottomPadding) +
+              (isMultiSelectEnabled ? bottomSheetOpenModifier : 0);
 
           final grid = CustomScrollView(
             primary: true,
@@ -347,7 +351,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> {
                   addRepaintBoundaries: false,
                 ),
               ),
-              const SliverPadding(padding: EdgeInsets.only(bottom: scrubberBottomPadding)),
+              SliverPadding(padding: EdgeInsets.only(bottom: bottomPadding)),
             ],
           );
 


### PR DESCRIPTION
## Description
Fixes #24469

## How Has This Been Tested?

- [x] Select assets at the bottom of a timeline
- [x] When the bottom sheet opens, drag to reveal the bottom assets that are no longer covered by the bottom sheet
- [x] Deselect the assets - the padding gets removed

<details><summary><h2>Video demo</h2></summary>

https://github.com/user-attachments/assets/e856ccc3-1b0b-45f1-9e7e-fb99c0c5175f



</details>