### PR TITLE
feat(web): change link expiration logic & presets 

### DIFF
--- a/web/src/lib/components/SharedLinkExpiration.svelte
+++ b/web/src/lib/components/SharedLinkExpiration.svelte
@@ -59,7 +59,7 @@
   </Field>
 
   <div class="flex flex-wrap gap-2 mt-2">
-    {#each expiredDateOptions as option}
+    {#each expiredDateOptions as option (option.value)}
       <Button
         size="tiny"
         variant={isSelected(option.value) ? 'filled' : 'outline'}

--- a/web/src/lib/components/SharedLinkFormFields.spec.ts
+++ b/web/src/lib/components/SharedLinkFormFields.spec.ts
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/svelte';
+import { renderWithTooltips } from '$tests/helpers';
 import userEvent from '@testing-library/user-event';
 import SharedLinkFormFields from './SharedLinkFormFields.svelte';
 
@@ -7,16 +7,14 @@ describe('SharedLinkFormFields component', () => {
     element instanceof HTMLInputElement ? element.checked : element.getAttribute('aria-checked') === 'true';
 
   it('turns downloads off when metadata is disabled', async () => {
-    const { container } = render(SharedLinkFormFields, {
-      props: {
-        slug: '',
-        password: '',
-        description: '',
-        allowDownload: true,
-        allowUpload: false,
-        showMetadata: true,
-        expiresAt: null,
-      },
+    const { container } = renderWithTooltips(SharedLinkFormFields, {
+      slug: '',
+      password: '',
+      description: '',
+      allowDownload: true,
+      allowUpload: false,
+      showMetadata: true,
+      expiresAt: null,
     });
     const user = userEvent.setup();
 

--- a/web/src/lib/components/SharedLinkFormFields.svelte
+++ b/web/src/lib/components/SharedLinkFormFields.svelte
@@ -11,7 +11,6 @@
     allowUpload: boolean;
     showMetadata: boolean;
     expiresAt: string | null;
-    createdAt?: string;
   };
 
   let {
@@ -22,7 +21,6 @@
     allowUpload = $bindable(),
     showMetadata = $bindable(),
     expiresAt = $bindable(),
-    createdAt,
   }: Props = $props();
 
   $effect(() => {

--- a/web/src/lib/components/SharedLinkFormFields.svelte
+++ b/web/src/lib/components/SharedLinkFormFields.svelte
@@ -50,7 +50,7 @@
     <Input bind:value={description} autocomplete="off" />
   </Field>
 
-  <SharedLinkExpiration {createdAt} bind:expiresAt />
+  <SharedLinkExpiration bind:expiresAt />
   <Field label={$t('show_metadata')}>
     <Switch bind:checked={showMetadata} />
   </Field>

--- a/web/src/routes/(user)/shared-links/(list)/[id]/edit/+page.svelte
+++ b/web/src/routes/(user)/shared-links/(list)/[id]/edit/+page.svelte
@@ -69,6 +69,5 @@
     bind:allowUpload
     bind:showMetadata
     bind:expiresAt
-    createdAt={sharedLink.createdAt}
   />
 </FormModal>


### PR DESCRIPTION
## Description
Changed the way the expiration selector works in the link sharing modal.
- Before this change, it was a dropdown of the expiration date from the creation of that link
- After this change, it is a date picker of the expiration, with quick presets below

## Screenshot

<img width="400px"  alt="Screenshot 2026-02-08 130855" src="https://github.com/user-attachments/assets/e5ec1c4c-f544-4172-ace9-f3f3f96694c6" />

</details>