### PR TITLE
fix: close tag modal after tagging assets

### DIFF
--- a/web/src/lib/modals/AssetTagModal.svelte
+++ b/web/src/lib/modals/AssetTagModal.svelte
@@ -33,6 +33,7 @@
 
     const updatedIds = await tagAssets({ tagIds: [...selectedIds], assetIds, showNotification: false });
     eventManager.emit('AssetsTag', updatedIds);
+    onClose();
   };
 
   const handleSelect = async (option?: ComboBoxOption) => {
@@ -81,7 +82,7 @@
       {#if tag}
         <div class="flex group transition-all">
           <span
-            class="inline-block h-min whitespace-nowrap ps-3 pe-1 group-hover:ps-3 py-1 text-center align-baseline leading-none text-gray-100 dark:text-immich-dark-gray bg-primary roudned-s-full hover:bg-immich-primary/80 dark:hover:bg-immich-dark-primary/80 transition-all"
+            class="inline-block h-min whitespace-nowrap ps-3 pe-1 group-hover:ps-3 py-1 text-center align-baseline leading-none text-gray-100 dark:text-immich-dark-gray bg-primary rounded-s-full hover:bg-immich-primary/80 dark:hover:bg-immich-dark-primary/80 transition-all"
           >
             <p class="text-sm">
               {tag.value}


### PR DESCRIPTION
- fixes #25880
- fix rounded class typo on tag pill

<img width="458" height="339" alt="image" src="https://github.com/user-attachments/assets/a74704b5-48a1-4668-ad5a-63adee820777" />