### PR TITLE
fix(mobile): reset asset index on timeline refresh

### DIFF
--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -227,6 +227,13 @@ class TimelineService {
     return _buffer.elementAt(index - _bufferOffset);
   }
 
+  /// Finds the index of an asset by its heroTag within the current buffer.
+  /// Returns null if the asset is not found in the buffer.
+  int? getIndex(String heroTag) {
+    final index = _buffer.indexWhere((a) => a.heroTag == heroTag);
+    return index >= 0 ? _bufferOffset + index : null;
+  }
+
   Future<void> dispose() async {
     await _bucketSubscription?.cancel();
     _bucketSubscription = null;

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_viewer.page.dart
@@ -451,21 +451,31 @@ class _AssetViewerState extends ConsumerState<AssetViewer> {
   }
 
   void _onTimelineReloadEvent() {
-    totalAssets = ref.read(timelineServiceProvider).totalAssets;
+    final timelineService = ref.read(timelineServiceProvider);
+    totalAssets = timelineService.totalAssets;
+
     if (totalAssets == 0) {
       context.maybePop();
       return;
     }
 
+    var index = pageController.page?.round() ?? 0;
+    final currentAsset = ref.read(currentAssetNotifier);
+    if (currentAsset != null) {
+      final newIndex = timelineService.getIndex(currentAsset.heroTag);
+      if (newIndex != null && newIndex != index) {
+        index = newIndex;
+        pageController.jumpToPage(index);
+      }
+    }
+
     if (assetReloadRequested) {
       assetReloadRequested = false;
-      _onAssetReloadEvent();
-      return;
+      _onAssetReloadEvent(index);
     }
   }
 
-  void _onAssetReloadEvent() async {
-    final index = pageController.page?.round() ?? 0;
+  void _onAssetReloadEvent(int index) async {
     final timelineService = ref.read(timelineServiceProvider);
     final newAsset = await timelineService.getAssetAsync(index);
 


### PR DESCRIPTION
## Description

The current asset changes when the timeline refreshes, which can be quite jarring. Assets are tracked by their index, and that index becomes stale when the timeline refreshes. This can be resolved by updating the index of asset based on a unique identifier (like the hero tag).

## How Has This Been Tested?

I have an emulator, and compared the behaviour. The current asset preview no longer changes when the timeline is refreshed, as expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A