### PR TITLE
fix(web): clear cache when asset changes

### DIFF
--- a/web/src/lib/managers/AssetCacheManager.svelte.ts
+++ b/web/src/lib/managers/AssetCacheManager.svelte.ts
@@ -9,10 +9,7 @@ class AsyncCache<K, V> {
 
   constructor(private fetcher: (params: K) => Promise<V>) {}
 
-  async getOrFetch(
-    params: K,
-    updateCache: boolean,
-  ): Promise<V> {
+  async getOrFetch(params: K, updateCache: boolean): Promise<V> {
     const cacheKey = defaultSerializer(params);
 
     const cached = this.#cache.get(cacheKey);
@@ -54,7 +51,7 @@ class AssetCacheManager {
   }
 
   async getAsset({ id, key, slug }: { id: string; key?: string; slug?: string }, updateCache = true) {
-    return this.#assetCache.getOrFetch({ id, key, slug}, updateCache);
+    return this.#assetCache.getOrFetch({ id, key, slug }, updateCache);
   }
 
   async getAssetOcr(id: string) {

--- a/web/src/lib/managers/AssetCacheManager.svelte.ts
+++ b/web/src/lib/managers/AssetCacheManager.svelte.ts
@@ -1,30 +1,36 @@
+import { authManager } from '$lib/managers/auth-manager.svelte';
 import { eventManager } from '$lib/managers/event-manager.svelte';
-import { getAssetInfo, getAssetOcr, type AssetOcrResponseDto, type AssetResponseDto } from '@immich/sdk';
+import { getAssetInfo, getAssetOcr } from '@immich/sdk';
 
 const defaultSerializer = <K>(params: K) => JSON.stringify(params);
 
-class AsyncCache<V> {
+class AsyncCache<K, V> {
   #cache = new Map<string, V>();
 
-  async getOrFetch<K>(
+  constructor(private fetcher: (params: K) => Promise<V>) {}
+
+  async getOrFetch(
     params: K,
-    fetcher: (params: K) => Promise<V>,
-    keySerializer: (params: K) => string = defaultSerializer,
     updateCache: boolean,
   ): Promise<V> {
-    const cacheKey = keySerializer(params);
+    const cacheKey = defaultSerializer(params);
 
     const cached = this.#cache.get(cacheKey);
     if (cached) {
       return cached;
     }
 
-    const value = await fetcher(params);
+    const value = await this.fetcher(params);
     if (value && updateCache) {
       this.#cache.set(cacheKey, value);
     }
 
     return value;
+  }
+
+  clearKey(params: K) {
+    const cacheKey = defaultSerializer(params);
+    this.#cache.delete(cacheKey);
   }
 
   clear() {
@@ -33,24 +39,32 @@ class AsyncCache<V> {
 }
 
 class AssetCacheManager {
-  #assetCache = new AsyncCache<AssetResponseDto>();
-  #ocrCache = new AsyncCache<AssetOcrResponseDto[]>();
+  #assetCache = new AsyncCache(getAssetInfo);
+  #ocrCache = new AsyncCache(getAssetOcr);
 
   constructor() {
     eventManager.on({
-      AssetEditsApplied: () => {
-        this.#assetCache.clear();
-        this.#ocrCache.clear();
+      AssetEditsApplied: (assetId) => {
+        this.invalidateAsset(assetId);
+      },
+      AssetUpdate: (asset) => {
+        this.invalidateAsset(asset.id);
       },
     });
   }
 
-  async getAsset(assetIdentifier: { key?: string; slug?: string; id: string }, updateCache = true) {
-    return this.#assetCache.getOrFetch(assetIdentifier, getAssetInfo, defaultSerializer, updateCache);
+  async getAsset({ id, key, slug }: { id: string; key?: string; slug?: string }, updateCache = true) {
+    return this.#assetCache.getOrFetch({ id, key, slug}, updateCache);
   }
 
   async getAssetOcr(id: string) {
-    return this.#ocrCache.getOrFetch({ id }, getAssetOcr, (params) => params.id, true);
+    return this.#ocrCache.getOrFetch({ id }, true);
+  }
+
+  invalidateAsset(id: string) {
+    const { key, slug } = authManager.params;
+    this.#assetCache.clearKey({ id, key, slug });
+    this.#ocrCache.clearKey({ id });
   }
 
   clearAssetCache() {

--- a/web/src/lib/stores/ocr.svelte.spec.ts
+++ b/web/src/lib/stores/ocr.svelte.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the SDK
 vi.mock('@immich/sdk', () => ({
+  getAssetInfo: vi.fn(),
   getAssetOcr: vi.fn(),
 }));
 

--- a/web/src/lib/stores/websocket.ts
+++ b/web/src/lib/stores/websocket.ts
@@ -77,6 +77,7 @@ websocket
   .on('on_new_release', (event) => eventManager.emit('ReleaseEvent', event))
   .on('on_session_delete', () => authManager.logout())
   .on('on_user_delete', (id) => eventManager.emit('UserAdminDeleted', { id }))
+  .on('on_asset_update', (asset) => eventManager.emit('AssetUpdate', asset))
   .on('on_person_thumbnail', (id) => eventManager.emit('PersonThumbnailReady', { id }))
   .on('on_notification', () => notificationManager.refresh())
   .on('connect_error', (e) => console.log('Websocket Connect Error', e));


### PR DESCRIPTION
This fixes a caching issue when updating an asset (description, rating, location, etc.) via the detail panel. If you open an asset and favorite it, then move to the next asset and return, the original asset incorrectly shows as no longer favorited until you reload the page, at which point the favorite status appears correctly.

Fixed by removing assets from the cache when they are updated.