### PR TITLE
fix(server): set isEdited=false for extracted preview

### DIFF
--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -308,7 +308,6 @@ export class MediaService extends BaseService {
       isEdited: useEdits,
       isProgressive: !!image.preview.progressive && image.preview.format !== ImageFormat.Webp,
     });
-    previewFile.isProgressive = !!image.preview.progressive && image.preview.format !== ImageFormat.Webp;
     const thumbnailFile = this.getImageFile(asset, {
       fileType: AssetFileType.Thumbnail,
       format: image.thumbnail.format,
@@ -349,10 +348,9 @@ export class MediaService extends BaseService {
       fullsizeFile = this.getImageFile(asset, {
         fileType: AssetFileType.FullSize,
         format: extracted.format,
-        isEdited: useEdits,
+        isEdited: false,
         isProgressive: !!image.fullsize.progressive && image.fullsize.format !== ImageFormat.Webp,
       });
-      fullsizeFile.isProgressive = !!image.fullsize.progressive && image.fullsize.format !== ImageFormat.Webp;
       this.storageCore.ensureFolders(fullsizeFile.path);
 
       // Write the buffer to disk with essential EXIF data


### PR DESCRIPTION
## Description

It seems this was set to false before and switched to `useEdits` in the refactor, probably a copy/paste error.