### PR TITLE
fix: fix inconsistencies between js date and postgres

### DIFF
--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -132,27 +132,25 @@ export const removeUndefinedKeys = <T extends object>(update: T, template: unkno
 };
 
 const convertTimestampToDate = (item: string) => {
+  if (!item.endsWith('BC')) {
+    return new Date(item);
+  }
+
   const match = item.match(/^(\d+)-(.+)$/i);
   if (!match) {
     return new Date(item);
   }
 
-  // 3 main differences between js date and postgres date
+  // 2 main differences between js date and postgres date
   // - postgres uses BC instead of negative year
   // - postgres uses Julian calendar for BC dates, while js uses Gregorian calendar
-  // - js needs extra + for years >= 10000, so use padded +002000 for all years
 
   const year = Number(match[1]);
   const rest = match[2];
-
-  if (item.endsWith('BC')) {
-    const astroYear = 1 - year;
-    const sign = astroYear < 0 ? '-' : '+';
-    const yearAbs = Math.abs(astroYear).toString().padStart(6, '0');
-    item = `${sign}${yearAbs}-${rest.slice(0, -3)}`;
-  } else {
-    item = `+${year.toString().padStart(6, '0')}-${rest}`;
-  }
+  const astroYear = 1 - year;
+  const sign = astroYear < 0 ? '-' : '+';
+  const yearAbs = Math.abs(astroYear).toString().padStart(6, '0');
+  item = `${sign}${yearAbs}-${rest.slice(0, -3)}`;
 
   return new Date(item);
 };
@@ -160,7 +158,8 @@ const convertTimestampToDate = (item: string) => {
 const pad = (n: number, l = 2) => String(n).padStart(l, '0');
 
 const convertDateToTimestamp = (item: Date) => {
-  if (Number.isNaN(item as any)) {
+  // eslint-disable-next-line unicorn/prefer-number-properties
+  if (isNaN(item as any)) {
     return item.toISOString();
   }
 

--- a/server/test/medium/specs/exif/exif-date-time.spec.ts
+++ b/server/test/medium/specs/exif/exif-date-time.spec.ts
@@ -62,4 +62,18 @@ describe('exif date time', () => {
       fileCreatedAt: stats.mtime,
     });
   });
+
+  it('test asset date in the very far future', async () => {
+    // 42603 AD uses a plus sign for year, which postgres does not support
+    const { ctx, sut, asset } = await setup('metadata/dates/future42603.mp4');
+
+    await sut.handleMetadataExtraction({ id: asset.id });
+
+    await expect(ctx.getDates(asset.id)).resolves.toEqual({
+      timeZone: 'UTC',
+      dateTimeOriginal: new Date('+042603-05-04T04:12:48.000Z'),
+      localDateTime: new Date('+042603-05-04T04:12:48.000Z'),
+      fileCreatedAt: new Date('+042603-05-04T04:12:48.000Z'),
+    });
+  });
 });


### PR DESCRIPTION
## Description

Postgres and the js date (toISOString) cannot be converted into each other without quirks.
This conversion is updated to fix the differences between js date and postgres date
- postgres uses BC instead of negative year
- postgres uses Julian calendar for BC dates, while js uses Gregorian calendar
- js needs extra + for years >= 10000, so use padded +002000 for all years
- postgres range is -4713 till 294276, while js -271821 to +275760

The getKyselyConfig is updated with new handlers that does these conversions.

This helps because the server crashes upon handling these cases. For example when an asset is added with a very high year.

Remarks:
- When the date itself is already invalid (e.g from fs.stats or ExifDateTime.fromEXIF), this will still fail. => do we want to insert made up data and make sure it doesn't fail?
- When the year is below -4713, we will silently put it into the postgres range, so update it to the year -4713
- This does nothing for hardening the job queue and will not stop a failing asset from bogging the queue till eternity

Fixes #26074

## How Has This Been Tested?

Testfixes are added

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
None
