### PR TITLE
fix(mobile): backfill asset dimensions to exif table

### DIFF
--- a/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
@@ -240,6 +240,8 @@ class SyncStreamRepository extends DriftDatabaseRepository {
             rating: Value(exif.rating),
             projectionType: Value(exif.projectionType),
             lens: Value(exif.lensModel),
+            width: Value(exif.exifImageWidth),
+            height: Value(exif.exifImageHeight),
           );
 
           batch.insert(


### PR DESCRIPTION
## Description

We were never populating width/height in the asset exif table. They were being updated on the asset table but were left as NULL in the asset exif table