### PR TITLE
fix: eventmanager callbacks don't need to be reactive

### DIFF
--- a/web/src/lib/utils/base-event-manager.svelte.ts
+++ b/web/src/lib/utils/base-event-manager.svelte.ts
@@ -14,7 +14,7 @@ const nextId = () => count++;
 const noop = () => {};
 
 export class BaseEventManager<Events extends EventMap> {
-  #callbacks: EventItem<Events>[] = $state([]);
+  #callbacks: EventItem<Events>[] = [];
 
   on<T extends keyof Events>(event: T, callback?: EventCallback<Events, T>) {
     if (!callback) {


### PR DESCRIPTION
Fixes flakey timeline tests (and probably other bugs) 

Underlying cause was the 'current' arg was undefined, which is called when unsubscribing. The playwright timeline tests jump around VERY fast possibly triggering svelte reactivity bugs/race conditions. 

Solution is to not use reactive properties for callbacks. The lifecycle of these callbacks are manually managed - and no derives should ever need to be re-evaluated when these callbacks change. 


```
    return () => {
      this.#callbacks = this.#callbacks.filter((current) => current.id !== item.id);
    };
```

   