### PR TITLE
fix: metadata crash

### DIFF
--- a/server/src/utils/tasks.ts
+++ b/server/src/utils/tasks.ts
@@ -1,0 +1,13 @@
+export type Task = () => Promise<unknown> | unknown;
+
+export class Tasks {
+  private tasks: Task[] = [];
+
+  push(...tasks: Task[]) {
+    this.tasks.push(...tasks);
+  }
+
+  async all() {
+    await Promise.all(this.tasks.map((item) => item()));
+  }
+}


### PR DESCRIPTION
There was an unawaited promise that was causing the metadata extraction job to crash the server. Fixed by delaying execution until the promise is awaited.