### PR TITLE
fix(web): auto-start slideshow when confirming settings modal

### DIFF
--- a/web/src/lib/modals/SlideshowSettingsModal.svelte
+++ b/web/src/lib/modals/SlideshowSettingsModal.svelte
@@ -14,7 +14,7 @@
   } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import SettingDropdown from '../components/shared-components/settings/setting-dropdown.svelte';
-  import { SlideshowLook, SlideshowNavigation, slideshowStore } from '../stores/slideshow.store';
+  import { SlideshowLook, SlideshowNavigation, SlideshowState, slideshowStore } from '../stores/slideshow.store';
 
   const {
     slideshowDelay,
@@ -23,6 +23,7 @@
     slideshowLook,
     slideshowTransition,
     slideshowAutoplay,
+    slideshowState,
   } = slideshowStore;
 
   interface Props {
@@ -69,6 +70,7 @@
     $slideshowLook = tempSlideshowLook;
     $slideshowTransition = tempSlideshowTransition;
     $slideshowAutoplay = tempSlideshowAutoplay;
+    $slideshowState = SlideshowState.PlaySlideshow;
     onClose();
   };
 </script>


### PR DESCRIPTION
## Description

Automatically starts the slideshow when the user clicks "Confirm" in the Slideshow Settings modal. Previously, users had to open the modal, confirm settings, then click "Slideshow" again. Now confirming settings starts the slideshow immediately.

Since the slideshow settings are only accessible after entering a slideshow this change does not have side effects.

Fixes # (issue)

## How Has This Been Tested?

- [x] Opened slideshow settings from the asset viewer context menu, changed settings, clicked "Confirm" → slideshow started immediately
- [x] Opened slideshow settings, changed settings, clicked "Cancel" → slideshow did not start (expected behavior)
- [x] Verified that existing slideshow functionality (starting from context menu, navigation, etc.) still works correctly

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/d25bf69e-2745-4aeb-b1fc-ca1f0c24df74

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Cursor's Auto agent) was used to implement this change.