### PR TITLE
chore(deps): ignore @parcel/watcher build script

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - .github
 ignoredBuiltDependencies:
   - '@nestjs/core'
+  - '@parcel/watcher'
   - '@scarf/scarf'
   - '@swc/core'
   - canvas


### PR DESCRIPTION
## Description
Makes warning about ignored build script go away. It was already ignored, now this is made explicit.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
