### PR TITLE
feat(mobile): use tabular figures in backup info card

### DIFF
--- a/mobile/lib/widgets/backup/backup_info_card.dart
+++ b/mobile/lib/widgets/backup/backup_info_card.dart
@@ -53,6 +53,7 @@ class BackupInfoCard extends StatelessWidget {
                       info,
                       style: context.textTheme.titleLarge?.copyWith(
                         color: context.colorScheme.onSurface.withAlpha(isLoading ? 50 : 255),
+                        fontFeatures: [FontFeature.tabularFigures()],
                       ),
                     ),
                     if (isLoading)

--- a/mobile/lib/widgets/backup/backup_info_card.dart
+++ b/mobile/lib/widgets/backup/backup_info_card.dart
@@ -53,7 +53,7 @@ class BackupInfoCard extends StatelessWidget {
                       info,
                       style: context.textTheme.titleLarge?.copyWith(
                         color: context.colorScheme.onSurface.withAlpha(isLoading ? 50 : 255),
-                        fontFeatures: [FontFeature.tabularFigures()],
+                        fontFeatures: const [FontFeature.tabularFigures()],
                       ),
                     ),
                     if (isLoading)


### PR DESCRIPTION
## Description

during large (initial) backups current non-tabular figures are jumping around the UI, making the UI hard to follow. this change makes sure there’s no jump in text width between e.g. 7888 to 7111

## How Has This Been Tested?

1. Prepared a big set of images and videos to upload
2. Visited the backup page
3. Took note of the “assets” counter shifts during upload process

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
![image](https://github.com/user-attachments/assets/af77c563-0b56-4ab7-aaa4-1235b69cdd80)

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- ~~[ ] I have made corresponding changes to the documentation if applicable~~
- [x] I have no unrelated changes in the PR.
- ~~[ ] I have confirmed that any new dependencies are strictly necessary.~~
- ~~[ ] I have written tests for new code (if applicable)~~
- [x] I have followed naming conventions/patterns in the surrounding code
- ~~[ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~
- ~~[ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~

## Please describe to which degree, if any, an LLM was used in creating this pull request.

none at all
