### PR TITLE
fix(web): removing a person in an asset, doesn't remove the asset in …

### DIFF
--- a/web/src/lib/components/faces-page/person-side-panel.svelte
+++ b/web/src/lib/components/faces-page/person-side-panel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import OnEvents from '$lib/components/OnEvents.svelte';
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
+  import { eventManager } from '$lib/managers/event-manager.svelte';
   import { assetViewingStore } from '$lib/stores/asset-viewing.store';
   import { boundingBoxesArray } from '$lib/stores/people.store';
   import { getPeopleThumbnailUrl, handlePromiseError } from '$lib/utils';
@@ -173,6 +174,8 @@
       }
 
       await deleteFace({ id: face.id, assetFaceDeleteDto: { force: false } });
+
+      eventManager.emit('PersonAssetDelete', { id: face.person.id, assetId });
 
       peopleWithFaces = peopleWithFaces.filter((f) => f.id !== face.id);
 

--- a/web/src/lib/managers/event-manager.svelte.ts
+++ b/web/src/lib/managers/event-manager.svelte.ts
@@ -48,7 +48,7 @@ export type Events = {
 
   PersonUpdate: [PersonResponseDto];
   PersonThumbnailReady: [{ id: string }];
-  PersonAssetDelete: [{ id: string, assetId: string }];
+  PersonAssetDelete: [{ id: string; assetId: string }];
 
   BackupDeleteStatus: [{ filename: string; isDeleting: boolean }];
   BackupDeleted: [{ filename: string }];

--- a/web/src/lib/managers/event-manager.svelte.ts
+++ b/web/src/lib/managers/event-manager.svelte.ts
@@ -48,6 +48,7 @@ export type Events = {
 
   PersonUpdate: [PersonResponseDto];
   PersonThumbnailReady: [{ id: string }];
+  PersonAssetDelete: [{ id: string, assetId: string }];
 
   BackupDeleteStatus: [{ filename: string; isDeleting: boolean }];
   BackupDeleted: [{ filename: string }];

--- a/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -297,6 +297,14 @@
     person = response;
   };
 
+  const handlePersonAssetDelete = async ({ id, assetId }: { id: string; assetId: string }) => {
+    if (id !== person.id) {
+      return;
+    }
+    timelineManager.removeAssets([assetId]);
+    await updateAssetCount();
+  };
+
   const { SetDateOfBirth, Favorite, Unfavorite, HidePerson, ShowPerson } = $derived(getPersonActions($t, person));
   const SelectFeaturePhoto: ActionItem = {
     title: $t('select_featured_photo'),
@@ -315,7 +323,12 @@
   };
 </script>
 
-<OnEvents {onPersonUpdate} onAssetsDelete={updateAssetCount} onAssetsArchive={updateAssetCount} />
+<OnEvents
+  {onPersonUpdate}
+  onPersonAssetDelete={handlePersonAssetDelete}
+  onAssetsDelete={updateAssetCount}
+  onAssetsArchive={updateAssetCount}
+/>
 
 <main
   class="relative z-0 h-dvh overflow-hidden px-2 md:px-6 md:pt-(--navbar-height-md) pt-(--navbar-height)"


### PR DESCRIPTION
…the persons view (without refresh)

## Description

When in the person asset view (on the web part). You click an asset, edit the people of that asset and then delete the person from that asset. (Now you actually have removed the asset from the person) When going to the person asset view, that asset is still visible on the timeline. 

## How Has This Been Tested?

steps to reproduce:
- goto the explore page
- open one of the people
- open one of the assets of that person
- on the people side panel, click the edit Button
- click the delete button of the person
- press the back button (to go back to timeline of the person)

expected result:
The asset is removed from the persons timeline

actual: result:
The asset is still visible (till refresh)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [n/a] I have confirmed that any new dependencies are strictly necessary.
- [n/a] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [n/a] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [n/a] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
none

