### PR TITLE
fix: free up space using small batch size to reliably work on Android

### DIFF
--- a/docs/docs/features/mobile-app.mdx
+++ b/docs/docs/features/mobile-app.mdx
@@ -66,7 +66,7 @@ Now make sure that the local album is selected in the backup screen (steps 1-2 a
     - **Keep on device:** You can choose to restrict removal to `Always keep` **All photos** or **All videos**, regardless of other settings. This setting can hamper freeing up space significantly — with 80 GB of videos and 40 GB photos, selecting `Always keep photos` retains thousands of photos on your device.
 
 2.  **Scan & Review:** Before any files are removed, you are presented with a review screen to verify which items will be deleted and how much storage is reclamable.
-3.  **Deletion:** Confirmed items are moved to your device's native Trash/Recycle Bin.
+3.  **Deletion:** Confirmed items are moved to your device's native Trash/Recycle Bin. For large queues, Immich processes deletion in batches for stability (`2000` assets per batch on Android, `10000` per batch on iOS).
 
 :::info reclaim storage
 To use the reclaimed space right away, you must empty the system/gallery trash manually outside of Immich.

--- a/mobile/lib/services/cleanup.service.dart
+++ b/mobile/lib/services/cleanup.service.dart
@@ -1,5 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/local_asset.repository.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
@@ -9,7 +10,7 @@ final cleanupServiceProvider = Provider<CleanupService>((ref) {
 });
 
 class CleanupService {
-  static const int _deleteBatchSize = 3000;
+  static final int _deleteBatchSize = CurrentPlatform.isAndroid ? 2000 : 10000;
 
   final DriftLocalAssetRepository _localAssetRepository;
   final AssetMediaRepository _assetMediaRepository;

--- a/mobile/lib/services/cleanup.service.dart
+++ b/mobile/lib/services/cleanup.service.dart
@@ -9,6 +9,8 @@ final cleanupServiceProvider = Provider<CleanupService>((ref) {
 });
 
 class CleanupService {
+  static const int _deleteBatchSize = 3000;
+
   final DriftLocalAssetRepository _localAssetRepository;
   final AssetMediaRepository _assetMediaRepository;
 
@@ -35,13 +37,20 @@ class CleanupService {
       return 0;
     }
 
-    final deletedIds = await _assetMediaRepository.deleteAll(localIds);
-    if (deletedIds.isNotEmpty) {
-      await _localAssetRepository.delete(deletedIds);
-      return deletedIds.length;
+    int deletedCount = 0;
+
+    for (int index = 0; index < localIds.length; index += _deleteBatchSize) {
+      final end = index + _deleteBatchSize < localIds.length ? index + _deleteBatchSize : localIds.length;
+      final batch = localIds.sublist(index, end);
+
+      final deletedIds = await _assetMediaRepository.deleteAll(batch);
+      if (deletedIds.isNotEmpty) {
+        await _localAssetRepository.delete(deletedIds);
+        deletedCount += deletedIds.length;
+      }
     }
 
-    return 0;
+    return deletedCount;
   }
 
   /// Returns album IDs that should be kept by default (e.g., messaging app albums)

--- a/mobile/test/services/cleanup.service_test.dart
+++ b/mobile/test/services/cleanup.service_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/services/cleanup.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../infrastructure/repository.mock.dart';
+import '../repository.mocks.dart';
+
+void main() {
+  late CleanupService sut;
+
+  late MockDriftLocalAssetRepository localAssetRepository;
+  late MockAssetMediaRepository assetMediaRepository;
+
+  setUp(() {
+    localAssetRepository = MockDriftLocalAssetRepository();
+    assetMediaRepository = MockAssetMediaRepository();
+    sut = CleanupService(localAssetRepository, assetMediaRepository);
+  });
+
+  group('CleanupService.deleteLocalAssets', () {
+    test('returns 0 and does nothing for empty input', () async {
+      final result = await sut.deleteLocalAssets([]);
+
+      expect(result, 0);
+      verifyNever(() => assetMediaRepository.deleteAll(any()));
+      verifyNever(() => localAssetRepository.delete(any()));
+    });
+
+    test('deletes in a single batch when under limit', () async {
+      final ids = List.generate(999, (i) => 'asset-$i');
+
+      when(() => assetMediaRepository.deleteAll(any())).thenAnswer((invocation) async {
+        return (invocation.positionalArguments.first as List<String>).toList();
+      });
+      when(() => localAssetRepository.delete(any())).thenAnswer((_) async {});
+
+      final result = await sut.deleteLocalAssets(ids);
+
+      expect(result, ids.length);
+      verify(() => assetMediaRepository.deleteAll(ids)).called(1);
+      verify(() => localAssetRepository.delete(ids)).called(1);
+    });
+
+    test('deletes in 1000-item batches when over limit', () async {
+      final ids = List.generate(2501, (i) => 'asset-$i');
+      final capturedBatches = <List<String>>[];
+
+      when(() => assetMediaRepository.deleteAll(any())).thenAnswer((invocation) async {
+        final batch = (invocation.positionalArguments.first as List<String>).toList();
+        capturedBatches.add(batch);
+        return batch;
+      });
+      when(() => localAssetRepository.delete(any())).thenAnswer((_) async {});
+
+      final result = await sut.deleteLocalAssets(ids);
+
+      expect(result, ids.length);
+      expect(capturedBatches.length, 3);
+      expect(capturedBatches[0].length, 1000);
+      expect(capturedBatches[1].length, 1000);
+      expect(capturedBatches[2].length, 501);
+      expect(capturedBatches[0].first, 'asset-0');
+      expect(capturedBatches[0].last, 'asset-999');
+      expect(capturedBatches[1].first, 'asset-1000');
+      expect(capturedBatches[1].last, 'asset-1999');
+      expect(capturedBatches[2].first, 'asset-2000');
+      expect(capturedBatches[2].last, 'asset-2500');
+      verify(() => localAssetRepository.delete(any())).called(3);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #25822 

Tested on Android and confirm without this, 7600 items cannot be sent to trash. 