### PR TITLE
fix: slideshow setting dropdown overflow

### DIFF
--- a/web/src/lib/components/shared-components/settings/setting-dropdown.svelte
+++ b/web/src/lib/components/shared-components/settings/setting-dropdown.svelte
@@ -29,7 +29,7 @@
 <div class="flex place-items-center justify-between">
   <div>
     <div class="flex h-6.5 place-items-center gap-1">
-      <label class="font-medium text-primary text-sm" for={title}>
+      <label class="font-medium text-sm" for={title}>
         {title}
       </label>
       {#if isEdited}
@@ -48,6 +48,7 @@
   <div class="w-fit">
     <Dropdown
       {options}
+      position="bottom-right"
       hideTextOnSmallScreen={false}
       bind:selectedOption
       render={(option) => {


### PR DESCRIPTION
- Fix dropdown overflow
- Remove `text-primary` to match the color of other labels

<img width="421" height="598" alt="image" src="https://github.com/user-attachments/assets/a8c057bb-3286-46b9-9711-a085fc7e4157" />
