### PR TITLE
fix(docs): slow upload speed with example nginx reverse proxy config

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -23,7 +23,7 @@ server {
 
     # disable buffering uploads to prevent OOM on reverse proxy server and make uploads twice as fast (no pause)
     proxy_request_buffering off;
-    client_body_buffer_size 512k;
+    client_body_buffer_size 1024k;
 
     # Set headers
     proxy_set_header Host              $host;

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -23,6 +23,7 @@ server {
 
     # disable buffering uploads to prevent OOM on reverse proxy server and make uploads twice as fast (no pause)
     proxy_request_buffering off;
+    client_body_buffer_size 512k;
 
     # Set headers
     proxy_set_header Host              $host;

--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -23,6 +23,8 @@ server {
 
     # disable buffering uploads to prevent OOM on reverse proxy server and make uploads twice as fast (no pause)
     proxy_request_buffering off;
+
+    # increase body buffer to avoid limiting upload speed
     client_body_buffer_size 1024k;
 
     # Set headers


### PR DESCRIPTION
## Description

Increases the client body buffer to 1MiB.

As a side effect of #24351, uploads speed may be limited by a small client body buffer (default is 2 memory pages - usually equals 8KiB or 16KiB depending on platform - https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size). On my setup for example, I went from my normal upload speed of 40MB/s down to 11MB/s due to the change in #24351. Increasing the buffer size returns my upload speed to my normal 40MB/s. 

The ideal size probably depends on the hardware setup to some extent, but 1MiB seems like a reasonable value from a little bit of testing. 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Confirm upload speed is back to normal
- [x] Use the app and web (timeline, asset viewer, video streaming, etc) to confirm nothing is catastrophically broken

## Checklist:

- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
