### PR TITLE
feat: warn when losing transparency during thumbnail generation

### DIFF
--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -142,13 +142,7 @@ export class MediaRepository {
 
   async decodeImage(input: string | Buffer, options: DecodeToBufferOptions) {
     const pipeline = await this.getImageDecodingPipeline(input, options);
-    let hasAlpha = false;
-    if (options.checkAlpha) {
-      const metadata = await pipeline.metadata();
-      hasAlpha = metadata.hasAlpha ?? false;
-    }
-    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
-    return { data, info, hasAlpha };
+    return pipeline.raw().toBuffer({ resolveWithObject: true });
   }
 
   private async applyEdits(pipeline: sharp.Sharp, edits: AssetEditActionItem[]): Promise<sharp.Sharp> {
@@ -315,9 +309,9 @@ export class MediaRepository {
     });
   }
 
-  async getImageDimensions(input: string | Buffer): Promise<ImageDimensions> {
-    const { width = 0, height = 0 } = await sharp(input).metadata();
-    return { width, height };
+  async getImageMetadata(input: string | Buffer): Promise<ImageDimensions & { isTransparent: boolean }> {
+    const { width = 0, height = 0, hasAlpha = false } = await sharp(input).metadata();
+    return { width, height, isTransparent: hasAlpha };
   }
 
   private configureFfmpegCall(input: string, output: string | Writable, options: TranscodeCommand) {

--- a/server/src/repositories/media.repository.ts
+++ b/server/src/repositories/media.repository.ts
@@ -142,7 +142,13 @@ export class MediaRepository {
 
   async decodeImage(input: string | Buffer, options: DecodeToBufferOptions) {
     const pipeline = await this.getImageDecodingPipeline(input, options);
-    return pipeline.raw().toBuffer({ resolveWithObject: true });
+    let hasAlpha = false;
+    if (options.checkAlpha) {
+      const metadata = await pipeline.metadata();
+      hasAlpha = metadata.hasAlpha ?? false;
+    }
+    const { data, info } = await pipeline.raw().toBuffer({ resolveWithObject: true });
+    return { data, info, hasAlpha };
   }
 
   private async applyEdits(pipeline: sharp.Sharp, edits: AssetEditActionItem[]): Promise<sharp.Sharp> {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -344,8 +344,8 @@ describe(MediaService.name, () => {
       mocks.media.decodeImage.mockImplementation((input) =>
         Promise.resolve(
           typeof input === 'string'
-            ? { data: rawBuffer, info: rawInfo as OutputInfo } // string implies original file
-            : { data: fullsizeBuffer, info: rawInfo as OutputInfo }, // buffer implies embedded image extracted
+            ? { data: rawBuffer, info: rawInfo as OutputInfo, hasAlpha: false } // string implies original file
+            : { data: fullsizeBuffer, info: rawInfo as OutputInfo, hasAlpha: false }, // buffer implies embedded image extracted
         ),
       );
     });
@@ -417,6 +417,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440,
@@ -655,6 +656,7 @@ describe(MediaService.name, () => {
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith(expect.any(String));
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.Srgb,
         processInvalidImages: false,
         size: 1440,
@@ -705,6 +707,7 @@ describe(MediaService.name, () => {
       expect(mocks.storage.mkdirSync).toHaveBeenCalledWith(expect.any(String));
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.Srgb,
         processInvalidImages: false,
         size: 1440,
@@ -865,6 +868,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(extractedBuffer, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440,
@@ -883,6 +887,7 @@ describe(MediaService.name, () => {
       await sut.handleGenerateThumbnails({ id: asset.id });
 
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440,
@@ -900,6 +905,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440,
@@ -918,6 +924,7 @@ describe(MediaService.name, () => {
       expect(mocks.media.extract).not.toHaveBeenCalled();
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440,
@@ -977,6 +984,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(extractedBuffer, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
         size: 1440, // capped to preview size as fullsize conversion is skipped
@@ -1015,6 +1023,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(extractedBuffer, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
       });
@@ -1063,6 +1072,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
       });
@@ -1115,6 +1125,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: true,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
       });
@@ -1146,6 +1157,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: false,
         colorspace: Colorspace.Srgb,
         processInvalidImages: false,
         size: 1440,
@@ -1178,6 +1190,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: true,
         colorspace: Colorspace.Srgb,
         orientation: undefined,
         processInvalidImages: false,
@@ -1223,6 +1236,7 @@ describe(MediaService.name, () => {
 
       expect(mocks.media.decodeImage).toHaveBeenCalledOnce();
       expect(mocks.media.decodeImage).toHaveBeenCalledWith(asset.originalPath, {
+        checkAlpha: true,
         colorspace: Colorspace.P3,
         processInvalidImages: false,
       });
@@ -1282,8 +1296,8 @@ describe(MediaService.name, () => {
       mocks.media.decodeImage.mockImplementation((input) =>
         Promise.resolve(
           typeof input === 'string'
-            ? { data: rawBuffer, info: rawInfo as OutputInfo } // string implies original file
-            : { data: fullsizeBuffer, info: rawInfo as OutputInfo }, // buffer implies embedded image extracted
+            ? { data: rawBuffer, info: rawInfo as OutputInfo, hasAlpha: false } // string implies original file
+            : { data: fullsizeBuffer, info: rawInfo as OutputInfo, hasAlpha: false }, // buffer implies embedded image extracted
         ),
       );
     });
@@ -1453,7 +1467,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 1000, height: 1000 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1498,7 +1512,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 1000, height: 1000 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1543,7 +1557,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 2160, height: 3840 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1586,7 +1600,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 1000, height: 1000 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1629,7 +1643,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 4624, height: 3080 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1672,7 +1686,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 4624, height: 3080 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1718,7 +1732,7 @@ describe(MediaService.name, () => {
       const data = Buffer.from('');
       const info = { width: 2160, height: 3840 } as OutputInfo;
       mocks.media.extract.mockResolvedValue({ buffer: extracted, format: RawExtractedFormat.Jpeg });
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
       mocks.media.getImageDimensions.mockResolvedValue(info);
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
@@ -1762,7 +1776,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 2160, height: 3840 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1778,7 +1792,7 @@ describe(MediaService.name, () => {
       mocks.media.generateThumbnail.mockResolvedValue();
       const data = Buffer.from('');
       const info = { width: 2160, height: 3840 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
 
       await expect(sut.handleGeneratePersonThumbnail({ id: personStub.primaryPerson.id })).resolves.toBe(
         JobStatus.Success,
@@ -1800,7 +1814,7 @@ describe(MediaService.name, () => {
       const extracted = Buffer.from('');
       const data = Buffer.from('');
       const info = { width: 1000, height: 1000 } as OutputInfo;
-      mocks.media.decodeImage.mockResolvedValue({ data, info });
+      mocks.media.decodeImage.mockResolvedValue({ data, info, hasAlpha: false });
       mocks.media.extract.mockResolvedValue({ buffer: extracted, format: RawExtractedFormat.Jpeg });
       mocks.media.getImageDimensions.mockResolvedValue(info);
 

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -62,6 +62,7 @@ type DecodeImageOptions = {
 export interface DecodeToBufferOptions extends DecodeImageOptions {
   size?: number;
   orientation?: ExifOrientation;
+  checkAlpha?: boolean;
 }
 
 export type GenerateThumbnailOptions = Pick<ImageOptions, 'format' | 'quality' | 'progressive'> & DecodeToBufferOptions;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -62,7 +62,6 @@ type DecodeImageOptions = {
 export interface DecodeToBufferOptions extends DecodeImageOptions {
   size?: number;
   orientation?: ExifOrientation;
-  checkAlpha?: boolean;
 }
 
 export type GenerateThumbnailOptions = Pick<ImageOptions, 'format' | 'quality' | 'progressive'> & DecodeToBufferOptions;

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -153,7 +153,7 @@ describe('mimeTypes', () => {
     }
   });
 
-  describe('canHaveAlpha', () => {
+  describe('canBeTransparent', () => {
     for (const img of [
       'a.avif',
       'a.bmp',
@@ -169,13 +169,13 @@ describe('mimeTypes', () => {
       'a.webp',
     ]) {
       it(`should return true for ${img}`, () => {
-        expect(mimeTypes.canHaveAlpha(img)).toBe(true);
+        expect(mimeTypes.canBeTransparent(img)).toBe(true);
       });
     }
 
     for (const img of ['a.jpg', 'a.jpeg', 'a.jpe', 'a.insp', 'a.jp2', 'a.cr3', 'a.dng', 'a.nef', 'a.arw']) {
       it(`should return false for ${img}`, () => {
-        expect(mimeTypes.canHaveAlpha(img)).toBe(false);
+        expect(mimeTypes.canBeTransparent(img)).toBe(false);
       });
     }
   });

--- a/server/src/utils/mime-types.spec.ts
+++ b/server/src/utils/mime-types.spec.ts
@@ -153,6 +153,33 @@ describe('mimeTypes', () => {
     }
   });
 
+  describe('canHaveAlpha', () => {
+    for (const img of [
+      'a.avif',
+      'a.bmp',
+      'a.gif',
+      'a.heic',
+      'a.heif',
+      'a.hif',
+      'a.jxl',
+      'a.png',
+      'a.svg',
+      'a.tif',
+      'a.tiff',
+      'a.webp',
+    ]) {
+      it(`should return true for ${img}`, () => {
+        expect(mimeTypes.canHaveAlpha(img)).toBe(true);
+      });
+    }
+
+    for (const img of ['a.jpg', 'a.jpeg', 'a.jpe', 'a.insp', 'a.jp2', 'a.cr3', 'a.dng', 'a.nef', 'a.arw']) {
+      it(`should return false for ${img}`, () => {
+        expect(mimeTypes.canHaveAlpha(img)).toBe(false);
+      });
+    }
+  });
+
   describe('animated image', () => {
     for (const img of ['a.avif', 'a.gif', 'a.webp']) {
       it('should identify animated image mime types as such', () => {

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -77,6 +77,21 @@ const extensionOverrides: Record<string, string> = {
   'image/jpeg': '.jpg',
 };
 
+const alphaCapableExtensions = new Set([
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.hif',
+  '.jxl',
+  '.png',
+  '.svg',
+  '.tif',
+  '.tiff',
+  '.webp',
+]);
+
 const profileExtensions = new Set(['.avif', '.dng', '.heic', '.heif', '.jpeg', '.jpg', '.png', '.webp', '.svg']);
 const profile: Record<string, string[]> = Object.fromEntries(
   Object.entries(image).filter(([key]) => profileExtensions.has(key)),
@@ -134,6 +149,7 @@ export const mimeTypes = {
   isProfile: (filename: string) => isType(filename, profile),
   isSidecar: (filename: string) => isType(filename, sidecar),
   isVideo: (filename: string) => isType(filename, video),
+  canHaveAlpha: (filename: string) => alphaCapableExtensions.has(extname(filename).toLowerCase()),
   isRaw: (filename: string) => isType(filename, raw),
   lookup,
   /** return an extension (including a leading `.`) for a mime-type */

--- a/server/src/utils/mime-types.ts
+++ b/server/src/utils/mime-types.ts
@@ -77,7 +77,7 @@ const extensionOverrides: Record<string, string> = {
   'image/jpeg': '.jpg',
 };
 
-const alphaCapableExtensions = new Set([
+const transparentCapableExtensions = new Set([
   '.avif',
   '.bmp',
   '.gif',
@@ -149,7 +149,7 @@ export const mimeTypes = {
   isProfile: (filename: string) => isType(filename, profile),
   isSidecar: (filename: string) => isType(filename, sidecar),
   isVideo: (filename: string) => isType(filename, video),
-  canHaveAlpha: (filename: string) => alphaCapableExtensions.has(extname(filename).toLowerCase()),
+  canBeTransparent: (filename: string) => transparentCapableExtensions.has(extname(filename).toLowerCase()),
   isRaw: (filename: string) => isType(filename, raw),
   lookup,
   /** return an extension (including a leading `.`) for a mime-type */

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -8,10 +8,10 @@ export const newMediaRepositoryMock = (): Mocked<RepositoryInterface<MediaReposi
     writeExif: vitest.fn().mockImplementation(() => Promise.resolve()),
     copyTagGroup: vitest.fn().mockImplementation(() => Promise.resolve()),
     generateThumbhash: vitest.fn().mockResolvedValue(Buffer.from('')),
-    decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {}, hasAlpha: false }),
+    decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {} }),
     extract: vitest.fn().mockResolvedValue(null),
     probe: vitest.fn(),
     transcode: vitest.fn(),
-    getImageDimensions: vitest.fn(),
+    getImageMetadata: vitest.fn(),
   };
 };

--- a/server/test/repositories/media.repository.mock.ts
+++ b/server/test/repositories/media.repository.mock.ts
@@ -8,7 +8,7 @@ export const newMediaRepositoryMock = (): Mocked<RepositoryInterface<MediaReposi
     writeExif: vitest.fn().mockImplementation(() => Promise.resolve()),
     copyTagGroup: vitest.fn().mockImplementation(() => Promise.resolve()),
     generateThumbhash: vitest.fn().mockResolvedValue(Buffer.from('')),
-    decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {} }),
+    decodeImage: vitest.fn().mockResolvedValue({ data: Buffer.from(''), info: {}, hasAlpha: false }),
     extract: vitest.fn().mockResolvedValue(null),
     probe: vitest.fn(),
     transcode: vitest.fn(),


### PR DESCRIPTION
When source format has alpha transparency(i.e. WEBP), but target format does not (JPG) - and the image has alpha channel, instead of losing the alpha channel, override the target format to be WEBP. 

Only for images with an actual alpha channel. 