### PR TITLE
fix(web): clear unsaved asset description when changing asset

### DIFF
--- a/web/src/lib/components/asset-viewer/detail-panel-description.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.spec.ts
@@ -1,0 +1,65 @@
+import { assetFactory } from '@test-data/factories/asset-factory';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import DetailPanelDescription from './detail-panel-description.svelte';
+
+describe('DetailPanelDescription', () => {
+  it('clears unsaved draft on asset change', async () => {
+    const user = userEvent.setup();
+
+    const assetA = assetFactory.build({
+      id: 'asset-a',
+      exifInfo: { description: '' },
+    });
+    const assetB = assetFactory.build({
+      id: 'asset-b',
+      exifInfo: { description: '' },
+    });
+
+    const { rerender } = render(DetailPanelDescription, {
+      props: {
+        asset: assetA,
+        isOwner: true,
+      },
+    });
+
+    const textarea = screen.getByTestId('autogrow-textarea') as HTMLTextAreaElement;
+    await user.type(textarea, 'unsaved draft');
+    expect(textarea).toHaveValue('unsaved draft');
+
+    await rerender({
+      asset: assetB,
+      isOwner: true,
+    });
+
+    expect(screen.getByTestId('autogrow-textarea')).toHaveValue('');
+  });
+
+  it('updates description on asset switch', async () => {
+    const assetA = assetFactory.build({
+      id: 'asset-a',
+      exifInfo: { description: 'first description' },
+    });
+    const assetB = assetFactory.build({
+      id: 'asset-b',
+      exifInfo: { description: 'second description' },
+    });
+
+    const { rerender } = render(DetailPanelDescription, {
+      props: {
+        asset: assetA,
+        isOwner: true,
+      },
+    });
+
+    expect(screen.getByTestId('autogrow-textarea')).toHaveValue('first description');
+
+    await rerender({
+      asset: assetB,
+      isOwner: true,
+    });
+
+    expect(screen.getByTestId('autogrow-textarea')).toHaveValue('second description');
+  });
+});

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -14,7 +14,12 @@
   let { asset, isOwner }: Props = $props();
 
   let currentDescription = $derived(asset.exifInfo?.description ?? '');
-  let description = $derived(currentDescription);
+  let description = $state('');
+
+  $effect.pre(() => {
+    void asset.id;
+    description = currentDescription;
+  });
 
   const handleFocusOut = async () => {
     if (description === currentDescription) {

--- a/web/src/lib/components/asset-viewer/detail-panel-description.svelte
+++ b/web/src/lib/components/asset-viewer/detail-panel-description.svelte
@@ -13,15 +13,10 @@
 
   let { asset, isOwner }: Props = $props();
 
-  let currentDescription = $derived(asset.exifInfo?.description ?? '');
-  let description = $state('');
-
-  $effect.pre(() => {
-    void asset.id;
-    description = currentDescription;
-  });
+  let description = $derived(asset.exifInfo?.description ?? '');
 
   const handleFocusOut = async () => {
+    const currentDescription = asset.exifInfo?.description ?? '';
     if (description === currentDescription) {
       return;
     }


### PR DESCRIPTION
This fixes a detail panel bug where an unsaved description could leak into the next asset when navigating between assets with the same saved description (for example, both empty)

Should fix #15990