### PR TITLE
feat: allow /memory?id= in AndroidManifest

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -119,6 +119,9 @@
           android:pathPrefix="/memories/" />
         <data
           android:host="my.immich.app"
+          android:path="/memory" />
+        <data
+          android:host="my.immich.app"
           android:pathPrefix="/photos/" />
       </intent-filter>
     </activity>


### PR DESCRIPTION
<!-- Allow singular memory route like /memory?id=... -->

## Description

<!--- using /memories/ causes problems-->
<!--- This fixes the call to /memory?id= that can be handled by the app-->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/ismaildakrory/immich-memories-notify/issues/1

Fixes # (issue)

## How Has This Been Tested?

<!-- Tested with ntfy -->

- [ ] https://my.immich.app/memories/{id}
- [ ] https://my.immich.app/memory?id=

<!-- Images go below this line. -->

</details>

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Show me in which file I must look to apply these changes.
...
