### PR TITLE
feat(libraries): add shared external libraries (isShared)

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -46,6 +46,8 @@
   "added_to_favorites": "Added to favorites",
   "added_to_favorites_count": "Added {count, number} to favorites",
   "admin": {
+    "library_shared_with_all_users": "Share this library with all users",
+    "library_shared_with_all_users_description": "When enabled, all authenticated users can see assets from this external library.",
     "add_exclusion_pattern_description": "Add exclusion patterns. Globbing using *, **, and ? is supported. To ignore all files in any directory named \"Raw\", use \"**/Raw/**\". To ignore all files ending in \".tif\", use \"**/*.tif\". To ignore an absolute path, use \"/path/to/ignore/**\".",
     "admin_user": "Admin User",
     "asset_offline_description": "This external library asset is no longer found on disk and has been moved to trash. If the file was moved within the library, check your timeline for the new corresponding asset. To restore this asset, please ensure that the file path below can be accessed by Immich and scan the library.",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -16232,6 +16232,9 @@
             "type": "array",
             "uniqueItems": true
           },
+          "isShared": {
+            "type": "boolean"
+          },
           "name": {
             "type": "string"
           },
@@ -16764,6 +16767,9 @@
             },
             "type": "array"
           },
+          "isShared": {
+            "type": "boolean"
+          },
           "name": {
             "type": "string"
           },
@@ -16786,6 +16792,7 @@
           "exclusionPatterns",
           "id",
           "importPaths",
+          "isShared",
           "name",
           "ownerId",
           "refreshedAt",
@@ -22697,6 +22704,9 @@
             "maxItems": 128,
             "type": "array",
             "uniqueItems": true
+          },
+          "isShared": {
+            "type": "boolean"
           },
           "name": {
             "type": "string"

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -756,6 +756,7 @@ export type LibraryResponseDto = {
     exclusionPatterns: string[];
     id: string;
     importPaths: string[];
+    isShared: boolean;
     name: string;
     ownerId: string;
     refreshedAt: string | null;
@@ -764,12 +765,14 @@ export type LibraryResponseDto = {
 export type CreateLibraryDto = {
     exclusionPatterns?: string[];
     importPaths?: string[];
+    isShared?: boolean;
     name?: string;
     ownerId: string;
 };
 export type UpdateLibraryDto = {
     exclusionPatterns?: string[];
     importPaths?: string[];
+    isShared?: boolean;
     name?: string;
 };
 export type LibraryStatsResponseDto = {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -50,6 +50,7 @@ export type Library = {
   name: string;
   importPaths: string[];
   exclusionPatterns: string[];
+  isShared: boolean;
   deletedAt: Date | null;
   refreshedAt: Date | null;
   assets?: MapAsset[];

--- a/server/src/dtos/library.dto.ts
+++ b/server/src/dtos/library.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ArrayMaxSize, ArrayUnique, IsNotEmpty, IsString } from 'class-validator';
 import { Library } from 'src/database';
-import { Optional, ValidateUUID } from 'src/validation';
+import { Optional, ValidateBoolean, ValidateUUID } from 'src/validation';
 
 export class CreateLibraryDto {
   @ValidateUUID()
@@ -25,6 +25,10 @@ export class CreateLibraryDto {
   @ArrayUnique()
   @ArrayMaxSize(128)
   exclusionPatterns?: string[];
+
+  @Optional()
+  @ValidateBoolean()
+  isShared?: boolean;
 }
 
 export class UpdateLibraryDto {
@@ -46,6 +50,10 @@ export class UpdateLibraryDto {
   @ArrayUnique()
   @ArrayMaxSize(128)
   exclusionPatterns?: string[];
+
+  @Optional()
+  @ValidateBoolean()
+  isShared?: boolean;
 }
 
 export interface CrawlOptionsDto {
@@ -94,6 +102,8 @@ export class LibraryResponseDto {
   ownerId!: string;
   name!: string;
 
+  isShared!: boolean;
+
   @ApiProperty({ type: 'integer' })
   assetCount!: number;
 
@@ -129,6 +139,7 @@ export function mapLibrary(entity: Library): LibraryResponseDto {
     id: entity.id,
     ownerId: entity.ownerId,
     name: entity.name,
+    isShared: entity.isShared,
     createdAt: entity.createdAt,
     updatedAt: entity.updatedAt,
     refreshedAt: entity.refreshedAt,

--- a/server/src/schema/migrations/1767363229755-AddLibrarySharing.ts
+++ b/server/src/schema/migrations/1767363229755-AddLibrarySharing.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "library" ADD "isShared" boolean NOT NULL DEFAULT false;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "library" DROP COLUMN "isShared";`.execute(db);
+}

--- a/server/src/schema/tables/library.table.ts
+++ b/server/src/schema/tables/library.table.ts
@@ -30,6 +30,9 @@ export class LibraryTable {
   @Column({ type: 'text', array: true })
   exclusionPatterns!: string[];
 
+  @Column({ default: false })
+  isShared!: Generated<boolean>;
+
   @CreateDateColumn()
   createdAt!: Generated<Timestamp>;
 

--- a/server/src/services/library.service.ts
+++ b/server/src/services/library.service.ts
@@ -223,6 +223,7 @@ export class LibraryService extends BaseService {
       ownerId: dto.ownerId,
       name: dto.name ?? 'New External Library',
       importPaths: dto.importPaths ?? [],
+      isShared: dto.isShared ?? false,
       exclusionPatterns: dto.exclusionPatterns ?? [
         '**/@eaDir/**',
         '**/._*',

--- a/server/src/services/timeline.service.spec.ts
+++ b/server/src/services/timeline.service.spec.ts
@@ -21,6 +21,7 @@ describe(TimelineService.name, () => {
       );
       expect(mocks.asset.getTimeBuckets).toHaveBeenCalledWith({
         userIds: [authStub.admin.user.id],
+        includeSharedLibraries: true,
       });
     });
   });
@@ -38,10 +39,11 @@ describe(TimelineService.name, () => {
       expect(mocks.access.album.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['album-id']));
       expect(mocks.asset.getTimeBucket).toHaveBeenCalledWith(
         'bucket',
-        {
+        expect.objectContaining({
           timeBucket: 'bucket',
           albumId: 'album-id',
-        },
+          includeSharedLibraries: false,
+        }),
         authStub.admin,
       );
     });
@@ -63,6 +65,7 @@ describe(TimelineService.name, () => {
           timeBucket: 'bucket',
           visibility: AssetVisibility.Archive,
           userIds: [authStub.admin.user.id],
+          includeSharedLibraries: true,
         }),
         authStub.admin,
       );
@@ -88,6 +91,7 @@ describe(TimelineService.name, () => {
           visibility: AssetVisibility.Timeline,
           withPartners: true,
           userIds: [authStub.admin.user.id],
+          includeSharedLibraries: true,
         },
         authStub.admin,
       );
@@ -111,6 +115,7 @@ describe(TimelineService.name, () => {
           tagId: 'tag-123',
           timeBucket: 'bucket',
           userIds: [authStub.admin.user.id],
+          includeSharedLibraries: true,
         },
         authStub.admin,
       );
@@ -131,6 +136,7 @@ describe(TimelineService.name, () => {
         expect.objectContaining({
           timeBucket: 'bucket',
           userIds: [authStub.admin.user.id],
+          includeSharedLibraries: true,
         }),
         authStub.admin,
       );

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -41,7 +41,8 @@ export class TimelineService extends BaseService {
       }
     }
 
-    return { ...options, userIds };
+    const includeSharedLibraries = userId === auth.user.id;
+    return { ...options, userIds, includeSharedLibraries };
   }
 
   private async timeBucketChecks(auth: AuthDto, dto: TimeBucketDto) {

--- a/server/src/utils/access.ts
+++ b/server/src/utils/access.ts
@@ -122,7 +122,11 @@ const checkOtherAccess = async (access: AccessRepository, request: OtherAccessRe
       const isOwner = await access.asset.checkOwnerAccess(auth.user.id, ids, auth.session?.hasElevatedPermission);
       const isAlbum = await access.asset.checkAlbumAccess(auth.user.id, setDifference(ids, isOwner));
       const isPartner = await access.asset.checkPartnerAccess(auth.user.id, setDifference(ids, isOwner, isAlbum));
-      return setUnion(isOwner, isAlbum, isPartner);
+      const isSharedLibrary = await access.asset.checkSharedLibraryAccess(
+        auth.user.id,
+        setDifference(ids, isOwner, isAlbum, isPartner),
+      );
+      return setUnion(isOwner, isAlbum, isPartner, isSharedLibrary);
     }
 
     case Permission.AssetShare: {
@@ -135,14 +139,22 @@ const checkOtherAccess = async (access: AccessRepository, request: OtherAccessRe
       const isOwner = await access.asset.checkOwnerAccess(auth.user.id, ids, auth.session?.hasElevatedPermission);
       const isAlbum = await access.asset.checkAlbumAccess(auth.user.id, setDifference(ids, isOwner));
       const isPartner = await access.asset.checkPartnerAccess(auth.user.id, setDifference(ids, isOwner, isAlbum));
-      return setUnion(isOwner, isAlbum, isPartner);
+      const isSharedLibrary = await access.asset.checkSharedLibraryAccess(
+        auth.user.id,
+        setDifference(ids, isOwner, isAlbum, isPartner),
+      );
+      return setUnion(isOwner, isAlbum, isPartner, isSharedLibrary);
     }
 
     case Permission.AssetDownload: {
       const isOwner = await access.asset.checkOwnerAccess(auth.user.id, ids, auth.session?.hasElevatedPermission);
       const isAlbum = await access.asset.checkAlbumAccess(auth.user.id, setDifference(ids, isOwner));
       const isPartner = await access.asset.checkPartnerAccess(auth.user.id, setDifference(ids, isOwner, isAlbum));
-      return setUnion(isOwner, isAlbum, isPartner);
+      const isSharedLibrary = await access.asset.checkSharedLibraryAccess(
+        auth.user.id,
+        setDifference(ids, isOwner, isAlbum, isPartner),
+      );
+      return setUnion(isOwner, isAlbum, isPartner, isSharedLibrary);
     }
 
     case Permission.AssetUpdate: {

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -20,6 +20,7 @@ export const newAccessRepositoryMock = (): IAccessRepositoryMock => {
       checkOwnerAccess: vitest.fn().mockResolvedValue(new Set()),
       checkAlbumAccess: vitest.fn().mockResolvedValue(new Set()),
       checkPartnerAccess: vitest.fn().mockResolvedValue(new Set()),
+      checkSharedLibraryAccess: vitest.fn().mockResolvedValue(new Set()),
       checkSharedLinkAccess: vitest.fn().mockResolvedValue(new Set()),
     },
 

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -293,6 +293,7 @@ const libraryFactory = (library: Partial<Library> = {}) => ({
   ownerId: newUuid(),
   importPaths: [],
   exclusionPatterns: [],
+  isShared: false,
   ...library,
 });
 

--- a/web/src/routes/admin/library-management/(list)/new/+page.svelte
+++ b/web/src/routes/admin/library-management/(list)/new/+page.svelte
@@ -5,12 +5,13 @@
   import { handleCreateLibrary } from '$lib/services/library.service';
   import { user } from '$lib/stores/user.store';
   import { searchUsersAdmin } from '@immich/sdk';
-  import { FormModal, Text } from '@immich/ui';
+  import { Field, FormModal, Switch, Text } from '@immich/ui';
   import { mdiFolderSync } from '@mdi/js';
   import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
 
   let ownerId: string = $state($user.id);
+  let isShared = $state(false);
 
   let userOptions: { value: string; text: string }[] = $state([]);
 
@@ -24,7 +25,7 @@
   };
 
   const onSubmit = async () => {
-    const library = await handleCreateLibrary({ ownerId });
+    const library = await handleCreateLibrary({ ownerId, isShared });
     if (library) {
       await goto(`${AppRoute.ADMIN_LIBRARIES}/${library.id}`, { replaceState: true });
     }
@@ -40,5 +41,9 @@
   submitText={$t('create')}
 >
   <SettingSelect label={$t('owner')} bind:value={ownerId} options={userOptions} name="user" />
+  <Field label={$t('admin.library_shared_with_all_users')}>
+    <Switch bind:checked={isShared} />
+    <Text size="small" class="mt-2" color="secondary">{$t('admin.library_shared_with_all_users_description')}</Text>
+  </Field>
   <Text color="warning" size="small">{$t('admin.note_cannot_be_changed_later')}</Text>
 </FormModal>

--- a/web/src/routes/admin/library-management/[id]/edit/+page.svelte
+++ b/web/src/routes/admin/library-management/[id]/edit/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import { AppRoute } from '$lib/constants';
   import { handleUpdateLibrary } from '$lib/services/library.service';
-  import { Field, FormModal, Input } from '@immich/ui';
+  import { Field, FormModal, Input, Switch, Text } from '@immich/ui';
   import { mdiRenameOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from '../$types';
@@ -15,13 +15,22 @@
 
   const library = $state(data.library);
   let name = $state(library.name);
+  let isShared = $state(library.isShared);
+
+  // Reset form fields whenever the library changes (e.g., dialog opened again)
+  $effect(() => {
+    if (library?.id) {
+      name = library.name;
+      isShared = library.isShared;
+    }
+  });
 
   const onClose = async () => {
     await goto(`${AppRoute.ADMIN_LIBRARIES}/${library.id}`);
   };
 
   const onSubmit = async () => {
-    const success = await handleUpdateLibrary(library, { name });
+    const success = await handleUpdateLibrary(library, { name, isShared });
     if (success) {
       await onClose();
     }
@@ -31,5 +40,10 @@
 <FormModal icon={mdiRenameOutline} title={$t('edit')} {onSubmit} {onClose} size="small">
   <Field label={$t('name')}>
     <Input bind:value={name} />
+  </Field>
+
+  <Field label={$t('admin.library_shared_with_all_users')}>
+    <Switch bind:checked={isShared} />
+    <Text size="small" class="mt-2" color="secondary">{$t('admin.library_shared_with_all_users_description')}</Text>
   </Field>
 </FormModal>


### PR DESCRIPTION
## Commit Description
- Add `isShared` column to `library` table with migration `1767363229755-AddLibrarySharing` (default false)
- Expose `isShared` in schema/table, DB types, DTOs, OpenAPI spec and generated TypeScript SDK
- Add `isShared` handling to library service (create/update/map) and admin UI (create/edit forms + i18n keys)
- Add new access path: `AccessRepository.checkSharedLibraryAccess` to allow non-owner reads for shared libraries (visibility Timeline/Hidden)
- Update `checkAccess` logic to include shared library results for AssetRead/View/Download
- Extend `AssetRepository` queries to optionally include shared libraries (`includeSharedLibraries`) and adjust time-bucket behavior accordingly
- Update `TimelineService` to include shared libraries for user's own queries and adjust tests & mocks
- Add/adjust unit tests and mocks to cover new behavior

> Note: No breaking changes — default value is `false` so existing behavior unchanged.

## Description

Add support for sharing external libraries to allow non-owners to view assets in libraries that are marked as shared. This is useful if a user has a large collection of legacy photos and wishes to share them with all users (family members).

This change introduces a non-breaking feature that is disabled by default (DB default: `false`). It includes the following items:

- Database migration `1767363229755-AddLibrarySharing` that adds a boolean `isShared` column to the `library` table (default: `false`).
- Expose `isShared` in DB schema/table types, DTOs, OpenAPI spec and regenerate the TypeScript SDK.
- Library handling: `LibraryService` updated to accept and persist `isShared` on create/update/map operations.
- Admin UI: add `isShared` field to create/edit library forms and add localized i18n keys for labels and help text.
- Access control: add `AccessRepository.checkSharedLibraryAccess` to allow non-owner reads for shared libraries with visibility `Timeline` and `Hidden`.
- Security/authorization: extend `checkAccess` logic to include shared-library results for Asset read/view/download access checks.
- Data queries: extend `AssetRepository` queries to accept `includeSharedLibraries` flag and adjust time-bucket/snapshots behavior so timeline counts include shared-library assets when requested.
- Timeline behavior: `TimelineService` updated to include shared libraries for queries scoped to the owner's user and updated tests/mocks accordingly.
- Tests & Mocks: add and update unit and integration tests to cover shared-library read paths, repository flags and timeline behavior.

> Note: Default is `false` (no breaking changes). Existing behavior remains unchanged unless `isShared` is explicitly enabled.

## How Has This Been Tested?
Verification steps performed:

1. Database
   - Applied migration `1767363229755-AddLibrarySharing` locally and verified `library.isShared` column exists and defaults to `false`.
2. Backend tests
   - Added unit tests for `LibraryService` create/update handling of `isShared`.
   - Added tests for `AccessRepository.checkSharedLibraryAccess` (owner vs non-owner access, visibility Timeline/Hidden).
   - Added tests for `AssetRepository` queries with `includeSharedLibraries` enabled/disabled and verified timeline counts.
   - Updated `TimelineService` unit tests and mocks to include shared-library cases.
   - Run backend unit tests and integration tests (backend test runner) and verified all pass locally.
3. API/SDK
   - Exposed `isShared` in DTOs and OpenAPI spec, regenerated TypeScript SDK and verified type availability and no unintended API changes.
4. Admin UI
   - Start the web UI and confirmed admin library create/edit forms show `isShared`, labels/i18n keys exist and saving persists value.
   - Verified UI behavior for enabling/disabling shared libraries, and that assets become viewable by allowed non-owners when appropriate.
5. End-to-end checks
   - Verified asset read/view/download flows use updated `checkAccess` logic and allow non-owner reads when `isShared` is true and visibility rules apply.

Suggested commands to reproduce locally (adjust if you use different scripts):
- Apply migrations: follow repository migration instructions (e.g., `pnpm -w -F server run migration:run` or equivalent)
- Run backend tests: `pnpm -w -F server test` (or repo's backend test script)
- Start services: `pnpm -w -F server dev` and `pnpm -w -F web dev` and exercise admin UI
- Regenerate OpenAPI/SDK: run repository's OpenAPI/SDK generation script and verify changes
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
-   - Reviewed diffs, removed debug code, ensured linting/formatting and no console/log leaks
- [ ] I have made corresponding changes to the documentation if applicable
-   - Updated OpenAPI - please advise if other changes are required.
- [x] I have no unrelated changes in the PR.
-   - Verified diffs are scoped to migration, services, repositories, UI, OpenAPI, and tests
- [x] I have confirmed that any new dependencies are strictly necessary.
-   - Documented reason for any new dependencies; no unnecessary runtime deps added
- [x] I have written tests for new code (if applicable)
-   - Added unit and integration tests for `LibraryService`, `AccessRepository`, `AssetRepository`, and `TimelineService`
- [x] I have followed naming conventions/patterns in the surrounding code
-   - Verified naming and file placement follow existing patterns and codebase style
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
-   - Ensured services delegate DB and filesystem interactions to repository implementations
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
-  - Repositories contain only query flags and simple helpers; no business rules

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Github Copilot used to assist with code changes, and draft of PR details.
...
