### PR TITLE
fix(web): improve api key modal responsiveness

### DIFF
--- a/web/src/lib/components/user-settings-page/user-api-key-grid.svelte
+++ b/web/src/lib/components/user-settings-page/user-api-key-grid.svelte
@@ -41,7 +41,7 @@
     />
     <Label label={title} for="permission-{title}" class="font-mono text-primary text-lg" />
   </div>
-  <div class="mx-6 mt-3 grid grid-cols-3 gap-2">
+  <div class="mx-6 mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
     {#each subItems as item (item)}
       <div class="flex items-center gap-2">
         <Checkbox


### PR DESCRIPTION
## Description

The New API Key modal had a fixed 3-column grid, which caused layout breakage and overlapping content on smaller screens (mobile and tablets). 
This PR introduces responsive breakpoints.

## How Has This Been Tested?

I tested this manually using the browser's developer tools to simulate different screen sizes

Test A: Verified the modal layout on mobile view - Now displays 1 column.

Test B: Verified the modal layout on tablet view - Now displays 2 columns.

Test C: Verified that the original 3-column layout remains intact on desktop view.

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

| Before | After |
| :---: | :---: |
|<img width="300" alt="before" src="https://github.com/user-attachments/assets/044a8388-9c06-4ceb-8502-942c5e4bad17" />|<img width="300" alt="after" src="https://github.com/user-attachments/assets/58e66693-7b58-41ee-bb08-eed58e7f87d7" />|

</details>


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have no unrelated changes in the PR.
- [x] I have followed naming conventions/patterns in the surrounding code

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used an LLM to help set up the development environment
