### PR TITLE
fix(mobile): prevent system UI from hiding on drag down gesture

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -527,7 +527,9 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
   void _onScaleStateChanged(PhotoViewScaleState scaleState) {
     if (scaleState != PhotoViewScaleState.initial) {
-      if (!dragInProgress) ref.read(assetViewerProvider.notifier).setControls(false);
+      if (!dragInProgress) {
+        ref.read(assetViewerProvider.notifier).setControls(false);
+      }
       ref.read(videoPlayerControlsProvider.notifier).pause();
       return;
     }

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -527,7 +527,7 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
 
   void _onScaleStateChanged(PhotoViewScaleState scaleState) {
     if (scaleState != PhotoViewScaleState.initial) {
-      ref.read(assetViewerProvider.notifier).setControls(false);
+      if (!dragInProgress) ref.read(assetViewerProvider.notifier).setControls(false);
       ref.read(videoPlayerControlsProvider.notifier).pause();
       return;
     }


### PR DESCRIPTION
## Description

Fixes small bug introduced in #24784: the controls would briefly hide during the asset viewer drag down gesture, causing the system UI to hide as well. In some cases, this would cause UI elements (mainly the bottom bar) to shift around when dismissing the asset viewer via the gesture. 

## How Has This Been Tested?

Tested on android device. Confirmed the controls/system UI no longer hide during the gesture and tested to make sure this fix doesn't cause any unintended regression in the auto hide/show controls mechanism.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Before:

https://github.com/user-attachments/assets/180d3830-52ef-4826-98f4-0a66a0b932e1


After:

https://github.com/user-attachments/assets/a0f2cc32-8ef4-4f11-af22-3855f8d13385


</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Not used.
