### PR TITLE
fix(mobile): handle image stream completion when no image is emitted

### DIFF
--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -31,7 +31,7 @@ class LocalThumbProvider extends CancellableImageProvider<LocalThumbProvider>
         DiagnosticsProperty<String>('Id', key.id),
         DiagnosticsProperty<Size>('Size', key.size),
       ],
-      onDispose: cancel,
+      onLastListenerRemoved: cancel,
     );
   }
 
@@ -76,7 +76,7 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
         DiagnosticsProperty<String>('Id', key.id),
         DiagnosticsProperty<Size>('Size', key.size),
       ],
-      onDispose: cancel,
+      onLastListenerRemoved: cancel,
     );
   }
 

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -60,8 +60,11 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
     final bool onlyCacheListenerLeft = _listenerCount == 1 && !didProvideImage;
     final bool noListenersAfterImage = _listenerCount == 0 && didProvideImage;
 
-    if (noListenersAfterImage || onlyCacheListenerLeft) {
-      _onLastListenerRemoved?.call();
+    final onLastListenerRemoved = _onLastListenerRemoved;
+
+    if (onLastListenerRemoved != null && (noListenersAfterImage || onlyCacheListenerLeft)) {
+      _onLastListenerRemoved = null;
+      onLastListenerRemoved();
     }
   }
 }

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -12,7 +12,6 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
   void Function()? _onLastListenerRemoved;
   int _listenerCount = 0;
 
-
   /// The constructor to create an OneFramePlaceholderImageStreamCompleter. The [images]
   /// should be the primary images to display (typically asynchronously as they load).
   /// The [initialImage] is an optional image that will be emitted synchronously

--- a/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
+++ b/mobile/lib/presentation/widgets/images/one_frame_multi_image_stream_completer.dart
@@ -9,8 +9,6 @@ import 'package:flutter/painting.dart';
 
 /// An ImageStreamCompleter with support for loading multiple images.
 class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
-  void Function()? _onDispose;
-
   /// The constructor to create an OneFramePlaceholderImageStreamCompleter. The [images]
   /// should be the primary images to display (typically asynchronously as they load).
   /// The [initialImage] is an optional image that will be emitted synchronously
@@ -19,12 +17,11 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
     Stream<ImageInfo> images, {
     ImageInfo? initialImage,
     InformationCollector? informationCollector,
-    void Function()? onDispose,
+    void Function()? onLastListenerRemoved,
   }) {
     if (initialImage != null) {
       setImage(initialImage);
     }
-    _onDispose = onDispose;
     images.listen(
       setImage,
       onError: (Object error, StackTrace stack) {
@@ -37,15 +34,11 @@ class OneFramePlaceholderImageStreamCompleter extends ImageStreamCompleter {
         );
       },
     );
-  }
 
-  @override
-  void onDisposed() {
-    final onDispose = _onDispose;
-    if (onDispose != null) {
-      _onDispose = null;
-      onDispose();
-    }
-    super.onDisposed();
+    addOnLastListenerRemovedCallback(() {
+      if (onLastListenerRemoved != null) {
+        onLastListenerRemoved();
+      }
+    });
   }
 }

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -32,7 +32,7 @@ class RemoteImageProvider extends CancellableImageProvider<RemoteImageProvider>
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<String>('URL', key.url),
       ],
-      onDispose: cancel,
+      onLastListenerRemoved: cancel,
     );
   }
 
@@ -76,7 +76,7 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<String>('Asset Id', key.assetId),
       ],
-      onDispose: cancel,
+      onLastListenerRemoved: cancel,
     );
   }
 

--- a/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
+++ b/mobile/lib/presentation/widgets/images/thumb_hash_provider.dart
@@ -17,7 +17,7 @@ class ThumbHashProvider extends CancellableImageProvider<ThumbHashProvider>
 
   @override
   ImageStreamCompleter loadImage(ThumbHashProvider key, ImageDecoderCallback decode) {
-    return OneFramePlaceholderImageStreamCompleter(_loadCodec(key, decode), onDispose: cancel);
+    return OneFramePlaceholderImageStreamCompleter(_loadCodec(key, decode), onLastListenerRemoved: cancel);
   }
 
   Stream<ImageInfo> _loadCodec(ThumbHashProvider key, ImageDecoderCallback decode) {

--- a/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
+++ b/mobile/lib/presentation/widgets/images/thumbnail.widget.dart
@@ -233,16 +233,6 @@ class _ThumbnailState extends State<Thumbnail> with SingleTickerProviderStateMix
 
   @override
   void dispose() {
-    final imageProvider = widget.imageProvider;
-    if (imageProvider is CancellableImageProvider) {
-      imageProvider.cancel();
-    }
-
-    final thumbhashProvider = widget.thumbhashProvider;
-    if (thumbhashProvider is CancellableImageProvider) {
-      thumbhashProvider.cancel();
-    }
-
     _fadeController.removeStatusListener(_onAnimationStatusChanged);
     _fadeController.dispose();
     _stopListeningToStream();


### PR DESCRIPTION
## Description

Issue:
Currently if you press on a loading Thumbnail (image not present), the new route (or how its called in flutter) gets created where the `RemoteFullImageProvider` will try to wait on the `initialImageStream` of the same Thumbnail (where the request is loading and is still the cache).

The problem: the Thumbnail widget calls `.cancel` on the Thumbnail provider **after** the `RemoteFullImageProvider` already loaded the provider `RemoteThumbProvider(assetId: key.assetId, thumbhash: key.thumbhash)`. 

So now the `RemoteThumbProvider` waits on the initialImage, while the Thumbnail widget canceled the request. So the provider never emits an image, and the `RemoteFullImageProvider ` will wait forever.

So short: race condition because one calls cancel, while the other one waits on the request

---

In the current immich application there are 2 ways the image request can get cancelled:
- by calling `provider.cancel()` (currently only the Thumbnail widget does that)
- by the `OneFramePlaceholderImageStreamCompleter` if its disposed and invokes the callback

That makes it problematical, as no Widget actually owns an image/imagestream or whatever. So it actually shouldn't be able to forcefully cancel an image request. 
It can be that the "same" stream is used by multiple widgets

---

The fix:

Instead of letting widgets call `cancel` or waiting till the `OneFramePlaceholderImageStreamCompleter` is disposed (whenever flutter engine decides to), I think we should just cancel the image if no more listener is subscribed to the ImageStream. 

So I think I implemented the quickest fix with the `addOnLastListenerRemovedCallback` in the ImageStreamCompleter.
 
No need to call `.cancel` anymore from the widgets, its just important that you always unsubscribe the stream if you don't need it anymore (same as before).


Fixes #25723

## How Has This Been Tested?

- Tested locally by opening a bunch of images on a really slow network connection


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Getting a quick overview of the code, and some insights on where to investigate.