### PR TITLE
fix(docs): document that fullsize thumbnail might redirect to original

### DIFF
--- a/mobile/openapi/lib/api/assets_api.dart
+++ b/mobile/openapi/lib/api/assets_api.dart
@@ -1691,7 +1691,7 @@ class AssetsApi {
 
   /// View asset thumbnail
   ///
-  /// Retrieve the thumbnail image for the specified asset.
+  /// Retrieve the thumbnail image for the specified asset. Viewing the fullsize thumbnail might redirect to downloadAsset, which requires a different permission.
   ///
   /// Note: This method returns the HTTP [Response].
   ///
@@ -1747,7 +1747,7 @@ class AssetsApi {
 
   /// View asset thumbnail
   ///
-  /// Retrieve the thumbnail image for the specified asset.
+  /// Retrieve the thumbnail image for the specified asset. Viewing the fullsize thumbnail might redirect to downloadAsset, which requires a different permission.
   ///
   /// Parameters:
   ///

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4277,7 +4277,7 @@
     },
     "/assets/{id}/thumbnail": {
       "get": {
-        "description": "Retrieve the thumbnail image for the specified asset.",
+        "description": "Retrieve the thumbnail image for the specified asset. Viewing the fullsize thumbnail might redirect to downloadAsset, which requires a different permission.",
         "operationId": "viewAsset",
         "parameters": [
           {

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -147,7 +147,8 @@ export class AssetMediaController {
   @Authenticated({ permission: Permission.AssetView, sharedLink: true })
   @Endpoint({
     summary: 'View asset thumbnail',
-    description: 'Retrieve the thumbnail image for the specified asset.',
+    description:
+      'Retrieve the thumbnail image for the specified asset. Viewing the fullsize thumbnail might redirect to downloadAsset, which requires a different permission.',
     history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
   async viewAsset(


### PR DESCRIPTION
## Description
`viewAsset` (`asset.view` permission) with fullsize size redirects to `downloadAsset` (`asset.download` permission) if the original is web-friendly. This was undocumented afaik.

Whether this is desirable behavior from an API design perspective is questionable, but changing the permission is a breaking change so documenting is the least we can do.

Fixes #21035

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None.
