### PR TITLE
fix(mobile): tall image scrolling

### DIFF
--- a/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
+++ b/mobile/lib/widgets/photo_view/src/core/photo_view_gesture_detector.dart
@@ -203,9 +203,13 @@ class PhotoViewGestureRecognizer extends ScaleGestureRecognizer {
 
   void _decideIfWeAcceptEvent(PointerEvent event) {
     final move = _initialFocalPoint! - _currentFocalPoint!;
-    final bool shouldMove = validateAxis == Axis.vertical
-        ? hitDetector!.shouldMove(move, Axis.vertical)
-        : hitDetector!.shouldMove(move, Axis.horizontal);
+
+    // Accept gesture if movement is possible in the direction the user is swiping
+    final bool isHorizontalGesture = move.dx.abs() > move.dy.abs();
+    final bool shouldMove = isHorizontalGesture
+        ? hitDetector!.shouldMove(move, Axis.horizontal)
+        : hitDetector!.shouldMove(move, Axis.vertical);
+
     if (shouldMove || _pointerLocations.keys.length > 1) {
       final double spanDelta = (_currentSpan! - _initialSpan!).abs();
       final double focalPointDelta = (_currentFocalPoint! - _initialFocalPoint!).distance;


### PR DESCRIPTION
## Description

Scrolling vertically in tall images (eg scrolling screenshots, 1000x9000px) did not work, if the image did not fill the width of the view. Please see video in spoiler. 

The reason for this is that vertical scrolling gestures are being passed to the PageView (for horizontal navigation) instead of being handled by PhotoView for vertical panning. The gesture recognizer only checked if movement was possible along the gallery's scroll axis (horizontal). When horizontal movement wasn't possible (image narrower than viewport), PhotoView wouldn't accept the gesture, letting PageView take it instead. Now it checks the axis the user is actually swiping on.

## How Has This Been Tested?

- Tall image with black bars on sides: vertical scroll works, horizontal swipe navigates gallery
- Tall image filling width: vertical scroll works, horizontal scroll works within image boundaries. Horizontal scroll at boundaries navigates gallery
- Normal images: horizontal swipe navigation works, pinch/double-tap zoom works

I tried to write tests, but they would have to be integration tests because the issue is only replicable because of the interactions between multiple widgets

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

heres my test image (open in new tab for full size)
<img width="50" height="100" alt="test" src="https://github.com/user-attachments/assets/548239c3-f168-4d26-8b18-411634a84b26" />

https://github.com/user-attachments/assets/75908924-3cb7-4705-b2f7-e2e4da2e7d33

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [N/A] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude during debugging
