### PR TITLE
fix(docs): Refactor Free Up Space to match app changes

### DIFF
--- a/docs/docs/features/mobile-app.mdx
+++ b/docs/docs/features/mobile-app.mdx
@@ -44,7 +44,7 @@ You can enable automatic backup on supported devices. For more information see [
 
 If you have a large number of photos on the device, and you would prefer not to backup all the photos, then it might be prudent to only backup selected photos from device to the Immich server.
 
-First, you need to enable the Storage Indicator in your app's settings. Navigate to **<ins>Settings -> Photo Grid</ins>** and enable **"Show Storage indicator on asset tiles"**; this makes it easy to distinguish local-only assets and synced assets.
+First, you need to enable the Storage Indicator in your app's settings. Navigate to **<ins>Settings -> Photo Grid</ins>** and enable **`Show Storage indicator on asset tiles`**; this makes it easy to distinguish local-only assets and synced assets.
 
 :::note
 
@@ -55,7 +55,7 @@ This will enable a small cloud icon on the bottom right corner of the asset tile
 
 :::
 
-Now make sure that the local album is selected in the backup screen (steps 1-2 above). You can find these albums listed in **<ins>Library -> On this device</ins>**. To selectively upload photos from these albums, simply select the local-only photos and tap on "Upload" button in the dynamic bottom menu.
+Now make sure that the local album is selected in the backup screen (steps 1-2 above). You can find these albums listed in **<ins>Library -> On this device</ins>**. To selectively upload photos from these albums, simply select the local-only photos and tap on the `Upload` button in the dynamic bottom menu.
 
 <img
   src={require('./img/mobile-upload-open-photo.webp').default}
@@ -70,53 +70,55 @@ Now make sure that the local album is selected in the backup screen (steps 1-2 a
 
 ## Free Up Space
 
-The **Free Up Space** tool allows you to remove local media files from your device that have already been successfully backed up to your Immich server (and are not in the Immich trash). This helps reclaim storage on your mobile device without losing your memories.
+**Free Up Space** allows you to remove local media files from your device that have already been successfully backed up to your Immich server (and are not in Immich trash). This helps reclaim storage on your mobile device without losing your memories.
 
 ### How it works
 
 1.  **Configuration:**
-    - **Cutoff Date:** You can select a cutoff date. The tool will only look for photos and videos **on or before** this date.
-    - **Filter Options:** You can choose to remove **All** assets, or restrict removal to **Photos only** or **Videos only**.
-    - **Keep Favorites:** By default, local assets marked as favorites are preserved on your device, even if they match the cutoff date.
+    - **Cutoff date:** Free Up Space will only look for photos and videos **on or before** this date. Photos removed from the device don't show up in other (messaging) apps and have to be shared from Immich in order to send them.
+    - **Keep on device:** You can choose to restrict removal to `Always keep` **All photos** or **All videos**, regardless of other settings. This setting can hamper freeing up space significantly — with 80 GB of videos and 40 GB photos, selecting `Always keep photos` retains thousands of photos on your device.
+    - **Keep albums:** Hold all photos and videos in the selected albums on your device, regardless of other settings. Assets not already on the device will not be re-downloaded. {/* TODO: Section on how to re-download photos, and then link to it from here. */}
+    - **Keep favorites:** This works the same way `Keep albums` does. By default, favorited assets are preserved on your device.
 2.  **Scan & Review:** Before any files are removed, you are presented with a review screen to verify which items will be deleted.
 3.  **Deletion:** Confirmed items are moved to your device's native Trash/Recycle Bin. They will be permanently removed by the OS based on your system settings (usually after 30 days).
+
+:::info reclaim storage
+You must empty the system/gallery trash manually outside of Immich to reclaim storage faster than 30 days.
+:::
+
+Provided the server is healthy and [backed up](/administration/backup-and-restore.md), assets removed by Free Up Space can always be accessed in the Immich app (which re-downloads them from the server). Selecting to keep an extra copy on your device serves as an additional safeguard against disasters with the server.
 
 :::info Android Permissions
 For the smoothest experience on Android, you should grant Immich special delete privileges. Without this, you may be prompted to confirm deletion for every single image.
 
-Go to **Immich Settings > Advanced** and enable **"Media Management Access"**.
+Go to **Immich Settings > Advanced** and enable **`Media Management Access`**.
 :::
 
 ### iCloud Photos (iOS Users)
 
-If you use **iCloud Photos** alongside Immich, it is vital to understand how deletion affects your data. iCloud utilizes a two-way sync; this means deleting a photo from your iPhone to free up space will **also delete it from iCloud**.
-
-:::warning iCloud & Backups
-If you rely on iCloud as a secondary backup (part of a 3-2-1 backup strategy), using the Free Up Space feature in Immich will remove the file from both your phone and iCloud.
-
-Once deleted, the photo will exist **only** on your Immich server (and your phone's "Recently Deleted" folder for 30 days).
-
-When you use iCloud Photos and delete a photo or video on one device, it's also deleted on all other devices where you're signed in with the same Apple Account.
-
-More information on the [Apple Support](https://support.apple.com/en-us/108922#iCloud_photo_library) website
+If you use **iCloud Photos** alongside Immich, it is vital to understand how deletion affects your data. After using Free Up Space, the photo will be stored **only** on your Immich server (and your phone's "Recently Deleted" folder for 30 days).
 
 **Shared Albums**
-Assets that are part of an **iCloud Shared Album** are automatically excluded from the cleanup scan to ensure they remain viewable to others in the shared album.
+Assets that are part of an **iCloud Shared Album** are automatically excluded from Free Up Space to ensure they remain accessible to others in the shared album.
 :::
+
+:::warning iCloud & Backups
+If, in addition to Immich, you rely on iCloud as a secondary backup (as part of your [3-2-1](https://www.backblaze.com/blog/the-3-2-1-backup-strategy/) backup strategy), you should instead use `Optimize iPhone Storage` in [iCloud Photos](https://support.apple.com/en-us/105061).
+
+iCloud utilizes a two-way sync; this means deleting a photo, or using Free Up Space from your iPhone will **also delete it from iCloud** and all other devices (Mac, iPad) where you're signed in with the same Apple Account. See [Apple Support](https://support.apple.com/en-us/108922#iCloud_photo_library) for more info.
 
 ### External App Dependencies (WhatsApp, etc.)
 
 :::danger WhatsApp & Local Files
 Android applications like **WhatsApp** rely on local files to display media in chat history.
 
-If Immich backs up your WhatsApp folder and you run **Free Up Space**, the local copies of these images will be deleted. Consequently, **media in your WhatsApp chats will appear blurry or missing.** You will only be able to view these photos inside the Immich app; they will no longer be visible within the WhatsApp interface.
-
-**Recommendation:** If keeping chat history intact is important, please ensure you review the deletion list carefully or consider excluding WhatsApp folders from the backup if you intend to use this feature frequently.
+If you've selected Immich to back up your WhatsApp folder and you run **Free Up Space**, the local copies of these images will be deleted. Consequently, **media in your WhatsApp chats will appear blurry or missing.** You will only be able to view these photos inside the Immich app; they will no longer be visible within the WhatsApp interface.
 :::
 
-:::info reclaim storage
-You must empty the system/gallery trash manually to reclaim storage.
-:::
+**Recommendation:** If keeping chat history intact is important, exclude WhatsApp with `Keep albums` in Free Up Space and review the deletion list carefully. You have to enable [Album Sync](#album-sync) for WhatsApp to show up in the list. Alternatively, don't [back up](#backup) WhatsApp with Immich.
+
+:::warning Chat history
+Immich does not back up WhatsApp chat history, only the photos in them. To back up chat history, see [WhatsApp documentation](https://faq.whatsapp.com/481135090640375).
 
 ## Album Sync
 


### PR DESCRIPTION
As a follow-up to https://github.com/immich-app/immich/pull/25460

IMO WhatsApp should be ticked in Keep albums by default. IIRC backup doesn't always create the named album, though.

If you opt-out of backing up WhatsApp entirely, I see a bug where chat media already backed up will still be removed by Free Up Space, after excluding the folder from backup.

It's inconsistent. I think there is a need for a terminology document. Does Photos mean both Photos and Video? What is media? What are assets? Files? This device? All devices? Are memories photos and videos, or stories?

Out of scope for this PR for now: login: encourage https, and just writing 'immich.mydomain.com' in the box (defaulting to https)

## How Has This Been Tested?
I hope CI/CD gives a preview.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have no unrelated changes in the PR.

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No
