### PR TITLE
fix: grammar in trigger_description string

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2153,7 +2153,7 @@
   "trigger": "Trigger",
   "trigger_asset_uploaded": "Asset Uploaded",
   "trigger_asset_uploaded_description": "Triggered when a new asset is uploaded",
-  "trigger_description": "An event that kick off the workflow",
+  "trigger_description": "An event that kicks off the workflow",
   "trigger_person_recognized": "Person Recognized",
   "trigger_person_recognized_description": "Triggered when a person is detected",
   "trigger_type": "Trigger type",


### PR DESCRIPTION
## Description

Fixes the grammar in the `trigger_description` string by updating the verb to agree with the singular subject: "An event that kick**s** off the workflow"

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No use