### PR TITLE
chore(web): refactor date section of asset viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -29,6 +29,7 @@
     await modalManager.show(AssetChangeDateModal, {
       asset: toTimelineAsset(asset),
       initialDate: dateTime,
+      initialTimeZone: timeZone,
     });
   };
 </script>

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
+  import { locale } from '$lib/stores/preferences.store';
+  import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
+  import { type AssetResponseDto } from '@immich/sdk';
+  import { Icon, modalManager } from '@immich/ui';
+  import { mdiCalendar, mdiPencil } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    asset: AssetResponseDto;
+    isOwner: boolean;
+  }
+
+  let { asset, isOwner }: Props = $props();
+
+  let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
+  let dateTime = $derived(
+    timeZone && asset.exifInfo?.dateTimeOriginal
+      ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
+      : fromISODateTimeUTC(asset.localDateTime),
+  );
+
+  const handleChangeDate = async () => {
+    if (!isOwner) {
+      return;
+    }
+
+    await modalManager.show(AssetChangeDateModal, {
+      asset: toTimelineAsset(asset),
+      initialDate: dateTime,
+    });
+  };
+</script>
+
+{#if dateTime}
+  <button
+    type="button"
+    class="flex w-full text-start justify-between place-items-start gap-4 py-4"
+    onclick={handleChangeDate}
+    title={isOwner ? $t('edit_date') : ''}
+    class:hover:text-primary={isOwner}
+  >
+    <div class="flex gap-4">
+      <div>
+        <Icon icon={mdiCalendar} size="24" />
+      </div>
+
+      <div>
+        <p>
+          {dateTime.toLocaleString(
+            {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            },
+            { locale: $locale },
+          )}
+        </p>
+        <div class="flex gap-2 text-sm">
+          <p>
+            {dateTime.toLocaleString(
+              {
+                weekday: 'short',
+                hour: 'numeric',
+                minute: '2-digit',
+                second: '2-digit',
+                timeZoneName: timeZone ? 'longOffset' : undefined,
+              },
+              { locale: $locale },
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    {#if isOwner}
+      <div class="p-1">
+        <Icon icon={mdiPencil} size="20" />
+      </div>
+    {/if}
+  </button>
+{:else if !dateTime && isOwner}
+  <div class="flex justify-between place-items-start gap-4 py-4">
+    <div class="flex gap-4">
+      <div>
+        <Icon icon={mdiCalendar} size="24" />
+      </div>
+    </div>
+    <div class="p-1">
+      <Icon icon={mdiPencil} size="20" />
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -40,6 +40,7 @@
     onclick={handleChangeDate}
     title={isOwner ? $t('edit_date') : ''}
     class:hover:text-primary={isOwner}
+    data-testid="detail-panel-edit-date-button"
   >
     <div class="flex gap-4">
       <div>

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -20,7 +20,7 @@
       ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
       : fromISODateTimeUTC(asset.localDateTime),
   );
-  const isOwner = $derived(asset.ownerId === authManager.user.id);
+  const isOwner = $derived(authManager.authenticated && asset.ownerId === authManager.user.id);
 
   const handleChangeDate = async () => {
     if (!isOwner) {

--- a/web/src/lib/components/asset-viewer/detail-panel-date.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-date.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { authManager } from '$lib/managers/auth-manager.svelte';
   import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
   import { locale } from '$lib/stores/preferences.store';
   import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
@@ -7,19 +8,19 @@
   import { mdiCalendar, mdiPencil } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
-  interface Props {
+  type Props = {
     asset: AssetResponseDto;
-    isOwner: boolean;
-  }
+  };
 
-  let { asset, isOwner }: Props = $props();
+  const { asset }: Props = $props();
 
-  let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
-  let dateTime = $derived(
+  const timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
+  const dateTime = $derived(
     timeZone && asset.exifInfo?.dateTimeOriginal
       ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
       : fromISODateTimeUTC(asset.localDateTime),
   );
+  const isOwner = $derived(asset.ownerId === authManager.user.id);
 
   const handleChangeDate = async () => {
     if (!isOwner) {
@@ -44,20 +45,11 @@
     data-testid="detail-panel-edit-date-button"
   >
     <div class="flex gap-4">
-      <div>
-        <Icon icon={mdiCalendar} size="24" />
-      </div>
+      <Icon icon={mdiCalendar} size="24" />
 
       <div>
         <p>
-          {dateTime.toLocaleString(
-            {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-            },
-            { locale: $locale },
-          )}
+          {dateTime.toLocaleString({ month: 'short', day: 'numeric', year: 'numeric' }, { locale: $locale })}
         </p>
         <div class="flex gap-2 text-sm">
           <p>
@@ -85,9 +77,7 @@
 {:else if !dateTime && isOwner}
   <div class="flex justify-between place-items-start gap-4 py-4">
     <div class="flex gap-4">
-      <div>
-        <Icon icon={mdiCalendar} size="24" />
-      </div>
+      <Icon icon={mdiCalendar} size="24" />
     </div>
     <div class="p-1">
       <Icon icon={mdiPencil} size="20" />

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -271,7 +271,7 @@
       <Text size="small" color="muted">{$t('no_exif_info_available')}</Text>
     {/if}
 
-    <DetailPanelDate {asset} {isOwner} />
+    <DetailPanelDate {asset} />
 
     <div class="flex gap-4 py-4">
       <div><Icon icon={mdiImageOutline} size="24" /></div>

--- a/web/src/lib/components/asset-viewer/detail-panel.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import DetailPanelDate from '$lib/components/asset-viewer/detail-panel-date.svelte';
   import DetailPanelDescription from '$lib/components/asset-viewer/detail-panel-description.svelte';
   import DetailPanelLocation from '$lib/components/asset-viewer/detail-panel-location.svelte';
   import DetailPanelRating from '$lib/components/asset-viewer/detail-panel-star-rating.svelte';
@@ -8,7 +9,6 @@
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
-  import AssetChangeDateModal from '$lib/modals/AssetChangeDateModal.svelte';
   import { Route } from '$lib/route';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { locale } from '$lib/stores/preferences.store';
@@ -16,7 +16,6 @@
   import { delay, getDimensions } from '$lib/utils/asset-utils';
   import { getByteUnitString } from '$lib/utils/byte-units';
   import { handleError } from '$lib/utils/handle-error';
-  import { fromISODateTime, fromISODateTimeUTC, toTimelineAsset } from '$lib/utils/timeline-util';
   import { getParentPath } from '$lib/utils/tree-utils';
   import {
     AssetMediaSize,
@@ -25,9 +24,8 @@
     type AlbumResponseDto,
     type AssetResponseDto,
   } from '@immich/sdk';
-  import { Icon, IconButton, LoadingSpinner, modalManager, Text } from '@immich/ui';
+  import { Icon, IconButton, LoadingSpinner, Text } from '@immich/ui';
   import {
-    mdiCalendar,
     mdiCamera,
     mdiCameraIris,
     mdiClose,
@@ -59,12 +57,6 @@
   let people = $derived(asset.people || []);
   let unassignedFaces = $derived(asset.unassignedFaces || []);
   let showingHiddenPeople = $state(false);
-  let timeZone = $derived(asset.exifInfo?.timeZone ?? undefined);
-  let dateTime = $derived(
-    timeZone && asset.exifInfo?.dateTimeOriginal
-      ? fromISODateTime(asset.exifInfo.dateTimeOriginal, timeZone)
-      : fromISODateTimeUTC(asset.localDateTime),
-  );
   let latlng = $derived(
     (() => {
       const lat = asset.exifInfo?.latitude;
@@ -125,18 +117,6 @@
   const getAssetFolderHref = (asset: AssetResponseDto) => {
     // Remove the last part of the path to get the parent path
     return Route.folders({ path: getParentPath(asset.originalPath) });
-  };
-
-  const handleChangeDate = async () => {
-    if (!isOwner) {
-      return;
-    }
-
-    await modalManager.show(AssetChangeDateModal, {
-      asset: toTimelineAsset(asset),
-      initialDate: dateTime,
-      initialTimeZone: timeZone,
-    });
   };
 </script>
 
@@ -291,65 +271,7 @@
       <Text size="small" color="muted">{$t('no_exif_info_available')}</Text>
     {/if}
 
-    {#if dateTime}
-      <button
-        type="button"
-        class="flex w-full text-start justify-between place-items-start gap-4 py-4"
-        onclick={handleChangeDate}
-        title={isOwner ? $t('edit_date') : ''}
-        class:hover:text-primary={isOwner}
-      >
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
-
-          <div>
-            <p>
-              {dateTime.toLocaleString(
-                {
-                  month: 'short',
-                  day: 'numeric',
-                  year: 'numeric',
-                },
-                { locale: $locale },
-              )}
-            </p>
-            <div class="flex gap-2 text-sm">
-              <p>
-                {dateTime.toLocaleString(
-                  {
-                    weekday: 'short',
-                    hour: 'numeric',
-                    minute: '2-digit',
-                    second: '2-digit',
-                    timeZoneName: timeZone ? 'longOffset' : undefined,
-                  },
-                  { locale: $locale },
-                )}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {#if isOwner}
-          <div class="p-1">
-            <Icon icon={mdiPencil} size="20" />
-          </div>
-        {/if}
-      </button>
-    {:else if !dateTime && isOwner}
-      <div class="flex justify-between place-items-start gap-4 py-4">
-        <div class="flex gap-4">
-          <div>
-            <Icon icon={mdiCalendar} size="24" />
-          </div>
-        </div>
-        <div class="p-1">
-          <Icon icon={mdiPencil} size="20" />
-        </div>
-      </div>
-    {/if}
+    <DetailPanelDate {asset} {isOwner} />
 
     <div class="flex gap-4 py-4">
       <div><Icon icon={mdiImageOutline} size="24" /></div>


### PR DESCRIPTION
Split up from #24498.

## Description

Refactoring: extracted DetailPanelDate into a separate file.
e2e: cover the change with a small test that uploads a test asset, then invokes the date editor and validates date and timezone shown in selectors by default.

**Depends** on this PR to be merged: https://github.com/immich-app/test-assets/pull/24.

## How Has This Been Tested?
e2e.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have written tests for new code (if applicable)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Assisted with element locators in tests.