### PR TITLE
feat: Add a confirmation dialog before stopping the backup process.

### DIFF
--- a/mobile/lib/pages/backup/drift_backup.page.dart
+++ b/mobile/lib/pages/backup/drift_backup.page.dart
@@ -137,8 +137,34 @@ class _DriftBackupPageState extends ConsumerState<DriftBackupPage> {
                   BackupToggleButton(
                     onStart: () async => await startBackup(),
                     onStop: () async {
-                      syncSuccess = null;
-                      await stopBackup();
+                      final confirm = await showDialog<bool>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: Text("backup_controller_page_stop_backup_dialog_title".tr(defaultValue: "Disable backup")),
+                          content: Text(
+                            "backup_controller_page_stop_backup_dialog_content".tr(
+                              defaultValue: "Are you sure you want to disable backup? This will clear the current progress and cache.",
+                            ),
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.of(context).pop(false),
+                              child: Text("cancel".tr()),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.of(context).pop(true),
+                              child: Text(
+                                "confirm".tr(),
+                                style: TextStyle(color: context.colorScheme.error),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirm == true) {
+                        syncSuccess = null;
+                        await stopBackup();
+                      }
                     },
                   ),
                   switch (error) {

--- a/mobile/test/pages/backup/drift_backup_page_test.dart
+++ b/mobile/test/pages/backup/drift_backup_page_test.dart
@@ -1,0 +1,147 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/album/local_album.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/utils/background_sync.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/entities/user.entity.dart';
+import 'package:immich_mobile/pages/backup/drift_backup.page.dart';
+import 'package:immich_mobile/presentation/widgets/backup/backup_toggle_button.widget.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
+import 'package:immich_mobile/providers/backup/backup_album.provider.dart';
+import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
+import 'package:immich_mobile/providers/sync_status.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../test_utils.dart';
+import '../../../widget_tester_extensions.dart';
+
+class MockDriftBackupNotifier extends StateNotifier<DriftBackupState>
+    with Mock
+    implements DriftBackupNotifier {
+  MockDriftBackupNotifier()
+      : super(
+          const DriftBackupState(
+            totalCount: 100,
+            backupCount: 50,
+            remainderCount: 50,
+            processingCount: 0,
+            isSyncing: false,
+            uploadItems: {},
+            error: BackupError.none,
+          ),
+        );
+}
+
+class MockBackgroundSyncManager extends Mock implements BackgroundSyncManager {}
+
+void main() {
+  late MockDriftBackupNotifier mockBackupNotifier;
+  late MockBackgroundSyncManager mockBackgroundSyncManager;
+  late User user;
+  
+  // Create a selected album to ensure the backup UI (and toggle button) is shown
+  final selectedAlbum = LocalAlbum(
+    id: 'album_1',
+    name: 'Camera',
+    updatedAt: DateTime.now(),
+    backupSelection: BackupSelection.selected,
+  );
+
+  setUpAll(() {
+    TestUtils.init();
+    registerFallbackValue(BackupError.none);
+  });
+
+  setUp(() {
+    mockBackupNotifier = MockDriftBackupNotifier();
+    mockBackgroundSyncManager = MockBackgroundSyncManager();
+    user = User(
+      id: 'user_1',
+      updatedAt: DateTime.now(),
+      createdAt: DateTime.now(),
+      email: 'test@example.com',
+      name: 'Test User',
+      profileImagePath: '',
+      isAdmin: false,
+      isPartnerSharedWith: false,
+      shouldChangePassword: false,
+      status: 'active',
+      deletedAt: null,
+      quotaSizeInBytes: 0,
+      quotaUsageInBytes: 0,
+      memoryEnabled: true,
+      oauthId: '',
+      profileColor: '',
+    );
+    
+    // Setup default mock behaviors
+    when(() => mockBackupNotifier.getBackupStatus(any())).thenAnswer((_) async {});
+    when(() => mockBackupNotifier.updateSyncing(any())).thenReturn(null);
+    when(() => mockBackupNotifier.stopForegroundBackup()).thenAnswer((_) async {});
+    when(() => mockBackupNotifier.startForegroundBackup(any())).thenAnswer((_) async {});
+    
+    // Store mock
+    Store.init(StoreKey.currentUser, user);
+  });
+
+  testWidgets(
+      'shows confirmation dialog when stopping backup and stops only on confirm',
+      (tester) async {
+    when(() => mockBackgroundSyncManager.syncRemote()).thenAnswer((_) async => true);
+
+    await tester.pumpConsumerWidget(
+      const DriftBackupPage(),
+      overrides: [
+        currentUserProvider.overrideWith((ref) => user),
+        driftBackupProvider.overrideWith((ref) => mockBackupNotifier),
+        backgroundSyncProvider.overrideWithValue(mockBackgroundSyncManager),
+        backupAlbumProvider.overrideWith((ref) => [selectedAlbum]),
+        syncStatusProvider.overrideWith((ref) => SyncStatusState()),
+      ],
+    );
+    
+    await tester.pumpAndSettle();
+
+    // Verify BackupToggleButton is present
+    final toggleButtonFinder = find.byType(BackupToggleButton);
+    expect(toggleButtonFinder, findsOneWidget);
+    
+    // Scroll to the button to make sure it's visible (it's in a ListView)
+    await tester.scrollUntilVisible(toggleButtonFinder, 100);
+    await tester.pumpAndSettle();
+    
+    // Tap the button to stop backup
+    await tester.tap(toggleButtonFinder);
+    await tester.pumpAndSettle();
+    
+    // Verify confirmation dialog appears
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text("backup_controller_page_stop_backup_dialog_title"), findsOneWidget);
+    
+    // Tap Cancel
+    await tester.tap(find.text("cancel"));
+    await tester.pumpAndSettle();
+    
+    // Verify dialog closed and stopForegroundBackup was NOT called
+    expect(find.byType(AlertDialog), findsNothing);
+    verifyNever(() => mockBackupNotifier.stopForegroundBackup());
+    
+    // Tap button again
+    await tester.tap(toggleButtonFinder);
+    await tester.pumpAndSettle();
+    
+    // Setup expect for stopForegroundBackup
+    // (Verification happens after action)
+    
+    // Tap Confirm
+    await tester.tap(find.text("confirm"));
+    await tester.pumpAndSettle();
+    
+    // Verify stopForegroundBackup WAS called
+    verify(() => mockBackupNotifier.stopForegroundBackup()).called(1);
+  });
+}


### PR DESCRIPTION
## Description

Adds a confirmation dialog to prompt before stopping the backup. If you accidentally click on the toggle, it disables without you realizing. 

Fixes # (issue)

## How Has This Been Tested?

- [x] Unit test for new prompt

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
