### PR TITLE
fix(server): use provided database username for restore & ensure name is not mangled

### DIFF
--- a/server/src/utils/database-backups.ts
+++ b/server/src/utils/database-backups.ts
@@ -98,14 +98,7 @@ export async function buildPostgresLaunchArguments(
   } else {
     databaseUsername = databaseConfig.username;
 
-    args.push(
-      '--username',
-      databaseConfig.username,
-      '--host',
-      databaseConfig.host,
-      '--port',
-      databaseConfig.port.toString(),
-    );
+    args.push('--username', databaseUsername, '--host', databaseConfig.host, '--port', databaseConfig.port.toString());
 
     switch (bin) {
       case 'pg_dumpall': {

--- a/server/src/utils/database-backups.ts
+++ b/server/src/utils/database-backups.ts
@@ -59,7 +59,6 @@ export async function buildPostgresLaunchArguments(
 ): Promise<{
   bin: string;
   args: string[];
-  databaseName: string;
   databaseUsername: string;
   databasePassword: string;
   databaseVersion: string;


### PR DESCRIPTION
This PR has a few changes:
- Extract the database username while generating arguments. Fallback to `postgres` if missing from or otherwise malformed URL.
- Fix issue where the generated SQL queries mangle names, e.g. `MyDatabase` -> `mydatabase`.
- For backups created from v2.5.0 onwards:
  - Don't use hard-coded role name when performing schema reset.
- For backups created before v2.5.0:
  - Don't try to connect by hard-coded `postgres` username.
  - Remove the code to try to recreate database for rollback since it is not technically possible anymore. (it may never be dropped as we are connected to it)

Tested this by setting up a fresh Immich instance on v2.4.1 and v2.5.0, then triggering backup on both, which runs pg_dumpall and pg_dump respectively. The instance was configured with a non-typical values for database configuration, i.e. random value for database name, username, and password. Then both backups were successfully restored on top of this branch using identical values for database name, username, and password.

fixes #25633