### PR TITLE
fix: 360 photos viewer

### DIFF
--- a/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
@@ -14,17 +14,16 @@
 
   let { asset, zoomToggle = $bindable() }: Props = $props();
 
-  const loadAssetData = async (id: string, useOriginal: boolean) => {
-    // For 360° panorama images, we must use the original or fullsize image
+  const loadAssetData = async (id: string) => {
+    // For 360° panorama images, we must use the fullsize image
     // because the preview may have a broken aspect ratio (2:1 is required for equirectangular projection)
-    const size = useOriginal ? AssetMediaSize.Fullsize : AssetMediaSize.Preview;
-    const data = await viewAsset({ ...authManager.params, id, size });
+    const data = await viewAsset({ ...authManager.params, id, size: AssetMediaSize.Fullsize });
     return URL.createObjectURL(data);
   };
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
-  {#await Promise.all([loadAssetData(asset.id, true), import('./photo-sphere-viewer-adapter.svelte')])}
+  {#await Promise.all([loadAssetData(asset.id), import('./photo-sphere-viewer-adapter.svelte')])}
     <LoadingSpinner />
   {:then [data, { default: PhotoSphereViewer }]}
     <PhotoSphereViewer

--- a/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
@@ -14,14 +14,17 @@
 
   let { asset, zoomToggle = $bindable() }: Props = $props();
 
-  const loadAssetData = async (id: string) => {
-    const data = await viewAsset({ ...authManager.params, id, size: AssetMediaSize.Preview });
+  const loadAssetData = async (id: string, useOriginal: boolean) => {
+    // For 360° panorama images, we must use the original or fullsize image
+    // because the preview may have a broken aspect ratio (2:1 is required for equirectangular projection)
+    const size = useOriginal ? AssetMediaSize.Fullsize : AssetMediaSize.Preview;
+    const data = await viewAsset({ ...authManager.params, id, size });
     return URL.createObjectURL(data);
   };
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
-  {#await Promise.all([loadAssetData(asset.id), import('./photo-sphere-viewer-adapter.svelte')])}
+  {#await Promise.all([loadAssetData(asset.id, true), import('./photo-sphere-viewer-adapter.svelte')])}
     <LoadingSpinner />
   {:then [data, { default: PhotoSphereViewer }]}
     <PhotoSphereViewer


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Load fullsize/original image instead of preview for 360° panorama viewer to maintain the correct 2:1 aspect ratio required for equirectangular projection.
<!--- Why is this change required? What problem does it solve? -->
Fixes the 360 photos viewers
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #24333 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Uploaded a 360 photos via the web interface 

<details><summary><h2>Screenshots (if appropriate)</h2></summary>
Before/After
<!-- Images go below this line. -->
<img width="1037" height="667" alt="image" src="https://github.com/user-attachments/assets/4713c647-54d8-47d4-8164-796c8712bd04" />
<img width="1671" height="968" alt="Screenshot 2026-01-03 at 20 24 15" src="https://github.com/user-attachments/assets/486f78f0-1026-4dc5-a9af-d242c4338165" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [X] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
To check where the 360 image handling where processed
...
