### PR TITLE
docs(openapi): preview for #25185

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -17900,6 +17900,7 @@
       "MaintenanceAuthDto": {
         "properties": {
           "username": {
+            "description": "The username to login with",
             "type": "string"
           }
         },
@@ -17911,6 +17912,7 @@
       "MaintenanceDetectInstallResponseDto": {
         "properties": {
           "storage": {
+            "description": "The storage folders to check",
             "items": {
               "$ref": "#/components/schemas/MaintenanceDetectInstallStorageFolderDto"
             },
@@ -17925,6 +17927,7 @@
       "MaintenanceDetectInstallStorageFolderDto": {
         "properties": {
           "files": {
+            "description": "The number of files in the folder",
             "type": "number"
           },
           "folder": {
@@ -17935,9 +17938,11 @@
             ]
           },
           "readable": {
+            "description": "Whether the folder is readable",
             "type": "boolean"
           },
           "writable": {
+            "description": "Whether the folder is writable",
             "type": "boolean"
           }
         },
@@ -17952,6 +17957,7 @@
       "MaintenanceLoginDto": {
         "properties": {
           "token": {
+            "description": "The maintenance token",
             "type": "string"
           }
         },
@@ -17967,15 +17973,19 @@
             ]
           },
           "active": {
+            "description": "Whether maintenance mode is active",
             "type": "boolean"
           },
           "error": {
+            "description": "The error message",
             "type": "string"
           },
           "progress": {
+            "description": "The progress of the current task",
             "type": "number"
           },
           "task": {
+            "description": "The current task",
             "type": "string"
           }
         },
@@ -20740,6 +20750,7 @@
             ]
           },
           "restoreBackupFilename": {
+            "description": "The filename of the backup to restore",
             "type": "string"
           }
         },

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -55,28 +55,39 @@ export type DatabaseBackupUploadDto = {
 };
 export type SetMaintenanceModeDto = {
     action: MaintenanceAction;
+    /** The filename of the backup to restore */
     restoreBackupFilename?: string;
 };
 export type MaintenanceDetectInstallStorageFolderDto = {
+    /** The number of files in the folder */
     files: number;
     folder: StorageFolder;
+    /** Whether the folder is readable */
     readable: boolean;
+    /** Whether the folder is writable */
     writable: boolean;
 };
 export type MaintenanceDetectInstallResponseDto = {
+    /** The storage folders to check */
     storage: MaintenanceDetectInstallStorageFolderDto[];
 };
 export type MaintenanceLoginDto = {
+    /** The maintenance token */
     token?: string;
 };
 export type MaintenanceAuthDto = {
+    /** The username to login with */
     username: string;
 };
 export type MaintenanceStatusResponseDto = {
     action: MaintenanceAction;
+    /** Whether maintenance mode is active */
     active: boolean;
+    /** The error message */
     error?: string;
+    /** The progress of the current task */
     progress?: number;
+    /** The current task */
     task?: string;
 };
 export type NotificationCreateDto = {

--- a/server/src/dtos/maintenance.dto.ts
+++ b/server/src/dtos/maintenance.dto.ts
@@ -1,6 +1,7 @@
 import { ValidateIf } from 'class-validator';
 import { MaintenanceAction, StorageFolder } from 'src/enum';
 import { ValidateEnum, ValidateString } from 'src/validation';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class SetMaintenanceModeDto {
   @ValidateEnum({ enum: MaintenanceAction, name: 'MaintenanceAction' })
@@ -8,37 +9,53 @@ export class SetMaintenanceModeDto {
 
   @ValidateIf((o) => o.action === MaintenanceAction.RestoreDatabase)
   @ValidateString()
+  @ApiProperty({ description: 'The filename of the backup to restore' })
   restoreBackupFilename?: string;
 }
 
 export class MaintenanceLoginDto {
   @ValidateString({ optional: true })
+  @ApiProperty({ description: 'The maintenance token' })
   token?: string;
 }
 
 export class MaintenanceAuthDto {
+  @ApiProperty({ description: 'The username to login with' })
   username!: string;
 }
 
 export class MaintenanceStatusResponseDto {
+  @ApiProperty({ description: 'Whether maintenance mode is active' })
   active!: boolean;
 
   @ValidateEnum({ enum: MaintenanceAction, name: 'MaintenanceAction' })
   action!: MaintenanceAction;
 
+  @ApiProperty({ description: 'The progress of the current task' })
   progress?: number;
+
+  @ApiProperty({ description: 'The current task' })
   task?: string;
+
+  @ApiProperty({ description: 'The error message' })
   error?: string;
 }
 
 export class MaintenanceDetectInstallStorageFolderDto {
   @ValidateEnum({ enum: StorageFolder, name: 'StorageFolder' })
   folder!: StorageFolder;
+
+  @ApiProperty({ description: 'Whether the folder is readable' })
   readable!: boolean;
+
+  @ApiProperty({ description: 'Whether the folder is writable' })
   writable!: boolean;
+
+  @ApiProperty({ description: 'The number of files in the folder' })
   files!: number;
 }
 
 export class MaintenanceDetectInstallResponseDto {
+  @ApiProperty({ description: 'The storage folders to check' })
   storage!: MaintenanceDetectInstallStorageFolderDto[];
 }


### PR DESCRIPTION
@jrasm91 as discussed on [Discord](https://discord.com/channels/979116623879368755/1460706621234745367) and #25185 . Here is the proposal:
- only update dtos
- don't use jsdoc as this has no openapi capabilities, instead use the built-in `ApiProperty` from `@nestjs/swagger`
- don't add descriptions to endpoints/controllers (yet 😄 )

If you accept this, I will go update #25185 (or recreate it) with this proposal