### PR TITLE
fix(web): timezone dropdown showing "No results" when seconds are set to 00

### DIFF
--- a/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
+++ b/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
@@ -71,6 +71,23 @@ describe('DateSelectionModal component', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  test('does not fall back to UTC when datetime-local value has no seconds', async () => {
+    render(AssetSelectionChangeDateModal, {
+      props: { initialDate, initialTimeZone, assets: [], onClose },
+    });
+
+    // Some browsers omit seconds when the seconds field is 00, emitting only minute precision.
+    await fireEvent.input(getDateInput(), { target: { value: '2024-01-01T00:00' } });
+    await fireEvent.blur(getDateInput());
+
+    // Should keep the initial timezone selection, not the UTC fallback caused by an empty options list.
+    expect(getTimeZoneInput().value).toBe('Europe/Berlin (+01:00)');
+
+    // Opening the dropdown should not show "no_results" (i18n key in tests) which would indicate empty options.
+    await fireEvent.focus(getTimeZoneInput());
+    expect(screen.queryByText('no_results')).not.toBeInTheDocument();
+  });
+
   describe('when date is in daylight saving time', () => {
     const dstDate = DateTime.fromISO('2024-07-01');
 

--- a/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
+++ b/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
@@ -85,6 +85,20 @@ describe('DateSelectionModal component', () => {
     expect(screen.queryByText('no_results')).not.toBeInTheDocument();
   });
 
+  test('does not fall back to UTC when datetime-local value has no milliseconds', async () => {
+    render(AssetSelectionChangeDateModal, {
+      props: { initialDate, initialTimeZone, assets: [], onClose },
+    });
+
+    await fireEvent.input(getDateInput(), { target: { value: '2024-01-01T00:00:00' } });
+    await fireEvent.blur(getDateInput());
+
+    expect(getTimeZoneInput().value).toBe('Europe/Berlin (+01:00)');
+
+    await fireEvent.focus(getTimeZoneInput());
+    expect(screen.queryByText('no_results')).not.toBeInTheDocument();
+  });
+
   describe('when date is in daylight saving time', () => {
     const dstDate = DateTime.fromISO('2024-07-01');
 

--- a/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
+++ b/web/src/lib/modals/AssetSelectionChangeDateModal.spec.ts
@@ -76,14 +76,11 @@ describe('DateSelectionModal component', () => {
       props: { initialDate, initialTimeZone, assets: [], onClose },
     });
 
-    // Some browsers omit seconds when the seconds field is 00, emitting only minute precision.
     await fireEvent.input(getDateInput(), { target: { value: '2024-01-01T00:00' } });
     await fireEvent.blur(getDateInput());
 
-    // Should keep the initial timezone selection, not the UTC fallback caused by an empty options list.
     expect(getTimeZoneInput().value).toBe('Europe/Berlin (+01:00)');
 
-    // Opening the dropdown should not show "no_results" (i18n key in tests) which would indicate empty options.
     await fireEvent.focus(getTimeZoneInput());
     expect(screen.queryByText('no_results')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Description

When setting the seconds in the date selector to 00 (e.g., 20:36:00.123), the browser's `datetime-local` input can emit values without seconds (e.g., `2024-01-01T00:00` instead of `2024-01-01T00:00:00`). The timezone validation function was comparing these values against a format that always included seconds, causing a mismatch that marked all timezones as invalid. This resulted in the timezone dropdown defaulting to UTC and showing "No results", even though the timezone should have remained selected.

This fix updates `zoneOptionForDate()` in `timezone-utils.ts` to detect whether the input datetime string includes seconds and compare using the appropriate format (with or without seconds). This ensures timezone validation works correctly regardless of whether the browser omits seconds from the datetime-local value.

Fixes #24661

## How Has This Been Tested?

- [x] Added regression test that verifies timezone options remain available when the datetime input omits seconds
- [x] Verified existing tests still pass
- [x] Manually tested the date picker with seconds set to 00 to confirm timezone dropdown shows correct options (see Recording below)

EDIT: added a test in https://github.com/immich-app/immich/pull/24662/commits/0e0f64485913183793a3daf812d8325a87e1cf60 to make sure that #23615 still works

> [!NOTE]
> The tests run successfully with this fix #24663 to the web tests 
<img width="918" height="241" alt="image" src="https://github.com/user-attachments/assets/103301b2-7c12-480e-b696-846b862d6cdf" />


<details><summary><h2>Screenshots</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/b63fa0f8-7695-4d4c-be20-98bffd47761d

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An ChatGPT 5.2 was used to analyze the bug and Implement the fix