### PR TITLE
fix(web): add min-width to setting input field

### DIFF
--- a/web/src/lib/components/shared-components/settings/setting-input-field.svelte
+++ b/web/src/lib/components/shared-components/settings/setting-input-field.svelte
@@ -128,7 +128,7 @@
 
       <input
         bind:this={input}
-        class="immich-form-input w-full pb-2"
+        class="immich-form-input w-full pb-2 min-w-[50px]"
         class:color-picker={inputType === SettingInputFieldType.COLOR}
         aria-describedby={description ? `${label}-desc` : undefined}
         aria-labelledby="{label}-label"


### PR DESCRIPTION
Prevents input fields from collapsing in flex layouts, such as the extension field in storage template settings. Fixes #25298.

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change adds a minimum width of 50px to input fields in the shared SettingInputField component. This prevents inputs from becoming invisible or unusable in narrow flex containers, particularly affecting fields like the "Extension" input in the Storage Template settings page when using languages with wider characters (e.g., Chinese from the issue #25298).

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

 - [x] Verified locally by running the development environment (Docker Compose).
 - [x] Checked the Storage Template settings page to ensure the extension input field is visible and functional.
 - [x] Tested in different screen sizes to confirm no layout breakage.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

<img width="1200" height="95" alt="image" src="https://github.com/user-attachments/assets/c532eb46-02fb-4d4f-801e-ecc5762f7088" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM was used in creating this pull request. The fix was implemented manually based on the issue description and local testing.
