### PR TITLE
fix: when removing asset (used as featured person asset), assign new …

### DIFF
--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -65,6 +65,7 @@ class JobName {
   static const personCleanup = JobName._(r'PersonCleanup');
   static const personFileMigration = JobName._(r'PersonFileMigration');
   static const personGenerateThumbnail = JobName._(r'PersonGenerateThumbnail');
+  static const personNewFeaturePhoto = JobName._(r'PersonNewFeaturePhoto');
   static const sessionCleanup = JobName._(r'SessionCleanup');
   static const sendMail = JobName._(r'SendMail');
   static const sidecarQueueAll = JobName._(r'SidecarQueueAll');
@@ -124,6 +125,7 @@ class JobName {
     personCleanup,
     personFileMigration,
     personGenerateThumbnail,
+    personNewFeaturePhoto,
     sessionCleanup,
     sendMail,
     sidecarQueueAll,
@@ -218,6 +220,7 @@ class JobNameTypeTransformer {
         case r'PersonCleanup': return JobName.personCleanup;
         case r'PersonFileMigration': return JobName.personFileMigration;
         case r'PersonGenerateThumbnail': return JobName.personGenerateThumbnail;
+        case r'PersonNewFeaturePhoto': return JobName.personNewFeaturePhoto;
         case r'SessionCleanup': return JobName.sessionCleanup;
         case r'SendMail': return JobName.sendMail;
         case r'SidecarQueueAll': return JobName.sidecarQueueAll;

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -18062,6 +18062,7 @@
           "PersonCleanup",
           "PersonFileMigration",
           "PersonGenerateThumbnail",
+          "PersonNewFeaturePhoto",
           "SessionCleanup",
           "SendMail",
           "SidecarQueueAll",

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -7139,6 +7139,7 @@ export enum JobName {
     PersonCleanup = "PersonCleanup",
     PersonFileMigration = "PersonFileMigration",
     PersonGenerateThumbnail = "PersonGenerateThumbnail",
+    PersonNewFeaturePhoto = "PersonNewFeaturePhoto",
     SessionCleanup = "SessionCleanup",
     SendMail = "SendMail",
     SidecarQueueAll = "SidecarQueueAll",

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -631,6 +631,7 @@ export enum JobName {
   PersonCleanup = 'PersonCleanup',
   PersonFileMigration = 'PersonFileMigration',
   PersonGenerateThumbnail = 'PersonGenerateThumbnail',
+  PersonNewFeaturePhoto = 'PersonNewFeaturePhoto',
 
   SessionCleanup = 'SessionCleanup',
 

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -354,3 +354,12 @@ from
   "person"
 where
   "id" in ($1)
+
+-- PersonRepository.getFeaturedPersonsFromAsset
+select
+  "person"."id"
+from
+  "person"
+  inner join "asset_face" on "asset_face"."id" = "person"."faceAssetId"
+where
+  "asset_face"."assetId" = $1

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -355,7 +355,7 @@ from
 where
   "id" in ($1)
 
--- PersonRepository.getFeaturedPersonsFromAsset
+-- PersonRepository.getFeaturedPeopleOfAsset
 select
   "person"."id"
 from

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -584,7 +584,7 @@ export class PersonRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID] })
-  getFeaturedPersonsFromAsset(assetId: string) {
+  getFeaturedPeopleOfAsset(assetId: string) {
     return this.db
       .selectFrom('person')
       .select(['person.id'])

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -582,4 +582,14 @@ export class PersonRepository {
       }
     });
   }
+
+  @GenerateSql({ params: [DummyValue.UUID] })
+  getFeaturedPersonsFromAsset(assetId: string) {
+    return this.db
+      .selectFrom('person')
+      .select(['person.id'])
+      .innerJoin('asset_face', 'asset_face.id', 'person.faceAssetId')
+      .where('asset_face.assetId', '=', assetId)
+      .execute();
+  }
 }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -493,7 +493,7 @@ describe(AssetService.name, () => {
 
     it('should force delete a batch of assets', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset1', 'asset2']));
-      mocks.person.getFeaturedPersonsFromAsset.mockResolvedValue([]);
+      mocks.person.getFeaturedPeopleOfAsset.mockResolvedValue([]);
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: true });
 
@@ -505,7 +505,7 @@ describe(AssetService.name, () => {
 
     it('should soft delete a batch of assets', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset1', 'asset2']));
-      mocks.person.getFeaturedPersonsFromAsset.mockResolvedValue([]);
+      mocks.person.getFeaturedPeopleOfAsset.mockResolvedValue([]);
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: false });
 

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -493,6 +493,7 @@ describe(AssetService.name, () => {
 
     it('should force delete a batch of assets', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset1', 'asset2']));
+      mocks.person.getFeaturedPersonsFromAsset.mockResolvedValue([]);
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: true });
 
@@ -504,6 +505,7 @@ describe(AssetService.name, () => {
 
     it('should soft delete a batch of assets', async () => {
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset1', 'asset2']));
+      mocks.person.getFeaturedPersonsFromAsset.mockResolvedValue([]);
 
       await sut.deleteAll(authStub.user1, { ids: ['asset1', 'asset2'], force: false });
 

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -393,7 +393,7 @@ export class AssetService extends BaseService {
 
     // Update feature photos of persons that had this asset as feature photo
     for (const id of ids) {
-      const persons = await this.personRepository.getFeaturedPersonsFromAsset(id);
+      const persons = await this.personRepository.getFeaturedPeopleOfAsset(id);
       for (const person of persons) {
         await this.jobRepository.queue({
           name: JobName.PersonNewFeaturePhoto,

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -391,7 +391,7 @@ export class AssetService extends BaseService {
       status: force ? AssetStatus.Deleted : AssetStatus.Trashed,
     });
 
-    // Update feature photos of persons that had this asset as feature photo
+    // Update feature photos of people that had this asset as feature photo
     for (const id of ids) {
       const persons = await this.personRepository.getFeaturedPersonsFromAsset(id);
       for (const person of persons) {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -704,7 +704,9 @@ export class PersonService extends BaseService {
   async deleteFace(auth: AuthDto, id: string, dto: AssetFaceDeleteDto): Promise<void> {
     await this.requireAccess({ auth, permission: Permission.FaceDelete, ids: [id] });
     const face = await this.personRepository.getFaceById(id);
-    dto.force ? await this.personRepository.deleteAssetFace(id) : await this.personRepository.softDeleteAssetFaces(id);
+    const _result = dto.force
+      ? await this.personRepository.deleteAssetFace(id)
+      : await this.personRepository.softDeleteAssetFaces(id);
 
     if (face?.personId) {
       const person = await this.personRepository.getById(face.personId);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -333,6 +333,7 @@ export type JobItem =
   | { name: JobName.FacialRecognitionQueueAll; data: INightlyJob }
   | { name: JobName.FacialRecognition; data: IDeferrableJob }
   | { name: JobName.PersonGenerateThumbnail; data: IEntityJob }
+  | { name: JobName.PersonNewFeaturePhoto; data: IEntityJob }
 
   // Smart Search
   | { name: JobName.SmartSearchQueueAll; data: IBaseJob }

--- a/server/test/medium/specs/services/asset.service.spec.ts
+++ b/server/test/medium/specs/services/asset.service.spec.ts
@@ -7,6 +7,7 @@ import { AssetRepository } from 'src/repositories/asset.repository';
 import { EventRepository } from 'src/repositories/event.repository';
 import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
+import { PersonRepository } from 'src/repositories/person.repository';
 import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
@@ -31,6 +32,7 @@ const setup = (db?: Kysely<DB>) => {
       SharedLinkAssetRepository,
       StackRepository,
       UserRepository,
+      PersonRepository,
     ],
     mock: [EventRepository, LoggingRepository, JobRepository, StorageRepository],
   });
@@ -529,6 +531,35 @@ describe(AssetService.name, () => {
           exifInfo: expect.objectContaining({ dateTimeOriginal: '2023-11-20T01:11:00+00:00', timeZone: 'UTC-7' }),
         }),
       );
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('should queue a new feature photo job for persons that had this asset as featured photo', async () => {
+      const { sut, ctx } = setup();
+      const jobMock = ctx.getMock(JobRepository);
+      const eventMock = ctx.getMock(EventRepository);
+
+      const { user } = await ctx.newUser();
+      const auth = factory.auth({ user });
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({
+        assetId: asset.id,
+        isVisible: true,
+        deletedAt: null,
+      });
+      const { person } = await ctx.newPerson({ ownerId: user.id, faceAssetId: assetFace.id });
+
+      jobMock.queue.mockResolvedValue();
+      eventMock.emit.mockResolvedValue();
+
+      await sut.deleteAll(auth, { ids: [asset.id], force: false });
+
+      expect(jobMock.queue).toHaveBeenCalledWith({
+        name: JobName.PersonNewFeaturePhoto,
+        data: { id: person.id },
+      });
     });
   });
 

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -21,7 +21,7 @@ const setup = (db?: Kysely<DB>) => {
   return newMediumService(PersonService, {
     database: db || defaultDatabase,
     real: [AccessRepository, DatabaseRepository, PersonRepository, AssetRepository, AssetEditRepository],
-    mock: [LoggingRepository, StorageRepository],
+    mock: [LoggingRepository, StorageRepository, JobRepository],
   });
 };
 

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -5,6 +5,7 @@ import { AccessRepository } from 'src/repositories/access.repository';
 import { AssetEditRepository } from 'src/repositories/asset-edit.repository';
 import { AssetRepository } from 'src/repositories/asset.repository';
 import { DatabaseRepository } from 'src/repositories/database.repository';
+import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { StorageRepository } from 'src/repositories/storage.repository';
@@ -684,6 +685,95 @@ describe(PersonService.name, () => {
           }),
         ]),
       );
+    });
+  });
+  describe('deleteAssetFace', () => {
+    it('should reassign faceAssetId if the deleted face was the feature photo', async () => {
+      const { ctx, sut } = setup();
+      const jobMock = ctx.getMock(JobRepository);
+      const personRepo = ctx.get(PersonRepository);
+
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const auth = factory.auth({ user });
+
+      jobMock.queueAll.mockResolvedValue();
+
+      const { assetFace: face1 } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: person.id,
+        isVisible: true,
+        deletedAt: null,
+      });
+      const { assetFace: face2 } = await ctx.newAssetFace({
+        assetId: asset.id,
+        personId: person.id,
+        isVisible: true,
+        deletedAt: null,
+      });
+
+      // Set face1 as the feature photo
+      await personRepo.update({ id: person.id, faceAssetId: face1.id });
+
+      // Verify setup
+      let updatedPerson = await personRepo.getById(person.id);
+      expect(updatedPerson?.faceAssetId).toBe(face1.id);
+
+      // Delete face1
+      await sut.deleteFace(auth, face1.id, { force: false });
+
+      // Check if faceAssetId was reassigned to face2 (since it's the only other face)
+      updatedPerson = await personRepo.getById(person.id);
+      expect(updatedPerson?.faceAssetId).toBe(face2.id);
+    });
+
+    it('should set faceAssetId to null if the deleted face was the feature photo and no other faces exist', async () => {
+      const { ctx, sut } = setup();
+      const jobMock = ctx.getMock(JobRepository);
+      const personRepo = ctx.get(PersonRepository);
+
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const auth = factory.auth({ user });
+
+      jobMock.queueAll.mockResolvedValue();
+
+      const { assetFace: face1 } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      // Set face1 as the feature photo
+      await personRepo.update({ id: person.id, faceAssetId: face1.id });
+
+      // Delete face1
+      await sut.deleteFace(auth, face1.id, { force: false });
+
+      // Check if faceAssetId is null
+      const updatedPerson = await personRepo.getById(person.id);
+      expect(updatedPerson?.faceAssetId).toBeNull();
+    });
+
+    it('should NOT change faceAssetId if the deleted face was NOT the feature photo', async () => {
+      const { ctx, sut } = setup();
+      const personRepo = ctx.get(PersonRepository);
+
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id });
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const auth = factory.auth({ user });
+
+      const { assetFace: face1 } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const { assetFace: face2 } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      // Set face1 as the feature photo
+      await personRepo.update({ id: person.id, faceAssetId: face1.id });
+
+      // Delete face2
+      await sut.deleteFace(auth, face2.id, { force: false });
+
+      // Check if faceAssetId is still face1
+      const updatedPerson = await personRepo.getById(person.id);
+      expect(updatedPerson?.faceAssetId).toBe(face1.id);
     });
   });
 });


### PR DESCRIPTION
…featured asset

## Description

With the person, there is a featured asset shown. But after deleting that asset delivering the thumbnail, the same asset is still shown as thumbnail. This can be triggered by 2 path. Either by deleting the asset or by deleting the person from the asset. In both paths, the asset should not be part of the person, so definitely not be used as thumbnail.

So as solution, a randomly new asset is chosen and afterwards the thumbnail is generated in a job.

## How Has This Been Tested?

steps to reproduce:
- goto the explore page
- open one of the people
- open the asset that is used as featured photo
- on the people side panel, click the edit Button
- click the delete button of the person
- press the back button (to go back to timeline of the person)

expected result:
The featured photo of the person is adapted

actual result:
The featured photo is changed => medium test provided

steps to reproduce:
- goto the explore page
- open one of the people
- open the asset that is used as featured photo
- on asset viewer, delete that photo
- press the back button (to go back to timeline of the person)

expected result:
The featured photo of the person is adapted

actual result:
The featured photo is changed => medium test provided

## Checklist:

- [x] I have performed a self-review of my own code
- [n/a] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
To create testcode, but no original code of the LLM is left...
