### PR TITLE
fix(mobile): sync custom headers back to widget

### DIFF
--- a/mobile/lib/pages/common/headers_settings.page.dart
+++ b/mobile/lib/pages/common/headers_settings.page.dart
@@ -98,13 +98,13 @@ class HeaderSettingsPage extends HookConsumerWidget {
       headersMap[key] = value;
     }
 
-    final customHeaders = headersMap.isNotEmpty ? jsonEncode(headersMap) : "";
-    await Store.put(StoreKey.customHeaders, customHeaders);
+    var encoded = jsonEncode(headersMap);
+    await Store.put(StoreKey.customHeaders, encoded);
 
     final serverEndpoint = Store.tryGet(StoreKey.serverEndpoint);
     final accessToken = Store.tryGet(StoreKey.accessToken);
     if (serverEndpoint != null && accessToken != null) {
-      await ref.read(widgetServiceProvider).writeCredentials(serverEndpoint, accessToken, customHeaders);
+      await ref.read(widgetServiceProvider).writeCredentials(serverEndpoint, accessToken, encoded);
     }
   }
 }

--- a/mobile/lib/pages/common/headers_settings.page.dart
+++ b/mobile/lib/pages/common/headers_settings.page.dart
@@ -60,6 +60,26 @@ class HeaderSettingsPage extends HookConsumerWidget {
       }),
     ];
 
+    Future<void> saveHeaders(List<SettingsHeader> headers) async {
+      final headersMap = {};
+      for (var header in headers) {
+        final key = header.key.trim();
+        final value = header.value.trim();
+
+        if (key.isEmpty || value.isEmpty) continue;
+        headersMap[key] = value;
+      }
+
+      var encoded = jsonEncode(headersMap);
+      await Store.put(StoreKey.customHeaders, encoded);
+
+      final serverEndpoint = Store.tryGet(StoreKey.serverEndpoint);
+      final accessToken = Store.tryGet(StoreKey.accessToken);
+      if (serverEndpoint != null && accessToken != null) {
+        await ref.read(widgetServiceProvider).writeCredentials(serverEndpoint, accessToken, encoded);
+      }
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: Text(context.t.headers_settings_tile_title),
@@ -76,7 +96,7 @@ class HeaderSettingsPage extends HookConsumerWidget {
         ],
       ),
       body: PopScope(
-        onPopInvokedWithResult: (didPop, _) => saveHeaders(headers.value, ref),
+        onPopInvokedWithResult: (didPop, _) => saveHeaders(headers.value),
         child: ListView.separated(
           padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
           itemCount: list.length,
@@ -86,26 +106,6 @@ class HeaderSettingsPage extends HookConsumerWidget {
         ),
       ),
     );
-  }
-
-  Future<void> saveHeaders(List<SettingsHeader> headers, WidgetRef ref) async {
-    final headersMap = {};
-    for (var header in headers) {
-      final key = header.key.trim();
-      final value = header.value.trim();
-
-      if (key.isEmpty || value.isEmpty) continue;
-      headersMap[key] = value;
-    }
-
-    var encoded = jsonEncode(headersMap);
-    await Store.put(StoreKey.customHeaders, encoded);
-
-    final serverEndpoint = Store.tryGet(StoreKey.serverEndpoint);
-    final accessToken = Store.tryGet(StoreKey.accessToken);
-    if (serverEndpoint != null && accessToken != null) {
-      await ref.read(widgetServiceProvider).writeCredentials(serverEndpoint, accessToken, encoded);
-    }
   }
 }
 

--- a/mobile/lib/services/widget.service.dart
+++ b/mobile/lib/services/widget.service.dart
@@ -16,9 +16,7 @@ class WidgetService {
     await _repository.saveData(kWidgetServerEndpoint, serverURL);
     await _repository.saveData(kWidgetAuthToken, sessionKey);
 
-    if (customHeaders != null && customHeaders.isNotEmpty) {
-      await _repository.saveData(kWidgetCustomHeaders, customHeaders);
-    }
+    await _repository.saveData(kWidgetCustomHeaders, customHeaders ?? "");
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);

--- a/mobile/lib/services/widget.service.dart
+++ b/mobile/lib/services/widget.service.dart
@@ -16,7 +16,7 @@ class WidgetService {
     await _repository.saveData(kWidgetServerEndpoint, serverURL);
     await _repository.saveData(kWidgetAuthToken, sessionKey);
 
-    await _repository.saveData(kWidgetCustomHeaders, customHeaders ?? "");
+    await _repository.saveData(kWidgetCustomHeaders, customHeaders ?? "{}");
 
     // wait 3 seconds to ensure the widget is updated, dont block
     Future.delayed(const Duration(seconds: 3), refreshWidgets);


### PR DESCRIPTION
## Description

Sets `kWidgetCustomHeaders` when changing the headers in the app (advanced settings), similar as in `saveAuthInfo()`, otherwise widgets keep using the old credentials.

This fixes "No assets available" shown in widgets when a certain header is required and it was correctly set in the app. Should I create an issue for this?

## How Has This Been Tested?

On my iPhone with my Immich instance behind an Nginx with `auth_request` that is configured to be skipped if a certain header is set (otherwise the app doesn't work: #3118):

Nginx config:
```
    location @noauth {
      proxy_pass http://immich_server:2283;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection "upgrade";
    }

    location @error401 {
        return 302 https://oidc_server/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
    }

    location / {
        error_page 599 = @noauth;

        if ($http_x_immich_bypass = "YOUR_SECRET_VALUE_HERE") {
            return 599;
        }

        auth_request /validate;
        error_page 401 = @error401;

        proxy_pass http://immich_server:2283;
        proxy_set_header   Upgrade    $http_upgrade;
        proxy_set_header   Connection "upgrade";
    }
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Opus 4.5 for pinpointing the issue.