### PR TITLE
fix(mobile): do not try to load video as image

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -120,7 +120,7 @@ ImageProvider getFullImageProvider(BaseAsset asset, {Size size = const Size(1080
     } else {
       throw ArgumentError("Unsupported asset type: ${asset.runtimeType}");
     }
-    provider = RemoteFullImageProvider(assetId: assetId, thumbhash: thumbhash);
+    provider = RemoteFullImageProvider(assetId: assetId, thumbhash: thumbhash, assetType: asset.type);
   }
 
   return provider;

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/setting.model.dart';
 import 'package:immich_mobile/domain/services/setting.service.dart';
 import 'package:immich_mobile/infrastructure/loaders/image_request.dart';
@@ -59,8 +60,9 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     with CancellableImageProviderMixin<RemoteFullImageProvider> {
   final String assetId;
   final String thumbhash;
+  final AssetType assetType;
 
-  RemoteFullImageProvider({required this.assetId, required this.thumbhash});
+  RemoteFullImageProvider({required this.assetId, required this.thumbhash, required this.assetType});
 
   @override
   Future<RemoteFullImageProvider> obtainKey(ImageConfiguration configuration) {
@@ -95,12 +97,12 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     );
     yield* loadRequest(request, decode);
 
-    if (isCancelled) {
-      PaintingBinding.instance.imageCache.evict(this);
-      return;
-    }
+    if (assetType == AssetType.image && AppSetting.get(Setting.loadOriginal)) {
+      if (isCancelled) {
+        PaintingBinding.instance.imageCache.evict(this);
+        return;
+      }
 
-    if (AppSetting.get(Setting.loadOriginal)) {
       final request = this.request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId), headers: headers);
       yield* loadRequest(request, decode);
     }

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -91,21 +91,23 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
     }
 
     final headers = ApiService.getRequestHeaders();
-    final request = this.request = RemoteImageRequest(
+    final previewRequest = request = RemoteImageRequest(
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
       headers: headers,
     );
-    yield* loadRequest(request, decode);
+    yield* loadRequest(previewRequest, decode);
 
-    if (assetType == AssetType.image && AppSetting.get(Setting.loadOriginal)) {
-      if (isCancelled) {
-        PaintingBinding.instance.imageCache.evict(this);
-        return;
-      }
-
-      final request = this.request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId), headers: headers);
-      yield* loadRequest(request, decode);
+    if (assetType != AssetType.image || !AppSetting.get(Setting.loadOriginal)) {
+      return;
     }
+
+    if (isCancelled) {
+      PaintingBinding.instance.imageCache.evict(this);
+      return;
+    }
+
+    final originalRequest = request = RemoteImageRequest(uri: getOriginalUrlForRemoteId(key.assetId), headers: headers);
+    yield* loadRequest(originalRequest, decode);
   }
 
   @override


### PR DESCRIPTION
## Description

The remote image provider tries to download the original video and decode it as if it's an image, which naturally doesn't work and is very wasteful.

Fixes #25484