### PR TITLE
fix(mobile): iOS local permission dialog extra whitespace

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -137,8 +137,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>We need to use FaceID to allow access to your locked folder</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>We need local network permission to connect to the local server using IP address and
-      allow the casting feature to work</string>
+	<string>We need local network permission to connect to the local server using IP address and allow the casting feature to work</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>We require this permission to access the local WiFi name for background upload mechanism</string>
 	<key>NSLocationUsageDescription</key>


### PR DESCRIPTION
## Description

On iOS initial login and setup, the location permission description renders oddly:

> <img width="292" height="234" alt="image" src="https://github.com/user-attachments/assets/162de3c7-89b0-4e89-bee7-efcd5f306820" />

This appears to be caused by extra whitespace, which this PR removes from the iOS `mobile/ios/Runner/Info.plist` file.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I've not done any testing of this change. I don't know whether these whitespace changes will affect translations.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Absolutely NO LLM or AI was used to create or evaluate this change. It's whitespace.