### PR TITLE
fix(web): use asset date for change date popup when single asset selected

### DIFF
--- a/web/src/lib/components/timeline/actions/ChangeDateAction.svelte
+++ b/web/src/lib/components/timeline/actions/ChangeDateAction.svelte
@@ -2,6 +2,7 @@
   import MenuOption from '$lib/components/shared-components/context-menu/menu-option.svelte';
   import { getAssetControlContext } from '$lib/components/timeline/AssetSelectControlBar.svelte';
   import AssetSelectionChangeDateModal from '$lib/modals/AssetSelectionChangeDateModal.svelte';
+  import { fromTimelinePlainDateTime } from '$lib/utils/timeline-util';
   import { modalManager } from '@immich/ui';
   import { mdiCalendarEditOutline } from '@mdi/js';
   import { DateTime } from 'luxon';
@@ -14,9 +15,11 @@
   const { clearSelect, getOwnedAssets } = getAssetControlContext();
 
   const handleChangeDate = async () => {
+    const assets = getOwnedAssets();
+    const initialDate = assets.length === 1 ? fromTimelinePlainDateTime(assets[0].localDateTime) : DateTime.now();
     const success = await modalManager.show(AssetSelectionChangeDateModal, {
-      initialDate: DateTime.now(),
-      assets: getOwnedAssets(),
+      initialDate,
+      assets,
     });
     if (success) {
       clearSelect();


### PR DESCRIPTION
## Summary
- When editing the date of a single asset from the timeline, the change date popup now shows the asset's current date/time instead of the current time
- This matches the behavior in the Photo Viewer's Details panel
- When multiple assets are selected, continues using current time (reasonable for batch operations)

## Test Plan
- [x] Select single asset in timeline, open change date popup - shows asset's date
- [x] Select multiple assets in timeline, open change date popup - shows current time
- [x] Code follows existing pattern from detail-panel.svelte

Fixes #24321