### PR TITLE
fix(web): added background gradient for video time visibility

### DIFF
--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -343,9 +343,7 @@
         onComplete={(errored) => ((loaded = true), (thumbError = errored))}
       />
       {#if asset.isVideo}
-        <div
-          class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
-        >
+        <div class="absolute top-0 h-full w-full pointer-events-none">
           <VideoThumbnail
             url={getAssetPlaybackUrl({ id: asset.id, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}
@@ -355,9 +353,7 @@
           />
         </div>
       {:else if asset.isImage && asset.livePhotoVideoId}
-        <div
-          class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
-        >
+        <div class="absolute top-0 h-full w-full pointer-events-none">
           <VideoThumbnail
             url={getAssetPlaybackUrl({ id: asset.livePhotoVideoId, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}

--- a/web/src/lib/components/assets/thumbnail/thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/thumbnail.svelte
@@ -343,7 +343,9 @@
         onComplete={(errored) => ((loaded = true), (thumbError = errored))}
       />
       {#if asset.isVideo}
-        <div class="absolute top-0 h-full w-full pointer-events-none">
+        <div
+          class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
+        >
           <VideoThumbnail
             url={getAssetPlaybackUrl({ id: asset.id, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}
@@ -353,7 +355,9 @@
           />
         </div>
       {:else if asset.isImage && asset.livePhotoVideoId}
-        <div class="absolute top-0 h-full w-full pointer-events-none">
+        <div
+          class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
+        >
           <VideoThumbnail
             url={getAssetPlaybackUrl({ id: asset.livePhotoVideoId, cacheKey: asset.thumbhash })}
             enablePlayback={mouseOver && $playVideoThumbnailOnHover}

--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -83,6 +83,9 @@
       );
     }}
   ></video>
+  <div
+    class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
+  ></div>
 {/if}
 
 <div class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">

--- a/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
+++ b/web/src/lib/components/assets/thumbnail/video-thumbnail.svelte
@@ -83,12 +83,11 @@
       );
     }}
   ></video>
-  <div
-    class="absolute top-0 h-full w-full pointer-events-none bg-linear-to-b from-black/25 via-[transparent_25%]"
-  ></div>
 {/if}
 
-<div class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white">
+<div
+  class="absolute end-0 top-0 flex place-items-center gap-1 text-xs font-medium text-white text-shadow-[1px_1px_6px_rgb(0_0_0)]"
+>
   {#if showTime}
     <span class="pt-2">
       {#if remainingSeconds < 60}
@@ -102,7 +101,7 @@
   {/if}
 
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <span class="pe-2 pt-2" onmouseenter={onMouseEnter} onmouseleave={onMouseLeave}>
+  <span class="pe-2 pt-2 drop-shadow-[1px_1px_6px_rgb(0_0_0)]" onmouseenter={onMouseEnter} onmouseleave={onMouseLeave}>
     {#if enablePlayback}
       {#if loading}
         <LoadingSpinner />


### PR DESCRIPTION
## Description
Added gradients to video thumbnail and video playback on hover.
This leads to clear timestamp visibility on white/bright backgrounds

Fixes #10213 

## How Has This Been Tested?
Tested by running application locally in development environment


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
before changes:
<img width="531" height="626" alt="image" src="https://github.com/user-attachments/assets/6b2830f8-d67d-4ada-8c71-a26c6dde18dd" />

after changes:
<img width="562" height="631" alt="image" src="https://github.com/user-attachments/assets/bfd7faf9-6e5c-4ce6-a0e6-65bc98460bf6" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
NONE
