### PR TITLE
fix(server): only extract image's duration if format supports animation

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -32,6 +32,7 @@ import { BaseService } from 'src/services/base.service';
 import { JobItem, JobOf } from 'src/types';
 import { getAssetFiles } from 'src/utils/asset.util';
 import { isAssetChecksumConstraint } from 'src/utils/database';
+import { mimeTypes } from 'src/utils/mime-types';
 import { isFaceImportEnabled } from 'src/utils/misc';
 import { upsertTags } from 'src/utils/tag';
 
@@ -486,7 +487,8 @@ export class MetadataService extends BaseService {
     }
 
     // prefer duration from video tags
-    if (videoTags) {
+    // don't save duration if asset is definitely not an animated image (see e.g. CR3 with Duration: 1s)
+    if (videoTags || !mimeTypes.isPossiblyAnimatedImage(asset.originalPath)) {
       delete mediaTags.Duration;
     }
 

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -152,6 +152,26 @@ describe('mimeTypes', () => {
     }
   });
 
+  describe('animated image', () => {
+    for (const img of ['a.avif', 'a.gif', 'a.webp']) {
+      it('should identify animated image mime types as such', () => {
+        expect(mimeTypes.isPossiblyAnimatedImage(img)).toBeTruthy();
+      });
+    }
+
+    for (const img of ['a.cr3', 'a.jpg', 'a.tiff']) {
+      it('should identify static image mime types as such', () => {
+        expect(mimeTypes.isPossiblyAnimatedImage(img)).toBeFalsy();
+      });
+    }
+
+    for (const extension of Object.keys(mimeTypes.video)) {
+      it('should not identify video mime types as animated', () => {
+        expect(mimeTypes.isPossiblyAnimatedImage(extension)).toBeFalsy();
+      });
+    }
+  });
+
   describe('video', () => {
     it('should contain only lowercase mime types', () => {
       const keys = Object.keys(mimeTypes.video);

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -64,6 +64,11 @@ const image: Record<string, string[]> = {
   '.tiff': ['image/tiff'],
 };
 
+const possiblyAnimatedImageExtensions = new Set(['.avif', '.gif', '.heic', '.heif', '.jxl', '.png', '.webp']);
+const possiblyAnimatedImage: Record<string, string[]> = Object.fromEntries(
+  Object.entries(image).filter(([key]) => possiblyAnimatedImageExtensions.has(key)),
+);
+
 const extensionOverrides: Record<string, string> = {
   'image/jpeg': '.jpg',
 };
@@ -119,6 +124,7 @@ export const mimeTypes = {
   isAsset: (filename: string) => isType(filename, image) || isType(filename, video),
   isImage: (filename: string) => isType(filename, image),
   isWebSupportedImage: (filename: string) => isType(filename, webSupportedImage),
+  isPossiblyAnimatedImage: (filename: string) => isType(filename, possiblyAnimatedImage),
   isProfile: (filename: string) => isType(filename, profile),
   isSidecar: (filename: string) => isType(filename, sidecar),
   isVideo: (filename: string) => isType(filename, video),


### PR DESCRIPTION
## Description
Apparently some image formats (CR3) are based on video containers and contain a duration tag. In the case of CR3, it's always `Duration: 1` second.

Proposed fix: only extract duration if the asset could maybe be an animated image, meaning: only extract for videos (behaviour unchanged) and .avif, .gif, and .webp images.

Fixes #24559. I couldn't properly test with the actual asset uploaded there due to thumbnail generation issues, but it seems like the linked issue does get fixed.

Alternative 1: instead of this 'positive inclusion' of the duration tag for avif gif and webp, use a 'negative exclusion' of cr3 (currently the only known format that is a static image with a duration tag)
Alternative 2: handle the animated image status in the frontend, based on the same criteria as now used in the backend.

## How Has This Been Tested?
- [x] Manual testing
- [x] Increased unit testing

no llm used.