### PR TITLE
fix(server): handle duplicate asset checksums atomically with ON CONFLICT

### DIFF
--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -373,7 +373,7 @@ describe(AssetMediaService.name, () => {
       );
     });
 
-    it('should handle a duplicate', async () => {
+    it('should handle a duplicate via ON CONFLICT', async () => {
       const file = {
         uuid: 'random-uuid',
         originalPath: 'fake_path/asset_1.jpeg',
@@ -382,10 +382,9 @@ describe(AssetMediaService.name, () => {
         originalName: 'asset_1.jpeg',
         size: 0,
       };
-      const error = new Error('unique key violation');
-      (error as any).constraint_name = ASSET_CHECKSUM_CONSTRAINT;
 
-      mocks.asset.create.mockRejectedValue(error);
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      mocks.asset.create.mockResolvedValue(undefined);
       mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue(assetEntity.id);
 
       await expect(sut.uploadAsset(authStub.user1, createDto, file)).resolves.toEqual({
@@ -409,10 +408,11 @@ describe(AssetMediaService.name, () => {
         originalName: 'asset_1.jpeg',
         size: 0,
       };
-      const error = new Error('unique key violation');
-      (error as any).constraint_name = ASSET_CHECKSUM_CONSTRAINT;
 
-      mocks.asset.create.mockRejectedValue(error);
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      mocks.asset.create.mockResolvedValue(undefined);
+      // eslint-disable-next-line unicorn/no-useless-undefined
+      mocks.asset.getUploadAssetIdByChecksum.mockResolvedValue(undefined);
 
       await expect(sut.uploadAsset(authStub.user1, createDto, file)).rejects.toBeInstanceOf(
         InternalServerErrorException,
@@ -844,7 +844,7 @@ describe(AssetMediaService.name, () => {
       // this is the original file size
       mocks.storage.stat.mockResolvedValue({ size: 0 } as Stats);
       // this is for the clone call
-      mocks.asset.create.mockResolvedValue(copiedAsset);
+      mocks.asset.createStrict.mockResolvedValue(copiedAsset);
 
       await expect(sut.replaceAsset(authStub.user1, existingAsset.id, replaceDto, updatedFile)).resolves.toEqual({
         status: AssetMediaStatus.REPLACED,
@@ -858,7 +858,7 @@ describe(AssetMediaService.name, () => {
           originalPath: 'fake_path/photo1.jpeg',
         }),
       );
-      expect(mocks.asset.create).toHaveBeenCalledWith(
+      expect(mocks.asset.createStrict).toHaveBeenCalledWith(
         expect.objectContaining({
           originalFileName: 'existing-filename.jpeg',
           originalPath: 'fake_path/asset_1.jpeg',
@@ -893,7 +893,7 @@ describe(AssetMediaService.name, () => {
       // this is the original file size
       mocks.storage.stat.mockResolvedValue({ size: 0 } as Stats);
       // this is for the clone call
-      mocks.asset.create.mockResolvedValue(copiedAsset);
+      mocks.asset.createStrict.mockResolvedValue(copiedAsset);
 
       await expect(
         sut.replaceAsset(authStub.user1, sidecarAsset.id, replaceDto, updatedFile, sidecarFile),
@@ -931,7 +931,7 @@ describe(AssetMediaService.name, () => {
       // this is the original file size
       mocks.storage.stat.mockResolvedValue({ size: 0 } as Stats);
       // this is for the copy call
-      mocks.asset.create.mockResolvedValue(copiedAsset);
+      mocks.asset.createStrict.mockResolvedValue(copiedAsset);
 
       await expect(sut.replaceAsset(authStub.user1, existingAsset.id, replaceDto, updatedFile)).resolves.toEqual({
         status: AssetMediaStatus.REPLACED,
@@ -968,14 +968,14 @@ describe(AssetMediaService.name, () => {
       // this is the original file size
       mocks.storage.stat.mockResolvedValue({ size: 0 } as Stats);
       // this is for the clone call
-      mocks.asset.create.mockResolvedValue(copiedAsset);
+      mocks.asset.createStrict.mockResolvedValue(copiedAsset);
 
       await expect(sut.replaceAsset(authStub.user1, sidecarAsset.id, replaceDto, updatedFile)).resolves.toEqual({
         status: AssetMediaStatus.DUPLICATE,
         id: sidecarAsset.id,
       });
 
-      expect(mocks.asset.create).not.toHaveBeenCalled();
+      expect(mocks.asset.createStrict).not.toHaveBeenCalled();
       expect(mocks.asset.updateAll).not.toHaveBeenCalled();
       expect(mocks.asset.upsertFile).not.toHaveBeenCalled();
       expect(mocks.asset.deleteFile).not.toHaveBeenCalled();

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -22,6 +22,143 @@ beforeAll(async () => {
 });
 
 describe(AssetRepository.name, () => {
+  describe('create', () => {
+    it('should return the asset on successful insert', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const checksum = Buffer.from('duplicate-test-checksum');
+
+      const result = await sut.create({
+        ownerId: user.id,
+        checksum,
+        originalPath: '/path/to/file.jpg',
+        originalFileName: 'file.jpg',
+        deviceAssetId: 'device-1',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.ownerId).toBe(user.id);
+    });
+
+    it('should return undefined on duplicate checksum for the same owner', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const checksum = Buffer.from('duplicate-test-checksum-2');
+
+      const first = await sut.create({
+        ownerId: user.id,
+        checksum,
+        originalPath: '/path/to/file1.jpg',
+        originalFileName: 'file1.jpg',
+        deviceAssetId: 'device-1',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+      expect(first).toBeDefined();
+
+      const second = await sut.create({
+        ownerId: user.id,
+        checksum,
+        originalPath: '/path/to/file2.jpg',
+        originalFileName: 'file2.jpg',
+        deviceAssetId: 'device-2',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+      expect(second).toBeUndefined();
+    });
+
+    it('should allow the same checksum for different owners', async () => {
+      const { ctx, sut } = setup();
+      const { user: user1 } = await ctx.newUser();
+      const { user: user2 } = await ctx.newUser();
+      const checksum = Buffer.from('shared-checksum');
+
+      const first = await sut.create({
+        ownerId: user1.id,
+        checksum,
+        originalPath: '/path/to/file1.jpg',
+        originalFileName: 'file1.jpg',
+        deviceAssetId: 'device-1',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+      expect(first).toBeDefined();
+
+      const second = await sut.create({
+        ownerId: user2.id,
+        checksum,
+        originalPath: '/path/to/file2.jpg',
+        originalFileName: 'file2.jpg',
+        deviceAssetId: 'device-2',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+      expect(second).toBeDefined();
+      expect(second!.ownerId).toBe(user2.id);
+    });
+  });
+
+  describe('createStrict', () => {
+    it('should throw on duplicate checksum', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const checksum = Buffer.from('strict-duplicate-checksum');
+
+      await sut.createStrict({
+        ownerId: user.id,
+        checksum,
+        originalPath: '/path/to/file1.jpg',
+        originalFileName: 'file1.jpg',
+        deviceAssetId: 'device-1',
+        deviceId: 'device',
+        type: 'IMAGE' as any,
+        fileCreatedAt: new Date().toISOString(),
+        fileModifiedAt: new Date().toISOString(),
+        localDateTime: new Date().toISOString(),
+        isFavorite: false,
+      });
+
+      await expect(
+        sut.createStrict({
+          ownerId: user.id,
+          checksum,
+          originalPath: '/path/to/file2.jpg',
+          originalFileName: 'file2.jpg',
+          deviceAssetId: 'device-2',
+          deviceId: 'device',
+          type: 'IMAGE' as any,
+          fileCreatedAt: new Date().toISOString(),
+          fileModifiedAt: new Date().toISOString(),
+          localDateTime: new Date().toISOString(),
+          isFavorite: false,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
   describe('upsertExif', () => {
     it('should append to locked columns', async () => {
       const { ctx, sut } = setup();

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -5,6 +5,7 @@ import { Mocked, vitest } from 'vitest';
 export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetRepository>> => {
   return {
     create: vitest.fn(),
+    createStrict: vitest.fn(),
     createAll: vitest.fn(),
     upsertExif: vitest.fn(),
     updateAllExif: vitest.fn(),


### PR DESCRIPTION
## Summary

Replaces the check-then-insert race condition in asset creation with PostgreSQL `ON CONFLICT DO NOTHING` on the `UQ_assets_owner_checksum` constraint. This eliminates the noisy constraint violation errors that spam server logs when the mobile app uploads duplicate assets.

Fixes #22742

## Changes

### `AssetRepository` (`asset.repository.ts`)
- **`create()`** now uses `ON CONFLICT (constraint UQ_assets_owner_checksum) DO NOTHING` with `executeTakeFirst()`, returning `undefined` when the asset already exists instead of throwing
- **`createStrict()`** (new) preserves the original throwing behavior via `executeTakeFirstOrThrow()`, used by `createCopy()` during asset replacement where a conflict is a real error
- **`createAll()`** also uses `ON CONFLICT DO NOTHING`, so batch inserts silently skip duplicates

### `AssetMediaService` (`asset-media.service.ts`)
- `uploadAsset()` handles the `undefined` return from `create()` as a duplicate: cleans up uploaded files, returns `DUPLICATE` status, and skips the usage update — all without logging a constraint violation
- `createCopy()` switched to `createStrict()` since backup copies during asset replacement should never conflict
- Private `create()` method now returns `{ id, duplicate }` for clean control flow

### `MetadataService` (`metadata.service.ts`)
- Motion photo extraction simplified from try/catch with `isAssetChecksumConstraint` to a straightforward `if (created) / else` pattern
- Removed unused `isAssetChecksumConstraint` import

### Tests
- Updated duplicate handling tests from `mockRejectedValue(error)` to `mockResolvedValue()` 
- Updated `replaceAsset` tests from `mocks.asset.create` to `mocks.asset.createStrict`
- Added `createStrict` to the asset repository mock

## Verification

- `tsc --noEmit` — clean
- All 2185 tests pass (102 test files)
- `pnpm lint` — clean (0 warnings, 0 errors)