### PR TITLE
fix(release): add docker-compose.rootless.yml to released assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
           body_path: ${{ steps.changelog.outputs.path }}
           draft: true
           files: |
-            docker/docker-compose*.yml
+            docker/docker-compose.yml
+            docker/docker-compose.rootless.yml
             docker/example.env
             docker/hwaccel.ml.yml
             docker/hwaccel.transcoding.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           body_path: ${{ steps.changelog.outputs.path }}
           draft: true
           files: |
-            docker/docker-compose.yml
+            docker/docker-compose*.yml
             docker/example.env
             docker/hwaccel.ml.yml
             docker/hwaccel.transcoding.yml


### PR DESCRIPTION

## Description

Since there is a warning in the [docker directory](https://github.com/immich-app/immich/tree/main/docker):
"Make sure to use the docker-compose.yml of the current release"

I imagine this warning applies to other docker-compose files, so it would make sense to release them.

E.g. It would make it slightly easier to get the assets for other configurations, e.g. rootless (#2750) for any new release:

```
wget -O docker-compose.rootless.yml https://github.com/immich-app/immich/releases/latest/download/docker-compose.rootless.yml
```

NOTE: I did not change the docs or FAQ entry that links the docker-compose file for rootless, mentioned in the comment https://github.com/immich-app/immich/issues/2750#issuecomment-2292022493 but that may be something worth changing if the file is released.

## How Has This Been Tested?

None, N/A

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

N/A