### PR TITLE
fix(web): server stats layout

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsPanel.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsPanel.svelte
@@ -3,7 +3,7 @@
   import { locale } from '$lib/stores/preferences.store';
   import { getByteUnitString, getBytesWithUnit } from '$lib/utils/byte-units';
   import type { ServerStatsResponseDto } from '@immich/sdk';
-  import { Heading, Icon } from '@immich/ui';
+  import { Code, Heading, Icon, Text } from '@immich/ui';
   import { mdiCameraIris, mdiChartPie, mdiPlayCircle } from '@mdi/js';
   import { t } from 'svelte-i18n';
 
@@ -38,40 +38,40 @@
     <div class="mt-5 flex lg:hidden">
       <div class="flex flex-col justify-between rounded-3xl bg-subtle p-5 dark:bg-immich-dark-gray">
         <div class="flex flex-wrap gap-x-12">
-          <div class="flex place-items-center gap-4 text-primary">
+          <div class="flex flex-1 place-items-center gap-4 text-primary">
             <Icon icon={mdiCameraIris} size="25" />
-            <p class="uppercase">{$t('photos')}</p>
+            <Text fontWeight="bold" class="uppercase">{$t('photos')}</Text>
           </div>
 
           <div class="relative text-center font-mono text-2xl font-semibold">
-            <span class="text-[#DCDADA] dark:text-[#525252]">{zeros(stats.photos)}</span><span class="text-primary"
+            <span class="text-gray-400 dark:text-gray-600">{zeros(stats.photos)}</span><span class="text-primary"
               >{stats.photos}</span
             >
           </div>
         </div>
         <div class="flex flex-wrap gap-x-12">
-          <div class="flex place-items-center gap-4 text-primary">
+          <div class="flex flex-1 place-items-center gap-4 text-primary">
             <Icon icon={mdiPlayCircle} size="25" />
-            <p class="uppercase">{$t('videos')}</p>
+            <Text fontWeight="bold" class="uppercase">{$t('videos')}</Text>
           </div>
 
           <div class="relative text-center font-mono text-2xl font-semibold">
-            <span class="text-[#DCDADA] dark:text-[#525252]">{zeros(stats.videos)}</span><span class="text-primary"
+            <span class="text-gray-400 dark:text-gray-600">{zeros(stats.videos)}</span><span class="text-primary"
               >{stats.videos}</span
             >
           </div>
         </div>
-        <div class="flex flex-wrap gap-x-7">
-          <div class="flex place-items-center gap-4 text-primary">
+        <div class="flex flex-wrap gap-x-5">
+          <div class="flex flex-1 flex-nowrap place-items-center gap-4 text-primary">
             <Icon icon={mdiChartPie} size="25" />
-            <p class="uppercase">{$t('storage')}</p>
+            <Text fontWeight="bold" class="uppercase">{$t('storage')}</Text>
           </div>
 
           <div class="relative flex text-center font-mono text-2xl font-semibold">
-            <span class="text-[#DCDADA] dark:text-[#525252]">{zeros(statsUsage)}</span><span class="text-primary"
+            <span class="text-gray-400 dark:text-gray-600">{zeros(statsUsage)}</span><span class="text-primary"
               >{statsUsage}</span
             >
-            <span class="my-auto ms-2 text-center text-base font-light text-gray-400">{statsUsageUnit}</span>
+            <Code color="muted" class="font-light">{statsUsageUnit}</Code>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Change alignment of server stats card on small-ish screens. Not perfect because I don't know how to align 'ignoring' the unit text without making a table out of it. It's an improvement at least. Screenshots below.

Also, I updated the text styling (color, weight) to be in line with the full size layout.

Fixes #24939

## How Has This Been Tested?
Tested on:
- Big window
- Smaller window
- Even smaller window
- Super small window

<details><summary><h2>Screenshots</h2></summary>

Before:

<img width="532" height="248" alt="Image" src="https://github.com/user-attachments/assets/a27ba109-fa0a-4ebc-9e26-a290a21b9fa6" />

After:

<img width="713" height="390" alt="image" src="https://github.com/user-attachments/assets/0a6c573e-7917-41b9-98e8-15154df6bc11" />

</details>

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
