### PR TITLE
feat: Hide/show controls when zoom state changes

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -92,6 +92,8 @@ class AssetViewer extends ConsumerStatefulWidget {
     if (asset.isVideo || asset.isMotionPhoto) {
       ref.read(videoPlaybackValueProvider.notifier).reset();
       ref.read(videoPlayerControlsProvider.notifier).pause();
+      // Hide controls by default for videos and motion photos
+      ref.read(assetViewerProvider.notifier).setControls(false);
     }
   }
 }
@@ -525,7 +527,13 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
   void _onScaleStateChanged(PhotoViewScaleState scaleState) {
     if (scaleState != PhotoViewScaleState.initial) {
+      ref.read(assetViewerProvider.notifier).setControls(false);
       ref.read(videoPlayerControlsProvider.notifier).pause();
+      return;
+    }
+
+    if (!showingBottomSheet) {
+      ref.read(assetViewerProvider.notifier).setControls(true);
     }
   }
 


### PR DESCRIPTION
## Description

1. When the zoom state changes (zooming out or zooming in), the control bars are hidden.
2. When a motion photo or video is opened, the controls are hidden by default.

## How Has This Been Tested?

- [x] Manual testing on a real device

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

no LLM
