### PR TITLE
chore: update ApiKeySecretModal to use monospace font

### DIFF
--- a/web/src/lib/modals/ApiKeySecretModal.svelte
+++ b/web/src/lib/modals/ApiKeySecretModal.svelte
@@ -15,7 +15,7 @@
 <Modal title={$t('api_key')} icon={mdiKeyVariant} {onClose} size="small">
   <ModalBody>
     <Text size="small" class="mb-4">{$t('api_key_description')}</Text>
-    <Textarea bind:value={secret} readonly />
+    <Textarea bind:value={secret} readonly class="font-mono" />
   </ModalBody>
 
   <ModalFooter>


### PR DESCRIPTION
use font-mono for the api key

suggested in #24250

https://github.com/user-attachments/assets/57de5609-ac91-4dad-8184-3b435bed9b2e

_mono > no mono (current) > mono_
