### PR TITLE
fix(i18n): shorten French library translation for mobile nav

### DIFF
--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1358,7 +1358,7 @@
   "lens_model": "Modèle d'objectif",
   "let_others_respond": "Laisser les autres réagir",
   "level": "Niveau",
-  "library": "Bibliothèque",
+  "library": "Biblio",
   "library_add_folder": "Ajouter un dossier",
   "library_edit_folder": "Modifier un dossier",
   "library_options": "Options de bibliothèque",


### PR DESCRIPTION
## Description

Fixes #25921

The French translation for 'Library' ('Bibliothèque') was too long for the bottom navigation bar, causing it to wrap to a second line.

Changed to 'Biblio' — a commonly used French abbreviation that fits the nav bar while remaining clear.

## Changes
- `i18n/fr.json`: Changed `library` from 'Bibliothèque' to 'Biblio'

## Checklist

- [x] This PR does not add or change user-facing strings (or they have been added to `/i18n/en.json`)
- [x] The only non-generated changes in this PR are the translation fix
- [x] PR is focused and does one thing
- [ ] Used generative AI: No