### PR TITLE
fix: propagate iCloud Shared Album flag

### DIFF
--- a/mobile/lib/domain/services/local_sync.service.dart
+++ b/mobile/lib/domain/services/local_sync.service.dart
@@ -360,6 +360,7 @@ extension on Iterable<PlatformAlbum> {
         name: e.name,
         updatedAt: tryFromSecondsSinceEpoch(e.updatedAt, isUtc: true) ?? DateTime.timestamp(),
         assetCount: e.assetCount,
+        isIosSharedAlbum: e.isCloud,
       ),
     ).toList();
   }

--- a/mobile/lib/infrastructure/entities/local_album.entity.dart
+++ b/mobile/lib/infrastructure/entities/local_album.entity.dart
@@ -33,6 +33,7 @@ extension LocalAlbumEntityDataHelper on LocalAlbumEntityData {
       assetCount: assetCount,
       backupSelection: backupSelection,
       linkedRemoteAlbumId: linkedRemoteAlbumId,
+      isIosSharedAlbum: isIosSharedAlbum,
     );
   }
 }

--- a/mobile/lib/widgets/backup/drift_album_info_list_tile.dart
+++ b/mobile/lib/widgets/backup/drift_album_info_list_tile.dart
@@ -4,6 +4,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/album/local_album.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
 import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -41,6 +42,13 @@ class DriftAlbumInfoListTile extends HookConsumerWidget {
       return Icon(Icons.circle, color: context.colorScheme.surfaceContainerHighest);
     }
 
+    Widget buildSubtitle() {
+      return Text(
+        album.isIosSharedAlbum ? '${album.assetCount} (iCloud Shared Album)' : album.assetCount.toString(),
+        style: context.textTheme.labelLarge?.copyWith(color: context.colorScheme.onSurfaceSecondary),
+      );
+    }
+
     return GestureDetector(
       onDoubleTap: () {
         ref.watch(hapticFeedbackProvider.notifier).selectionClick();
@@ -73,8 +81,8 @@ class DriftAlbumInfoListTile extends HookConsumerWidget {
           }
         },
         leading: buildIcon(),
-        title: Text(album.name, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold)),
-        subtitle: Text(album.assetCount.toString()),
+        title: Text(album.name, style: context.textTheme.titleSmall),
+        subtitle: buildSubtitle(),
         trailing: IconButton(
           onPressed: () {
             context.pushRoute(LocalTimelineRoute(album: album));


### PR DESCRIPTION
- Propagate `isIosSharedAlbum` flag.
- Show indication of iCloud Shared Album in album selection for upload interface 

<img width="300" alt="Screenshot 2026-01-05 at 4 05 54 PM" src="https://github.com/user-attachments/assets/226989c4-3436-455d-b767-b6ce8eb3beaf" />
