### PR TITLE
fix(web): show inferred timezone in date editor

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -114,7 +114,11 @@
       return;
     }
 
-    await modalManager.show(AssetChangeDateModal, { asset: toTimelineAsset(asset), initialDate: dateTime });
+    await modalManager.show(AssetChangeDateModal, {
+      asset: toTimelineAsset(asset),
+      initialDate: dateTime,
+      initialTimeZone: timeZone,
+    });
   };
 </script>
 


### PR DESCRIPTION
Split up from #24498.

## Description

Issue: 
Currently the date editor displays (selects) the _first_ timezone from the sorted list of timezones having the same offset. Even if the asset already has an inferred timezone (America/New_York -05:00), the selector still falls back to the _first_ timezone having same offset (America/Atikokan -05:00). See the screenshots below. 

Previously, `initialTimezone` was passed to the modal, but it was dropped (mistakenly?) in one of the recent PRs that touched it.

This PR adds `initialTimezone` back to the list of properties passed to the modal.
## How Has This Been Tested?
Tested manually.

e2e + refactoring will go into another PR.

<details><summary><h2>Screenshots</h2></summary>
Before (bug):
<img width="2558" height="1478" alt="image" src="https://github.com/user-attachments/assets/f633c250-f311-4f53-9a64-d7cfee9d2666" />

After (fix):
<img width="2562" height="1470" alt="image" src="https://github.com/user-attachments/assets/4b5a5672-a3ea-462d-9a74-de8f087ed578" />
</details>

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.