### PR TITLE
Fix path comparison for highlighting in duplicates side-by-side view

### DIFF
--- a/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
+++ b/web/src/lib/components/utilities-page/duplicates/duplicate-asset.svelte
@@ -52,7 +52,12 @@
     fileName: isDifferent((a) => a.originalFileName),
     fileSize: isDifferent((a) => getFileSize(a)),
     resolution: isDifferent((a) => getAssetResolution(a)),
-    originalPath: isDifferent((a) => a.originalPath ?? $t('unknown')),
+    originalPath: isDifferent((a) => {
+      const basePath = a.originalPath && a.originalFileName 
+        ? getBasePath(a.originalPath, a.originalFileName)
+        : a.originalPath ?? $t('unknown');
+      return basePath || $t('unknown');
+    }),
     date: isDifferent((a) => {
       const tz = a.exifInfo?.timeZone;
       const dt =


### PR DESCRIPTION
## Description

In the duplicates side-by-side view the path was always highlighting as if it were different because the originalPath includes the file name.  This caused the isDifferent check to always return true.

## How Has This Been Tested?

- Create a duplicate image in a different folder, can be same name or different. Verified paths are highlighted.

- Create a duplicate image in the same folder but with a different name. Verified paths are not highlighted.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

Claude Sonnet 4.5 used to identify issue and proposed the change.
