### PR TITLE
chore: mock localStorage in web tests

### DIFF
--- a/web/src/test-data/setup.ts
+++ b/web/src/test-data/setup.ts
@@ -18,6 +18,18 @@ Object.defineProperty(globalThis, 'matchMedia', {
   })),
 });
 
+// Mock localStorage for svelte-persisted-store
+const localStorageMock = {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(globalThis, 'localStorage', {
+  writable: true,
+  value: localStorageMock,
+});
+
 vi.mock('$env/dynamic/public', () => {
   return {
     env: {

--- a/web/src/test-data/setup.ts
+++ b/web/src/test-data/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { init } from 'svelte-i18n';
+import { vi } from 'vitest';
 
 beforeAll(async () => {
   await init({ fallbackLocale: 'dev' });
@@ -25,10 +26,7 @@ const localStorageMock = {
   removeItem: vi.fn(),
   clear: vi.fn(),
 };
-Object.defineProperty(globalThis, 'localStorage', {
-  writable: true,
-  value: localStorageMock,
-});
+vi.stubGlobal('localStorage', localStorageMock);
 
 vi.mock('$env/dynamic/public', () => {
   return {


### PR DESCRIPTION
## Test Fix

Fixed test environment issue where `svelte-persisted-store` was failing to access `localStorage` during test initialization, causing 20 test files to fail. The fix ensures `localStorage` is properly available in the test environment, resolving all localStorage-related errors and allowing all tests to run correctly.

**Test results:**
- Run with: `cd web && pnpm test`
- Before fix: See [before.log](https://github.com/user-attachments/files/24237697/before.log) - 20 failed test files due to localStorage errors
- After fix: See [after.log](https://github.com/user-attachments/files/24237696/after.log) - 35 passed test files, localStorage errors resolved

**Note:** The remaining failing tests in `timeline-manager.svelte.spec.ts` are unrelated to this fix and are out of scope for this PR. These appear to be pre-existing test issues.