### PR TITLE
chore: update task commands in web/mise.toml to use pnpm

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -37,13 +37,12 @@ run = "pnpm install --filter @immich/sdk --frozen-lockfile"
 
 [tasks."sdk:build"]
 dir = "open-api/typescript-sdk"
-env._.path = "./node_modules/.bin"
-run = "tsc"
+run = "pnpm run build"
 
 # i18n tasks
 [tasks."i18n:format"]
 dir = "i18n"
-run = { task = ":i18n:format-fix" }
+run = "pnpm run format"
 
 [tasks."i18n:format-fix"]
 dir = "i18n"

--- a/web/mise.toml
+++ b/web/mise.toml
@@ -1,6 +1,3 @@
-[env]
-IMMICH_SERVER_URL = "https://demo.immich.app"
-
 [tasks.install]
 run = "pnpm install --filter immich-web --frozen-lockfile"
 
@@ -16,6 +13,10 @@ run = "pnpm run preview"
 [tasks.start]
 depends = [":install", "//:sdk:install", "//:sdk:build"]
 run = "pnpm run dev"
+
+[tasks."start-demo"]
+env.IMMICH_SERVER_URL = "https://demo.immich.app"
+run = { task = ":start" }
 
 [tasks.test]
 run = "pnpm run test"

--- a/web/mise.toml
+++ b/web/mise.toml
@@ -1,56 +1,44 @@
+[env]
+IMMICH_SERVER_URL = "https://demo.immich.app"
+
 [tasks.install]
 run = "pnpm install --filter immich-web --frozen-lockfile"
 
-[tasks."svelte-kit-sync"]
-env._.path = "./node_modules/.bin"
-run = "svelte-kit sync"
-
 [tasks.build]
-env._.path = "./node_modules/.bin"
-run = "vite build"
+run = "pnpm run build"
 
 [tasks."build-stats"]
-env.BUILD_STATS = "true"
-env._.path = "./node_modules/.bin"
-run = "vite build"
+run = "pnpm run build:stats"
 
 [tasks.preview]
-env._.path = "./node_modules/.bin"
-run = "vite preview"
+run = "pnpm run preview"
 
 [tasks.start]
-env._.path = "./node_modules/.bin"
-run = "vite dev --host 0.0.0.0 --port 3000"
+run = "pnpm run dev"
 
 [tasks.test]
-depends = ["svelte-kit-sync"]
-env._.path = "./node_modules/.bin"
-run = "vitest"
+run = "pnpm run test"
 
 [tasks.format]
-env._.path = "./node_modules/.bin"
-run = "prettier --check ."
+run = "pnpm run format"
 
 [tasks."format-fix"]
-env._.path = "./node_modules/.bin"
-run = "prettier --write ."
+run = "pnpm run format:fix"
 
 [tasks.lint]
-env._.path = "./node_modules/.bin"
-run = "eslint . --max-warnings 0 --concurrency 4"
+run = "pnpm run lint"
 
 [tasks."lint-fix"]
-run = { task = "lint --fix" }
+run = "pnpm run lint:fix"
 
-[tasks.check]
-depends = ["svelte-kit-sync"]
-env._.path = "./node_modules/.bin"
-run = "tsc --noEmit"
+[tasks.check-typescript]
+run = "pnpm run check:typescript"
 
 [tasks."check-svelte"]
-depends = ["svelte-kit-sync"]
-env._.path = "./node_modules/.bin"
-run = "svelte-check --no-tsconfig --fail-on-warnings"
+run = "pnpm run check:svelte"
+
+[tasks.check]
+run = { tasks = [":check-typescript", ":check-svelte"] }
 
 [tasks.checklist]
 run = [

--- a/web/mise.toml
+++ b/web/mise.toml
@@ -14,6 +14,7 @@ run = "pnpm run build:stats"
 run = "pnpm run preview"
 
 [tasks.start]
+depends = [":install", "//:sdk:install", "//:sdk:build"]
 run = "pnpm run dev"
 
 [tasks.test]


### PR DESCRIPTION
Refactor web/mise.toml to delegate to package.json scripts via pnpm run instead of duplicating commands. This avoids sync drift and keeps tasks aligned with package.json.

IMMICH_SERVER_URL is set automatically in the env, so `IMMICH_SERVER_URL=https://demo.immich.app/ pnpm run dev` becomes `mise run //web:start`

Removed explicit svelte-kit-sync dependencies; pnpm's prepare script handles it automatically
The checklist task includes Svelte (check:svelte) and TypeScript (check:typescript) code checks
