### PR TITLE
fix: import config from json

### DIFF
--- a/web/src/lib/services/system-config.service.ts
+++ b/web/src/lib/services/system-config.service.ts
@@ -41,7 +41,7 @@ export const getSystemConfigActions = (
     description: $t('admin.import_config_from_json_description'),
     type: $t('command'),
     icon: mdiUpload,
-    // $if: () => !featureFlags.configFile,
+    $if: () => !featureFlags.configFile,
     onAction: () => handleUploadConfig(),
     shortcuts: { shift: true, key: 'u' },
   };

--- a/web/src/lib/services/system-config.service.ts
+++ b/web/src/lib/services/system-config.service.ts
@@ -41,7 +41,7 @@ export const getSystemConfigActions = (
     description: $t('admin.import_config_from_json_description'),
     type: $t('command'),
     icon: mdiUpload,
-    $if: () => !featureFlags.configFile,
+    // $if: () => !featureFlags.configFile,
     onAction: () => handleUploadConfig(),
     shortcuts: { shift: true, key: 'u' },
   };
@@ -94,23 +94,31 @@ export const handleDownloadConfig = (config: SystemConfigDto) => {
 };
 
 export const handleUploadConfig = () => {
-  const input = globalThis.document.createElement('input');
+  const input = document.createElement('input');
   input.setAttribute('type', 'file');
-  input.setAttribute('accept', 'json');
+  input.setAttribute('accept', '.json');
   input.setAttribute('style', 'display: none');
 
-  input.addEventListener('change', ({ target }) => {
-    const file = (target as HTMLInputElement).files?.[0];
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
     if (!file) {
       return;
     }
-    const reader = async () => {
-      const text = await file.text();
-      const newConfig = JSON.parse(text);
-      await handleSystemConfigSave(newConfig);
-    };
-    reader().catch((error) => console.error('Error handling JSON config upload', error));
-    globalThis.document.append(input);
+
+    file
+      .text()
+      .then((text) => {
+        const newConfig = JSON.parse(text);
+        return handleSystemConfigSave(newConfig);
+      })
+      .catch((error) => {
+        console.error('Error handling JSON config upload', error);
+      })
+      .finally(() => {
+        input.remove();
+      });
   });
-  input.remove();
+
+  document.body.append(input);
+  input.click();
 };

--- a/web/src/lib/services/system-config.service.ts
+++ b/web/src/lib/services/system-config.service.ts
@@ -94,31 +94,25 @@ export const handleDownloadConfig = (config: SystemConfigDto) => {
 };
 
 export const handleUploadConfig = () => {
-  const input = document.createElement('input');
+  const input = globalThis.document.createElement('input');
   input.setAttribute('type', 'file');
   input.setAttribute('accept', '.json');
   input.setAttribute('style', 'display: none');
 
-  input.addEventListener('change', () => {
-    const file = input.files?.[0];
+  input.addEventListener('change', ({ target }) => {
+    const file = (target as HTMLInputElement).files?.[0];
     if (!file) {
       return;
     }
-
-    file
-      .text()
-      .then((text) => {
-        const newConfig = JSON.parse(text);
-        return handleSystemConfigSave(newConfig);
-      })
-      .catch((error) => {
-        console.error('Error handling JSON config upload', error);
-      })
-      .finally(() => {
-        input.remove();
-      });
+    const reader = async () => {
+      const text = await file.text();
+      const newConfig = JSON.parse(text);
+      await handleSystemConfigSave(newConfig);
+    };
+    reader()
+      .catch((error) => console.error('Error handling JSON config upload', error))
+      .finally(() => input.remove());
   });
-
-  document.body.append(input);
+  globalThis.document.body.append(input);
   input.click();
 };


### PR DESCRIPTION
## Description
The file selector wasn't opening

Fixes #24057 

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Go to admin settings and import a config file

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation if applicable~~
- [x] I have no unrelated changes in the PR.
- [ ] ~~I have confirmed that any new dependencies are strictly necessary.~~
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] ~~All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~~
- [ ] ~~All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~~

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
