### PR TITLE
fix: image and video download complete notification shows "file_name"

### DIFF
--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -27,7 +27,6 @@ import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
 void configureFileDownloaderNotifications() {
-
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupImage,
     running: TaskNotification('downloading_media'.t(), '${'file_name_text'.t()}: {filename}'),

--- a/mobile/lib/utils/bootstrap.dart
+++ b/mobile/lib/utils/bootstrap.dart
@@ -27,19 +27,18 @@ import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
 void configureFileDownloaderNotifications() {
-  final fileName = 'file_name'.t(args: {'file_name': '{filename}'});
 
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupImage,
-    running: TaskNotification('downloading_media'.t(), fileName),
-    complete: TaskNotification('download_finished'.t(), fileName),
+    running: TaskNotification('downloading_media'.t(), '${'file_name_text'.t()}: {filename}'),
+    complete: TaskNotification('download_finished'.t(), '${'file_name_text'.t()}: {filename}'),
     progressBar: true,
   );
 
   FileDownloader().configureNotificationForGroup(
     kDownloadGroupVideo,
-    running: TaskNotification('downloading_media'.t(), fileName),
-    complete: TaskNotification('download_finished'.t(), fileName),
+    running: TaskNotification('downloading_media'.t(), '${'file_name_text'.t()}: {filename}'),
+    complete: TaskNotification('download_finished'.t(), '${'file_name_text'.t()}: {filename}'),
     progressBar: true,
   );
 


### PR DESCRIPTION
## Description

Caused by: #25916

used new `file_name_text`
![IMG_0910](https://github.com/user-attachments/assets/9b9b9385-8976-4ea3-864b-0aca707f4259)

Sorry for closing the last one #25972 <3 