### PR TITLE
feat(server): Add config option to disable admin registration

### DIFF
--- a/docs/docs/install/config-file.md
+++ b/docs/docs/install/config-file.md
@@ -201,7 +201,8 @@ The default configuration looks like this:
     "storageLabelClaim": "preferred_username",
     "storageQuotaClaim": "immich_quota",
     "timeout": 30000,
-    "tokenEndpointAuthMethod": "client_secret_post"
+    "tokenEndpointAuthMethod": "client_secret_post",
+    "disableAdminRegistration": false
   },
   "passwordLogin": {
     "enabled": true

--- a/mobile/openapi/lib/model/system_config_o_auth_dto.dart
+++ b/mobile/openapi/lib/model/system_config_o_auth_dto.dart
@@ -19,6 +19,7 @@ class SystemConfigOAuthDto {
     required this.clientId,
     required this.clientSecret,
     required this.defaultStorageQuota,
+    required this.disableAdminRegistration,
     required this.enabled,
     required this.issuerUrl,
     required this.mobileOverrideEnabled,
@@ -45,6 +46,8 @@ class SystemConfigOAuthDto {
 
   /// Minimum value: 0
   int? defaultStorageQuota;
+
+  bool disableAdminRegistration;
 
   bool enabled;
 
@@ -79,6 +82,7 @@ class SystemConfigOAuthDto {
     other.clientId == clientId &&
     other.clientSecret == clientSecret &&
     other.defaultStorageQuota == defaultStorageQuota &&
+    other.disableAdminRegistration == disableAdminRegistration &&
     other.enabled == enabled &&
     other.issuerUrl == issuerUrl &&
     other.mobileOverrideEnabled == mobileOverrideEnabled &&
@@ -101,6 +105,7 @@ class SystemConfigOAuthDto {
     (clientId.hashCode) +
     (clientSecret.hashCode) +
     (defaultStorageQuota == null ? 0 : defaultStorageQuota!.hashCode) +
+    (disableAdminRegistration.hashCode) +
     (enabled.hashCode) +
     (issuerUrl.hashCode) +
     (mobileOverrideEnabled.hashCode) +
@@ -115,7 +120,7 @@ class SystemConfigOAuthDto {
     (tokenEndpointAuthMethod.hashCode);
 
   @override
-  String toString() => 'SystemConfigOAuthDto[autoLaunch=$autoLaunch, autoRegister=$autoRegister, buttonText=$buttonText, clientId=$clientId, clientSecret=$clientSecret, defaultStorageQuota=$defaultStorageQuota, enabled=$enabled, issuerUrl=$issuerUrl, mobileOverrideEnabled=$mobileOverrideEnabled, mobileRedirectUri=$mobileRedirectUri, profileSigningAlgorithm=$profileSigningAlgorithm, roleClaim=$roleClaim, scope=$scope, signingAlgorithm=$signingAlgorithm, storageLabelClaim=$storageLabelClaim, storageQuotaClaim=$storageQuotaClaim, timeout=$timeout, tokenEndpointAuthMethod=$tokenEndpointAuthMethod]';
+  String toString() => 'SystemConfigOAuthDto[autoLaunch=$autoLaunch, autoRegister=$autoRegister, buttonText=$buttonText, clientId=$clientId, clientSecret=$clientSecret, defaultStorageQuota=$defaultStorageQuota, disableAdminRegistration=$disableAdminRegistration, enabled=$enabled, issuerUrl=$issuerUrl, mobileOverrideEnabled=$mobileOverrideEnabled, mobileRedirectUri=$mobileRedirectUri, profileSigningAlgorithm=$profileSigningAlgorithm, roleClaim=$roleClaim, scope=$scope, signingAlgorithm=$signingAlgorithm, storageLabelClaim=$storageLabelClaim, storageQuotaClaim=$storageQuotaClaim, timeout=$timeout, tokenEndpointAuthMethod=$tokenEndpointAuthMethod]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -129,6 +134,7 @@ class SystemConfigOAuthDto {
     } else {
     //  json[r'defaultStorageQuota'] = null;
     }
+      json[r'disableAdminRegistration'] = this.disableAdminRegistration;
       json[r'enabled'] = this.enabled;
       json[r'issuerUrl'] = this.issuerUrl;
       json[r'mobileOverrideEnabled'] = this.mobileOverrideEnabled;
@@ -159,6 +165,7 @@ class SystemConfigOAuthDto {
         clientId: mapValueOfType<String>(json, r'clientId')!,
         clientSecret: mapValueOfType<String>(json, r'clientSecret')!,
         defaultStorageQuota: mapValueOfType<int>(json, r'defaultStorageQuota'),
+        disableAdminRegistration: mapValueOfType<bool>(json, r'disableAdminRegistration')!,
         enabled: mapValueOfType<bool>(json, r'enabled')!,
         issuerUrl: mapValueOfType<String>(json, r'issuerUrl')!,
         mobileOverrideEnabled: mapValueOfType<bool>(json, r'mobileOverrideEnabled')!,
@@ -224,6 +231,7 @@ class SystemConfigOAuthDto {
     'clientId',
     'clientSecret',
     'defaultStorageQuota',
+    'disableAdminRegistration',
     'enabled',
     'issuerUrl',
     'mobileOverrideEnabled',

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -21804,6 +21804,9 @@
             "nullable": true,
             "type": "integer"
           },
+          "disableAdminRegistration": {
+            "type": "boolean"
+          },
           "enabled": {
             "type": "boolean"
           },
@@ -21854,6 +21857,7 @@
           "clientId",
           "clientSecret",
           "defaultStorageQuota",
+          "disableAdminRegistration",
           "enabled",
           "issuerUrl",
           "mobileOverrideEnabled",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1555,6 +1555,7 @@ export type SystemConfigOAuthDto = {
     clientId: string;
     clientSecret: string;
     defaultStorageQuota: number | null;
+    disableAdminRegistration: boolean;
     enabled: boolean;
     issuerUrl: string;
     mobileOverrideEnabled: boolean;

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -114,6 +114,7 @@ export interface SystemConfig {
     storageLabelClaim: string;
     storageQuotaClaim: string;
     roleClaim: string;
+    disableAdminRegistration: boolean;
   };
   passwordLogin: {
     enabled: boolean;
@@ -304,6 +305,7 @@ export const defaults = Object.freeze<SystemConfig>({
     roleClaim: 'immich_role',
     tokenEndpointAuthMethod: OAuthTokenEndpointAuthMethod.ClientSecretPost,
     timeout: 30_000,
+    disableAdminRegistration: false,
   },
   passwordLogin: {
     enabled: true,

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -431,6 +431,9 @@ class SystemConfigOAuthDto {
 
   @IsString()
   roleClaim!: string;
+
+  @ValidateBoolean()
+  disableAdminRegistration!: boolean;
 }
 
 class SystemConfigPasswordLoginDto {

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -116,7 +116,8 @@ export class ServerService extends BaseService {
 
   async getSystemConfig(): Promise<ServerConfigDto> {
     const config = await this.getConfig({ withCache: false });
-    const isInitialized = await this.userRepository.hasAdmin();
+    const isInitialized =
+      (config.oauth.enabled && config.oauth.disableAdminRegistration) || (await this.userRepository.hasAdmin());
     const onboarding = await this.systemMetadataRepository.get(SystemMetadataKey.AdminOnboarding);
 
     return {

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -147,6 +147,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     storageLabelClaim: 'preferred_username',
     storageQuotaClaim: 'immich_quota',
     roleClaim: 'immich_role',
+    disableAdminRegistration: false,
   },
   passwordLogin: {
     enabled: true,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since it is possible to create Immich admin users via OIDC, registering an admin user first is no longer a strict requirement. Therefore an option (default disabled) is needed to skip this step.

Fixes https://github.com/immich-app/immich/discussions/18847

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Setup a fresh instance with OIDC config. Open the web page, get redirect to the OIDC provider instead of having to register an admin user first.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None, all written by hand.
