### PR TITLE
fix(server): Document HTTP 200 response for duplicate uploads in OpenAPI

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3753,7 +3753,7 @@
                 }
               }
             },
-            "description": "Asset replaced or duplicate detected"
+            "description": "Asset replaced successfully"
           }
         },
         "security": [

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -2528,6 +2528,16 @@
           "required": true
         },
         "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetMediaResponseDto"
+                }
+              }
+            },
+            "description": "Asset is a duplicate"
+          },
           "201": {
             "content": {
               "application/json": {
@@ -2536,7 +2546,7 @@
                 }
               }
             },
-            "description": ""
+            "description": "Asset uploaded successfully"
           }
         },
         "security": [
@@ -3743,7 +3753,17 @@
                 }
               }
             },
-            "description": ""
+            "description": "Asset is a duplicate"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetMediaResponseDto"
+                }
+              }
+            },
+            "description": "Asset replaced successfully"
           }
         },
         "security": [

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3753,17 +3753,7 @@
                 }
               }
             },
-            "description": "Asset is a duplicate"
-          },
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AssetMediaResponseDto"
-                }
-              }
-            },
-            "description": "Asset replaced successfully"
+            "description": "Asset replaced or duplicate detected"
           }
         },
         "security": [

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2679,9 +2679,6 @@ export function replaceAsset({ id, key, slug, assetMediaReplaceDto }: {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
         data: AssetMediaResponseDto;
-    } | {
-        status: 201;
-        data: AssetMediaResponseDto;
     }>(`/assets/${encodeURIComponent(id)}/original${QS.query(QS.explode({
         key,
         slug

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2390,6 +2390,9 @@ export function uploadAsset({ key, slug, xImmichChecksum, assetMediaCreateDto }:
     assetMediaCreateDto: AssetMediaCreateDto;
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: AssetMediaResponseDto;
+    } | {
         status: 201;
         data: AssetMediaResponseDto;
     }>(`/assets${QS.query(QS.explode({
@@ -2675,6 +2678,9 @@ export function replaceAsset({ id, key, slug, assetMediaReplaceDto }: {
 }, opts?: Oazapfts.RequestOpts) {
     return oazapfts.ok(oazapfts.fetchJson<{
         status: 200;
+        data: AssetMediaResponseDto;
+    } | {
+        status: 201;
         data: AssetMediaResponseDto;
     }>(`/assets/${encodeURIComponent(id)}/original${QS.query(QS.explode({
         key,

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -115,7 +115,7 @@ export class AssetMediaController {
   @ApiConsumes('multipart/form-data')
   @ApiResponse({
     status: 200,
-    description: 'Asset replaced or duplicate detected',
+    description: 'Asset replaced successfully',
     type: AssetMediaResponseDto,
   })
   @Endpoint({

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -115,12 +115,7 @@ export class AssetMediaController {
   @ApiConsumes('multipart/form-data')
   @ApiResponse({
     status: 200,
-    description: 'Asset is a duplicate',
-    type: AssetMediaResponseDto,
-  })
-  @ApiResponse({
-    status: 201,
-    description: 'Asset replaced successfully',
+    description: 'Asset replaced or duplicate detected',
     type: AssetMediaResponseDto,
   })
   @Endpoint({

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -15,7 +15,7 @@ import {
   UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common';
-import { ApiBody, ApiConsumes, ApiHeader, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiHeader, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { NextFunction, Request, Response } from 'express';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import {
@@ -62,6 +62,16 @@ export class AssetMediaController {
     required: false,
   })
   @ApiBody({ description: 'Asset Upload Information', type: AssetMediaCreateDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Asset is a duplicate',
+    type: AssetMediaResponseDto,
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Asset uploaded successfully',
+    type: AssetMediaResponseDto,
+  })
   @Endpoint({
     summary: 'Upload asset',
     description: 'Uploads a new asset to the server.',
@@ -103,6 +113,16 @@ export class AssetMediaController {
   @Put(':id/original')
   @UseInterceptors(FileUploadInterceptor)
   @ApiConsumes('multipart/form-data')
+  @ApiResponse({
+    status: 200,
+    description: 'Asset is a duplicate',
+    type: AssetMediaResponseDto,
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Asset replaced successfully',
+    type: AssetMediaResponseDto,
+  })
   @Endpoint({
     summary: 'Replace asset',
     description: 'Replace the asset with new file, without changing its id.',


### PR DESCRIPTION
## Problem

The server returns HTTP 200 for duplicate asset uploads, but the OpenAPI spec only documented HTTP 201. This caused generated clients to fail deserializing duplicate responses.

## Solution

Added `@ApiResponse` decorators to document both HTTP 200 (duplicates) and HTTP 201 (success) responses for upload and replace endpoints (only 200 resp.)

## Changes

- Added `@ApiResponse` decorators for 200 and 201 status codes
- Updated OpenAPI spec to include both responses
- Updated TypeScript SDK to handle both status codes

Fixes issue where Python client returns `None` for duplicate uploads.
