### PR TITLE
feat: Allow disabling image or text processing for individual machine-learning containers

### DIFF
--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -60,7 +60,7 @@ In such instances, searching by context in the web UI or mobile apps will also f
 ```yaml
 environment:
   MACHINE_LEARNING__PROCESS_IMAGES: false
-  MACHINE_LEARNING__PROCESS_TEXT: false
+  MACHINE_LEARNING__PROCESS_TEXT: true
 ```
 
 This allows the local container to handle text processing for Smart Search, while the remote container processes images. Add the remote container's URL to the Machine Learning Settings as described above, and both containers will work together seamlessly.

--- a/docs/docs/guides/remote-machine-learning.md
+++ b/docs/docs/guides/remote-machine-learning.md
@@ -55,6 +55,16 @@ Adding a new URL to the settings is recommended over replacing the existing URL.
 
 Do note that this will mean that Smart Search and Face Detection jobs will fail to be processed when the remote instance is not available. This in turn means that tasks dependent on these features—Duplicate Detection and Facial Recognition—will not run for affected assets. If this occurs, you must manually click the _Missing_ button next to Smart Search and Face Detection in the [Job Status](http://my.immich.app/admin/queues) page for the jobs to be retried.
 
+In such instances, searching by context in the web UI or mobile apps will also fail. This is because the inputted text needs to be processed before matching images can be found, which is done by the machine-learning container. To combat this, two containers can be used: one on the same device that the server is running on, and one on a remote server. The local machine learning container can then be configured to only process text by adding the following environment variables to its service definition in `docker-compose.yml`:
+
+```yaml
+environment:
+  MACHINE_LEARNING__PROCESS_IMAGES: false
+  MACHINE_LEARNING__PROCESS_TEXT: false
+```
+
+This allows the local container to handle text processing for Smart Search, while the remote container processes images. Add the remote container's URL to the Machine Learning Settings as described above, and both containers will work together seamlessly.
+
 ## Load balancing
 
 While several URLs can be provided in the settings, they are tried sequentially; there is no attempt to distribute load across multiple containers. It is recommended to use a dedicated load balancer for such use-cases and specify it as the only URL. Among other things, it may enable the use of different APIs on the same server by running multiple containers with different configurations. For example, one might run an OpenVINO container in addition to a CUDA container, or run a standard release container to maximize both CPU and GPU utilization.

--- a/machine-learning/immich_ml/config.py
+++ b/machine-learning/immich_ml/config.py
@@ -79,6 +79,8 @@ class Settings(BaseSettings):
     preload: PreloadModelData | None = None
     max_batch_size: MaxBatchSize | None = None
     openvino_precision: ModelPrecision = ModelPrecision.FP32
+    process_images: bool = True
+    process_text: bool = True
 
     @property
     def device_id(self) -> str:

--- a/machine-learning/immich_ml/main.py
+++ b/machine-learning/immich_ml/main.py
@@ -183,8 +183,12 @@ async def predict(
     text: str | None = Form(default=None),
 ) -> Any:
     if image is not None:
+        if not settings.process_images:
+            raise HTTPException(400, "Image inputs are not allowed by this server")
         inputs: Image | str = await run(lambda: decode_pil(image))
     elif text is not None:
+        if not settings.process_text:
+            raise HTTPException(400, "Text inputs are not allowed by this server")
         inputs = text
     else:
         raise HTTPException(400, "Either image or text must be provided")


### PR DESCRIPTION
## Description

Two boolean settings are added (`MACHINE_LEARNING__PROCESS_IMAGES` and `MACHINE_LEARNING__PROCESS_TEXT`), that allow each machine learning container to "decline" processing of texts or images. These settings are using the pydantic settings system and don't change any behaviour if they are not explicitly changed. If one or both flags are enabled, requests to the `/predict` endpoint with an image or some text respectively will respond with a 400 error code.
This allows a local machine learning container on the same system as the server to process smart-search user requests, even if the primary machine-learning container on a remote server is not reachable. Critically, the local server will not not process uploaded images though, which otherwise could drastically impact performance on smaller systems.

## How Has This Been Tested?

Since the change is quite basic and only affects the machine-learning container, I didn't write any tests. However, I built a new image and tested it on two separate systems, both as the primary and fallback servers.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Copilot was used to write an initial draft of the documentation changes, which intern used Claude Haiku 4.5.

...
