### PR TITLE
feat: use fd for library crawling

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -73,6 +73,12 @@ RUN --mount=type=cache,id=pnpm-plugins,target=/buildcache/pnpm-store \
 
 FROM ghcr.io/immich-app/base-server-prod:202601131104@sha256:c649c5838b6348836d27db6d49cadbbc6157feae7a1a237180c3dec03577ba8f
 
+RUN apt-get update && \
+  apt-get install -y fd-find && \
+  ln -s /usr/bin/fdfind /usr/local/bin/fd && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 WORKDIR /usr/src/app
 ENV NODE_ENV=production \
   NVIDIA_DRIVER_CAPABILITIES=all \

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -18,6 +18,12 @@ WORKDIR /tmp/create-dep-cache
 RUN pnpm fetch && rm -rf /tmp/create-dep-cache && chmod -R o+rw /buildcache
 WORKDIR /usr/src/app
 
+RUN apt-get update && \
+  apt-get install -y fd-find && \
+  ln -s /usr/bin/fdfind /usr/local/bin/fd && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 ENV PATH="${PATH}:/usr/src/app/server/bin:/usr/src/app/web/bin" \
   IMMICH_ENV=development \
   NVIDIA_DRIVER_CAPABILITIES=all \

--- a/server/src/dtos/library.dto.ts
+++ b/server/src/dtos/library.dto.ts
@@ -58,10 +58,7 @@ export interface CrawlOptionsDto {
   pathsToCrawl: string[];
   includeHidden?: boolean;
   exclusionPatterns?: string[];
-}
-
-export interface WalkOptionsDto extends CrawlOptionsDto {
-  take: number;
+  take?: number;
 }
 
 export class ValidateLibraryDto {

--- a/server/src/repositories/storage.repository.ts
+++ b/server/src/repositories/storage.repository.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import archiver from 'archiver';
 import chokidar, { ChokidarOptions } from 'chokidar';
-import { escapePath, glob, globStream } from 'fast-glob';
+import { spawn } from 'node:child_process';
 import { constants, createReadStream, createWriteStream, existsSync, mkdirSync, ReadOptionsWithBuffer } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { PassThrough, Readable, Writable } from 'node:stream';
 import { createGunzip, createGzip } from 'node:zlib';
-import { CrawlOptionsDto, WalkOptionsDto } from 'src/dtos/library.dto';
+import { CrawlOptionsDto } from 'src/dtos/library.dto';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { mimeTypes } from 'src/utils/mime-types';
 
@@ -198,52 +198,87 @@ export class StorageRepository {
     };
   }
 
-  crawl(crawlOptions: CrawlOptionsDto): Promise<string[]> {
+  async crawl(crawlOptions: CrawlOptionsDto): Promise<string[]> {
     const { pathsToCrawl, exclusionPatterns, includeHidden } = crawlOptions;
     if (pathsToCrawl.length === 0) {
-      return Promise.resolve([]);
+      return [];
     }
 
-    const globbedPaths = pathsToCrawl.map((path) => this.asGlob(path));
+    return new Promise((resolve, reject) => {
+      const args: string[] = [
+        '-t',
+        'f', // File type: only files
+        '-a', // Absolute paths
+        '-i', // Case insensitive
+        '.', // Search pattern: match all files
+      ];
 
-    return glob(globbedPaths, {
-      absolute: true,
-      caseSensitiveMatch: false,
-      onlyFiles: true,
-      dot: includeHidden,
-      ignore: exclusionPatterns,
-    });
-  }
-
-  async *walk(walkOptions: WalkOptionsDto): AsyncGenerator<string[]> {
-    const { pathsToCrawl, exclusionPatterns, includeHidden } = walkOptions;
-    if (pathsToCrawl.length === 0) {
-      async function* emptyGenerator() {}
-      return emptyGenerator();
-    }
-
-    const globbedPaths = pathsToCrawl.map((path) => this.asGlob(path));
-
-    const stream = globStream(globbedPaths, {
-      absolute: true,
-      caseSensitiveMatch: false,
-      onlyFiles: true,
-      dot: includeHidden,
-      ignore: exclusionPatterns,
-    });
-
-    let batch: string[] = [];
-    for await (const value of stream) {
-      batch.push(value.toString());
-      if (batch.length === walkOptions.take) {
-        yield batch;
-        batch = [];
+      if (includeHidden) {
+        args.push('-H');
       }
-    }
 
-    if (batch.length > 0) {
-      yield batch;
-    }
+      for (const pattern of exclusionPatterns ?? []) {
+        args.push('-E', pattern);
+      }
+
+      const extensions = mimeTypes.getSupportedFileExtensions();
+      for (const ext of extensions) {
+        // fd expects extensions without the dot
+        args.push('-e', ext.replace(/^\./, ''));
+      }
+
+      args.push(...pathsToCrawl);
+
+      const fdfind = spawn('fdfind', args);
+
+      const files: string[] = [];
+      let buffer = '';
+      let stderr = '';
+
+      fdfind.stdout.on('data', (data) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        // Keep the last partial line in the buffer
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed.length > 0) {
+            files.push(trimmed);
+          }
+        }
+      });
+
+      fdfind.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      fdfind.on('close', (code) => {
+        // Process any remaining data in the buffer
+        if (buffer.length > 0) {
+          const trimmed = buffer.trim();
+          if (trimmed.length > 0) {
+            files.push(trimmed);
+          }
+        }
+
+        if (code === 0) {
+          resolve(files);
+        } else {
+          reject(new Error(`fdfind process exited with code ${code}: ${stderr}`));
+        }
+      });
+
+      fdfind.on('error', (error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          reject(
+            new Error('fdfind command not found. Please install fd-find: https://github.com/sharkdp/fd#installation'),
+          );
+        } else {
+          reject(new Error(`Failed to spawn fdfind: ${error.message}`));
+        }
+      });
+    });
   }
 
   watch(paths: string[], options: ChokidarOptions, events: Partial<WatchEvents>) {
@@ -256,11 +291,5 @@ export class StorageRepository {
     watcher.on('error', (error) => events.onError?.(error as Error));
 
     return () => watcher.close();
-  }
-
-  private asGlob(pathToCrawl: string): string {
-    const escapedPath = escapePath(pathToCrawl).replaceAll('"', '["]').replaceAll("'", "[']").replaceAll('`', '[`]');
-    const extensions = `*{${mimeTypes.getSupportedFileExtensions().join(',')}}`;
-    return `${escapedPath}/**/${extensions}`;
   }
 }


### PR DESCRIPTION
fast-glob has been nice to us but it's time to go.

Instead we use fd: https://github.com/sharkdp/fd

This is an external binary but is much faster. The performance is unbelievable, I was able to crawl 11M assets in 25 seconds...over NFS! This does not include the actual import, but since the disk crawl has had lots of issues in the past (#12713 for instance) we are able to make this more robust as well as clean up some old bugs.

This is still a draft since testing is needed as well as notifying package managers; it's a possible breaking change for those not using docker

TODO:
* storage repo crawl unit tests need to be moved to end to end because it is no longer self-contained