### PR TITLE
fix(mobile): birthday off by one day on remote

### DIFF
--- a/mobile/lib/repositories/person_api.repository.dart
+++ b/mobile/lib/repositories/person_api.repository.dart
@@ -17,8 +17,10 @@ class PersonApiRepository extends ApiRepository {
   }
 
   Future<PersonDto> update(String id, {String? name, DateTime? birthday}) async {
-    final dto = await checkNull(_api.updatePerson(id, PersonUpdateDto(name: name, birthDate: birthday)));
-    return _toPerson(dto);
+    final birthdayUtc = birthday == null ? null : DateTime.utc(birthday.year, birthday.month, birthday.day);
+    final dto = PersonUpdateDto(name: name, birthDate: birthdayUtc);
+    final response = await checkNull(_api.updatePerson(id, dto));
+    return _toPerson(response);
   }
 
   static PersonDto _toPerson(PersonResponseDto dto) => PersonDto(


### PR DESCRIPTION
## Description
Fixes #24525

Previously, the app would save and show the birthday correctly locally (using drift), but would update the birthday on the server incorrectly (by one day off).

## How Has This Been Tested?

- [x] Go to a person and set a birthday
- [x] Check the updated birthday on the web interface, it is set correctly.
