### PR TITLE
fix: prevent server crash when extraction of metadata fails if the assets are corrupted

### DIFF
--- a/server/src/services/metadata.service.ts
+++ b/server/src/services/metadata.service.ts
@@ -38,6 +38,10 @@ import { isFaceImportEnabled } from 'src/utils/misc';
 import { upsertTags } from 'src/utils/tag';
 import { Tasks } from 'src/utils/tasks';
 
+/** constants got image metadata validation */
+const POSTGRES_INT_MAX = 2147483647;
+const POSTGRES_INT_MIN = -2147483648;
+
 /** look for a date from these tags (in order) */
 const EXIF_DATE_TAGS: Array<keyof ImmichTags> = [
   'SubSecDateTimeOriginal',
@@ -91,6 +95,21 @@ const validate = <T>(value: T): NonNullable<T> | null => {
   }
 
   if (typeof value === 'number' && (Number.isNaN(value) || !Number.isFinite(value))) {
+    return null;
+  }
+
+  return value ?? null;
+};
+
+const validateInteger = (value: number | undefined): number | null => {
+  const val = validate(value);
+
+  if (val === null) {
+    return null;
+  }
+
+  // Check if value is within PostgreSQL INTEGER range
+  if (val < POSTGRES_INT_MIN || val > POSTGRES_INT_MAX) {
     return null;
   }
 
@@ -275,8 +294,8 @@ export class MetadataService extends BaseService {
 
       // image/file
       fileSizeInByte: stats.size,
-      exifImageHeight: validate(height),
-      exifImageWidth: validate(width),
+      exifImageHeight: validateInteger(height),
+      exifImageWidth: validateInteger(width),
       orientation: validate(exifTags.Orientation)?.toString() ?? null,
       projectionType: exifTags.ProjectionType ? String(exifTags.ProjectionType).toUpperCase() : null,
       bitsPerSample: this.getBitsPerSample(exifTags),
@@ -305,8 +324,8 @@ export class MetadataService extends BaseService {
     };
 
     const isSidewards = exifTags.Orientation && this.isOrientationSidewards(exifTags.Orientation);
-    const assetWidth = isSidewards ? validate(height) : validate(width);
-    const assetHeight = isSidewards ? validate(width) : validate(height);
+    const assetWidth = isSidewards ? validateInteger(height) : validateInteger(width);
+    const assetHeight = isSidewards ? validateInteger(width) : validateInteger(height);
 
     const tasks = new Tasks();
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This change handles a corrupt image file in external library

<!--- Why is this change required? What problem does it solve? -->
If any images are corrupted in the external library then the immich-server blows up and restarts with an error, we want to handle this such that the server is not restarted but an error is printed in logs.

Fixes #25968

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
I have a corrupted image where it's exiftool output is like below
```
$ exiftool File0115.JPG 
ExifTool Version Number         : 12.76
File Name                       : File0115.JPG
Directory                       : .
File Size                       : 2.3 MB
File Modification Date/Time     : 2026:02:08 23:23:26+05:30
File Access Date/Time           : 2026:02:08 23:23:39+05:30
File Inode Change Date/Time     : 2026:02:08 23:23:26+05:30
File Permissions                : -rwxrwxr-x
File Type                       : JPEG
File Type Extension             : jpg
MIME Type                       : image/jpeg
Warning                         : [minor] Skipped unknown 230 bytes after JPEG APP0 segment
Image Width                     : 3376640208
Image Height                    : 2650642471
Comment                         : ~|..���;Ƌ�o���D^����f����.��&������.�R��^K�.�.�G...pA�Q.��.���>�Ǹ�؏5y޸��L,�8�9s�*69��$��^�.pAέ���W@���ֆ5.��M�.&�r�O�%���U�NW.�3�3��O��.��S���.f�.�.@.
... wr.qS��...��+�]��O*��.�.pG...�oSqO��.��z2�M�z-0�K.���/��.�嚴���
Image Size                      : 3376640208x2650642471
Megapixels                      : 8950265944611.1

If you see the height and width it is larger then Int.
I added this image in external library and ran extract metadata that blew up the server

- [X] Test A Ran the test on current main branch and the server blew up
- [X] Test B Updated the code and ran the same test and I saw below error in logs and server was still running

[Nest] 16449  - 02/08/2026, 6:38:34 PM     LOG [Microservices:LibraryService] Checked existing asset(s): 0 offlined, 1 onlined, 0 updated, 0 unchanged of current batch of 1 (Total progress: 1 of 1, 100.0 %) in library 675b05c9-124f-4ba4-84cc-a7d7213024ea.
[Nest] 16449  - 02/08/2026, 6:38:34 PM     LOG [Microservices:LibraryService] Imported 1 (2 done so far) file(s) into library 675b05c9-124f-4ba4-84cc-a7d7213024ea
[Nest] 16449  - 02/08/2026, 6:38:34 PM   ERROR [Microservices:{"source":"upload","id":"ab31e9aa-9854-43e5-a0f0-6fc162f9d64b"}] Unable to run job handler (AssetGenerateThumbnails): Error: Input file has corrupt header: VipsJpeg: ./lib/jpegli/decode_marker.cc:499: Skipped 944 bytes before marker 0xee
VipsJpeg: ./lib/jpegli/decode.cc:645: jpegli_read_header: unexpected EOI marker.
Error: Input file has corrupt header: VipsJpeg: ./lib/jpegli/decode_marker.cc:499: Skipped 944 bytes before marker 0xee
VipsJpeg: ./lib/jpegli/decode.cc:645: jpegli_read_header: unexpected EOI marker.
    at Sharp.toBuffer (/workspaces/immich/node_modules/.pnpm/sharp@0.34.5/node_modules/sharp/lib/output.js:163:17)
    at MediaRepository.decodeImage (/workspaces/immich/server/src/repositories/media.repository.ts:145:27)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async MediaService.decodeImage (/workspaces/immich/server/src/services/media.service.ts:276:28)
    at async MediaService.extractOriginalImage (/workspaces/immich/server/src/services/media.service.ts:289:40)
    at async MediaService.generateImageThumbnails (/workspaces/immich/server/src/services/media.service.ts:323:28)
    at async MediaService.handleGenerateThumbnails (/workspaces/immich/server/src/services/media.service.ts:236:19)
    at async JobService.onJobRun (/workspaces/immich/server/src/services/job.service.ts:53:24)
    at async EventRepository.onEvent (/workspaces/immich/server/src/repositories/event.repository.ts:228:7)
    at async <anonymous> (/workspaces/immich/node_modules/.pnpm/bullmq@5.66.5/node_modules/bullmq/src/classes/worker.ts:990:26)
[Nest] 16546  - 02/08/2026, 6:38:52 PM     LOG [Api:WebsocketRepository] Websocket Disconnect: sr2E8-3yPsxsYhydAAAD
[Nest] 16546  - 02/08/2026, 6:38:53 PM     LOG [Api:WebsocketRepository] Websocket Connect:    QXC0PbqlbIh4bvv9AAAF
```

<details><summary><h2>Screenshots (if appropriate)</h2></summary>


<!-- Images go below this line. -->
<img width="733" height="392" alt="test_result" src="https://github.com/user-attachments/assets/accd2a62-a572-4387-aca0-7186076e81e4" />


</details>

## Checklist:

- [X] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [X] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None