### PR TITLE
feat: improve HEIC, HEIF and JPEG XL browser support detection

### DIFF
--- a/web/src/lib/utils/asset-utils.ts
+++ b/web/src/lib/utils/asset-utils.ts
@@ -301,19 +301,54 @@ const supportedImageMimeTypes = new Set([
   'image/webp',
 ]);
 
-const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // https://stackoverflow.com/a/23522755
-if (isSafari) {
-  supportedImageMimeTypes.add('image/heic').add('image/heif');
-}
+async function addSupportedMimeTypes(): Promise<void> {
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // https://stackoverflow.com/a/23522755
+  if (isSafari) {
+    const match = navigator.userAgent.match(/Version\/(\d+)/);
 
-function checkJxlSupport(): void {
-  const img = new Image();
-  img.addEventListener('load', () => {
+    if (!match) {
+      return;
+    }
+
+    const majorVersion = Number.parseInt(match[1]);
+    const MIN_REQUIRED_VERSION = 17;
+
+    if (majorVersion >= MIN_REQUIRED_VERSION) {
+      supportedImageMimeTypes.add('image/jxl').add('image/heic').add('image/heif');
+    }
+
+    return;
+  }
+
+  if (globalThis.isSecureContext && typeof ImageDecoder !== 'undefined') {
+    const dynamicMimeTypes = [{ type: 'image/jxl' }, { type: 'image/heic', aliases: ['image/heif'] }];
+
+    for (const mime of dynamicMimeTypes) {
+      const isMimeTypeSupported = await ImageDecoder.isTypeSupported(mime.type);
+      if (isMimeTypeSupported) {
+        for (const mimeType of [mime.type, ...(mime.aliases || [])]) {
+          supportedImageMimeTypes.add(mimeType);
+        }
+      }
+    }
+
+    return;
+  }
+
+  const jxlImg = new Image();
+  jxlImg.addEventListener('load', () => {
     supportedImageMimeTypes.add('image/jxl');
   });
-  img.src = 'data:image/jxl;base64,/woIAAAMABKIAgC4AF3lEgA='; // Small valid JPEG XL image
+  jxlImg.src = 'data:image/jxl;base64,/woIAAAMABKIAgC4AF3lEgA='; // Small valid JPEG XL image
+
+  const heicImg = new Image();
+  heicImg.addEventListener('load', () => {
+    supportedImageMimeTypes.add('image/heic');
+  });
+  heicImg.src =
+    'data:image/heic;base64,AAAAGGZ0eXBoZWljAAAAAG1pZjFoZWljAAABrW1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAHBpY3QAAAAAAAAAAAAAAAAAAAAADnBpdG0AAAAAAAIAAAAQaWRhdAAAAAAAAQABAAAAOGlsb2MBAAAAREAAAgABAAAAAAAAAc0AAQAAAAAAAAAsAAIAAQAAAAAAAAABAAAAAAAAAAgAAAA4aWluZgAAAAAAAgAAABVpbmZlAgAAAQABAABodmMxAAAAABVpbmZlAgAAAAACAABncmlkAAAAANhpcHJwAAAAtmlwY28AAAB2aHZjQwEDcAAAAAAAAAAAAB7wAPz9+PgAAA8DIAABABhAAQwB//8DcAAAAwCQAAADAAADAB66AkAhAAEAKkIBAQNwAAADAJAAAAMAAAMAHqAggQWW6q6a5uBAQMCAAAADAIAAAAMAhCIAAQAGRAHBc8GJAAAAFGlzcGUAAAAAAAAAAQAAAAEAAAAUaXNwZQAAAAAAAABAAAAAQAAAABBwaXhpAAAAAAMICAgAAAAaaXBtYQAAAAAAAAACAAECgQMAAgIChAAAABppcmVmAAAAAAAAAA5kaW1nAAIAAQABAAAANG1kYXQAAAAoKAGvCchMZYA50NoPIfzz81Qfsm577GJt3lf8kLAr+NbNIoeRR7JeYA=='; // Small valid HEIC/HEIF image
 }
-checkJxlSupport();
+void addSupportedMimeTypes();
 
 /**
  * Returns true if the asset is an image supported by web browsers, false otherwise


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following up on #25599, this PR improves browser support detection for JXL, and HEIC/HEIF mime types by:
- Detecting support on any new browser that adds it.
  - Adds support for Chrome stable and Firefox nightly with the jxl flag enabled, as well as Zen Browser (flag enabled by default).
- Excluding Safari versions <17 that don't support these mime types.

### Details

The HEIC image was generated with ImageMagick from a 1x1 white PNG with this command:

```sh
./magick input.png -strip output.heic
```

and then turned into a base64 string:

```sh
base64 -w 0 output.heic > heic_b64.txt
```

Changing the output to `.heif` instead of `.heic` yields the same result, so I guess any browser supporting one format would support the other one too? If this is certainly true I can remove the redundant HEIF test, otherwise it's best to keep it.

Unfortunately the resulting string can't be as short as JPEG XL, but it's the shortest I could achieve.
If anyone else wants to improve it later, [this slide](https://docs.google.com/presentation/d/1LlmUR0Uoh4dgT3DjanLjhlXrk_5W2nJBDqDAMbhe8v8/view?slide=id.gde87dfbe27_0_43#slide=id.gde87dfbe27_0_43) suggests a theoretical minimum size of """only""" 386 bytes.

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Unfortunately this change would need tests running on different browsers to be validated:

- [x] Copy the added code, along with the `supportedImageMimeTypes` definition and test the added mime types on:
  - Safari -> it should add jxl, heic and heif.
  - Chrome -> it should not add anything.
  - Chrome with the [#enable-jxl-image-format](chrome://flags/#enable-jxl-image-format) flag on -> it should add jxl.
  - Firefox -> it should not add anything.
  - Firefox nightly with the `image.jxl.enabled` flag turned on in about:config -> it should add jxl.
  - Zen Browser -> it should add jxl.
- [x] Tested `isSecureContext` on secure and insecure contexts.
- [x] Tested `ImageDecoder.isTypeSupported` on browsers with and without support for jxl, heic and heif mime types.
- [x] Tested the fallback support detection with base64 images (also tested in the previous PR).

<!-- <details><summary><h2>Screenshots (if appropriate)</h2></summary> -->

<!-- Images go below this line. -->

<!-- </details> -->

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

No LLM.
