### PR TITLE
feat: nested albums (sub-albums)

### DIFF
--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -663,6 +663,10 @@ export type AlbumResponseDto = {
     owner: UserResponseDto;
     /** Owner user ID */
     ownerId: string;
+    /** Parent album ID */
+    parentId: string | null;
+    /** Number of child (sub) albums */
+    childAlbumCount: number;
     /** Is shared album */
     shared: boolean;
     /** Start date (earliest asset) */
@@ -685,6 +689,8 @@ export type CreateAlbumDto = {
     assetIds?: string[];
     /** Album description */
     description?: string;
+    /** Parent album ID for nesting */
+    parentId?: string;
 };
 export type AlbumsAddAssetsDto = {
     /** Album IDs */
@@ -3716,6 +3722,19 @@ export function getAlbumInfo({ id, key, slug, withoutAssets }: {
         slug,
         withoutAssets
     }))}`, {
+        ...opts
+    }));
+}
+/**
+ * Get child albums
+ */
+export function getChildAlbums({ id }: {
+    id: string;
+}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.ok(oazapfts.fetchJson<{
+        status: 200;
+        data: AlbumResponseDto[];
+    }>(`/albums/${encodeURIComponent(id)}/children`, {
         ...opts
     }));
 }

--- a/server/src/controllers/album.controller.ts
+++ b/server/src/controllers/album.controller.ts
@@ -73,6 +73,20 @@ export class AlbumController {
     return this.service.get(auth, id, dto);
   }
 
+  @Get(':id/children')
+  @Authenticated({ permission: Permission.AlbumRead })
+  @Endpoint({
+    summary: 'Get child albums',
+    description: 'Retrieve the direct child (sub) albums of a specific album.',
+    history: new HistoryBuilder().added('v1').beta('v1').stable('v2'),
+  })
+  getChildAlbums(
+    @Auth() auth: AuthDto,
+    @Param() { id }: UUIDParamDto,
+  ): Promise<AlbumResponseDto[]> {
+    return this.service.getChildAlbums(auth, id);
+  }
+
   @Patch(':id')
   @Authenticated({ permission: Permission.AlbumUpdate })
   @Endpoint({

--- a/server/src/dtos/album.dto.ts
+++ b/server/src/dtos/album.dto.ts
@@ -61,6 +61,9 @@ export class CreateAlbumDto {
 
   @ValidateUUID({ optional: true, each: true, description: 'Initial asset IDs' })
   assetIds?: string[];
+
+  @ValidateUUID({ optional: true, description: 'Parent album ID for nesting' })
+  parentId?: string;
 }
 
 export class AlbumsAddAssetsDto {
@@ -183,6 +186,12 @@ export class AlbumResponseDto {
   @ValidateEnum({ enum: AssetOrder, name: 'AssetOrder', description: 'Asset sort order', optional: true })
   order?: AssetOrder;
 
+  @ApiProperty({ description: 'Parent album ID', nullable: true })
+  parentId!: string | null;
+
+  @ApiProperty({ type: 'integer', description: 'Number of child (sub) albums' })
+  childAlbumCount!: number;
+
   // Description lives on schema to avoid duplication
   @ApiPropertyOptional({ description: undefined })
   @Type(() => ContributorCountResponseDto)
@@ -203,6 +212,8 @@ export type MapAlbumDto = {
   owner: User;
   isActivityEnabled: boolean;
   order: AssetOrder;
+  parentId?: string | null;
+  childAlbumCount?: number;
 };
 
 export const mapAlbum = (entity: MapAlbumDto, withAssets: boolean, auth?: AuthDto): AlbumResponseDto => {
@@ -250,6 +261,8 @@ export const mapAlbum = (entity: MapAlbumDto, withAssets: boolean, auth?: AuthDt
     assetCount: entity.assets?.length || 0,
     isActivityEnabled: entity.isActivityEnabled,
     order: entity.order,
+    parentId: entity.parentId ?? null,
+    childAlbumCount: entity.childAlbumCount ?? 0,
   };
 };
 

--- a/server/src/schema/migrations/1771007071000-AddAlbumParentId.ts
+++ b/server/src/schema/migrations/1771007071000-AddAlbumParentId.ts
@@ -1,0 +1,13 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "album" ADD "parentId" uuid;`.execute(db);
+  await sql`ALTER TABLE "album" ADD CONSTRAINT "FK_album_parentId" FOREIGN KEY ("parentId") REFERENCES "album"("id") ON DELETE SET NULL ON UPDATE CASCADE;`.execute(db);
+  await sql`CREATE INDEX "IDX_album_parentId" ON "album" ("parentId");`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX "IDX_album_parentId";`.execute(db);
+  await sql`ALTER TABLE "album" DROP CONSTRAINT "FK_album_parentId";`.execute(db);
+  await sql`ALTER TABLE "album" DROP COLUMN "parentId";`.execute(db);
+}

--- a/server/src/schema/tables/album.table.ts
+++ b/server/src/schema/tables/album.table.ts
@@ -60,6 +60,9 @@ export class AlbumTable {
   @Column({ default: AssetOrder.Desc })
   order!: Generated<AssetOrder>;
 
+  @ForeignKeyColumn(() => AlbumTable, { nullable: true, onDelete: 'SET NULL', onUpdate: 'CASCADE' })
+  parentId!: string | null;
+
   @UpdateIdColumn({ index: true })
   updateId!: Generated<string>;
 }

--- a/web/src/lib/components/album-page/album-breadcrumbs.svelte
+++ b/web/src/lib/components/album-page/album-breadcrumbs.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { Route } from '$lib/route';
+  import { getAlbumInfo, type AlbumResponseDto } from '@immich/sdk';
+  import { Icon } from '@immich/ui';
+  import { mdiChevronRight } from '@mdi/js';
+  import { onMount } from 'svelte';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    album: AlbumResponseDto;
+  }
+
+  let { album }: Props = $props();
+
+  let breadcrumbs = $state<{ id: string; name: string }[]>([]);
+
+  const buildBreadcrumbs = async () => {
+    const crumbs: { id: string; name: string }[] = [];
+    let currentAlbum: AlbumResponseDto | null = album;
+
+    // Walk up the parent chain
+    while (currentAlbum?.parentId) {
+      try {
+        const parent = await getAlbumInfo({ id: currentAlbum.parentId, withoutAssets: true });
+        crumbs.unshift({ id: parent.id, name: parent.albumName || 'Untitled Album' });
+        currentAlbum = parent;
+      } catch {
+        break;
+      }
+    }
+
+    breadcrumbs = crumbs;
+  };
+
+  onMount(() => {
+    buildBreadcrumbs();
+  });
+
+  // Rebuild when album changes
+  $effect(() => {
+    album.parentId;
+    buildBreadcrumbs();
+  });
+</script>
+
+{#if breadcrumbs.length > 0}
+  <nav class="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 mb-2" aria-label="Breadcrumb">
+    <a
+      href={Route.albums()}
+      class="hover:text-immich-primary dark:hover:text-immich-dark-primary transition-colors"
+    >
+      {$t('albums') ?? 'Albums'}
+    </a>
+
+    {#each breadcrumbs as crumb (crumb.id)}
+      <Icon icon={mdiChevronRight} size="16" />
+      <a
+        href={Route.viewAlbum({ id: crumb.id })}
+        class="hover:text-immich-primary dark:hover:text-immich-dark-primary transition-colors truncate max-w-[200px]"
+        title={crumb.name}
+      >
+        {crumb.name}
+      </a>
+    {/each}
+
+    <Icon icon={mdiChevronRight} size="16" />
+    <span class="text-primary font-medium truncate max-w-[200px]" title={album.albumName}>
+      {album.albumName || 'Untitled Album'}
+    </span>
+  </nav>
+{/if}

--- a/web/src/lib/components/album-page/sub-albums-section.svelte
+++ b/web/src/lib/components/album-page/sub-albums-section.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import AlbumCard from '$lib/components/album-page/album-card.svelte';
+  import { Route } from '$lib/route';
+  import { createSubAlbumAndRedirect } from '$lib/utils/album-utils';
+  import { getChildAlbums, type AlbumResponseDto } from '@immich/sdk';
+  import { Icon } from '@immich/ui';
+  import { mdiPlus, mdiFolderMultipleOutline } from '@mdi/js';
+  import { onMount } from 'svelte';
+  import { t } from 'svelte-i18n';
+
+  interface Props {
+    album: AlbumResponseDto;
+    isOwned: boolean;
+  }
+
+  let { album, isOwned }: Props = $props();
+
+  let childAlbums = $state<AlbumResponseDto[]>([]);
+  let isLoading = $state(true);
+
+  const loadChildAlbums = async () => {
+    try {
+      childAlbums = await getChildAlbums({ id: album.id });
+    } catch {
+      childAlbums = [];
+    } finally {
+      isLoading = false;
+    }
+  };
+
+  onMount(() => {
+    loadChildAlbums();
+  });
+
+  // Reload when album changes
+  $effect(() => {
+    album.id;
+    loadChildAlbums();
+  });
+</script>
+
+{#if !isLoading && (childAlbums.length > 0 || isOwned)}
+  <section class="my-6">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2">
+        <Icon icon={mdiFolderMultipleOutline} size="20" class="text-immich-primary dark:text-immich-dark-primary" />
+        <h2 class="text-lg font-semibold dark:text-white">{$t('sub_albums') ?? 'Sub-Albums'}</h2>
+        {#if childAlbums.length > 0}
+          <span class="text-sm text-gray-500 dark:text-gray-400">({childAlbums.length})</span>
+        {/if}
+      </div>
+      {#if isOwned}
+        <button
+          type="button"
+          class="flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-immich-primary hover:bg-immich-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/10 transition-colors"
+          onclick={() => createSubAlbumAndRedirect(album.id)}
+        >
+          <Icon icon={mdiPlus} size="18" />
+          {$t('create_sub_album') ?? 'Create Sub-Album'}
+        </button>
+      {/if}
+    </div>
+
+    {#if childAlbums.length > 0}
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))]">
+        {#each childAlbums as childAlbum (childAlbum.id)}
+          <a href={Route.viewAlbum(childAlbum)} data-sveltekit-preload-data="hover">
+            <AlbumCard album={childAlbum} showItemCount />
+          </a>
+        {/each}
+      </div>
+    {:else if isOwned}
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        {$t('no_sub_albums') ?? 'No sub-albums yet. Create one to organize your photos.'}
+      </p>
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/services/album.service.ts
+++ b/web/src/lib/services/album.service.ts
@@ -71,7 +71,7 @@ export const getAlbumActions = ($t: MessageFormatter, album: AlbumResponseDto, v
     title: $t('go_back'),
     type: $t('command'),
     icon: mdiArrowLeft,
-    onAction: () => goto(Route.albums()),
+    onAction: () => goto(album.parentId ? Route.viewAlbum({ id: album.parentId }) : Route.albums()),
     $if: () => viewMode === AlbumPageViewMode.VIEW,
     shortcuts: { key: 'Escape' },
   };

--- a/web/src/lib/utils/album-utils.ts
+++ b/web/src/lib/utils/album-utils.ts
@@ -21,12 +21,13 @@ import { get } from 'svelte/store';
  * Albums General Management
  * -------------------------
  */
-export const createAlbum = async (name?: string, assetIds?: string[]) => {
+export const createAlbum = async (name?: string, assetIds?: string[], parentId?: string) => {
   try {
     const newAlbum: AlbumResponseDto = await sdk.createAlbum({
       createAlbumDto: {
         albumName: name ?? '',
         assetIds,
+        parentId,
       },
     });
     return newAlbum;
@@ -38,6 +39,13 @@ export const createAlbum = async (name?: string, assetIds?: string[]) => {
 
 export const createAlbumAndRedirect = async (name?: string, assetIds?: string[]) => {
   const newAlbum = await createAlbum(name, assetIds);
+  if (newAlbum) {
+    await goto(Route.viewAlbum(newAlbum));
+  }
+};
+
+export const createSubAlbumAndRedirect = async (parentId: string, name?: string) => {
+  const newAlbum = await createAlbum(name, undefined, parentId);
   if (newAlbum) {
     await goto(Route.viewAlbum(newAlbum));
   }

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -2,10 +2,12 @@
   import { goto, onNavigate } from '$app/navigation';
   import { scrollMemoryClearer } from '$lib/actions/scroll-memory';
   import ActionButton from '$lib/components/ActionButton.svelte';
+  import AlbumBreadcrumbs from '$lib/components/album-page/album-breadcrumbs.svelte';
   import AlbumDescription from '$lib/components/album-page/album-description.svelte';
   import AlbumMap from '$lib/components/album-page/album-map.svelte';
   import AlbumSummary from '$lib/components/album-page/album-summary.svelte';
   import AlbumTitle from '$lib/components/album-page/album-title.svelte';
+  import SubAlbumsSection from '$lib/components/album-page/sub-albums-section.svelte';
   import ActivityStatus from '$lib/components/asset-viewer/activity-status.svelte';
   import ActivityViewer from '$lib/components/asset-viewer/activity-viewer.svelte';
   import HeaderActionButton from '$lib/components/HeaderActionButton.svelte';
@@ -278,7 +280,7 @@
 
   const onAlbumDelete = async ({ id }: AlbumResponseDto) => {
     if (id === album.id) {
-      await goto(Route.albums());
+      await goto(album.parentId ? Route.viewAlbum({ id: album.parentId }) : Route.albums());
       viewMode = AlbumPageViewMode.VIEW;
     }
   };
@@ -340,8 +342,15 @@
       >
         {#if viewMode !== AlbumPageViewMode.SELECT_ASSETS}
           {#if viewMode !== AlbumPageViewMode.SELECT_THUMBNAIL}
+            <!-- BREADCRUMBS -->
+            {#if album.parentId}
+              <section class="pt-8 md:pt-24 pb-0">
+                <AlbumBreadcrumbs {album} />
+              </section>
+            {/if}
+
             <!-- ALBUM TITLE -->
-            <section class="pt-8 md:pt-24">
+            <section class={album.parentId ? 'pt-2' : 'pt-8 md:pt-24'}>
               <AlbumTitle
                 id={album.id}
                 albumName={album.albumName}
@@ -397,6 +406,9 @@
               {/if}
               <!-- ALBUM DESCRIPTION -->
               <AlbumDescription id={album.id} bind:description={album.description} {isOwned} />
+
+              <!-- SUB-ALBUMS -->
+              <SubAlbumsSection {album} {isOwned} />
             </section>
           {/if}
 
@@ -485,7 +497,7 @@
       </AssetSelectControlBar>
     {:else}
       {#if viewMode === AlbumPageViewMode.VIEW}
-        <ControlAppBar showBackButton backIcon={mdiArrowLeft} onClose={() => goto(Route.albums())}>
+        <ControlAppBar showBackButton backIcon={mdiArrowLeft} onClose={() => goto(album.parentId ? Route.viewAlbum({ id: album.parentId }) : Route.albums())}>
           {#snippet trailing()}
             <ActionButton action={Cast} />
 


### PR DESCRIPTION
Add nested album support with parentId column, sub-album UI section, and breadcrumb navigation. All existing functionality preserved.

- Database migration adding nullable parentId UUID column with FK to albums(id)
- Album table schema updated with self-referencing ForeignKeyColumn
- Create Album DTO accepts optional parentId
- Album Response DTO includes parentId and childAlbumCount
- Album repository: getChildAlbums and getChildAlbumCounts queries
- Album service: parentId validation on create, child count on get
- New GET /albums/:id/children endpoint
- Web UI: Sub-Albums section with album cards and Create Sub-Album button
- Web UI: Breadcrumb navigation for nested albums
- Back button navigates to parent album when inside a sub-album
- SDK updated with new types and getChildAlbums function

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
