### PR TITLE
feat: add server-wide storage quota configuration

### DIFF
--- a/docs/docs/administration/system-settings.md
+++ b/docs/docs/administration/system-settings.md
@@ -174,6 +174,27 @@ Overrides the domain name in shared links and email notifications. The URL shoul
 
 The administrator can set a custom message on the login screen (the message will be displayed to all users).
 
+### Server Storage Quota
+
+Configure a server-wide storage quota that limits the total storage used across all users on the instance. This complements per-user quotas and provides an additional layer of control.
+
+**Configuration options:**
+
+- **UI**: Enter the quota value in GiB (gibibytes). Leave empty for unlimited (default).
+- **Config file**: Use gigabytes (number): `"storageQuotaSizeInGigabytes": 100` (for 100GiB)
+
+**How it works:**
+
+- When enabled, the server-wide quota limits the total storage across all users
+- Both per-user quotas and server-wide quota are checked during uploads
+- If either quota would be exceeded, the upload is rejected
+- External libraries do not count toward the quota (same as per-user quotas)
+
+**Default behavior:**
+
+- Disabled by default (`null`) - no server-wide quota enforcement
+- Existing instances are unaffected unless explicitly configured
+
 ## Storage Template
 
 Immich supports a custom [Storage Template](/administration/storage-template). Learn more about this feature and its configuration [here](/administration/storage-template).

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -305,6 +305,8 @@
     "server_stats_page_description": "Admin server statistics page",
     "server_welcome_message": "Welcome message",
     "server_welcome_message_description": "A message that is displayed on the login page.",
+    "server_storage_quota_gib": "Server Storage Quota (GiB)",
+    "server_storage_quota_gib_description": "Total storage allowed across all users. Leave empty or set to 0 for unlimited. External libraries do not count towards this quota.",
     "settings_page_description": "Admin settings page",
     "sidecar_job": "Sidecar metadata",
     "sidecar_job_description": "Discover or synchronize sidecar metadata from the filesystem",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -19417,6 +19417,17 @@
             "default": 0,
             "type": "integer"
           },
+          "serverQuotaSizeInBytes": {
+            "default": null,
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "serverQuotaUsageInBytes": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          },
           "usage": {
             "default": 0,
             "format": "int64",
@@ -19456,6 +19467,8 @@
         },
         "required": [
           "photos",
+          "serverQuotaSizeInBytes",
+          "serverQuotaUsageInBytes",
           "usage",
           "usageByUser",
           "usagePhotos",
@@ -21989,12 +22002,18 @@
           },
           "publicUsers": {
             "type": "boolean"
+          },
+          "storageQuotaSizeInGigabytes": {
+            "minimum": 0,
+            "nullable": true,
+            "type": "number"
           }
         },
         "required": [
           "externalDomain",
           "loginPageMessage",
-          "publicUsers"
+          "publicUsers",
+          "storageQuotaSizeInGigabytes"
         ],
         "type": "object"
       },

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -183,6 +183,7 @@ export interface SystemConfig {
     externalDomain: string;
     loginPageMessage: string;
     publicUsers: boolean;
+    storageQuotaSizeInGigabytes: number | null;
   };
   user: {
     deleteDelay: number;
@@ -363,6 +364,7 @@ export const defaults = Object.freeze<SystemConfig>({
     externalDomain: '',
     loginPageMessage: '',
     publicUsers: true,
+    storageQuotaSizeInGigabytes: null,
   },
   notifications: {
     smtp: {

--- a/server/src/dtos/server.dto.ts
+++ b/server/src/dtos/server.dto.ts
@@ -116,6 +116,12 @@ export class ServerStatsResponseDto {
   @ApiProperty({ type: 'integer', format: 'int64' })
   usageVideos = 0;
 
+  @ApiProperty({ type: 'integer', format: 'int64', nullable: true })
+  serverQuotaSizeInBytes: number | null = null;
+
+  @ApiProperty({ type: 'integer', format: 'int64' })
+  serverQuotaUsageInBytes = 0;
+
   @ApiProperty({
     isArray: true,
     type: UsageByUserDto,

--- a/server/src/dtos/system-config.dto.ts
+++ b/server/src/dtos/system-config.dto.ts
@@ -465,6 +465,12 @@ class SystemConfigServerDto {
 
   @ValidateBoolean()
   publicUsers!: boolean;
+
+  @IsNumber()
+  @Min(0)
+  @Optional({ nullable: true })
+  @ApiProperty({ type: 'number', nullable: true })
+  storageQuotaSizeInGigabytes!: number | null;
 }
 
 class SystemConfigSmtpTransportDto {

--- a/server/src/services/server.service.spec.ts
+++ b/server/src/services/server.service.spec.ts
@@ -206,6 +206,7 @@ describe(ServerService.name, () => {
           quotaSizeInBytes: 0,
         },
       ]);
+      mocks.systemMetadata.get.mockResolvedValue(null);
 
       await expect(sut.getStatistics()).resolves.toEqual({
         photos: 120,
@@ -213,6 +214,8 @@ describe(ServerService.name, () => {
         usage: 1_123_455,
         usagePhotos: 1001,
         usageVideos: 122_455,
+        serverQuotaSizeInBytes: null,
+        serverQuotaUsageInBytes: 1_123_455,
         usageByUser: [
           {
             photos: 10,

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -138,6 +138,7 @@ export class ServerService extends BaseService {
   async getStatistics(): Promise<ServerStatsResponseDto> {
     const userStats: UserStatsQueryResponse[] = await this.userRepository.getUserStats();
     const serverStats = new ServerStatsResponseDto();
+    const config = await this.getConfig({ withCache: false });
 
     for (const user of userStats) {
       const usage = new UsageByUserDto();
@@ -158,6 +159,12 @@ export class ServerService extends BaseService {
 
       serverStats.usageByUser.push(usage);
     }
+
+    // Set server-wide quota information
+    // Convert from GiB (config) to bytes (API response)
+    serverStats.serverQuotaSizeInBytes =
+      config.server.storageQuotaSizeInGigabytes === null ? null : config.server.storageQuotaSizeInGigabytes * 1024 ** 3;
+    serverStats.serverQuotaUsageInBytes = serverStats.usage;
 
     return serverStats;
   }

--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -155,6 +155,7 @@ const updatedConfig = Object.freeze<SystemConfig>({
     externalDomain: '',
     loginPageMessage: '',
     publicUsers: true,
+    storageQuotaSizeInGigabytes: null,
   },
   storageTemplate: {
     enabled: false,

--- a/server/test/fixtures/system-config.stub.ts
+++ b/server/test/fixtures/system-config.stub.ts
@@ -117,4 +117,14 @@ export const systemConfigStub = {
       publicUsers: false,
     },
   },
+  serverQuotaEnabled: {
+    server: {
+      storageQuotaSizeInGigabytes: 100,
+    },
+  },
+  serverQuotaDisabled: {
+    server: {
+      storageQuotaSizeInGigabytes: null,
+    },
+  },
 } satisfies Record<string, DeepPartial<SystemConfig>>;

--- a/web/src/lib/components/admin-settings/ServerSettings.svelte
+++ b/web/src/lib/components/admin-settings/ServerSettings.svelte
@@ -5,12 +5,32 @@
   import { SettingInputFieldType } from '$lib/constants';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { systemConfigManager } from '$lib/managers/system-config-manager.svelte';
+  import { userInteraction } from '$lib/stores/user.svelte';
+  import { ByteUnit, convertToBytes } from '$lib/utils/byte-units';
+  import { Text } from '@immich/ui';
   import { t } from 'svelte-i18n';
   import { fade } from 'svelte/transition';
 
   const disabled = $derived(featureFlagsManager.value.configFile);
   const config = $derived(systemConfigManager.value);
   let configToEdit = $state(systemConfigManager.cloneValue());
+
+  const previousQuota = $state(config.server.storageQuotaSizeInGigabytes);
+
+  const quotaSizeBytes = $derived(
+    typeof configToEdit.server.storageQuotaSizeInGigabytes === 'number'
+      ? convertToBytes(configToEdit.server.storageQuotaSizeInGigabytes, ByteUnit.GiB)
+      : null,
+  );
+
+  let quotaSizeWarning = $derived(
+    previousQuota !== configToEdit.server.storageQuotaSizeInGigabytes &&
+      typeof configToEdit.server.storageQuotaSizeInGigabytes === 'number' &&
+      configToEdit.server.storageQuotaSizeInGigabytes > 0 &&
+      userInteraction.serverInfo &&
+      quotaSizeBytes !== null &&
+      quotaSizeBytes > userInteraction.serverInfo.diskSizeRaw,
+  );
 </script>
 
 <div>
@@ -39,6 +59,22 @@
           {disabled}
           bind:checked={configToEdit.server.publicUsers}
         />
+
+        <SettingInputField
+          inputType={SettingInputFieldType.NUMBER}
+          label={$t('admin.server_storage_quota_gib')}
+          description={$t('admin.server_storage_quota_gib_description')}
+          bind:value={configToEdit.server.storageQuotaSizeInGigabytes}
+          min={0}
+          step="1"
+          {disabled}
+          isEdited={configToEdit.server.storageQuotaSizeInGigabytes !== config.server.storageQuotaSizeInGigabytes}
+        />
+        {#if quotaSizeWarning}
+          <div class="ms-4 mt-2">
+            <Text size="small" color="danger">{$t('errors.quota_higher_than_disk_size')}</Text>
+          </div>
+        {/if}
 
         <div class="ms-4">
           <SettingButtonsRow bind:configToEdit keys={['server']} {disabled} />

--- a/web/src/lib/stores/user.svelte.ts
+++ b/web/src/lib/stores/user.svelte.ts
@@ -2,6 +2,7 @@ import { eventManager } from '$lib/managers/event-manager.svelte';
 import type {
   AlbumResponseDto,
   ServerAboutResponseDto,
+  ServerStatsResponseDto,
   ServerStorageResponseDto,
   ServerVersionHistoryResponseDto,
 } from '@immich/sdk';
@@ -11,6 +12,7 @@ interface UserInteractions {
   versions?: ServerVersionHistoryResponseDto[];
   aboutInfo?: ServerAboutResponseDto;
   serverInfo?: ServerStorageResponseDto;
+  serverStats?: ServerStatsResponseDto;
 }
 
 const defaultUserInteraction: UserInteractions = {
@@ -18,6 +20,7 @@ const defaultUserInteraction: UserInteractions = {
   versions: undefined,
   aboutInfo: undefined,
   serverInfo: undefined,
+  serverStats: undefined,
 };
 
 export const userInteraction = $state<UserInteractions>(defaultUserInteraction);


### PR DESCRIPTION
## Description

Adds an optional server-wide storage quota feature that limits total storage across all users, complementing the existing per-user quota system. This feature is useful for self-hosted instances where administrators want to control total storage usage across all users, not just individual user limits.

**Why is this change required?**
For self-hosted Immich instances, administrators may want to set a total storage limit for the entire server, in addition to (or instead of) per-user quotas. This is especially useful for:
- Shared instances where total storage costs need to be managed
- Instances with many users where setting individual quotas is impractical
- Organizations that want both user-level and server-level storage controls

**What problem does it solve?**
Currently, Immich only supports per-user storage quotas. This feature adds a complementary server-wide quota that works alongside per-user quotas, giving administrators more flexibility in managing storage.

## How Has This Been Tested?

- [x] Unit tests added for server quota enforcement in `asset-media.service.spec.ts`
  - Server quota exceeded scenario
  - Server quota disabled (null) scenario
  - Server quota enabled and satisfied scenario
  - Interaction with per-user quotas
  - Server quota checked even when user quota is unlimited
- [x] Updated existing tests in `server.service.spec.ts` and `system-config.service.spec.ts` to include new config field
- [x] All existing tests pass (1997 tests)
- [x] Manual testing:
  - Configured server quota via UI (Administration → Settings → Server Settings)
  - Configured server quota via config file
  - Verified uploads are rejected when server quota is exceeded
  - Verified storage space component displays server quota when enabled
  - Verified fallback behavior (user quota → server quota → disk space)

## How It Works

- When enabled, both per-user and server-wide quotas are checked during uploads
- If either quota would be exceeded, the upload is rejected
- External libraries do not count toward the quota (consistent with per-user quotas)
- Priority for display: User quota → Server quota → Disk space

## Configuration

**UI**: Administration → Settings → Server Settings → "Server Storage Quota (GiB)"

<img width="1093" height="586" alt="Screenshot 2026-01-07 at 17 35 30" src="https://github.com/user-attachments/assets/a0ea050e-3287-4518-98c1-575c48dd67e6" />



**Config File**:
```{
  "server": {
    "storageQuotaSizeInGigabytes": 100
  }
}
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Breaking Changes

None - feature is opt-in and disabled by default.

I would love to help get this merged and to work in any feedback there might be.