### PR TITLE
feat(server): sync metadata when removing a tag

### DIFF
--- a/server/src/repositories/tag.repository.ts
+++ b/server/src/repositories/tag.repository.ts
@@ -88,6 +88,28 @@ export class TagRepository {
     await this.db.deleteFrom('tag').where('id', '=', id).execute();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  async getAssetIdsForTag(tagId: string): Promise<string[]> {
+    const results = await this.db
+      .selectFrom('tag_asset')
+      .select(['assetId'])
+      .where('tagId', '=', tagId)
+      .execute();
+
+    return results.map(({ assetId }) => assetId);
+  }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  async getDescendantTagIds(tagId: string): Promise<string[]> {
+    const results = await this.db
+      .selectFrom('tag_closure')
+      .select(['id_descendant'])
+      .where('id_ancestor', '=', tagId)
+      .execute();
+
+    return results.map(({ id_descendant }) => id_descendant);
+  }
+
   @ChunkedSet({ paramIndex: 1 })
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
   async getAssetIds(tagId: string, assetIds: string[]): Promise<Set<string>> {


### PR DESCRIPTION
## Description

When removing a tag, metadata are now synced to reflect the changes back in the sidecars. 
Fixes #23792

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual tests

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

100%