### PR TITLE
fix(mobile): hide latest version warnings

### DIFF
--- a/mobile/lib/models/server_info/server_info.model.dart
+++ b/mobile/lib/models/server_info/server_info.model.dart
@@ -28,7 +28,7 @@ class ServerInfo {
 
   const ServerInfo({
     required this.serverVersion,
-    required this.latestVersion,
+    this.latestVersion,
     required this.serverFeatures,
     required this.serverConfig,
     required this.serverDiskInfo,

--- a/mobile/lib/providers/server_info.provider.dart
+++ b/mobile/lib/providers/server_info.provider.dart
@@ -15,7 +15,6 @@ class ServerInfoNotifier extends StateNotifier<ServerInfo> {
     : super(
         const ServerInfo(
           serverVersion: ServerVersion(major: 0, minor: 0, patch: 0),
-          latestVersion: null,
           serverFeatures: ServerFeatures(map: true, trash: true, oauthEnabled: false, passwordLogin: true),
           serverConfig: ServerConfig(
             trashDays: 30,
@@ -104,7 +103,9 @@ final serverInfoProvider = StateNotifierProvider<ServerInfoNotifier, ServerInfo>
 
 final versionWarningPresentProvider = Provider.family<bool, UserDto?>((ref, user) {
   final serverInfo = ref.watch(serverInfoProvider);
-  return serverInfo.versionStatus == VersionStatus.clientOutOfDate ||
-      serverInfo.versionStatus == VersionStatus.error ||
-      ((user?.isAdmin ?? false) && serverInfo.versionStatus == VersionStatus.serverOutOfDate);
+  return switch (serverInfo.versionStatus) {
+    VersionStatus.clientOutOfDate || VersionStatus.error => true,
+    VersionStatus.serverOutOfDate => serverInfo.latestVersion != null && (user?.isAdmin ?? false),
+    VersionStatus.upToDate => false,
+  };
 });

--- a/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
+++ b/mobile/lib/widgets/common/app_bar_dialog/app_bar_server_info.dart
@@ -23,8 +23,6 @@ class AppBarServerInfo extends HookConsumerWidget {
     final bool showVersionWarning = ref.watch(versionWarningPresentProvider(user));
 
     final appInfo = useState({});
-    const titleFontSize = 12.0;
-    const contentFontSize = 11.0;
 
     getPackageInfo() async {
       PackageInfo packageInfo = await PackageInfo.fromPlatform();
@@ -37,180 +35,103 @@ class AppBarServerInfo extends HookConsumerWidget {
       return null;
     }, []);
 
+    const divider = Divider(thickness: 1);
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          if (showVersionWarning) ...[
-            const Padding(padding: EdgeInsets.symmetric(horizontal: 8.0), child: ServerUpdateNotification()),
-            const Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Divider(thickness: 1)),
-          ],
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 10.0),
-                  child: Text(
-                    "server_info_box_app_version".tr(),
-                    style: TextStyle(
-                      fontSize: titleFontSize,
-                      color: context.textTheme.labelSmall?.color,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 0,
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 10.0),
-                  child: Text(
-                    "${appInfo.value["version"]} build.${appInfo.value["buildNumber"]}",
-                    style: TextStyle(
-                      fontSize: contentFontSize,
-                      color: context.colorScheme.onSurfaceSecondary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ),
-            ],
+          if (showVersionWarning) ...[const ServerUpdateNotification(), divider],
+          _ServerInfoItem(
+            label: "server_info_box_app_version".tr(),
+            text: "${appInfo.value["version"]} build.${appInfo.value["buildNumber"]}",
           ),
-          const Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Divider(thickness: 1)),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 10.0),
-                  child: Text(
-                    "server_version".tr(),
-                    style: TextStyle(
-                      fontSize: titleFontSize,
-                      color: context.textTheme.labelSmall?.color,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 0,
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 10.0),
-                  child: Text(
-                    serverInfoState.serverVersion.major > 0
-                        ? "${serverInfoState.serverVersion.major}.${serverInfoState.serverVersion.minor}.${serverInfoState.serverVersion.patch}"
-                        : "--",
-                    style: TextStyle(
-                      fontSize: contentFontSize,
-                      color: context.colorScheme.onSurfaceSecondary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-              ),
-            ],
+          divider,
+          _ServerInfoItem(
+            label: "server_version".tr(),
+            text: serverInfoState.serverVersion.major > 0
+                ? "${serverInfoState.serverVersion.major}.${serverInfoState.serverVersion.minor}.${serverInfoState.serverVersion.patch}"
+                : "--",
           ),
-          const Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Divider(thickness: 1)),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 10.0),
-                  child: Text(
-                    "server_info_box_server_url".tr(),
-                    style: TextStyle(
-                      fontSize: titleFontSize,
-                      color: context.textTheme.labelSmall?.color,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 0,
-                child: Container(
-                  width: 200,
-                  padding: const EdgeInsets.only(right: 10.0),
-                  child: Tooltip(
-                    verticalOffset: 0,
-                    decoration: BoxDecoration(
-                      color: context.primaryColor.withValues(alpha: 0.9),
-                      borderRadius: const BorderRadius.all(Radius.circular(10)),
-                    ),
-                    textStyle: TextStyle(
-                      color: context.isDarkTheme ? Colors.black : Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                    message: getServerUrl() ?? '--',
-                    preferBelow: false,
-                    triggerMode: TooltipTriggerMode.tap,
-                    child: Text(
-                      getServerUrl() ?? '--',
-                      style: TextStyle(
-                        fontSize: contentFontSize,
-                        color: context.colorScheme.onSurfaceSecondary,
-                        fontWeight: FontWeight.bold,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      textAlign: TextAlign.end,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
+          divider,
+          _ServerInfoItem(label: "server_info_box_server_url".tr(), text: getServerUrl() ?? '--', tooltip: true),
           if (serverInfoState.latestVersion != null) ...[
-            const Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Divider(thickness: 1)),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 10.0),
-                    child: Row(
-                      children: [
-                        if (serverInfoState.versionStatus == VersionStatus.serverOutOfDate)
-                          const Padding(
-                            padding: EdgeInsets.only(right: 5.0),
-                            child: Icon(Icons.info, color: Color.fromARGB(255, 243, 188, 106), size: 12),
-                          ),
-                        Text(
-                          "latest_version".tr(),
-                          style: TextStyle(
-                            fontSize: titleFontSize,
-                            color: context.textTheme.labelSmall?.color,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Expanded(
-                  flex: 0,
-                  child: Padding(
-                    padding: const EdgeInsets.only(right: 10.0),
-                    child: Text(
-                      serverInfoState.latestVersion!.major > 0
-                          ? "${serverInfoState.latestVersion!.major}.${serverInfoState.latestVersion!.minor}.${serverInfoState.latestVersion!.patch}"
-                          : "--",
-                      style: TextStyle(
-                        fontSize: contentFontSize,
-                        color: context.colorScheme.onSurfaceSecondary,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+            divider,
+            _ServerInfoItem(
+              label: "latest_version".tr(),
+              text: serverInfoState.latestVersion!.major > 0
+                  ? "${serverInfoState.latestVersion!.major}.${serverInfoState.latestVersion!.minor}.${serverInfoState.latestVersion!.patch}"
+                  : "--",
+              tooltip: true,
+              icon: serverInfoState.versionStatus == VersionStatus.serverOutOfDate
+                  ? const Icon(Icons.info, color: Color.fromARGB(255, 243, 188, 106), size: 12)
+                  : null,
             ),
           ],
         ],
       ),
     );
   }
+}
+
+class _ServerInfoItem extends StatelessWidget {
+  final String label;
+  final String text;
+  final bool tooltip;
+  final Icon? icon;
+
+  static const titleFontSize = 12.0;
+  static const contentFontSize = 11.0;
+
+  const _ServerInfoItem({required this.label, required this.text, this.tooltip = false, this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        if (icon != null) ...[icon as Widget, const SizedBox(width: 8)],
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: titleFontSize,
+            color: context.textTheme.labelSmall?.color,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: _maybeTooltip(
+            context,
+            Text(
+              text,
+              style: TextStyle(
+                fontSize: contentFontSize,
+                color: context.colorScheme.onSurfaceSecondary,
+                fontWeight: FontWeight.bold,
+                overflow: TextOverflow.ellipsis,
+              ),
+              textAlign: TextAlign.end,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _maybeTooltip(BuildContext context, Widget child) => tooltip
+      ? Tooltip(
+          verticalOffset: 0,
+          decoration: BoxDecoration(
+            color: context.primaryColor.withValues(alpha: 0.9),
+            borderRadius: const BorderRadius.all(Radius.circular(10)),
+          ),
+          textStyle: TextStyle(color: context.colorScheme.onPrimary, fontWeight: FontWeight.bold),
+          message: text,
+          preferBelow: false,
+          triggerMode: TooltipTriggerMode.tap,
+          child: child,
+        )
+      : child;
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1217,10 +1217,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1910,10 +1910,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   thumbhash:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Description

The latest version is already hidden in the server info widget if disabled (https://github.com/immich-app/immich/pull/25691), however I did not realise there are more places where this warning is shown. This hides the warning everywhere, and cleans up the code a bit.

## How Has This Been Tested?

I've tested this in an emulator.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A
