### PR TITLE
fix(maintenance): prevent enable/disable maintenance CLI hanging on occasion

### DIFF
--- a/server/src/maintenance/maintenance-websocket.repository.ts
+++ b/server/src/maintenance/maintenance-websocket.repository.ts
@@ -37,8 +37,8 @@ export class MaintenanceWebsocketRepository implements OnGatewayConnection, OnGa
 
   afterInit(websocketServer: Server) {
     this.logger.log('Initialized websocket server');
-    websocketServer.on('AppRestart', (_, ack) => {
-      ack('ok');
+    websocketServer.on('AppRestart', (_, ack?: (ok: 'ok') => void) => {
+      ack?.('ok');
       this.appRepository.exitApp();
     });
   }

--- a/server/src/maintenance/maintenance-websocket.repository.ts
+++ b/server/src/maintenance/maintenance-websocket.repository.ts
@@ -37,7 +37,10 @@ export class MaintenanceWebsocketRepository implements OnGatewayConnection, OnGa
 
   afterInit(websocketServer: Server) {
     this.logger.log('Initialized websocket server');
-    websocketServer.on('AppRestart', (_, ack?: (ok: 'ok') => void) => {
+
+    websocketServer.on('AppRestart', (event: ArgsOf<'AppRestart'>, ack?: (ok: 'ok') => void) => {
+      this.logger.log(`Restarting due to event... ${JSON.stringify(event)}`);
+
       ack?.('ok');
       this.appRepository.exitApp();
     });

--- a/server/src/maintenance/maintenance-websocket.repository.ts
+++ b/server/src/maintenance/maintenance-websocket.repository.ts
@@ -37,7 +37,10 @@ export class MaintenanceWebsocketRepository implements OnGatewayConnection, OnGa
 
   afterInit(websocketServer: Server) {
     this.logger.log('Initialized websocket server');
-    websocketServer.on('AppRestart', () => this.appRepository.exitApp());
+    websocketServer.on('AppRestart', (_, ack) => {
+      ack('ok');
+      this.appRepository.exitApp();
+    });
   }
 
   clientBroadcast<T extends keyof ClientEventMap>(event: T, ...data: ClientEventMap[T]) {

--- a/server/src/repositories/app.repository.ts
+++ b/server/src/repositories/app.repository.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { createAdapter } from '@socket.io/redis-adapter';
+import Redis from 'ioredis';
+import { Server as SocketIO } from 'socket.io';
 import { ExitCode } from 'src/enum';
+import { ConfigRepository } from 'src/repositories/config.repository';
+import { AppRestartEvent } from 'src/repositories/event.repository';
 
 @Injectable()
 export class AppRepository {
@@ -16,5 +21,27 @@ export class AppRepository {
 
   setCloseFn(fn: () => Promise<void>) {
     this.closeFn = fn;
+  }
+
+  async sendOneShotAppRestart(state: AppRestartEvent): Promise<void> {
+    const server = new SocketIO();
+    const { redis } = new ConfigRepository().getEnv();
+    const pubClient = new Redis({ ...redis, lazyConnect: true });
+    const subClient = pubClient.duplicate();
+
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    server.adapter(createAdapter(pubClient, subClient));
+
+    // => corresponds to notification.service.ts#onAppRestart
+    server.emit('AppRestartV1', state, async () => {
+      const responses = await server.serverSideEmitWithAck('AppRestart', state);
+      if (responses.some((response) => response !== 'ok')) {
+        throw new Error("One or more node(s) returned a non-'ok' response to our restart request!");
+      }
+
+      pubClient.disconnect();
+      subClient.disconnect();
+    });
   }
 }

--- a/server/src/services/cli.service.spec.ts
+++ b/server/src/services/cli.service.spec.ts
@@ -5,6 +5,8 @@ import { factory } from 'test/small.factory';
 import { newTestService, ServiceMocks } from 'test/utils';
 import { describe, it } from 'vitest';
 
+const mockSendRestart = vi.fn();
+
 describe(CliService.name, () => {
   let sut: CliService;
   let mocks: ServiceMocks;
@@ -85,7 +87,7 @@ describe(CliService.name, () => {
   describe('disableMaintenanceMode', () => {
     it('should not do anything if not in maintenance mode', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ isMaintenanceMode: false });
-      await expect(sut.disableMaintenanceMode()).resolves.toEqual({
+      await expect(sut.disableMaintenanceMode(mockSendRestart)).resolves.toEqual({
         alreadyDisabled: true,
       });
 
@@ -95,7 +97,7 @@ describe(CliService.name, () => {
 
     it('should disable maintenance mode', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ isMaintenanceMode: true, secret: 'secret' });
-      await expect(sut.disableMaintenanceMode()).resolves.toEqual({
+      await expect(sut.disableMaintenanceMode(mockSendRestart)).resolves.toEqual({
         alreadyDisabled: false,
       });
 
@@ -108,7 +110,7 @@ describe(CliService.name, () => {
   describe('enableMaintenanceMode', () => {
     it('should not do anything if in maintenance mode', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ isMaintenanceMode: true, secret: 'secret' });
-      await expect(sut.enableMaintenanceMode()).resolves.toEqual(
+      await expect(sut.enableMaintenanceMode(mockSendRestart)).resolves.toEqual(
         expect.objectContaining({
           alreadyEnabled: true,
         }),
@@ -120,7 +122,7 @@ describe(CliService.name, () => {
 
     it('should enable maintenance mode', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ isMaintenanceMode: false });
-      await expect(sut.enableMaintenanceMode()).resolves.toEqual(
+      await expect(sut.enableMaintenanceMode(mockSendRestart)).resolves.toEqual(
         expect.objectContaining({
           alreadyEnabled: false,
         }),
@@ -137,7 +139,7 @@ describe(CliService.name, () => {
     it('should return a valid login URL', async () => {
       mocks.systemMetadata.get.mockResolvedValue({ isMaintenanceMode: true, secret: 'secret' });
 
-      const result = await sut.enableMaintenanceMode();
+      const result = await sut.enableMaintenanceMode(mockSendRestart);
 
       expect(result).toEqual(
         expect.objectContaining({

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -56,7 +56,7 @@ export class CliService extends BaseService {
     const state = { isMaintenanceMode: false as const };
     await this.systemMetadataRepository.set(SystemMetadataKey.MaintenanceMode, state);
 
-    sendOneShotAppRestart(state);
+    await sendOneShotAppRestart(state);
 
     return {
       alreadyDisabled: false,
@@ -89,7 +89,7 @@ export class CliService extends BaseService {
       secret,
     });
 
-    sendOneShotAppRestart({
+    await sendOneShotAppRestart({
       isMaintenanceMode: true,
     });
 

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -88,7 +88,9 @@ export class CliService extends BaseService {
       secret,
     });
 
-    await this.appRepository.sendOneShotAppRestart(state);
+    await this.appRepository.sendOneShotAppRestart({
+      isMaintenanceMode: true,
+    });
 
     return {
       authUrl: await createMaintenanceLoginUrl(baseUrl, payload, secret),

--- a/server/src/services/cli.service.ts
+++ b/server/src/services/cli.service.ts
@@ -42,7 +42,7 @@ export class CliService extends BaseService {
     await this.updateConfig(config);
   }
 
-  async disableMaintenanceMode(): Promise<{ alreadyDisabled: boolean }> {
+  async disableMaintenanceMode(sendAppRestartCallback = sendOneShotAppRestart): Promise<{ alreadyDisabled: boolean }> {
     const currentState = await this.systemMetadataRepository
       .get(SystemMetadataKey.MaintenanceMode)
       .then((state) => state ?? { isMaintenanceMode: false as const });
@@ -56,14 +56,16 @@ export class CliService extends BaseService {
     const state = { isMaintenanceMode: false as const };
     await this.systemMetadataRepository.set(SystemMetadataKey.MaintenanceMode, state);
 
-    await sendOneShotAppRestart(state);
+    await sendAppRestartCallback(state);
 
     return {
       alreadyDisabled: false,
     };
   }
 
-  async enableMaintenanceMode(): Promise<{ authUrl: string; alreadyEnabled: boolean }> {
+  async enableMaintenanceMode(
+    sendAppRestartCallback = sendOneShotAppRestart,
+  ): Promise<{ authUrl: string; alreadyEnabled: boolean }> {
     const { server } = await this.getConfig({ withCache: true });
     const baseUrl = getExternalDomain(server);
 
@@ -89,7 +91,7 @@ export class CliService extends BaseService {
       secret,
     });
 
-    await sendOneShotAppRestart({
+    await sendAppRestartCallback({
       isMaintenanceMode: true,
     });
 

--- a/server/src/services/maintenance.service.ts
+++ b/server/src/services/maintenance.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { OnEvent } from 'src/decorators';
 import { MaintenanceAuthDto } from 'src/dtos/maintenance.dto';
 import { SystemMetadataKey } from 'src/enum';
+import { ArgOf } from 'src/repositories/event.repository';
 import { BaseService } from 'src/services/base.service';
 import { MaintenanceModeState } from 'src/types';
 import { createMaintenanceLoginUrl, generateMaintenanceSecret, signMaintenanceJwt } from 'src/utils/maintenance';
@@ -31,7 +32,9 @@ export class MaintenanceService extends BaseService {
   }
 
   @OnEvent({ name: 'AppRestart', server: true })
-  onRestart(_: undefined, ack?: (ok: 'ok') => void): void {
+  onRestart(event: ArgOf<'AppRestart'>, ack?: (ok: 'ok') => void): void {
+    this.logger.log(`Restarting due to event... ${JSON.stringify(event)}`);
+
     ack?.('ok');
     this.appRepository.exitApp();
   }

--- a/server/src/services/maintenance.service.ts
+++ b/server/src/services/maintenance.service.ts
@@ -31,8 +31,8 @@ export class MaintenanceService extends BaseService {
   }
 
   @OnEvent({ name: 'AppRestart', server: true })
-  onRestart(_: undefined, ack: (ok: 'ok') => void): void {
-    ack('ok');
+  onRestart(_: undefined, ack?: (ok: 'ok') => void): void {
+    ack?.('ok');
     this.appRepository.exitApp();
   }
 

--- a/server/src/services/maintenance.service.ts
+++ b/server/src/services/maintenance.service.ts
@@ -31,7 +31,8 @@ export class MaintenanceService extends BaseService {
   }
 
   @OnEvent({ name: 'AppRestart', server: true })
-  onRestart(): void {
+  onRestart(_: undefined, ack: (ok: 'ok') => void): void {
+    ack('ok');
     this.appRepository.exitApp();
   }
 

--- a/server/src/utils/maintenance.ts
+++ b/server/src/utils/maintenance.ts
@@ -7,47 +7,22 @@ import { MaintenanceAuthDto } from 'src/dtos/maintenance.dto';
 import { ConfigRepository } from 'src/repositories/config.repository';
 import { AppRestartEvent } from 'src/repositories/event.repository';
 
-export function sendOneShotAppRestart(state: AppRestartEvent): void {
+export async function sendOneShotAppRestart(state: AppRestartEvent): Promise<void> {
   const server = new SocketIO();
   const { redis } = new ConfigRepository().getEnv();
-  const pubClient = new Redis(redis);
+  const pubClient = new Redis({ ...redis, lazyConnect: true });
   const subClient = pubClient.duplicate();
+
+  await Promise.all([pubClient.connect(), subClient.connect()]);
+
   server.adapter(createAdapter(pubClient, subClient));
 
-  /**
-   * Keep trying until we manage to stop Immich
-   *
-   * Sometimes there appear to be communication
-   * issues between to the other servers.
-   *
-   * This issue only occurs with this method.
-   */
-  async function tryTerminate() {
-    while (true) {
-      try {
-        const responses = await server.serverSideEmitWithAck('AppRestart', state);
-        if (responses.length > 0) {
-          return;
-        }
-      } catch (error) {
-        console.error(error);
-        console.error('Encountered an error while telling Immich to stop.');
-      }
-
-      console.info(
-        "\nIt doesn't appear that Immich stopped, trying again in a moment.\nIf Immich is already not running, you can ignore this error.",
-      );
-
-      await new Promise((r) => setTimeout(r, 1e3));
-    }
-  }
-
   // => corresponds to notification.service.ts#onAppRestart
-  server.emit('AppRestartV1', state, () => {
-    void tryTerminate().finally(() => {
-      pubClient.disconnect();
-      subClient.disconnect();
-    });
+  server.emit('AppRestartV1', state, async () => {
+    await server.serverSideEmitWithAck('AppRestart', state);
+
+    pubClient.disconnect();
+    subClient.disconnect();
   });
 }
 

--- a/server/src/utils/maintenance.ts
+++ b/server/src/utils/maintenance.ts
@@ -1,33 +1,6 @@
-import { createAdapter } from '@socket.io/redis-adapter';
-import Redis from 'ioredis';
 import { SignJWT } from 'jose';
 import { randomBytes } from 'node:crypto';
-import { Server as SocketIO } from 'socket.io';
 import { MaintenanceAuthDto } from 'src/dtos/maintenance.dto';
-import { ConfigRepository } from 'src/repositories/config.repository';
-import { AppRestartEvent } from 'src/repositories/event.repository';
-
-export async function sendOneShotAppRestart(state: AppRestartEvent): Promise<void> {
-  const server = new SocketIO();
-  const { redis } = new ConfigRepository().getEnv();
-  const pubClient = new Redis({ ...redis, lazyConnect: true });
-  const subClient = pubClient.duplicate();
-
-  await Promise.all([pubClient.connect(), subClient.connect()]);
-
-  server.adapter(createAdapter(pubClient, subClient));
-
-  // => corresponds to notification.service.ts#onAppRestart
-  server.emit('AppRestartV1', state, async () => {
-    const responses = await server.serverSideEmitWithAck('AppRestart', state);
-    if (responses.some((response) => response !== 'ok')) {
-      throw new Error("One or more node(s) returned a non-'ok' response to our restart request!");
-    }
-
-    pubClient.disconnect();
-    subClient.disconnect();
-  });
-}
 
 export async function createMaintenanceLoginUrl(
   baseUrl: string,

--- a/server/src/utils/maintenance.ts
+++ b/server/src/utils/maintenance.ts
@@ -19,7 +19,10 @@ export async function sendOneShotAppRestart(state: AppRestartEvent): Promise<voi
 
   // => corresponds to notification.service.ts#onAppRestart
   server.emit('AppRestartV1', state, async () => {
-    await server.serverSideEmitWithAck('AppRestart', state);
+    const responses = await server.serverSideEmitWithAck('AppRestart', state);
+    if (responses.some((response) => response !== 'ok')) {
+      throw new Error("One or more node(s) returned a non-'ok' response to our restart request!");
+    }
 
     pubClient.disconnect();
     subClient.disconnect();


### PR DESCRIPTION
Small fixes for the maintenance mode CLI
- Always acknowledge messages on the server side
- Ensure Redis is definitely connected before doing anything else
- Validate acknowledgement messages are correct

Also removes the retry logic since this seems to now work correctly (having had enable/disable run in a loop for a couple dozen iterations)

Not super happy about how the one shot function is mocked ... but the alternative would be spinning up a whole repository and mocking it there I'd imagine? (this was seemingly fine before because we would never reach the Redis error case but it shouldn't trying to spin up Redis/SocketIO in a unit test anyways)

Related discussion: https://github.com/immich-app/immich/discussions/24676