### PR TITLE
feat: jxl browser support detection

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -303,8 +303,17 @@ const supportedImageMimeTypes = new Set([
 
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // https://stackoverflow.com/a/23522755
 if (isSafari) {
-  supportedImageMimeTypes.add('image/heic').add('image/heif').add('image/jxl');
+  supportedImageMimeTypes.add('image/heic').add('image/heif');
 }
+
+function checkJxlSupport(): void {
+  const img = new Image();
+  img.addEventListener('load', () => {
+    supportedImageMimeTypes.add('image/jxl');
+  });
+  img.src = 'data:image/jxl;base64,/woIAAAMABKIAgC4AF3lEgA='; // Small valid JPEG XL image
+}
+checkJxlSupport();
 
 /**
  * Returns true if the asset is an image supported by web browsers, false otherwise


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Besides Safari, other browsers support (or are adding support) to JPEG XL images. One example is Zen Browser, which inherited the flag from Firefox's upstream and enabled it by default.
This means that adding support for more and more browsers one by one can be problematic.

At the same time, there is an easy and fast way to detect whether a browser supports JPEG XL images. It involves creating an Image object, assigning a minimal `image/jxl` payload to its `src` and monitoring the async loading with an event listener.

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Run this test code from any browser's console:
```js
const img = new Image();
img.addEventListener('load', () => alert('yes'));
img.addEventListener('error', () => alert('no'));
img.src = 'data:image/jxl;base64,/woIAAAMABKIAgC4AF3lEgA=';
```
It will show an alert with:
- `yes` if supported, expected in these browsers as of 2026-01-28:
  - Safari
  - Zen Browser
  - Firefox, with the `image.jxl.enabled` set to `true` in `about:config`. Otherwise no
- `no` if not supported

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
  - I'm not sure how a test could check this change, but I'm happy to add any specific test if required
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM.
