### PR TITLE
feat: allow partner sharing to configure a start date

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1670,6 +1670,8 @@
   "partner_can_access": "{partner} can access",
   "partner_can_access_assets": "All your photos and videos except those in Archived and Deleted",
   "partner_can_access_location": "The location where your photos were taken",
+  "partner_sharing_from_date": "Share from date",
+  "partner_sharing_from_date_description": "Only share photos and videos taken from this date onward",
   "partner_list_user_photos": "{user}'s photos",
   "partner_list_view_all": "View all",
   "partner_page_empty_message": "Your photos are not yet shared with any partner.",

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -19400,6 +19400,12 @@
       },
       "PartnerCreateDto": {
         "properties": {
+          "shareFromDate": {
+            "description": "Only share assets from this date onward",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
           "sharedWithId": {
             "description": "User ID to share with",
             "format": "uuid",
@@ -19452,6 +19458,11 @@
           "profileImagePath": {
             "description": "Profile image path",
             "type": "string"
+          },
+          "shareFromDate": {
+            "description": "Share assets from this date onward",
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -19469,11 +19480,14 @@
           "inTimeline": {
             "description": "Show partner assets in timeline",
             "type": "boolean"
+          },
+          "shareFromDate": {
+            "description": "Only share assets from this date onward",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           }
         },
-        "required": [
-          "inTimeline"
-        ],
         "type": "object"
       },
       "PeopleResponse": {
@@ -23276,6 +23290,12 @@
             "description": "In timeline",
             "type": "boolean"
           },
+          "shareFromDate": {
+            "description": "Share from date",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
           "sharedById": {
             "description": "Shared by ID",
             "type": "string"
@@ -23287,6 +23307,7 @@
         },
         "required": [
           "inTimeline",
+          "shareFromDate",
           "sharedById",
           "sharedWithId"
         ],

--- a/open-api/typescript-sdk/src/fetch-client.ts
+++ b/open-api/typescript-sdk/src/fetch-client.ts
@@ -1476,14 +1476,20 @@ export type PartnerResponseDto = {
     profileChangedAt: string;
     /** Profile image path */
     profileImagePath: string;
+    /** Share assets from this date onward */
+    shareFromDate?: string | null;
 };
 export type PartnerCreateDto = {
+    /** Only share assets from this date onward */
+    shareFromDate?: string | null;
     /** User ID to share with */
     sharedWithId: string;
 };
 export type PartnerUpdateDto = {
     /** Show partner assets in timeline */
-    inTimeline: boolean;
+    inTimeline?: boolean;
+    /** Only share assets from this date onward */
+    shareFromDate?: string | null;
 };
 export type PeopleResponseDto = {
     /** Whether there are more pages */
@@ -3169,6 +3175,8 @@ export type SyncPartnerDeleteV1 = {
 export type SyncPartnerV1 = {
     /** In timeline */
     inTimeline: boolean;
+    /** Share from date */
+    shareFromDate: string | null;
     /** Shared by ID */
     sharedById: string;
     /** Shared with ID */

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -213,6 +213,7 @@ export type Partner = {
   updatedAt: Date;
   updateId: string;
   inTimeline: boolean;
+  shareFromDate: Date | null;
 };
 
 export type Place = {

--- a/server/src/dtos/partner.dto.ts
+++ b/server/src/dtos/partner.dto.ts
@@ -1,18 +1,22 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { UserResponseDto } from 'src/dtos/user.dto';
 import { PartnerDirection } from 'src/repositories/partner.repository';
-import { ValidateEnum, ValidateUUID } from 'src/validation';
+import { ValidateBoolean, ValidateDate, ValidateEnum, ValidateUUID } from 'src/validation';
 
 export class PartnerCreateDto {
   @ValidateUUID({ description: 'User ID to share with' })
   sharedWithId!: string;
+
+  @ValidateDate({ optional: true, nullable: true, description: 'Only share assets from this date onward' })
+  shareFromDate?: Date | null;
 }
 
 export class PartnerUpdateDto {
-  @ApiProperty({ description: 'Show partner assets in timeline' })
-  @IsNotEmpty()
-  inTimeline!: boolean;
+  @ValidateBoolean({ optional: true, description: 'Show partner assets in timeline' })
+  inTimeline?: boolean;
+
+  @ValidateDate({ optional: true, nullable: true, description: 'Only share assets from this date onward' })
+  shareFromDate?: Date | null;
 }
 
 export class PartnerSearchDto {
@@ -23,4 +27,7 @@ export class PartnerSearchDto {
 export class PartnerResponseDto extends UserResponseDto {
   @ApiPropertyOptional({ description: 'Show in timeline' })
   inTimeline?: boolean;
+
+  @ApiPropertyOptional({ description: 'Share assets from this date onward' })
+  shareFromDate?: string | null;
 }

--- a/server/src/dtos/sync.dto.ts
+++ b/server/src/dtos/sync.dto.ts
@@ -106,6 +106,8 @@ export class SyncPartnerV1 {
   sharedWithId!: string;
   @ApiProperty({ description: 'In timeline' })
   inTimeline!: boolean;
+  @ApiProperty({ description: 'Share from date' })
+  shareFromDate!: Date | null;
 }
 
 @ExtraModel()

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -207,7 +207,12 @@ class AssetAccess {
           eb('asset.visibility', '=', sql.lit(AssetVisibility.Hidden)),
         ]),
       )
-
+      .where((eb) =>
+        eb.or([
+          eb('partner.shareFromDate', 'is', null),
+          eb('asset.localDateTime', '>=', eb.ref('partner.shareFromDate')),
+        ]),
+      )
       .where('asset.id', 'in', [...assetIds])
       .execute()
       .then((assets) => new Set(assets.map((asset) => asset.id)));

--- a/server/src/repositories/map.repository.ts
+++ b/server/src/repositories/map.repository.ts
@@ -14,7 +14,7 @@ import { SystemMetadataRepository } from 'src/repositories/system-metadata.repos
 import { DB } from 'src/schema';
 import { GeodataPlacesTable } from 'src/schema/tables/geodata-places.table';
 import { NaturalEarthCountriesTable } from 'src/schema/tables/natural-earth-countries.table';
-import { AssetOwnerFilter, PartnerDateConstraint } from 'src/utils/asset.util';
+import { AssetOwnerFilter } from 'src/utils/asset.util';
 
 export interface MapMarkerSearchOptions {
   isArchived?: boolean;

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -8,7 +8,7 @@ import { AssetStatus, AssetType, AssetVisibility, VectorIndex } from 'src/enum';
 import { probes } from 'src/repositories/database.repository';
 import { DB } from 'src/schema';
 import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
-import { AssetOwnerFilter, PartnerDateConstraint } from 'src/utils/asset.util';
+import { AssetOwnerFilter } from 'src/utils/asset.util';
 import { anyUuid, searchAssetBuilder, withExif } from 'src/utils/database';
 import { paginationHelper } from 'src/utils/pagination';
 import { isValidInteger } from 'src/validation';
@@ -402,7 +402,7 @@ export class SearchRepository {
           .$if(!!partnerDateConstraints?.length, (qb) =>
             qb.where((eb) =>
               eb.or([
-                ...(userIds.length ? [eb('asset.ownerId', '=', anyUuid(userIds))] : []),
+                ...(userIds.length > 0 ? [eb('asset.ownerId', '=', anyUuid(userIds))] : []),
                 ...partnerDateConstraints!.map((pc) =>
                   eb.and([eb('asset.ownerId', '=', pc.userId), eb('asset.localDateTime', '>=', pc.shareFromDate)]),
                 ),
@@ -428,7 +428,7 @@ export class SearchRepository {
                 .$if(!!partnerDateConstraints?.length, (qb) =>
                   qb.where((eb) =>
                     eb.or([
-                      ...(userIds.length ? [eb('asset.ownerId', '=', anyUuid(userIds))] : []),
+                      ...(userIds.length > 0 ? [eb('asset.ownerId', '=', anyUuid(userIds))] : []),
                       ...partnerDateConstraints!.map((pc) =>
                         eb.and([
                           eb('asset.ownerId', '=', pc.userId),

--- a/server/src/schema/migrations/1771501145860-AddPartnerShareFromDate.ts
+++ b/server/src/schema/migrations/1771501145860-AddPartnerShareFromDate.ts
@@ -1,0 +1,9 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "partner" ADD "shareFromDate" date;`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`ALTER TABLE "partner" DROP COLUMN "shareFromDate";`.execute(db);
+}

--- a/server/src/schema/tables/partner.table.ts
+++ b/server/src/schema/tables/partner.table.ts
@@ -44,6 +44,9 @@ export class PartnerTable {
   @Column({ type: 'boolean', default: false })
   inTimeline!: Generated<boolean>;
 
+  @Column({ type: 'date', nullable: true })
+  shareFromDate!: Date | null;
+
   @UpdateIdColumn({ index: true })
   updateId!: Generated<string>;
 }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -75,7 +75,10 @@ describe(AssetService.name, () => {
 
       await sut.getRandom(authStub.admin, 1);
 
-      expect(mocks.asset.getRandom).toHaveBeenCalledWith([authStub.admin.user.id], 1);
+      expect(mocks.asset.getRandom).toHaveBeenCalledWith(
+        { userIds: [authStub.admin.user.id], partnerDateConstraints: [] },
+        1,
+      );
     });
 
     it('should not include partner assets if not in timeline', async () => {
@@ -87,7 +90,7 @@ describe(AssetService.name, () => {
 
       await sut.getRandom(auth, 1);
 
-      expect(mocks.asset.getRandom).toHaveBeenCalledWith([auth.user.id], 1);
+      expect(mocks.asset.getRandom).toHaveBeenCalledWith({ userIds: [auth.user.id], partnerDateConstraints: [] }, 1);
     });
 
     it('should include partner assets if in timeline', async () => {
@@ -99,7 +102,10 @@ describe(AssetService.name, () => {
 
       await sut.getRandom(auth, 1);
 
-      expect(mocks.asset.getRandom).toHaveBeenCalledWith([auth.user.id, partner.sharedById], 1);
+      expect(mocks.asset.getRandom).toHaveBeenCalledWith(
+        { userIds: [auth.user.id, partner.sharedById], partnerDateConstraints: [] },
+        1,
+      );
     });
   });
 

--- a/server/src/services/map.service.spec.ts
+++ b/server/src/services/map.service.spec.ts
@@ -58,7 +58,7 @@ describe(MapService.name, () => {
       const markers = await sut.getMapMarkers(auth, { withPartners: true });
 
       expect(mocks.map.getMapMarkers).toHaveBeenCalledWith(
-        [auth.user.id, partner.sharedById],
+        { userIds: [auth.user.id, partner.sharedById] },
         expect.arrayContaining([]),
         { withPartners: true },
       );

--- a/server/src/services/map.service.ts
+++ b/server/src/services/map.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AuthDto } from 'src/dtos/auth.dto';
 import { MapMarkerDto, MapMarkerResponseDto, MapReverseGeocodeDto } from 'src/dtos/map.dto';
 import { BaseService } from 'src/services/base.service';
-import { AssetOwnerFilter, getMyPartners, PartnerDateConstraint } from 'src/utils/asset.util';
+import { AssetOwnerFilter, getMyPartners } from 'src/utils/asset.util';
 
 @Injectable()
 export class MapService extends BaseService {

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -90,7 +90,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.COUNTRY }),
       ).resolves.toEqual(['USA']);
-      expect(mocks.search.getCountries).toHaveBeenCalledWith([authStub.user1.user.id]);
+      expect(mocks.search.getCountries).toHaveBeenCalledWith({
+        userIds: [authStub.user1.user.id],
+        partnerDateConstraints: [],
+      });
     });
 
     it('should return search suggestions for country (including null)', async () => {
@@ -100,7 +103,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.COUNTRY }),
       ).resolves.toEqual(['USA', null]);
-      expect(mocks.search.getCountries).toHaveBeenCalledWith([authStub.user1.user.id]);
+      expect(mocks.search.getCountries).toHaveBeenCalledWith({
+        userIds: [authStub.user1.user.id],
+        partnerDateConstraints: [],
+      });
     });
 
     it('should return search suggestions for state', async () => {
@@ -110,7 +116,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.STATE }),
       ).resolves.toEqual(['California']);
-      expect(mocks.search.getStates).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getStates).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for state (including null)', async () => {
@@ -120,7 +129,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.STATE }),
       ).resolves.toEqual(['California', null]);
-      expect(mocks.search.getStates).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getStates).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for city', async () => {
@@ -130,7 +142,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.CITY }),
       ).resolves.toEqual(['Denver']);
-      expect(mocks.search.getCities).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCities).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for city (including null)', async () => {
@@ -140,7 +155,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.CITY }),
       ).resolves.toEqual(['Denver', null]);
-      expect(mocks.search.getCities).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCities).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera make', async () => {
@@ -150,7 +168,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.CAMERA_MAKE }),
       ).resolves.toEqual(['Nikon']);
-      expect(mocks.search.getCameraMakes).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraMakes).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera make (including null)', async () => {
@@ -160,7 +181,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.CAMERA_MAKE }),
       ).resolves.toEqual(['Nikon', null]);
-      expect(mocks.search.getCameraMakes).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraMakes).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera model', async () => {
@@ -170,7 +194,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.CAMERA_MODEL }),
       ).resolves.toEqual(['Fujifilm X100VI']);
-      expect(mocks.search.getCameraModels).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraModels).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera model (including null)', async () => {
@@ -180,7 +207,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.CAMERA_MODEL }),
       ).resolves.toEqual(['Fujifilm X100VI', null]);
-      expect(mocks.search.getCameraModels).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraModels).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera lens model', async () => {
@@ -190,7 +220,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: false, type: SearchSuggestionType.CAMERA_LENS_MODEL }),
       ).resolves.toEqual(['10-24mm']);
-      expect(mocks.search.getCameraLensModels).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraLensModels).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
 
     it('should return search suggestions for camera lens model (including null)', async () => {
@@ -200,7 +233,10 @@ describe(SearchService.name, () => {
       await expect(
         sut.getSearchSuggestions(authStub.user1, { includeNull: true, type: SearchSuggestionType.CAMERA_LENS_MODEL }),
       ).resolves.toEqual(['10-24mm', null]);
-      expect(mocks.search.getCameraLensModels).toHaveBeenCalledWith([authStub.user1.user.id], expect.anything());
+      expect(mocks.search.getCameraLensModels).toHaveBeenCalledWith(
+        { userIds: [authStub.user1.user.id], partnerDateConstraints: [] },
+        expect.anything(),
+      );
     });
   });
 
@@ -239,7 +275,12 @@ describe(SearchService.name, () => {
       );
       expect(mocks.search.searchSmart).toHaveBeenCalledWith(
         { page: 1, size: 100 },
-        { query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id] },
+        {
+          query: 'test',
+          embedding: '[1, 2, 3]',
+          userIds: [authStub.user1.user.id],
+          partnerDateConstraints: [],
+        },
       );
     });
 
@@ -252,7 +293,12 @@ describe(SearchService.name, () => {
       );
       expect(mocks.search.searchSmart).toHaveBeenCalledWith(
         { page: 2, size: 50 },
-        expect.objectContaining({ query: 'test', embedding: '[1, 2, 3]', userIds: [authStub.user1.user.id] }),
+        expect.objectContaining({
+          query: 'test',
+          embedding: '[1, 2, 3]',
+          userIds: [authStub.user1.user.id],
+          partnerDateConstraints: [],
+        }),
       );
     });
 

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -30,7 +30,7 @@ import { SyncQueryOptions } from 'src/repositories/sync.repository';
 import { SessionSyncCheckpointTable } from 'src/schema/tables/sync-checkpoint.table';
 import { BaseService } from 'src/services/base.service';
 import { SyncAck } from 'src/types';
-import { getMyPartnerIds, getMyPartners, PartnerDateConstraint } from 'src/utils/asset.util';
+import { getMyPartners, PartnerDateConstraint } from 'src/utils/asset.util';
 import { hexOrBufferToBase64 } from 'src/utils/bytes';
 import { setIsEqual } from 'src/utils/set';
 import { fromAck, serialize, SerializeOptions, toAck } from 'src/utils/sync';

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -31,15 +31,15 @@ export class TimelineService extends BaseService {
     let partnerDateConstraints: PartnerDateConstraint[] | undefined = undefined;
 
     if (userId) {
-      if (userId !== auth.user.id) {
+      if (userId === auth.user.id) {
+        userIds = [userId];
+      } else {
         const partner = await this.partnerRepository.get({ sharedById: userId, sharedWithId: auth.user.id });
         if (partner?.shareFromDate) {
           partnerDateConstraints = [{ userId, shareFromDate: partner.shareFromDate }];
         } else {
           userIds = [userId];
         }
-      } else {
-        userIds = [userId];
       }
 
       if (dto.withPartners) {

--- a/server/test/small.factory.ts
+++ b/server/test/small.factory.ts
@@ -137,6 +137,7 @@ const partnerFactory = (partner: Partial<Partner> = {}) => {
     updatedAt: newDate(),
     updateId: newUuidV7(),
     inTimeline: true,
+    shareFromDate: null,
     ...partner,
   };
 };

--- a/web/src/lib/modals/PartnerSelectionModal.svelte
+++ b/web/src/lib/modals/PartnerSelectionModal.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
   import UserAvatar from '$lib/components/shared-components/user-avatar.svelte';
   import { getPartners, PartnerDirection, searchUsers, type UserResponseDto } from '@immich/sdk';
-  import { Button, ListButton, LoadingSpinner, Modal, ModalBody, ModalFooter, Text } from '@immich/ui';
+  import { Button, IconButton, ListButton, LoadingSpinner, Modal, ModalBody, ModalFooter, Text } from '@immich/ui';
+  import { mdiCloseCircle } from '@mdi/js';
   import { t } from 'svelte-i18n';
+
+  export interface PartnerSelectionResult {
+    users: UserResponseDto[];
+    shareFromDate: string | null;
+  }
 
   interface Props {
     user: UserResponseDto;
-    onClose: (users?: UserResponseDto[]) => void;
+    onClose: (result?: PartnerSelectionResult) => void;
   }
 
   let { user, onClose }: Props = $props();
 
   let availableUsers: UserResponseDto[] = $state([]);
   let selectedUsers: UserResponseDto[] = $state([]);
+  let shareFromDate: string = $state('');
 
   const loadUsers = async () => {
     let users = await searchUsers();
@@ -52,9 +59,44 @@
             </ListButton>
           {/each}
 
+          <div class="mt-2 px-1">
+            <label for="shareFromDate" class="font-medium text-primary text-sm">
+              {$t('partner_sharing_from_date')}
+            </label>
+            <p class="text-sm dark:text-immich-dark-fg">
+              {$t('partner_sharing_from_date_description')}
+            </p>
+            <div class="flex items-center gap-2 mt-2">
+              <input
+                class="immich-form-input w-full"
+                id="shareFromDate"
+                name="shareFromDate"
+                type="date"
+                bind:value={shareFromDate}
+              />
+              {#if shareFromDate}
+                <IconButton
+                  shape="round"
+                  color="secondary"
+                  variant="ghost"
+                  size="small"
+                  icon={mdiCloseCircle}
+                  aria-label={$t('clear_value')}
+                  onclick={() => (shareFromDate = '')}
+                />
+              {/if}
+            </div>
+          </div>
+
           <ModalFooter>
             {#if selectedUsers.length > 0}
-              <Button shape="round" fullWidth onclick={() => onClose(selectedUsers)}>{$t('add')}</Button>
+              <Button
+                shape="round"
+                fullWidth
+                onclick={() => onClose({ users: selectedUsers, shareFromDate: shareFromDate || null })}
+              >
+                {$t('add')}
+              </Button>
             {/if}
           </ModalFooter>
         </div>


### PR DESCRIPTION
## Description

Adds an optional `shareFromDate` field to partner sharing, allowing the sharer to restrict which assets are visible to the partner. Only assets with `localDateTime >= shareFromDate` will be shown. When unset (`null`), all assets are shared (existing behavior).

### Key design decisions:
- `inTimeline` remains receiver-controlled, `shareFromDate` is sharer-controlled. The update endpoint validates that only the correct party sets each field.
- Partners are split into "unconstrained" (no date, added to `userIds`) and "constrained" (has date, added to `partnerDateConstraints`) for efficient SQL filtering via AssetOwnerFilter.
- Access control enforced at the `checkPartnerAccess` level as the security boundary, with query-level filtering in all asset listing paths (timeline, search, map, sync, random, suggestions, statistics).

### Frontend:
- Date picker in both the partner selection modal (initial setup) and partner settings page (edit later)
- Clearable via X button, auto-saves on change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Fixes:
- https://github.com/immich-app/immich/discussions/2654

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests for partner service: create with shareFromDate, update from sharer, clear date, reject invalid combinations
- [ ] Updated test expectations for AssetOwnerFilter refactor across search, asset, and map services
- [ ] Manual testing of timeline, search, map markers, and sync with constrained partner sharing

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->
<img width="976" height="838" alt="image" src="https://github.com/user-attachments/assets/0c111e8b-9ff8-448c-a5bd-d29e25622516" />
<img width="536" height="413" alt="image" src="https://github.com/user-attachments/assets/5152bdb8-ec4e-4c37-8ecd-194481e0341b" />

</details>


## API Changes

- POST /partners now accepts optional shareFromDate (ISO date string)
- PUT /partners/{id} accepts optional shareFromDate (sharer-only, mutually exclusive with inTimeline)
- PartnerResponseDto now includes shareFromDate

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [x] I have confirmed that any new dependencies are strictly necessary.
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code
- [x] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [x] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

An LLM (Claude) was used as a coding assistant for:
- Researching the codebase to identify all query paths that needed shareFromDate enforcement
- Double-checking for missed spots across repositories and services
- Inline code completion for repetitive patterns (e.g., the OR-filter logic across multiple query methods)
- Writing tests and fixing failing tests
- Drafting this PR description
