### PR TITLE
Fix a French translations in fr.json

### DIFF
--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2226,7 +2226,7 @@
   "to_parent": "Aller au dossier parent",
   "to_select": "pour faire une sélection",
   "to_trash": "Corbeille",
-  "toggle_settings": "Inverser les paramètres",
+  "toggle_settings": "Afficher/masquer les paramètres",
   "toggle_theme_description": "Changer le thème",
   "total": "Total",
   "total_usage": "Utilisation globale",


### PR DESCRIPTION
The current french translation for  "toggle_settings" "Inverser les paramètres", is not correct.
Updated to "Afficher/masquer les paramètres"