### PR TITLE
feat: Shared Links: Slug Support, UI Refactor, and Simplified Actions

### DIFF
--- a/mobile/lib/models/shared_link/shared_link.model.dart
+++ b/mobile/lib/models/shared_link/shared_link.model.dart
@@ -14,6 +14,7 @@ class SharedLink {
   final String key;
   final bool showMetadata;
   final SharedLinkSource type;
+  final String? slug;
 
   const SharedLink({
     required this.id,
@@ -27,6 +28,7 @@ class SharedLink {
     required this.key,
     required this.showMetadata,
     required this.type,
+    required this.slug,
   });
 
   SharedLink copyWith({
@@ -41,6 +43,7 @@ class SharedLink {
     String? key,
     bool? showMetadata,
     SharedLinkSource? type,
+    String? slug,
   }) {
     return SharedLink(
       id: id ?? this.id,
@@ -54,6 +57,7 @@ class SharedLink {
       key: key ?? this.key,
       showMetadata: showMetadata ?? this.showMetadata,
       type: type ?? this.type,
+      slug: slug ?? this.slug,
     );
   }
 
@@ -66,6 +70,7 @@ class SharedLink {
       expiresAt = dto.expiresAt,
       key = dto.key,
       showMetadata = dto.showMetadata,
+      slug = dto.slug,
       type = dto.type == SharedLinkType.ALBUM ? SharedLinkSource.album : SharedLinkSource.individual,
       title = dto.type == SharedLinkType.ALBUM
           ? dto.album?.albumName.toUpperCase() ?? "UNKNOWN SHARE"
@@ -78,7 +83,7 @@ class SharedLink {
 
   @override
   String toString() =>
-      'SharedLink(id=$id, title=$title, thumbAssetId=$thumbAssetId, allowDownload=$allowDownload, allowUpload=$allowUpload, description=$description, password=$password, expiresAt=$expiresAt, key=$key, showMetadata=$showMetadata, type=$type)';
+      'SharedLink(id=$id, title=$title, thumbAssetId=$thumbAssetId, allowDownload=$allowDownload, allowUpload=$allowUpload, description=$description, password=$password, expiresAt=$expiresAt, key=$key, showMetadata=$showMetadata, type=$type, slug=$slug)';
 
   @override
   bool operator ==(Object other) =>
@@ -94,7 +99,8 @@ class SharedLink {
           other.expiresAt == expiresAt &&
           other.key == key &&
           other.showMetadata == showMetadata &&
-          other.type == type;
+          other.type == type &&
+          other.slug == slug;
 
   @override
   int get hashCode =>
@@ -108,5 +114,6 @@ class SharedLink {
       expiresAt.hashCode ^
       key.hashCode ^
       showMetadata.hashCode ^
-      type.hashCode;
+      type.hashCode ^
+      slug.hashCode;
 }

--- a/mobile/lib/pages/library/shared_link/shared_link.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link.page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
-import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/models/shared_link/shared_link.model.dart';
 import 'package:immich_mobile/providers/shared_link.provider.dart';
 import 'package:immich_mobile/widgets/shared_link/shared_link_item.dart';
@@ -26,71 +25,41 @@ class SharedLinkPage extends HookConsumerWidget {
     }, []);
 
     Widget buildNoShares() {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(left: 16.0, top: 16.0),
-            child: const Text(
-              "shared_link_manage_links",
-              style: TextStyle(fontSize: 14, color: Colors.grey, fontWeight: FontWeight.bold),
-            ).tr(),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 10),
-              child: const Text("you_dont_have_any_shared_links", style: TextStyle(fontSize: 14)).tr(),
-            ),
-          ),
-          Expanded(
-            child: Center(
-              child: Icon(Icons.link_off, size: 100, color: context.themeData.iconTheme.color?.withValues(alpha: 0.5)),
-            ),
-          ),
-        ],
+      return Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.link_off, size: 100, color: Theme.of(context).colorScheme.onSurface.withAlpha(128)),
+            const SizedBox(height: 20),
+            const Text("you_dont_have_any_shared_links", style: TextStyle(fontSize: 14)).tr(),
+          ],
+        ),
       );
     }
 
     Widget buildSharesList(List<SharedLink> links) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.only(left: 16.0, top: 16.0, bottom: 30.0),
-            child: Text(
-              "shared_link_manage_links",
-              style: context.textTheme.labelLarge?.copyWith(color: context.textTheme.labelLarge?.color?.withAlpha(200)),
-            ).tr(),
-          ),
-          Expanded(
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                if (constraints.maxWidth > 600) {
-                  // Two column
-                  return GridView.builder(
-                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      mainAxisExtent: 180,
-                    ),
-                    itemCount: links.length,
-                    itemBuilder: (context, index) {
-                      return SharedLinkItem(links.elementAt(index));
-                    },
-                  );
-                }
-
-                // Single column
-                return ListView.builder(
-                  itemCount: links.length,
-                  itemBuilder: (context, index) {
-                    return SharedLinkItem(links.elementAt(index));
-                  },
-                );
-              },
-            ),
-          ),
-        ],
+      return LayoutBuilder(
+        builder: (context, constraints) => constraints.maxWidth > 600
+            ? GridView.builder(
+                key: const PageStorageKey('shared-links-grid'),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  mainAxisExtent: 180,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                ),
+                padding: const EdgeInsets.all(12),
+                itemCount: links.length,
+                itemBuilder: (context, index) => SharedLinkItem(links[index]),
+              )
+            : ListView.separated(
+                key: const PageStorageKey('shared-links-list'),
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: links.length,
+                itemBuilder: (context, index) => SharedLinkItem(links[index]),
+                separatorBuilder: (context, index) => const Divider(height: 1),
+              ),
       );
     }
 

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -125,7 +125,9 @@ class SharedLinkEditPage extends HookConsumerWidget {
         autofocus: false,
         style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
         decoration: InputDecoration(
-          labelText: 'custom_url'.tr(),
+          hintText: 'custom_url'.tr(),
+          labelText: slugController.text.isNotEmpty ? 'custom_url'.tr() : null,
+          labelStyle: const TextStyle(fontWeight: FontWeight.bold),
           border: const OutlineInputBorder(),
           prefixText: slugController.text.isNotEmpty ? '/s/' : null,
           prefixStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
@@ -216,9 +218,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
     Widget buildExpiryAfterButton() {
       return ExpansionTile(
         title: Text("expire_after", style: themeData.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.bold)).tr(),
-        subtitle: expiryAfter.value == null
-            ? const Text("shared_link_expires_never").tr()
-            : Text(formatDateTime(expiryAfter.value!), style: TextStyle(color: themeData.colorScheme.primary)),
+        subtitle: Text(
+          expiryAfter.value == null ? "shared_link_expires_never".tr() : formatDateTime(expiryAfter.value!),
+          style: TextStyle(color: themeData.colorScheme.primary),
+        ),
         children: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -421,9 +424,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
       body: SafeArea(
         child: newShareLink.value.isEmpty
             ? Padding(
-                padding: const EdgeInsets.all(20),
+                padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: ListView(
                   children: [
+                    const SizedBox(height: 20),
                     buildLinkTitle(),
                     if (existingLink != null)
                       Column(
@@ -479,6 +483,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
                         ],
                       ),
                     ),
+                    const SizedBox(height: 40),
                   ],
                 ),
               )

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -55,10 +55,12 @@ class SharedLinkEditPage extends HookConsumerWidget {
       return Row(
         children: [
           Expanded(
-            child: Text(
-              content,
-              style: TextStyle(color: colorScheme.primary, fontWeight: FontWeight.bold),
-              overflow: TextOverflow.ellipsis,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Text(
+                content,
+                style: TextStyle(color: colorScheme.primary, fontWeight: FontWeight.bold),
+              ),
             ),
           ),
           const SizedBox(width: 8),

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -45,7 +45,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          const Spacer(),
+          const SizedBox(width: 8),
           Text(leading, style: const TextStyle(fontWeight: FontWeight.bold)).tr(),
         ],
       );

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/services/shared_link.service.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
 import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:share_plus/share_plus.dart';
 
 @RoutePage()
 class SharedLinkEditPage extends HookConsumerWidget {
@@ -290,11 +291,12 @@ class SharedLinkEditPage extends HookConsumerWidget {
     Widget buildLinkCopyField(String link) {
       return TextFormField(
         readOnly: true,
+        onTap: () => copyToClipboard(link),
         initialValue: link,
         decoration: InputDecoration(
           border: const OutlineInputBorder(),
           enabledBorder: themeData.inputDecorationTheme.focusedBorder,
-          suffixIcon: IconButton(onPressed: () => copyToClipboard(link), icon: const Icon(Icons.copy)),
+          suffixIcon: IconButton(onPressed: () => Share.share(link), icon: const Icon(Icons.share)),
         ),
       );
     }

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -126,7 +126,6 @@ class SharedLinkEditPage extends HookConsumerWidget {
         focusNode: slugFocusNode,
         textInputAction: TextInputAction.done,
         autofocus: false,
-        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
         decoration: InputDecoration(
           hintText: 'custom_url'.tr(),
           labelText: slugController.text.isNotEmpty ? 'custom_url'.tr() : null,
@@ -489,9 +488,10 @@ class SharedLinkEditPage extends HookConsumerWidget {
                                 style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
                               ).tr(),
                             ),
-                          ElevatedButton(
+                          ElevatedButton.icon(
+                            icon: const Icon(Icons.check),
                             onPressed: existingLink != null ? handleEditLink : handleNewLink,
-                            child: Text(
+                            label: Text(
                               existingLink != null ? "shared_link_edit_submit_button" : "create_link",
                               style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
                             ).tr(),

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -48,7 +48,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
     final showMetadata = useState(existingLink?.showMetadata ?? true);
     final allowDownload = useState(existingLink?.allowDownload ?? true);
     final allowUpload = useState(existingLink?.allowUpload ?? false);
-    final expiryAfter = useState<DateTime?>(existingLink?.expiresAt);
+    final expiryAfter = useState<DateTime?>(existingLink?.expiresAt?.toLocal());
     final newShareLink = useState("");
 
     Widget buildSharedLinkRow({required String leading, required String content}) {
@@ -330,7 +330,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
             description: descriptionController.text.isEmpty ? null : descriptionController.text,
             password: passwordController.text.isEmpty ? null : passwordController.text,
             slug: slugController.text.isEmpty ? null : slugController.text,
-            expiresAt: calculateExpiry(),
+            expiresAt: calculateExpiry()?.toUtc(),
           );
       ref.invalidate(sharedLinksStateProvider);
 
@@ -404,7 +404,7 @@ class SharedLinkEditPage extends HookConsumerWidget {
             description: desc,
             password: password,
             slug: slug,
-            expiresAt: expiry,
+            expiresAt: expiry?.toUtc(),
             changeExpiry: changeExpiry,
           );
       ref.invalidate(sharedLinksStateProvider);

--- a/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
+++ b/mobile/lib/pages/library/shared_link/shared_link_edit.page.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/shared_link.provider.dart';
 import 'package:immich_mobile/services/shared_link.service.dart';
 import 'package:immich_mobile/utils/url_helper.dart';
+import 'package:immich_mobile/widgets/common/confirm_dialog.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 @RoutePage()
@@ -336,6 +337,21 @@ class SharedLinkEditPage extends HookConsumerWidget {
       await context.maybePop();
     }
 
+    Future<void> handleDeleteLink() async {
+      return showDialog(
+        context: context,
+        builder: (BuildContext context) => ConfirmDialog(
+          title: "delete_shared_link_dialog_title",
+          content: "confirm_delete_shared_link",
+          onOk: () async {
+            await ref.read(sharedLinkServiceProvider).deleteSharedLink(existingLink!.id);
+            ref.invalidate(sharedLinksStateProvider);
+            if (context.mounted) await context.maybePop();
+          },
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(existingLink == null ? "create_link_to_share" : "edit_link").tr(),
@@ -375,12 +391,28 @@ class SharedLinkEditPage extends HookConsumerWidget {
                 alignment: Alignment.bottomRight,
                 child: Padding(
                   padding: const EdgeInsets.only(right: padding + 10, bottom: padding),
-                  child: ElevatedButton(
-                    onPressed: existingLink != null ? handleEditLink : handleNewLink,
-                    child: Text(
-                      existingLink != null ? "shared_link_edit_submit_button" : "create_link",
-                      style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-                    ).tr(),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    spacing: 8,
+                    children: [
+                      if (existingLink != null)
+                        OutlinedButton.icon(
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: themeData.colorScheme.error,
+                            side: BorderSide(color: themeData.colorScheme.error),
+                          ),
+                          onPressed: handleDeleteLink,
+                          icon: const Icon(Icons.delete_outline),
+                          label: const Text("delete", style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold)).tr(),
+                        ),
+                      ElevatedButton(
+                        onPressed: existingLink != null ? handleEditLink : handleNewLink,
+                        child: Text(
+                          existingLink != null ? "shared_link_edit_submit_button" : "create_link",
+                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                        ).tr(),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/mobile/lib/services/shared_link.service.dart
+++ b/mobile/lib/services/shared_link.service.dart
@@ -37,6 +37,7 @@ class SharedLinkService {
     required bool allowUpload,
     String? description,
     String? password,
+    String? slug,
     String? albumId,
     List<String>? assetIds,
     DateTime? expiresAt,
@@ -54,6 +55,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
         );
       } else if (assetIds != null) {
         dto = SharedLinkCreateDto(
@@ -64,6 +66,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
           assetIds: assetIds,
         );
       }
@@ -88,6 +91,7 @@ class SharedLinkService {
     bool? changeExpiry = false,
     String? description,
     String? password,
+    String? slug,
     DateTime? expiresAt,
   }) async {
     try {
@@ -100,6 +104,7 @@ class SharedLinkService {
           expiresAt: expiresAt,
           description: description,
           password: password,
+          slug: slug,
           changeExpiryTime: changeExpiry,
         ),
       );

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -177,7 +177,7 @@ class SharedLinkItem extends ConsumerWidget {
           builder: (BuildContext context) => ConfirmDialog(
             title: "delete_shared_link_dialog_title",
             content: "confirm_delete_shared_link",
-            onOk: () => Navigator.of(context).pop(true),
+            onOk: () {},
           ),
         );
 

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -94,9 +94,9 @@ class SharedLinkItem extends ConsumerWidget {
         height: imageSize * 1.2,
         width: imageSize,
         child: thumbnailUrl == null
-            ? Card(
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                child: const Icon(Icons.image_not_supported_outlined),
+            ? const Card(
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(10))),
+                child: Icon(Icons.image_not_supported_outlined),
               )
             : ThumbnailWithInfo(
                 imageUrl: thumbnailUrl,

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -89,19 +89,6 @@ class SharedLinkItem extends ConsumerWidget {
       );
     }
 
-    Future<void> deleteShareLink() async {
-      return showDialog(
-        context: context,
-        builder: (BuildContext context) {
-          return ConfirmDialog(
-            title: "delete_shared_link_dialog_title",
-            content: "confirm_delete_shared_link",
-            onOk: () => ref.read(sharedLinksStateProvider.notifier).deleteLink(sharedLink.id),
-          );
-        },
-      );
-    }
-
     Widget buildThumbnail() {
       return SizedBox(
         height: imageSize * 1.2,

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -171,7 +171,23 @@ class SharedLinkItem extends ConsumerWidget {
         padding: const EdgeInsets.only(right: 20),
         child: Icon(Icons.delete, color: Theme.of(context).colorScheme.onError),
       ),
-      onDismissed: (_) => deleteShareLink(),
+      confirmDismiss: (_) async {
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (BuildContext context) => ConfirmDialog(
+            title: "delete_shared_link_dialog_title",
+            content: "confirm_delete_shared_link",
+            onOk: () => Navigator.of(context).pop(true),
+          ),
+        );
+
+        if (confirmed == true) {
+          await ref.read(sharedLinksStateProvider.notifier).deleteLink(sharedLink.id);
+          return true;
+        }
+
+        return false;
+      },
       child: InkWell(
         onTap: () => context.pushRoute(SharedLinkEditRoute(existingLink: sharedLink)),
         onLongPress: copyShareLinkToClipboard,

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -27,9 +27,13 @@ class SharedLinkItem extends ConsumerWidget {
 
   Widget buildExpiryDuration() {
     var expiresText = "shared_link_expires_never".tr();
+    IconData expiryIcon = Icons.schedule;
 
     if (sharedLink.expiresAt != null) {
-      if (isExpired()) return const Text("expired").tr();
+      if (isExpired()) {
+        expiresText = "expired".tr();
+        expiryIcon = Icons.timer_off_outlined;
+      }
 
       final difference = sharedLink.expiresAt!.difference(DateTime.now());
       dPrint(() => "Difference: $difference");
@@ -47,7 +51,7 @@ class SharedLinkItem extends ConsumerWidget {
       }
     }
 
-    return Row(children: [const Icon(Icons.schedule, size: 12), const SizedBox(width: 4), Text(expiresText)]);
+    return Row(children: [Icon(expiryIcon, size: 12), const SizedBox(width: 4), Text(expiresText)]);
   }
 
   @override

--- a/mobile/lib/widgets/shared_link/shared_link_item.dart
+++ b/mobile/lib/widgets/shared_link/shared_link_item.dart
@@ -74,8 +74,10 @@ class SharedLinkItem extends ConsumerWidget {
         return;
       }
 
-      Clipboard.setData(ClipboardData(text: "${serverUrl}share/${sharedLink.key}")).then((_) {
-        context.scaffoldMessenger.showSnackBar(
+      final urlPath = sharedLink.slug?.isNotEmpty == true ? sharedLink.slug : sharedLink.key;
+
+      Clipboard.setData(ClipboardData(text: "${serverUrl}s/$urlPath")).then(
+        (_) => context.scaffoldMessenger.showSnackBar(
           SnackBar(
             content: Text(
               "shared_link_clipboard_copied_massage",
@@ -83,8 +85,8 @@ class SharedLinkItem extends ConsumerWidget {
             ).tr(),
             duration: const Duration(seconds: 2),
           ),
-        );
-      });
+        ),
+      );
     }
 
     Future<void> deleteShareLink() async {


### PR DESCRIPTION
## Description
This pull request introduces support for a new `slug` field in the `SharedLink` model and refactors the shared link UI for improved usability and maintainability. The changes ensure that slugs are handled throughout the model, service, and UI layers, and update the shared link list and item presentation for a more modern and user-friendly experience.

**Model and Service Enhancements:**

* Added a nullable `slug` field to the `SharedLink` model, updated constructors, `copyWith`, equality, and hashcode methods to include `slug`.

**UI/UX Improvements:**

* Refactored the shared link list page to use a centered empty state and a responsive layout: grid for wide screens and a separated list for narrow screens, removing unnecessary headers and padding.
* Improved the `SharedLinkItem` widget:
  - Simplified expiry calculation and display, added icons for expiry status, and replaced chips with outlined cards for share parameter info.
  - Updated the share link copy logic to use the `slug` if available and changed the URL path from `/share/{key}` to `/s/{slug or key}`.
  - Changed the item layout to use `Dismissible` for swipe-to-delete with confirmation, made the whole item tappable for editing, and enabled long-press to copy the link.

## How Has This Been Tested?

- [x] Manual testing on physical device

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

https://github.com/user-attachments/assets/876b36ca-3e55-49df-95b7-c9ceecf9705b

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
GPT-5-Codex for time selection mechanism and GitHub Copilot for PR Summary
