### PR TITLE
fix(web): prevent panorama image reload during asset updates

### DIFF
--- a/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/image-panorama-viewer.svelte
@@ -12,6 +12,8 @@
 
   let { asset }: Props = $props();
 
+  const assetId = $derived(asset.id);
+
   const loadAssetData = async (id: string) => {
     const data = await viewAsset({ ...authManager.params, id, size: AssetMediaSize.Preview });
     return URL.createObjectURL(data);
@@ -19,7 +21,7 @@
 </script>
 
 <div transition:fade={{ duration: 150 }} class="flex h-full select-none place-content-center place-items-center">
-  {#await Promise.all([loadAssetData(asset.id), import('./photo-sphere-viewer-adapter.svelte')])}
+  {#await Promise.all([loadAssetData(assetId), import('./photo-sphere-viewer-adapter.svelte')])}
     <LoadingSpinner />
   {:then [data, { default: PhotoSphereViewer }]}
     <PhotoSphereViewer panorama={data} originalPanorama={getAssetUrl({ asset, forceOriginal: true })} />


### PR DESCRIPTION
Panorama image reloads when not needed like when favoriting, updating description, etc.


https://github.com/user-attachments/assets/9ec99b86-229f-4c7d-97c7-01ff9937649b

