### PR TITLE
fix(web): search-bar usability improvements 

### DIFF
--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -26,7 +26,6 @@
   let showClearIcon = $derived(value.length > 0);
 
   let input = $state<HTMLInputElement>();
-  let searchTypeMenu = $state<HTMLDivElement>();
   let searchHistoryBox = $state<ReturnType<typeof SearchHistoryBox>>();
   let showSuggestions = $state(false);
   let isSearchSuggestions = $state(false);
@@ -174,12 +173,8 @@
     searchHistoryBox?.clearSelection();
   };
 
-  const toggleSearchTypeDropdown = async () => {
+  const toggleSearchTypeDropdown = () => {
     showSearchTypeDropdown = !showSearchTypeDropdown;
-    if (showSearchTypeDropdown) {
-      await tick();
-      searchTypeMenu?.focus();
-    }
   };
 
   const closeSearchTypeDropdown = () => {
@@ -332,7 +327,6 @@
 
           {#if showSearchTypeDropdown}
             <div
-              bind:this={searchTypeMenu}
               class="absolute top-full right-0 mt-1 bg-white dark:bg-immich-dark-gray border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg py-1 min-w-32 z-9999"
             >
               {#each searchTypes as searchType (searchType.value)}

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -313,18 +313,6 @@
       />
     </div>
 
-    <div class="absolute inset-y-0 {showClearIcon ? 'end-14' : 'end-2'} flex items-center ps-6 transition-all">
-      <IconButton
-        aria-label={$t('show_search_options')}
-        shape="round"
-        icon={mdiTune}
-        onclick={onFilterClick}
-        size="medium"
-        color="secondary"
-        variant="ghost"
-      />
-    </div>
-
     {#if searchStore.isSearchEnabled}
       <div
         id={searchTypeId}
@@ -363,6 +351,18 @@
         </div>
       </div>
     {/if}
+
+    <div class="absolute inset-y-0 {showClearIcon ? 'end-14' : 'end-2'} flex items-center ps-6 transition-all">
+      <IconButton
+        aria-label={$t('show_search_options')}
+        shape="round"
+        icon={mdiTune}
+        onclick={onFilterClick}
+        size="medium"
+        color="secondary"
+        variant="ghost"
+      />
+    </div>
 
     {#if showClearIcon}
       <div class="absolute inset-y-0 end-0 flex items-center pe-2">

--- a/web/src/lib/components/shared-components/search-bar/search-bar.svelte
+++ b/web/src/lib/components/shared-components/search-bar/search-bar.svelte
@@ -26,6 +26,7 @@
   let showClearIcon = $derived(value.length > 0);
 
   let input = $state<HTMLInputElement>();
+  let searchTypeMenu = $state<HTMLDivElement>();
   let searchHistoryBox = $state<ReturnType<typeof SearchHistoryBox>>();
   let showSuggestions = $state(false);
   let isSearchSuggestions = $state(false);
@@ -173,8 +174,12 @@
     searchHistoryBox?.clearSelection();
   };
 
-  const toggleSearchTypeDropdown = () => {
+  const toggleSearchTypeDropdown = async () => {
     showSearchTypeDropdown = !showSearchTypeDropdown;
+    if (showSearchTypeDropdown) {
+      await tick();
+      searchTypeMenu?.focus();
+    }
   };
 
   const closeSearchTypeDropdown = () => {
@@ -327,7 +332,7 @@
         class:max-md:hidden={value}
         class:end-28={value.length > 0}
       >
-        <div class="relative">
+        <div class="relative" use:focusOutside={{ onFocusOut: closeSearchTypeDropdown }}>
           <Button
             class="bg-immich-primary text-white dark:bg-immich-dark-primary/90 dark:text-black/75 rounded-full px-3 py-1 text-xs hover:opacity-80 transition-opacity cursor-pointer"
             onclick={toggleSearchTypeDropdown}
@@ -339,12 +344,13 @@
 
           {#if showSearchTypeDropdown}
             <div
+              bind:this={searchTypeMenu}
               class="absolute top-full right-0 mt-1 bg-white dark:bg-immich-dark-gray border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg py-1 min-w-32 z-9999"
-              use:focusOutside={{ onFocusOut: closeSearchTypeDropdown }}
             >
               {#each searchTypes as searchType (searchType.value)}
                 <button
                   type="button"
+                  tabindex="0"
                   class="w-full text-left px-3 py-2 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors
                          {currentSearchType === searchType.value ? 'bg-gray-100 dark:bg-gray-700' : ''}"
                   onclick={() => selectSearchType(searchType.value)}


### PR DESCRIPTION
## Description

Issue 1. The searchtype dropdown is never actually closed when clicking away from it.
As it's mostly only hidden by other state changes.

Issue 2. Tabbing through the search bar felt kind of weird, as if you started in the input field, and press "tab", it would select the search option icon, and if you press tab again, it jumps back to the search type pill. 

Additionally adds: tab index to the search type dropdown buttons, which makes navigation possible there.


(Another accessibility issue would be that the search type button/pill doesn't have a select indicator, so you don't really see if you tabbed there)

## How Has This Been Tested?


Issue 1. In the browser:

- click the search bar input field
- press the searchtype pill (dropdown opens)
- Now click on the search bar  
- previously the search type dropdown stayed open, now it closes

or another scenario:

- click the search bar input field
- press the searchtype pill (dropdown opens)
- Now click something unrelated like the background of the page
- Click the search bar again
- Previously the search type dropdown stayed open, now its closed

Issue 2. in the browser: 
- tab through the search bar.
- previously the active element jumped around, now it first focuses the search type and then the search options. 


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

As I never worked with svelte, LLM was used to get an introduction to it.
