### PR TITLE
perf(web): speed up multi asset operations

### DIFF
--- a/web/src/lib/managers/timeline-manager/day-group.svelte.ts
+++ b/web/src/lib/managers/timeline-manager/day-group.svelte.ts
@@ -102,25 +102,21 @@ export class DayGroup {
   }
 
   runAssetCallback(ids: Set<string>, callback: (asset: TimelineAsset) => void | { remove?: boolean }) {
-    if (ids.size === 0) {
-      return {
-        moveAssets: [] as MoveAsset[],
-        processedIds: new SvelteSet<string>(),
-        unprocessedIds: ids,
-        changedGeometry: false,
-      };
-    }
     const unprocessedIds = new SvelteSet<string>(ids);
     const processedIds = new SvelteSet<string>();
     const moveAssets: MoveAsset[] = [];
     let changedGeometry = false;
-    for (const assetId of unprocessedIds) {
-      const index = this.viewerAssets.findIndex((viewAsset) => viewAsset.id == assetId);
-      if (index === -1) {
+
+    if (ids.size === 0) {
+      return { moveAssets, processedIds, unprocessedIds, changedGeometry };
+    }
+
+    for (let index = this.viewerAssets.length - 1; index >= 0; index--) {
+      const { id: assetId, asset } = this.viewerAssets[index];
+      if (!ids.has(assetId)) {
         continue;
       }
 
-      const asset = this.viewerAssets[index].asset!;
       const oldTime = { ...asset.localDateTime };
       const callbackResult = callback(asset);
       let remove = (callbackResult as { remove?: boolean } | undefined)?.remove ?? false;


### PR DESCRIPTION
Favoriting all my 12,585 assets was taking 23 seconds. A similar delay affects all timeline operations that modify or remove assets, like favorite, archive, trash, etc. With these changes favoriting all assets takes 600ms.
