### PR TITLE
fix: process query param for my.immich.app/memory?id=

### DIFF
--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -99,7 +99,7 @@ class DeepLinkService {
     const uuidRegex = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
     final assetRegex = RegExp('/photos/($uuidRegex)');
     final albumRegex = RegExp('/albums/($uuidRegex)');
-    final memoryQueryRegex = RegExp('^/memory$');
+    final memoryRegex = RegExp('/memory\\?id=($uuidRegex)');
 
     PageRouteInfo<dynamic>? deepLinkRoute;
     if (assetRegex.hasMatch(path)) {
@@ -108,11 +108,9 @@ class DeepLinkService {
     } else if (albumRegex.hasMatch(path)) {
       final albumId = albumRegex.firstMatch(path)?.group(1) ?? '';
       deepLinkRoute = await _buildAlbumDeepLink(albumId);
-    } else if (memoryQueryRegex.hasMatch(path)) {
-      final memoryId = link.uri.queryParameters['id'] ?? '';
-      if (RegExp('^$uuidRegex\$').hasMatch(memoryId)) {
-        deepLinkRoute = await _buildMemoryDeepLink(memoryId);
-      }
+    } else if (memoryRegex.hasMatch(path)) {
+      final memoryId = memoryRegex.firstMatch(path)?.group(1) ?? '';
+      deepLinkRoute = await _buildMemoryDeepLink(memoryId);
     }
 
     // Deep link resolution failed, safely handle it based on the app state

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -99,6 +99,7 @@ class DeepLinkService {
     const uuidRegex = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
     final assetRegex = RegExp('/photos/($uuidRegex)');
     final albumRegex = RegExp('/albums/($uuidRegex)');
+    final memoryQueryRegex = RegExp('^/memory$');
 
     PageRouteInfo<dynamic>? deepLinkRoute;
     if (assetRegex.hasMatch(path)) {
@@ -107,6 +108,11 @@ class DeepLinkService {
     } else if (albumRegex.hasMatch(path)) {
       final albumId = albumRegex.firstMatch(path)?.group(1) ?? '';
       deepLinkRoute = await _buildAlbumDeepLink(albumId);
+    } else if (memoryQueryRegex.hasMatch(path)) {
+      final memoryId = link.uri.queryParameters['id'] ?? '';
+      if (RegExp('^$uuidRegex\$').hasMatch(memoryId)) {
+        deepLinkRoute = await _buildMemoryDeepLink(memoryId);
+      }
     }
 
     // Deep link resolution failed, safely handle it based on the app state

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -1,5 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart' as beta_asset_service;
 import 'package:immich_mobile/domain/services/memory.service.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
@@ -12,6 +14,7 @@ import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart' as beta_asset_provider;
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/album.service.dart';
 import 'package:immich_mobile/services/asset.service.dart';
@@ -30,6 +33,7 @@ final deepLinkServiceProvider = Provider(
     ref.watch(beta_asset_provider.assetServiceProvider),
     ref.watch(remoteAlbumServiceProvider),
     ref.watch(driftMemoryServiceProvider),
+    ref.watch(currentUserProvider.select((user) => user!)),
   ),
 );
 
@@ -47,6 +51,8 @@ class DeepLinkService {
   final RemoteAlbumService _betaRemoteAlbumService;
   final DriftMemoryService _betaMemoryServiceProvider;
 
+  final UserDto _currentUser;
+
   const DeepLinkService(
     this._memoryService,
     this._assetService,
@@ -57,6 +63,7 @@ class DeepLinkService {
     this._betaAssetService,
     this._betaRemoteAlbumService,
     this._betaMemoryServiceProvider,
+    this._currentUser,
   );
 
   DeepLink _handleColdStart(PageRouteInfo<dynamic> route, bool isColdStart) {
@@ -99,7 +106,6 @@ class DeepLinkService {
     const uuidRegex = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
     final assetRegex = RegExp('/photos/($uuidRegex)');
     final albumRegex = RegExp('/albums/($uuidRegex)');
-    final memoryRegex = RegExp('/memory\\?id=($uuidRegex)');
 
     PageRouteInfo<dynamic>? deepLinkRoute;
     if (assetRegex.hasMatch(path)) {
@@ -108,9 +114,8 @@ class DeepLinkService {
     } else if (albumRegex.hasMatch(path)) {
       final albumId = albumRegex.firstMatch(path)?.group(1) ?? '';
       deepLinkRoute = await _buildAlbumDeepLink(albumId);
-    } else if (memoryRegex.hasMatch(path)) {
-      final memoryId = memoryRegex.firstMatch(path)?.group(1) ?? '';
-      deepLinkRoute = await _buildMemoryDeepLink(memoryId);
+    } else if (path == "/memory") {
+      deepLinkRoute = await _buildMemoryDeepLink(null);
     }
 
     // Deep link resolution failed, safely handle it based on the app state
@@ -122,17 +127,24 @@ class DeepLinkService {
     return _handleColdStart(deepLinkRoute, isColdStart);
   }
 
-  Future<PageRouteInfo?> _buildMemoryDeepLink(String memoryId) async {
+  Future<PageRouteInfo?> _buildMemoryDeepLink(String? memoryId) async {
     if (Store.isBetaTimelineEnabled) {
-      final memory = await _betaMemoryServiceProvider.get(memoryId);
+      List<DriftMemory> memories = [];
 
-      if (memory == null) {
+      memories = memoryId == null
+          ? await _betaMemoryServiceProvider.getMemoryLane(_currentUser.id)
+          : [await _betaMemoryServiceProvider.get(memoryId)].whereType<DriftMemory>().toList();
+
+      if (memories.isEmpty) {
         return null;
       }
 
-      return DriftMemoryRoute(memories: [memory], memoryIndex: 0);
+      return DriftMemoryRoute(memories: memories, memoryIndex: 0);
     } else {
       // TODO: Remove this when beta is default
+      if (memoryId == null) {
+        return null;
+      }
       final memory = await _memoryService.getMemoryById(memoryId);
 
       if (memory == null) {


### PR DESCRIPTION
Add regex for memory deep link handling of
https://my.immich.app/memory?id=<uuid>
Completing the work for the Android app to handle memory links. https://github.com/immich-app/immich/pull/25373


## Description
This is a continuation of this PR to be able to handle the https://my.immich.app/memory?id=<uuid>
https://github.com/immich-app/immich/pull/25373

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] No Tests done

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Code completly writen by LLM. Please help me review it @bwees 
...
