### PR TITLE
fix(mobile): photo grid reflows on foldable display fold/unfold

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -62,6 +62,10 @@ class Timeline extends StatelessWidget {
       floatingActionButton: const DownloadStatusFloatingButton(),
       body: LayoutBuilder(
         builder: (_, constraints) => ProviderScope(
+          // Key changes when dimensions change significantly, forcing rebuild on fold/unfold
+          key: ValueKey(
+            'timeline_${(constraints.maxWidth / 50).round()}_${(constraints.maxHeight / 50).round()}',
+          ),
           overrides: [
             timelineArgsProvider.overrideWith(
               (ref) => TimelineArgs(


### PR DESCRIPTION
## Summary
- Fixes photo grid not reflowing when switching between folded and unfolded displays on foldable devices
- Adds `ValueKey` to `ProviderScope` in timeline widget to force widget rebuild when screen dimensions change significantly

## Root Cause
The `LayoutBuilder` in `timeline.widget.dart` correctly rebuilds with new constraints when the screen size changes, but the child `ProviderScope` had no key. This caused Flutter to reuse the existing widget state instead of creating a new one with the updated dimensions.

## Solution
Added a `ValueKey` based on rounded dimensions (divided by 50 to avoid rebuilds for tiny changes). When the key changes significantly (e.g., on fold/unfold), Flutter discards and recreates the widget subtree, properly propagating the new dimensions.

## Test plan
- [x] Open app on foldable device in folded state
- [x] Unfold device - grid should immediately reflow to fill the screen
- [x] Fold device - grid should reflow back to smaller layout
- [x] Pinch-to-zoom still works after fold/unfold

Fixes #20466