### PR TITLE
fix(web): don't show ocr button on panoramas

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -431,6 +431,7 @@
   const showOcrButton = $derived(
     $slideshowState === SlideshowState.None &&
       asset.type === AssetTypeEnum.Image &&
+      !(asset.exifInfo?.projectionType === 'EQUIRECTANGULAR') &&
       !isShowEditor &&
       ocrManager.hasOcrData,
   );


### PR DESCRIPTION
## Description
360 panoramas don't (yet) support overlaying ocr textboxes; don't show the button because that's confusing.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None