### PR TITLE
docs: update ml-hardware-acceleration.md

### DIFF
--- a/docs/docs/features/ml-hardware-acceleration.md
+++ b/docs/docs/features/ml-hardware-acceleration.md
@@ -86,8 +86,8 @@ You do not need to redo any machine learning jobs after enabling hardware accele
 ## Setup
 
 1. If you do not already have it, download the latest [`hwaccel.ml.yml`][hw-file] file and ensure it's in the same folder as the `docker-compose.yml`.
-2. In the `docker-compose.yml` under `immich-machine-learning`, uncomment the `extends` section and change `cpu` to the appropriate backend.
-3. Still in `immich-machine-learning`, add one of -[armnn, cuda, rocm, openvino, rknn] to the `image` section's tag at the end of the line.
+2. In `immich-machine-learning`, add one of -[armnn, cuda, rocm, openvino, rknn] to the `image` section's tag at the end of the line.
+3. Still in the `docker-compose.yml` under `immich-machine-learning`, uncomment the `extends` section and change `cpu` to the appropriate backend.
 4. Redeploy the `immich-machine-learning` container with these updated settings.
 
 ### Confirming Device Usage


### PR DESCRIPTION
## Description

Invert the lines about editing the docker-compose.yml file to have users add the tag to the image first, then uncomment the extends section. This should help users follow the instructions as they flow through the YAML file.

This is very much a PEBKAC-type change: it took me longer than I care to admit to realize why the OpenVINO executor was not even showing up in the container, because I was convinced that after extending with `hwaccel.ml.yml` I didn't have to make any more changes. I didn't change the wording, simply swapped the two steps.

Yes, I should've read the documentation more thoroughly, but I'm submitting this anyway for consideration because I believe having the instruction have the same "flow" as the `docker-compose.yml` file would be an overall improvement.

## How Has This Been Tested?

Not tested (documentation change)

## Checklist:

- [ X ] I have performed a self-review of my own code
- [ X ] I have made corresponding changes to the documentation if applicable
- [ X ] I have no unrelated changes in the PR.
- [ N/A ] I have confirmed that any new dependencies are strictly necessary.
- [ N/A ] I have written tests for new code (if applicable)
- [ N/A ] I have followed naming conventions/patterns in the surrounding code
- [ N/A ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ N/A ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLMs were used.
...
