### PR TITLE
Documentation: database name change for command line restore process

### DIFF
--- a/docs/docs/administration/backup-and-restore.md
+++ b/docs/docs/administration/backup-and-restore.md
@@ -151,11 +151,12 @@ docker compose pull             # Update to latest version of Immich (if desired
 docker compose create           # Create Docker containers for Immich apps without running them
 docker start immich_postgres    # Start Postgres server
 sleep 10                        # Wait for Postgres server to start up
+# Replace <DB_DATABASE_NAME> with the database name from configuration file - usually immich unless you have changed it.
 # Check the database user if you deviated from the default
 # Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 gunzip --stdout "/path/to/backup/dump.sql.gz" \
 | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
-| docker exec -i immich_postgres psql --dbname=postgres --username=<DB_USERNAME>  # Restore Backup
+| docker exec -i immich_postgres psql --dbname=<DB_DATABASE_NAME> --username=<DB_USERNAME>  # Restore Backup
 docker compose up -d            # Start remainder of Immich apps
 ```
 
@@ -178,9 +179,10 @@ docker start immich_postgres                      # Start Postgres server
 sleep 10                                          # Wait for Postgres server to start up
 docker exec -it immich_postgres bash              # Enter the Docker shell and run the following command
 # If your backup ends in `.gz`, replace `cat` with `gunzip --stdout`
+# Replace <DB_DATABASE_NAME> with the database name from configuration file - usually immich unless you have changed it.
 # Replace <DB_USERNAME> with the database username - usually postgres unless you have changed it.
 
-cat "/dump.sql" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | psql --dbname=postgres --username=<DB_USERNAME>
+cat "/dump.sql" | sed "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" | psql --dbname=<DB_DATABASE_NAME> --username=<DB_USERNAME>
 exit                                              # Exit the Docker shell
 docker compose up -d                              # Start remainder of Immich apps
 ```


### PR DESCRIPTION
## Description

Reflected database name change resulting from switch from pg_dumpall to pg_dump in database backup process

Partialy fixes #25772

## How Has This Been Tested?

Manually tested database restore process using automated backups created in version 2.5.2 and 2.4.1

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- n/a I have confirmed that any new dependencies are strictly necessary.
- n/a I have written tests for new code (if applicable)
- n/a I have followed naming conventions/patterns in the surrounding code
- n/a All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- n/a All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
No LLM used
