### PR TITLE
feat: shared link login

### DIFF
--- a/e2e/src/responses.ts
+++ b/e2e/src/responses.ts
@@ -43,10 +43,10 @@ export const errorDto = {
     message: 'Invalid share key',
     correlationId: expect.any(String),
   },
-  invalidSharePassword: {
+  passwordRequired: {
     error: 'Unauthorized',
     statusCode: 401,
-    message: 'Invalid password',
+    message: 'Password required',
     correlationId: expect.any(String),
   },
   badRequest: (message: any = null) => ({

--- a/e2e/src/specs/server/api/shared-link.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-link.e2e-spec.ts
@@ -239,7 +239,7 @@ describe('/shared-links', () => {
       const { status, body } = await request(app).get('/shared-links/me').query({ key: linkWithPassword.key });
 
       expect(status).toBe(401);
-      expect(body).toEqual(errorDto.invalidSharePassword);
+      expect(body).toEqual(errorDto.passwordRequired);
     });
 
     it('should get data for correct password protected link', async () => {

--- a/mobile/openapi/README.md
+++ b/mobile/openapi/README.md
@@ -256,6 +256,7 @@ Class | Method | HTTP request | Description
 *SharedLinksApi* | [**getSharedLinkById**](doc//SharedLinksApi.md#getsharedlinkbyid) | **GET** /shared-links/{id} | Retrieve a shared link
 *SharedLinksApi* | [**removeSharedLink**](doc//SharedLinksApi.md#removesharedlink) | **DELETE** /shared-links/{id} | Delete a shared link
 *SharedLinksApi* | [**removeSharedLinkAssets**](doc//SharedLinksApi.md#removesharedlinkassets) | **DELETE** /shared-links/{id}/assets | Remove assets from a shared link
+*SharedLinksApi* | [**sharedLinkLogin**](doc//SharedLinksApi.md#sharedlinklogin) | **POST** /shared-links/login | Shared link login
 *SharedLinksApi* | [**updateSharedLink**](doc//SharedLinksApi.md#updatesharedlink) | **PATCH** /shared-links/{id} | Update a shared link
 *StacksApi* | [**createStack**](doc//StacksApi.md#createstack) | **POST** /stacks | Create a stack
 *StacksApi* | [**deleteStack**](doc//StacksApi.md#deletestack) | **DELETE** /stacks/{id} | Delete a stack
@@ -552,6 +553,7 @@ Class | Method | HTTP request | Description
  - [SetMaintenanceModeDto](doc//SetMaintenanceModeDto.md)
  - [SharedLinkCreateDto](doc//SharedLinkCreateDto.md)
  - [SharedLinkEditDto](doc//SharedLinkEditDto.md)
+ - [SharedLinkLoginDto](doc//SharedLinkLoginDto.md)
  - [SharedLinkResponseDto](doc//SharedLinkResponseDto.md)
  - [SharedLinkType](doc//SharedLinkType.md)
  - [SharedLinksResponse](doc//SharedLinksResponse.md)

--- a/mobile/openapi/lib/api.dart
+++ b/mobile/openapi/lib/api.dart
@@ -292,6 +292,7 @@ part 'model/session_update_dto.dart';
 part 'model/set_maintenance_mode_dto.dart';
 part 'model/shared_link_create_dto.dart';
 part 'model/shared_link_edit_dto.dart';
+part 'model/shared_link_login_dto.dart';
 part 'model/shared_link_response_dto.dart';
 part 'model/shared_link_type.dart';
 part 'model/shared_links_response.dart';

--- a/mobile/openapi/lib/api/shared_links_api.dart
+++ b/mobile/openapi/lib/api/shared_links_api.dart
@@ -495,6 +495,77 @@ class SharedLinksApi {
     return null;
   }
 
+  /// Shared link login
+  ///
+  /// Login to a password protected shared link
+  ///
+  /// Note: This method returns the HTTP [Response].
+  ///
+  /// Parameters:
+  ///
+  /// * [SharedLinkLoginDto] sharedLinkLoginDto (required):
+  ///
+  /// * [String] key:
+  ///
+  /// * [String] slug:
+  Future<Response> sharedLinkLoginWithHttpInfo(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, }) async {
+    // ignore: prefer_const_declarations
+    final apiPath = r'/shared-links/login';
+
+    // ignore: prefer_final_locals
+    Object? postBody = sharedLinkLoginDto;
+
+    final queryParams = <QueryParam>[];
+    final headerParams = <String, String>{};
+    final formParams = <String, String>{};
+
+    if (key != null) {
+      queryParams.addAll(_queryParams('', 'key', key));
+    }
+    if (slug != null) {
+      queryParams.addAll(_queryParams('', 'slug', slug));
+    }
+
+    const contentTypes = <String>['application/json'];
+
+
+    return apiClient.invokeAPI(
+      apiPath,
+      'POST',
+      queryParams,
+      postBody,
+      headerParams,
+      formParams,
+      contentTypes.isEmpty ? null : contentTypes.first,
+    );
+  }
+
+  /// Shared link login
+  ///
+  /// Login to a password protected shared link
+  ///
+  /// Parameters:
+  ///
+  /// * [SharedLinkLoginDto] sharedLinkLoginDto (required):
+  ///
+  /// * [String] key:
+  ///
+  /// * [String] slug:
+  Future<SharedLinkResponseDto?> sharedLinkLogin(SharedLinkLoginDto sharedLinkLoginDto, { String? key, String? slug, }) async {
+    final response = await sharedLinkLoginWithHttpInfo(sharedLinkLoginDto,  key: key, slug: slug, );
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    }
+    // When a remote server returns no body with a status of 204, we shall not decode it.
+    // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
+    // FormatException when trying to decode an empty string.
+    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'SharedLinkResponseDto',) as SharedLinkResponseDto;
+    
+    }
+    return null;
+  }
+
   /// Update a shared link
   ///
   /// Update an existing shared link by its ID.

--- a/mobile/openapi/lib/api_client.dart
+++ b/mobile/openapi/lib/api_client.dart
@@ -630,6 +630,8 @@ class ApiClient {
           return SharedLinkCreateDto.fromJson(value);
         case 'SharedLinkEditDto':
           return SharedLinkEditDto.fromJson(value);
+        case 'SharedLinkLoginDto':
+          return SharedLinkLoginDto.fromJson(value);
         case 'SharedLinkResponseDto':
           return SharedLinkResponseDto.fromJson(value);
         case 'SharedLinkType':

--- a/mobile/openapi/lib/model/shared_link_login_dto.dart
+++ b/mobile/openapi/lib/model/shared_link_login_dto.dart
@@ -1,0 +1,100 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+// @dart=2.18
+
+// ignore_for_file: unused_element, unused_import
+// ignore_for_file: always_put_required_named_parameters_first
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: lines_longer_than_80_chars
+
+part of openapi.api;
+
+class SharedLinkLoginDto {
+  /// Returns a new [SharedLinkLoginDto] instance.
+  SharedLinkLoginDto({
+    required this.password,
+  });
+
+  /// Shared link password
+  String password;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is SharedLinkLoginDto &&
+    other.password == password;
+
+  @override
+  int get hashCode =>
+    // ignore: unnecessary_parenthesis
+    (password.hashCode);
+
+  @override
+  String toString() => 'SharedLinkLoginDto[password=$password]';
+
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{};
+      json[r'password'] = this.password;
+    return json;
+  }
+
+  /// Returns a new [SharedLinkLoginDto] instance and imports its values from
+  /// [value] if it's a [Map], null otherwise.
+  // ignore: prefer_constructors_over_static_methods
+  static SharedLinkLoginDto? fromJson(dynamic value) {
+    upgradeDto(value, "SharedLinkLoginDto");
+    if (value is Map) {
+      final json = value.cast<String, dynamic>();
+
+      return SharedLinkLoginDto(
+        password: mapValueOfType<String>(json, r'password')!,
+      );
+    }
+    return null;
+  }
+
+  static List<SharedLinkLoginDto> listFromJson(dynamic json, {bool growable = false,}) {
+    final result = <SharedLinkLoginDto>[];
+    if (json is List && json.isNotEmpty) {
+      for (final row in json) {
+        final value = SharedLinkLoginDto.fromJson(row);
+        if (value != null) {
+          result.add(value);
+        }
+      }
+    }
+    return result.toList(growable: growable);
+  }
+
+  static Map<String, SharedLinkLoginDto> mapFromJson(dynamic json) {
+    final map = <String, SharedLinkLoginDto>{};
+    if (json is Map && json.isNotEmpty) {
+      json = json.cast<String, dynamic>(); // ignore: parameter_assignments
+      for (final entry in json.entries) {
+        final value = SharedLinkLoginDto.fromJson(entry.value);
+        if (value != null) {
+          map[entry.key] = value;
+        }
+      }
+    }
+    return map;
+  }
+
+  // maps a json object with a list of SharedLinkLoginDto-objects as value to a dart map
+  static Map<String, List<SharedLinkLoginDto>> mapListFromJson(dynamic json, {bool growable = false,}) {
+    final map = <String, List<SharedLinkLoginDto>>{};
+    if (json is Map && json.isNotEmpty) {
+      // ignore: parameter_assignments
+      json = json.cast<String, dynamic>();
+      for (final entry in json.entries) {
+        map[entry.key] = SharedLinkLoginDto.listFromJson(entry.value, growable: growable,);
+      }
+    }
+    return map;
+  }
+
+  /// The list of required keys that must be present in a JSON.
+  static const requiredKeys = <String>{
+    'password',
+  };
+}
+

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -11239,6 +11239,78 @@
         "x-immich-state": "Stable"
       }
     },
+    "/shared-links/login": {
+      "post": {
+        "description": "Login to a password protected shared link",
+        "operationId": "sharedLinkLogin",
+        "parameters": [
+          {
+            "name": "key",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "slug",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SharedLinkLoginDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SharedLinkResponseDto"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "summary": "Shared link login",
+        "tags": [
+          "Shared links"
+        ],
+        "x-immich-history": [
+          {
+            "version": "v2.6.0",
+            "state": "Added"
+          },
+          {
+            "version": "v2.6.0",
+            "state": "Beta"
+          }
+        ],
+        "x-immich-state": "Beta"
+      }
+    },
     "/shared-links/me": {
       "get": {
         "description": "Retrieve the current shared link associated with authentication method.",
@@ -21686,6 +21758,19 @@
         },
         "type": "object"
       },
+      "SharedLinkLoginDto": {
+        "properties": {
+          "password": {
+            "description": "Shared link password",
+            "example": "password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "password"
+        ],
+        "type": "object"
+      },
       "SharedLinkResponseDto": {
         "properties": {
           "album": {
@@ -21744,9 +21829,25 @@
             "type": "string"
           },
           "token": {
+            "deprecated": true,
             "description": "Access token",
             "nullable": true,
-            "type": "string"
+            "type": "string",
+            "x-immich-history": [
+              {
+                "version": "v1",
+                "state": "Added"
+              },
+              {
+                "version": "v2",
+                "state": "Stable"
+              },
+              {
+                "version": "v2.6.0",
+                "state": "Deprecated"
+              }
+            ],
+            "x-immich-state": "Deprecated"
           },
           "type": {
             "allOf": [

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -2287,6 +2287,10 @@ export type SharedLinkCreateDto = {
     /** Shared link type */
     "type": SharedLinkType;
 };
+export type SharedLinkLoginDto = {
+    /** Shared link password */
+    password: string;
+};
 export type SharedLinkEditDto = {
     /** Allow downloads */
     allowDownload?: boolean;
@@ -5859,6 +5863,26 @@ export function createSharedLink({ sharedLinkCreateDto }: {
         ...opts,
         method: "POST",
         body: sharedLinkCreateDto
+    })));
+}
+/**
+ * Shared link login
+ */
+export function sharedLinkLogin({ key, slug, sharedLinkLoginDto }: {
+    key?: string;
+    slug?: string;
+    sharedLinkLoginDto: SharedLinkLoginDto;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 201;
+        data: SharedLinkResponseDto;
+    }>(`/shared-links/login${QS.query(QS.explode({
+        key,
+        slug
+    }))}`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: sharedLinkLoginDto
     })));
 }
 /**

--- a/server/src/dtos/shared-link.dto.ts
+++ b/server/src/dtos/shared-link.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 import { SharedLink } from 'src/database';
-import { HistoryBuilder } from 'src/decorators';
+import { HistoryBuilder, Property } from 'src/decorators';
 import { AlbumResponseDto, mapAlbumWithoutAssets } from 'src/dtos/album.dto';
 import { AssetResponseDto, mapAsset } from 'src/dtos/asset-response.dto';
 import { SharedLinkType } from 'src/enum';
-import { Optional, ValidateBoolean, ValidateDate, ValidateEnum, ValidateUUID } from 'src/validation';
+import { Optional, ValidateBoolean, ValidateDate, ValidateEnum, ValidateString, ValidateUUID } from 'src/validation';
 
 export class SharedLinkSearchDto {
   @ValidateUUID({ optional: true, description: 'Filter by album ID' })
@@ -94,6 +94,11 @@ export class SharedLinkEditDto {
   changeExpiryTime?: boolean;
 }
 
+export class SharedLinkLoginDto {
+  @ValidateString({ description: 'Shared link password', example: 'password' })
+  password!: string;
+}
+
 export class SharedLinkPasswordDto {
   @ApiPropertyOptional({ example: 'password', description: 'Link password' })
   @IsString()
@@ -112,7 +117,10 @@ export class SharedLinkResponseDto {
   description!: string | null;
   @ApiProperty({ description: 'Has password' })
   password!: string | null;
-  @ApiPropertyOptional({ description: 'Access token' })
+  @Property({
+    description: 'Access token',
+    history: new HistoryBuilder().added('v1').stable('v2').deprecated('v2.6.0'),
+  })
   token?: string | null;
   @ApiProperty({ description: 'Owner user ID' })
   userId!: string;

--- a/server/test/medium/specs/services/shared-link.service.spec.ts
+++ b/server/test/medium/specs/services/shared-link.service.spec.ts
@@ -90,7 +90,7 @@ describe(SharedLinkService.name, () => {
       assetIds: assets.map(({ asset }) => asset.id),
     });
 
-    await expect(sut.getMine({ user, sharedLink }, {})).resolves.toMatchObject({
+    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toMatchObject({
       assets: assets.map(({ asset }) => expect.objectContaining({ id: asset.id })),
     });
   });
@@ -114,7 +114,7 @@ describe(SharedLinkService.name, () => {
       assetIds: [asset.id],
     });
 
-    await expect(sut.getMine({ user, sharedLink }, {})).resolves.toMatchObject({
+    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toMatchObject({
       assets: [expect.objectContaining({ id: asset.id })],
     });
 
@@ -122,6 +122,6 @@ describe(SharedLinkService.name, () => {
       assetIds: [asset.id],
     });
 
-    await expect(sut.getMine({ user, sharedLink }, {})).resolves.toHaveProperty('assets', []);
+    await expect(sut.getMine({ user, sharedLink }, [])).resolves.toHaveProperty('assets', []);
   });
 });

--- a/web/src/lib/components/pages/SharedLinkPage.svelte
+++ b/web/src/lib/components/pages/SharedLinkPage.svelte
@@ -8,7 +8,7 @@
   import { setSharedLink } from '$lib/utils';
   import { handleError } from '$lib/utils/handle-error';
   import { navigate } from '$lib/utils/navigation';
-  import { getMySharedLink, SharedLinkType, type AssetResponseDto, type SharedLinkResponseDto } from '@immich/sdk';
+  import { sharedLinkLogin, SharedLinkType, type AssetResponseDto, type SharedLinkResponseDto } from '@immich/sdk';
   import { Button, Logo, PasswordInput } from '@immich/ui';
   import { tick } from 'svelte';
   import { t } from 'svelte-i18n';
@@ -39,7 +39,7 @@
 
   const handlePasswordSubmit = async () => {
     try {
-      sharedLink = await getMySharedLink({ password, key, slug });
+      sharedLink = await sharedLinkLogin({ key, slug, sharedLinkLoginDto: { password } });
       setSharedLink(sharedLink);
       passwordRequired = false;
       title = (sharedLink.album ? sharedLink.album.albumName : $t('public_share')) + ' - Immich';

--- a/web/src/lib/utils/shared-links.ts
+++ b/web/src/lib/utils/shared-links.ts
@@ -49,7 +49,7 @@ export const loadSharedLink = async ({
       },
     };
   } catch (error) {
-    if (isHttpError(error) && error.data.message === 'Invalid password') {
+    if (isHttpError(error) && error.data.message === 'Password required') {
       return {
         ...common,
         passwordRequired: true,


### PR DESCRIPTION
Add a new endpoint `POST /shared-links/login` to prevent from having to send the shared link `password` as a query param.

Sending `password` as a query param on `GET /shared-links/me` is still supported for now, but will be removed in `v3`.