### PR TITLE
fix(server): search statistics with personIds returns 500

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -446,7 +446,7 @@ export function searchAssetBuilder(kysely: Kysely<DB>, options: AssetSearchBuild
       qb.where((eb) => eb.not(eb.exists((eb) => eb.selectFrom('album_asset').whereRef('assetId', '=', 'asset.id')))),
     )
     .$if(!!options.withExif, withExifInner)
-    .$if(!!(options.withFaces || options.withPeople || options.personIds), (qb) => qb.select(withFacesAndPeople))
+    .$if(!!(options.withFaces || options.withPeople), (qb) => qb.select(withFacesAndPeople))
     .$if(!options.withDeleted, (qb) => qb.where('asset.deletedAt', 'is', null));
 }
 


### PR DESCRIPTION
## Summary
- Fix SQL error when using `/search/statistics` endpoint with `personIds` parameter
- The issue was caused by `searchAssetBuilder` incorrectly adding `withFacesAndPeople` select when `personIds` was provided, which referenced `asset.id` in a subquery when only `count(*)` was selected

## Test Plan
- [x] Added medium test for `searchStatistics` with `personIds` filter
- [x] All existing unit tests pass
- [x] Lint and format checks pass

Fixes #25003