### PR TITLE
fix(web): display storage unit next to value instead of absolute positioning in admin user page

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -26,10 +26,10 @@
     <Text size="giant" fontWeight="medium">{title}</Text>
   </div>
 
-  <div class="relative mx-auto font-mono text-2xl font-medium">
+  <div class="mx-auto font-mono text-2xl font-medium">
     <span class="text-gray-300 dark:text-gray-600">{zeros()}</span><span>{value}</span>
     {#if unit}
-      <Code color="muted" class="font-mono absolute -top-5 end-1 font-light p-0">{unit}</Code>
+      <Code color="muted" class="font-mono font-light p-0 ml-1">{unit}</Code>
     {/if}
   </div>
 </div>

--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ByteUnit } from '$lib/utils/byte-units';
-  import { Code, Icon, Text } from '@immich/ui';
+  import { Icon, Text } from '@immich/ui';
 
   interface Props {
     icon: string;
@@ -29,7 +29,7 @@
   <div class="mx-auto font-mono text-2xl font-medium">
     <span class="text-gray-300 dark:text-gray-600">{zeros()}</span><span>{value}</span>
     {#if unit}
-      <Code color="muted" class="font-mono font-light p-0 ml-1">{unit}</Code>
+      <code class="font-mono text-base font-normal">{unit}</code>
     {/if}
   </div>
 </div>


### PR DESCRIPTION
## Description

fixes the positioning of the storage unit in the ServerStatisticsCard component on the admin user page. Previously, the unit was displayed using absolute positioning, which caused it to appear in unpredictable locations within the card. The fix changes the unit to be displayed inline next to the value for better layout consistency and readability.


Fixes #25973

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Verified the change by running the development environment with docker compose

- [x] Checked the admin user page at /admin/users/{user_uuid} to ensure the storage unit appears correctly next to the value


<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

<img width="324" height="127" alt="image" src="https://github.com/user-attachments/assets/4876c72e-e1cc-48e7-a1fa-d83614858a71" />

</details>

Before: The unit appeared randomly positioned due to absolute CSS positioning.
After: The unit is now inline next to the value.