### PR TITLE
docs: add MASH Ansible Playbook installation method

### DIFF
--- a/docs/docs/install/ansible-mash-playbook.md
+++ b/docs/docs/install/ansible-mash-playbook.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 75
+---
+
+# Ansible - MASH Playbook [Community]
+
+:::note
+This is a community contribution and not officially supported by the Immich team, but included here for convenience.
+
+**Please report issues to the [MASH playbook][mash-playbook] or [Ansible role for Immich][ansible-role-immich] GitHub repositories.**
+:::
+
+[MASH][mash-playbook] (**M**other-of-**A**ll-**S**elf-**H**osting) is an [Ansible](https://www.ansible.com/) playbook that helps you self-host [Immich](https://immich.app/) and [many other FOSS services](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/supported-services.md) as [Docker](https://www.docker.com/) containers on your own server.
+
+MASH is free software, available under the [AGPLv3 license][mash-playbook]. The [Ansible role for Immich][ansible-role-immich] which powers it is also free software, available under the [GPLv3 license][ansible-role-immich].
+
+## Why Use an Ansible Playbook?
+
+Using Docker containers directly (via [Docker Compose](/install/docker-compose.mdx)) is a good way to run Immich, but the Ansible playbook approach offers some additional benefits:
+
+- **Automation**: Ansible automates the entire setup process, making it easy to deploy Immich consistently across multiple servers or to rebuild your setup from scratch.
+
+- **Security Hardening**: The [Ansible role for Immich][ansible-role-immich]t runs containers with security best practices, including:
+  - Dropping all Linux capabilities (`--cap-drop=ALL`) and only adding back the minimal required ones
+  - Running containers as non-root users (`--user`)
+  - Read-only root filesystems (`--read-only`)
+
+- **Reproducibility**: Your entire server configuration is defined in code (Ansible inventory files), making it easy to version control, review, and replicate.
+
+- **Integrated Ecosystem**: MASH supports [many other services](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/supported-services.md) (reverse proxy via [Traefik](https://traefik.io/), databases, backup solutions, etc.) that can be deployed alongside Immich with minimal additional configuration.
+
+## Features
+
+The Ansible role uses official Immich container images and manages the following components:
+
+- **Immich Server**: The main application server handling HTTP requests, media processing, and transcoding
+- **Immich Machine Learning**: The ML service for image classification and facial recognition (can be disabled or hosted separately)
+- **PostgreSQL**: A dedicated [Immich-specific Postgres](https://github.com/immich-app/base-images/tree/main/postgres) instance with the required extensions (pgvector, etc.)
+- **Valkey/Redis**: A dedicated data store for Immich
+
+It also supports configuring:
+
+- [Hardware acceleration for video transcoding](/features/hardware-transcoding.md) (VAAPI, QuickSync, NVENC, RKMPP)
+- [Hardware acceleration for machine learning](/features/ml-hardware-acceleration.md) (OpenVINO, CUDA, ARM NN, ROCm, RKNN)
+- Automatic Traefik reverse proxy integration
+
+## Installation
+
+To get started:
+
+1. First, follow the [MASH playbook setup guide](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/README.md) to prepare your server and configure the playbook
+2. Then, add Immich to your setup by following the [MASH Immich service documentation](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/immich.md)
+
+## Related Projects
+
+- [Immich Kiosk](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/immich-kiosk.md) - A slideshow application for displaying Immich photos on browsers and devices, also available via MASH
+
+## Support
+
+Community support is available via:
+
+- Matrix room: [#mash-playbook:devture.com](https://matrix.to/#/#mash-playbook:devture.com)
+- GitHub issues: [mother-of-all-self-hosting/mash-playbook/issues](https://github.com/mother-of-all-self-hosting/mash-playbook/issues)
+
+[mash-playbook]: https://github.com/mother-of-all-self-hosting/mash-playbook
+[ansible-role-immich]: https://github.com/mother-of-all-self-hosting/ansible-role-immich

--- a/docs/docs/install/docker-compose.mdx
+++ b/docs/docs/install/docker-compose.mdx
@@ -6,6 +6,10 @@ sidebar_position: 30
 
 Docker Compose is the recommended method to run Immich in production. Below are the steps to deploy Immich with Docker Compose.
 
+:::tip Looking for automation?
+If you prefer a more automated and reproducible setup, consider using the community [MASH Ansible Playbook](/install/ansible-mash-playbook.md) method, which also provides additional security hardening for your containers.
+:::
+
 import DockerComposeSteps from '/docs/partials/_docker-compose-install-steps.mdx';
 
 <DockerComposeSteps />


### PR DESCRIPTION
## Description

Add documentation for installing Immich via the [MASH](https://github.com/mother-of-all-self-hosting/mash-playbook) (Mother-of-All-Self-Hosting) Ansible playbook, a community-maintained method that provides automated deployment with security hardening.

Changes:
- Create new install page: `docs/docs/install/ansible-mash-playbook.md`
- Add cross-link tip on the Docker Compose install page pointing to the new Ansible method

The MASH playbook uses official Immich container images and provides additional security hardening (capability dropping, non-root users, read-only filesystems, etc.).

For reference, the MASH Immich service documentation is here: https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/immich.md

## How Has This Been Tested?

- [x] `pnpm run build` in docs/ directory succeeds
- [x] Verified page renders correctly in local dev server (`pnpm run start`)
- [x] Verified cross-links to other docs pages work correctly

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary. (N/A - no new dependencies)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used to assist with drafting the documentation content, exploring the codebase structure, and identifying cross-linking patterns used in the existing documentation. All content was reviewed and refined by the author.