### PR TITLE
docs: remove writeTimeout on traefik example

### DIFF
--- a/docs/docs/administration/reverse-proxy.md
+++ b/docs/docs/administration/reverse-proxy.md
@@ -98,7 +98,6 @@ entryPoints:
       respondingTimeouts:
         readTimeout: 600s
         idleTimeout: 600s
-        writeTimeout: 600s
 ```
 
 The second part is in the `docker-compose.yml` file where immich is in. Add the Traefik specific labels like in the example.


### PR DESCRIPTION
## Description

Removed `writeTimeout: 600s` from the example `traefik.yml` file.

Unlike `readTimeout` and `idleTimeout`, `writeTimeout` defaults to 0, meaning there is no limit for how long traefik has to respond to a request (see https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/#opt-transport-respondingTimeouts-writeTimeout).

*Reducing* this, by setting it to 10 minutes, means that any download from any service, including immich, on that traefik instance will fail after 10 minutes. This is especially problematic because home upload speeds are generally significantly lower than download. 20Mbps is a common limit, and at that speed, any download larger than 1.5GB will fail. This affects both immich and other services like media downloaders (e.g. plex, jellyfin) where large downloads are common.

It's less of a problem in the other direction for two reasons: many users upload/backup only on wi-fi, meaning they're likely at home and local to their instance; and cellular upload speeds are often uncapped, limited only by reception and congestion. 

## How Has This Been Tested?

Tested on my own traefik+immich deployment

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None