### PR TITLE
chore: update uv version setting command in release script

### DIFF
--- a/misc/release/pump-version.sh
+++ b/misc/release/pump-version.sh
@@ -75,7 +75,7 @@ if [ "$CURRENT_SERVER" != "$NEXT_SERVER" ]; then
   pnpm --prefix server run build
   ( cd ./open-api && bash ./bin/generate-open-api.sh )
 
-  uvx --from=toml-cli toml set --toml-path=machine-learning/pyproject.toml project.version "$NEXT_SERVER"
+  uv version --directory machine-learning "$NEXT_SERVER"
 
   ./misc/release/archive-version.js "$NEXT_SERVER"
 fi


### PR DESCRIPTION
uv supports this out of the box: https://docs.astral.sh/uv/reference/cli/#uv-version. Also this has the benefit of additionally updating the `uv.lock` file with the new version

<img width="640" height="148" alt="image" src="https://github.com/user-attachments/assets/6cdf1f9a-a369-4398-ba35-d11f228f1650" />
<img width="537" height="328" alt="image" src="https://github.com/user-attachments/assets/c96eca6c-b570-4558-815a-b0b7d808a509" />
