### PR TITLE
fix(web): stale album info

### DIFF
--- a/web/src/lib/components/album-page/album-card-group.svelte
+++ b/web/src/lib/components/album-page/album-card-group.svelte
@@ -65,7 +65,6 @@
     <div class="grid grid-auto-fill-56 gap-y-4" transition:slide={{ duration: 300 }}>
       {#each albums as album, index (album.id)}
         <a
-          data-sveltekit-preload-data="hover"
           href={resolve(`${AppRoute.ALBUMS}/${album.id}`)}
           animate:flip={{ duration: 400 }}
           oncontextmenu={(event) => oncontextmenu(event, album)}


### PR DESCRIPTION
Fix stale album info

There is a bug going from the card view to the album detail page. Svelte will preload the load function and use it on hover, making it possible for the data to become outdated in the meantime. This is true when you use the card menu button to change the album name or description.