### PR TITLE
fix(web): redirect to login

### DIFF
--- a/web/src/lib/utils/auth.ts
+++ b/web/src/lib/utils/auth.ts
@@ -11,7 +11,7 @@ import { AppRoute } from '../constants';
 
 export interface AuthOptions {
   admin?: true;
-  public?: true;
+  public?: boolean;
 }
 
 export const loadUser = async () => {

--- a/web/src/routes/(user)/+layout.ts
+++ b/web/src/routes/(user)/+layout.ts
@@ -1,7 +1,9 @@
-import { getAssetInfoFromParam } from '$lib/utils/navigation';
+import { authenticate } from '$lib/utils/auth';
+import { getAssetInfoFromParam, isSharedLinkRoute } from '$lib/utils/navigation';
 import type { LayoutLoad } from './$types';
 
-export const load = (async ({ params }) => {
+export const load = (async ({ url, params, route }) => {
+  await authenticate(url, { public: isSharedLinkRoute(route.id) });
   const asset = await getAssetInfoFromParam(params);
 
   return {

--- a/web/src/routes/admin/+layout.ts
+++ b/web/src/routes/admin/+layout.ts
@@ -1,6 +1,8 @@
 import { systemConfigManager } from '$lib/managers/system-config-manager.svelte';
+import { authenticate } from '$lib/utils/auth';
 import type { LayoutLoad } from './$types';
 
-export const load = (async () => {
+export const load = (async ({ url }) => {
+  await authenticate(url, { admin: true });
   await systemConfigManager.init();
 }) satisfies LayoutLoad;


### PR DESCRIPTION
Fix a few pages that were not redirecting to the login page, but would instead show an error (401 authentication required)