### PR TITLE
fix(server) Live Photo migration bug when album is in template

### DIFF
--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -340,27 +340,9 @@ export class AssetJobRepository {
     return this.storageTemplateAssetQuery().where('asset.id', '=', id).executeTakeFirst();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID] })
-  getLivePhotoParentAsset(livePhotoVideoId: string) {
-    return this.storageTemplateAssetQuery()
-      .where('asset.livePhotoVideoId', '=', livePhotoVideoId)
-      .executeTakeFirst();
-  }
-
   @GenerateSql({ params: [], stream: true })
   streamForStorageTemplateJob() {
-    return this.storageTemplateAssetQuery()
-      .where((eb) =>
-        eb.not(
-          eb.exists(
-            eb
-              .selectFrom('asset as parent')
-              .select('parent.id')
-              .whereRef('parent.livePhotoVideoId', '=', 'asset.id'),
-          ),
-        ),
-      )
-      .stream();
+    return this.storageTemplateAssetQuery().stream();
   }
 
   @GenerateSql({ params: [DummyValue.DATE], stream: true })

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -340,9 +340,27 @@ export class AssetJobRepository {
     return this.storageTemplateAssetQuery().where('asset.id', '=', id).executeTakeFirst();
   }
 
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getLivePhotoParentAsset(livePhotoVideoId: string) {
+    return this.storageTemplateAssetQuery()
+      .where('asset.livePhotoVideoId', '=', livePhotoVideoId)
+      .executeTakeFirst();
+  }
+
   @GenerateSql({ params: [], stream: true })
   streamForStorageTemplateJob() {
-    return this.storageTemplateAssetQuery().stream();
+    return this.storageTemplateAssetQuery()
+      .where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom('asset as parent')
+              .select('parent.id')
+              .whereRef('parent.livePhotoVideoId', '=', 'asset.id'),
+          ),
+        ),
+      )
+      .stream();
   }
 
   @GenerateSql({ params: [DummyValue.DATE], stream: true })

--- a/server/src/services/storage-template.service.ts
+++ b/server/src/services/storage-template.service.ts
@@ -154,62 +154,42 @@ export class StorageTemplateService extends BaseService {
       return JobStatus.Failed;
     }
 
-    // Check if this asset is a live photo video (referenced by a parent image)
-    // If so, skip it - the parent image will handle migrating it with proper metadata
-    const parentAsset = await this.assetJobRepository.getLivePhotoParentAsset(id);
-    if (parentAsset) {
-      return JobStatus.Skipped;
-    }
-
     const user = await this.userRepository.get(asset.ownerId, {});
     const storageLabel = user?.storageLabel || null;
     const filename = asset.originalFileName || asset.id;
+      
+      // Get asset metadata so that live photos and regular photos can share the same asset information
+      let albumName  = null;
+      let albumStartDate = null;
+      let albumEndDate = null;
+      if (this.template.needsAlbum) {
+        const albums = await this.albumRepository.getByAssetId(asset.ownerId, asset.id);
+        const album = albums?.[0];
+        if (album) {
+          albumName = album.albumName ?? null;
 
-    // Get asset metadata so that live photos and regular photos can share the same asset information
-    let albumName = null;
-    let albumStartDate = null;
-    let albumEndDate = null;
-    if (this.template.needsAlbum) {
-      const albums = await this.albumRepository.getByAssetId(asset.ownerId, asset.id);
-      const album = albums?.[0];
-      if (album) {
-        albumName = album.albumName ?? null;
-
-        if (this.template.needsAlbumMetadata) {
-          const [metadata] = await this.albumRepository.getMetadataForIds([album.id]);
-          albumStartDate = metadata?.startDate ?? null;
-          albumEndDate = metadata?.endDate ?? null;
+          if (this.template.needsAlbumMetadata) {
+            const [metadata] =
+              await this.albumRepository.getMetadataForIds([album.id]);
+            albumStartDate = metadata?.startDate ?? null;
+            albumEndDate = metadata?.endDate ?? null;
+          }
         }
       }
-    }
 
-    const assetMetadata: MoveAssetMetadata = { storageLabel, filename, albumName, albumStartDate, albumEndDate };
-    await this.moveAsset(asset, assetMetadata);
+      const assetMetadata:MoveAssetMetadata  = { storageLabel, filename, albumName, albumStartDate, albumEndDate };
+      await this.moveAsset(asset, assetMetadata);
 
-    // move motion part of live photo, inheriting metadata from parent image
+
+    // move motion part of live photo
     if (asset.livePhotoVideoId) {
       const livePhotoVideo = await this.assetJobRepository.getForStorageTemplateJob(asset.livePhotoVideoId);
       if (!livePhotoVideo) {
         return JobStatus.Failed;
       }
       const motionFilename = getLivePhotoMotionFilename(filename, livePhotoVideo.originalPath);
-      const liveAssetMetadata: MoveAssetMetadata = {
-        storageLabel: assetMetadata.storageLabel,
-        filename: motionFilename,
-        albumName: assetMetadata.albumName,
-        albumStartDate: assetMetadata.albumStartDate,
-        albumEndDate: assetMetadata.albumEndDate,
-      };
-      // Use parent image's metadata (make, model, lensModel) for the live photo video
-      await this.moveAsset(
-        {
-          ...livePhotoVideo,
-          make: livePhotoVideo.make ?? asset.make,
-          model: livePhotoVideo.model ?? asset.model,
-          lensModel: livePhotoVideo.lensModel ?? asset.lensModel,
-        },
-        liveAssetMetadata,
-      );
+      const liveAssetMetadata:MoveAssetMetadata = { storageLabel: assetMetadata.storageLabel , filename: motionFilename, albumName: assetMetadata.albumName, albumStartDate: assetMetadata.albumStartDate, albumEndDate: assetMetadata.albumEndDate};
+      await this.moveAsset(livePhotoVideo, liveAssetMetadata);
     }
     return JobStatus.Success;
   }
@@ -233,7 +213,7 @@ export class StorageTemplateService extends BaseService {
       const user = users.find((user) => user.id === asset.ownerId);
       const storageLabel = user?.storageLabel || null;
       const filename = asset.originalFileName || asset.id;
-
+      
       // Get asset metadata so that live photos and regular photos can share the same asset information
       let albumName  = null;
       let albumStartDate = null;
@@ -253,31 +233,16 @@ export class StorageTemplateService extends BaseService {
         }
       }
 
-      const assetMetadata: MoveAssetMetadata = { storageLabel, filename, albumName, albumStartDate, albumEndDate };
+      const assetMetadata:MoveAssetMetadata  = { storageLabel, filename, albumName, albumStartDate, albumEndDate };
       await this.moveAsset(asset, assetMetadata);
 
-      // move motion part of live photo, inheriting metadata from parent image
+      // move motion part of live photo
       if (asset.livePhotoVideoId) {
         const livePhotoVideo = await this.assetJobRepository.getForStorageTemplateJob(asset.livePhotoVideoId);
         if (livePhotoVideo) {
           const motionFilename = getLivePhotoMotionFilename(filename, livePhotoVideo.originalPath);
-          const liveAssetMetadata: MoveAssetMetadata = {
-            storageLabel: assetMetadata.storageLabel,
-            filename: motionFilename,
-            albumName: assetMetadata.albumName,
-            albumStartDate: assetMetadata.albumStartDate,
-            albumEndDate: assetMetadata.albumEndDate,
-          };
-          // Use parent image's metadata (make, model, lensModel) for the live photo video
-          await this.moveAsset(
-            {
-              ...livePhotoVideo,
-              make: livePhotoVideo.make ?? asset.make,
-              model: livePhotoVideo.model ?? asset.model,
-              lensModel: livePhotoVideo.lensModel ?? asset.lensModel,
-            },
-            liveAssetMetadata,
-          );
+          const liveAssetMetadata:MoveAssetMetadata = { storageLabel: assetMetadata.storageLabel , filename: motionFilename, albumName: assetMetadata.albumName, albumStartDate: assetMetadata.albumStartDate, albumEndDate: assetMetadata.albumEndDate};
+          await this.moveAsset(livePhotoVideo, liveAssetMetadata);
         }
       }
     }


### PR DESCRIPTION
Fix live photo migration bug where if album is in template the live video will not get moved to the album. With this it will be moved with or without an album

## Description
I have previously made this PR https://github.com/immich-app/immich/pull/24688 which aimed to fix live photo video parts not getting moved by the storage template properly, that PR fixes the issue only partially where the images and live videos are moved to the correct place when there is no album defined in the template, or if the live photo isn't attached to an album. This PR improves upon https://github.com/immich-app/immich/pull/24688 by extending the migration to storage templates and/or live photos inside albums.

Fixes https://github.com/immich-app/immich/issues/17668

## How Has This Been Tested?
1) Launched up an empty Immich instance
2) Uploaded Live Photo without storage template enabled
3) Noted that photos show has been uploaded and show up in uploads folder (See Screenshots section for evidence)
4) Enabled Storage Template. Template used(no album in template): {{y}}/{{MM}}/{{filename}}
5) Kicked off Storage Template Migration Job
6) Noted that live photos have been moved away from uploads folder and migrated to library folder under the correct user and in the same location (See Screenshots section for evidence)
7) Updated storage template to include album. Template used {{album}}/{{y}}/{{MM}}/{{filename}}

Log File:  [immichTestingEvidenceLog2.txt](https://github.com/user-attachments/files/24681608/immichTestingEvidenceLog2.txt)

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
Uploading images with storage template disabled
Images uploaded to upload folder
<img width="1994" height="622" alt="Pasted image 20260116115014" src="https://github.com/user-attachments/assets/a17c72f1-2568-4fc5-b11a-71d72106853d" />


MOV part
<img width="1792" height="544" alt="Pasted image 20260116115040" src="https://github.com/user-attachments/assets/03cadab2-004a-477b-a229-5fe86c0fcf1a" />


HEIC part

<img width="1908" height="608" alt="Pasted image 20260116115106" src="https://github.com/user-attachments/assets/8c7bb165-c8cb-4abd-a816-3ab90b5e584a" />


Now enable storage template without album. Template used: "{{y}}/{{MM}}/{{filename}}"

After running migration job

Upload folders empty
<img width="1432" height="1042" alt="Pasted image 20260116115237" src="https://github.com/user-attachments/assets/2b45ad89-c050-4fdd-a157-34c779170ce6" />


Library folder moved assets as expected where live part and HEIC part are in same folder
<img width="2028" height="546" alt="Pasted image 20260116115313" src="https://github.com/user-attachments/assets/b55cb780-1f21-4a12-8a4c-97d44fb8cecf" />

Now test with album name inside the template and added live photo to an album named "test". Template used "{{album}}/{{y}}/{{MM}}/{{filename}}"

After running migration job photo is correctly moved to album

<img width="2194" height="500" alt="Pasted image 20260116115620" src="https://github.com/user-attachments/assets/7054bcd7-81af-4244-8631-34dc4b0eb1c5" />

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- ~[ ] I have made corresponding changes to the documentation if applicable~
- [x] I have no unrelated changes in the PR.
- ~[ ] I have confirmed that any new dependencies are strictly necessary.~
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Used LLM to understand existing implementations
...
