### PR TITLE
fix: revert "fix(web): Ensure profile picture is cropped to 1:1 ratio (#25892)"

### DIFF
--- a/web/src/lib/modals/ProfileImageCropperModal.svelte
+++ b/web/src/lib/modals/ProfileImageCropperModal.svelte
@@ -16,7 +16,6 @@
   let { asset, onClose }: Props = $props();
 
   let imgElement: HTMLDivElement | undefined = $state();
-  let cropContainer: HTMLDivElement | undefined = $state();
 
   onMount(() => {
     if (!imgElement) {
@@ -52,23 +51,16 @@
   };
 
   const onSubmit = async () => {
-    if (!cropContainer) {
+    if (!imgElement) {
       return;
     }
 
     try {
-      // Get the container dimensions (which is always square due to aspect-square class)
-      const containerSize = cropContainer.offsetWidth;
-
-      // Capture the crop container which maintains 1:1 aspect ratio
-      // Override border-radius and border to avoid transparent corners from rounded-full
-      const blob = await domtoimage.toBlob(cropContainer, {
-        width: containerSize,
-        height: containerSize,
-        style: {
-          borderRadius: '0',
-          border: 'none',
-        },
+      const imgElementHeight = imgElement.offsetHeight;
+      const imgElementWidth = imgElement.offsetWidth;
+      const blob = await domtoimage.toBlob(imgElement, {
+        width: imgElementWidth,
+        height: imgElementHeight,
       });
 
       if (await hasTransparentPixels(blob)) {
@@ -91,7 +83,6 @@
 <FormModal size="small" title={$t('set_profile_picture')} {onClose} {onSubmit}>
   <div class="flex place-items-center items-center justify-center">
     <div
-      bind:this={cropContainer}
       class="relative flex aspect-square w-62.5 overflow-hidden rounded-full border-4 border-immich-primary bg-immich-dark-primary dark:border-immich-dark-primary dark:bg-immich-primary"
     >
       <PhotoViewer bind:element={imgElement} cursor={{ current: asset }} />


### PR DESCRIPTION
Reverts #25892

Upon testing it seems the original issue was no longer relevant and this change effectively fixed a non-existent issue, as also noted in https://github.com/immich-app/immich/issues/20097#issuecomment-3733439518. The follow-up PR #25950 introduces a new issue where borders are included in the profile image:

| v2.5.3 | main |
| - | - |
| <img width="242" height="242" alt="image" src="https://github.com/user-attachments/assets/9f440587-35fc-4003-b42b-c2cdbf79cf4a" /> | <img width="275" height="275" alt="image" src="https://github.com/user-attachments/assets/19aaaa4f-3dbe-4d40-83db-7bbfccc44a40" /> |