### PR TITLE
fix: reduce queue graph jitter and include paused count

### DIFF
--- a/web/src/lib/components/QueueGraph.svelte
+++ b/web/src/lib/components/QueueGraph.svelte
@@ -75,6 +75,7 @@
       show: false,
     },
     width: 2,
+    pxAlign: 0,
   };
 
   const options: uPlot.Options = {
@@ -91,7 +92,7 @@
     width: 200,
     height: 200,
     ms: 1,
-    pxAlign: true,
+    pxAlign: 0,
     scales: {
       y: {
         distr: 1,

--- a/web/src/routes/admin/queues/[name]/+page.svelte
+++ b/web/src/routes/admin/queues/[name]/+page.svelte
@@ -53,7 +53,7 @@
 
       <div class="flex gap-1 mb-4">
         <Badge>{$t('active_count', { values: { count: queue.statistics.active } })}</Badge>
-        <Badge>{$t('waiting_count', { values: { count: queue.statistics.waiting } })}</Badge>
+        <Badge>{$t('waiting_count', { values: { count: queue.statistics.waiting + queue.statistics.paused } })}</Badge>
         {#if queue.statistics.failed > 0}
           <Badge color="danger">{$t('failed_count', { values: { count: queue.statistics.failed } })}</Badge>
         {/if}


### PR DESCRIPTION
- Reduce jitteryness of queue graph by disabling `pxAlign` (see: https://leeoniya.github.io/uPlot/demos/pixel-align.html)
- Include paused queue count so the `Waiting` label matches the graph value

<img width="500" height="601" alt="image" src="https://github.com/user-attachments/assets/88f81c4c-0c75-4c69-8b06-c2cda292ed77" />