### PR TITLE
fix(docs): typo in maintenance mode command

### DIFF
--- a/docs/docs/administration/server-commands.md
+++ b/docs/docs/administration/server-commands.md
@@ -52,7 +52,7 @@ Password login has been enabled.
 Disable Maintenance Mode
 
 ```
-immich-admin disable-maintenace-mode
+immich-admin disable-maintenance-mode
 Maintenance mode has been disabled.
 ```
 


### PR DESCRIPTION
## Description
Got some ugly error with a command from the docs. Seems there is a typo error.