### PR TITLE
fix(ml): fix rocm ci

### DIFF
--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -47,17 +47,17 @@ RUN /bin/sh ./dockerfiles/scripts/install_common_deps.sh
 ENV PATH=/opt/rocm-venv/bin:/code/cmake-3.31.9-linux-x86_64/bin:${PATH}
 ENV CCACHE_DIR="/ccache"
 # Note: the `parallel` setting uses a substantial amount of RAM
-RUN --mount=type=cache,target=/ccache \
+RUN --mount=type=cache,target=/ccache,id=rocm-ccache \
     ./build.sh \
     --allow_running_as_root \
     --config Release \
     --build_wheel \
     --update \
     --build \
-    --parallel 17 \
+    --parallel 21 \
     --cmake_extra_defines \
     ONNXRUNTIME_VERSION="${ONNXRUNTIME_VERSION}" \
-    CMAKE_HIP_ARCHITECTURES="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201" \
+    CMAKE_HIP_ARCHITECTURES="gfx900;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201" \
     --skip_tests \
     --use_rocm \
     --rocm_home=/opt/rocm \

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -45,10 +45,8 @@ RUN git apply /tmp/*.patch
 RUN /bin/sh ./dockerfiles/scripts/install_common_deps.sh
 
 ENV PATH=/opt/rocm-venv/bin:/code/cmake-3.31.9-linux-x86_64/bin:${PATH}
-ENV CCACHE_DIR="/ccache"
 # Note: the `parallel` setting uses a substantial amount of RAM
-RUN --mount=type=cache,target=/ccache,id=rocm-ccache \
-    ./build.sh \
+RUN ./build.sh \
     --allow_running_as_root \
     --config Release \
     --build_wheel \
@@ -61,7 +59,6 @@ RUN --mount=type=cache,target=/ccache,id=rocm-ccache \
     --skip_tests \
     --use_rocm \
     --rocm_home=/opt/rocm \
-    --use_cache \
     --compile_no_warning_as_error
 RUN mv /code/onnxruntime/build/Linux/Release/dist/*.whl /opt/
 

--- a/machine-learning/Dockerfile
+++ b/machine-learning/Dockerfile
@@ -44,22 +44,26 @@ RUN git apply /tmp/*.patch
 
 RUN /bin/sh ./dockerfiles/scripts/install_common_deps.sh
 
+ARG ORT_BUILD_FLAGS=""
 ENV PATH=/opt/rocm-venv/bin:/code/cmake-3.31.9-linux-x86_64/bin:${PATH}
+ENV CCACHE_DIR="/ccache"
 # Note: the `parallel` setting uses a substantial amount of RAM
-RUN ./build.sh \
+RUN --mount=type=cache,target=/ccache,id=rocm-ccache \
+    ./build.sh \
     --allow_running_as_root \
     --config Release \
     --build_wheel \
     --update \
     --build \
-    --parallel 21 \
+    --parallel 17 \
     --cmake_extra_defines \
     ONNXRUNTIME_VERSION="${ONNXRUNTIME_VERSION}" \
     CMAKE_HIP_ARCHITECTURES="gfx900;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201" \
     --skip_tests \
     --use_rocm \
     --rocm_home=/opt/rocm \
-    --compile_no_warning_as_error
+    --compile_no_warning_as_error \
+    $ORT_BUILD_FLAGS
 RUN mv /code/onnxruntime/build/Linux/Release/dist/*.whl /opt/
 
 FROM builder-${DEVICE} AS builder


### PR DESCRIPTION
## Description

The targets were expanded in #23458 and ccache was added, but it causes the build to take over six hours. This PR removes the added target and ups parallelism temporarily to get a working image, which should hopefully improve future build time with ccache.