### PR TITLE
fix(server): db restore failure when `DB_URL` is set to unix-domain socket connection

### DIFF
--- a/server/src/services/database-backup.service.spec.ts
+++ b/server/src/services/database-backup.service.spec.ts
@@ -554,7 +554,7 @@ describe(DatabaseBackupService.name, () => {
             "bin": "/usr/lib/postgresql/14/bin/psql",
             "databaseMajorVersion": 14,
             "databasePassword": "",
-            "databaseUsername": "",
+            "databaseUsername": "postgres",
             "databaseVersion": "14.10 (Debian 14.10-1.pgdg120+1)",
           }
         `);

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -139,7 +139,13 @@ export class DatabaseBackupService {
         // remove known bad parameters
         parsedUrl.searchParams.delete('uselibpqcompat');
 
-        databaseUsername = parsedUrl.username;
+        databaseUsername = parsedUrl.username || undefined;
+
+        // Fallback to query param
+        if (!databaseUsername) {
+          databaseUsername = parsedUrl.searchParams.get('user');
+        }
+
         url = parsedUrl.toString();
       }
 

--- a/server/src/services/database-backup.service.ts
+++ b/server/src/services/database-backup.service.ts
@@ -139,12 +139,7 @@ export class DatabaseBackupService {
         // remove known bad parameters
         parsedUrl.searchParams.delete('uselibpqcompat');
 
-        databaseUsername = parsedUrl.username || undefined;
-
-        // Fallback to query param
-        if (!databaseUsername) {
-          databaseUsername = parsedUrl.searchParams.get('user');
-        }
+        databaseUsername = parsedUrl.username || parsedUrl.searchParams.get('user');
 
         url = parsedUrl.toString();
       }


### PR DESCRIPTION
## Description

When setting `DB_URL` to a postgres unix socket like:

```
postgresql:///immich?host=/var/run/postgresql
  or
postgresql://%2Fvar%2Frun%2Fpostgresql/immich
```

`parsedUrl.username` returns an empty string instead of null, so `databaseUsername ??= 'postgres'` never gets executed causing the following error during the postgres dump restore process

```
Error: psql non-zero exit code (3)
ERROR:  zero-length delimited identifier at or near """"
LINE 1: GRANT ALL ON SCHEMA public TO "";
```

And also try to get postgres username from query parameters if parsedUrl didn't return any username:
```
if (!databaseUsername) {
  databaseUsername = parsedUrl.searchParams.get('user');
}
```

to support `DB_URL` set to `postgresql:///immich?host=/var/run/postgresql&user=immich&password=immich`

Fixes #26140

## How Has This Been Tested?

In devcontainer I've removed the defaults env `DB_USERNAME`, `DB_PASSWORD`, `DS_DATABASE_NAME` and set `DB_URL`

mounted a docker volume to `/var/run/postgresql` for both immich-server and database in docker-compose.dev.yml

Tested with the following urls:
```
postgresql:///immich?host=/var/run/postgresql
postgresql:///immich?host=/var/run/postgresql&user=immich&password=immich
postgresql://%2Fvar%2Flib%2Fpostgresql/immich?user=immich&password=immich
```
- [x] Onboarding setup
- [x] Backup (from UI)
- [x] Restore from settings page
- [x] Restore from onboarding

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.
none
...
