### PR TITLE
fix: clarify external domain setting is used for emails too

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -311,7 +311,7 @@
     "search_jobs": "Search jobs…",
     "send_welcome_email": "Send welcome email",
     "server_external_domain_settings": "External domain",
-    "server_external_domain_settings_description": "Domain for public shared links, including http(s)://",
+    "server_external_domain_settings_description": "Domain used for shared links and email notifications, including http(s)://",
     "server_public_users": "Public Users",
     "server_public_users_description": "All users (name and email) are listed when adding a user to shared albums. When disabled, the user list will only be available to admin users.",
     "server_settings": "Server Settings",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -311,7 +311,7 @@
     "search_jobs": "Search jobs…",
     "send_welcome_email": "Send welcome email",
     "server_external_domain_settings": "External domain",
-    "server_external_domain_settings_description": "Domain used for shared links and email notifications, including http(s)://",
+    "server_external_domain_settings_description": "Domain used for external links",
     "server_public_users": "Public Users",
     "server_public_users_description": "All users (name and email) are listed when adding a user to shared albums. When disabled, the user list will only be available to admin users.",
     "server_settings": "Server Settings",


### PR DESCRIPTION
Fixes #24950

The description for the external domain setting stated it was only for 'public shared links', but it is also used as the base URL in email templates (welcome, album invite, album update) via `getExternalDomain()` in `notification.service.ts`.

Updated `server_external_domain_settings_description` in `i18n/en.json` to reflect actual usage.