### PR TITLE
chore: use setup-uv action to install python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -572,11 +572,8 @@ jobs:
           token: ${{ steps.token.outputs.token }}
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
-      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        # TODO: add caching when supported (https://github.com/actions/setup-python/pull/818)
         with:
           python-version: 3.11
-          #cache: 'uv'
       - name: Install dependencies
         run: |
           uv sync --extra cpu


### PR DESCRIPTION
The setup-uv action can [manage the python installation](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#python-version) and persists [uv's cache](https://github.com/actions/setup-python/pull/818#issuecomment-2415302675).

See [their FAQ](https://github.com/astral-sh/setup-uv?tab=readme-ov-file#do-i-still-need-actionssetup-python-alongside-setup-uv).

related to #25066

EDIT: possibly omit the python version at all to match with https://github.com/immich-app/immich/blob/main/.github/workflows/prepare-release.yml#L66:L67 and https://github.com/immich-app/immich/blob/main/.github/workflows/release-pr.yml#L33:L34. The python version set in `pyproject.toml` would then be used (as per uv docs).
