### PR TITLE
fix: canceling a bucket while findMonthGroupForAsset is waiting fails

### DIFF
--- a/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts
@@ -346,7 +346,7 @@ export class TimelineManager extends VirtualScrollManager {
 
   async findMonthGroupForAsset(asset: AssetDescriptor | AssetResponseDto) {
     if (!this.isInitialized) {
-      await this.initTask.waitUntilCompletion();
+      await this.initTask.waitUntilExecution();
     }
 
     const { id } = asset;


### PR DESCRIPTION
1 line bug fix. 

`waitUntilCompletion` will be canceled if the initialization task of timeline-manager will be reset (can happen multiple times during component construction) -- completion is triggered when task is canceled

`waitUntilExecution` will wait until the task is executed - if it happens to be canceled before execution it will continue to wait until execution succeeds (or fails) -- but not for cancelation. 