### PR TITLE
style: consistent dark browser UI with Safari in asset viewer

### DIFF
--- a/web/src/lib/actions/__test__/force-dark-theme.spec.ts
+++ b/web/src/lib/actions/__test__/force-dark-theme.spec.ts
@@ -1,0 +1,38 @@
+import { Theme } from '$lib/constants';
+import { themeManager } from '$lib/managers/theme-manager.svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { forceDarkTheme } from '../force-dark-theme';
+
+describe('forceDarkTheme Action', () => {
+  beforeEach(() => {
+    document.body.className = '';
+  });
+
+  it('adds dark class on render, and removes it on destroy when light theme in use', () => {
+    themeManager.setTheme(Theme.LIGHT);
+
+    expect(document.body.classList.contains('dark')).toBe(false);
+
+    const node = document.createElement('div');
+    const action = forceDarkTheme(node);
+
+    expect(document.body.classList.contains('dark')).toBe(true);
+
+    action?.destroy?.();
+    expect(document.body.classList.contains('dark')).toBe(false);
+  });
+
+  it('does not remove dark class on destroy when dark theme in use', () => {
+    themeManager.setTheme(Theme.DARK);
+
+    expect(document.body.classList.contains('dark')).toBe(true);
+
+    const node = document.createElement('div');
+    const action = forceDarkTheme(node);
+
+    expect(document.body.classList.contains('dark')).toBe(true);
+
+    action?.destroy?.();
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+});

--- a/web/src/lib/actions/force-dark-theme.ts
+++ b/web/src/lib/actions/force-dark-theme.ts
@@ -1,0 +1,18 @@
+import { themeManager } from '$lib/managers/theme-manager.svelte';
+import type { Action } from 'svelte/action';
+
+/**
+ * Ensures the 'dark' theme is used while the element is mounted, which makes
+ * Safari 26 darken the browser UI. More "cinema" like UX for AssetViewer.
+ */
+export const forceDarkTheme: Action = (_) => {
+  document.body.classList.add('dark');
+
+  return {
+    destroy() {
+      if (!themeManager.isDark) {
+        document.body.classList.remove('dark');
+      }
+    },
+  };
+};

--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { focusTrap } from '$lib/actions/focus-trap';
+  import { forceDarkTheme } from '$lib/actions/force-dark-theme';
   import type { Action, OnAction, PreAction } from '$lib/components/asset-viewer/actions/action';
   import NextAssetAction from '$lib/components/asset-viewer/actions/next-asset-action.svelte';
   import PreviousAssetAction from '$lib/components/asset-viewer/actions/previous-asset-action.svelte';
@@ -442,6 +443,7 @@
   id="immich-asset-viewer"
   class="fixed start-0 top-0 grid size-full grid-cols-4 grid-rows-[64px_1fr] overflow-hidden bg-black"
   use:focusTrap
+  use:forceDarkTheme
   bind:this={assetViewerHtmlElement}
 >
   <!-- Top navigation bar -->


### PR DESCRIPTION
## Description

This is not critical and affects a single browser.

Safari 26 matches the colour of the browser UI (address bar, tabs etc) to the background colour of `body` (rather than `meta name="theme-colour"` in earlier versions). When a photo is displayed in the asset manager, which has a black background, it's nice for the browser UI to also be black / dark to give focus to the photo.

When the site theme is dark, the browser UI is always black, so all good.
When the site theme is light, the browser UI is usually grey, with an exception. If you go directly to the photo URL, then it's black.

- Go to https://demo.immich.app/
- Enable light theme
  - Browser UI is grey, which suits this view
- Click on an image to open asset viewer
  - Browser UI remains grey
- Reload URL (or go to https://demo.immich.app/photos/7ed1f888-1a8f-407a-8f5c-7163231b8cc6)
  - Browser UI is black, which better suits this view
- Exit asset viewer 
  - Browser UI is grey (expected, to match the light theme)

This change makes the UI consistently dark when AssetViewer is rendered.
It adds an action which is used by AssetViewer.
That adds the `dark` class to `body` when the component mounts. It removes the `dark` class from `body` if the dark theme is not in use. Adding/removing the class causes Safari to update the UI colour.

<img width="966" height="686" alt="Bildschirmfoto 2026-02-16 um 22 08 20" src="https://github.com/user-attachments/assets/eae1345e-8608-440c-85fa-8f8684b23425" />
<img width="966" height="686" alt="Bildschirmfoto 2026-02-16 um 22 08 42" src="https://github.com/user-attachments/assets/13c4996e-db8a-4389-9adf-900c4d9e9551" />

## How Has This Been Tested?

- Follow the steps above in Safari 26, with and without the change. With the change, the browser UI is always dark regardless of the site theme setting.
- Tests added

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- ~[ ] I have made corresponding changes to the documentation if applicable~ N/A
- [x] I have no unrelated changes in the PR.
- ~[ ] I have confirmed that any new dependencies are strictly necessary.~ N/A
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- ~[ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~ N/A
- ~[ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~ N/A

## Please describe to which degree, if any, an LLM was used in creating this pull request.
Some research of the codebase looking for what is implemented where. Not LLM-generated code.