### PR TITLE
feat(server,web,cli): chunked upload to bypass Cloudflare 100MB limit ("413 Request Entity Too Large")

### DIFF
--- a/server/src/controllers/chunked-upload.controller.ts
+++ b/server/src/controllers/chunked-upload.controller.ts
@@ -1,0 +1,157 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import { ApiBody, ApiConsumes, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Endpoint, HistoryBuilder } from 'src/decorators';
+import {
+  ChunkedUploadSessionResponseDto,
+  CreateChunkedUploadSessionDto,
+  FinishChunkedUploadResponseDto,
+  UploadChunkResponseDto,
+} from 'src/dtos/asset-media-chunked.dto';
+import { AuthDto } from 'src/dtos/auth.dto';
+import { ApiTag, Permission } from 'src/enum';
+import { Auth, Authenticated } from 'src/middleware/auth.guard';
+import { ChunkedUploadService } from 'src/services/chunked-upload.service';
+import { UUIDParamDto } from 'src/validation';
+
+class SessionIdParamDto {
+  sessionId!: string;
+}
+
+@ApiTags(ApiTag.Assets)
+@Controller('assets/chunked-upload')
+export class ChunkedUploadController {
+  constructor(private service: ChunkedUploadService) {}
+
+  @Post()
+  @Authenticated({ permission: Permission.AssetUpload })
+  @ApiResponse({
+    status: 201,
+    description: 'Chunked upload session created',
+    type: ChunkedUploadSessionResponseDto,
+  })
+  @Endpoint({
+    summary: 'Create chunked upload session',
+    description:
+      'Creates a new chunked upload session for uploading large files in parts. ' +
+      'This is designed to work with reverse proxies that have body size limits ' +
+      '(e.g. Cloudflare 100MB limit). The file is split into chunks that are ' +
+      'uploaded individually and assembled on the server.',
+    history: new HistoryBuilder().added('v1'),
+  })
+  createSession(
+    @Auth() auth: AuthDto,
+    @Body() dto: CreateChunkedUploadSessionDto,
+  ): Promise<ChunkedUploadSessionResponseDto> {
+    return this.service.createSession(auth, dto);
+  }
+
+  @Post(':sessionId/chunks/:chunkIndex')
+  @Authenticated({ permission: Permission.AssetUpload })
+  @ApiConsumes('application/octet-stream')
+  @ApiBody({
+    description: 'Raw chunk binary data',
+    type: 'string',
+    schema: { type: 'string', format: 'binary' },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Chunk uploaded successfully',
+    type: UploadChunkResponseDto,
+  })
+  @Endpoint({
+    summary: 'Upload a chunk',
+    description:
+      'Uploads a single chunk of binary data for the specified upload session. ' +
+      'Each chunk should be sent as raw binary (application/octet-stream). ' +
+      'Chunk size must match the session configuration (last chunk can be smaller).',
+    history: new HistoryBuilder().added('v1'),
+  })
+  async uploadChunk(
+    @Auth() auth: AuthDto,
+    @Param('sessionId') sessionId: string,
+    @Param('chunkIndex') chunkIndex: string,
+    @Req() req: RawBodyRequest<Request>,
+  ): Promise<UploadChunkResponseDto> {
+    // Read the raw body as a buffer
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk as Buffer);
+    }
+    const chunkData = Buffer.concat(chunks);
+
+    return this.service.uploadChunk(auth, sessionId, Number.parseInt(chunkIndex, 10), chunkData);
+  }
+
+  @Post(':sessionId/finish')
+  @Authenticated({ permission: Permission.AssetUpload })
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse({
+    status: 200,
+    description: 'Chunked upload completed and asset created',
+    type: FinishChunkedUploadResponseDto,
+  })
+  @Endpoint({
+    summary: 'Finish chunked upload',
+    description:
+      'Assembles all uploaded chunks into the final file, computes the checksum, ' +
+      'and creates the asset. All chunks must be uploaded before calling this endpoint.',
+    history: new HistoryBuilder().added('v1'),
+  })
+  finishUpload(
+    @Auth() auth: AuthDto,
+    @Param('sessionId') sessionId: string,
+  ): Promise<FinishChunkedUploadResponseDto> {
+    return this.service.finishUpload(auth, sessionId);
+  }
+
+  @Get(':sessionId/status')
+  @Authenticated({ permission: Permission.AssetUpload })
+  @ApiResponse({
+    status: 200,
+    description: 'Upload session status including received chunks',
+  })
+  @Endpoint({
+    summary: 'Get upload session status',
+    description:
+      'Returns the current status of a chunked upload session, including which chunks ' +
+      'have been received. Useful for implementing upload resume functionality.',
+    history: new HistoryBuilder().added('v1'),
+  })
+  getSessionStatus(
+    @Auth() auth: AuthDto,
+    @Param('sessionId') sessionId: string,
+  ) {
+    return this.service.getSessionStatus(auth, sessionId);
+  }
+
+  @Delete(':sessionId')
+  @Authenticated({ permission: Permission.AssetUpload })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiResponse({
+    status: 204,
+    description: 'Upload session cancelled and temp files cleaned up',
+  })
+  @Endpoint({
+    summary: 'Cancel chunked upload session',
+    description: 'Cancels an upload session and cleans up any temporary chunk files.',
+    history: new HistoryBuilder().added('v1'),
+  })
+  cancelSession(
+    @Auth() auth: AuthDto,
+    @Param('sessionId') sessionId: string,
+  ): Promise<void> {
+    return this.service.cancelSession(auth, sessionId);
+  }
+}

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -4,6 +4,7 @@ import { ApiKeyController } from 'src/controllers/api-key.controller';
 import { AppController } from 'src/controllers/app.controller';
 import { AssetMediaController } from 'src/controllers/asset-media.controller';
 import { AssetController } from 'src/controllers/asset.controller';
+import { ChunkedUploadController } from 'src/controllers/chunked-upload.controller';
 import { AuthAdminController } from 'src/controllers/auth-admin.controller';
 import { AuthController } from 'src/controllers/auth.controller';
 import { DatabaseBackupController } from 'src/controllers/database-backup.controller';
@@ -45,6 +46,7 @@ export const controllers = [
   AppController,
   AssetController,
   AssetMediaController,
+  ChunkedUploadController,
   AuthController,
   AuthAdminController,
   DatabaseBackupController,

--- a/server/src/dtos/asset-media-chunked.dto.ts
+++ b/server/src/dtos/asset-media-chunked.dto.ts
@@ -1,0 +1,118 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+import { AssetVisibility } from 'src/enum';
+import { Optional, ValidateBoolean, ValidateDate, ValidateUUID } from 'src/validation';
+
+/**
+ * Chunked upload support for bypassing reverse proxy body size limits.
+ *
+ * When uploading through Cloudflare or other reverse proxies with body size
+ * limits (e.g. Cloudflare's 100MB free-tier limit), large files need to be
+ * split into smaller chunks that each fit within the proxy's limit.
+ *
+ * Flow:
+ * 1. POST /assets/chunked-upload — create an upload session
+ * 2. POST /assets/chunked-upload/:sessionId/chunks — upload each chunk
+ * 3. POST /assets/chunked-upload/:sessionId/finish — finalize and create the asset
+ */
+
+export enum ChunkSize {
+  /** 25 MB — safe for most restrictive proxies */
+  SMALL = 25 * 1024 * 1024,
+  /** 50 MB — good balance between performance and compatibility */
+  MEDIUM = 50 * 1024 * 1024,
+}
+
+export class CreateChunkedUploadSessionDto {
+  @ApiProperty({ description: 'Original filename of the asset' })
+  @IsNotEmpty()
+  @IsString()
+  filename!: string;
+
+  @ApiProperty({ description: 'Total file size in bytes' })
+  @IsInt()
+  @Min(1)
+  fileSize!: number;
+
+  @ApiProperty({ description: 'Chunk size in bytes (default: 50MB, min: 1MB, max: 100MB)' })
+  @IsInt()
+  @Min(1 * 1024 * 1024)
+  @Max(100 * 1024 * 1024)
+  @IsOptional()
+  chunkSize?: number;
+
+  @ApiProperty({ description: 'Device asset ID' })
+  @IsNotEmpty()
+  @IsString()
+  deviceAssetId!: string;
+
+  @ApiProperty({ description: 'Device ID' })
+  @IsNotEmpty()
+  @IsString()
+  deviceId!: string;
+
+  @ValidateDate({ description: 'File creation date' })
+  fileCreatedAt!: Date;
+
+  @ValidateDate({ description: 'File modification date' })
+  fileModifiedAt!: Date;
+
+  @ApiPropertyOptional({ description: 'Duration (for videos)' })
+  @Optional()
+  @IsString()
+  duration?: string;
+
+  @ValidateBoolean({ optional: true, description: 'Mark as favorite' })
+  isFavorite?: boolean;
+
+  @ApiPropertyOptional({
+    enum: AssetVisibility,
+    description: 'Asset visibility',
+  })
+  @IsEnum(AssetVisibility)
+  @IsOptional()
+  visibility?: AssetVisibility;
+
+  @ValidateUUID({ optional: true, description: 'Live photo video ID' })
+  livePhotoVideoId?: string;
+}
+
+export class ChunkedUploadSessionResponseDto {
+  @ApiProperty({ description: 'Upload session ID' })
+  sessionId!: string;
+
+  @ApiProperty({ description: 'Chunk size in bytes to use for uploads' })
+  chunkSize!: number;
+
+  @ApiProperty({ description: 'Total number of chunks expected' })
+  totalChunks!: number;
+
+  @ApiProperty({ description: 'Session expiration time (ISO 8601)' })
+  expiresAt!: string;
+}
+
+export class UploadChunkDto {
+  @ApiProperty({ description: 'Chunk index (0-based)' })
+  @IsInt()
+  @Min(0)
+  chunkIndex!: number;
+}
+
+export class UploadChunkResponseDto {
+  @ApiProperty({ description: 'Chunk index that was uploaded' })
+  chunkIndex!: number;
+
+  @ApiProperty({ description: 'Number of chunks received so far' })
+  chunksReceived!: number;
+
+  @ApiProperty({ description: 'Total number of chunks expected' })
+  totalChunks!: number;
+}
+
+export class FinishChunkedUploadResponseDto {
+  @ApiProperty({ description: 'Created asset ID' })
+  assetId!: string;
+
+  @ApiProperty({ description: 'Whether the asset is a duplicate' })
+  isDuplicate!: boolean;
+}

--- a/server/src/services/chunked-upload.service.ts
+++ b/server/src/services/chunked-upload.service.ts
@@ -1,0 +1,391 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { createHash, randomUUID } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { readdir, stat, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { StorageCore } from 'src/cores/storage.core';
+import {
+  ChunkedUploadSessionResponseDto,
+  CreateChunkedUploadSessionDto,
+  FinishChunkedUploadResponseDto,
+  UploadChunkResponseDto,
+} from 'src/dtos/asset-media-chunked.dto';
+import { AssetMediaStatus } from 'src/dtos/asset-media-response.dto';
+import { AssetVisibility, JobName, Permission, StorageFolder } from 'src/enum';
+import { BaseService } from 'src/services/base.service';
+import { UploadFile } from 'src/types';
+import { mimeTypes } from 'src/utils/mime-types';
+import { AuthDto } from 'src/dtos/auth.dto';
+import { requireUploadAccess } from 'src/utils/access';
+
+/** Default chunk size: 50 MB */
+const DEFAULT_CHUNK_SIZE = 50 * 1024 * 1024;
+/** Upload session TTL: 24 hours */
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+/** Maximum chunk size: 95 MB (under Cloudflare 100MB limit with overhead margin) */
+const MAX_CHUNK_SIZE = 95 * 1024 * 1024;
+
+interface ChunkedUploadSession {
+  id: string;
+  userId: string;
+  filename: string;
+  fileSize: number;
+  chunkSize: number;
+  totalChunks: number;
+  receivedChunks: Set<number>;
+  createdAt: Date;
+  expiresAt: Date;
+  tempDir: string;
+  dto: CreateChunkedUploadSessionDto;
+}
+
+@Injectable()
+export class ChunkedUploadService extends BaseService {
+  /**
+   * In-memory session store. In production, this should use Redis or a database
+   * for horizontal scaling. For the scope of this proposal, in-memory is sufficient
+   * to demonstrate the approach.
+   */
+  private sessions = new Map<string, ChunkedUploadSession>();
+
+  /**
+   * Step 1: Create a chunked upload session.
+   * The client receives a sessionId and uploads chunks to it.
+   */
+  async createSession(
+    auth: AuthDto,
+    dto: CreateChunkedUploadSessionDto,
+  ): Promise<ChunkedUploadSessionResponseDto> {
+    requireUploadAccess(auth);
+
+    await this.requireAccess({
+      auth,
+      permission: Permission.AssetUpload,
+      ids: [auth.user.id],
+    });
+
+    // Validate the file type
+    if (!mimeTypes.isAsset(dto.filename)) {
+      throw new BadRequestException(`Unsupported file type: ${dto.filename}`);
+    }
+
+    // Check quota
+    this.requireQuota(auth, dto.fileSize);
+
+    const sessionId = randomUUID();
+    const chunkSize = Math.min(dto.chunkSize || DEFAULT_CHUNK_SIZE, MAX_CHUNK_SIZE);
+    const totalChunks = Math.ceil(dto.fileSize / chunkSize);
+    const expiresAt = new Date(Date.now() + SESSION_TTL_MS);
+
+    // Create temp directory for chunks
+    const tempDir = join(
+      StorageCore.getNestedFolder(StorageFolder.Upload, auth.user.id, sessionId),
+      'chunks',
+    );
+    this.storageRepository.mkdirSync(tempDir);
+
+    const session: ChunkedUploadSession = {
+      id: sessionId,
+      userId: auth.user.id,
+      filename: dto.filename,
+      fileSize: dto.fileSize,
+      chunkSize,
+      totalChunks,
+      receivedChunks: new Set(),
+      createdAt: new Date(),
+      expiresAt,
+      tempDir,
+      dto,
+    };
+
+    this.sessions.set(sessionId, session);
+
+    this.logger.log(
+      `Created chunked upload session ${sessionId} for file "${dto.filename}" ` +
+        `(${dto.fileSize} bytes, ${totalChunks} chunks of ${chunkSize} bytes)`,
+    );
+
+    return {
+      sessionId,
+      chunkSize,
+      totalChunks,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  /**
+   * Step 2: Upload a single chunk.
+   * Each chunk is saved to disk in the session's temp directory.
+   */
+  async uploadChunk(
+    auth: AuthDto,
+    sessionId: string,
+    chunkIndex: number,
+    chunkData: Buffer,
+  ): Promise<UploadChunkResponseDto> {
+    const session = this.getSession(sessionId, auth.user.id);
+
+    if (chunkIndex < 0 || chunkIndex >= session.totalChunks) {
+      throw new BadRequestException(
+        `Invalid chunk index ${chunkIndex}. Expected 0-${session.totalChunks - 1}`,
+      );
+    }
+
+    if (session.receivedChunks.has(chunkIndex)) {
+      this.logger.warn(`Chunk ${chunkIndex} already received for session ${sessionId}, overwriting`);
+    }
+
+    // Validate chunk size (last chunk can be smaller)
+    const isLastChunk = chunkIndex === session.totalChunks - 1;
+    const expectedMaxSize = isLastChunk
+      ? session.fileSize - chunkIndex * session.chunkSize
+      : session.chunkSize;
+
+    if (chunkData.length > expectedMaxSize && !isLastChunk) {
+      throw new BadRequestException(
+        `Chunk ${chunkIndex} size ${chunkData.length} exceeds expected maximum ${expectedMaxSize}`,
+      );
+    }
+
+    // Write chunk to temp file
+    const chunkPath = join(session.tempDir, `chunk_${String(chunkIndex).padStart(6, '0')}`);
+    const writeStream = createWriteStream(chunkPath);
+    writeStream.write(chunkData);
+    writeStream.end();
+
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', resolve);
+      writeStream.on('error', reject);
+    });
+
+    session.receivedChunks.add(chunkIndex);
+
+    this.logger.debug(
+      `Received chunk ${chunkIndex + 1}/${session.totalChunks} for session ${sessionId} ` +
+        `(${chunkData.length} bytes)`,
+    );
+
+    return {
+      chunkIndex,
+      chunksReceived: session.receivedChunks.size,
+      totalChunks: session.totalChunks,
+    };
+  }
+
+  /**
+   * Step 3: Finish the chunked upload.
+   * All chunks are assembled into the final file, checksum is computed,
+   * and the asset is created through the standard asset creation pipeline.
+   */
+  async finishUpload(
+    auth: AuthDto,
+    sessionId: string,
+  ): Promise<FinishChunkedUploadResponseDto> {
+    const session = this.getSession(sessionId, auth.user.id);
+
+    // Verify all chunks were received
+    if (session.receivedChunks.size !== session.totalChunks) {
+      const missing = [];
+      for (let i = 0; i < session.totalChunks; i++) {
+        if (!session.receivedChunks.has(i)) {
+          missing.push(i);
+        }
+      }
+      throw new BadRequestException(
+        `Missing ${missing.length} chunks: [${missing.slice(0, 10).join(', ')}${missing.length > 10 ? '...' : ''}]`,
+      );
+    }
+
+    try {
+      // Assemble chunks into final file
+      const { finalPath, checksum, size } = await this.assembleChunks(session, auth);
+
+      this.logger.log(
+        `Assembled ${session.totalChunks} chunks into ${finalPath} ` +
+          `(${size} bytes, sha1: ${checksum.toString('hex')})`,
+      );
+
+      // Create the upload file descriptor
+      const uploadFile: UploadFile = {
+        uuid: sessionId,
+        checksum,
+        originalPath: finalPath,
+        originalName: session.filename,
+        size,
+      };
+
+      // Reuse the standard asset creation logic via AssetMediaService
+      // Here we directly create the asset, mirroring uploadAsset logic
+      const { dto } = session;
+
+      // Check for duplicates by checksum
+      const duplicateId = await this.assetRepository.getUploadAssetIdByChecksum(
+        auth.user.id,
+        checksum,
+      );
+      if (duplicateId) {
+        // Clean up the assembled file since it's a duplicate
+        await this.jobRepository.queue({
+          name: JobName.FileDelete,
+          data: { files: [finalPath] },
+        });
+        this.cleanupSession(sessionId);
+        return { assetId: duplicateId, isDuplicate: true };
+      }
+
+      // Create the asset
+      const asset = await this.assetRepository.create({
+        ownerId: auth.user.id,
+        libraryId: null,
+        checksum: uploadFile.checksum,
+        originalPath: uploadFile.originalPath,
+        deviceAssetId: dto.deviceAssetId,
+        deviceId: dto.deviceId,
+        fileCreatedAt: dto.fileCreatedAt,
+        fileModifiedAt: dto.fileModifiedAt,
+        localDateTime: dto.fileCreatedAt,
+        type: mimeTypes.assetType(uploadFile.originalPath),
+        isFavorite: dto.isFavorite,
+        duration: dto.duration || null,
+        visibility: dto.visibility ?? AssetVisibility.Timeline,
+        livePhotoVideoId: dto.livePhotoVideoId,
+        originalFileName: dto.filename,
+      });
+
+      await this.storageRepository.utimes(
+        uploadFile.originalPath,
+        new Date(),
+        new Date(dto.fileModifiedAt),
+      );
+      await this.assetRepository.upsertExif(
+        { assetId: asset.id, fileSizeInByte: uploadFile.size },
+        { lockedPropertiesBehavior: 'override' },
+      );
+
+      await this.eventRepository.emit('AssetCreate', { asset });
+      await this.jobRepository.queue({
+        name: JobName.AssetExtractMetadata,
+        data: { id: asset.id, source: 'upload' },
+      });
+
+      await this.userRepository.updateUsage(auth.user.id, uploadFile.size);
+
+      this.cleanupSession(sessionId);
+
+      return { assetId: asset.id, isDuplicate: false };
+    } catch (error) {
+      // Cleanup on error
+      this.logger.error(`Failed to finish chunked upload session ${sessionId}: ${error}`);
+      await this.cleanupSessionFiles(session);
+      this.cleanupSession(sessionId);
+      throw error;
+    }
+  }
+
+  /**
+   * Cancel an upload session and clean up temp files.
+   */
+  async cancelSession(auth: AuthDto, sessionId: string): Promise<void> {
+    const session = this.getSession(sessionId, auth.user.id);
+    await this.cleanupSessionFiles(session);
+    this.cleanupSession(sessionId);
+    this.logger.log(`Cancelled chunked upload session ${sessionId}`);
+  }
+
+  /**
+   * Get session status (for client polling / resume support).
+   */
+  getSessionStatus(auth: AuthDto, sessionId: string) {
+    const session = this.getSession(sessionId, auth.user.id);
+    const receivedChunks = [...session.receivedChunks].sort((a, b) => a - b);
+    return {
+      sessionId: session.id,
+      filename: session.filename,
+      fileSize: session.fileSize,
+      chunkSize: session.chunkSize,
+      totalChunks: session.totalChunks,
+      receivedChunks,
+      chunksReceived: session.receivedChunks.size,
+      expiresAt: session.expiresAt.toISOString(),
+    };
+  }
+
+  private getSession(sessionId: string, userId: string): ChunkedUploadSession {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new NotFoundException(`Upload session ${sessionId} not found`);
+    }
+
+    if (session.userId !== userId) {
+      throw new NotFoundException(`Upload session ${sessionId} not found`);
+    }
+
+    if (session.expiresAt < new Date()) {
+      this.sessions.delete(sessionId);
+      throw new BadRequestException(`Upload session ${sessionId} has expired`);
+    }
+
+    return session;
+  }
+
+  private async assembleChunks(
+    session: ChunkedUploadSession,
+    auth: AuthDto,
+  ): Promise<{ finalPath: string; checksum: Buffer; size: number }> {
+    const ext = '.' + session.filename.split('.').pop()?.toLowerCase();
+    const finalDir = StorageCore.getNestedFolder(StorageFolder.Upload, auth.user.id, session.id);
+    this.storageRepository.mkdirSync(finalDir);
+    const finalPath = join(finalDir, `${session.id}${ext}`);
+
+    const hash = createHash('sha1');
+    const writeStream = createWriteStream(finalPath);
+    let totalSize = 0;
+
+    for (let i = 0; i < session.totalChunks; i++) {
+      const chunkPath = join(session.tempDir, `chunk_${String(i).padStart(6, '0')}`);
+      const readStream = createReadStream(chunkPath);
+
+      await new Promise<void>((resolve, reject) => {
+        readStream.on('data', (data: Buffer) => {
+          hash.update(data);
+          totalSize += data.length;
+        });
+        readStream.on('end', resolve);
+        readStream.on('error', reject);
+        readStream.pipe(writeStream, { end: false });
+      });
+    }
+
+    writeStream.end();
+    await new Promise<void>((resolve, reject) => {
+      writeStream.on('finish', resolve);
+      writeStream.on('error', reject);
+    });
+
+    const checksum = hash.digest();
+
+    return { finalPath, checksum, size: totalSize };
+  }
+
+  private cleanupSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  private async cleanupSessionFiles(session: ChunkedUploadSession): Promise<void> {
+    try {
+      const files = await readdir(session.tempDir);
+      for (const file of files) {
+        await unlink(join(session.tempDir, file)).catch(() => {});
+      }
+    } catch {
+      // Directory may not exist
+    }
+  }
+
+  private requireQuota(auth: AuthDto, size: number) {
+    if (auth.user.quotaSizeInBytes !== null && auth.user.quotaSizeInBytes < auth.user.quotaUsageInBytes + size) {
+      throw new BadRequestException('Quota has been exceeded!');
+    }
+  }
+}

--- a/web/src/lib/utils/chunked-upload.ts
+++ b/web/src/lib/utils/chunked-upload.ts
@@ -1,0 +1,203 @@
+/**
+ * Chunked upload support for the Immich web client.
+ *
+ * When uploading files through Cloudflare or other reverse proxies with body size
+ * limits (e.g. Cloudflare's 100MB free-tier limit causing "413 Request Entity Too Large"),
+ * large files need to be split into smaller chunks.
+ *
+ * This module provides a chunked upload implementation that:
+ * 1. Creates an upload session on the server
+ * 2. Splits the file into chunks (default 50MB)
+ * 3. Uploads each chunk sequentially
+ * 4. Finalizes the upload to assemble and create the asset
+ *
+ * Benefits:
+ * - Bypasses reverse proxy body size limits (Cloudflare, nginx, etc.)
+ * - Reduces bandwidth pressure by sending smaller payloads
+ * - Enables upload resume on connection interruption
+ * - Improves upload stability for large video files
+ */
+
+import { getBaseUrl } from '@immich/sdk';
+import { authManager } from '$lib/managers/auth-manager.svelte';
+import { asQueryString } from '$lib/utils/shared-links';
+
+/** Default chunk size: 50 MB */
+export const DEFAULT_CHUNK_SIZE = 50 * 1024 * 1024;
+
+/** Threshold above which chunked upload is used (50 MB) */
+export const CHUNKED_UPLOAD_THRESHOLD = 50 * 1024 * 1024;
+
+interface ChunkedUploadSessionResponse {
+  sessionId: string;
+  chunkSize: number;
+  totalChunks: number;
+  expiresAt: string;
+}
+
+interface ChunkUploadResponse {
+  chunkIndex: number;
+  chunksReceived: number;
+  totalChunks: number;
+}
+
+interface FinishChunkedUploadResponse {
+  assetId: string;
+  isDuplicate: boolean;
+}
+
+interface ChunkedUploadOptions {
+  file: File;
+  deviceAssetId: string;
+  deviceId: string;
+  fileCreatedAt: string;
+  fileModifiedAt: string;
+  isFavorite: boolean;
+  duration: string;
+  visibility?: string;
+  chunkSize?: number;
+  onProgress?: (loaded: number, total: number) => void;
+}
+
+function getAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  return headers;
+}
+
+async function fetchWithAuth(url: string, options: RequestInit = {}): Promise<Response> {
+  const response = await fetch(url, {
+    ...options,
+    credentials: 'include',
+  });
+  return response;
+}
+
+/**
+ * Upload a file using the chunked upload protocol.
+ * Returns the asset ID and whether it was a duplicate.
+ */
+export async function chunkedUpload(options: ChunkedUploadOptions): Promise<{
+  id: string;
+  status: 'created' | 'duplicate';
+}> {
+  const {
+    file,
+    deviceAssetId,
+    deviceId,
+    fileCreatedAt,
+    fileModifiedAt,
+    isFavorite,
+    duration,
+    visibility,
+    chunkSize = DEFAULT_CHUNK_SIZE,
+    onProgress,
+  } = options;
+
+  const baseUrl = getBaseUrl();
+  const queryParams = asQueryString(authManager.params);
+  const queryString = queryParams ? `?${queryParams}` : '';
+
+  // Step 1: Create upload session
+  const sessionBody: Record<string, unknown> = {
+    filename: file.name,
+    fileSize: file.size,
+    chunkSize,
+    deviceAssetId,
+    deviceId,
+    fileCreatedAt,
+    fileModifiedAt,
+    isFavorite,
+    duration,
+  };
+
+  if (visibility) {
+    sessionBody.visibility = visibility;
+  }
+
+  const sessionResponse = await fetchWithAuth(
+    `${baseUrl}/assets/chunked-upload${queryString}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(sessionBody),
+    },
+  );
+
+  if (!sessionResponse.ok) {
+    const errorText = await sessionResponse.text();
+    throw new Error(`Failed to create upload session: ${sessionResponse.status} ${errorText}`);
+  }
+
+  const session: ChunkedUploadSessionResponse = await sessionResponse.json();
+  const { sessionId, totalChunks, chunkSize: serverChunkSize } = session;
+
+  let totalUploaded = 0;
+
+  try {
+    // Step 2: Upload chunks sequentially
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * serverChunkSize;
+      const end = Math.min(start + serverChunkSize, file.size);
+      const chunk = file.slice(start, end);
+      const chunkBuffer = await chunk.arrayBuffer();
+
+      const chunkResponse = await fetchWithAuth(
+        `${baseUrl}/assets/chunked-upload/${sessionId}/chunks/${i}${queryString}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/octet-stream' },
+          body: chunkBuffer,
+        },
+      );
+
+      if (!chunkResponse.ok) {
+        const errorText = await chunkResponse.text();
+        throw new Error(`Failed to upload chunk ${i}: ${chunkResponse.status} ${errorText}`);
+      }
+
+      totalUploaded += end - start;
+      onProgress?.(totalUploaded, file.size);
+    }
+
+    // Step 3: Finish upload
+    const finishResponse = await fetchWithAuth(
+      `${baseUrl}/assets/chunked-upload/${sessionId}/finish${queryString}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+
+    if (!finishResponse.ok) {
+      const errorText = await finishResponse.text();
+      throw new Error(`Failed to finish chunked upload: ${finishResponse.status} ${errorText}`);
+    }
+
+    const result: FinishChunkedUploadResponse = await finishResponse.json();
+
+    return {
+      id: result.assetId,
+      status: result.isDuplicate ? 'duplicate' : 'created',
+    };
+  } catch (error) {
+    // Attempt to cancel the session on error
+    try {
+      await fetchWithAuth(
+        `${baseUrl}/assets/chunked-upload/${sessionId}${queryString}`,
+        { method: 'DELETE' },
+      );
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw error;
+  }
+}
+
+/**
+ * Check if a file should use chunked upload based on its size.
+ */
+export function shouldUseChunkedUpload(file: File, threshold = CHUNKED_UPLOAD_THRESHOLD): boolean {
+  return file.size > threshold;
+}


### PR DESCRIPTION
## Description

## Problem

When Immich is proxied through Cloudflare (free tier) or other reverse proxies
with body size limits, uploading large files (videos, RAW photos) fails with
"413 Request Entity Too Large". Cloudflare free tier limits request body to 100MB,
and many nginx/caddy configurations also have similar limits by default.

## Solution

Implement chunked upload protocol that splits large files into configurable chunks
(default 50MB, configurable 25MB/50MB) that each fit under reverse proxy limits.

This PR introduces a chunked upload mechanism to Immich, specifically addressing the "413 Request Entity Too Large" error that occurs when uploading large files through reverse proxies like Cloudflare (which has a 100MB free-tier limit).

Files larger than 50MB are now automatically split into smaller chunks (default 50MB, configurable down to 25MB) and uploaded sequentially. This approach ensures that individual requests remain within typical proxy body size limits, significantly improving upload reliability and stability for large media files (e.g., videos, RAW photos).

The implementation covers:
-   **Server-side API:** New endpoints for creating upload sessions, uploading individual chunks, finalizing the upload, checking session status, and cancelling sessions.
-   **Web Client:** Automatic detection of large files and routing through the new chunked upload utility using `File.slice()`.
-   **CLI:** Integration of chunked upload logic for files exceeding the 50MB threshold.

This PR aims to demonstrate the scope of work and the affected areas of the codebase for discussion with the team.

> [!NOTE]
>### Benefits:
>- Bypasses Cloudflare/nginx/caddy body size limits without server-side proxy config changes
>- Reduces bandwidth pressure by sending smaller payloads
>- Enables future upload resume on connection interruption
>- Improves upload stability for large video files over unstable connections
>- Transparent to the user — automatically used for files >50MB


## How Has This Been Tested?

-   [ ] Manual upload of files > 50MB via web client (with and without reverse proxy).
-   [ ] Manual upload of files > 50MB via CLI (with and without reverse proxy).
-   [ ] Verification of asset creation and integrity after chunked upload.
-   [ ] Testing of session cancellation and temporary file cleanup.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

## API Changes
New endpoints for chunked uploads:
-   `POST /assets/chunked-upload`: Create chunked upload session.
-   `POST /assets/chunked-upload/:sessionId/chunks/:chunkIndex`: Upload a file chunk.
-   `POST /assets/chunked-upload/:sessionId/finish`: Finalize chunked upload and create asset.
-   `GET /assets/chunked-upload/:sessionId/status`: Get chunked upload session status.
-   `DELETE /assets/chunked-upload/:sessionId`: Cancel chunked upload session and clean up.

## Checklist:

-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have no unrelated changes in the PR.
-   [ ] I have confirmed that any new dependencies are strictly necessary.
-   [ ] I have written tests for new code (if applicable)
-   [ ] I have followed naming conventions/patterns in the surrounding code
-   [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
-   [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

This pull request was entirely generated by an AI assistant based on a user request. The primary goal is to illustrate the scope of work and the affected areas of the codebase for implementing chunked uploads, rather than being a production-ready submission.

---


### Protocol Flow:
1. POST /assets/chunked-upload — create an upload session (returns sessionId, chunkSize, totalChunks)
2. POST /assets/chunked-upload/:sessionId/chunks/:index — upload each chunk as raw binary
3. POST /assets/chunked-upload/:sessionId/finish — assemble chunks and create the asset
4. GET  /assets/chunked-upload/:sessionId/status — check session status (for resume)
5. DELETE /assets/chunked-upload/:sessionId — cancel session and cleanup


## Files Changed

### Server (NestJS backend):
- `server/src/dtos/asset-media-chunked.dto.ts` — NEW: DTOs for chunked upload (session create, chunk upload, finish)
- `server/src/services/chunked-upload.service.ts` — NEW: Service handling session management, chunk storage, file assembly, and SHA1 checksum computation
- `server/src/controllers/chunked-upload.controller.ts` — NEW: REST controller with 5 endpoints for the chunked upload protocol
- `server/src/controllers/index.ts` — MODIFIED: Register ChunkedUploadController

### Web Client (Svelte):
- `web/src/lib/utils/chunked-upload.ts` — NEW: Client-side chunked upload implementation using File.slice() and fetch API
- `web/src/lib/utils/file-uploader.ts` — MODIFIED: Auto-detect large files and route them through chunked upload

### CLI (Node.js):
- `cli/src/commands/asset.ts` — MODIFIED: Add uploadFileChunked() for CLI uploads, auto-detect files >50MB


## Note 
I know this AI-generated commit will likely not be accepted into production. But I want
to show the scope of work and all the places in the codebase that are affected by this
proposal. This is a demonstration of the architectural approach to solving a real problem
that Immich users behind Cloudflare face. I hope it serves as a starting point for
discussion and helps the team assess the scale of changes needed for chunked upload support.