### PR TITLE
fix: evict image from cache on error during image loading

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -62,6 +62,9 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         return;
       }
       yield image;
+    } catch (e) {
+      PaintingBinding.instance.imageCache.evict(this);
+      rethrow;
     } finally {
       this.request = null;
     }


### PR DESCRIPTION
## Description

In my recent testing for PR #25984 I noticed that images that failed loading, could never be loaded correctly. In the timeline they always showed up as Thumbhash, and the Thumbnail never finished loading. Even when switching to albums and then going back to the asset viewer.

Or if a thumbnail was already cached/working, I clicked on it. The asset viewer loaded, and for some reason the actual image request failed, the thumbnail was shown instead (as intended).
When closing the asset viewer, and clicking on the same image again, it doesn't start show the image thumbnail like before, but a grey background.

**The Issue:**
If in the `CancellableImageProviderMixin.loadRequest`  the `await request.load(decode);` throws for whatever reason, the error is propagated to the listeners but the cache for the entry is never cleared. 

That means, `ImageProvider.resolve` will actually resolve to that erroring cached ImageStreamCompleter and the cache entry is never cleared.

The thing is from my understanding `await request.load(decode)` could throw for a lot of networking reasons, so I think its better to clear the cache from this entry, and try to load the image again if it is requested again.

In this PR: When an error happens while loading the image, we remove it from the cache, and then the error is propagated like before.

Also, I am not sure but this could help with issues such as #25662 ?

## How Has This Been Tested?

- this can be tested really well if you clear the immich cache from the settings and then turn of wifi/cellular

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

-