### PR TITLE
feat: add people deeplink

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -116,7 +116,7 @@
           android:pathPrefix="/albums/" />
         <data
           android:host="my.immich.app"
-          android:pathPrefix="/memories/" />
+          android:pathPrefix="/people/" />
         <data
           android:host="my.immich.app"
           android:path="/memory" />

--- a/mobile/lib/domain/services/people.service.dart
+++ b/mobile/lib/domain/services/people.service.dart
@@ -10,6 +10,10 @@ class DriftPeopleService {
 
   const DriftPeopleService(this._repository, this._personApiRepository);
 
+  Future<DriftPerson?> get(String personId) {
+    return _repository.get(personId);
+  }
+
   Future<List<DriftPerson>> getAssetPeople(String assetId) {
     return _repository.getAssetPeople(assetId);
   }

--- a/mobile/lib/infrastructure/repositories/people.repository.dart
+++ b/mobile/lib/infrastructure/repositories/people.repository.dart
@@ -7,6 +7,13 @@ class DriftPeopleRepository extends DriftDatabaseRepository {
   final Drift _db;
   const DriftPeopleRepository(this._db) : super(_db);
 
+  Future<DriftPerson?> get(String personId) async {
+    final query = _db.select(_db.personEntity)..where((row) => row.id.equals(personId));
+
+    final result = await query.getSingleOrNull();
+    return result?.toDto();
+  }
+
   Future<List<DriftPerson>> getAssetPeople(String assetId) async {
     final query = _db.select(_db.assetFaceEntity).join([
       innerJoin(_db.personEntity, _db.personEntity.id.equalsExp(_db.assetFaceEntity.personId)),

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -84,6 +84,7 @@ class DeepLinkService {
       "memory" => await _buildMemoryDeepLink(queryParams['id'] ?? ''),
       "asset" => await _buildAssetDeepLink(queryParams['id'] ?? '', ref),
       "album" => await _buildAlbumDeepLink(queryParams['id'] ?? ''),
+      "people" => await _buildPeopleDeepLink(queryParams['id'] ?? ''),
       "activity" => await _buildActivityDeepLink(queryParams['albumId'] ?? ''),
       _ => null,
     };
@@ -117,7 +118,7 @@ class DeepLinkService {
       deepLinkRoute = await _buildAlbumDeepLink(albumId);
     } else if (peopleRegex.hasMatch(path)) {
       final peopleId = peopleRegex.firstMatch(path)?.group(1) ?? '';
-      deepLinkRoute = await _buildAlbumDeepLink(peopleId);
+      deepLinkRoute = await _buildPeopleDeepLink(peopleId);
     } else if (path == "/memory") {
       deepLinkRoute = await _buildMemoryDeepLink(null);
     }

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -4,6 +4,7 @@ import 'package:immich_mobile/domain/models/memory.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart' as beta_asset_service;
 import 'package:immich_mobile/domain/services/memory.service.dart';
+import 'package:immich_mobile/domain/services/people.service.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -13,6 +14,7 @@ import 'package:immich_mobile/providers/asset_viewer/current_asset.provider.dart
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart' as beta_asset_provider;
 import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -33,6 +35,7 @@ final deepLinkServiceProvider = Provider(
     ref.watch(beta_asset_provider.assetServiceProvider),
     ref.watch(remoteAlbumServiceProvider),
     ref.watch(driftMemoryServiceProvider),
+    ref.watch(driftPeopleServiceProvider),
     ref.watch(currentUserProvider),
   ),
 );
@@ -49,7 +52,8 @@ class DeepLinkService {
   final TimelineFactory _betaTimelineFactory;
   final beta_asset_service.AssetService _betaAssetService;
   final RemoteAlbumService _betaRemoteAlbumService;
-  final DriftMemoryService _betaMemoryServiceProvider;
+  final DriftMemoryService _betaMemoryService;
+  final DriftPeopleService _betaPeopleService;
 
   final UserDto? _currentUser;
 
@@ -62,7 +66,8 @@ class DeepLinkService {
     this._betaTimelineFactory,
     this._betaAssetService,
     this._betaRemoteAlbumService,
-    this._betaMemoryServiceProvider,
+    this._betaMemoryService,
+    this._betaPeopleService,
     this._currentUser,
   );
 
@@ -141,9 +146,9 @@ class DeepLinkService {
           return null;
         }
 
-        memories = await _betaMemoryServiceProvider.getMemoryLane(_currentUser.id);
+        memories = await _betaMemoryService.getMemoryLane(_currentUser.id);
       } else {
-        final memory = await _betaMemoryServiceProvider.get(memoryId);
+        final memory = await _betaMemoryService.get(memoryId);
         if (memory != null) {
           memories = [memory];
         }
@@ -229,5 +234,19 @@ class DeepLinkService {
     }
 
     return DriftActivitiesRoute(album: album);
+  }
+
+  Future<PageRouteInfo?> _buildPeopleDeepLink(String personId) async {
+    if (Store.isBetaTimelineEnabled == false) {
+      return null;
+    }
+
+    final person = await _betaPeopleService.get(personId);
+
+    if (person == null) {
+      return null;
+    }
+
+    return DriftPersonRoute(person: person);
   }
 }

--- a/mobile/lib/services/deep_link.service.dart
+++ b/mobile/lib/services/deep_link.service.dart
@@ -106,6 +106,7 @@ class DeepLinkService {
     const uuidRegex = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
     final assetRegex = RegExp('/photos/($uuidRegex)');
     final albumRegex = RegExp('/albums/($uuidRegex)');
+    final peopleRegex = RegExp('/people/($uuidRegex)');
 
     PageRouteInfo<dynamic>? deepLinkRoute;
     if (assetRegex.hasMatch(path)) {
@@ -114,6 +115,9 @@ class DeepLinkService {
     } else if (albumRegex.hasMatch(path)) {
       final albumId = albumRegex.firstMatch(path)?.group(1) ?? '';
       deepLinkRoute = await _buildAlbumDeepLink(albumId);
+    } else if (peopleRegex.hasMatch(path)) {
+      final peopleId = peopleRegex.firstMatch(path)?.group(1) ?? '';
+      deepLinkRoute = await _buildAlbumDeepLink(peopleId);
     } else if (path == "/memory") {
       deepLinkRoute = await _buildMemoryDeepLink(null);
     }


### PR DESCRIPTION
Updated the AndroidManifest.xml to change the path prefix from '/memories/' to '/people/'. Memories is anyway wrong and was replaced by /memory and now the people path completes the known deeplinks.

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] https://my.immich.app/people/...


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
...
