### PR TITLE
fix: image download complete notification shows an extra {file_name} template tag

### DIFF
--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -27,19 +27,19 @@ import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
 void configureFileDownloaderNotifications() {
-  final FileName = 'file_name'.t( args: {'file_name': '{filename}', }, );
-  
+  final fileName = 'file_name'.t(args: {'file_name': '{filename}'});
+
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupImage,
-    running: TaskNotification('downloading_media'.t(), FileName),
-    complete: TaskNotification('download_finished'.t(), FileName),
+    running: TaskNotification('downloading_media'.t(), fileName),
+    complete: TaskNotification('download_finished'.t(), fileName),
     progressBar: true,
   );
 
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupVideo,
-    running: TaskNotification('downloading_media'.t(), FileName),
-    complete: TaskNotification('download_finished'.t(), FileName),
+    running: TaskNotification('downloading_media'.t(), fileName),
+    complete: TaskNotification('download_finished'.t(), fileName),
     progressBar: true,
   );
 

--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -27,17 +27,19 @@ import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
 void configureFileDownloaderNotifications() {
+  final FileName = 'file_name'.t( args: {'file_name': '{filename}', }, );
+  
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupImage,
-    running: TaskNotification('downloading_media'.t(), '${'file_name'.t()}: {filename}'),
-    complete: TaskNotification('download_finished'.t(), '${'file_name'.t()}: {filename}'),
+    running: TaskNotification('downloading_media'.t(), FileName),
+    complete: TaskNotification('download_finished'.t(), FileName),
     progressBar: true,
   );
 
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupVideo,
-    running: TaskNotification('downloading_media'.t(), '${'file_name'.t()}: {filename}'),
-    complete: TaskNotification('download_finished'.t(), '${'file_name'.t()}: {filename}'),
+    running: TaskNotification('downloading_media'.t(), FileName),
+    complete: TaskNotification('download_finished'.t(), FileName),
     progressBar: true,
   );
 


### PR DESCRIPTION
## Description

Caused by #24547
Fixes #25690

## How Has This Been Tested?

I have not tested this, but looking at the code it looks good

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used a AI to make sure the args were correct.
