### PR TITLE
fix(server): scoped permissions for more endpoints

### DIFF
--- a/mobile/openapi/lib/model/permission.dart
+++ b/mobile/openapi/lib/model/permission.dart
@@ -72,6 +72,7 @@ class Permission {
   static const facePeriodRead = Permission._(r'face.read');
   static const facePeriodUpdate = Permission._(r'face.update');
   static const facePeriodDelete = Permission._(r'face.delete');
+  static const folderPeriodRead = Permission._(r'folder.read');
   static const jobPeriodCreate = Permission._(r'job.create');
   static const jobPeriodRead = Permission._(r'job.read');
   static const libraryPeriodCreate = Permission._(r'library.create');
@@ -230,6 +231,7 @@ class Permission {
     facePeriodRead,
     facePeriodUpdate,
     facePeriodDelete,
+    folderPeriodRead,
     jobPeriodCreate,
     jobPeriodRead,
     libraryPeriodCreate,
@@ -423,6 +425,7 @@ class PermissionTypeTransformer {
         case r'face.read': return Permission.facePeriodRead;
         case r'face.update': return Permission.facePeriodUpdate;
         case r'face.delete': return Permission.facePeriodDelete;
+        case r'folder.read': return Permission.folderPeriodRead;
         case r'job.create': return Permission.jobPeriodCreate;
         case r'job.read': return Permission.jobPeriodRead;
         case r'library.create': return Permission.libraryPeriodCreate;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -3173,6 +3173,7 @@
             "state": "Stable"
           }
         ],
+        "x-immich-permission": "asset.upload",
         "x-immich-state": "Stable"
       }
     },
@@ -3225,6 +3226,7 @@
             "state": "Stable"
           }
         ],
+        "x-immich-permission": "job.create",
         "x-immich-state": "Stable"
       }
     },
@@ -14618,6 +14620,7 @@
             "state": "Stable"
           }
         ],
+        "x-immich-permission": "folder.read",
         "x-immich-state": "Stable"
       }
     },
@@ -14670,6 +14673,7 @@
             "state": "Stable"
           }
         ],
+        "x-immich-permission": "folder.read",
         "x-immich-state": "Stable"
       }
     },
@@ -18958,6 +18962,7 @@
           "face.read",
           "face.update",
           "face.delete",
+          "folder.read",
           "job.create",
           "job.read",
           "library.create",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -5524,6 +5524,7 @@ export enum Permission {
     FaceRead = "face.read",
     FaceUpdate = "face.update",
     FaceDelete = "face.delete",
+    FolderRead = "folder.read",
     JobCreate = "job.create",
     JobRead = "job.read",
     LibraryCreate = "library.create",

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -202,7 +202,7 @@ export class AssetMediaController {
   }
 
   @Post('exist')
-  @Authenticated()
+  @Authenticated({ permission: Permission.AssetUpload })
   @Endpoint({
     summary: 'Check existing assets',
     description: 'Checks if multiple assets exist on the server and returns all existing - used by background backup',

--- a/server/src/controllers/asset.controller.ts
+++ b/server/src/controllers/asset.controller.ts
@@ -66,7 +66,7 @@ export class AssetController {
   }
 
   @Post('jobs')
-  @Authenticated()
+  @Authenticated({ permission: Permission.JobCreate })
   @HttpCode(HttpStatus.NO_CONTENT)
   @Endpoint({
     summary: 'Run an asset job',

--- a/server/src/controllers/view.controller.ts
+++ b/server/src/controllers/view.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { AuthDto } from 'src/dtos/auth.dto';
-import { ApiTag } from 'src/enum';
+import { ApiTag, Permission } from 'src/enum';
 import { Auth, Authenticated } from 'src/middleware/auth.guard';
 import { ViewService } from 'src/services/view.service';
 
@@ -13,7 +13,7 @@ export class ViewController {
   constructor(private service: ViewService) {}
 
   @Get('folder/unique-paths')
-  @Authenticated()
+  @Authenticated({ permission: Permission.FolderRead })
   @Endpoint({
     summary: 'Retrieve unique paths',
     description: 'Retrieve a list of unique folder paths from asset original paths.',
@@ -24,7 +24,7 @@ export class ViewController {
   }
 
   @Get('folder')
-  @Authenticated()
+  @Authenticated({ permission: Permission.FolderRead })
   @Endpoint({
     summary: 'Retrieve assets by original path',
     description: 'Retrieve assets that are children of a specific folder.',

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -146,6 +146,8 @@ export enum Permission {
   FaceUpdate = 'face.update',
   FaceDelete = 'face.delete',
 
+  FolderRead = 'folder.read',
+
   JobCreate = 'job.create',
   JobRead = 'job.read',
 


### PR DESCRIPTION
## Description
Adds a new `view.folder` permission to /view/folder/.. endpoints and some scoped permissions to others.

The only endpoints left without scoped permissions are either deprecated or (o)auth related, and I don't think it makes sense to add api key permissions to those.

Fixes #24782

API endpoint changes
## API Changes
- The `POST /api/assets/exist` endpoint now has the `asset.upload` permission (endpoint is related to uploading)
- The `POST /api/assets/jobs` endpoint now has the `job.create` permission
- The `/api/view/folder(/...)` endpoints now have the new `view.folder` permission
