### PR TITLE
fix: duplicate api call on new library page

### DIFF
--- a/web/src/routes/admin/library-management/(list)/new/+page.svelte
+++ b/web/src/routes/admin/library-management/(list)/new/+page.svelte
@@ -4,20 +4,20 @@
   import { AppRoute } from '$lib/constants';
   import { handleCreateLibrary } from '$lib/services/library.service';
   import { user } from '$lib/stores/user.store';
-  import { searchUsersAdmin } from '@immich/sdk';
   import { FormModal, Text } from '@immich/ui';
   import { mdiFolderSync } from '@mdi/js';
-  import { onMount } from 'svelte';
   import { t } from 'svelte-i18n';
+  import { type PageData } from './$types';
+
+  type Props = {
+    data: PageData;
+  };
+
+  const { data }: Props = $props();
 
   let ownerId: string = $state($user.id);
-
-  let userOptions: { value: string; text: string }[] = $state([]);
-
-  onMount(async () => {
-    const users = await searchUsersAdmin({});
-    userOptions = users.map((user) => ({ value: user.id, text: user.name }));
-  });
+  const users = $state(data.allUsers);
+  const userOptions = $derived(users.map((user) => ({ value: user.id, text: user.name })));
 
   const onClose = async () => {
     await goto(AppRoute.ADMIN_LIBRARIES);


### PR DESCRIPTION
Avoid making a second (duplicate) call to load users on the new library page.