### PR TITLE
feat: use fastlane sigh to manage signing profiles

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -30,18 +30,6 @@ on:
         required: true
       IOS_CERTIFICATE_PASSWORD:
         required: true
-      IOS_PROVISIONING_PROFILE:
-        required: true
-      IOS_PROVISIONING_PROFILE_SHARE_EXTENSION:
-        required: true
-      IOS_PROVISIONING_PROFILE_WIDGET_EXTENSION:
-        required: true
-      IOS_DEVELOPMENT_PROVISIONING_PROFILE:
-        required: true
-      IOS_DEVELOPMENT_PROVISIONING_PROFILE_SHARE_EXTENSION:
-        required: true
-      IOS_DEVELOPMENT_PROVISIONING_PROFILE_WIDGET_EXTENSION:
-        required: true
       FASTLANE_TEAM_ID:
         required: true
   pull_request:
@@ -240,34 +228,13 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "$API_KEY_CONTENT" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8
 
-      - name: Import Certificate and Provisioning Profiles
+      - name: Import Certificate
         env:
           IOS_CERTIFICATE_P12: ${{ secrets.IOS_CERTIFICATE_P12 }}
-          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
-          IOS_PROVISIONING_PROFILE: ${{ secrets.IOS_PROVISIONING_PROFILE }}
-          IOS_PROVISIONING_PROFILE_SHARE_EXTENSION: ${{ secrets.IOS_PROVISIONING_PROFILE_SHARE_EXTENSION }}
-          IOS_PROVISIONING_PROFILE_WIDGET_EXTENSION: ${{ secrets.IOS_PROVISIONING_PROFILE_WIDGET_EXTENSION }}
-          IOS_DEVELOPMENT_PROVISIONING_PROFILE: ${{ secrets.IOS_DEVELOPMENT_PROVISIONING_PROFILE }}
-          IOS_DEVELOPMENT_PROVISIONING_PROFILE_SHARE_EXTENSION: ${{ secrets.IOS_DEVELOPMENT_PROVISIONING_PROFILE_SHARE_EXTENSION }}
-          IOS_DEVELOPMENT_PROVISIONING_PROFILE_WIDGET_EXTENSION: ${{ secrets.IOS_DEVELOPMENT_PROVISIONING_PROFILE_WIDGET_EXTENSION }}
-          ENVIRONMENT: ${{ inputs.environment || 'development' }}
         working-directory: ./mobile/ios
         run: |
           # Decode certificate
           echo "$IOS_CERTIFICATE_P12" | base64 --decode > certificate.p12
-
-          # Decode provisioning profiles based on environment
-          if [[ "$ENVIRONMENT" == "development" ]]; then
-            echo "$IOS_DEVELOPMENT_PROVISIONING_PROFILE" | base64 --decode > profile_dev.mobileprovision
-            echo "$IOS_DEVELOPMENT_PROVISIONING_PROFILE_SHARE_EXTENSION" | base64 --decode > profile_dev_share.mobileprovision
-            echo "$IOS_DEVELOPMENT_PROVISIONING_PROFILE_WIDGET_EXTENSION" | base64 --decode > profile_dev_widget.mobileprovision
-            ls -lh profile_dev*.mobileprovision
-          else
-            echo "$IOS_PROVISIONING_PROFILE" | base64 --decode > profile.mobileprovision
-            echo "$IOS_PROVISIONING_PROFILE_SHARE_EXTENSION" | base64 --decode > profile_share.mobileprovision
-            echo "$IOS_PROVISIONING_PROFILE_WIDGET_EXTENSION" | base64 --decode > profile_widget.mobileprovision
-            ls -lh profile*.mobileprovision
-          fi
 
       - name: Create keychain and import certificate
         env:

--- a/mobile/ios/.gitignore
+++ b/mobile/ios/.gitignore
@@ -34,3 +34,4 @@ Runner/GeneratedPluginRegistrant.*
 
 fastlane/report.xml
 Gemfile.lock
+certs/

--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -44,13 +44,8 @@ def get_version_from_pubspec
 end
   
   # Helper method to configure code signing for all targets
-  def configure_code_signing(bundle_id_suffix: "", profile_name_main: nil, profile_name_share: nil, profile_name_widget: nil)
+  def configure_code_signing(bundle_id_suffix: "", profile_name_main:, profile_name_share:, profile_name_widget:)
     bundle_suffix = bundle_id_suffix.empty? ? "" : ".#{bundle_id_suffix}"
-    
-    # Use provided profile names or fall back to default naming convention
-    main_profile = profile_name_main || "#{BASE_BUNDLE_ID}#{bundle_suffix} AppStore"
-    share_profile = profile_name_share || "#{BASE_BUNDLE_ID}#{bundle_suffix}.ShareExtension AppStore"
-    widget_profile = profile_name_widget || "#{BASE_BUNDLE_ID}#{bundle_suffix}.Widget AppStore"
     
     # Runner (main app)
     update_code_signing_settings(
@@ -59,7 +54,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}",
-      profile_name: main_profile,
+      profile_name: profile_name_main,
       targets: ["Runner"]
     )
     
@@ -70,7 +65,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}.ShareExtension",
-      profile_name: share_profile,
+      profile_name: profile_name_share,
       targets: ["ShareExtension"]
     )
     
@@ -81,7 +76,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}.Widget",
-      profile_name: widget_profile,
+      profile_name: profile_name_widget,
       targets: ["WidgetExtension"]
     )
   end
@@ -93,17 +88,12 @@ end
     configuration: "Release",
     distribute_external: true,
     version_number: nil,
-    profile_name_main: nil,
-    profile_name_share: nil,
-    profile_name_widget: nil
+    profile_name_main:,
+    profile_name_share:,
+    profile_name_widget:
   )
     bundle_suffix = bundle_id_suffix.empty? ? "" : ".#{bundle_id_suffix}"
     app_identifier = "#{BASE_BUNDLE_ID}#{bundle_suffix}"
-    
-    # Use provided profile names or fall back to default naming convention
-    main_profile = profile_name_main || "#{app_identifier} AppStore"
-    share_profile = profile_name_share || "#{app_identifier}.ShareExtension AppStore"
-    widget_profile = profile_name_widget || "#{app_identifier}.Widget AppStore"
     
     # Set version number if provided
     if version_number
@@ -128,9 +118,9 @@ end
       xcargs: "-skipMacroValidation CODE_SIGN_IDENTITY='#{CODE_SIGN_IDENTITY}' CODE_SIGN_STYLE=Manual",
       export_options: {
         provisioningProfiles: {
-          "#{app_identifier}" => main_profile,
-          "#{app_identifier}.ShareExtension" => share_profile,
-          "#{app_identifier}.Widget" => widget_profile
+          "#{app_identifier}" => profile_name_main,
+          "#{app_identifier}.ShareExtension" => profile_name_share,
+          "#{app_identifier}.Widget" => profile_name_widget
         },
         signingStyle: "manual",
         signingCertificate: CODE_SIGN_IDENTITY

--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -44,8 +44,13 @@ def get_version_from_pubspec
 end
   
   # Helper method to configure code signing for all targets
-  def configure_code_signing(bundle_id_suffix: "")
+  def configure_code_signing(bundle_id_suffix: "", profile_name_main: nil, profile_name_share: nil, profile_name_widget: nil)
     bundle_suffix = bundle_id_suffix.empty? ? "" : ".#{bundle_id_suffix}"
+    
+    # Use provided profile names or fall back to default naming convention
+    main_profile = profile_name_main || "#{BASE_BUNDLE_ID}#{bundle_suffix} AppStore"
+    share_profile = profile_name_share || "#{BASE_BUNDLE_ID}#{bundle_suffix}.ShareExtension AppStore"
+    widget_profile = profile_name_widget || "#{BASE_BUNDLE_ID}#{bundle_suffix}.Widget AppStore"
     
     # Runner (main app)
     update_code_signing_settings(
@@ -54,7 +59,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}",
-      profile_name: "#{BASE_BUNDLE_ID}#{bundle_suffix} AppStore",
+      profile_name: main_profile,
       targets: ["Runner"]
     )
     
@@ -65,7 +70,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}.ShareExtension",
-      profile_name: "#{BASE_BUNDLE_ID}#{bundle_suffix}.ShareExtension AppStore",
+      profile_name: share_profile,
       targets: ["ShareExtension"]
     )
     
@@ -76,7 +81,7 @@ end
       team_id: ENV["FASTLANE_TEAM_ID"] || TEAM_ID,
       code_sign_identity: CODE_SIGN_IDENTITY,
       bundle_identifier: "#{BASE_BUNDLE_ID}#{bundle_suffix}.Widget",
-      profile_name: "#{BASE_BUNDLE_ID}#{bundle_suffix}.Widget AppStore",
+      profile_name: widget_profile,
       targets: ["WidgetExtension"]
     )
   end
@@ -87,10 +92,18 @@ end
     bundle_id_suffix: "",
     configuration: "Release",
     distribute_external: true,
-    version_number: nil
+    version_number: nil,
+    profile_name_main: nil,
+    profile_name_share: nil,
+    profile_name_widget: nil
   )
     bundle_suffix = bundle_id_suffix.empty? ? "" : ".#{bundle_id_suffix}"
     app_identifier = "#{BASE_BUNDLE_ID}#{bundle_suffix}"
+    
+    # Use provided profile names or fall back to default naming convention
+    main_profile = profile_name_main || "#{app_identifier} AppStore"
+    share_profile = profile_name_share || "#{app_identifier}.ShareExtension AppStore"
+    widget_profile = profile_name_widget || "#{app_identifier}.Widget AppStore"
     
     # Set version number if provided
     if version_number
@@ -115,9 +128,9 @@ end
       xcargs: "-skipMacroValidation CODE_SIGN_IDENTITY='#{CODE_SIGN_IDENTITY}' CODE_SIGN_STYLE=Manual",
       export_options: {
         provisioningProfiles: {
-          "#{app_identifier}" => "#{app_identifier} AppStore",
-          "#{app_identifier}.ShareExtension" => "#{app_identifier}.ShareExtension AppStore",
-          "#{app_identifier}.Widget" => "#{app_identifier}.Widget AppStore"
+          "#{app_identifier}" => main_profile,
+          "#{app_identifier}.ShareExtension" => share_profile,
+          "#{app_identifier}.Widget" => widget_profile
         },
         signingStyle: "manual",
         signingCertificate: CODE_SIGN_IDENTITY
@@ -136,20 +149,35 @@ end
   lane :gha_testflight_dev do
     api_key = get_api_key
     
-    # Install development provisioning profiles
-    install_provisioning_profile(path: "profile_dev.mobileprovision")
-    install_provisioning_profile(path: "profile_dev_share.mobileprovision")
-    install_provisioning_profile(path: "profile_dev_widget.mobileprovision")
+    # Download and install provisioning profiles from App Store Connect
+    # Certificate is imported by GHA workflow into build.keychain
+    # Capture profile names after each sigh call
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development", force: true)
+    main_profile_name = lane_context[SharedValues::SIGH_NAME]
     
-    # Configure code signing for dev bundle IDs
-    configure_code_signing(bundle_id_suffix: "development")
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development.ShareExtension", force: true)
+    share_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development.Widget", force: true)
+    widget_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    # Configure code signing for dev bundle IDs using the downloaded profile names
+    configure_code_signing(
+      bundle_id_suffix: "development",
+      profile_name_main: main_profile_name,
+      profile_name_share: share_profile_name,
+      profile_name_widget: widget_profile_name
+    )
     
     # Build and upload
     build_and_upload(
       api_key: api_key,
       bundle_id_suffix: "development",
       configuration: "Profile",
-      distribute_external: false
+      distribute_external: false,
+      profile_name_main: main_profile_name,
+      profile_name_share: share_profile_name,
+      profile_name_widget: widget_profile_name
     )
   end
 
@@ -157,20 +185,33 @@ end
   lane :gha_release_prod do
     api_key = get_api_key
     
-    # Install provisioning profiles
-    install_provisioning_profile(path: "profile.mobileprovision")
-    install_provisioning_profile(path: "profile_share.mobileprovision")
-    install_provisioning_profile(path: "profile_widget.mobileprovision")
+    # Download and install provisioning profiles from App Store Connect
+    # Certificate is imported by GHA workflow into build.keychain
+    sigh(api_key: api_key, app_identifier: BASE_BUNDLE_ID, force: true)
+    main_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.ShareExtension", force: true)
+    share_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.Widget", force: true)
+    widget_profile_name = lane_context[SharedValues::SIGH_NAME]
     
     
     # Configure code signing for production bundle IDs
-    configure_code_signing
+    configure_code_signing(
+      profile_name_main: main_profile_name,
+      profile_name_share: share_profile_name,
+      profile_name_widget: widget_profile_name
+    )
 
     # Build and upload with version number
     build_and_upload(
       api_key: api_key,
       version_number: get_version_from_pubspec,
       distribute_external: false,
+      profile_name_main: main_profile_name,
+      profile_name_share: share_profile_name,
+      profile_name_widget: widget_profile_name
     )
   end
 
@@ -215,13 +256,26 @@ end
     # Use the same build process as production, just skip the upload
     # This ensures PR builds validate the same way as production builds
     
-    # Install provisioning profiles (use development profiles for PR builds)
-    install_provisioning_profile(path: "profile_dev.mobileprovision")
-    install_provisioning_profile(path: "profile_dev_share.mobileprovision")
-    install_provisioning_profile(path: "profile_dev_widget.mobileprovision")
+    api_key = get_api_key
+    
+    # Download and install provisioning profiles from App Store Connect
+    # Certificate is imported by GHA workflow into build.keychain
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development", force: true)
+    main_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development.ShareExtension", force: true)
+    share_profile_name = lane_context[SharedValues::SIGH_NAME]
+    
+    sigh(api_key: api_key, app_identifier: "#{BASE_BUNDLE_ID}.development.Widget", force: true)
+    widget_profile_name = lane_context[SharedValues::SIGH_NAME]
     
     # Configure code signing for dev bundle IDs
-    configure_code_signing(bundle_id_suffix: "development")
+    configure_code_signing(
+      bundle_id_suffix: "development",
+      profile_name_main: main_profile_name,
+      profile_name_share: share_profile_name,
+      profile_name_widget: widget_profile_name
+    )
     
     # Build the app (same as gha_testflight_dev but without upload)
     build_app(
@@ -233,9 +287,9 @@ end
       xcargs: "-skipMacroValidation CODE_SIGN_IDENTITY='#{CODE_SIGN_IDENTITY}' CODE_SIGN_STYLE=Manual",
       export_options: {
         provisioningProfiles: {
-          "#{BASE_BUNDLE_ID}.development" => "#{BASE_BUNDLE_ID}.development AppStore",
-          "#{BASE_BUNDLE_ID}.development.ShareExtension" => "#{BASE_BUNDLE_ID}.development.ShareExtension AppStore",
-          "#{BASE_BUNDLE_ID}.development.Widget" => "#{BASE_BUNDLE_ID}.development.Widget AppStore"
+          "#{BASE_BUNDLE_ID}.development" => main_profile_name,
+          "#{BASE_BUNDLE_ID}.development.ShareExtension" => share_profile_name,
+          "#{BASE_BUNDLE_ID}.development.Widget" => widget_profile_name
         },
         signingStyle: "manual",
         signingCertificate: CODE_SIGN_IDENTITY


### PR DESCRIPTION
This PR uses the `fastlane sigh` command to manage the signing profiles for GitHub action instead of manually installing pre-generated profiles from files.

Profiles are now fetched from App Store Connect on each build.