### PR TITLE
fix: Swagger UI generates incorrect double-prefixed URLs (/api/api/...)

### DIFF
--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -261,6 +261,7 @@ export const useSwagger = (app: INestApplication, { write }: { write: boolean })
   const options: SwaggerDocumentOptions = {
     operationIdFactory: (controllerKey: string, methodKey: string) => methodKey,
     extraModels: extraSyncModels,
+    ignoreGlobalPrefix: true,
   };
 
   const specification = SwaggerModule.createDocument(app, config, options);


### PR DESCRIPTION
- fix: #24781
  - we can confirm this issue on https://demo.immich.app/doc
    <img width="438" height="300" alt="image" src="https://github.com/user-attachments/assets/cc4ef7f5-87db-4748-8601-ec7d60105b74" />

Because the app uses `app.setGlobalPrefix('api')`, Swagger UI applied /api twice (global prefix + `addServer('/api')`), causing “Try it out - Execute” requests to be sent to /api/api/*.