### PR TITLE
fix(server): add missing history metadata to getAuthStatus endpoint

### DIFF
--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -4959,7 +4959,22 @@
         "summary": "Retrieve auth status",
         "tags": [
           "Authentication"
-        ]
+        ],
+        "x-immich-history": [
+          {
+            "version": "v1",
+            "state": "Added"
+          },
+          {
+            "version": "v1",
+            "state": "Beta"
+          },
+          {
+            "version": "v2",
+            "state": "Stable"
+          }
+        ],
+        "x-immich-state": "Stable"
       }
     },
     "/auth/validateToken": {

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -112,6 +112,7 @@ export class AuthController {
     summary: 'Retrieve auth status',
     description:
       'Get information about the current session, including whether the user has a password, and if the session can access locked assets.',
+    history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
   })
   getAuthStatus(@Auth() auth: AuthDto): Promise<AuthStatusResponseDto> {
     return this.service.getAuthStatus(auth);


### PR DESCRIPTION
## Description

Adds missing `history` metadata to the `getAuthStatus` endpoint in `auth.controller.ts`.

This endpoint was the only one in the controller missing the `history` property, which caused a console log during module loading:


The pattern `new HistoryBuilder().added('v1').beta('v1').stable('v2')` matches all adjacent endpoints in the same controller.

Fixes #25909 (partially - addresses the "Missing history" log message)

## How Has This Been Tested?

- [x] ESLint passes on modified file
- [x] Pattern matches adjacent endpoints in same controller
- [x] No TypeScript errors

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

LLM was used to help analyze the codebase.