### PR TITLE
fix(mobile): infer drag intent early

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_page.widget.dart
@@ -143,8 +143,8 @@ class _AssetPageState extends ConsumerState<AssetPage> {
 
     if (_dragIntent == _DragIntent.none) {
       _dragIntent = switch ((details.globalPosition - _dragStart!.globalPosition).dy) {
-        < -kTouchSlop => _DragIntent.scroll,
-        > kTouchSlop => _DragIntent.dismiss,
+        < 0 => _DragIntent.scroll,
+        > 0 => _DragIntent.dismiss,
         _ => _DragIntent.none,
       };
     }


### PR DESCRIPTION
## Description

The drag intent was not set until it reached the kTouchSlop threshold. This is not necessary as flutter already has its own heuristics for preventing unintended drags.

The result of using kTouchSlop is that dismissing or scroll can feel a little delayed, and will jump from 0 to kTouchSlop (18px) rather than moving smoothly.

## How Has This Been Tested?

Pixel 8a.