### PR TITLE
fix: prevent stale values in edit user form after save

### DIFF
--- a/web/src/routes/admin/users/[id]/+layout.svelte
+++ b/web/src/routes/admin/users/[id]/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import AdminCard from '$lib/components/AdminCard.svelte';
   import AdminPageLayout from '$lib/components/layouts/AdminPageLayout.svelte';
   import OnEvents from '$lib/components/OnEvents.svelte';
@@ -48,10 +48,7 @@
 
   const { children, data }: Props = $props();
 
-  let user = $state(data.user);
-  const userPreferences = $state(data.userPreferences);
-  const userStatistics = $state(data.userStatistics);
-  const userSessions = $state(data.userSessions);
+  const { user, userPreferences, userStatistics, userSessions } = $derived(data);
   const TiB = 1024 ** 4;
   const usage = $derived(user.quotaUsageInBytes ?? 0);
   let [statsUsage, statsUsageUnit] = $derived(getBytesWithUnit(usage, usage > TiB ? 2 : 0));
@@ -79,9 +76,10 @@
 
   const { ResetPassword, ResetPinCode, Update, Delete, Restore } = $derived(getUserAdminActions($t, user));
 
-  const onUpdate = (update: UserAdminResponseDto) => {
+  const onUpdate = async (update: UserAdminResponseDto) => {
     if (update.id === user.id) {
-      user = update;
+      data.user = update;
+      await invalidateAll();
     }
   };
 

--- a/web/src/routes/admin/users/[id]/edit/+page.svelte
+++ b/web/src/routes/admin/users/[id]/edit/+page.svelte
@@ -16,12 +16,10 @@
 
   let { data }: Props = $props();
 
-  const user = $state(data.user);
-  let isAdmin = $state(user.isAdmin);
-  let name = $state(user.name);
-  let email = $state(user.email);
-  let storageLabel = $state(user.storageLabel || '');
-  const previousQuota = $state(user.quotaSizeInBytes);
+  const user = $derived(data.user);
+  let { isAdmin, name, email } = $derived(user);
+  let storageLabel = $derived(user.storageLabel || '');
+  const previousQuota = $derived(user.quotaSizeInBytes);
 
   let quotaSize = $derived(
     typeof user.quotaSizeInBytes === 'number' ? convertFromBytes(user.quotaSizeInBytes, ByteUnit.GiB) : undefined,


### PR DESCRIPTION
Fixes a UI state bug in Admin → User Management → Edit User where the form keeps showing stale values after saving changes and clicking Edit user again as reported in https://github.com/immich-app/immich/issues/25752