### PR TITLE
chore(mobile): enable high refresh rate in debug builds

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -75,7 +75,7 @@ Future<void> initApp() async {
   await EasyLocalization.ensureInitialized();
   await initializeDateFormatting();
 
-  if (kReleaseMode && Platform.isAndroid) {
+  if (Platform.isAndroid) {
     try {
       await FlutterDisplayMode.setHighRefreshRate();
       dPrint(() => "Enabled high refresh mode");


### PR DESCRIPTION


## Description

I'm testing changes to animations and app performance, and noticed it felt quite sluggish on a 120hz display. It turns out that high refresh is disabled in debug builds. It's probably a good idea to enable it so that it more closely mirrors the production build.

## How Has This Been Tested?

On a real device.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A