### PR TITLE
Add read-write permissions to volume mounts

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     #   service: cpu # set to one of [nvenc, quicksync, rkmpp, vaapi, vaapi-wsl] for accelerated transcoding
     volumes:
       # Do not edit the next line. If you want to change the media storage location on your system, edit the value of UPLOAD_LOCATION in the .env file
-      - ${UPLOAD_LOCATION}:/data
+      - ${UPLOAD_LOCATION}:/data:rw
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - .env
@@ -40,7 +40,7 @@ services:
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable
     volumes:
-      - model-cache:/cache
+      - model-cache:/cache:rw
     env_file:
       - .env
     restart: always
@@ -66,7 +66,7 @@ services:
       # DB_STORAGE_TYPE: 'HDD'
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
-      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data:rw
     shm_size: 128mb
     restart: always
     healthcheck:


### PR DESCRIPTION
## Description

When executing docker compose up on a SElinux environment, the database container does not have write-access to its DB_DATA_LOCATION. This is solved by setting the read-write permissions to the volume mounts.



## How Has This Been Tested?

Tested by running compose up before and after the change.


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [X] I have confirmed that any new dependencies are strictly necessary.
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [N/A] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [N/A] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

None
