### PR TITLE
fix(mobile): cancel share download when dialog is dismissed

### DIFF
--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -405,11 +405,11 @@ class ActionNotifier extends Notifier<void> {
     }
   }
 
-  Future<ActionResult> shareAssets(ActionSource source, BuildContext context) async {
+  Future<ActionResult> shareAssets(ActionSource source, BuildContext context, {CancellationToken? cancelToken}) async {
     final ids = _getAssets(source).toList(growable: false);
 
     try {
-      await _service.shareAssets(ids, context);
+      await _service.shareAssets(ids, context, cancelToken: cancelToken);
       return ActionResult(count: ids.length, success: true);
     } catch (error, stack) {
       _logger.severe('Failed to share assets', error, stack);

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -405,11 +405,15 @@ class ActionNotifier extends Notifier<void> {
     }
   }
 
-  Future<ActionResult> shareAssets(ActionSource source, BuildContext context, {CancellationToken? cancelToken}) async {
+  Future<ActionResult> shareAssets(
+    ActionSource source,
+    BuildContext context, {
+    Completer<void>? cancelCompleter,
+  }) async {
     final ids = _getAssets(source).toList(growable: false);
 
     try {
-      await _service.shareAssets(ids, context, cancelToken: cancelToken);
+      await _service.shareAssets(ids, context, cancelCompleter: cancelCompleter);
       return ActionResult(count: ids.length, success: true);
     } catch (error, stack) {
       _logger.severe('Failed to share assets', error, stack);

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -24,7 +24,6 @@ final assetMediaRepositoryProvider = Provider((ref) => AssetMediaRepository(ref.
 
 class AssetMediaRepository {
   final AssetApiRepository _assetApiRepository;
-
   static final Logger _log = Logger("AssetMediaRepository");
 
   const AssetMediaRepository(this._assetApiRepository);
@@ -59,6 +58,7 @@ class AssetMediaRepository {
 
   static asset_entity.Asset? toAsset(AssetEntity? local) {
     if (local == null) return null;
+
     final asset_entity.Asset asset = asset_entity.Asset(
       checksum: "",
       localId: local.id,
@@ -73,19 +73,21 @@ class AssetMediaRepository {
       height: local.height,
       isFavorite: local.isFavorite,
     );
+
     if (asset.fileCreatedAt.year == 1970) {
       asset.fileCreatedAt = asset.fileModifiedAt;
     }
+
     if (local.latitude != null) {
       asset.exifInfo = ExifInfo(latitude: local.latitude, longitude: local.longitude);
     }
+
     asset.local = local;
     return asset;
   }
 
   Future<String?> getOriginalFilename(String id) async {
     final entity = await AssetEntity.fromId(id);
-
     if (entity == null) {
       return null;
     }
@@ -102,6 +104,19 @@ class AssetMediaRepository {
     }
   }
 
+  /// Deletes temporary files in parallel
+  Future<void> _cleanupTempFiles(List<File> tempFiles) async {
+    await Future.wait(
+      tempFiles.map((file) async {
+        try {
+          await file.delete();
+        } catch (e) {
+          _log.warning("Failed to delete temporary file: ${file.path}", e);
+        }
+      }),
+    );
+  }
+
   // TODO: make this more efficient
   Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {CancellationToken? cancelToken}) async {
     final downloadedXFiles = <XFile>[];
@@ -110,13 +125,7 @@ class AssetMediaRepository {
     for (var asset in assets) {
       if (cancelToken != null && cancelToken.isCancelled) {
         // if cancelled, delete any temp files created so far
-        for (var file in tempFiles) {
-          try {
-            await file.delete();
-          } catch (e) {
-            _log.warning("Failed to delete temporary file: ${file.path}", e);
-          }
-        }
+        await _cleanupTempFiles(tempFiles);
         return 0;
       }
 
@@ -160,13 +169,7 @@ class AssetMediaRepository {
     }
 
     if (cancelToken != null && cancelToken.isCancelled) {
-      for (var file in tempFiles) {
-        try {
-          await file.delete();
-        } catch (e) {
-          _log.warning("Failed to delete temporary file: ${file.path}", e);
-        }
-      }
+      await _cleanupTempFiles(tempFiles);
       return 0;
     }
 
@@ -178,13 +181,7 @@ class AssetMediaRepository {
         downloadedXFiles,
         sharePositionOrigin: Rect.fromPoints(Offset.zero, Offset(size.width / 3, size.height)),
       ).then((result) async {
-        for (var file in tempFiles) {
-          try {
-            await file.delete();
-          } catch (e) {
-            _log.warning("Failed to delete temporary file: ${file.path}", e);
-          }
-        }
+        await _cleanupTempFiles(tempFiles);
       }),
     );
 

--- a/mobile/lib/repositories/asset_media.repository.dart
+++ b/mobile/lib/repositories/asset_media.repository.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:cancellation_token_http/http.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -118,12 +117,12 @@ class AssetMediaRepository {
   }
 
   // TODO: make this more efficient
-  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {CancellationToken? cancelToken}) async {
+  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {Completer<void>? cancelCompleter}) async {
     final downloadedXFiles = <XFile>[];
     final tempFiles = <File>[];
 
     for (var asset in assets) {
-      if (cancelToken != null && cancelToken.isCancelled) {
+      if (cancelCompleter != null && cancelCompleter.isCompleted) {
         // if cancelled, delete any temp files created so far
         await _cleanupTempFiles(tempFiles);
         return 0;
@@ -168,7 +167,7 @@ class AssetMediaRepository {
       return 0;
     }
 
-    if (cancelToken != null && cancelToken.isCancelled) {
+    if (cancelCompleter != null && cancelCompleter.isCompleted) {
       await _cleanupTempFiles(tempFiles);
       return 0;
     }

--- a/mobile/lib/services/action.service.dart
+++ b/mobile/lib/services/action.service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
+import 'package:cancellation_token_http/http.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
@@ -232,8 +233,8 @@ class ActionService {
     await _assetApiRepository.unStack(stackIds);
   }
 
-  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context) {
-    return _assetMediaRepository.shareAssets(assets, context);
+  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {CancellationToken? cancelToken}) {
+    return _assetMediaRepository.shareAssets(assets, context, cancelToken: cancelToken);
   }
 
   Future<List<bool>> downloadAll(List<RemoteAsset> assets) {

--- a/mobile/lib/services/action.service.dart
+++ b/mobile/lib/services/action.service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
-import 'package:cancellation_token_http/http.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
@@ -233,8 +232,8 @@ class ActionService {
     await _assetApiRepository.unStack(stackIds);
   }
 
-  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {CancellationToken? cancelToken}) {
-    return _assetMediaRepository.shareAssets(assets, context, cancelToken: cancelToken);
+  Future<int> shareAssets(List<BaseAsset> assets, BuildContext context, {Completer<void>? cancelCompleter}) {
+    return _assetMediaRepository.shareAssets(assets, context, cancelCompleter: cancelCompleter);
   }
 
   Future<List<bool>> downloadAll(List<RemoteAsset> assets) {


### PR DESCRIPTION
## Description

This PR fixes a bug where interrupting the share process (e.g., by pressing the Android back button or using the back gesture during the "Preparing" stage) would not stop the asset download. This caused the system share sheet to pop up unexpectedly later once the download finished, even if the user had moved on from that intent.

Changes made:
- Added a CancellationToken into the sharing flow to allow for explicit termination.
- Updated AssetMediaRepository.shareAssets to check the cancellation status within the download loop and before triggering the system share sheet.
- Immediate cleanup of temporary files if the operation is cancelled.
- updated ShareActionButton to prevent a "Bad state: Cannot use 'ref' after the widget was disposed" crash by checking context.mounted and the cancellation status before accessing the Provider reference.

Fixes #22353 

## How Has This Been Tested?

- [x] Test A (Cancellation): Initiated a share for a large remote video. Pressed the back button during the "Preparing" dialog. Verified that the dialog disappeared and the system share sheet did not appear later.
- [x] Test B (Normal Share): Initiated a share and waited for the download to complete. Verified that the system share sheet appeared correctly with the file.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

<!-- API endpoint changes (if relevant)
## API Changes
- None
-->

## Checklist:

-   [x]  I have performed a self-review of my own code
-   [x]  I have made corresponding changes to the documentation if applicable
-   [x]  I have no unrelated changes in the PR.
-   [x]  I have confirmed that any new dependencies are strictly necessary.
-   [ ]  I have written tests for new code (if applicable)
-   [x]  I have followed naming conventions/patterns in the surrounding code
-   [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
-   [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)


## Please describe to which degree, if any, an LLM was used in creating this pull request.
- I used it to query the app structure and provide suggested solution strategies
- Used it to help debug error messages while implementing the solution

...
