### PR TITLE
chore(deployment): add healthcheck option for DB

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -146,6 +146,8 @@ services:
     ports:
       - 5432:5432
     shm_size: 128mb
+    healthcheck:
+      disable: false
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics
   # immich-prometheus:
   #   container_name: immich_prometheus

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -77,6 +77,8 @@ services:
       - 5432:5432
     shm_size: 128mb
     restart: always
+    healthcheck:
+      disable: false
 
   # set IMMICH_TELEMETRY_INCLUDE=all in .env to enable metrics
   immich-prometheus:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
     shm_size: 128mb
     restart: always
+    healthcheck:
+      disable: false
 
 volumes:
   model-cache:


### PR DESCRIPTION
While we recommend keeping them enabled, it probably makes sense to expose this option to the user. 