### PR TITLE
fix(web): fix badge value in queues page

### DIFF
--- a/web/src/routes/admin/queues/[name]/+page.svelte
+++ b/web/src/routes/admin/queues/[name]/+page.svelte
@@ -29,13 +29,11 @@
 
   const queue = $derived(queueManager.queues.find((q) => q.name === data.queue.name) ?? data.queue);
 
-
   const { Pause, Resume, Empty, RemoveFailedJobs } = $derived(getQueueActions($t, queue));
   const item = $derived(asQueueItem($t, queue));
 
   onMount(() => queueManager.listen());
 </script>
-
 
 <AdminPageLayout
   breadcrumbs={[{ title: $t('admin.queues'), href: Route.queues() }, { title: item.title }]}

--- a/web/src/routes/admin/queues/[name]/+page.svelte
+++ b/web/src/routes/admin/queues/[name]/+page.svelte
@@ -27,7 +27,7 @@
 
   const { data }: Props = $props();
 
-  let queue = $derived(queueManager.queues.find((q) => q.name === data.queue.name) || data.queue);
+  const queue = $derived(queueManager.queues.find((q) => q.name === data.queue.name) ?? data.queue);
 
 
   const { Pause, Resume, Empty, RemoveFailedJobs } = $derived(getQueueActions($t, queue));

--- a/web/src/routes/admin/queues/[name]/+page.svelte
+++ b/web/src/routes/admin/queues/[name]/+page.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import AdminPageLayout from '$lib/components/layouts/AdminPageLayout.svelte';
-  import OnEvents from '$lib/components/OnEvents.svelte';
   import QueueGraph from '$lib/components/QueueGraph.svelte';
   import { queueManager } from '$lib/managers/queue-manager.svelte';
   import { Route } from '$lib/route';
   import { asQueueItem, getQueueActions } from '$lib/services/queue.service';
-  import { type QueueResponseDto } from '@immich/sdk';
   import {
     Badge,
     Card,
@@ -29,21 +27,15 @@
 
   const { data }: Props = $props();
 
-  let queue = $derived(data.queue);
+  let queue = $derived(queueManager.queues.find((q) => q.name === data.queue.name) || data.queue);
+
 
   const { Pause, Resume, Empty, RemoveFailedJobs } = $derived(getQueueActions($t, queue));
   const item = $derived(asQueueItem($t, queue));
 
   onMount(() => queueManager.listen());
-
-  const onQueueUpdate = (update: QueueResponseDto) => {
-    if (update.name === queue.name) {
-      queue = update;
-    }
-  };
 </script>
 
-<OnEvents {onQueueUpdate} />
 
 <AdminPageLayout
   breadcrumbs={[{ title: $t('admin.queues'), href: Route.queues() }, { title: item.title }]}


### PR DESCRIPTION
Remove OnEvents component and manual queue updates, using queueManager for derived queue state instead. This reduces complexity and leverages centralized queue management.

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #25145

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested on firefox browser
- [x] Tested on fresh clone with minimal setup and on around 300 assets thumbnail generation

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<img width="797" height="576" alt="image" src="https://github.com/user-attachments/assets/2530e340-21a6-48b2-b420-6b048d5af786" />
<img width="791" height="623" alt="image" src="https://github.com/user-attachments/assets/d09e9073-380d-4db2-b74c-72a0bebe575d" />


</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->


## Please describe to which degree, if any, an LLM was used in creating this pull request.
used to generate commit message
...
