### PR TITLE
feat: add .mxf file support

### DIFF
--- a/docs/docs/features/supported-formats.md
+++ b/docs/docs/features/supported-formats.md
@@ -38,6 +38,7 @@ For the full list, refer to the [Immich source code](https://github.com/immich-a
 | `MP2T`      | `.mts` `.m2ts` `.m2t` | :white_check_mark: |       |
 | `MP4`       | `.mp4` `.insv`        | :white_check_mark: |       |
 | `MPEG`      | `.mpg` `.mpe` `.mpeg` | :white_check_mark: |       |
+| `MXF`       | `.mxf`                | :white_check_mark: |       |
 | `QUICKTIME` | `.mov`                | :white_check_mark: |       |
 | `WEBM`      | `.webm`               | :white_check_mark: |       |
 | `WMV`       | `.wmv`                | :white_check_mark: |       |

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -110,6 +110,7 @@ const validVideos = [
   '.mp4',
   '.mpg',
   '.mts',
+  '.mxf',
   '.vob',
   '.webm',
   '.wmv',

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -189,7 +189,7 @@ describe('mimeTypes', () => {
 
     it('should contain only video mime types', () => {
       const values = Object.values(mimeTypes.video).flat();
-      expect(values).toEqual(values.filter((mimeType) => mimeType.startsWith('video/')));
+      expect(values).toEqual(values.filter((mimeType) => mimeType.startsWith('video/') || mimeType === 'application/mxf'));
     });
 
     for (const [extension, v] of Object.entries(mimeTypes.video)) {

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -76,6 +76,7 @@ describe('mimeTypes', () => {
     { mimetype: 'image/x-sony-sr2', extension: '.sr2' },
     { mimetype: 'image/x-sony-srf', extension: '.srf' },
     { mimetype: 'image/x3f', extension: '.x3f' },
+    { mimetype: 'application/mxf', extension: '.mxf' },
     { mimetype: 'video/3gpp', extension: '.3gp' },
     { mimetype: 'video/3gpp', extension: '.3gpp' },
     { mimetype: 'video/avi', extension: '.avi' },

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -189,7 +189,9 @@ describe('mimeTypes', () => {
 
     it('should contain only video mime types', () => {
       const values = Object.values(mimeTypes.video).flat();
-      expect(values).toEqual(values.filter((mimeType) => mimeType.startsWith('video/') || mimeType === 'application/mxf'));
+      expect(values).toEqual(
+        values.filter((mimeType) => mimeType.startsWith('video/') || mimeType === 'application/mxf'),
+      );
     });
 
     for (const [extension, v] of Object.entries(mimeTypes.video)) {

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -139,20 +139,15 @@ export const mimeTypes = {
   /** return an extension (including a leading `.`) for a mime-type */
   toExtension,
   assetType: (filename: string) => {
-    // Check file extension first to handle cases like MXF (application/mxf) that are video containers
-    if (isType(filename, video)) {
-      return AssetType.Video;
-    }
-    if (isType(filename, image)) {
-      return AssetType.Image;
-    }
-    // Fallback to mime type check for any edge cases
     const contentType = lookup(filename);
     if (contentType.startsWith('image/')) {
       return AssetType.Image;
-    } else if (contentType.startsWith('video/')) {
+    }
+
+    if (contentType.startsWith('video/') || contentType === 'application/mxf') {
       return AssetType.Video;
     }
+
     return AssetType.Other;
   },
   getSupportedFileExtensions: () => [...Object.keys(image), ...Object.keys(video)],

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -139,6 +139,14 @@ export const mimeTypes = {
   /** return an extension (including a leading `.`) for a mime-type */
   toExtension,
   assetType: (filename: string) => {
+    // Check file extension first to handle cases like MXF (application/mxf) that are video containers
+    if (isType(filename, video)) {
+      return AssetType.Video;
+    }
+    if (isType(filename, image)) {
+      return AssetType.Image;
+    }
+    // Fallback to mime type check for any edge cases
     const contentType = lookup(filename);
     if (contentType.startsWith('image/')) {
       return AssetType.Image;

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -98,6 +98,7 @@ const video: Record<string, string[]> = {
   '.mpeg': ['video/mpeg'],
   '.mpg': ['video/mpeg'],
   '.mts': ['video/mp2t'],
+  '.mxf': ['application/mxf'],
   '.vob': ['video/mpeg'],
   '.webm': ['video/webm'],
   '.wmv': ['video/x-ms-wmv'],


### PR DESCRIPTION
## Description

Adds support for MXF (Material Exchange Format) video files in Immich.

**What was added:**
- Added `.mxf` extension to the supported video formats list
- Registered `application/mxf` as the mime type for MXF files (official SMPTE mime type)
- Updated asset type classification to correctly identify MXF files as video assets
- Updated tests to validate MXF file handling

**Technical details:**
MXF is a container format with the mime type `application/mxf` (not `video/mxf`). The `assetType()` function was updated to check file extensions first (against the `video` and `image` objects) before falling back to mime type prefixes. This ensures container formats like MXF are correctly classified based on their extension listing, regardless of mime type prefix.

**Rationale for 5316bcf:**
Container formats (MXF, MOV, MP4, MKV, WebM) can have non-standard mime types. File extensions are more reliable for classification since Immich maintains explicit extension lists for video/image types. By checking extensions first, we ensure that any file extension listed in the `video` object is correctly classified as `AssetType.Video`, enabling proper playback, thumbnail generation, and metadata extraction.

Fixes #24640

## How Has This Been Tested?

- [x] Added test case for MXF file extension to mime type mapping
- [x] Updated test to allow `application/mxf` in video mime types validation
- [x] Verified MXF files are correctly classified as `AssetType.Video` during upload
- [x] Confirmed video playback endpoint works for MXF files (`/api/assets/{id}/video/playback`)
- [x] Verified thumbnail generation works for MXF files
- [x] Tested that existing video formats (MP4, MOV, etc.) continue to work correctly

Sample files downloaded from https://toolsfairy.com/video-test/sample-mxf-files were used to test the implementation.

EDIT: tested this now with two big video .mxf files i got sent from a fellow Discord user. See screenshots and recordings below

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->

*Note: the last file upload fails due to size constraints of github codespaces (also happens on standard .mov files)*

https://github.com/user-attachments/assets/3e3c895c-cb4b-4f3d-a9eb-299e3130d6b7

EDIT (after test with "real" images/videos):

_Selecting .mxf files allowed now_

<img width="1702" height="884" alt="image" src="https://github.com/user-attachments/assets/60dfefa4-ec8f-426b-a25b-7d9fa82fb06d" />

_Upload (20x, slow machine 🤣 )_

https://github.com/user-attachments/assets/b6c2cc52-7229-4fec-9c3d-4c63045965a9

_Replay (2x)_

https://github.com/user-attachments/assets/9ef40472-081a-4241-8e2c-f0410c6a4509




</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used LLM assistance to research MXF mime type specifications and identify the classification logic issue.