### PR TITLE
fix(web): prevent event manager from throwing error

### DIFF
--- a/web/src/lib/utils/base-event-manager.svelte.ts
+++ b/web/src/lib/utils/base-event-manager.svelte.ts
@@ -15,7 +15,7 @@ const nextId = () => count++;
 const noop = () => {};
 
 export class BaseEventManager<Events extends EventsBase> {
-  #callbacks: EventItem<Events>[] = $state([]);
+  #callbacks: EventItem<Events>[] = $state.raw([]);
 
   on(subscriptions: EventMap<Events>): () => void {
     const cleanups = Object.entries(subscriptions).map(([event, callback]) =>
@@ -36,7 +36,7 @@ export class BaseEventManager<Events extends EventsBase> {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const item = { id: nextId(), event, callback } as EventItem<Events, any>;
-    this.#callbacks.push(item);
+    this.#callbacks = [...this.#callbacks, item];
 
     return () => {
       this.#callbacks = this.#callbacks.filter((current) => current.id !== item.id);


### PR DESCRIPTION
#26143 unexpectedly caused e2e test failures by exposing an existing runtime error: `Uncaught TypeError: can't access property "id", current is undefined`. It turns out that removing `{#await}` from the theme button no longer catches this error thrown in the following situation:

1. A logged in user visits a shared album link
2. User clicks the Immich logo

The error comes from: https://github.com/immich-app/immich/blob/913904f4188cdcaac133c69490fdfd73cda06845/web/src/lib/utils/base-event-manager.svelte.ts#L41-L43

When listeners are removed while new listeners are being registered, the callback array mutation can become inconsistent and the cleanup filter can receive undefined for `current` causing an error. There seems to be a mismatch between the actual length of `#callbacks` and the amount of times the filter is called. I'm not entirely sure how that can happen, but switching to `$state.raw()` solves this issue.