### PR TITLE
fix(web): improve text contrast in minimized upload panel

### DIFF
--- a/web/src/lib/components/shared-components/upload-panel.svelte
+++ b/web/src/lib/components/shared-components/upload-panel.svelte
@@ -131,7 +131,7 @@
           type="button"
           in:scale={{ duration: 250, easing: quartInOut }}
           onclick={() => (showDetail = true)}
-          class="absolute -start-4 -top-4 flex h-10 w-10 place-content-center place-items-center rounded-full bg-primary p-5 text-xs text-gray-200"
+          class="absolute -start-4 -top-4 flex h-10 w-10 place-content-center place-items-center rounded-full bg-primary p-5 text-xs text-light"
         >
           {$remainingUploads.toLocaleString($locale)}
         </button>
@@ -140,7 +140,7 @@
             type="button"
             in:scale={{ duration: 250, easing: quartInOut }}
             onclick={() => (showDetail = true)}
-            class="absolute -end-4 -top-4 flex h-10 w-10 place-content-center place-items-center rounded-full bg-danger p-5 text-xs text-gray-200"
+            class="absolute -end-4 -top-4 flex h-10 w-10 place-content-center place-items-center rounded-full bg-danger p-5 text-xs text-light"
           >
             {$stats.errors.toLocaleString($locale)}
           </button>


### PR DESCRIPTION
## Summary
- Fix poor text contrast in minimized upload status buttons in dark mode
- Changed `text-gray-200` to `text-light` on the `bg-primary` and `bg-danger` buttons

## Test Plan
- [x] Visual verification in both light and dark modes
- [x] Text is now clearly visible on colored backgrounds in both themes

Fixes #24683