### PR TITLE
fix(server): qualify column reference in duplicate detection query

### DIFF
--- a/server/src/queries/asset.job.repository.sql
+++ b/server/src/queries/asset.job.repository.sql
@@ -2,7 +2,7 @@
 
 -- AssetJobRepository.getForSearchDuplicatesJob
 select
-  "id",
+  "asset"."id",
   "type",
   "ownerId",
   "duplicateId",

--- a/server/src/repositories/asset-job.repository.ts
+++ b/server/src/repositories/asset-job.repository.ts
@@ -30,7 +30,7 @@ export class AssetJobRepository {
       .selectFrom('asset')
       .where('asset.id', '=', asUuid(id))
       .leftJoin('smart_search', 'asset.id', 'smart_search.assetId')
-      .select(['id', 'type', 'ownerId', 'duplicateId', 'stackId', 'visibility', 'smart_search.embedding'])
+      .select(['asset.id', 'type', 'ownerId', 'duplicateId', 'stackId', 'visibility', 'smart_search.embedding'])
       .limit(1)
       .executeTakeFirst();
   }


### PR DESCRIPTION
## Description

Qualifies unqualified `'id'` to `'asset.id'` in the `getForSearchDuplicatesJob` select array. The LEFT JOIN with `smart_search` makes `"id"` ambiguous since VectorChord added an integer `id` PK to that table. Same fix pattern as PR #18433.

Fixes #26224

## How Has This Been Tested?

- [x] Verified the generated SQL (`sync:sql`) now produces `"asset"."id"` instead of `"id"` in the `getForSearchDuplicatesJob` query
- [x] `pnpm run lint` passes
- [x] `pnpm run check` passes (tsc --noEmit)
- [x] `pnpm run build` passes