### PR TITLE
fix(server): avoid upserting empty metadata array

### DIFF
--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -433,7 +433,7 @@ export class AssetMediaService extends BaseService {
       originalFileName: dto.filename || file.originalName,
     });
 
-    if (dto.metadata) {
+    if (dto.metadata?.length) {
       await this.assetRepository.upsertMetadata(asset.id, dto.metadata);
     }
 


### PR DESCRIPTION
- Prevents metadata upsert when metadata is an empty array ([] is always truthy in JS/TS)
- Uses a length check instead of truthiness to match intended behavior

resolves:
```
[Nest] 23  - 01/08/2026, 9:37:31 PM   ERROR [Api:AssetMediaService~2g69cv1m] Error uploading file PostgresError: syntax error at or near ")"
PostgresError: syntax error at or near ")"
    at ErrorResponse (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:794:26)
    at handle (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:480:6)
    at Socket.data (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.7/node_modules/postgres/cjs/src/connection.js:315:9)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TCP.onStreamRead (node:internal/stream_base_commons:189:23)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)
```

this error can be reproduced on the server by running

```
# first request
printf '\xFF\xD8\xFF\xD9' > /tmp/minimal.jpg && \
  curl -X POST "http://ip/api/assets" \
    -H "x-api-key: key" \
    -F "assetData=@/tmp/minimal.jpg" \
    -F "deviceAssetId=test-image-12345" \
    -F "deviceId=curl-test-client" \
    -F "fileCreatedAt=2024-01-15T10:30:00.000Z" \
    -F "fileModifiedAt=2024-01-15T10:30:00.000Z" \
    -F 'metadata=[]' && \
  rm /tmp/minimal.jpg

{"message":"Failed to upload asset","error":"Internal Server Error","statusCode":500,"correlationId":"16cbzwls"}

# second request
printf printf '\xFF\xD8\xFF\xD9' > /tmp/minimal.jpg && \
  curl -X POST "http://ip/api/assets" \
    -H "x-api-key: key" \
    -F "assetData=@/tmp/minimal.jpg" \
    -F "deviceAssetId=test-image-12345" \
    -F "deviceId=curl-test-client" \
    -F "fileCreatedAt=2024-01-15T10:30:00.000Z" \
    -F "fileModifiedAt=2024-01-15T10:30:00.000Z" \
    -F 'metadata=[]' && \
  rm /tmp/minimal.jpg

{"status":"duplicate","id":"cc099558-de68-46fe-9126-e18b0c658ed8"}
```
_First upload: asset is created → metadata upsert fails → error is thrown → asset remains in DB.
Second upload: duplicate detected (checksum constraint) → handled gracefully in handleUploadError → returns success response._