### PR TITLE
chore: replace patch doc links

### DIFF
--- a/docs/static/archived-versions.json
+++ b/docs/static/archived-versions.json
@@ -8,32 +8,12 @@
     "url": "https://docs.v2.4.1.archive.immich.app"
   },
   {
-    "label": "v2.4.0",
-    "url": "https://docs.v2.4.0.archive.immich.app"
-  },
-  {
     "label": "v2.3.1",
     "url": "https://docs.v2.3.1.archive.immich.app"
   },
   {
-    "label": "v2.3.0",
-    "url": "https://docs.v2.3.0.archive.immich.app"
-  },
-  {
     "label": "v2.2.3",
     "url": "https://docs.v2.2.3.archive.immich.app"
-  },
-  {
-    "label": "v2.2.2",
-    "url": "https://docs.v2.2.2.archive.immich.app"
-  },
-  {
-    "label": "v2.2.1",
-    "url": "https://docs.v2.2.1.archive.immich.app"
-  },
-  {
-    "label": "v2.2.0",
-    "url": "https://docs.v2.2.0.archive.immich.app"
   },
   {
     "label": "v2.1.0",
@@ -44,16 +24,8 @@
     "url": "https://docs.v2.0.1.archive.immich.app"
   },
   {
-    "label": "v2.0.0",
-    "url": "https://docs.v2.0.0.archive.immich.app"
-  },
-  {
     "label": "v1.144.1",
     "url": "https://docs.v1.144.1.archive.immich.app"
-  },
-  {
-    "label": "v1.144.0",
-    "url": "https://docs.v1.144.0.archive.immich.app"
   },
   {
     "label": "v1.143.1",

--- a/misc/release/archive-version.js
+++ b/misc/release/archive-version.js
@@ -1,6 +1,12 @@
 #! /usr/bin/env node
 const { readFileSync, writeFileSync } = require('node:fs');
 
+const asVersion = (item) => {
+  const { label, url } = item;
+  const [major, minor, patch] = label.substring(1).split('.').map(Number);
+  return { major, minor, patch, label, url };
+};
+
 const nextVersion = process.argv[2];
 if (!nextVersion) {
   console.log('Usage: archive-version.js <version>');
@@ -8,10 +14,32 @@ if (!nextVersion) {
 }
 
 const filename = './docs/static/archived-versions.json';
-const oldVersions = JSON.parse(readFileSync(filename));
-const newVersions = [
-  { label: `v${nextVersion}`, url: `https://docs.v${nextVersion}.archive.immich.app` },
-  ...oldVersions,
-];
+let versions = JSON.parse(readFileSync(filename));
+const newVersion = {
+  label: `v${nextVersion}`,
+  url: `https://docs.v${nextVersion}.archive.immich.app`,
+};
 
-writeFileSync(filename, JSON.stringify(newVersions, null, 2) + '\n');
+let lastVersion = asVersion(newVersion);
+for (const item of versions) {
+  const version = asVersion(item);
+  // only keep the latest patch version for each minor release
+  if (
+    lastVersion.major === version.major &&
+    lastVersion.minor === version.minor &&
+    lastVersion.patch >= version.patch
+  ) {
+    versions = versions.filter((item) => item.label !== version.label);
+    console.log(
+      `Removed ${version.label} (replaced with ${lastVersion.label})`
+    );
+    continue;
+  }
+
+  lastVersion = version;
+}
+
+writeFileSync(
+  filename,
+  JSON.stringify([newVersion, ...versions], null, 2) + '\n'
+);


### PR DESCRIPTION
Automatically replace links to previous versions with the latest patch release.

```
Removed v2.4.0 (replaced with v2.4.1)
Removed v2.3.0 (replaced with v2.3.1)
Removed v2.2.2 (replaced with v2.2.3)
Removed v2.2.1 (replaced with v2.2.3)
Removed v2.2.0 (replaced with v2.2.3)
Removed v2.0.0 (replaced with v2.0.1)
Removed v1.144.0 (replaced with v1.144.1)
```