### PR TITLE
fix(web): show correct assets in memory gallery

### DIFF
--- a/web/src/lib/components/memory-page/memory-viewer.svelte
+++ b/web/src/lib/components/memory-page/memory-viewer.svelte
@@ -68,7 +68,8 @@
   let currentMemoryAssetFull = $derived.by(async () =>
     current?.asset ? await getAssetInfo({ ...authManager.params, id: current.asset.id }) : undefined,
   );
-  let currentTimelineAssets = $derived([
+  let currentTimelineAssets = $derived(current?.memory.assets ?? []);
+  let viewerAssets = $derived([
     ...(current?.previousMemory?.assets ?? []),
     ...(current?.memory.assets ?? []),
     ...(current?.nextMemory?.assets ?? []),
@@ -657,6 +658,7 @@
     >
       <GalleryViewer
         assets={currentTimelineAssets}
+        {viewerAssets}
         viewport={galleryViewport}
         {assetInteraction}
         slidingWindowOffset={viewerHeight}

--- a/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/gallery-viewer.svelte
@@ -34,6 +34,7 @@
 
   type Props = {
     assets: AssetResponseDto[];
+    viewerAssets?: AssetResponseDto[];
     assetInteraction: AssetInteraction;
     disableAssetSelect?: boolean;
     showArchiveIcon?: boolean;
@@ -48,6 +49,7 @@
 
   let {
     assets = $bindable(),
+    viewerAssets,
     assetInteraction,
     disableAssetSelect = false,
     showArchiveIcon = false,
@@ -61,6 +63,7 @@
   }: Props = $props();
 
   let { isViewing: isViewerOpen, asset: viewingAsset } = assetViewingStore;
+  const navigationAssets = $derived(viewerAssets ?? assets);
 
   const geometry = $derived(
     getJustifiedLayoutFromAssets(assets, {
@@ -282,12 +285,12 @@
   );
 
   const handleRandom = async (): Promise<{ id: string } | undefined> => {
-    if (assets.length === 0) {
+    if (navigationAssets.length === 0) {
       return;
     }
     try {
-      const randomIndex = Math.floor(Math.random() * assets.length);
-      const asset = assets[randomIndex];
+      const randomIndex = Math.floor(Math.random() * navigationAssets.length);
+      const asset = navigationAssets[randomIndex];
 
       await navigateToAsset(asset);
       return asset;
@@ -344,8 +347,8 @@
 
   const assetCursor = $derived({
     current: $viewingAsset,
-    nextAsset: getNextAsset(assets, $viewingAsset),
-    previousAsset: getPreviousAsset(assets, $viewingAsset),
+    nextAsset: getNextAsset(navigationAssets, $viewingAsset),
+    previousAsset: getPreviousAsset(navigationAssets, $viewingAsset),
   });
 </script>
 


### PR DESCRIPTION
Fixes #26119 while ensuring:
- Navigation between different memories works in the asset viewer
- Only assets of the current memory are shown in the gallery