### PR TITLE
fix: prevent backspace from accidentally triggering delete modals

### DIFF
--- a/web/src/lib/services/library.service.ts
+++ b/web/src/lib/services/library.service.ts
@@ -67,7 +67,7 @@ export const getLibraryActions = ($t: MessageFormatter, library: LibraryResponse
     color: 'danger',
     onAction: () => handleDeleteLibrary(library),
     shortcuts: { key: 'Backspace' },
-    shortcutOptions: { ignoreInputFields: true }
+    shortcutOptions: { ignoreInputFields: true },
   };
 
   const AddFolder: ActionItem = {

--- a/web/src/lib/services/library.service.ts
+++ b/web/src/lib/services/library.service.ts
@@ -66,7 +66,6 @@ export const getLibraryActions = ($t: MessageFormatter, library: LibraryResponse
     title: $t('delete'),
     color: 'danger',
     onAction: () => handleDeleteLibrary(library),
-    shortcuts: { key: 'Backspace' },
   };
 
   const AddFolder: ActionItem = {

--- a/web/src/lib/services/library.service.ts
+++ b/web/src/lib/services/library.service.ts
@@ -66,6 +66,8 @@ export const getLibraryActions = ($t: MessageFormatter, library: LibraryResponse
     title: $t('delete'),
     color: 'danger',
     onAction: () => handleDeleteLibrary(library),
+    shortcuts: { key: 'Backspace' },
+    shortcutOptions: { ignoreInputFields: true }
   };
 
   const AddFolder: ActionItem = {

--- a/web/src/lib/services/user-admin.service.ts
+++ b/web/src/lib/services/user-admin.service.ts
@@ -66,7 +66,6 @@ export const getUserAdminActions = ($t: MessageFormatter, user: UserAdminRespons
     color: 'danger',
     $if: () => get(authUser).id !== user.id && !user.deletedAt,
     onAction: () => modalManager.show(UserDeleteConfirmModal, { user }),
-    shortcuts: { key: 'Backspace' },
   };
 
   const getDeleteDate = (deletedAt: string): Date =>

--- a/web/src/lib/services/user-admin.service.ts
+++ b/web/src/lib/services/user-admin.service.ts
@@ -67,7 +67,7 @@ export const getUserAdminActions = ($t: MessageFormatter, user: UserAdminRespons
     $if: () => get(authUser).id !== user.id && !user.deletedAt,
     onAction: () => modalManager.show(UserDeleteConfirmModal, { user }),
     shortcuts: { key: 'Backspace' },
-    shortcutOptions: { ignoreInputFields: true }
+    shortcutOptions: { ignoreInputFields: true },
   };
 
   const getDeleteDate = (deletedAt: string): Date =>

--- a/web/src/lib/services/user-admin.service.ts
+++ b/web/src/lib/services/user-admin.service.ts
@@ -66,6 +66,8 @@ export const getUserAdminActions = ($t: MessageFormatter, user: UserAdminRespons
     color: 'danger',
     $if: () => get(authUser).id !== user.id && !user.deletedAt,
     onAction: () => modalManager.show(UserDeleteConfirmModal, { user }),
+    shortcuts: { key: 'Backspace' },
+    shortcutOptions: { ignoreInputFields: true }
   };
 
   const getDeleteDate = (deletedAt: string): Date =>


### PR DESCRIPTION
Hello again, it's been awhile :)

Fixes #25752 by removing the `Backspace` key from delete modals, since it can trigger at the wrong time (like when you hit backspace while editing an input)