### PR TITLE
fix(mobile): actually load original image

### DIFF
--- a/mobile/ios/Runner/Images/RemoteImagesImpl.swift
+++ b/mobile/ios/Runner/Images/RemoteImagesImpl.swift
@@ -79,6 +79,7 @@ class RemoteImageApiDelegate: NSObject, URLSessionDataDelegate {
     kCGImageSourceShouldCache: false,
     kCGImageSourceShouldCacheImmediately: true,
     kCGImageSourceCreateThumbnailWithTransform: true,
+    kCGImageSourceCreateThumbnailFromImageAlways: true
   ] as CFDictionary
   
   func urlSession(


### PR DESCRIPTION
## Description

It tries to use an embedded preview without this, which varies in resolution.

Fixes #25628

## How Has This Been Tested?

Tested with a sample image reproducing the issue.