### PR TITLE
feat(mobile): Prevent premature image cache eviction when higher image loading is enabled

### DIFF
--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -61,7 +61,6 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
         PaintingBinding.instance.imageCache.evict(this);
         return;
       } else if (image == null) {
-        _log.warning('Image request completed with null image');
         return;
       }
       yield image;

--- a/mobile/lib/presentation/widgets/images/image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/image_provider.dart
@@ -48,7 +48,7 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
     return null;
   }
 
-  Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode) async* {
+  Stream<ImageInfo> loadRequest(ImageRequest request, ImageDecoderCallback decode, {bool evictOnError = true}) async* {
     if (isCancelled) {
       this.request = null;
       PaintingBinding.instance.imageCache.evict(this);
@@ -57,14 +57,20 @@ mixin CancellableImageProviderMixin<T extends Object> on CancellableImageProvide
 
     try {
       final image = await request.load(decode);
-      if (image == null || isCancelled) {
+      if ((image == null && evictOnError) || isCancelled) {
         PaintingBinding.instance.imageCache.evict(this);
+        return;
+      } else if (image == null) {
+        _log.warning('Image request completed with null image');
         return;
       }
       yield image;
-    } catch (e) {
-      PaintingBinding.instance.imageCache.evict(this);
-      rethrow;
+    } catch (e, stack) {
+      if (evictOnError) {
+        PaintingBinding.instance.imageCache.evict(this);
+        rethrow;
+      }
+      _log.warning('Non-fatal image load error', e, stack);
     } finally {
       this.request = null;
     }

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -94,10 +94,10 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
+    final loadOriginal = Store.get(StoreKey.loadOriginal, false);
+    yield* loadRequest(request, decode, evictOnError: !loadOriginal);
 
-    yield* loadRequest(request, decode);
-
-    if (!Store.get(StoreKey.loadOriginal, false)) {
+    if (!loadOriginal) {
       return;
     }
 

--- a/mobile/lib/presentation/widgets/images/local_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/local_image_provider.dart
@@ -94,10 +94,9 @@ class LocalFullImageProvider extends CancellableImageProvider<LocalFullImageProv
       size: Size(size.width * devicePixelRatio, size.height * devicePixelRatio),
       assetType: key.assetType,
     );
-    final loadOriginal = Store.get(StoreKey.loadOriginal, false);
-    yield* loadRequest(request, decode, evictOnError: !loadOriginal);
+    yield* loadRequest(request, decode);
 
-    if (!loadOriginal) {
+    if (!Store.get(StoreKey.loadOriginal, false)) {
       return;
     }
 

--- a/mobile/lib/presentation/widgets/images/remote_image_provider.dart
+++ b/mobile/lib/presentation/widgets/images/remote_image_provider.dart
@@ -93,9 +93,10 @@ class RemoteFullImageProvider extends CancellableImageProvider<RemoteFullImagePr
       uri: getThumbnailUrlForRemoteId(key.assetId, type: AssetMediaSize.preview, thumbhash: key.thumbhash),
       headers: headers,
     );
-    yield* loadRequest(previewRequest, decode);
+    final loadOriginal = assetType == AssetType.image && AppSetting.get(Setting.loadOriginal);
+    yield* loadRequest(previewRequest, decode, evictOnError: !loadOriginal);
 
-    if (assetType != AssetType.image || !AppSetting.get(Setting.loadOriginal)) {
+    if (!loadOriginal) {
       return;
     }
 


### PR DESCRIPTION
## Description

Add an evictOnError flag to loadRequest to make image cache eviction on load failure configurable.
Default behavior is unchanged (evict on error).

This is used to avoid evicting the cache when loadOriginal is enabled, preview loading failed and a the original could still load.

---

### Open Question

`loadRequest` currently completes silently when `request.load(...)` returns `null` and if the request didn't get cancelled.
In this case, the cache entry is evicted, but no error is emitted, so subscribers cannot distinguish between waiting on an image and a failed image load.

I think we should throw an error (e.g. in `_codec`) when the *final* image load attempt returns `null`, so subscribers are explicitly notified that image loading failed and can react accordingly? (remove subscription etc.)


## How Has This Been Tested?

Not really, as I don't have failing images.


## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
/