### PR TITLE
fix(mobile): Login routing on Splash screen

### DIFF
--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -10,7 +10,6 @@ import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
-import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -26,16 +25,6 @@ class SplashScreenPage extends StatefulHookConsumerWidget {
 
 class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
   final log = Logger("SplashScreenPage");
-
-  Future<void> _goToLoginFromSplash() async {
-    final previousRouteName = ref.read(previousRouteNameProvider);
-    // App can return with Splash pushed over existing Login route.
-    if (previousRouteName == LoginRoute.name && context.router.canPop()) {
-      await context.router.maybePop();
-      return;
-    }
-    await context.router.replaceAll([const LoginRoute()]);
-  }
 
   @override
   void initState() {
@@ -104,14 +93,14 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
           onError: (exception) => {
             log.severe('Failed to update auth info with access token: $accessToken'),
             ref.read(authProvider.notifier).logout(),
-            _goToLoginFromSplash(),
+            context.replaceRoute(const LoginRoute()),
           },
         ),
       );
     } else {
       log.severe('Missing crucial offline login info - Logging out completely');
       unawaited(ref.read(authProvider.notifier).logout());
-      unawaited(_goToLoginFromSplash());
+      unawaited(context.replaceRoute(const LoginRoute()));
       return;
     }
 

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/providers/routes.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -25,6 +26,16 @@ class SplashScreenPage extends StatefulHookConsumerWidget {
 
 class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
   final log = Logger("SplashScreenPage");
+
+  Future<void> _goToLoginFromSplash() async {
+    final previousRouteName = ref.read(previousRouteNameProvider);
+    // App can return with Splash pushed over existing Login route.
+    if (previousRouteName == LoginRoute.name && context.router.canPop()) {
+      await context.router.maybePop();
+      return;
+    }
+    await context.router.replaceAll([const LoginRoute()]);
+  }
 
   @override
   void initState() {
@@ -93,14 +104,14 @@ class SplashScreenPageState extends ConsumerState<SplashScreenPage> {
           onError: (exception) => {
             log.severe('Failed to update auth info with access token: $accessToken'),
             ref.read(authProvider.notifier).logout(),
-            context.replaceRoute(const LoginRoute()),
+            _goToLoginFromSplash(),
           },
         ),
       );
     } else {
       log.severe('Missing crucial offline login info - Logging out completely');
       unawaited(ref.read(authProvider.notifier).logout());
-      unawaited(context.replaceRoute(const LoginRoute()));
+      unawaited(_goToLoginFromSplash());
       return;
     }
 

--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -165,7 +165,7 @@ class AppRouter extends RootStackRouter {
   late final List<AutoRoute> routes = [
     AutoRoute(page: SplashScreenRoute.page, initial: true),
     AutoRoute(page: PermissionOnboardingRoute.page, guards: [_authGuard, _duplicateGuard]),
-    AutoRoute(page: LoginRoute.page, guards: [_duplicateGuard]),
+    AutoRoute(page: LoginRoute.page),
     AutoRoute(page: ChangePasswordRoute.page),
     AutoRoute(page: SearchRoute.page, guards: [_authGuard, _duplicateGuard], maintainState: false),
     AutoRoute(


### PR DESCRIPTION
**Description**  
Fix navigation conflict when an incoming Android `ACTION_VIEW` intent resumes the app while the Login screen is already active in the foreground. In this case `SplashScreen` is pushed on top of `LoginRoute` and the subsequent redirect to Login is blocked by `DuplicateGuard`, leaving the app stuck on Splash. The fix pops Splash only when the previous route is `LoginRoute`; otherwise it replaces the stack with `LoginRoute`.

**Steps to Reproduce**  
1. Open the app and log out so the Login screen is active.
2. Keep the app in foreground on `LoginRoute`.
3. Trigger an external `ACTION_VIEW` intent (depends on PR [`#26109`](https://github.com/immich-app/immich/pull/26109), e.g., open an image file with Immich).
4. Observe that `SplashScreen` appears and the app gets stuck there.

**Expected Behavior**  
- App should show the Login screen after handling the intent (or immediately if already on Login).
- No duplicate navigation guard should block the transition.

**Actual Behavior**  
- App stays on `SplashScreen`.
- Logs show `DuplicateGuard: Preventing duplicate route navigation for LoginRoute` while `SplashScreen` remains on top.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
...
