### PR TITLE
docs: config options for hardware transcoding

### DIFF
--- a/docs/docs/features/hardware-transcoding.md
+++ b/docs/docs/features/hardware-transcoding.md
@@ -71,6 +71,22 @@ For RKMPP to work:
 
 5. (Optional) Enable hardware decoding for optimal performance.
 
+<details>
+<summary>immich.json</summary>
+
+If you use a [configuration file](/install/config-file.md), use the `accel` option to select the hardware (e.g. `qsv` for Intel or `nvenc` for Nvidia). Set `accelDecode` to `true` if you want hardware decoding.
+
+```json
+{
+  "ffmpeg": {
+    "accel": "qsv",
+    "accelDecode": true
+  }
+}
+```
+
+</details>
+
 #### Single Compose File
 
 Some platforms, including Unraid and Portainer, do not support multiple Compose files as of writing. As an alternative, you can "inline" the relevant contents of the [`hwaccel.transcoding.yml`][hw-file] file into the `immich-server` service directly.


### PR DESCRIPTION
## Description

The default configuration file values are already documented, but when setting up hardware transcoding while using a config file, it's not easy to figure out what options map to the settings, nor is it obvious what the right values would be.

I've added a block that documents the equivalent options for the config file based on what's described above. I picked `qsv` as my example and added `nvenc` as another option.


## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Deployed the config to my own installation
- [x] Ran docs server locally to check it renders correctly

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM was used at all for this
