### PR TITLE
fix(mobile): delete local check for merged assets

### DIFF
--- a/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
+++ b/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
@@ -208,7 +208,7 @@ class ControlBottomAppBar extends HookConsumerWidget {
               label: "control_bottom_app_bar_delete_from_local".tr(),
               onPressed: enabled
                   ? () {
-                      if (!selectionAssetState.hasLocal) {
+                      if (!hasLocal) {
                         return onDeleteLocal?.call(true);
                       }
 


### PR DESCRIPTION
Replace `selectionAssetState.hasLocal` with computed `hasLocal` variable in delete local logic to properly handle merged assets that have local copies.