### PR TITLE
feat(web): add content security policy (CSP)

### DIFF
--- a/web/src/app.html
+++ b/web/src/app.html
@@ -66,7 +66,7 @@
         background-color: black;
       }
     </style>
-    <script>
+    <script nonce="%sveltekit.nonce%">
       /**
        * Prevent FOUC on page load.
        */

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -31,6 +31,15 @@ const config = {
       $i18n: '../i18n',
       'chromecast-caf-sender': './node_modules/@types/chromecast-caf-sender/index.d.ts',
     },
+    csp: {
+      directives: {
+        'default-src': ['self'],
+        'connect-src': ['self', 'blob:', 'https://*.immich.cloud', 'https://*.maptiler.com'], // TODO: check if custom maptiler json works
+        'img-src': ['self', 'blob:', 'data:'],
+        'script-src': ['self', 'wasm-unsafe-eval', 'https://*.gstatic.com'],
+        'worker-src': ['self', 'blob:'],
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Description
Adds CSP config to svelte config which in turn generates and adds the Content-Security-Policy header.

Fixes #23261
Closes #24633

Related discussion on how to setup CSP and other security measures on the proxy side: #13043

(not sure what to do about the docker build failure)

## How Has This Been Tested?
- Navigate to all pages within Immich checking the console for CSP errors, including the map, hovering over all types of assets, opening the asset viewer for all types of assets (e.g. photo sphere viewer does some weird blob loading), etc.
- Service worker loads
- Justified layout wasm loads
- Enable Google cast support which requires the gstatic.com domain
- UNTESTED: custom map styles

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
