### PR TITLE
fix(mobile): hide delete action for remote-only assets

### DIFF
--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -119,7 +119,7 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
           const MoveToLockFolderActionButton(source: ActionSource.timeline),
           if (multiselect.selectedAssets.length > 1) const StackActionButton(source: ActionSource.timeline),
           if (multiselect.hasStacked) const UnStackActionButton(source: ActionSource.timeline),
-          const DeleteActionButton(source: ActionSource.timeline),
+          if (multiselect.hasLocal || multiselect.hasMerged) const DeleteActionButton(source: ActionSource.timeline),
         ],
         if (multiselect.hasLocal || multiselect.hasMerged) const DeleteLocalActionButton(source: ActionSource.timeline),
         if (multiselect.hasLocal) const UploadActionButton(source: ActionSource.timeline),


### PR DESCRIPTION
## Description

This PR reduces confusion in the timeline action sheet by only showing "Delete" (delete from device + server) when the selected assets exist both locally and on the server. For remote-only assets, "Move to Trash" already covers the server-side action, so showing "Delete" at the same time is redundant and unclear.

Refs: #20789, #14441

## How Has This Been Tested?

- Manual test on Android: verified the bottom sheet only shows "Delete" when the selection includes assets.
- On Android, long-press an asset to enter multi-select and open the bottom action sheet.
- Select a mix (remote-only + local/merged): "Delete" is shown.
- Select remote-only assets: "Delete" is not shown.

## Follow-up suggestion

Would it be acceptable to change the mobile button key from `delete` to more explicit one like `control_bottom_app_bar_delete_everywhere: "Delete Everywhere"`, to make it clear that this action removes the asset from both the device and the server?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
