### PR TITLE
chore(mise): use explicit monorepo config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,18 @@
 experimental_monorepo_root = true
 
+[monorepo]
+config_roots = [
+  "plugins",
+  "server",
+  "cli",
+  "deployment",
+  "mobile",
+  "e2e",
+  "web",
+  "docs",
+  ".github",
+]
+
 [tools]
 node = "24.13.0"
 flutter = "3.35.7"


### PR DESCRIPTION
mise introduced explicit monorepo config in [v2026.1.4](https://github.com/jdx/mise/releases/tag/v2026.1.4) and deprecated automatic filesystem discovery. see https://github.com/jdx/mise/pull/7705