### PR TITLE
fix(web): queue graph formatting for y-axis labels

### DIFF
--- a/web/src/lib/components/QueueGraph.svelte
+++ b/web/src/lib/components/QueueGraph.svelte
@@ -60,7 +60,7 @@
   const axisOptions: Axis = {
     stroke: () => (isDark ? '#ccc' : 'black'),
     ticks: {
-      show: true,
+      show: false,
       stroke: () => (isDark ? '#444' : '#ddd'),
     },
     grid: {
@@ -116,6 +116,8 @@
     axes: [
       {
         ...axisOptions,
+        size: 40,
+        ticks: { show: true },
         values: (plot, values) => {
           return values.map((value) => {
             if (!value) {
@@ -125,7 +127,10 @@
           });
         },
       },
-      axisOptions,
+      {
+        ...axisOptions,
+        size: 60,
+      },
     ],
   };
 


### PR DESCRIPTION
- Increase space taken for y-axis to show label until 7 digits (up to 9 million jobs)
- Reduce space taken for x-axis because 50px is a lot
- Only show ticks on x-axis: for the y-axis, data disappearing before it 'slides' off the chart is confusing since the ticks have the exact same appearance as the grid, so they look like they are part of the grid, not ticks

Fixes #25560 