### PR TITLE
fix(i18n): clarify OAuth client secret requirement for confidential and public clients

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -272,7 +272,7 @@
     "oauth_auto_register": "Auto register",
     "oauth_auto_register_description": "Automatically register new users after signing in with OAuth",
     "oauth_button_text": "Button text",
-    "oauth_client_secret_description": "Required if PKCE (Proof Key for Code Exchange) is not supported by the OAuth provider",
+    "oauth_client_secret_description": "Required for confidential client, or if PKCE (Proof Key for Code Exchange) is not supported for public client.",
     "oauth_enable_description": "Login with OAuth",
     "oauth_mobile_redirect_uri": "Mobile redirect URI",
     "oauth_mobile_redirect_uri_override": "Mobile redirect URI override",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Updates the i18n description for the OAuth client secret requirement to accurately reflect when it is required for confidential and public clients.

## How Has This Been Tested?

<!-- Images go below this line. -->
<img width="903" height="522" alt="image" src="https://github.com/user-attachments/assets/82f6db44-548e-4ae3-8c62-38be3cfcbec8" />
</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Wordings
...
