### PR TITLE
feat(web): show ocr text boxes in panoramas

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -424,7 +424,6 @@
   const showOcrButton = $derived(
     $slideshowState === SlideshowState.None &&
       asset.type === AssetTypeEnum.Image &&
-      !(asset.exifInfo?.projectionType === 'EQUIRECTANGULAR') &&
       !assetViewerManager.isShowEditor &&
       ocrManager.hasOcrData,
   );


### PR DESCRIPTION
This has to be one of the least useful features in Immich ever, but here we are.

- Add blue OCR boxes to panorama when OCR button is set to show text recognition.
- Show a (text-selectable) tooltip in the place of the box when a box is clicked. (Different from the hover behavior in the normal photo viewer, but this wouldn't work otherwise.)
- Tooltip is hidden when clicking anywhere else.

For the normal photo viewer:
- I used the new & improved box transform method using a matrix, for the photo viewer too. This more accurately maps the box to the actual OCR results, although it barely makes a difference in practice.
- Merged the blue box and text overlay into a single div. I think this better represents how it was originally intended.
- Text now scales between `text-sm` and `text-6xl` according to the width of the box.

## Screenshots
<img width="973" height="618" alt="image" src="https://github.com/user-attachments/assets/a785c983-8493-4905-8557-3ebfbd483f5a" />
<img width="973" height="618" alt="image" src="https://github.com/user-attachments/assets/defc51ca-7ed4-4415-aec2-a86f6f3f0894" />

Normal photo viewer (note slightly darker blue on the hovered box, as seemed to be the original intention based off the classlists) with bigger text:

<img width="900" height="141" alt="image" src="https://github.com/user-attachments/assets/6d338ae1-12c3-4177-b745-fbdca47e6bd1" />

## LLM
No LLM used except to inspire me to use `matrix3d` and fine-tune some logic.
