### PR TITLE
feat: cli album management

### DIFF
--- a/cli/src/commands/album.spec.ts
+++ b/cli/src/commands/album.spec.ts
@@ -1,0 +1,159 @@
+import { addAssetsToAlbum, getAlbumInfo, getAllAlbums } from '@immich/sdk';
+import { addAssets, albumInfo, listAlbums } from 'src/commands/album';
+import { BaseOptions } from 'src/utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@immich/sdk');
+vi.mock('src/utils', async () => {
+  const actual = await vi.importActual('src/utils');
+  return {
+    ...actual,
+    authenticate: vi.fn(),
+    logError: vi.fn(),
+    withError: (promise: Promise<any>) => promise.then((data) => [null, data]).catch((err) => [err, null]),
+  };
+});
+
+describe('album commands', () => {
+  const options = {} as BaseOptions;
+  const jsonOptions = { jsonOutput: true } as any;
+
+  describe('listAlbums', () => {
+    it('should list albums', async () => {
+      const albums = [
+        { id: '1', albumName: 'Album 1' },
+        { id: '2', albumName: 'Album 2' },
+      ];
+      vi.mocked(getAllAlbums).mockResolvedValue(albums as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await listAlbums(options);
+
+      expect(consoleSpy).toHaveBeenCalledWith('1\tAlbum 1');
+      expect(consoleSpy).toHaveBeenCalledWith('2\tAlbum 2');
+    });
+
+    it('should list albums in JSON', async () => {
+      const albums = [
+        { id: '1', albumName: 'Album 1' },
+        { id: '2', albumName: 'Album 2' },
+      ];
+      vi.mocked(getAllAlbums).mockResolvedValue(albums as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await listAlbums(jsonOptions);
+
+      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(albums, undefined, 4));
+    });
+  });
+
+  describe('albumInfo', () => {
+    it('should show album info', async () => {
+      const album = {
+        id: '1',
+        albumName: 'Album 1',
+        assetCount: 2,
+        assets: [
+          { id: 'a1', originalFileName: 'photo1.jpg' },
+          { id: 'a2', originalFileName: 'photo2.jpg' },
+        ],
+      };
+      vi.mocked(getAlbumInfo).mockResolvedValue(album as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await albumInfo('1', options);
+
+      expect(consoleSpy).toHaveBeenCalledWith('ID: 1');
+      expect(consoleSpy).toHaveBeenCalledWith('Name: Album 1');
+      expect(consoleSpy).toHaveBeenCalledWith('Assets: 2');
+      expect(consoleSpy).toHaveBeenCalledWith('a1\tphoto1.jpg');
+      expect(consoleSpy).toHaveBeenCalledWith('a2\tphoto2.jpg');
+    });
+
+    it('should show album info in JSON', async () => {
+      const album = {
+        id: '1',
+        albumName: 'Album 1',
+        assetCount: 2,
+        assets: [
+          { id: 'a1', originalFileName: 'photo1.jpg' },
+          { id: 'a2', originalFileName: 'photo2.jpg' },
+        ],
+      };
+      vi.mocked(getAlbumInfo).mockResolvedValue(album as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await albumInfo('1', jsonOptions);
+
+      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(album, undefined, 4));
+    });
+  });
+
+  describe('addAssets', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should add assets to album', async () => {
+      vi.mocked(addAssetsToAlbum).mockResolvedValue([
+        { id: 'a1', success: true },
+        { id: 'a2', success: true },
+      ] as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await addAssets('1', ['a1', 'a2'], options);
+
+      expect(addAssetsToAlbum).toHaveBeenCalledWith({ id: '1', bulkIdsDto: { ids: ['a1', 'a2'] } });
+      expect(consoleSpy).toHaveBeenCalledWith('Added 2 assets to album 1');
+    });
+
+    it('should add assets to album and output JSON', async () => {
+      const result = [{ id: 'a1', success: true }];
+      vi.mocked(addAssetsToAlbum).mockResolvedValue(result as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await addAssets('1', ['a1'], jsonOptions);
+
+      expect(addAssetsToAlbum).toHaveBeenCalledWith({ id: '1', bulkIdsDto: { ids: ['a1'] } });
+      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(result, undefined, 4));
+    });
+
+    it('should report failed additions', async () => {
+      vi.mocked(addAssetsToAlbum).mockResolvedValue([
+        { id: 'a1', success: true },
+        { id: 'a2', success: false, error: 'not_found' },
+      ] as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await addAssets('1', ['a1', 'a2'], options);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Added 1 asset to album 1 (1 asset failed)');
+    });
+
+    it('should report duplicates separately', async () => {
+      vi.mocked(addAssetsToAlbum).mockResolvedValue([
+        { id: 'a1', success: true },
+        { id: 'a2', success: false, error: 'duplicate' },
+      ] as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await addAssets('1', ['a1', 'a2'], options);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Added 1 asset to album 1 (1 asset already in album)');
+    });
+
+    it('should batch asset additions', async () => {
+      vi.mocked(addAssetsToAlbum).mockResolvedValue([{ id: 'a1', success: true }] as any);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await addAssets(
+        '1',
+        ['a1', 'a2'],
+        { ...options, batchSize: 1 },
+      );
+
+      expect(addAssetsToAlbum).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenCalledWith('Added 2 assets to album 1');
+    });
+  });
+});

--- a/cli/src/commands/album.ts
+++ b/cli/src/commands/album.ts
@@ -1,0 +1,86 @@
+import { AlbumResponseDto, BulkIdResponseDto, addAssetsToAlbum, getAlbumInfo, getAllAlbums } from '@immich/sdk';
+import { chunk } from 'lodash-es';
+import { BaseOptions, authenticate, logError, withError } from 'src/utils';
+import { s } from './asset';
+
+export interface AlbumOptions extends BaseOptions {
+  batchSize?: number;
+  jsonOutput?: boolean;
+}
+
+export const listAlbums = async (options: AlbumOptions) => {
+  await authenticate(options);
+  const [error, albums] = await withError<AlbumResponseDto[]>(getAllAlbums({}));
+  if (error) {
+    logError(error, 'Failed to list albums');
+    process.exit(1);
+  }
+
+  if (options.jsonOutput) {
+    console.log(JSON.stringify(albums, undefined, 4));
+    return;
+  }
+
+  for (const album of albums) {
+    console.log(`${album.id}\t${album.albumName}`);
+  }
+};
+
+export const albumInfo = async (albumId: string, options: AlbumOptions) => {
+  await authenticate(options);
+  const [error, album] = await withError<AlbumResponseDto>(getAlbumInfo({ id: albumId }));
+  if (error) {
+    logError(error, `Failed to get album info for ${albumId}`);
+    process.exit(1);
+  }
+
+  if (options.jsonOutput) {
+    console.log(JSON.stringify(album, undefined, 4));
+    return;
+  }
+
+  console.log(`ID: ${album.id}`);
+  console.log(`Name: ${album.albumName}`);
+  console.log(`Assets: ${album.assetCount}`);
+  if (album.assets) {
+    for (const asset of album.assets) {
+      console.log(`${asset.id}\t${asset.originalFileName}`);
+    }
+  }
+};
+
+export const addAssets = async (albumId: string, assetIds: string[], options: AlbumOptions) => {
+  await authenticate(options);
+  const results: BulkIdResponseDto[] = [];
+  const batchSize = Math.max(1, Number(options.batchSize ?? 1000));
+
+  for (const assetBatch of chunk(assetIds, batchSize)) {
+    const [error, result] = await withError(addAssetsToAlbum({ id: albumId, bulkIdsDto: { ids: assetBatch } }));
+    if (error) {
+      logError(error, `Failed to add assets to album ${albumId}`);
+      process.exit(1);
+    }
+
+    results.push(...result);
+  }
+
+  if (options.jsonOutput) {
+    console.log(JSON.stringify(results, undefined, 4));
+    return;
+  }
+
+  const successCount = results.filter(({ success }) => success).length;
+  const duplicateCount = results.filter(({ success, error }) => !success && error === 'duplicate').length;
+  const failureCount = results.length - successCount - duplicateCount;
+
+  const suffixParts: string[] = [];
+  if (duplicateCount > 0) {
+    suffixParts.push(`${duplicateCount} asset${s(duplicateCount)} already in album`);
+  }
+  if (failureCount > 0) {
+    suffixParts.push(`${failureCount} asset${s(failureCount)} failed`);
+  }
+  const suffix = suffixParts.length > 0 ? ` (${suffixParts.join(', ')})` : '';
+
+  console.log(`Added ${successCount} asset${s(successCount)} to album ${albumId}${suffix}`);
+};

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,8 @@
 import { Command, Option } from 'commander';
 import os from 'node:os';
 import path from 'node:path';
-import { upload } from 'src/commands/asset';
+import { addAssets, albumInfo, listAlbums } from 'src/commands/album';
+import { listAssets, upload } from 'src/commands/asset';
 import { login, logout } from 'src/commands/auth';
 import { serverInfo } from 'src/commands/server-info';
 import { version } from '../package.json';
@@ -39,6 +40,58 @@ program
   .command('server-info')
   .description('Display server information')
   .action(() => serverInfo(program.opts()));
+
+const album = program.command('album').description('Manage albums');
+
+album
+  .command('list')
+  .description('List all albums')
+  .addOption(
+    new Option('-j, --json-output', 'Output detailed information in json format')
+      .env('IMMICH_JSON_OUTPUT')
+      .default(false),
+  )
+  .action((options) => listAlbums({ ...program.opts(), ...options }));
+
+album
+  .command('info')
+  .description('Show album information')
+  .argument('<id>', 'Album ID')
+  .addOption(
+    new Option('-j, --json-output', 'Output detailed information in json format')
+      .env('IMMICH_JSON_OUTPUT')
+      .default(false),
+  )
+  .action((id, options) => albumInfo(id, { ...program.opts(), ...options }));
+
+album
+  .command('add')
+  .description('Add assets to an album')
+  .argument('<albumId>', 'Album ID')
+  .argument('<assetIds...>', 'Asset IDs')
+  .addOption(
+    new Option('-b, --batch-size <number>', 'Number of assets to add per request')
+      .env('IMMICH_ALBUM_BATCH_SIZE')
+      .default(1000),
+  )
+  .addOption(
+    new Option('-j, --json-output', 'Output detailed information in json format')
+      .env('IMMICH_JSON_OUTPUT')
+      .default(false),
+  )
+  .action((albumId, assetIds, options) => addAssets(albumId, assetIds, { ...program.opts(), ...options }));
+
+const asset = program.command('asset').description('Manage assets');
+
+asset
+  .command('list')
+  .description('List all assets')
+  .addOption(
+    new Option('-j, --json-output', 'Output detailed information in json format')
+      .env('IMMICH_JSON_OUTPUT')
+      .default(false),
+  )
+  .action((options) => listAssets({ ...program.opts(), ...options }));
 
 program
   .command('upload')

--- a/docs/docs/features/command-line-interface.md
+++ b/docs/docs/features/command-line-interface.md
@@ -5,6 +5,8 @@ Immich has a command line interface (CLI) that allows you to perform certain act
 ## Features
 
 - Upload photos and videos to Immich
+- List assets and albums
+- Add assets to albums
 - Check server version
 
 More features are planned for the future.
@@ -71,6 +73,8 @@ Commands:
   login|login-key <url> <key>         Login using an API key
   logout                              Remove stored credentials
   server-info                         Display server information
+  album                               Manage albums
+  asset                               Manage assets
   upload [options] [paths...]         Upload assets
   help [command]                      display help for command
 ```
@@ -112,6 +116,59 @@ Options:
 </details>
 
 Note that the above options can read from environment variables as well.
+
+The album command supports the following subcommands:
+
+<details>
+<summary>Album Commands</summary>
+
+```
+Usage: immich album [options] [command]
+
+Manage albums
+
+Options:
+  -h, --help                        display help for command
+
+Commands:
+  list [options]                    List all albums
+  info [options] <id>               Show album information
+  add [options] <albumId> <assetIds...>  Add assets to an album
+  help [command]                    display help for command
+```
+
+```
+Options:
+  -b, --batch-size <number>         Number of assets to add per request (default: 1000, env: IMMICH_ALBUM_BATCH_SIZE)
+  -j, --json-output                 Output detailed information in json format (default: false, env: IMMICH_JSON_OUTPUT)
+```
+
+</details>
+
+The asset command supports the following subcommands:
+
+<details>
+<summary>Asset Commands</summary>
+
+```
+Usage: immich asset [options] [command]
+
+Manage assets
+
+Options:
+  -h, --help                        display help for command
+
+Commands:
+  list [options]                    List all assets
+  help [command]                    display help for command
+```
+
+```
+Options:
+  -j, --json-output                 Output detailed information in json format (default: false, env: IMMICH_JSON_OUTPUT)
+```
+
+</details>
 
 ## Quick Start
 


### PR DESCRIPTION
## Description

I wanted to do some scripting (eg automatically adding new assets to a particular album) and so this PR extends the CLI functionality to enable that. Specifically, it adds the `album` and `asset` commands to the cli to facilitate programmatic album management.
- `album`: 
  - `list`: list all assets in album
  - `info [ID]`: print album info 
  - `add [album ID] [asset IDs...]`: add asset IDs to album
- `asset`
  - `list`: list all assets

Full documentation is added to `docs/docs/features/command-line-interface.md`. All new commands have the `-j`/`--json-output` option.

Will be happy to continue adding to the CLI as I find needs from my scripting.

Eg:
```
node@immich-dev:/workspaces/immich$ node cli/bin/immich album list
e92645b2-c28e-419f-98ba-c9cae6b5598d    hello
node@immich-dev:/workspaces/immich$ node cli/bin/immich album info
error: missing required argument 'id'
node@immich-dev:/workspaces/immich$ node cli/bin/immich album info e92645b2-c28e-419f-98ba-c9cae6b5598d
ID: e92645b2-c28e-419f-98ba-c9cae6b5598d
Name: hello
Assets: 7
bf31012a-ea35-409e-b07b-1b1e850fbec4    Screenshot 2025-12-07 at 1.21.18 PM.png
5712237a-51da-40fe-9d8a-7fd03f56d712    Screenshot 2025-12-07 at 1.21.11 PM.png
afb37d15-3031-43cc-95be-f619c590f490    Screenshot 2025-12-07 at 1.21.04 PM.png
6d164375-694f-4183-8bd7-a1f08775d782    IMG_4055.JPG
80679693-c9f7-408c-8e35-9dc3232f85c1    IMG_4846.jpg
f161a85a-c737-4077-8024-99c3bfb7b0a5    IMG_0576.jpg
2c31317b-f110-47ba-aff8-11ba59834f62    IMG_3971.jpg
node@immich-dev:/workspaces/immich$ node cli/bin/immich album add e92645b2-c28e-419f-98ba-c9cae6b5598d 6d164375-694f-4183-8bd7-a1f08775d782
Added 0 assets to album e92645b2-c28e-419f-98ba-c9cae6b5598d (1 asset already in album)
```

Or, a script like so:
```
#!/usr/bin/env bash
set -euo pipefail

ALBUM_ID="e92645b2-c28e-419f-98ba-c9cae6b5598d"

node cli/bin/immich asset list \
| awk -F'\t' '{print $1}' \
| xargs -n 1000 node cli/bin/immich album add "$ALBUM_ID"
```

## How Has This Been Tested?

Added unit tests, run with `pnpm --filter @immich/cli run test`.

Manually tested in devcontainer (saving above script to `script.sh` in project root):
```
node@immich-dev:/workspaces/immich$ sudo chmod +x script.sh 
node@immich-dev:/workspaces/immich$ ./script.sh
Added 3 assets to album e92645b2-c28e-419f-98ba-c9cae6b5598d (4 assets already in album)
```

<!-- API endpoint changes (if relevant)
## API Changes
NONE
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [NA] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [NA] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [NA] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
- Initial changes generated with Gemini 3 Pro (high) in antigravity. 
- Batching behavior added to `album add` command with Codex + `gpt-5.2-codex medium`
- I am a professional software engineer and personally reviewed all code in this PR