### PR TITLE
feat(server): untag descendant tags

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -12455,6 +12455,14 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "name": "untagDescendants",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "requestBody": {

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -4695,14 +4695,17 @@ export function updateTag({ id, tagUpdateDto }: {
 /**
  * Untag assets
  */
-export function untagAssets({ id, bulkIdsDto }: {
+export function untagAssets({ id, untagDescendants, bulkIdsDto }: {
     id: string;
+    untagDescendants?: boolean;
     bulkIdsDto: BulkIdsDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: BulkIdResponseDto[];
-    }>(`/tags/${encodeURIComponent(id)}/assets`, oazapfts.json({
+    }>(`/tags/${encodeURIComponent(id)}/assets${QS.query(QS.explode({
+        untagDescendants
+    }))}`, oazapfts.json({
         ...opts,
         method: "DELETE",
         body: bulkIdsDto

--- a/server/src/controllers/tag.controller.ts
+++ b/server/src/controllers/tag.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Query, Post, Put } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import { BulkIdResponseDto, BulkIdsDto } from 'src/dtos/asset-ids.response.dto';
@@ -10,6 +10,7 @@ import {
   TagResponseDto,
   TagUpdateDto,
   TagUpsertDto,
+  UntagAssetsOptionsDto,
 } from 'src/dtos/tag.dto';
 import { ApiTag, Permission } from 'src/enum';
 import { Auth, Authenticated } from 'src/middleware/auth.guard';
@@ -125,7 +126,8 @@ export class TagController {
     @Auth() auth: AuthDto,
     @Body() dto: BulkIdsDto,
     @Param() { id }: UUIDParamDto,
+    @Query() { untagDescendants }: UntagAssetsOptionsDto,
   ): Promise<BulkIdResponseDto[]> {
-    return this.service.removeAssets(auth, id, dto);
+    return this.service.removeAssets(auth, id, dto, untagDescendants);
   }
 }

--- a/server/src/dtos/tag.dto.ts
+++ b/server/src/dtos/tag.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsHexColor, IsNotEmpty, IsString } from 'class-validator';
+import { IsHexColor, IsNotEmpty, IsString, IsBoolean } from 'class-validator';
 import { Tag } from 'src/database';
 import { Optional, ValidateHexColor, ValidateUUID } from 'src/validation';
 
@@ -40,6 +40,11 @@ export class TagBulkAssetsResponseDto {
   @ApiProperty({ type: 'integer' })
   count!: number;
 }
+
+export class UntagAssetsOptionsDto {
+  @IsBoolean()
+  untagDescendants?: boolean;
+} 
 
 export class TagResponseDto {
   id!: string;

--- a/server/src/repositories/tag.repository.ts
+++ b/server/src/repositories/tag.repository.ts
@@ -128,6 +128,17 @@ export class TagRepository {
     await this.db.deleteFrom('tag_asset').where('tagId', '=', tagId).where('assetId', 'in', assetIds).execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  async getDescendantIds(tagId: string): Promise<string[]> {
+    const results = await this.db
+      .selectFrom('tag_closure')
+      .select('id_descendant')
+      .where('id_ancestor', '=', tagId)
+      .execute();
+
+    return results.map(({ id_descendant }) => id_descendant);
+  }
+
   @GenerateSql({ params: [[{ assetId: DummyValue.UUID, tagIds: DummyValue.UUID }]] })
   @Chunked()
   upsertAssetIds(items: Insertable<TagAssetTable>[]) {

--- a/server/src/services/tag.service.spec.ts
+++ b/server/src/services/tag.service.spec.ts
@@ -249,6 +249,7 @@ describe(TagService.name, () => {
     it('should throw an error for an invalid id', async () => {
       mocks.tag.getAssetIds.mockResolvedValue(new Set());
       mocks.tag.removeAssetIds.mockResolvedValue();
+      mocks.tag.getDescendantIds.mockResolvedValue(['tag-1']);
 
       await expect(sut.removeAssets(authStub.admin, 'tag-1', { ids: ['asset-1'] })).resolves.toEqual([
         { id: 'asset-1', success: false, error: 'not_found' },
@@ -259,6 +260,7 @@ describe(TagService.name, () => {
       mocks.tag.get.mockResolvedValue(tagStub.tag);
       mocks.tag.getAssetIds.mockResolvedValue(new Set(['asset-1']));
       mocks.tag.removeAssetIds.mockResolvedValue();
+      mocks.tag.getDescendantIds.mockResolvedValue(['tag-1']);
 
       await expect(
         sut.removeAssets(authStub.admin, 'tag-1', {
@@ -271,6 +273,27 @@ describe(TagService.name, () => {
 
       expect(mocks.tag.getAssetIds).toHaveBeenCalledWith('tag-1', ['asset-1', 'asset-2']);
       expect(mocks.tag.removeAssetIds).toHaveBeenCalledWith('tag-1', ['asset-1']);
+    });
+
+    it('should remove assets from parent tag and all child tags', async () => {
+      mocks.tag.get.mockResolvedValue(tagStub.tag);
+      mocks.tag.getAssetIds.mockResolvedValue(new Set(['asset-1', 'asset-2']));
+      mocks.tag.removeAssetIds.mockResolvedValue();
+      mocks.tag.getDescendantIds.mockResolvedValue(['tag-1', 'tag-child-1', 'tag-child-2']);
+
+      await expect(
+        sut.removeAssets(authStub.admin, 'tag-1', {
+          ids: ['asset-1', 'asset-2'],
+        }),
+      ).resolves.toEqual([
+        { id: 'asset-1', success: true },
+        { id: 'asset-2', success: true },
+      ]);
+
+      expect(mocks.tag.getAssetIds).toHaveBeenCalledWith('tag-1', ['asset-1', 'asset-2']);
+      expect(mocks.tag.removeAssetIds).toHaveBeenCalledWith('tag-1', ['asset-1', 'asset-2']);
+      expect(mocks.tag.removeAssetIds).toHaveBeenCalledWith('tag-child-1', ['asset-1', 'asset-2']);
+      expect(mocks.tag.removeAssetIds).toHaveBeenCalledWith('tag-child-2', ['asset-1', 'asset-2']);
     });
   });
 

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -123,6 +123,13 @@ export class TagService extends BaseService {
       { parentId: id, assetIds: dto.ids, canAlwaysRemove: Permission.TagDelete },
     );
 
+    const descendantTagIds = await this.tagRepository.getDescendantIds(id);
+    for (const descendantTagId of descendantTagIds) {
+      if (descendantTagId !== id) {
+        await this.tagRepository.removeAssetIds(descendantTagId, dto.ids);
+      }
+    }
+
     for (const { id: assetId, success } of results) {
       if (success) {
         await this.eventRepository.emit('AssetUntag', { assetId });

--- a/server/src/services/tag.service.ts
+++ b/server/src/services/tag.service.ts
@@ -114,7 +114,7 @@ export class TagService extends BaseService {
     return results;
   }
 
-  async removeAssets(auth: AuthDto, id: string, dto: BulkIdsDto): Promise<BulkIdResponseDto[]> {
+  async removeAssets(auth: AuthDto, id: string, dto: BulkIdsDto, untagDescendants?: boolean): Promise<BulkIdResponseDto[]> {
     await this.requireAccess({ auth, permission: Permission.TagAsset, ids: [id] });
 
     const results = await removeAssets(
@@ -123,10 +123,12 @@ export class TagService extends BaseService {
       { parentId: id, assetIds: dto.ids, canAlwaysRemove: Permission.TagDelete },
     );
 
-    const descendantTagIds = await this.tagRepository.getDescendantIds(id);
-    for (const descendantTagId of descendantTagIds) {
-      if (descendantTagId !== id) {
-        await this.tagRepository.removeAssetIds(descendantTagId, dto.ids);
+    if(untagDescendants) {
+      const descendantTagIds = await this.tagRepository.getDescendantIds(id);
+      for (const descendantTagId of descendantTagIds) {
+        if (descendantTagId !== id) {
+          await this.tagRepository.removeAssetIds(descendantTagId, dto.ids);
+        }
       }
     }
 


### PR DESCRIPTION
## Description

When untagging, added an option to also remove descendant tags from the assets. Doesn't change default behaviour.
Will help for #24538

## How Has This Been Tested?

- [X] Added unit tests
- [x] Manually tested from frontend

## API Changes
Added `?untagDescendants=true` query parameter to `DELETE /api/tag/:id/assets`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Nope.
