### PR TITLE
fix(docs): Use full git clone in CI to enable accurate last update times

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           persist-credentials: false
           token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0


### PR DESCRIPTION
## Summary

This PR fixes the docs build CI to use a full git clone instead of a shallow clone, enabling Docusaurus to accurately display last update times for markdown pages.

## Problem

Currently, the last update time shown on all documentation pages is always the same, matching the latest deployment date. This happens because the CI workflow uses a shallow clone (the default for `actions/checkout`), which doesn't include the full git history needed by Docusaurus to determine when each page was last modified.

## Solution

Added `fetch-depth: 0` to the checkout step in `.github/workflows/docs-build.yml` to ensure a full clone with complete git history. This allows Docusaurus to access the git history during the build process and correctly display the last update time for each page.

## Reference

- [Docusaurus `showLastUpdateTime` documentation](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-pages#showLastUpdateTime)

## Testing

The next docs build will fetch the full git history, and each page should display its actual last update time instead of the deployment date.
