### PR TITLE
fix(web): favoriting assets opened via GalleryViewer

### DIFF
--- a/web/src/lib/components/asset-viewer/asset-viewer.svelte
+++ b/web/src/lib/components/asset-viewer/asset-viewer.svelte
@@ -398,7 +398,7 @@
 
   const onAssetUpdate = (update: AssetResponseDto) => {
     if (asset.id === update.id) {
-      cursor.current = update;
+      cursor = { ...cursor, current: update };
     }
   };
 


### PR DESCRIPTION
Fixes this issue where changing favorite status for an asset opened via `GalleryViewer` does not update the favorite state

https://github.com/user-attachments/assets/0e4299ec-2014-4050-acb4-edc5e4ca6b07

