### PR TITLE
fix(web): show inferred timezone in the date editor

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -41,6 +41,7 @@
     onclick={handleChangeDate}
     title={isOwner ? $t('edit_date') : ''}
     class:hover:text-primary={isOwner}
+    data-testid="detail-panel-edit-date-button"
   >
     <div class="flex gap-4">
       <div>

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -29,6 +29,7 @@
     await modalManager.show(AssetChangeDateModal, {
       asset: toTimelineAsset(asset),
       initialDate: dateTime,
+      initialTimeZone: timeZone,
     });
   };
 </script>

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
+  import { locale } from '$lib/stores/preferences.store';
+  import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
+  import { type AssetResponseDto } from '@immich/sdk';
+  import { Icon, modalManager } from '@immich/ui';
+  import { mdiCalendar, mdiPencil } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    asset: AssetResponseDto;
+    isOwner: boolean;
+  }
+
+  let { asset, isOwner }: Props = $props();
+
+  let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
+  let dateTime = $derived(
+    timeZone && asset.exifInfo?.dateTimeOriginal
+      ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
+      : fromISODateTimeUTC(asset.localDateTime),
+  );
+
+  const handleChangeDate = async () => {
+    if (!isOwner) {
+      return;
+    }
+
+    await modalManager.show(AssetChangeDateModal, {
+      asset: toTimelineAsset(asset),
+      initialDate: dateTime,
+    });
+  };
+</script>
+
+{#if dateTime}
+  <button
+    type="button"
+    class="flex w-full text-start justify-between place-items-start gap-4 py-4"
+    onclick={handleChangeDate}
+    title={isOwner ? $t('edit_date') : ''}
+    class:hover:text-primary={isOwner}
+  >
+    <div class="flex gap-4">
+      <div>
+        <Icon icon={mdiCalendar} size="24" />
+      </div>
+
+      <div>
+        <p>
+          {dateTime.toLocaleString(
+            {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            },
+            { locale: $locale },
+          )}
+        </p>
+        <div class="flex gap-2 text-sm">
+          <p>
+            {dateTime.toLocaleString(
+              {
+                weekday: 'short',
+                hour: 'numeric',
+                minute: '2-digit',
+                second: '2-digit',
+                timeZoneName: timeZone ? 'longOffset' : undefined,
+              },
+              { locale: $locale },
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    {#if isOwner}
+      <div class="p-1">
+        <Icon icon={mdiPencil} size="20" />
+      </div>
+    {/if}
+  </button>
+{:else if !dateTime && isOwner}
+  <div class="flex justify-between place-items-start gap-4 py-4">
+    <div class="flex gap-4">
+      <div>
+        <Icon icon={mdiCalendar} size="24" />
+      </div>
+    </div>
+    <div class="p-1">
+      <Icon icon={mdiPencil} size="20" />
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
+  import DetailPanelDate from '$lib/components/asset-viewer/detail-panel-date.svelte';
   import DetailPanelDescription from '$lib/components/asset-viewer/detail-panel-description.svelte';
   import DetailPanelLocation from '$lib/components/asset-viewer/detail-panel-location.svelte';
   import DetailPanelRating from '$lib/components/asset-viewer/detail-panel-star-rating.svelte';
@@ -8,7 +9,6 @@
   import { AppRoute, QueryParameter, timeToLoadTheMap } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
-  import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
   import { isFaceEditMode } from '$lib/stores/face-edit.svelte';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { locale } from '$lib/stores/preferences.store';
@@ -17,12 +17,10 @@
   import { delay, getDimensions } from '$lib/utils/asset-utils';
   import { getByteUnitString } from '$lib/utils/byte-units';
   import { getMetadataSearchQuery } from '$lib/utils/metadata-search';
-  import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
   import { getParentPath } from '$lib/utils/tree-utils';
   import { AssetMediaSize, getAssetInfo, type AlbumResponseDto, type AssetResponseDto } from '@immich/sdk';
-  import { Icon, IconButton, LoadingSpinner, modalManager } from '@immich/ui';
+  import { Icon, IconButton, LoadingSpinner } from '@immich/ui';
   import {
-    mdiCalendar,
     mdiCamera,
     mdiCameraIris,
     mdiClose,
@@ -56,12 +54,6 @@
   let people = $derived(asset.people || []);
   let unassignedFaces = $derived(asset.unassignedFaces || []);
   let showingHiddenPeople = $state(false);
-  let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
-  let dateTime = $derived(
-    timeZone && asset.exifInfo?.dateTimeOriginal
-      ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
-      : fromISODateTimeUTC(asset.localDateTime),
-  );
   let latlng = $derived(
     (() => {
       const lat = asset.exifInfo?.latitude;
@@ -108,14 +100,6 @@
   };
 
   const toggleAssetPath = () => (showAssetPath = !showAssetPath);
-
-  const handleChangeDate = async () => {
-    if (!isOwner) {
-      return;
-    }
-
-    await modalManager.show(AssetChangeDateModal, { asset: toTimelineAsset(asset), initialDate: dateTime });
-  };
 </script>
 
 <section class="relative p-2">
@@ -268,65 +252,7 @@
       <p class="uppercase text-sm">{$t('no_exif_info_available')}</p>
     {/if}
 
-    {#if dateTime}
-      <button
-        type="button"
-        class="flex w-full text-start justify-between place-items-start gap-4 py-4"
-        onclick={handleChangeDate}
-        title={isOwner ? $t('edit_date') : ''}
-        class:hover:text-primary={isOwner}
-      >
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
-
-          <div>
-            <p>
-              {dateTime.toLocaleString(
-                {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
-                },
-                { locale: $locale },
-              )}
-            </p>
-            <div class="flex gap-2 text-sm">
-              <p>
-                {dateTime.toLocaleString(
-                  {
-                    weekday: 'short',
-                    hour: 'numeric',
-                    minute: '2-digit',
-                    second: '2-digit',
-                    timeZoneName: timeZone ? 'longOffset' : undefined,
-                  },
-                  { locale: $locale },
-                )}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {#if isOwner}
-          <div class="p-1">
-            <Icon icon={mdiPencil} size="20" />
-          </div>
-        {/if}
-      </button>
-    {:else if !dateTime && isOwner}
-      <div class="flex justify-between place-items-start gap-4 py-4">
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
-        </div>
-        <div class="p-1">
-          <Icon icon={mdiPencil} size="20" />
-        </div>
-      </div>
-    {/if}
+    <DetailPanelDate {asset} {isOwner} />
 
     <div class="flex gap-4 py-4">
       <div><Icon icon={mdiImageOutline} size="24" /></div>


### PR DESCRIPTION
UPD: the one line bugfix moved into a separate #24513.

## Description

Issue: 
Currently the date editor displays (selects) the _first_ timezone from the sorted list of timezones having the same offset. Even if the asset already has an inferred timezone (America/New_York -05:00), the selector still falls back to the _first_ timezone having same offset (America/Atikokan -05:00). See the screenshots below. 
Previously, `initialTimezone` was passed to the modal, but it was dropped (mistakenly?) in one of the recent PRs that touched it.

PR:
Basically a one line fix https://github.com/immich-app/immich/commit/3ff1c8f8ef848af9d1eba9001954bbfb6bab10b5 - pass `initialTimezone` as needed.
The rest:
- refactoring: extracted DatePanelDate
- e2e: a small test that uploads a test asset, then invokes the date editor and validates date and timezone.

**Depends** on this PR to be merged: https://github.com/immich-app/test-assets/pull/24. Or should I change the submodule URL to point to my fork until it's merged?

## How Has This Been Tested?
Added e2e test.

Considered adding unit tests, but they seem too implementation-specific (which is reasonable): expect timezone to be consumed from exifInfo and passed from the date panel to AssetChangeDateModal, expect timezone to be consumed and displayed in AssetChangeDateModal. Let me know if it makes sense to add. For now I skipped unit tests.

<details><summary><h2>Screenshots</h2></summary>
Before (bug):
<img width="2558" height="1478" alt="image" src="https://github.com/user-attachments/assets/f633c250-f311-4f53-9a64-d7cfee9d2666" />

After (fix):
<img width="2562" height="1470" alt="image" src="https://github.com/user-attachments/assets/4b5a5672-a3ea-462d-9a74-de8f087ed578" />
</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Assisted with tests.