### PR TITLE
feat(cli): Generate unique album names for nested directories

### DIFF
--- a/cli/src/commands/asset.ts
+++ b/cli/src/commands/asset.ts
@@ -451,26 +451,72 @@ const deleteFiles = async (uploaded: Asset[], duplicates: Asset[], options: Uplo
   }
 };
 
+const resolveServerDuplicates = async (albumTuples: AlbumPathTuple[]): Promise<Map<string, string>> => {
+  const dirToAlbumName = new Map<string, string>();
+  const usedNames = new Set<string>();
+
+  // Sort by path depth (deepest first) to handle nesting properly
+  const sortedTuples = [...albumTuples].toSorted(([a], [b]) => b.split(path.sep).length - a.split(path.sep).length);
+
+  for (const [dir, albumName] of sortedTuples) {
+    const finalName = albumName;
+    let uniqueName = finalName;
+    let counter = 1;
+
+    // Only check against already used names in this batch
+    while (usedNames.has(uniqueName)) {
+      uniqueName = `${finalName} ${counter++}`;
+    }
+
+    usedNames.add(uniqueName);
+    dirToAlbumName.set(dir, uniqueName);
+  }
+
+  return dirToAlbumName;
+};
+
 const updateAlbums = async (assets: Asset[], options: UploadOptionsDto) => {
   if (!options.album && !options.albumName) {
     return;
   }
   const { dryRun, concurrency } = options;
 
+  // Get existing albums from server
   const albums = await getAllAlbums({});
   const existingAlbums = new Map(albums.map((album) => [album.albumName, album.id]));
   const newAlbums: Set<string> = new Set();
+
+  // Generate album names for all directories
+  const albumTuples = generateAlbumNames(assets.map((a) => a.filepath));
+
+  // Resolve any duplicates within this batch
+  const dirToAlbumName = await resolveServerDuplicates(albumTuples);
+
+  // Create mapping from filepath to album name
+  const uploadAlbumNames = new Map<string, string>(); // filepath -> albumName
+
   for (const { filepath } of assets) {
-    const albumName = getAlbumName(filepath, options);
-    if (albumName && !existingAlbums.has(albumName)) {
-      newAlbums.add(albumName);
+    const dir = path.dirname(filepath);
+    const albumName = dirToAlbumName.get(dir);
+    if (albumName) {
+      uploadAlbumNames.set(filepath, albumName);
+      if (!existingAlbums.has(albumName)) {
+        newAlbums.add(albumName);
+      }
     }
   }
 
   if (dryRun) {
-    // TODO print asset counts for new albums
     console.log(`Would have created ${newAlbums.size} new album${s(newAlbums.size)}`);
     console.log(`Would have updated albums of ${assets.length} asset${s(assets.length)}`);
+
+    if (options.jsonOutput) {
+      const output = {
+        albums: [...newAlbums],
+        albumMappings: Object.fromEntries(uploadAlbumNames),
+      };
+      console.log(JSON.stringify(output, undefined, 2));
+    }
     return;
   }
 
@@ -497,9 +543,17 @@ const updateAlbums = async (assets: Asset[], options: UploadOptionsDto) => {
   console.log(`Successfully created ${newAlbums.size} new album${s(newAlbums.size)}`);
   console.log(`Successfully updated ${assets.length} asset${s(assets.length)}`);
 
+  if (options.jsonOutput) {
+    const output = {
+      albums: [...newAlbums],
+      albumMappings: Object.fromEntries(uploadAlbumNames),
+    };
+    console.log(JSON.stringify(output, undefined, 2));
+  }
+
   const albumToAssets = new Map<string, string[]>();
   for (const asset of assets) {
-    const albumName = getAlbumName(asset.filepath, options);
+    const albumName = uploadAlbumNames.get(asset.filepath);
     if (!albumName) {
       continue;
     }
@@ -535,4 +589,75 @@ const updateAlbums = async (assets: Asset[], options: UploadOptionsDto) => {
 // - Unix: `/test/Filename.txt`
 export const getAlbumName = (filepath: string, options: UploadOptionsDto) => {
   return options.albumName ?? path.basename(path.dirname(filepath));
+};
+
+type AlbumPathTuple = [string, string]; // [directoryPath, albumName]
+
+/**
+ * Generate album names for all directories, resolving duplicates by adding parent directories
+ */
+const generateAlbumNames = (filepaths: string[]): AlbumPathTuple[] => {
+  // First pass: collect all unique directories
+  const directories = new Set<string>();
+  for (const filepath of filepaths) {
+    directories.add(path.dirname(filepath));
+  }
+
+  // Second pass: for each directory, collect all possible album name candidates
+  // with increasing levels of context
+  const dirCandidates = new Map<string, string[]>();
+
+  for (const dir of directories) {
+    const parts = dir.split(path.sep).filter(Boolean);
+    const candidates: string[] = [];
+
+    // Generate candidates with increasing context
+    for (let i = 1; i <= parts.length; i++) {
+      candidates.push(parts.slice(-i).join(' '));
+    }
+
+    dirCandidates.set(dir, candidates);
+  }
+
+  // Third pass: find the minimal unique name for each directory
+  const result: AlbumPathTuple[] = [];
+  const usedNames = new Set<string>();
+
+  // Sort directories by depth (deepest first) to handle nesting properly
+  const sortedDirs = [...directories].toSorted((a, b) => b.split(path.sep).length - a.split(path.sep).length);
+
+  for (const dir of sortedDirs) {
+    const candidates = dirCandidates.get(dir) || [];
+    let selectedName = candidates[0] || '';
+
+    // Find the shortest unique name
+    for (const candidate of candidates) {
+      selectedName = candidate;
+
+      // Check if this name is already used
+      let isUnique = true;
+      for (const [otherDir, otherCandidates] of dirCandidates) {
+        if (otherDir === dir) {
+          continue;
+        }
+
+        if (otherCandidates.includes(candidate)) {
+          isUnique = false;
+          break;
+        }
+      }
+
+      if (isUnique) {
+        break;
+      }
+    }
+
+    // Add to used names and result
+    if (selectedName) {
+      usedNames.add(selectedName);
+      result.push([dir, selectedName]);
+    }
+  }
+
+  return result;
 };


### PR DESCRIPTION
## Description
Generates a unique album name when several directories have the same name. It does that using the parent folders names.

This is especially useful for directory structure like:
```
photos/
├── 2023
  ├── Bretagne
    ├── image.png
    ├── photo.jpg
  ├── summer
    ├── beach
      ├── image.png
      ├── photo.jpg
    ├── city
      ├── image.png
      ├── photo.jpg
    ├── image.png
    ├── photo.jpg
├── 2024
  ├── Bretagne
    ├── image.png
    ├── photo.jpg
  ├── summer
    ├── beach
      ├── image.png
      ├── photo.jpg
    ├── city
      ├── image.png
      ├── photo.jpg
    ├── image.png
    ├── photo.jpg
```
The albums created are:
- "2023 Bretagne"
- "2023 summer beach"
- "2023 summer city"
- "2023 summer"
- "2024 Bretagne"
- "2024 summer beach"
- "2024 summer city"
- "2024 summer"

This was moved from #19855 

## How Has This Been Tested?
Tested on a dummy file structure

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

