### PR TITLE
fix(mobile): hide favorite icon in partner shared library views

### DIFF
--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -12,8 +12,7 @@ import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-import 'package:immich_mobile/providers/partner.provider.dart';
-import 'package:immich_mobile/utils/hash.dart';
+import 'package:immich_mobile/providers/infrastructure/partner.provider.dart';
 
 class ThumbnailTile extends ConsumerStatefulWidget {
   const ThumbnailTile(
@@ -75,7 +74,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
         ? ref.watch(assetUploadProgressProvider.select((map) => map[asset.id]))
         : null;
     final isPartnerShared = asset is RemoteAsset
-        ? ref.watch(partnerSharedWithProvider).map((e) => fastHash(e.id)).contains(fastHash(asset.ownerId))
+        ? ref.watch(driftSharedWithPartnerProvider).value?.any((e) => e.id == asset.ownerId) ?? false
         : false;
 
     return Stack(

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -12,6 +12,8 @@ import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/partner.provider.dart';
+import 'package:immich_mobile/utils/hash.dart';
 
 class ThumbnailTile extends ConsumerStatefulWidget {
   const ThumbnailTile(
@@ -72,6 +74,9 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
     final uploadProgress = asset is LocalAsset
         ? ref.watch(assetUploadProgressProvider.select((map) => map[asset.id]))
         : null;
+    final isPartnerShared = asset is RemoteAsset
+        ? ref.watch(partnerSharedWithProvider).map((e) => fastHash(e.id)).contains(fastHash(asset.ownerId))
+        : false;
 
     return Stack(
       children: [
@@ -171,7 +176,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     },
                   ),
 
-                if (asset != null && asset.isFavorite)
+                if (asset != null && asset.isFavorite && !isPartnerShared)
                   AnimatedOpacity(
                     duration: Durations.short4,
                     opacity: _hideIndicators ? 0.0 : 1.0,


### PR DESCRIPTION
## Description

Hides the favorite icon when viewing partner shared libraries. Viewers should not see which images the partner has favorited.

Fixes #21968

## How Has This Been Tested?

- [x] Verified favorite icon is hidden in timeline view when viewing partner shared library
- [x] Verified favorite icon still displays correctly for own assets

_Note: the old timeline already hides the favorite icon. see https://github.com/immich-app/immich/pull/24651#issuecomment-3667311004 for details_

<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->
**The view of the partner that shared (can see his favorites)**
<img width="563" height="1218" alt="IMG_9539" src="https://github.com/user-attachments/assets/4362e733-5171-4bae-9b2a-700c3f21a7e6" />
**The view of the partner that got shared access (can not see favorites)**
<img width="563" height="1218" alt="IMG_9538" src="https://github.com/user-attachments/assets/03d4fd44-6a4f-4fa4-99e8-f5290f894ee2" />
<img width="563" height="1218" alt="IMG_9541" src="https://github.com/user-attachments/assets/c3ddfb15-d300-416b-a053-3546176f8dcf" />


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM was used to identify where the favorite icon is displayed in the UI and implement the partner detection logic