### PR TITLE
fix(mobile): indicators not showing on thumbnail tile after asset change in viewer

### DIFF
--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -48,10 +48,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
   Widget build(BuildContext context) {
     final asset = widget.asset;
     final heroIndex = widget.heroOffset ?? TabsRouterScope.of(context)?.controller.activeIndex ?? 0;
-    // Only watch if this specific tile's asset is the current asset
     final isCurrentAsset = ref.watch(assetViewerProvider.select((current) => current.currentAsset == asset));
-
-    log.info("Thumbnail: ${asset!.name} rebuilt");
 
     final assetContainerColor = context.isDarkTheme
         ? context.primaryColor.darken(amount: 0.4)
@@ -102,7 +99,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                 Positioned.fill(
                   child: Hero(
                     key: ValueKey(isCurrentAsset),
-                    tag: '${asset.heroTag}_$heroIndex',
+                    tag: '${asset!.heroTag}_$heroIndex',
                     child: Thumbnail.fromAsset(asset: asset, size: widget.size),
                     // Placeholderbuilder used to hide indicators on first hero animation, since flightShuttleBuilder isn't called until both source and destination hero exist in widget tree.
                     placeholderBuilder: (context, heroSize, child) {

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -101,7 +101,7 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
                     // It doesn't seem like the best solution, and only works to reset the hero, not prime the hero of the new active asset for animation,
                     // but other solutions have failed thus far.
                     key: ValueKey(isCurrentAsset),
-                    tag: '${asset!.heroTag}_$heroIndex',
+                    tag: '${asset?.heroTag}_$heroIndex',
                     child: Thumbnail.fromAsset(asset: asset, size: widget.size),
                     // Placeholderbuilder used to hide indicators on first hero animation, since flightShuttleBuilder isn't called until both source and destination hero exist in widget tree.
                     placeholderBuilder: (context, heroSize, child) {

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -98,6 +98,9 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
               children: [
                 Positioned.fill(
                   child: Hero(
+                    // This key resets the hero animation when the asset is changed in the asset viewer.
+                    // It doesn't seem like the best solution, and only works to reset the hero, not prime the hero of the new active asset for animation,
+                    // but other solutions have failed thus far.
                     key: ValueKey(isCurrentAsset),
                     tag: '${asset!.heroTag}_$heroIndex',
                     child: Thumbnail.fromAsset(asset: asset, size: widget.size),

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -11,6 +11,8 @@ import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
+
 class ThumbnailTile extends ConsumerStatefulWidget {
   const ThumbnailTile(
     this.asset, {
@@ -46,6 +48,10 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
   Widget build(BuildContext context) {
     final asset = widget.asset;
     final heroIndex = widget.heroOffset ?? TabsRouterScope.of(context)?.controller.activeIndex ?? 0;
+    // Only watch if this specific tile's asset is the current asset
+    final isCurrentAsset = ref.watch(assetViewerProvider.select((current) => current.currentAsset == asset));
+
+    log.info("Thumbnail: ${asset!.name} rebuilt");
 
     final assetContainerColor = context.isDarkTheme
         ? context.primaryColor.darken(amount: 0.4)
@@ -57,6 +63,10 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
 
     final bool storageIndicator =
         ref.watch(settingsProvider.select((s) => s.get(Setting.showStorageIndicator))) && widget.showStorageIndicator;
+
+    if (!isCurrentAsset) {
+      _hideIndicators = false;
+    }
 
     if (isSelected) {
       _showSelectionContainer = true;
@@ -91,7 +101,8 @@ class _ThumbnailTileState extends ConsumerState<ThumbnailTile> {
               children: [
                 Positioned.fill(
                   child: Hero(
-                    tag: '${asset?.heroTag ?? ''}_$heroIndex',
+                    key: ValueKey(isCurrentAsset),
+                    tag: '${asset.heroTag}_$heroIndex',
                     child: Thumbnail.fromAsset(asset: asset, size: widget.size),
                     // Placeholderbuilder used to hide indicators on first hero animation, since flightShuttleBuilder isn't called until both source and destination hero exist in widget tree.
                     placeholderBuilder: (context, heroSize, child) {

--- a/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail_tile.widget.dart
@@ -6,12 +6,11 @@ import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/duration_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/providers/infrastructure/setting.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-
-import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_viewer.state.dart';
 
 class ThumbnailTile extends ConsumerStatefulWidget {
   const ThumbnailTile(


### PR DESCRIPTION
## Description

Fixes an issue where the indicators on the thumbnail tile wouldn't reappear after returning to the timeline. This would happen when opening one photo, swiping to the next, and then returning to the timeline. The implementation of this fix causes rebuilds of 2 thumbnail tiles on every asset change in the viewer, but there seems to be no noticeable performance impact, even on the debug build. 

Partially addresses #20173 (please do not close this issue yet)

## How Has This Been Tested?

Open and closed assets in various different ways, specifically testing the case described in the description.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

Fixed behaviour:

https://github.com/user-attachments/assets/df7aa32b-196a-4718-a06d-0aa1ad303f11

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding codeservices/`)

(Removed N/A checks)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Not used
