### PR TITLE
fix(mobile): use cached asset when possible

### DIFF
--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -23,6 +23,7 @@ class RemoteImageApiImpl: NSObject, RemoteImageApi {
   static let session = {
     let cacheDir = FileManager.default.temporaryDirectory.appendingPathComponent("thumbnails", isDirectory: true)
     let config = URLSessionConfiguration.default
+    config.requestCachePolicy = .returnCacheDataElseLoad
     let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
     config.httpAdditionalHeaders = ["User-Agent": "Immich_iOS_\(version)"]
     try! FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)


### PR DESCRIPTION
## Description

When trying to load an image that was cached more than `max-age` ago, URLSession wants to revalidate before displaying the asset. This doesn't work offline and it displays an error instead of displaying the stale asset. Since we already use the thumbhash in the URL, I think it can just always load the cached asset.