### PR TITLE
fix(web): download panel being hidden by admin sidebar

### DIFF
--- a/web/src/lib/components/asset-viewer/download-panel.svelte
+++ b/web/src/lib/components/asset-viewer/download-panel.svelte
@@ -16,7 +16,7 @@
 {#if downloadManager.isDownloading}
   <div
     transition:fly={{ x: -100, duration: 350 }}
-    class="fixed bottom-10 start-2 max-h-67.5 w-79 rounded-2xl border dark:border-white/10 p-4 shadow-lg bg-subtle"
+    class="fixed bottom-10 start-2 max-h-67.5 w-79 z-60 rounded-2xl border dark:border-white/10 p-4 shadow-lg bg-subtle"
   >
     <Heading size="tiny">{$t('downloading')}</Heading>
     <div class="my-2 mb-2 flex max-h-50 flex-col overflow-y-auto text-sm">


### PR DESCRIPTION
## Description

Fixes download panel being hidden by admin sidebar (see screenshots below).

This only happened on admin pages because the admin sidebar has [z-index 30](https://github.com/immich-app/ui/blob/a8d7418d577ac1e836101bf2acdd63f655ebf973/packages/ui/src/lib/constants.ts#L18), while the user sidebar has [z-index 1](https://github.com/immich-app/immich/blob/33cdea88aae0ee7cf506a4d19180c10003e41567/web/src/lib/components/sidebar/sidebar.svelte#L38).

I have fixed this by setting the z-index of the download panel to 60, the [same as toasts](https://github.com/immich-app/ui/blob/a8d7418d577ac1e836101bf2acdd63f655ebf973/packages/ui/src/lib/constants.ts#L22).
If you have a better suggestion for a z-index value I don't mind changing it.

## How Has This Been Tested?

Go into Administration -> Settings and click "Export as JSON" to trigger the download panel.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before:
<img width="347" height="190" alt="image" src="https://github.com/user-attachments/assets/d53bc51d-6dd0-423f-96cc-082d519f637f" />

After:
<img width="339" height="228" alt="image" src="https://github.com/user-attachments/assets/1169d70c-e001-49b6-ae18-69332619398b" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM has been used.
