### PR TITLE
fix: preserve hidden people state across pagination

### DIFF
--- a/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
+++ b/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
@@ -1,0 +1,82 @@
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { personFactory } from '@test-data/factories/person-factory';
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import ManagePeopleVisibilityWrapper from './manage-people-visibility.test-wrapper.svelte';
+
+describe('ManagePeopleVisibility component', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+  });
+
+  it('keeps toggled hidden state when loading more people', async () => {
+    const onClose = vi.fn();
+    const loadNextPage = vi.fn();
+
+    const [personA, personB, personC] = [
+      personFactory.build({ id: 'a', isHidden: false }),
+      personFactory.build({ id: 'b', isHidden: false }),
+      personFactory.build({ id: 'c', isHidden: true }),
+    ];
+
+    const { container, rerender } = render(ManagePeopleVisibilityWrapper, {
+      props: {
+        people: [personA, personB],
+        totalPeopleCount: 3,
+        onClose,
+        loadNextPage,
+      },
+    });
+    const user = userEvent.setup();
+
+    let personButtons = container.querySelectorAll('button[aria-pressed]');
+    expect(personButtons).toHaveLength(2);
+
+    await user.click(personButtons[0]);
+    expect(personButtons[0].getAttribute('aria-pressed')).toBe('true');
+
+    await rerender({
+      people: [personA, personB, personC],
+      totalPeopleCount: 3,
+      onClose,
+      loadNextPage,
+    });
+
+    personButtons = container.querySelectorAll('button[aria-pressed]');
+    expect(personButtons).toHaveLength(3);
+    expect(personButtons[0].getAttribute('aria-pressed')).toBe('true');
+    expect(personButtons[2].getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('shows newly loaded hidden people as hidden', async () => {
+    const onClose = vi.fn();
+    const loadNextPage = vi.fn();
+
+    const [personA, personB, personC] = [
+      personFactory.build({ id: 'a', isHidden: false }),
+      personFactory.build({ id: 'b', isHidden: false }),
+      personFactory.build({ id: 'c', isHidden: true }),
+    ];
+
+    const { container, rerender } = render(ManagePeopleVisibilityWrapper, {
+      props: {
+        people: [personA, personB],
+        totalPeopleCount: 3,
+        onClose,
+        loadNextPage,
+      },
+    });
+
+    await rerender({
+      people: [personA, personB, personC],
+      totalPeopleCount: 3,
+      onClose,
+      loadNextPage,
+    });
+
+    const personButtons = container.querySelectorAll('button[aria-pressed]');
+    expect(personButtons).toHaveLength(3);
+    expect(personButtons[2].getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
+++ b/web/src/lib/components/faces-page/manage-people-visibility.spec.ts
@@ -12,6 +12,7 @@ describe('ManagePeopleVisibility component', () => {
 
   it('keeps toggled hidden state when loading more people', async () => {
     const onClose = vi.fn();
+    const onUpdate = vi.fn();
     const loadNextPage = vi.fn();
 
     const [personA, personB, personC] = [
@@ -25,6 +26,7 @@ describe('ManagePeopleVisibility component', () => {
         people: [personA, personB],
         totalPeopleCount: 3,
         onClose,
+        onUpdate,
         loadNextPage,
       },
     });
@@ -40,6 +42,7 @@ describe('ManagePeopleVisibility component', () => {
       people: [personA, personB, personC],
       totalPeopleCount: 3,
       onClose,
+      onUpdate,
       loadNextPage,
     });
 
@@ -51,6 +54,7 @@ describe('ManagePeopleVisibility component', () => {
 
   it('shows newly loaded hidden people as hidden', async () => {
     const onClose = vi.fn();
+    const onUpdate = vi.fn();
     const loadNextPage = vi.fn();
 
     const [personA, personB, personC] = [
@@ -64,6 +68,7 @@ describe('ManagePeopleVisibility component', () => {
         people: [personA, personB],
         totalPeopleCount: 3,
         onClose,
+        onUpdate,
         loadNextPage,
       },
     });
@@ -72,6 +77,7 @@ describe('ManagePeopleVisibility component', () => {
       people: [personA, personB, personC],
       totalPeopleCount: 3,
       onClose,
+      onUpdate,
       loadNextPage,
     });
 

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -17,10 +17,11 @@
     totalPeopleCount: number;
     titleId?: string | undefined;
     onClose: () => void;
+    onUpdate: (people: PersonResponseDto[]) => void;
     loadNextPage: () => void;
   }
 
-  let { people = $bindable(), totalPeopleCount, titleId = undefined, onClose, loadNextPage }: Props = $props();
+  let { people, totalPeopleCount, titleId = undefined, onClose, onUpdate, loadNextPage }: Props = $props();
 
   let toggleVisibility = $state(ToggleVisibility.SHOW_ALL);
   let showLoadingSpinner = $state(false);
@@ -77,6 +78,7 @@
       }
       overrides.clear();
 
+      onUpdate(people);
       onClose();
     } catch (error) {
       handleError(error, $t('errors.unable_to_change_visibility', { values: { count: changed.length } }));

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -10,6 +10,7 @@
   import { Button, IconButton, toastManager } from '@immich/ui';
   import { mdiClose, mdiEye, mdiEyeOff, mdiEyeSettings, mdiRestart } from '@mdi/js';
   import { t } from 'svelte-i18n';
+  import { SvelteMap } from 'svelte/reactivity';
 
   interface Props {
     people: PersonResponseDto[];
@@ -23,14 +24,7 @@
 
   let toggleVisibility = $state(ToggleVisibility.SHOW_ALL);
   let showLoadingSpinner = $state(false);
-
-  const getPersonIsHidden = (people: PersonResponseDto[]) => {
-    const personIsHidden: Record<string, boolean> = {};
-    for (const person of people) {
-      personIsHidden[person.id] = person.isHidden;
-    }
-    return personIsHidden;
-  };
+  const overrides = new SvelteMap<string, boolean>();
 
   const getNextVisibility = (toggleVisibility: ToggleVisibility) => {
     if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
@@ -46,23 +40,23 @@
     toggleVisibility = getNextVisibility(toggleVisibility);
 
     for (const person of people) {
+      let isHidden = overrides.get(person.id) ?? person.isHidden;
+
       if (toggleVisibility === ToggleVisibility.HIDE_ALL) {
-        personIsHidden[person.id] = true;
+        isHidden = true;
       } else if (toggleVisibility === ToggleVisibility.SHOW_ALL) {
-        personIsHidden[person.id] = false;
+        isHidden = false;
       } else if (toggleVisibility === ToggleVisibility.HIDE_UNNANEMD && !person.name) {
-        personIsHidden[person.id] = true;
+        isHidden = true;
       }
+
+      setHiddenOverride(person, isHidden);
     }
   };
 
-  const handleResetVisibility = () => (personIsHidden = getPersonIsHidden(people));
-
   const handleSaveVisibility = async () => {
     showLoadingSpinner = true;
-    const changed = people
-      .filter((person) => person.isHidden !== personIsHidden[person.id])
-      .map((person) => ({ id: person.id, isHidden: personIsHidden[person.id] }));
+    const changed = Array.from(overrides, ([id, isHidden]) => ({ id, isHidden }));
 
     try {
       if (changed.length > 0) {
@@ -76,8 +70,12 @@
       }
 
       for (const person of people) {
-        person.isHidden = personIsHidden[person.id];
+        const isHidden = overrides.get(person.id);
+        if (isHidden !== undefined) {
+          person.isHidden = isHidden;
+        }
       }
+      overrides.clear();
 
       onClose();
     } catch (error) {
@@ -87,15 +85,13 @@
     }
   };
 
-  let personIsHidden = $state<Record<string, boolean>>({});
-
-  $effect(() => {
-    for (const person of people) {
-      if (!(person.id in personIsHidden)) {
-        personIsHidden[person.id] = person.isHidden;
-      }
+  const setHiddenOverride = (person: PersonResponseDto, isHidden: boolean) => {
+    if (isHidden === person.isHidden) {
+      overrides.delete(person.id);
+      return;
     }
-  });
+    overrides.set(person.id, isHidden);
+  };
 
   let toggleButtonOptions: Record<ToggleVisibility, { icon: string; label: string }> = $derived({
     [ToggleVisibility.HIDE_ALL]: { icon: mdiEyeOff, label: $t('hide_all_people') },
@@ -132,7 +128,7 @@
         variant="ghost"
         aria-label={$t('reset_people_visibility')}
         icon={mdiRestart}
-        onclick={handleResetVisibility}
+        onclick={() => overrides.clear()}
       />
       <IconButton
         shape="round"
@@ -150,11 +146,11 @@
 <div class="flex flex-wrap gap-1 p-2 pb-8 md:px-8 mt-16">
   <PeopleInfiniteScroll {people} hasNextPage={true} {loadNextPage}>
     {#snippet children({ person })}
-      {@const hidden = personIsHidden[person.id]}
+      {@const hidden = overrides.get(person.id) ?? person.isHidden}
       <button
         type="button"
         class="group relative w-full h-full"
-        onclick={() => (personIsHidden[person.id] = !hidden)}
+        onclick={() => setHiddenOverride(person, !hidden)}
         aria-pressed={hidden}
         aria-label={person.name ? $t('hide_named_person', { values: { name: person.name } }) : $t('hide_person')}
       >

--- a/web/src/lib/components/faces-page/manage-people-visibility.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.svelte
@@ -87,7 +87,15 @@
     }
   };
 
-  let personIsHidden = $state(getPersonIsHidden(people));
+  let personIsHidden = $state<Record<string, boolean>>({});
+
+  $effect(() => {
+    for (const person of people) {
+      if (!(person.id in personIsHidden)) {
+        personIsHidden[person.id] = person.isHidden;
+      }
+    }
+  });
 
   let toggleButtonOptions: Record<ToggleVisibility, { icon: string; label: string }> = $derived({
     [ToggleVisibility.HIDE_ALL]: { icon: mdiEyeOff, label: $t('hide_all_people') },

--- a/web/src/lib/components/faces-page/manage-people-visibility.test-wrapper.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.test-wrapper.svelte
@@ -8,12 +8,13 @@
     totalPeopleCount: number;
     titleId?: string | undefined;
     onClose: () => void;
+    onUpdate: (people: PersonResponseDto[]) => void;
     loadNextPage: () => void;
   }
 
-  let { people, totalPeopleCount, titleId = undefined, onClose, loadNextPage }: Props = $props();
+  let props: Props = $props();
 </script>
 
 <TooltipProvider>
-  <ManagePeopleVisibility {people} {totalPeopleCount} {titleId} {onClose} {loadNextPage} />
+  <ManagePeopleVisibility {...props} />
 </TooltipProvider>

--- a/web/src/lib/components/faces-page/manage-people-visibility.test-wrapper.svelte
+++ b/web/src/lib/components/faces-page/manage-people-visibility.test-wrapper.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { PersonResponseDto } from '@immich/sdk';
+  import { TooltipProvider } from '@immich/ui';
+  import ManagePeopleVisibility from './manage-people-visibility.svelte';
+
+  interface Props {
+    people: PersonResponseDto[];
+    totalPeopleCount: number;
+    titleId?: string | undefined;
+    onClose: () => void;
+    loadNextPage: () => void;
+  }
+
+  let { people, totalPeopleCount, titleId = undefined, onClose, loadNextPage }: Props = $props();
+</script>
+
+<TooltipProvider>
+  <ManagePeopleVisibility {people} {totalPeopleCount} {titleId} {onClose} {loadNextPage} />
+</TooltipProvider>

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -213,7 +213,11 @@
     await clearQueryParam(QueryParameter.SEARCHED_PEOPLE, $page.url);
   };
 
-  let people = $derived(data.people.people);
+  let people = $derived.by(() => {
+    // make deeply reactive
+    const _ = $state(data.people.people);
+    return _;
+  });
   let visiblePeople = $derived(people.filter((people) => !people.isHidden));
   let countVisiblePeople = $derived(searchName ? searchedPeopleLocal.length : data.people.total - data.people.hidden);
   let showPeople = $derived(searchName ? searchedPeopleLocal : visiblePeople);

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -213,11 +213,8 @@
     await clearQueryParam(QueryParameter.SEARCHED_PEOPLE, $page.url);
   };
 
-  let people = $derived.by(() => {
-    // make deeply reactive
-    const _ = $state(data.people.people);
-    return _;
-  });
+  let people = $derived(data.people.people);
+
   let visiblePeople = $derived(people.filter((people) => !people.isHidden));
   let countVisiblePeople = $derived(searchName ? searchedPeopleLocal.length : data.people.total - data.people.hidden);
   let showPeople = $derived(searchName ? searchedPeopleLocal : visiblePeople);
@@ -392,10 +389,11 @@
     use:focusTrap
   >
     <ManagePeopleVisibility
-      bind:people
+      {people}
       totalPeopleCount={data.people.total}
       titleId="manage-visibility-title"
       onClose={() => (selectHidden = false)}
+      onUpdate={(updatedPeople) => (people = updatedPeople.slice())}
       {loadNextPage}
     />
   </dialog>


### PR DESCRIPTION
On the People -> "Show & hide people" page the hidden state isn't set when loading the next page, causing hidden people to appear as visible.

Fixes #17158 with the solution provided by @nicosemp