### PR TITLE
fix(server): deleting stacked assets

### DIFF
--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -8,7 +8,6 @@ import { AssetStats } from 'src/repositories/asset.repository';
 import { AssetService } from 'src/services/asset.service';
 import { assetStub } from 'test/fixtures/asset.stub';
 import { authStub } from 'test/fixtures/auth.stub';
-import { faceStub } from 'test/fixtures/face.stub';
 import { userStub } from 'test/fixtures/user.stub';
 import { factory } from 'test/small.factory';
 import { makeStream, newTestService, ServiceMocks } from 'test/utils';
@@ -565,12 +564,11 @@ describe(AssetService.name, () => {
   });
 
   describe('handleAssetDeletion', () => {
-    it('should remove faces', async () => {
-      const assetWithFace = { ...assetStub.image, faces: [faceStub.face1, faceStub.mergeFace1] };
+    it('should clean up files', async () => {
+      const asset = assetStub.image;
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(asset);
 
-      mocks.assetJob.getForAssetDeletion.mockResolvedValue(assetWithFace);
-
-      await sut.handleAssetDeletion({ id: assetWithFace.id, deleteOnDisk: true });
+      await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
 
       expect(mocks.job.queue.mock.calls).toEqual([
         [
@@ -581,38 +579,29 @@ describe(AssetService.name, () => {
                 '/uploads/user-id/webp/path.ext',
                 '/uploads/user-id/thumbs/path.jpg',
                 '/uploads/user-id/fullsize/path.webp',
-                assetWithFace.originalPath,
+                asset.originalPath,
               ],
             },
           },
         ],
       ]);
-
-      expect(mocks.asset.remove).toHaveBeenCalledWith(assetWithFace);
-    });
-
-    it('should update stack primary asset if deleted asset was primary asset in a stack', async () => {
-      mocks.stack.update.mockResolvedValue(factory.stack() as any);
-      mocks.assetJob.getForAssetDeletion.mockResolvedValue(assetStub.primaryImage);
-
-      await sut.handleAssetDeletion({ id: assetStub.primaryImage.id, deleteOnDisk: true });
-
-      expect(mocks.stack.update).toHaveBeenCalledWith('stack-1', {
-        id: 'stack-1',
-        primaryAssetId: 'stack-child-asset-1',
-      });
+      expect(mocks.asset.remove).toHaveBeenCalledWith(asset);
     });
 
     it('should delete the entire stack if deleted asset was the primary asset and the stack would only contain one asset afterwards', async () => {
       mocks.stack.delete.mockResolvedValue();
       mocks.assetJob.getForAssetDeletion.mockResolvedValue({
         ...assetStub.primaryImage,
-        stack: { ...assetStub.primaryImage.stack, assets: assetStub.primaryImage.stack!.assets.slice(0, 2) },
+        stack: {
+          id: 'stack-id',
+          primaryAssetId: assetStub.primaryImage.id,
+          assets: [{ id: 'one-asset' }],
+        },
       });
 
       await sut.handleAssetDeletion({ id: assetStub.primaryImage.id, deleteOnDisk: true });
 
-      expect(mocks.stack.delete).toHaveBeenCalledWith('stack-1');
+      expect(mocks.stack.delete).toHaveBeenCalledWith('stack-id');
     });
 
     it('should delete a live photo', async () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -327,10 +327,11 @@ export class AssetService extends BaseService {
       return JobStatus.Failed;
     }
 
-    // Replace the parent of the stack children with a new asset
+    // replace the parent of the stack children with a new asset
     if (asset.stack?.primaryAssetId === id) {
-      const stackAssetIds = asset.stack?.assets.map((a) => a.id) ?? [];
-      if (stackAssetIds.length > 2) {
+      // this only includes timeline visible assets and excludes the primary asset
+      const stackAssetIds = asset.stack.assets.map((a) => a.id);
+      if (stackAssetIds.length >= 2) {
         const newPrimaryAssetId = stackAssetIds.find((a) => a !== id)!;
         await this.stackRepository.update(asset.stack.id, {
           id: asset.stack.id,


### PR DESCRIPTION
Fixes #25841

Correctly fetch stack information, including `primaryStackId`, regardless of whether the stack contains archived or deleted assets.

Fixes a flaky e2e test because `fs.rm` would sometimes throw ENOTEMPTY errors.