### PR TITLE
fix(cli): allow easily crawling paths with parentheses

### DIFF
--- a/cli/src/utils.spec.ts
+++ b/cli/src/utils.spec.ts
@@ -63,6 +63,15 @@ const tests: Test[] = [
     skipOnWin32: true, // single quote interferes with mockfs root on Windows
   },
   {
+    test: 'should crawl folders with parentheses',
+    options: {
+      pathsToCrawl: ['/photos/album (year)'],
+    },
+    files: {
+      '/photos/album (year)/image.jpg': true,
+    },
+  },
+  {
     test: 'should crawl a single file',
     options: {
       pathsToCrawl: ['/photos/image.jpg'],

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -176,7 +176,12 @@ export const crawl = async (options: CrawlOptions): Promise<string[]> => {
   }
 
   const searchPatterns = patterns.map((pattern) => {
-    let escapedPattern = pattern.replaceAll("'", "[']").replaceAll('"', '["]').replaceAll('`', '[`]');
+    let escapedPattern = pattern
+      .replaceAll("'", "[']")
+      .replaceAll('"', '["]')
+      .replaceAll('`', '[`]')
+      .replaceAll('(', '[(]')
+      .replaceAll(')', '[)]');
     if (recursive) {
       escapedPattern = escapedPattern + '/**';
     }


### PR DESCRIPTION
## Description
Escape parentheses in glob paths.

This might technically be a regression for users that use the `(a|b)` regex/glob syntax. I didn't see any explicit note of that anywhere in the cli docs, and folder/album names with years are a reasonably common use case I'd say.

If not desired I'll open another PR specifying what to expect from the globbed inputs and how to crawl folders with e.g. parentheses.

Fixes #23885

## How Has This Been Tested?

Added a unit test for the crawl.

