### PR TITLE
fix(server): migrate motion part of live photo

### DIFF
--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -188,6 +188,15 @@ export class StorageTemplateService extends BaseService {
       const storageLabel = user?.storageLabel || null;
       const filename = asset.originalFileName || asset.id;
       await this.moveAsset(asset, { storageLabel, filename });
+
+      // move motion part of live photo
+      if (asset.livePhotoVideoId) {
+        const livePhotoVideo = await this.assetJobRepository.getForStorageTemplateJob(asset.livePhotoVideoId);
+        if (livePhotoVideo) {
+          const motionFilename = getLivePhotoMotionFilename(filename, livePhotoVideo.originalPath);
+          await this.moveAsset(livePhotoVideo, { storageLabel, filename: motionFilename });
+        }
+      }
     }
 
     this.logger.debug('Cleaning up empty directories...');


### PR DESCRIPTION
## Description

Updated Storage Template Spec and Service to ensure live photos motion parts(MOVs) get migrated along with their HEIC sibling. 

Fixes #17668 

## How Has This Been Tested?
1) Launched up an empty Immich instance
2) Uploaded Example Live Photo [ExampleLivePhotoUsed.zip](https://github.com/user-attachments/files/24246361/ExampleLivePhotoUsed.zip)
3) Noted that photos show has been uploaded and show up in uploads folder (See Screenshots section for evidence)
4) Enabled Storage Template. Template used: {{album}}/{{y}}/{{MM}}/{{filename}}
5) Kicked off Storage Template Migration Job
6) Noted that live photos have been moved away from uploads folder and migrated to library folder under the correct user and in the same location (See Screenshots section for evidence)

Log File: [immichTestingEvidence.log.txt](https://github.com/user-attachments/files/24246630/immichTestingEvidence.log.txt)

Log Contains uploading of files, enabling storage template, kicking off the template migration job
<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Uploading Live Photo Before Storage Template Migration is Enabled. Two folders one with live photo and one with regular HEIC
<img width="1788" height="492" alt="Pasted image 20251218135014" src="https://github.com/user-attachments/assets/51e6b177-8301-418a-9acc-3f8a5761563f" />

Live Photo Video Part
<img width="1948" height="454" alt="Pasted image 20251218135049" src="https://github.com/user-attachments/assets/66bec912-4aae-445c-a60d-d7a6cd73d535" />

Live Photo HEIC part
<img width="1818" height="622" alt="Pasted image 20251218135119" src="https://github.com/user-attachments/assets/898da1bd-dbe0-4354-bae6-a920d6d673de" />

After Storage Template Migration

<img width="1990" height="636" alt="Pasted image 20251218135418" src="https://github.com/user-attachments/assets/779394fd-4d2e-444c-9a3e-edf24121bf3b" />

Both locations in the uploads location are now empty as expected
<img width="1394" height="702" alt="image" src="https://github.com/user-attachments/assets/7459d534-e47e-4016-b51a-ffc09d9f94d3" />


</details>

## Checklist:

- [x] I have performed a self-review of my own code
~~- [ ] I have made corresponding changes to the documentation if applicable~~
- [x] I have no unrelated changes in the PR.
~~- [ ] I have confirmed that any new dependencies are strictly necessary.~~
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Used LLM to research/find existing storage template code 