### PR TITLE
fix(ml): disable Objective-C fork safety check on macOS

### DIFF
--- a/machine-learning/immich_ml/gunicorn_conf.py
+++ b/machine-learning/immich_ml/gunicorn_conf.py
@@ -1,10 +1,19 @@
 import os
+import sys
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
 
 device_ids = os.environ.get("MACHINE_LEARNING_DEVICE_IDS", "0").replace(" ", "").split(",")
 env = os.environ
+
+# On macOS, CoreML and other Objective-C frameworks are not fork-safe.
+# When gunicorn forks workers, the Objective-C runtime may crash with:
+# "NSPlaceholderString initialize may have been in progress in another thread when fork() was called"
+# This environment variable disables the fork safety check to allow CoreML to work.
+# See: https://github.com/immich-app/immich/issues/24493
+if sys.platform == "darwin":
+    env.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
 
 
 # Round-robin device assignment for each worker


### PR DESCRIPTION
## Summary
- Fixes CoreML crash on macOS when gunicorn forks worker processes
- Sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` environment variable on macOS platforms
- This allows CoreML execution provider to work properly with gunicorn's fork-based worker model

## Problem
On macOS, CoreML and other Objective-C frameworks are not fork-safe. When gunicorn forks workers, the Objective-C runtime crashes with:

```
objc[87476]: +[NSPlaceholderString initialize] may have been in progress in another thread
when fork() was called. We cannot safely call it or ignore it in the fork() child process.
Crashing instead.
```

## Solution
Setting `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` is a known workaround for this macOS-specific issue. The environment variable is only set on macOS (`sys.platform == "darwin"`) and uses `setdefault()` to allow users to override if needed.

## References
- [Python multiprocessing and macOS](https://bugs.python.org/issue33725)
- [Gunicorn macOS issues](https://github.com/benoitc/gunicorn/issues/1701)

## Test Plan
- [ ] Test on macOS with CoreML execution provider enabled
- [ ] Verify ML worker processes start without crashing
- [ ] Confirm no regression on Linux/other platforms

Closes #24493
