### PR TITLE
fix(web): let slideshow videos play (#19601)

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -451,6 +451,7 @@
     <div class="absolute w-full flex">
       <SlideshowBar
         {isFullScreen}
+        assetType={previewStackedAsset?.type ?? asset.type}
         onSetToFullScreen={() => assetViewerHtmlElement?.requestFullscreen?.()}
         onPrevious={() => navigateAsset('previous')}
         onNext={() => navigateAsset('next')}

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { shortcuts } from '$lib/actions/shortcut';
+  import { shortcuts, type ShortcutOptions } from '$lib/actions/shortcut';
   import ProgressBar from '$lib/components/shared-components/progress-bar/progress-bar.svelte';
   import { ProgressBarStatus } from '$lib/constants';
   import SlideshowSettingsModal from '$lib/modals/SlideshowSettingsModal.svelte';
   import { SlideshowNavigation, slideshowStore } from '$lib/stores/slideshow.store';
+  import { AssetTypeEnum } from '@immich/sdk';
   import { IconButton, modalManager } from '@immich/ui';
   import { mdiChevronLeft, mdiChevronRight, mdiClose, mdiCog, mdiFullscreen, mdiPause, mdiPlay } from '@mdi/js';
   import { onDestroy, onMount } from 'svelte';
@@ -13,6 +14,7 @@
 
   interface Props {
     isFullScreen: boolean;
+    assetType: AssetTypeEnum;
     onNext?: () => void;
     onPrevious?: () => void;
     onClose?: () => void;
@@ -21,6 +23,7 @@
 
   let {
     isFullScreen,
+    assetType,
     onNext = () => {},
     onPrevious = () => {},
     onClose = () => {},
@@ -35,6 +38,7 @@
   let showControls = $state(true);
   let timer: NodeJS.Timeout;
   let isOverControls = $state(false);
+  let isVideoSlide = $derived(assetType === AssetTypeEnum.Video);
 
   let unsubscribeRestart: () => void;
   let unsubscribeStop: () => void;
@@ -132,26 +136,36 @@
     { onswipedown: showControlBar },
     true,
   );
+
+  const shortcutBindings = $derived.by((): ShortcutOptions[] => {
+    const bindings: ShortcutOptions[] = [
+      { shortcut: { key: 'Escape' }, onShortcut: onClose },
+      { shortcut: { key: 'ArrowLeft' }, onShortcut: onPrevious },
+      { shortcut: { key: 'ArrowRight' }, onShortcut: onNext },
+    ];
+
+    // For videos, allow the native HTML5 element to handle space for play/pause
+    if (!isVideoSlide) {
+      bindings.push({
+        shortcut: { key: ' ' },
+        onShortcut: () => {
+          if (progressBarStatus === ProgressBarStatus.Paused) {
+            progressBar?.play();
+          } else {
+            progressBar?.pause();
+          }
+        },
+        preventDefault: true,
+      });
+    }
+
+    return bindings;
+  });
 </script>
 
 <svelte:document
   onmousemove={showControlBar}
-  use:shortcuts={[
-    { shortcut: { key: 'Escape' }, onShortcut: onClose },
-    { shortcut: { key: 'ArrowLeft' }, onShortcut: onPrevious },
-    { shortcut: { key: 'ArrowRight' }, onShortcut: onNext },
-    {
-      shortcut: { key: ' ' },
-      onShortcut: () => {
-        if (progressBarStatus === ProgressBarStatus.Paused) {
-          progressBar?.play();
-        } else {
-          progressBar?.pause();
-        }
-      },
-      preventDefault: true,
-    },
-  ]}
+  use:shortcuts={shortcutBindings}
 />
 
 {/* @ts-expect-error https://github.com/Rezi/svelte-gestures/issues/38#issuecomment-3315953573 */ null}
@@ -174,14 +188,16 @@
       aria-label={$t('exit_slideshow')}
     />
 
-    <IconButton
-      variant="ghost"
-      shape="round"
-      color="secondary"
-      icon={progressBarStatus === ProgressBarStatus.Paused ? mdiPlay : mdiPause}
-      onclick={() => (progressBarStatus === ProgressBarStatus.Paused ? progressBar?.play() : progressBar?.pause())}
-      aria-label={progressBarStatus === ProgressBarStatus.Paused ? $t('play') : $t('pause')}
-    />
+    {#if !isVideoSlide}
+      <IconButton
+        variant="ghost"
+        shape="round"
+        color="secondary"
+        icon={progressBarStatus === ProgressBarStatus.Paused ? mdiPlay : mdiPause}
+        onclick={() => (progressBarStatus === ProgressBarStatus.Paused ? progressBar?.play() : progressBar?.pause())}
+        aria-label={progressBarStatus === ProgressBarStatus.Paused ? $t('play') : $t('pause')}
+      />
+    {/if}
     <IconButton
       variant="ghost"
       shape="round"
@@ -219,11 +235,13 @@
   </div>
 {/if}
 
-<ProgressBar
-  autoplay={$slideshowAutoplay}
-  hidden={!$showProgressBar}
-  duration={$slideshowDelay}
-  bind:this={progressBar}
-  bind:status={progressBarStatus}
-  onDone={handleDone}
-/>
+{#if !isVideoSlide}
+  <ProgressBar
+    autoplay={$slideshowAutoplay}
+    hidden={!$showProgressBar}
+    duration={$slideshowDelay}
+    bind:this={progressBar}
+    bind:status={progressBarStatus}
+    onDone={handleDone}
+  />
+{/if}

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -38,7 +38,7 @@
   let showControls = $state(true);
   let timer: NodeJS.Timeout;
   let isOverControls = $state(false);
-  let isVideoSlide = $derived(assetType === AssetTypeEnum.Video);
+  const isVideoSlide = $derived(assetType === AssetTypeEnum.Video);
 
   let unsubscribeRestart: () => void;
   let unsubscribeStop: () => void;

--- a/web/src/lib/components/asset-viewer/slideshow-bar.svelte
+++ b/web/src/lib/components/asset-viewer/slideshow-bar.svelte
@@ -163,10 +163,7 @@
   });
 </script>
 
-<svelte:document
-  onmousemove={showControlBar}
-  use:shortcuts={shortcutBindings}
-/>
+<svelte:document onmousemove={showControlBar} use:shortcuts={shortcutBindings} />
 
 {/* @ts-expect-error https://github.com/Rezi/svelte-gestures/issues/38#issuecomment-3315953573 */ null}
 <svelte:body {@attach swipe} {onswipe} {onswipedown} />


### PR DESCRIPTION
## Description

I and many others have been experiencing an issue with the slideshow feature (#19601) where the picture interval time is forcefully applied to video files thus preventing them from fully playing to completion.

This PR adds the `AssetType` prop to the `SlideshowBar` component, prevents the spacebar shortcut from playing/pausing the slideshow when a video is playing, and also prevents the ProgressBar component from rendering if a video is being played (which ensures videos are not prematurely cut off).

There may be a more sophisciated and elegant way to get the progress bar component to work & sync up with the video, but I wanted to author as simple of a fix as possible, so I'll leave that up to someone else to implement if they wish. (Personally I think the UI looks cleaner without the progress bar for a video).

Fixes #19601.

## How Has This Been Tested?

I manually tested this on my own Immich server's photo library using my local web UI changes by using a) the Slideshow feature and also b) checking the default asset viewer to make sure no functionality was disrupted.

In slideshow mode I did the following:
1. Start a slideshow on any picture/video
2. Wait for video to fully finish & autoplay onto next photo/video

I also double checked that the spacebar shortcut wouldn't play/pause the slideshow when on a video, and I can confirm that the spacebar play/pause shortcut only affects the native HTML5 video elements when playing a video. 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="1919" height="1199" alt="2025-12-29_12-49" src="https://github.com/user-attachments/assets/bb95751d-8a38-4649-b86c-6c995235a597" />

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used GPT-5.2 Codex to help me generate a starting point for my patch. All code has been manually audited, reviewed and tested by myself before pushing.
