### PR TITLE
chore: add node options env var

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,6 +23,9 @@ RUN --mount=type=cache,id=pnpm-server,target=/buildcache/pnpm-store \
 
 FROM builder AS web
 
+ARG NODE_OPTIONS
+ENV NODE_OPTIONS=$NODE_OPTIONS
+
 WORKDIR /usr/src/app
 COPY ./web ./web/
 COPY ./i18n ./i18n/


### PR DESCRIPTION
## Description
I tried to build the server in my local fork and while compiling the github CI ran out of memory.


<!--- Describe your changes in detail -->
The change only exposes NODE_OPTIONS from dockerfile so workflows can pass these values if needed.

<!--- Why is this change required? What problem does it solve? -->
I am trying to build the server code with a regular github CI runner and it runs out of memory with the message below.
Setting NODE_OPTIONS=--max-old-space-size=4096
removed the problem.

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?
When I set NODE_OPTIONS =--max-old-space-size=4096 the build passes in the CI.

<details><summary><h2>CI logs</h2></summary>
```
#24 199.9 web build: [64:0x41349000]   121606 ms: Scavenge 2027.0 (2087.4) -> 2025.5 (2087.4) MB, pooled: 0 MB, 8.63 / 0.00 ms  (average mu = 0.158, current mu = 0.043) allocation failure; 
#24 199.9 web build: [64:0x41349000]   123796 ms: Mark-Compact (reduce) 2029.8 (2091.4) -> 2021.4 (2077.1) MB, pooled: 0 MB, 1880.79 / 0.00 ms  (+ 277.8 ms in 0 steps since start of marking, biggest step 0.0 ms, walltime since start of marking 2190 ms) (average mu = 0.156, cu
#24 199.9 web build: <--- JS stacktrace --->
#24 199.9 web build: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Codex proposed the fix and it worked. 
This PR does not change any values, or behaviour, it just offers a way to set NODE_OPTIONS from the "outside" if needed.
