### PR TITLE
feat: Upload both JPEG and RAW files in iOS App

### DIFF
--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/Messages.g.kt
@@ -315,6 +315,21 @@ interface NativeSyncApi {
   fun hashAssets(assetIds: List<String>, allowNetworkAccess: Boolean, callback: (Result<List<HashResult>>) -> Unit)
   fun cancelHashing()
   fun getTrashedAssets(): Map<String, List<PlatformAsset>>
+  /**
+   * Get the file path for the main resource of an asset.
+   * Returns null if the asset cannot be found.
+   */
+  fun getAssetFilePath(assetId: String, callback: (Result<String?>) -> Unit)
+  /**
+   * Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+   * Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+   */
+  fun hasRawResource(assetId: String): Boolean
+  /**
+   * Get the file path for the RAW resource of an asset.
+   * Returns null if the asset has no RAW resource.
+   */
+  fun getRawFilePath(assetId: String, callback: (Result<String?>) -> Unit)
 
   companion object {
     /** The codec used by NativeSyncApi. */
@@ -503,6 +518,63 @@ interface NativeSyncApi {
               MessagesPigeonUtils.wrapError(exception)
             }
             reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getAssetFilePath$separatedMessageChannelSuffix", codec, taskQueue)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val assetIdArg = args[0] as String
+            api.getAssetFilePath(assetIdArg) { result: Result<String?> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(MessagesPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(MessagesPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hasRawResource$separatedMessageChannelSuffix", codec, taskQueue)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val assetIdArg = args[0] as String
+            val wrapped: List<Any?> = try {
+              listOf(api.hasRawResource(assetIdArg))
+            } catch (exception: Throwable) {
+              MessagesPigeonUtils.wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getRawFilePath$separatedMessageChannelSuffix", codec, taskQueue)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val assetIdArg = args[0] as String
+            api.getRawFilePath(assetIdArg) { result: Result<String?> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(MessagesPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(MessagesPigeonUtils.wrapResult(data))
+              }
+            }
           }
         } else {
           channel.setMessageHandler(null)

--- a/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
+++ b/mobile/android/app/src/main/kotlin/app/alextran/immich/sync/MessagesImplBase.kt
@@ -316,4 +316,42 @@ open class NativeSyncApiImplBase(context: Context) : ImmichPlugin() {
     hashTask?.cancel()
     hashTask = null
   }
+
+  fun getAssetFilePath(assetId: String, callback: (Result<String?>) -> Unit) {
+    try {
+      val projection = arrayOf(MediaStore.MediaColumns.DATA)
+      getCursor(
+        MediaStore.VOLUME_EXTERNAL,
+        "${MediaStore.MediaColumns._ID} = ?",
+        arrayOf(assetId),
+        projection
+      )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+          val dataColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA)
+          val path = cursor.getString(dataColumn)
+          if (path != null && File(path).exists()) {
+            completeWhenActive(callback, Result.success(path))
+            return
+          }
+        }
+      }
+      completeWhenActive(callback, Result.success(null))
+    } catch (e: Exception) {
+      completeWhenActive(callback, Result.failure(e))
+    }
+  }
+
+  fun hasRawResource(assetId: String): Boolean {
+    // Android doesn't have the same JPEG+RAW pairing concept as iOS.
+    // On Android, RAW files are stored as separate files in MediaStore.
+    // This feature is primarily for iOS JPEG+RAW support.
+    return false
+  }
+
+  fun getRawFilePath(assetId: String, callback: (Result<String?>) -> Unit) {
+    // Android doesn't have the same JPEG+RAW pairing concept as iOS.
+    // On Android, RAW files are stored as separate files in MediaStore.
+    // This feature is primarily for iOS JPEG+RAW support.
+    completeWhenActive(callback, Result.success(null))
+  }
 }

--- a/mobile/ios/Runner/Sync/Messages.g.swift
+++ b/mobile/ios/Runner/Sync/Messages.g.swift
@@ -377,6 +377,15 @@ protocol NativeSyncApi {
   func hashAssets(assetIds: [String], allowNetworkAccess: Bool, completion: @escaping (Result<[HashResult], Error>) -> Void)
   func cancelHashing() throws
   func getTrashedAssets() throws -> [String: [PlatformAsset]]
+  /// Get the file path for the main resource of an asset.
+  /// Returns null if the asset cannot be found.
+  func getAssetFilePath(assetId: String, completion: @escaping (Result<String?, Error>) -> Void)
+  /// Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+  /// Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+  func hasRawResource(assetId: String) throws -> Bool
+  /// Get the file path for the RAW resource of an asset.
+  /// Returns null if the asset has no RAW resource.
+  func getRawFilePath(assetId: String, completion: @escaping (Result<String?, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -559,6 +568,67 @@ class NativeSyncApiSetup {
       }
     } else {
       getTrashedAssetsChannel.setMessageHandler(nil)
+    }
+    /// Get the file path for the main resource of an asset.
+    /// Returns null if the asset cannot be found.
+    let getAssetFilePathChannel = taskQueue == nil
+      ? FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getAssetFilePath\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+      : FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getAssetFilePath\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec, taskQueue: taskQueue)
+    if let api = api {
+      getAssetFilePathChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let assetIdArg = args[0] as! String
+        api.getAssetFilePath(assetId: assetIdArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      getAssetFilePathChannel.setMessageHandler(nil)
+    }
+    /// Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+    /// Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+    let hasRawResourceChannel = taskQueue == nil
+      ? FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hasRawResource\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+      : FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.hasRawResource\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec, taskQueue: taskQueue)
+    if let api = api {
+      hasRawResourceChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let assetIdArg = args[0] as! String
+        do {
+          let result = try api.hasRawResource(assetId: assetIdArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      hasRawResourceChannel.setMessageHandler(nil)
+    }
+    /// Get the file path for the RAW resource of an asset.
+    /// Returns null if the asset has no RAW resource.
+    let getRawFilePathChannel = taskQueue == nil
+      ? FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getRawFilePath\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+      : FlutterBasicMessageChannel(name: "dev.flutter.pigeon.immich_mobile.NativeSyncApi.getRawFilePath\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec, taskQueue: taskQueue)
+    if let api = api {
+      getRawFilePathChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let assetIdArg = args[0] as! String
+        api.getRawFilePath(assetId: assetIdArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      getRawFilePathChannel.setMessageHandler(nil)
     }
   }
 }

--- a/mobile/lib/infrastructure/repositories/storage.repository.dart
+++ b/mobile/lib/infrastructure/repositories/storage.repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/platform_extensions.dart';
+import 'package:immich_mobile/platform/native_sync_api.g.dart';
 import 'package:logging/logging.dart';
 import 'package:photo_manager/photo_manager.dart';
 
@@ -29,6 +30,55 @@ class StorageRepository {
       log.warning("Error getting file for asset $assetId", error, stackTrace);
     }
     return file;
+  }
+
+  /// Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+  /// Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+  Future<bool> hasRawResource(String assetId) async {
+    if (!CurrentPlatform.isIOS) {
+      return false;
+    }
+
+    try {
+      final nativeSyncApi = NativeSyncApi();
+      return await nativeSyncApi.hasRawResource(assetId);
+    } catch (error, stackTrace) {
+      final log = Logger('StorageRepository');
+      log.warning("Error checking RAW resource for asset $assetId", error, stackTrace);
+      return false;
+    }
+  }
+
+  /// Get the RAW file for an asset (iOS only).
+  /// Returns null if the asset has no RAW resource.
+  Future<File?> getRawFileForAsset(String assetId) async {
+    if (!CurrentPlatform.isIOS) {
+      return null;
+    }
+
+    final log = Logger('StorageRepository');
+
+    try {
+      final nativeSyncApi = NativeSyncApi();
+      final filePath = await nativeSyncApi.getRawFilePath(assetId);
+
+      if (filePath == null) {
+        return null;
+      }
+
+      final file = File(filePath);
+      final exists = await file.exists();
+
+      if (!exists) {
+        log.warning("RAW file for asset $assetId does not exist at path: $filePath");
+        return null;
+      }
+
+      return file;
+    } catch (error, stackTrace) {
+      log.warning("Error getting RAW file for asset $assetId", error, stackTrace);
+      return null;
+    }
   }
 
   Future<File?> getMotionFileForAsset(LocalAsset asset) async {

--- a/mobile/lib/platform/native_sync_api.g.dart
+++ b/mobile/lib/platform/native_sync_api.g.dart
@@ -616,4 +616,84 @@ class NativeSyncApi {
       return (pigeonVar_replyList[0] as Map<Object?, Object?>?)!.cast<String, List<PlatformAsset>>();
     }
   }
+
+  /// Get the file path for the main resource of an asset.
+  /// Returns null if the asset cannot be found.
+  Future<String?> getAssetFilePath(String assetId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NativeSyncApi.getAssetFilePath$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[assetId]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return (pigeonVar_replyList[0] as String?);
+    }
+  }
+
+  /// Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+  /// Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+  Future<bool> hasRawResource(String assetId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NativeSyncApi.hasRawResource$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[assetId]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else if (pigeonVar_replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (pigeonVar_replyList[0] as bool?)!;
+    }
+  }
+
+  /// Get the file path for the RAW resource of an asset.
+  /// Returns null if the asset has no RAW resource.
+  Future<String?> getRawFilePath(String assetId) async {
+    final String pigeonVar_channelName =
+        'dev.flutter.pigeon.immich_mobile.NativeSyncApi.getRawFilePath$pigeonVar_messageChannelSuffix';
+    final BasicMessageChannel<Object?> pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[assetId]);
+    final List<Object?>? pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+    if (pigeonVar_replyList == null) {
+      throw _createConnectionError(pigeonVar_channelName);
+    } else if (pigeonVar_replyList.length > 1) {
+      throw PlatformException(
+        code: pigeonVar_replyList[0]! as String,
+        message: pigeonVar_replyList[1] as String?,
+        details: pigeonVar_replyList[2],
+      );
+    } else {
+      return (pigeonVar_replyList[0] as String?);
+    }
+  }
 }

--- a/mobile/lib/services/upload.service.dart
+++ b/mobile/lib/services/upload.service.dart
@@ -537,7 +537,12 @@ class UploadTaskMetadata {
   final String livePhotoVideoId;
   final bool isRawFile;
 
-  const UploadTaskMetadata({required this.localAssetId, required this.isLivePhotos, required this.livePhotoVideoId, this.isRawFile = false});
+  const UploadTaskMetadata({
+    required this.localAssetId,
+    required this.isLivePhotos,
+    required this.livePhotoVideoId,
+    this.isRawFile = false,
+  });
 
   UploadTaskMetadata copyWith({String? localAssetId, bool? isLivePhotos, String? livePhotoVideoId, bool? isRawFile}) {
     return UploadTaskMetadata(

--- a/mobile/pigeon/native_sync_api.dart
+++ b/mobile/pigeon/native_sync_api.dart
@@ -121,4 +121,21 @@ abstract class NativeSyncApi {
 
   @TaskQueue(type: TaskQueueType.serialBackgroundThread)
   Map<String, List<PlatformAsset>> getTrashedAssets();
+
+  /// Get the file path for the main resource of an asset.
+  /// Returns null if the asset cannot be found.
+  @async
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
+  String? getAssetFilePath(String assetId);
+
+  /// Check if an asset has a RAW resource (iOS only, JPEG+RAW pair).
+  /// Returns true if the asset has a RAW resource alongside the main JPEG/HEIC.
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
+  bool hasRawResource(String assetId);
+
+  /// Get the file path for the RAW resource of an asset.
+  /// Returns null if the asset has no RAW resource.
+  @async
+  @TaskQueue(type: TaskQueueType.serialBackgroundThread)
+  String? getRawFilePath(String assetId);
 }


### PR DESCRIPTION
## Description

This PR addresses an issue where the iOS app only uploads the JPEG version of a JPEG+RAW pair stored in the iOS Photos library. With this change, the app will now recognize and upload both the JPEG and the RAW files as separate assets, ensuring no asset is lost during the backup process.

This PR fulfills the feature asked in [#18201](https://github.com/immich-app/immich/discussions/18201).

## How Has This Been Tested?

1. Configure the camera to save photos in both JPEG and RAW file formats.
2. Transfer photos to the iPhone. You should see your photo shows `JPEG+RAW` in Apple Photos.
3. Open the Immich app, and let it upload photos.
4. Validate in your Immich server, you should now see the JPEG one with the RAW one.
5. (Optional) You can also validate in the database

```
immich=# SELECT * FROM asset WHERE "id"='edcb13c2-3252-43d9-8711-ab5adf5390fd';
-[ RECORD 1 ]----+-----------------------------------------------------------------
id               | edcb13c2-3252-43d9-8711-ab5adf5390fd
deviceAssetId    | 853C1324-50DD-4B0C-8D68-331F15AE59ED/L0/001:raw
ownerId          | 5c1b77b0-a767-4904-a751-16e61db224b6
deviceId         | e1936978a68e6fef639a4c5d189319ad892aa917fe6971dbedd6fe546fdcaa38
type             | IMAGE
originalPath     | /usr/src/app/upload/library/admin/2025/2025-12-17/IMG_1805.cr3
fileCreatedAt    | 2025-12-17 09:31:34.89+00
fileModifiedAt   | 2025-12-17 10:58:53+00
isFavorite       | f
duration         |
encodedVideoPath |
checksum         | \x52054531734ff6372d6656682275a052ee2f6d54
livePhotoVideoId |
updatedAt        | 2025-12-22 14:31:25.5096+00
createdAt        | 2025-12-22 14:31:14.794458+00
originalFileName | IMG_1805.CR3
thumbhash        | \x51180e15844377887f7777b28968787a726720c506
isOffline        | f
libraryId        |
isExternal       | f
deletedAt        |
localDateTime    | 2025-12-17 17:31:34.89+00
stackId          |
duplicateId      | 8367438e-b43a-4214-ac4e-7e30267bbfb1
status           | active
updateId         | 019b4678-e045-7898-8669-0c0eff842b7b
visibility       | timeline

immich=# SELECT * FROM asset WHERE "id"='6691b7aa-40bc-410b-a882-bc50bc4d1f32';
-[ RECORD 1 ]----+-----------------------------------------------------------------
id               | 6691b7aa-40bc-410b-a882-bc50bc4d1f32
deviceAssetId    | 853C1324-50DD-4B0C-8D68-331F15AE59ED/L0/001
ownerId          | 5c1b77b0-a767-4904-a751-16e61db224b6
deviceId         | e1936978a68e6fef639a4c5d189319ad892aa917fe6971dbedd6fe546fdcaa38
type             | IMAGE
originalPath     | /usr/src/app/upload/library/admin/2025/2025-12-17/IMG_1805.jpg
fileCreatedAt    | 2025-12-17 09:31:34.89+00
fileModifiedAt   | 2025-12-17 10:58:53+00
isFavorite       | f
duration         |
encodedVideoPath |
checksum         | \x4db9e68449e664b4e86536bad85680c7b017b1d6
livePhotoVideoId |
updatedAt        | 2025-12-22 14:31:25.508399+00
createdAt        | 2025-12-22 14:31:13.605596+00
originalFileName | IMG_1805.JPG
thumbhash        | \x51180e15844377887f7777b28968787a726720c506
isOffline        | f
libraryId        |
isExternal       | f
deletedAt        |
localDateTime    | 2025-12-17 17:31:34.89+00
stackId          |
duplicateId      | 8367438e-b43a-4214-ac4e-7e30267bbfb1
status           | active
updateId         | 019b4678-e044-75dc-a285-810f56735669
visibility       | timeline
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

All these code changes in this PR were generated by Claude 4.5 Opus.

However, I have manually verified the logic and tested the implementation on a physical iOS device to ensure it correctly identifies and uploads both JPEG and RAW assets. Please let me know If any part of the implementation does not align with the project's coding standards or architectural preferences.
