### PR TITLE
fix(docker): add SELinux :z labels to bind mount volumes

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -27,8 +27,8 @@ services:
       target: dev
     restart: unless-stopped
     volumes:
-      - ..:/usr/src/app
-      - ${UPLOAD_LOCATION}/photos:/data
+      - ..:/usr/src/app:z
+      - ${UPLOAD_LOCATION}/photos:/data:z
       - /etc/localtime:/etc/localtime:ro
       - pnpm-store:/usr/src/app/.pnpm-store
       - server-node_modules:/usr/src/app/server/node_modules
@@ -41,7 +41,7 @@ services:
       - app-node_modules:/usr/src/app/node_modules
       - sveltekit:/usr/src/app/web/.svelte-kit
       - coverage:/usr/src/app/web/coverage
-      - ../plugins:/build/corePlugin
+      - ../plugins:/build/corePlugin:z
     env_file:
       - .env
     environment:
@@ -84,7 +84,7 @@ services:
       - 3000:3000
       - 24678:24678
     volumes:
-      - ..:/usr/src/app
+      - ..:/usr/src/app:z
       - pnpm-store:/usr/src/app/.pnpm-store
       - server-node_modules:/usr/src/app/server/node_modules
       - web-node_modules:/usr/src/app/web/node_modules
@@ -115,7 +115,7 @@ services:
     ports:
       - 3003:3003
     volumes:
-      - ../machine-learning/immich_ml:/usr/src/immich_ml
+      - ../machine-learning/immich_ml:/usr/src/immich_ml:z
       - model-cache:/cache
     env_file:
       - .env
@@ -142,7 +142,7 @@ services:
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
-      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data
+      - ${UPLOAD_LOCATION}/postgres:/var/lib/postgresql/data:z
     ports:
       - 5432:5432
     shm_size: 128mb

--- a/e2e/docker-compose.dev.yml
+++ b/e2e/docker-compose.dev.yml
@@ -20,9 +20,9 @@ services:
       - IMMICH_PORT=2285
       - IMMICH_IGNORE_MOUNT_CHECK_ERRORS=true
     volumes:
-      - ./test-assets:/test-assets
-      - ..:/usr/src/app
-      - ${UPLOAD_LOCATION}/photos:/data
+      - ./test-assets:/test-assets:z
+      - ..:/usr/src/app:z
+      - ${UPLOAD_LOCATION}/photos:/data:z
       - /etc/localtime:/etc/localtime:ro
       - pnpm-store:/usr/src/app/.pnpm-store
       - server-node_modules:/usr/src/app/server/node_modules
@@ -35,7 +35,7 @@ services:
       - app-node_modules:/usr/src/app/node_modules
       - sveltekit:/usr/src/app/web/.svelte-kit
       - coverage:/usr/src/app/web/coverage
-      - ../plugins:/build/corePlugin
+      - ../plugins:/build/corePlugin:z
     depends_on:
       redis:
         condition: service_started
@@ -55,7 +55,7 @@ services:
     environment:
       - IMMICH_SERVER_URL=http://immich-server:2285/
     volumes:
-      - ..:/usr/src/app
+      - ..:/usr/src/app:z
       - pnpm-store:/usr/src/app/.pnpm-store
       - server-node_modules:/usr/src/app/server/node_modules
       - web-node_modules:/usr/src/app/web/node_modules

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - IMMICH_PORT=2285
       - IMMICH_IGNORE_MOUNT_CHECK_ERRORS=true
     volumes:
-      - ./test-assets:/test-assets
+      - ./test-assets:/test-assets:z
     extra_hosts:
       - 'auth-server:host-gateway'
     depends_on:


### PR DESCRIPTION
## Description
On systems with SELinux enabled (Fedora, RHEL, CentOS), Docker containers cannot access bind-mounted host directories without proper SELinux labels.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add the :z suffix to all bind mount volumes to enable shared access with proper SELinux context relabeling. This allows containers to read and write to mounted host directories when SELinux is in enforcing mode.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] make dev

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
I used an LLM to debug the log messages during startup and let it apply the docker volume configurations. I manually  tested and verified the fix.
...
