### PR TITLE
fix: ignore checksum constraint error when logging

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -102,6 +102,10 @@ export const getKyselyConfig = (
     }),
     log(event) {
       if (event.level === 'error') {
+        if (isAssetChecksumConstraint(event.error)) {
+          return;
+        }
+
         console.error('Query failed :', {
           durationMs: event.queryDurationMillis,
           error: event.error,


### PR DESCRIPTION
No need to log expected constraint errors.