### PR TITLE
fix: include `DROP INDEX` in transaction to prevent missing index on rollback

### DIFF
--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -8,8 +8,7 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
 RUN npm install --global corepack@latest && \
   corepack enable pnpm && \
   echo "store-dir=/buildcache/pnpm-store" >> /usr/local/etc/npmrc && \
-  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc && \
-  echo "package-import-method=copy" >> /usr/local/etc/npmrc
+  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc
 
 COPY ./package* ./pnpm* .pnpmfile.cjs /tmp/create-dep-cache/
 COPY ./web/package* ./web/pnpm* /tmp/create-dep-cache/web/

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -8,7 +8,8 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
 RUN npm install --global corepack@latest && \
   corepack enable pnpm && \
   echo "store-dir=/buildcache/pnpm-store" >> /usr/local/etc/npmrc && \
-  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc
+  echo "devdir=/buildcache/node-gyp" >> /usr/local/etc/npmrc && \
+  echo "package-import-method=copy" >> /usr/local/etc/npmrc
 
 COPY ./package* ./pnpm* .pnpmfile.cjs /tmp/create-dep-cache/
 COPY ./web/package* ./web/pnpm* /tmp/create-dep-cache/web/

--- a/server/src/repositories/database.repository.ts
+++ b/server/src/repositories/database.repository.ts
@@ -246,11 +246,11 @@ export class DatabaseRepository {
     }
     const dimSize = await this.getDimensionSize(table);
     lists ||= this.targetListCount(await this.getRowCount(table));
-    await this.db.schema.dropIndex(indexName).ifExists().execute();
-    if (table === 'smart_search') {
-      await this.db.schema.alterTable(table).dropConstraint('dim_size_constraint').ifExists().execute();
-    }
     await this.db.transaction().execute(async (tx) => {
+      await sql`DROP INDEX IF EXISTS ${sql.raw(indexName)}`.execute(tx);
+      if (table === 'smart_search') {
+        await sql`ALTER TABLE ${sql.raw(table)} DROP CONSTRAINT IF EXISTS dim_size_constraint`.execute(tx);
+      }
       if (!rows.some((row) => row.columnName === 'embedding')) {
         this.logger.warn(`Column 'embedding' does not exist in table '${table}', truncating and adding column.`);
         await sql`TRUNCATE TABLE ${sql.raw(table)}`.execute(tx);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I have a large dataset. When the number of vector records exceeds a certain threshold, the `reindexVectors` method is called during system boot. Since the vector index is enormous, the transaction costed too much system resources and resulted in an error and was rolled back. However, because the `DROP INDEX` command was not included in the transaction, I ended up without any vector indexes.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Transaction rollbacks were performed, and the previous vector index was retained.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
