### PR TITLE
fix: prettier not found

### DIFF
--- a/mobile/makefile
+++ b/mobile/makefile
@@ -37,7 +37,7 @@ migration:
 	dart run drift_dev make-migrations
 
 translation:
-	npm --prefix ../i18n run format:fix
+	pnpm --prefix ../i18n run format:fix
 	dart run easy_localization:generate -S ../i18n
 	dart run bin/generate_keys.dart
 	dart format lib/generated/codegen_loader.g.dart


### PR DESCRIPTION
We use pnpm now, plus it will automatically install dependencies if they're missing or outdated.

Closes #25511.