### PR TITLE
fix(server): don't assume maintenance action is set

### DIFF
--- a/server/src/maintenance/maintenance-worker.service.ts
+++ b/server/src/maintenance/maintenance-worker.service.ts
@@ -79,7 +79,7 @@ export class MaintenanceWorkerService {
     this.#secret = state.secret;
     this.#status = {
       active: true,
-      action: state.action.action,
+      action: state.action?.action ?? MaintenanceAction.Start,
     };
 
     StorageCore.setMediaLocation(this.detectMediaLocation());
@@ -88,7 +88,10 @@ export class MaintenanceWorkerService {
     this.maintenanceWebsocketRepository.setStatusUpdateFn((status) => (this.#status = status));
 
     await this.logSecret();
-    void this.runAction(state.action);
+
+    if (state.action) {
+      void this.runAction(state.action);
+    }
   }
 
   /**

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -490,7 +490,7 @@ export interface MemoryData {
 export type VersionCheckMetadata = { checkedAt: string; releaseVersion: string };
 export type SystemFlags = { mountChecks: Record<StorageFolder, boolean> };
 export type MaintenanceModeState =
-  | { isMaintenanceMode: true; secret: string; action: SetMaintenanceModeDto }
+  | { isMaintenanceMode: true; secret: string; action?: SetMaintenanceModeDto }
   | { isMaintenanceMode: false };
 export type MemoriesState = {
   /** memories have already been created through this date */


### PR DESCRIPTION
Assuming maintenance action is set causes crash for users upgrading from v2.4 who have maintenance mode enabled during the upgrade.

fixes #25614