### PR TITLE
fix(web): unblock escape after opening context menu

### DIFF
--- a/web/src/lib/actions/context-menu-navigation.ts
+++ b/web/src/lib/actions/context-menu-navigation.ts
@@ -98,7 +98,7 @@ export const contextMenuNavigation: Action<HTMLElement, Options> = (node, option
   const { destroy } = shortcuts(node, [
     { shortcut: { key: 'ArrowUp' }, onShortcut: (event) => moveSelection('up', event) },
     { shortcut: { key: 'ArrowDown' }, onShortcut: (event) => moveSelection('down', event) },
-    { shortcut: { key: 'Escape' }, onShortcut: (event) => onEscape(event) },
+    { shortcut: { key: 'Escape' }, onShortcut: (event) => onEscape(event), preventDefault: false },
     { shortcut: { key: ' ' }, onShortcut: (event) => handleClick(event) },
     { shortcut: { key: 'Enter' }, onShortcut: (event) => handleClick(event) },
   ]);


### PR DESCRIPTION
Fixes `Escape` being swallowed for elements that use `contextMenuNavigation` like in this situation:
1. Select an asset on the timeline
2. Open more options menu and press escape
3. Press escape again to clear selection, but does not work