### PR TITLE
fix: apply dark styles to context menu in dark theme

### DIFF
--- a/web/src/lib/components/shared-components/context-menu/menu-option.svelte
+++ b/web/src/lib/components/shared-components/context-menu/menu-option.svelte
@@ -20,8 +20,8 @@
     text,
     subtitle = '',
     icon,
-    activeColor = 'bg-slate-300',
-    textColor = 'text-immich-fg dark:text-immich-dark-bg',
+    activeColor = 'bg-slate-300 dark:bg-gray-600',
+    textColor = 'text-immich-fg dark:text-immich-dark-fg',
     onClick,
     shortcut = null,
     shortcutLabel = '',
@@ -53,9 +53,9 @@
   onclick={handleClick}
   onmouseover={() => ($selectedIdStore = id)}
   onmouseleave={() => ($selectedIdStore = undefined)}
-  class="w-full p-4 text-start text-sm font-medium {textColor} focus:outline-none focus:ring-2 focus:ring-inset cursor-pointer border-gray-200 flex gap-2 items-center {isActive
+  class="w-full p-4 text-start text-sm font-medium {textColor} focus:outline-none focus:ring-2 focus:ring-inset cursor-pointer border-gray-200 dark:border-gray-700 flex gap-2 items-center {isActive
     ? activeColor
-    : 'bg-slate-100'}"
+    : 'bg-slate-100 dark:bg-gray-900'}"
   role="menuitem"
 >
   {#if icon}
@@ -65,13 +65,13 @@
     <div class="flex justify-between">
       {text}
       {#if shortcutLabel}
-        <span class="text-gray-500 ps-4">
+        <span class="text-gray-500 dark:text-gray-400 ps-4">
           {shortcutLabel}
         </span>
       {/if}
     </div>
     {#if subtitle}
-      <p class="text-xs text-gray-500">
+      <p class="text-xs text-gray-500 dark:text-gray-400">
         {subtitle}
       </p>
     {/if}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #26198

Adds `dark:` classes, aiming to align with other components.

I've used `dark:bg-gray-900` for the menu options and `dark:bg-gray-400`, which gives decent contrast.

## How Has This Been Tested?

- [ ] Enable dark theme, select photo, click menu or add to button. Menu is dark.
- [ ] Enable light theme, select photo, click menu or add to button. Menu is light.

## Screenshot

<!-- Images go below this line. -->

<img width="331" height="162" alt="Bildschirmfoto 2026-02-18 um 12 04 08" src="https://github.com/user-attachments/assets/a7238c38-fb88-4e7f-ba0b-17232fe2c32b" />


## API Changes
N/A

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- ~[ ] I have made corresponding changes to the documentation if applicable~ N/A
- [x] I have no unrelated changes in the PR.
- ~[ ] I have confirmed that any new dependencies are strictly necessary.~ N/A
- ~[ ] I have written tests for new code (if applicable) ~ N/A
- [x] I have followed naming conventions/patterns in the surrounding code
- ~[ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.~ N/A
- ~[ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)~ N/A

## Please describe to which degree, if any, an LLM was used in creating this pull request.
N/A
