### PR TITLE
fix: don't include metadata when upload motion part of LivePhotos

### DIFF
--- a/mobile/lib/services/background_upload.service.dart
+++ b/mobile/lib/services/background_upload.service.dart
@@ -307,10 +307,10 @@ class BackgroundUploadService {
       priority: priority,
       isFavorite: asset.isFavorite,
       requiresWiFi: requiresWiFi,
-      cloudId: asset.cloudId,
-      adjustmentTime: asset.adjustmentTime?.toIso8601String(),
-      latitude: asset.latitude?.toString(),
-      longitude: asset.longitude?.toString(),
+      cloudId: entity.isLivePhoto ? null : asset.cloudId,
+      adjustmentTime: entity.isLivePhoto ? null : asset.adjustmentTime?.toIso8601String(),
+      latitude: entity.isLivePhoto ? null : asset.latitude?.toString(),
+      longitude: entity.isLivePhoto ? null : asset.longitude?.toString(),
     );
   }
 

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -322,19 +322,6 @@ class ForegroundUploadService {
         'fileModifiedAt': asset.updatedAt.toUtc().toIso8601String(),
         'isFavorite': asset.isFavorite.toString(),
         'duration': asset.duration.toString(),
-        if (CurrentPlatform.isIOS && asset.cloudId != null)
-          'metadata': jsonEncode([
-            RemoteAssetMetadataItem(
-              key: RemoteAssetMetadataKey.mobileApp,
-              value: RemoteAssetMobileAppMetadata(
-                cloudId: asset.cloudId,
-                createdAt: asset.createdAt.toIso8601String(),
-                adjustmentTime: asset.adjustmentTime?.toIso8601String(),
-                latitude: asset.latitude?.toString(),
-                longitude: asset.longitude?.toString(),
-              ),
-            ),
-          ]),
       };
 
       // Upload live photo video first if available
@@ -361,6 +348,22 @@ class ForegroundUploadService {
 
       if (livePhotoVideoId != null) {
         fields['livePhotoVideoId'] = livePhotoVideoId;
+      }
+
+      // Add cloudId metadata only to the still image, not the motion video, becasue when the sync id happens, the motion video can get associated with the wrong still image.
+      if (CurrentPlatform.isIOS && asset.cloudId != null) {
+        fields['metadata'] = jsonEncode([
+          RemoteAssetMetadataItem(
+            key: RemoteAssetMetadataKey.mobileApp,
+            value: RemoteAssetMobileAppMetadata(
+              cloudId: asset.cloudId,
+              createdAt: asset.createdAt.toIso8601String(),
+              adjustmentTime: asset.adjustmentTime?.toIso8601String(),
+              latitude: asset.latitude?.toString(),
+              longitude: asset.longitude?.toString(),
+            ),
+          ),
+        ]);
       }
 
       final result = await _uploadRepository.uploadFile(

--- a/mobile/lib/services/foreground_upload.service.dart
+++ b/mobile/lib/services/foreground_upload.service.dart
@@ -315,7 +315,6 @@ class ForegroundUploadService {
         return;
       }
 
-      print("assetName: ${asset.name}");
       final fileName = await _assetMediaRepository.getOriginalFilename(asset.id) ?? asset.name;
       final originalFileName = entity.isLivePhoto ? p.setExtension(fileName, p.extension(file.path)) : fileName;
       final deviceId = Store.get(StoreKey.deviceId);
@@ -335,7 +334,6 @@ class ForegroundUploadService {
       if (entity.isLivePhoto && livePhotoFile != null) {
         final livePhotoTitle = p.setExtension(originalFileName, p.extension(livePhotoFile.path));
 
-        print("livePhotoTitle: $livePhotoTitle");
         final livePhotoResult = await _uploadRepository.uploadFile(
           file: livePhotoFile,
           originalFileName: livePhotoTitle,
@@ -373,7 +371,6 @@ class ForegroundUploadService {
         ]);
       }
 
-      print("Uploading asset ${asset.localId} - $originalFileName");
       final result = await _uploadRepository.uploadFile(
         file: file,
         originalFileName: originalFileName,


### PR DESCRIPTION
- Only send metadata for the still image part of LivePhotos
- Get correct original file name