### PR TITLE
fix(web): allow exiting pin setup flow

### DIFF
--- a/web/src/routes/auth/pin-prompt/+page.svelte
+++ b/web/src/routes/auth/pin-prompt/+page.svelte
@@ -40,9 +40,9 @@
 </script>
 
 <AuthPageLayout withHeader={false}>
-  {#if hasPinCode}
-    <div class="flex items-center justify-center">
-      <div class="w-96 flex flex-col gap-6 items-center justify-center">
+  <div class="flex items-center justify-center">
+    <div class="w-96 flex flex-col gap-6 items-center justify-center">
+      {#if hasPinCode}
         {#if isVerified}
           <div in:fade={{ duration: 200 }}>
             <Icon icon={mdiLockOpenVariantOutline} size="64" class="text-success/90" />
@@ -64,13 +64,7 @@
           pinLength={6}
           onFilled={handleUnlockSession}
         />
-
-        <Button type="button" color="secondary" onclick={() => goto(Route.photos())}>{$t('cancel')}</Button>
-      </div>
-    </div>
-  {:else}
-    <div class="flex items-center justify-center">
-      <div class="w-96 flex flex-col gap-6 items-center justify-center">
+      {:else}
         <div class="text-primary">
           <Icon icon={mdiLockSmart} size="64" />
         </div>
@@ -78,7 +72,11 @@
           {$t('new_pin_code_subtitle')}
         </p>
         <PinCodeCreateForm showLabel={false} onCreated={() => (hasPinCode = true)} />
+      {/if}
+
+      <div class={hasPinCode ? '' : 'flex w-full items-start'}>
+        <Button type="button" color="secondary" onclick={() => goto(Route.photos())}>{$t('cancel')}</Button>
       </div>
     </div>
-  {/if}
+  </div>
 </AuthPageLayout>


### PR DESCRIPTION
## Description
Allows user to cancel/exit the PIN auth setup flow with a button. Previously this was only possible by using the back button in the browser.

Moves the cancel button outside the if statement with a conditional left-align. The `hasPinCode` screen is unchanged.

Fixes #25146 (exiting the error page was fixed already)

| Old (in Dutch sorry :p) | New |
|---|---|
| <img width="813" height="739" alt="image" src="https://github.com/user-attachments/assets/cfaaa9c9-b37e-4fa2-8ddf-be048b0fc365" /> | <img width="813" height="739" alt="image" src="https://github.com/user-attachments/assets/7d110631-e4e9-4cbc-ae9e-c5df150f5347" /> |

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
