### PR TITLE
fix(mobile): prevent nav bar label text wrapping

### DIFF
--- a/mobile/lib/theme/theme_data.dart
+++ b/mobile/lib/theme/theme_data.dart
@@ -73,7 +73,7 @@ ThemeData getThemeData({required ColorScheme colorScheme, required Locale locale
     ),
     navigationBarTheme: NavigationBarThemeData(
       backgroundColor: isDark ? colorScheme.surfaceContainer : colorScheme.surface,
-      labelTextStyle: const WidgetStatePropertyAll(TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+      labelTextStyle: const WidgetStatePropertyAll(TextStyle(fontSize: 14, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis)),
     ),
     inputDecorationTheme: InputDecorationTheme(
       focusedBorder: OutlineInputBorder(

--- a/mobile/lib/theme/theme_data.dart
+++ b/mobile/lib/theme/theme_data.dart
@@ -73,7 +73,9 @@ ThemeData getThemeData({required ColorScheme colorScheme, required Locale locale
     ),
     navigationBarTheme: NavigationBarThemeData(
       backgroundColor: isDark ? colorScheme.surfaceContainer : colorScheme.surface,
-      labelTextStyle: const WidgetStatePropertyAll(TextStyle(fontSize: 14, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis)),
+      labelTextStyle: const WidgetStatePropertyAll(
+        TextStyle(fontSize: 14, fontWeight: FontWeight.w500, overflow: TextOverflow.ellipsis),
+      ),
     ),
     inputDecorationTheme: InputDecorationTheme(
       focusedBorder: OutlineInputBorder(


### PR DESCRIPTION
Fixes #25921

Added `overflow: TextOverflow.ellipsis` to `NavigationBarThemeData.labelTextStyle` in the app theme to prevent long translations (e.g. French "Bibliothèque") from wrapping to a second line in the bottom navigation bar.

Note: I don't have a Flutter dev environment set up, so this was not tested on-device. Happy to make adjustments based on review.