### PR TITLE
chore(server): improve log messages

### DIFF
--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -358,7 +358,7 @@ export class DatabaseRepository {
   }
 
   async runMigrations(): Promise<void> {
-    this.logger.debug('Running migrations');
+    this.logger.log('Running migrations');
 
     const migrator = this.createMigrator();
 
@@ -379,7 +379,7 @@ export class DatabaseRepository {
       throw error;
     }
 
-    this.logger.debug('Finished running migrations');
+    this.logger.log('Finished running migrations');
   }
 
   async migrateFilePaths(sourceFolder: string, targetFolder: string): Promise<void> {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -158,7 +158,7 @@ export class MediaService extends BaseService {
   async handleGenerateThumbnails({ id }: JobOf<JobName.AssetGenerateThumbnails>): Promise<JobStatus> {
     const asset = await this.assetJobRepository.getForGenerateThumbnailJob(id);
     if (!asset) {
-      this.logger.warn(`Thumbnail generation failed for asset ${id}: not found`);
+      this.logger.warn(`Thumbnail generation failed for asset ${id}: not found in database or missing metadata`);
       return JobStatus.Failed;
     }
 

--- a/server/src/services/memory.service.ts
+++ b/server/src/services/memory.service.ts
@@ -28,6 +28,7 @@ export class MemoryService extends BaseService {
           continue;
         }
 
+        this.logger.log(`Creating memories for ${target.toISO()}`);
         try {
           await Promise.all(users.map((owner) => this.createOnThisDayMemories(owner.id, target)));
         } catch (error) {

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -862,9 +862,13 @@ export class MetadataService extends BaseService {
     const result = firstDateTime(exifTags);
     const tag = result?.tag;
     const dateTime = result?.dateTime;
-    this.logger.verbose(
-      `Date and time is ${dateTime} using exifTag ${tag} for asset ${asset.id}: ${asset.originalPath}`,
-    );
+    if (dateTime) {
+      this.logger.verbose(
+        `Date and time is ${dateTime} using exifTag ${tag} for asset ${asset.id}: ${asset.originalPath}`,
+      );
+    } else {
+      this.logger.verbose(`No exif date time information found for asset ${asset.id}: ${asset.originalPath}`);
+    }
 
     // timezone
     let timeZone = exifTags.tz ?? null;

--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -366,9 +366,13 @@ export class MetadataService extends BaseService {
 
     const isChanged = sidecarPath !== sidecarFile?.path;
 
-    this.logger.debug(
-      `Sidecar check found old=${sidecarFile?.path}, new=${sidecarPath} will ${isChanged ? 'update' : 'do nothing for'}  asset ${asset.id}: ${asset.originalPath}`,
-    );
+    if (sidecarFile?.path || sidecarPath) {
+      this.logger.debug(
+        `Sidecar check found old=${sidecarFile?.path}, new=${sidecarPath} will ${isChanged ? 'update' : 'do nothing for'} asset ${asset.id}: ${asset.originalPath}`,
+      );
+    } else {
+      this.logger.verbose(`No sidecars found for asset ${asset.id}: ${asset.originalPath}`);
+    }
 
     if (!isChanged) {
       return JobStatus.Skipped;


### PR DESCRIPTION
## Description

- Clarify log messages to avoid misinterpretation/confusion
- Add logs for troubleshooting

### 1. Clarify the "asset not found" log during thumbnail generation

Before:
- `Thumbnail generation failed for asset ...: not found`

After:
- `Thumbnail generation failed for asset ...: not found in database or missing metadata`

The "not found" part is about database: an asset not found among the database query results. This is not about missing files on disk, as one might read it.

### 2. Log memory creation at default level

Add new log:
- `LOG [Microservices:MemoryService] Creating memories for 2025-12-17T00:00:00.000Z`

This new log in context:
```log
  DEBUG [Api:LoggingInterceptor~o5pp8kh9] POST /api/jobs 204 4.60ms ::ffff:127.0.0.1
VERBOSE [Api:LoggingInterceptor~o5pp8kh9] {"name":"memory-create"}
    LOG [Microservices:MemoryService] Creating memories for 2025-12-17T00:00:00.000Z
    LOG [Microservices:MemoryService] Creating memories for 2025-12-18T00:00:00.000Z
```

### 3. Log database migration start/end at default level

Before: these messages were assigned to "debug" level. But they were not printed (at any Immich logging level) due to a known limitation of SystemConfigService which sets LogLevel only later on, after migrations run. (So any debug/verbose logs are simply lost at start-up)

After:
```log
[Nest] 92568  - 12/20/2025, 12:37:07 PM     LOG [Microservices:DatabaseRepository] Running migrations
[Nest] 92568  - 12/20/2025, 12:37:07 PM     LOG [Microservices:DatabaseRepository] Finished running migrations
[Nest] 92653  - 12/20/2025, 12:37:07 PM     LOG [Api:DatabaseRepository] Running migrations
[Nest] 92653  - 12/20/2025, 12:37:07 PM     LOG [Api:DatabaseRepository] Finished running migrations
```

### 4. Add explicit log for missing exif date time

Before:
- `VERBOSE [Microservices:MetadataService] Date and time is undefined using exifTag undefined for asset ...`

After:
- `VERBOSE [Microservices:MetadataService] No exif date time information found for asset ...`

Alternatively, we can remove this log altogether because a similar message is logged later at "debug" level: `No exif date time found, falling back on ..., earliest of file creation and modification`

In context:
```log
VERBOSE [Microservices:MetadataService] No exif date time information found for asset 8ed4a910-b9cb-4f75-8061-22bdf4adbd81: /data/library/admin/2025/2025-01/15752-IMG-20250108-WA0000.jpg
  DEBUG [Microservices:MetadataService] No timezone information found for asset 8ed4a910-b9cb-4f75-8061-22bdf4adbd81: /data/library/admin/2025/2025-01/15752-IMG-20250108-WA0000.jpg
  DEBUG [Microservices:MetadataService] No exif date time found, falling back on 2025-01-29T19:46:19.000+00:00, earliest of file creation and modification for asset 8ed4a910-b9cb-4f75-8061-22bdf4adbd81: /data/library/admin/2025/2025-01/15752-IMG-20250108-WA0000.jpg
VERBOSE [Microservices:MetadataService] Found local date time 2025-01-29T19:46:19.000+00:00 for asset 8ed4a910-b9cb-4f75-8061-22bdf4adbd81: /data/library/admin/2025/2025-01/15752-IMG-20250108-WA0000.jpg
```

### 5. Move not found sidecars to verbose level instead of "old=null, new=null" at debug

Before:
- `DEBUG [Microservices:MetadataService] Sidecar check found old=null, new=null will do nothing for  asset ...`

After:
- `VERBOSE [Microservices:MetadataService] No sidecars found for asset ...`


## How Has This Been Tested?

Trigger relevant scenarios and view logs.

This PR introduces a couple of `if`'s where previously was a plain `this.logger...()`. These conditionals worked fine in my tests, but I haven't tested all possible combinations.
- `if (sidecarFile?.path || sidecarPath)`
- `if (dateTime)`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.