### PR TITLE
Append `:z`  to Certain Volumes to Avoid SeLinux Access Control Errors

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     volumes:
       # Do not edit the next line. If you want to change the media storage location on your system, edit the value of UPLOAD_LOCATION in the .env file
-      - ${UPLOAD_LOCATION}:/data
+      - ${UPLOAD_LOCATION}:/data:z
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
@@ -66,7 +66,7 @@ services:
       # DB_STORAGE_TYPE: 'HDD'
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
-      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data:z
     shm_size: 128mb
     restart: always
 


### PR DESCRIPTION
## Description

### Changes
I appended `:z` to the 2 following lines:
```
${UPLOAD_LOCATION}:/data:z
```
```
${DB_DATA_LOCATION}:/var/lib/postgresql/data:z
```
To have docker relabel these volumes and avoid SeLinux Access Control Errors.

Fixes [this issue](https://github.com/immich-app/immich/issues/14912).

Without these changes and SeLinux enabled, the `UPLOAD` and `DB` directories may not have the correct selinux labels and the containers will fail to launch and will restart indefinitely.

## How Has This Been Tested?
Tested on my own Fedora Server in fresh install of immich. See Screenshots and explanations below

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="2558" height="849" alt="Screenshot From 2025-12-19 09-53-52" src="https://github.com/user-attachments/assets/0a33ddde-c707-4080-a489-fc6cb1ed0405" />

_Fresh immich install in SeLinux environment without the proposed fixes._ Access control errors keep forcing `immich-server` and `immich-postgres` to restart.

## Immich Server Logs:
```
Node.js v22.18.0
Initializing Immich v2.3.1
Detected CPU Cores: 8
Missing history for endpoint: Retrieve auth status
(node:7) ExperimentalWarning: WASI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
    ^

Error: getaddrinfo ENOTFOUND database
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'database'
}
```
## Immich Postgres Logs:
```
Using SSD storage
chmod: changing permissions of '/var/lib/postgresql/data': Permission denied
chown: changing ownership of '/var/lib/postgresql/data': Permission denied
```

__Note:__ I started the immich instance with `sudo`.

## SeLinux Logs:
<img width="2021" height="816" alt="Screenshot From 2025-12-19 10-03-54" src="https://github.com/user-attachments/assets/e097a8c5-bba7-40ca-826c-e43ee086094c" />
</details>

Adding the proposed changes fixes these issues, and `immich-server` and `immich-postgres` are able to boot up fine.

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No use of LLM.
...
