### PR TITLE
perf: add indexes to improve People API response times

### DIFF
--- a/server/src/schema/migrations/1771478781948-PeopleSearchIndex.ts
+++ b/server/src/schema/migrations/1771478781948-PeopleSearchIndex.ts
@@ -1,0 +1,15 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`CREATE INDEX "asset_id_timeline_notDeleted_idx" ON "asset" ("id") WHERE visibility = 'timeline' AND "deletedAt" IS NULL;`.execute(db);
+  await sql`CREATE INDEX "asset_face_personId_assetId_notDeleted_isVisible_idx" ON "asset_face" ("personId", "assetId") WHERE "deletedAt" IS NULL AND "isVisible" IS TRUE;`.execute(db);
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_asset_id_timeline_notDeleted_idx', '{"type":"index","name":"asset_id_timeline_notDeleted_idx","sql":"CREATE INDEX \\"asset_id_timeline_notDeleted_idx\\" ON \\"asset\\" (\\"id\\") WHERE visibility = ''timeline'' AND \\"deletedAt\\" IS NULL;"}'::jsonb);`.execute(db);
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('index_asset_face_personId_assetId_notDeleted_isVisible_idx', '{"type":"index","name":"asset_face_personId_assetId_notDeleted_isVisible_idx","sql":"CREATE INDEX \\"asset_face_personId_assetId_notDeleted_isVisible_idx\\" ON \\"asset_face\\" (\\"personId\\", \\"assetId\\") WHERE \\"deletedAt\\" IS NULL AND \\"isVisible\\" IS TRUE;"}'::jsonb);`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP INDEX "asset_id_timeline_notDeleted_idx";`.execute(db);
+  await sql`DROP INDEX "asset_face_personId_assetId_notDeleted_isVisible_idx";`.execute(db);
+  await sql`DELETE FROM "migration_overrides" WHERE "name" = 'index_asset_id_timeline_notDeleted_idx';`.execute(db);
+  await sql`DELETE FROM "migration_overrides" WHERE "name" = 'index_asset_face_personId_assetId_notDeleted_isVisible_idx';`.execute(db);
+}

--- a/server/src/schema/tables/asset-face.table.ts
+++ b/server/src/schema/tables/asset-face.table.ts
@@ -27,6 +27,11 @@ import {
 })
 // schemaFromDatabase does not preserve column order
 @Index({ name: 'asset_face_assetId_personId_idx', columns: ['assetId', 'personId'] })
+@Index({
+  name: 'asset_face_personId_assetId_notDeleted_isVisible_idx',
+  columns: ['personId', 'assetId'],
+  where: '"deletedAt" IS NULL AND "isVisible" IS TRUE',
+})
 @Index({ columns: ['personId', 'assetId'] })
 export class AssetFaceTable {
   @PrimaryGeneratedColumn()

--- a/server/src/schema/tables/asset.table.ts
+++ b/server/src/schema/tables/asset.table.ts
@@ -55,6 +55,11 @@ import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
   using: 'gin',
   expression: 'f_unaccent("originalFileName") gin_trgm_ops',
 })
+@Index({
+  name: 'asset_id_timeline_notDeleted_idx',
+  columns: ['id'],
+  where: `visibility = 'timeline' AND "deletedAt" IS NULL`,
+})
 // For all assets, each originalpath must be unique per user and library
 export class AssetTable {
   @PrimaryGeneratedColumn()


### PR DESCRIPTION
## Description

Opening the search modal at the top of the page makes a call to `/api/people?withHidden=false` to show the people you can filter by. Browsing to /people from the left nav makes a call to `/api/people?withHidden=true` to list all people before the page appears to change. 

Both of these calls are slow on my production server (650k+ assets, ~1.9m faces), taking 5.5s - 6s on average.

This PR adds SQL indexes to improve the API's responsiveness.

On my less-powerful dev server (using my production database), this speeds up the API response from about 12s -> 2s. 


## How Has This Been Tested?

I've timed API responsiveness (while opening the search modal or browsing to /people) using Chrome's DevTools, testing 4-5x to make sure it's warm. 

I've also timed raw queries with and without the indexes in postgres. Both queries timed at about 3-4s each before indexing. After adding the index, the first times at around 350ms and the second times at around 1.2s.

```
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
select
  p.*
from person p
join asset_face af
  on af."personId" = p.id
join asset a
  on af."assetId" = a.id
 and a.visibility = 'timeline'
 and a."deletedAt" is null
where
  p."ownerId" = '<OWNER_UUID>'
  and af."deletedAt" is null
  and af."isVisible" is true
  and p."isHidden" = false
group by p.id
having
  (p.name <> '' or count(af."assetId") >= 1)
order by
  p."isHidden" asc,
  p."isFavorite" desc,
  (NULLIF(p.name, '') is null) asc,
  count(af."assetId") desc,
  NULLIF(p.name, '') asc nulls last,
  p."createdAt"
limit 501
offset 0;
```

```
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
select
  coalesce(count(*), 0) as total,
  coalesce(count(*) filter (where "isHidden" = true), 0) as hidden
from person p
where exists (
  select 1
  from asset_face af
  where af."personId" = p.id
    and af."deletedAt" is null
    and af."isVisible" = true
    and exists (
      select 1
      from asset a
      where a.id = af."assetId"
        and a.visibility = 'timeline'
        and a."deletedAt" is null
    )
)
and p."ownerId" = '<OWNER_UUID>';
```

## Note

There's a potential for further optimization here if the [getNumberOfPeople() query](https://github.com/immich-app/immich/blob/316f86d25e0300481d30b1aab6f77b9dcc6e4b90/server/src/repositories/person.repository.ts#L370) (second query above) could avoid doing a join on asset_face and asset just to end with a count for pagination. This is the much slower query on my system, even with the indexes. 

But I don't feel comfortable suggesting a change here, as I know person visibility is a sensitive and important area for users, and I'm not familiar with the differences between person's `isHidden` column and asset_face's `isVisible` column and how Immich actually uses those — or if either would actually matter when counting a total of how many people belong to a specific person `ownerId` for pagination purposes.


## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code — **the index names might be too descriptive... I couldn't find a similar example in the other schema files**
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I used Codex to search the codebase for the relevant queries, convert them from Kysely functions to raw SQL, and analyze the postgres explain() outputs.


