### PR TITLE
fix: ERR_PNPM_ENOENT error while `make dev` on macOS.

### DIFF
--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -8,7 +8,8 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
 RUN npm install --global corepack@latest && \
   corepack enable pnpm && \
   echo "store-dir=/buildcache/pnpm-store" >> /usr/local/etc/npmrc && \
-  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc
+  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc && \
+  echo "package-import-method=copy" >> /usr/local/etc/npmrc
 
 COPY ./package* ./pnpm* .pnpmfile.cjs /tmp/create-dep-cache/
 COPY ./web/package* ./web/pnpm* /tmp/create-dep-cache/web/


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #24600

It appears that pnpm by default uses hard links to efficiently share files from pnpm-store to node_modules. However, docker volumes on macOS don’t support these filesystem operations very well.

To resolve this issue, I have to modify the server/Dockerfile.dev file at line 11 by explicitly instructing pnpm to copy files instead of using hard links, using package-import-method=copy.

This solution is slower, but it works reliably on macOS for me.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] No 'ERR_PNPM_ENOENT' error on Macbook Pro after this fix.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
